### PR TITLE
Account for periodic boundary conditions in the halo callback

### DIFF
--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -152,11 +152,11 @@ class PlotCallback(object):
 
         # We need a special case for when we are only given one coordinate.
         if ccoord.shape == (2,):
-            return (np.mod((ccoord[0]-x0)/(x1-x0), 1.0)*(xx1-xx0) + xx0,
-                    np.mod((ccoord[1]-y0)/(y1-y0), 1.0)*(yy1-yy0) + yy0)
+            return ((ccoord[0]-x0)/(x1-x0)*(xx1-xx0) + xx0,
+                    (ccoord[1]-y0)/(y1-y0)*(yy1-yy0) + yy0)
         else:
-            return (np.mod((ccoord[0][:]-x0)/(x1-x0), 1.0)*(xx1-xx0) + xx0,
-                    np.mod((ccoord[1][:]-y0)/(y1-y0), 1.0)*(yy1-yy0) + yy0)
+            return ((ccoord[0][:]-x0)/(x1-x0)*(xx1-xx0) + xx0,
+                    (ccoord[1][:]-y0)/(y1-y0)*(yy1-yy0) + yy0)
 
     def sanitize_coord_system(self, plot, coord, coord_system):
         """
@@ -1442,7 +1442,25 @@ class HaloCatalogCallback(PlotCallback):
         px = halo_data[field_x][:].in_units(units)
         py = halo_data[field_y][:].in_units(units)
 
-        px, py = self.convert_to_plot(plot,[px,py])
+        xplotcenter = (plot.xlim[0] + plot.xlim[1])/2
+        yplotcenter = (plot.ylim[0] + plot.ylim[1])/2
+
+        xdomaincenter = plot.ds.domain_center[xax]
+        ydomaincenter = plot.ds.domain_center[yax]
+
+        xoffset = xplotcenter - xdomaincenter
+        yoffset = yplotcenter - ydomaincenter
+
+        xdw = plot.ds.domain_width[xax].to(units)
+        ydw = plot.ds.domain_width[yax].to(units)
+
+        modpx = np.mod(px - xoffset, xdw) + xoffset
+        modpy = np.mod(py - yoffset, ydw) + yoffset
+
+        px[modpx != px] = modpx[modpx != px]
+        py[modpy != py] = modpy[modpy != py]
+
+        px, py = self.convert_to_plot(plot, [px, py])
 
         # Convert halo radii to a radius in pixels
         radius = halo_data[self.radius_field][:].in_units(units)


### PR DESCRIPTION
This is a rethinking of [bitbucket PR 2492](https://bitbucket.org/yt_analysis/yt/pull-requests/2492). Rather than trying to handle periodicity in convert_to_plot (which does not always deal with plot windows spanning the full domain width) let's deal with periodicity before we pass data to convert_to_plot.

This avoids issues plotting halos in plot windows that don't span the full width of the domain.