### PR TITLE
[BUGFIX] Fix multiple mesh support for streaming unstructured datasets . Closes Issue #1350.

### DIFF
--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -1401,14 +1401,50 @@ dataset as follows:
 
     ds = yt.load_unstructured_mesh(connect, coords, data)
 
-Note that load_unstructured_mesh can take either a single mesh or a list of meshes.
-Here, we only have one mesh. The in-memory dataset can then be visualized as usual,
-e.g.:
+The in-memory dataset can then be visualized as usual, e.g.:
 
 .. code-block:: python
 
     sl = yt.SlicePlot(ds, 'z', 'test')
     sl.annotate_mesh_lines()
+
+Note that load_unstructured_mesh can take either a single mesh or a list of meshes.
+To load multiple meshes, you can do:
+
+.. code-block:: python
+
+   import yt
+   import numpy as np
+
+   coordsMulti = np.array([[0.0, 0.0],
+                           [1.0, 0.0],
+                           [1.0, 1.0],
+                           [0.0, 1.0]], dtype=np.float64)
+
+   connect1 = np.array([[0, 1, 3], ], dtype=np.int64)
+   connect2 = np.array([[1, 2, 3], ], dtype=np.int64)
+
+   data1 = {}
+   data2 = {}
+   data1['connect1', 'test'] = np.array([[0.0, 1.0, 3.0], ], dtype=np.float64)
+   data2['connect2', 'test'] = np.array([[1.0, 2.0, 3.0], ], dtype=np.float64)
+
+   connectList = [connect1, connect2]
+   dataList    = [data1, data2]
+
+   ds = yt.load_unstructured_mesh(connectList, coordsMulti, dataList)
+
+   # only plot the first mesh
+   sl = yt.SlicePlot(ds, 'z', ('connect1', 'test'))
+
+   # only plot the second
+   sl = yt.SlicePlot(ds, 'z', ('connect2', 'test'))
+   
+   # plot both
+   sl = yt.SlicePlot(ds, 'z', ('all', 'test'))
+
+Note that you must respect the field naming convention that fields on the first
+mesh will have the type 'connect1', fields on the second will have 'connect2', etc...
 
 .. rubric:: Caveats
 

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -1647,7 +1647,7 @@ class StreamUnstructuredIndex(UnstructuredIndex):
         coords = ensure_list(self.stream_handler.fields.pop("coordinates"))
         connec = ensure_list(self.stream_handler.fields.pop("connectivity"))
         self.meshes = [StreamUnstructuredMesh(
-          i, self.index_filename, c1, c2, self)
+                       i, self.index_filename, c1, c2, self)
                        for i, (c1, c2) in enumerate(zip(connec, repeat(coords[0])))]
         self.mesh_union = MeshUnion("mesh_union", self.meshes)
 

--- a/yt/frontends/stream/io.py
+++ b/yt/frontends/stream/io.py
@@ -263,26 +263,37 @@ class IOHandlerStreamUnstructured(BaseIOHandler):
 
     def _read_fluid_selection(self, chunks, selector, fields, size):
         chunks = list(chunks)
-        chunk = chunks[0]
-        mesh_id = chunk.objs[0].mesh_id
         rv = {}
         for field in fields:
-            if field in self.ds._node_fields:
-                nodes_per_element = self.fields[mesh_id][field].shape[1]
-                rv[field] = np.empty((size, nodes_per_element), dtype="float64")
+            ftype, fname = field
+            if ftype == "all":
+                ci = np.concatenate([mesh.connectivity_indices
+                                     for mesh in self.ds.index.mesh_union])
             else:
-                rv[field] = np.empty(size, dtype="float64")
-        ngrids = sum(len(chunk.objs) for chunk in chunks)
-        mylog.debug("Reading %s cells of %s fields in %s blocks",
-                    size, [fname for ftype, fname in fields], ngrids)
+                mesh_id = int(ftype[-1]) - 1
+                m = self.ds.index.meshes[mesh_id]
+                ci = m.connectivity_indices
+            num_elem = ci.shape[0]
+            if fname in self.ds._node_fields:
+                nodes_per_element = ci.shape[1]
+                rv[field] = np.empty((num_elem, nodes_per_element), dtype="float64")
+            else:
+                rv[field] = np.empty(num_elem, dtype="float64")
         for field in fields:
             ind = 0
             ftype, fname = field
