### PR TITLE
Use output_units instead of units when generating ghost zones. closes #1368

### DIFF
--- a/yt/data_objects/grid_patch.py
+++ b/yt/data_objects/grid_patch.py
@@ -274,7 +274,7 @@ class AMRGridPatch(YTSelectionContainer):
         for field in fields:
             finfo = self.ds._get_field_info(field)
             new_fields[field] = self.ds.arr(
-                np.zeros(self.ActiveDimensions + 1), finfo.units)
+                np.zeros(self.ActiveDimensions + 1), finfo.output_units)
         if no_ghost:
             for field in fields:
                 # Ensure we have the native endianness in this array.  Avoid making

--- a/yt/data_objects/tests/test_fluxes.py
+++ b/yt/data_objects/tests/test_fluxes.py
@@ -101,3 +101,13 @@ class ExporterTests(TestCase):
 
         assert os.path.exists('my_galaxy_emis.obj')
         assert os.path.exists('my_galaxy_emis.mtl')
+
+@requires_file(ISOGAL)
+def test_correct_output_unit():
+    # see issue #1368
+    ds = load(ISOGAL)
+    x = y = z = .5
+    sp1 = ds.sphere((x,y,z), (300, 'kpc'))
+    Nmax = sp1.max('HI_Density')
+    sur = ds.surface(sp1,"HI_Density", .5*Nmax)
+    sur['x'][0]


### PR DESCRIPTION
This fixes the issue reported by Joe Tomlinson on the mailing list and filed by me in #1368. The issue in his test script is that ('gas', 'x') has `units` of `code_length` but `output_units` of `cm`. Usually this doesn't matter for internal operations but since we are directly using `np.add` this distinction triggers an error.

Sadly yet another case where the distinction between `units` and `output_units` causes issues. In the long run I'd like to make a plan to get rid of `output_unit`, but for now we'll need fixes like this to avoid errors in user scripts.