### PR TITLE
plot the same field multiple times along with other fields in ProfilePlot

### DIFF
--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -350,17 +350,19 @@ class ProfilePlot(object):
                 self.axes[field].plot(np.array(profile.x), np.array(field_data),
                                       label=self.label[i], **self.plot_spec[i])
 
-        for (fname, axes), profile in zip(self.axes.items(), self.profiles):
-            xscale, yscale = self._get_field_log(fname, profile)
-            xtitle, ytitle = self._get_field_title(fname, profile)
-            axes.set_xscale(xscale)
-            axes.set_yscale(yscale)
-            axes.set_xlabel(xtitle)
-            axes.set_ylabel(ytitle)
-            axes.set_ylim(*self.axes.ylim[fname])
-            axes.set_xlim(*self.axes.xlim)
-            if any(self.label):
-                axes.legend(loc="best")
+        for profile in self.profiles:
+            for fname in profile.keys():
+                axes = self.axes[fname]
+                xscale, yscale = self._get_field_log(fname, profile)
+                xtitle, ytitle = self._get_field_title(fname, profile)
+                axes.set_xscale(xscale)
+                axes.set_yscale(yscale)
+                axes.set_xlabel(xtitle)
+                axes.set_ylabel(ytitle)
+                axes.set_ylim(*self.axes.ylim[fname])
+                axes.set_xlim(*self.axes.xlim)
+                if any(self.label):
+                    axes.legend(loc="best")
         self._set_font_properties()
         self._plot_valid = True
 

--- a/yt/visualization/tests/test_profile_plots.py
+++ b/yt/visualization/tests/test_profile_plots.py
@@ -16,12 +16,14 @@ import os
 import tempfile
 import shutil
 import unittest
+import yt
 from yt.data_objects.profiles import create_profile
 from yt.extern.parameterized import\
     parameterized, param
 from yt.testing import \
     fake_random_ds, \
-    assert_array_almost_equal
+    assert_array_almost_equal, \
+    requires_file
 from yt.visualization.profile_plotter import \
     ProfilePlot, PhasePlot
 from yt.visualization.tests.test_plotwindow import \
@@ -143,3 +145,25 @@ class TestProfilePlotSave(unittest.TestCase):
     def test_ipython_repr(self):
         self.profiles[0]._repr_html_()
         self.phases[0]._repr_html_()
+
+
+ETC46 = "enzo_tiny_cosmology/DD0046/DD0046"
+
+@requires_file(ETC46)
+def test_profile_plot_multiple_field_multiple_plot():
+    ds = yt.load("enzo_tiny_cosmology/DD0046/DD0046")
+    sphere = ds.sphere("max", (1.0, "Mpc"))
+    profiles = []
+    profiles.append(yt.create_profile(
+        sphere, ["radius"],
+        fields=["density"],n_bins=32))
+    profiles.append(yt.create_profile(
+        sphere, ["radius"],
+        fields=["density"],n_bins=64))
+    profiles.append(yt.create_profile(
+        sphere, ["radius"],
+        fields=["dark_matter_density"],n_bins=64))
+
+    plot = yt.ProfilePlot.from_profiles(profiles)
+    with tempfile.NamedTemporaryFile(suffix='png') as f:
+        plot.save(name=f.name)


### PR DESCRIPTION
## PR Summary

This fixes an issue reported by @pgrete on Slack. If we try to plot multiple fields but still have two or more profiles of at least one field we break the logic in this for loop. See the test I added for an example. The fix is a straightforward refactoring.