-            for chunk in chunks:
-                for g in chunk.objs:
-                    ds = self.fields[g.mesh_id].get(field, None)
-                    if ds is None:
-                        ds = self.fields[g.mesh_id][fname]
-                    ind += g.select(selector, ds, rv[field], ind) # caches
+            if ftype == "all":
+                mesh_ids = [mesh.mesh_id + 1 for mesh in self.ds.index.mesh_union]
+                objs = [mesh for mesh in self.ds.index.mesh_union]
+            else:
+                mesh_ids = [int(ftype[-1])]
+                chunk = chunks[mesh_ids[0] - 1]
+                objs = chunk.objs
+            for g in objs:
+                ds = self.fields[g.mesh_id].get(field, None)
+                if ds is None:
+                    f = ('connect%d' % (g.mesh_id + 1), fname)
+                    ds = self.fields[g.mesh_id][f]
+                ind += g.select(selector, ds, rv[field], ind) # caches
         return rv
 

--- a/yt/frontends/stream/io.py
+++ b/yt/frontends/stream/io.py
@@ -283,7 +283,6 @@ class IOHandlerStreamUnstructured(BaseIOHandler):
             ind = 0
             ftype, fname = field
             if ftype == "all":
-                mesh_ids = [mesh.mesh_id + 1 for mesh in self.ds.index.mesh_union]
                 objs = [mesh for mesh in self.ds.index.mesh_union]
             else:
                 mesh_ids = [int(ftype[-1])]

--- a/yt/frontends/stream/tests/test_stream_unstructured.py
+++ b/yt/frontends/stream/tests/test_stream_unstructured.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+from yt import load_unstructured_mesh, SlicePlot
+
+def test_multi_mesh():
+    coordsMulti = np.array([[0.0, 0.0],
+                            [1.0, 0.0],
+                            [1.0, 1.0],
+                            [0.0, 1.0]], dtype=np.float64)
+
+    connect1 = np.array([[0, 1, 3], ], dtype=np.int64)
+    connect2 = np.array([[1, 2, 3], ], dtype=np.int64)
+
+    data1 = {}
+    data2 = {}
+    data1['connect1', 'test'] = np.array([[0.0, 1.0, 3.0], ], dtype=np.float64)
+    data2['connect2', 'test'] = np.array([[1.0, 2.0, 3.0], ], dtype=np.float64)
+
+    connectList = [connect1, connect2]
+    dataList    = [data1, data2]
+
+    ds = load_unstructured_mesh(connectList, coordsMulti, dataList)
+
+    sl = SlicePlot(ds, 'z', ('connect1', 'test'))
+    sl = SlicePlot(ds, 'z', ('connect2', 'test'))
+    sl = SlicePlot(ds, 'z', ('all', 'test'))
+    sl.annotate_mesh_lines()
+

--- a/yt/visualization/volume_rendering/render_source.py
+++ b/yt/visualization/volume_rendering/render_source.py
@@ -531,6 +531,9 @@ class MeshSource(OpaqueSource):
         # Error checking
         assert(self.field is not None)
         assert(self.data_source is not None)
+        if self.field[0] == 'all':
+            raise NotImplementedError("Mesh unions are not implemented "
+                                       "for 3D rendering")
 
         if self.engine == 'embree':
             self.volume = mesh_traversal.YTEmbreeScene()

--- a/yt/visualization/volume_rendering/tests/test_mesh_render.py
+++ b/yt/visualization/volume_rendering/tests/test_mesh_render.py
@@ -40,6 +40,8 @@ def surface_mesh_render():
 
     ds = fake_tetrahedral_ds()
     for field in ds.field_list:
+        if field[0] == 'all':
+            continue
         sc = Scene()
         sc.add_source(MeshSource(ds, field))
         sc.add_camera()
@@ -48,6 +50,8 @@ def surface_mesh_render():
 
     ds = fake_hexahedral_ds()
     for field in ds.field_list:
+        if field[0] == 'all':
+            continue
         sc = Scene()
         sc.add_source(MeshSource(ds, field))
         sc.add_camera()


### PR DESCRIPTION
This fixes support for multiple meshes in the streaming unstructured frontend. It also sets up mesh unions for that frontend, so that multiple meshes can be shown on the same plot. 