### PR TITLE
Add travis builds for various python versions and MacOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,61 @@
+language: python
+sudo: false
+cache:
+  pip: true
+  directories:
+    - $HOME/.ccache  # https://github.com/travis-ci/travis-ci/issues/5853
+
+addons:
+  apt:
+    packages:
+      - libhdf5-serial-dev
+
+matrix:
+  include:
+    - python: 2.7
+    - python: 3.4
+    - python: 3.5
+    - python: 3.6
+    - os: osx
+      osx_image: xcode7.3
+      language: generic  # https://github.com/travis-ci/travis-ci/issues/2312
+      cache:
+        pip: false
+        directories:
+          - $HOME/Library/Caches/pip
+          # `cache` does not support `env`-like `global` so copy-paste from top
+          - $HOME/.ccache  # https://github.com/travis-ci/travis-ci/issues/5853
+
+before_install:
+  - |
+    if [[ $TRAVIS_OS_NAME != 'osx' ]]; then
+      pip install --upgrade virtualenv
+      python -m virtualenv venv
+      source venv/bin/activate
+      export PATH=/usr/lib/ccache:$PATH
+    else
+      brew update
+      brew install ccache hdf5
+      export PATH=/usr/local/opt/ccache/libexec:$PATH
+    fi
+    mkdir -p $HOME/.config/yt
+    echo "[yt]" > $HOME/.config/yt/ytrc
+    echo "suppressStreamLogging = True" >> $HOME/.config/yt/ytrc
+    cat $HOME/.config/yt/ytrc
+
+install:
+  - |
+    # setup environment
+    ccache -s
+    # Upgrade pip and setuptools and wheel to get clean install
+    pip install --upgrade pip
+    pip install --upgrade wheel
+    pip install --upgrade setuptools
+    # Install dependencies
+    pip install mock numpy scipy cython matplotlib sympy fastcache nose flake8 h5py ipython
+    # install yt
+    pip install -e .
+
+script:
+  - |
+    nosetests -sv yt

--- a/yt/data_objects/tests/test_image_array.py
+++ b/yt/data_objects/tests/test_image_array.py
@@ -5,7 +5,8 @@ import shutil
 import unittest
 from yt.data_objects.image_array import ImageArray
 from yt.testing import \
-    assert_equal
+    assert_equal, \
+    requires_module
 
 
 def setup():
@@ -55,6 +56,7 @@ class TestImageArray(unittest.TestCase):
 
         assert str(new_im.units) == 'km'
 
+    @requires_module('h5py')
     def test_image_array_hdf5(self):
         myinfo = {'field': 'dinosaurs', 'east_vector': np.array([1., 0., 0.]),
                   'north_vector': np.array([0., 0., 1.]),

--- a/yt/tests/test_flake8.py
+++ b/yt/tests/test_flake8.py
@@ -1,6 +1,8 @@
 import subprocess
 import yt
 import os
+import sys
+import tempfile
 
 from yt.testing import requires_module
 
@@ -8,17 +10,19 @@ from yt.testing import requires_module
 @requires_module('flake8')
 def test_flake8():
     yt_dir = os.path.dirname(os.path.abspath(yt.__file__))
-    output_file = os.environ.get("WORKSPACE", None) or os.getcwd()
+    output_file = os.environ.get("WORKSPACE", None) or tempfile.mkdtemp()
     output_file = os.path.join(output_file, 'flake8.out')
     if os.path.exists(output_file):
         os.remove(output_file)
     output_string = "--output-file=%s" % output_file
     config_string = "--config=%s" % os.path.join(os.path.dirname(yt_dir), 
                                                  'setup.cfg')
-    subprocess.call(['flake8', output_string, config_string, yt_dir])
-    
-    with open(output_file) as f:
-        flake8_output = f.readlines()
-    if flake8_output != []:
-        raise AssertionError(
-            "flake8 found style errors:\n\n%s" % "\n".join(flake8_output))
+    subprocess.call([sys.executable, '-m', 'flake8', output_string,
+                     config_string, yt_dir])
+
+    if os.path.exists(output_file):
+        with open(output_file) as f:
+            flake8_output = f.readlines()
+        if flake8_output != []:
+            raise AssertionError(
+                "flake8 found style errors:\n\n%s" % "\n".join(flake8_output))

--- a/yt/units/tests/test_ytarray.py
+++ b/yt/units/tests/test_ytarray.py
@@ -39,7 +39,8 @@ from yt.units.yt_array import \
 from yt.utilities.exceptions import \
     YTUnitOperationError, YTUfuncUnitError
 from yt.testing import \
-    fake_random_ds, requires_module, \
+    fake_random_ds, \
+    requires_module, \
     assert_allclose_units
 from yt.funcs import fix_length
 from yt.units.unit_symbols import \
@@ -976,7 +977,8 @@ def test_subclass():
     assert_isinstance(a[:], YTASubclass)
     assert_isinstance(a[:2], YTASubclass)
     assert_isinstance(YTASubclass(yta), YTASubclass)
-    
+
+@requires_module('h5py')
 def test_h5_io():
     tmpdir = tempfile.mkdtemp()
     curdir = os.getcwd()

--- a/yt/units/yt_array.py
+++ b/yt/units/yt_array.py
@@ -787,7 +787,7 @@ class YTArray(np.ndarray):
         >>> a.write_hdf5('test_array_data.h5', dataset_name='dinosaurs',
         ...              info=myinfo)
         """
-        import h5py
+        from yt.utilities.on_demand_imports import _h5py as h5py
         from yt.extern.six.moves import cPickle as pickle
         if info is None:
             info = {}

--- a/yt/utilities/tests/test_config.py
+++ b/yt/utilities/tests/test_config.py
@@ -158,7 +158,8 @@ class TestYTConfigMigration(TestYTConfig):
         
         my_plugin_name = _TEST_PLUGIN
         plugin_file = os.path.join(CONFIG_DIR, my_plugin_name)
-        os.remove(plugin_file)
+        if os.path.exists(plugin_file):
+            os.remove(plugin_file)
 
         old_config_dir = os.path.join(os.path.expanduser('~'), '.yt')
         for base_prefix in ('', CONFIG_DIR, old_config_dir):


### PR DESCRIPTION
## PR Summary

This adds configuration for a travis builder. I've enabled support for Travis for yt-project/yt which I hope won't break other pull requests while this gets reviewed.

I tested this mainly in my fork and saw mysterious failures. Unfortunately the errors contained tracebacks in the multiprocessing module (nothing in yt or nose) and seemed to magically go away this evening. I think it might be due to flakyness on Travis's end? We'll see if it was a transient issue I was running into.

If the failures recur often we can at least make these tests run on a chron job or marked as allowed to fail until we can debug them as it will be nice to have some test coverage on a variety of python versions.

Next on my list is adding an Appveyor build for Windows testing and seeing if moving the MacOS build to CircleCI makes any sense.