### PR TITLE
Reduce the memory usage of the unit tests

### DIFF
--- a/yt/analysis_modules/ppv_cube/tests/test_ppv.py
+++ b/yt/analysis_modules/ppv_cube/tests/test_ppv.py
@@ -26,7 +26,7 @@ def test_ppv():
 
     np.random.seed(seed=0x4d3d3d3)
 
-    dims = (8,8,1024)
+    dims = (8, 8, 128)
     v_shift = 1.0e7*u.cm/u.s
     sigma_v = 2.0e7*u.cm/u.s
     T_0 = 1.0e8*u.Kelvin

--- a/yt/data_objects/tests/test_boolean_regions.py
+++ b/yt/data_objects/tests/test_boolean_regions.py
@@ -280,6 +280,7 @@ def test_boolean_cylinders_overlap():
     b6 = bo6["index", "morton_index"]
     b6.sort()
     assert_array_equal(b6, np.setxor1d(i1, i2))
+    del ds
 
 def test_boolean_ellipsoids_no_overlap():
     r"""Test to make sure that boolean objects (ellipsoids, no overlap)

--- a/yt/data_objects/tests/test_covering_grid.py
+++ b/yt/data_objects/tests/test_covering_grid.py
@@ -90,7 +90,7 @@ def test_smoothed_covering_grid():
 
 
 def test_arbitrary_grid():
-    for ncells in [64, 128, 256]:
+    for ncells in [32, 64]:
         for px in [0.125, 0.25, 0.55519]:
 
             particle_data = {

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -895,7 +895,7 @@ def periodicity_cases(ds):
                 yield center
 
 def run_nose(verbose=False, run_answer_tests=False, answer_big_data=False,
-             call_pdb = False):
+             call_pdb=False, module=None):
     from yt.utilities.on_demand_imports import _nose
     import sys
     from yt.utilities.logger import ytLogger as mylog
@@ -911,6 +911,8 @@ def run_nose(verbose=False, run_answer_tests=False, answer_big_data=False,
         nose_argv.append('--with-answer-testing')
     if answer_big_data:
         nose_argv.append('--answer-big-data')
+    if module:
+        nose_argv.append(module)
     initial_dir = os.getcwd()
     yt_file = os.path.abspath(__file__)
     yt_dir = os.path.dirname(yt_file)

--- a/yt/utilities/lib/image_samplers.pyx
+++ b/yt/utilities/lib/image_samplers.pyx
@@ -216,8 +216,16 @@ cdef class ImageSampler:
         self.image.vp_pos = None
         self.image.vp_dir = None
         self.image.zbuffer = None
-        self.image.camera_data = None
         self.image.image_used = None
+        self.image.mesh_lines = None
+        self.image.camera_data = None
+        self.aimage = None
+        self.acenter = None
+        self.ax_vec = None
+        self.ay_vec = None
+        self.azbuffer = None
+        self.aimage_used = None
+        self.amesh_lines = None
         free(self.image)
 
 cdef class ProjectionSampler(ImageSampler):

--- a/yt/utilities/tests/test_particle_generator.py
+++ b/yt/utilities/tests/test_particle_generator.py
@@ -11,12 +11,9 @@ import yt.utilities.initial_conditions as ic
 import yt.utilities.flagging_methods as fm
 from yt.units.yt_array import uconcatenate
 
-def setup() :
-    pass
-
 def test_particle_generator():
     # First generate our dataset
-    domain_dims = (128, 128, 128)
+    domain_dims = (64, 64, 64)
     dens = np.zeros(domain_dims) + 0.1
     temp = 4.*np.ones(domain_dims)
     fields = {"density": (dens, 'code_mass/code_length**3'),
@@ -114,3 +111,11 @@ def test_particle_generator():
     assert_equal(particles_per_grid3, particles1.NumberOfParticles+particles2.NumberOfParticles)
     particles_per_grid2 = [len(grid["particle_position_z"]) for grid in ds.index.grids]
     assert_equal(particles_per_grid3, particles1.NumberOfParticles+particles2.NumberOfParticles)
+
+    del pdata
+    del ds
+    del particles1
+    del particles2
+    del fields
+    del dens
+    del temp

--- a/yt/utilities/tests/test_particle_generator.py
+++ b/yt/utilities/tests/test_particle_generator.py
@@ -13,7 +13,7 @@ from yt.units.yt_array import uconcatenate
 
 def test_particle_generator():
     # First generate our dataset
-    domain_dims = (64, 64, 64)
+    domain_dims = (32, 32, 32)
     dens = np.zeros(domain_dims) + 0.1
     temp = 4.*np.ones(domain_dims)
     fields = {"density": (dens, 'code_mass/code_length**3'),
@@ -47,8 +47,11 @@ def test_particle_generator():
 
     tags = uconcatenate([grid["particle_index"] for grid in ds.index.grids])
     assert(np.unique(tags).size == num_particles)
+
+    del tags
+    
     # Set up a lattice of particles
-    pdims = np.array([64,64,64])
+    pdims = np.array([32,32,32])
     def new_indices() :
         # We just add new indices onto the existing ones
         return np.arange((np.product(pdims)))+num_particles
@@ -75,6 +78,9 @@ def test_particle_generator():
     assert_almost_equal( ypos, ypred)
     assert_almost_equal( zpos, zpred)
 
+    del xpos, ypos, zpos
+    del xpred, ypred, zpred
+
     #Test the number of particles again
     particles2.apply_to_stream()
     particles_per_grid2 = [grid.NumberOfParticles for grid in ds.index.grids]
@@ -89,12 +95,17 @@ def test_particle_generator():
     tags.sort()
     assert_equal(tags, np.arange((np.product(pdims)+num_particles)))
 
+    del tags
+
     # Test that the old particles have zero for the new field
     old_particle_temps = [grid["particle_gas_temperature"][:particles_per_grid1[i]]
                           for i, grid in enumerate(ds.index.grids)]
     test_zeros = [np.zeros((particles_per_grid1[i])) 
                   for i, grid in enumerate(ds.index.grids)]
     assert_equal(old_particle_temps, test_zeros)
+
+    del old_particle_temps
+    del test_zeros
 
     #Now dump all of these particle fields out into a dict
     pdata = {}

--- a/yt/visualization/tests/test_particle_plot.py
+++ b/yt/visualization/tests/test_particle_plot.py
@@ -209,6 +209,11 @@ class TestParticlePhasePlotSave(unittest.TestCase):
         os.chdir(self.curdir)
         shutil.rmtree(self.tmpdir)
 
+    @classmethod
+    def tearDownClass(cls):
+        del cls.ds
+        del cls.particle_phases
+
     @parameterized.expand(param.explicit((fname, )) for fname in TEST_FLNMS)
     def test_particle_phase_plot(self, fname):
         for p in self.particle_phases:
@@ -266,6 +271,15 @@ class TestParticleProjectionPlotSave(unittest.TestCase):
     def tearDown(self):
         os.chdir(self.curdir)
         shutil.rmtree(self.tmpdir)
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.pplots
+        del cls.pplots_ds
+        del cls.pplots_c
+        del cls.pplots_wf
+        del cls.pplots_w
+        del cls.pplots_m
 
     @parameterized.expand(
         param.explicit(item)

--- a/yt/visualization/tests/test_particle_plot.py
+++ b/yt/visualization/tests/test_particle_plot.py
@@ -167,8 +167,16 @@ def test_particle_phase_answers():
 
 class TestParticlePhasePlotSave(unittest.TestCase):
 
-    @classmethod
-    def setUpClass(cls):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.curdir = os.getcwd()
+        os.chdir(self.tmpdir)
+
+    def tearDown(self):
+        os.chdir(self.curdir)
+        shutil.rmtree(self.tmpdir)
+
+    def test_particle_phase_plot(self):
         test_ds = fake_particle_ds()
         data_sources = [test_ds.region([0.5] * 3, [0.4] * 3, [0.6] * 3),
                         test_ds.all_data()]
@@ -196,73 +204,14 @@ class TestParticlePhasePlotSave(unittest.TestCase):
                                     n_bins=[16, 16])
 
                 particle_phases.append(ParticlePhasePlot.from_profile(pp))
-
-        cls.particle_phases = particle_phases
-        cls.ds = test_ds
-
-    def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
-        self.curdir = os.getcwd()
-        os.chdir(self.tmpdir)
-
-    def tearDown(self):
-        os.chdir(self.curdir)
-        shutil.rmtree(self.tmpdir)
-
-    @classmethod
-    def tearDownClass(cls):
-        del cls.ds
-        del cls.particle_phases
-
-    @parameterized.expand(param.explicit((fname, )) for fname in TEST_FLNMS)
-    def test_particle_phase_plot(self, fname):
-        for p in self.particle_phases:
-            assert assert_fname(p.save(fname)[0])
-
-    def test_ipython_repr(self):
-        self.particle_phases[0]._repr_html_()
+        particle_phases[0]._repr_html_()
+        for p in particle_phases:
+            for fname in TEST_FLNMS:
+                assert assert_fname(p.save(fname)[0])
 
 
 class TestParticleProjectionPlotSave(unittest.TestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        test_ds = fake_particle_ds()
-        ds_region = test_ds.region([0.5] * 3, [0.4] * 3, [0.6] * 3)
-        pplots = []
-        pplots_ds = []
-        pplots_c = []
-        pplots_wf = []
-        pplots_w = {}
-        pplots_m = []
-        for dim in range(3):
-            pplots.append(ParticleProjectionPlot(test_ds, dim,
-                                                 "particle_mass"))
-
-            pplots_ds.append(ParticleProjectionPlot(test_ds, dim,
-                                                    "particle_mass",
-                                                    data_source=ds_region))
-
-        for center in CENTER_SPECS:
-            pplots_c.append(ParticleProjectionPlot(test_ds, dim,
-                                                   "particle_mass",
-                                                    center=center))
-
-        for width in WIDTH_SPECS:
-            pplots_w[width] = ParticleProjectionPlot(test_ds, dim,
-                                                     'particle_mass',
-                                                     width=width)
-        for wf in WEIGHT_FIELDS:
-            pplots_wf.append(ParticleProjectionPlot(test_ds, dim,
-                                                    "particle_mass",
-                                                    weight_field=wf))
-        cls.pplots = pplots
-        cls.pplots_ds = pplots_ds
-        cls.pplots_c = pplots_c
-        cls.pplots_wf = pplots_wf
-        cls.pplots_w = pplots_w
-        cls.pplots_m = pplots_m
-
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
         self.curdir = os.getcwd()
@@ -272,44 +221,47 @@ class TestParticleProjectionPlotSave(unittest.TestCase):
         os.chdir(self.curdir)
         shutil.rmtree(self.tmpdir)
 
-    @classmethod
-    def tearDownClass(cls):
-        del cls.pplots
-        del cls.pplots_ds
-        del cls.pplots_c
-        del cls.pplots_wf
-        del cls.pplots_w
-        del cls.pplots_m
+    def test_particle_plot(self):
+        test_ds = fake_particle_ds()
+        for dim in range(3):
+            pplot = ParticleProjectionPlot(test_ds, dim, "particle_mass")
+            for fname in TEST_FLNMS:
+                assert assert_fname(pplot.save(fname)[0])
 
-    @parameterized.expand(
-        param.explicit(item)
-        for item in itertools.product(range(3), TEST_FLNMS))
-    def test_particle_plot(self, dim, fname):
-        assert assert_fname(self.pplots[dim].save(fname)[0])
+    def test_particle_plot_ds(self):
+        test_ds = fake_particle_ds()
+        ds_region = test_ds.region([0.5] * 3, [0.4] * 3, [0.6] * 3)
+        for dim in range(3):
+            pplot_ds = ParticleProjectionPlot(
+                test_ds, dim, "particle_mass", data_source=ds_region)
+            pplot_ds.save()
 
-    @parameterized.expand([(0, ), (1, ), (2, )])
-    def test_particle_plot_ds(self, dim):
-        self.pplots_ds[dim].save()
+    def test_particle_plot_c(self):
+        test_ds = fake_particle_ds()
+        for center in CENTER_SPECS:
+            for dim in range(3):
+                pplot_c = ParticleProjectionPlot(
+                    test_ds, dim, "particle_mass", center=center)
+                pplot_c.save()
 
-    @parameterized.expand([(i, ) for i in range(len(CENTER_SPECS))])
-    def test_particle_plot_c(self, dim):
-        self.pplots_c[dim].save()
+    def test_particle_plot_wf(self):
+        test_ds = fake_particle_ds()
+        for dim in range(3):
+            for weight_field in WEIGHT_FIELDS:
+                pplot_wf = ParticleProjectionPlot(
+                    test_ds, dim, "particle_mass", weight_field=weight_field)
+                pplot_wf.save()
 
-    @parameterized.expand([(i, ) for i in range(len(WEIGHT_FIELDS))])
-    def test_particle_plot_wf(self, dim):
-        self.pplots_wf[dim].save()
+    def test_creation_with_width(self):
+        test_ds = fake_particle_ds()
+        for width, (xlim, ylim, pwidth, aun) in WIDTH_SPECS.items():
+            plot = ParticleProjectionPlot(
+                test_ds, 0, 'particle_mass', width=width)
 
-    @parameterized.expand(
-        param.explicit((width, ))
-        for width in WIDTH_SPECS)
-    def test_creation_with_width(self, width):
-        xlim, ylim, pwidth, aun = WIDTH_SPECS[width]
-        plot = self.pplots_w[width]
+            xlim = [plot.ds.quan(el[0], el[1]) for el in xlim]
+            ylim = [plot.ds.quan(el[0], el[1]) for el in ylim]
+            pwidth = [plot.ds.quan(el[0], el[1]) for el in pwidth]
 
-        xlim = [plot.ds.quan(el[0], el[1]) for el in xlim]
-        ylim = [plot.ds.quan(el[0], el[1]) for el in ylim]
-        pwidth = [plot.ds.quan(el[0], el[1]) for el in pwidth]
-
-        [assert_array_almost_equal(px, x, 14) for px, x in zip(plot.xlim, xlim)]
-        [assert_array_almost_equal(py, y, 14) for py, y in zip(plot.ylim, ylim)]
-        [assert_array_almost_equal(pw, w, 14) for pw, w in zip(plot.width, pwidth)]
+            [assert_array_almost_equal(px, x, 14) for px, x in zip(plot.xlim, xlim)]
+            [assert_array_almost_equal(py, y, 14) for py, y in zip(plot.ylim, ylim)]
+            [assert_array_almost_equal(pw, w, 14) for pw, w in zip(plot.width, pwidth)]

--- a/yt/visualization/tests/test_particle_plot.py
+++ b/yt/visualization/tests/test_particle_plot.py
@@ -12,13 +12,11 @@ Test suite for Particle Plots
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-import itertools
 import os
 import tempfile
 import shutil
 import unittest
 from yt.data_objects.profiles import create_profile
-from yt.extern.parameterized import parameterized, param
 from yt.visualization.tests.test_plotwindow import \
     assert_fname, WIDTH_SPECS, ATTR_ARGS
 from yt.data_objects.particle_filters import add_particle_filter

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -266,6 +266,10 @@ class TestSetWidth(unittest.TestCase):
             self.ds = fake_random_ds(64)
             self.slc = SlicePlot(self.ds, 0, "density")
 
+    def tearDown(self):
+        del self.ds
+        del self.slc
+
     def _assert_05cm(self):
         assert_array_equal([self.slc.xlim, self.slc.ylim, self.slc.width],
                          [(YTQuantity(0.25, 'cm'), YTQuantity(0.75, 'cm')),
@@ -353,17 +357,19 @@ class TestPlotWindowSave(unittest.TestCase):
     def tearDown(self):
         os.chdir(self.curdir)
         shutil.rmtree(self.tmpdir)
-        del self.ds
-        del self.slc
-        del self.slices
-        del self.projections
-        del self.projections_ds
-        del self.projections_c
-        del self.projections_wf
-        del self.projections_w
-        del self.projection_m
-        del self.offaxis_slice
-        del self.offaxis_proj
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.slc
+        del cls.slices
+        del cls.projections
+        del cls.projections_ds
+        del cls.projections_c
+        del cls.projections_wf
+        del cls.projections_w
+        del cls.projection_m
+        del cls.offaxis_slice
+        del cls.offaxis_proj
 
     @parameterized.expand(
         param.explicit(item)

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -310,45 +310,7 @@ class TestSetWidth(unittest.TestCase):
 
 
 class TestPlotWindowSave(unittest.TestCase):
-
-    @classmethod
-    def setUpClass(cls):
-        test_ds = fake_random_ds(64)
-        normal = [1, 1, 1]
-        ds_region = test_ds.region([0.5] * 3, [0.4] * 3, [0.6] * 3)
-        projections = []
-        projections_ds = []
-        projections_c = []
-        projections_wf = []
-        projections_w = {}
-        projections_m = []
-        for dim in range(3):
-            projections.append(ProjectionPlot(test_ds, dim, "density"))
-            projections_ds.append(ProjectionPlot(test_ds, dim, "density",
-                                                 data_source=ds_region))
-        for center in CENTER_SPECS:
-            projections_c.append(ProjectionPlot(test_ds, dim, "density",
-                                                center=center))
-        for width in WIDTH_SPECS:
-            projections_w[width] = ProjectionPlot(test_ds, dim, 'density',
-                                                  width=width)
-        for wf in WEIGHT_FIELDS:
-            projections_wf.append(ProjectionPlot(test_ds, dim, "density",
-                                                 weight_field=wf))
-        for m in PROJECTION_METHODS:
-            projections_m.append(ProjectionPlot(test_ds, dim, "density",
-                                                 method=m))
-
-        cls.slices = [SlicePlot(test_ds, dim, "density") for dim in range(3)]
-        cls.projections = projections
-        cls.projections_ds = projections_ds
-        cls.projections_c = projections_c
-        cls.projections_wf = projections_wf
-        cls.projections_w = projections_w
-        cls.projections_m = projections_m
-        cls.offaxis_slice = OffAxisSlicePlot(test_ds, normal, "density")
-        cls.offaxis_proj = OffAxisProjectionPlot(test_ds, normal, "density")
-
+        
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
         self.curdir = os.getcwd()
@@ -358,77 +320,76 @@ class TestPlotWindowSave(unittest.TestCase):
         os.chdir(self.curdir)
         shutil.rmtree(self.tmpdir)
 
-    @classmethod
-    def tearDownClass(cls):
-        del cls.slc
-        del cls.slices
-        del cls.projections
-        del cls.projections_ds
-        del cls.projections_c
-        del cls.projections_wf
-        del cls.projections_w
-        del cls.projection_m
-        del cls.offaxis_slice
-        del cls.offaxis_proj
+    def test_slice_plot(self):
+        test_ds = fake_random_ds(16)
+        for dim in range(3):
+            slc = SlicePlot(test_ds, dim, 'density')
+            for fname in TEST_FLNMS:
+                assert assert_fname(slc.save(fname)[0])
 
-    @parameterized.expand(
-        param.explicit(item)
-        for item in itertools.product(range(3), TEST_FLNMS))
-    def test_slice_plot(self, dim, fname):
-        assert assert_fname(self.slices[dim].save(fname)[0])
+    def test_repr_html(self):
+        test_ds = fake_random_ds(16)
+        slc = SlicePlot(test_ds, 0, 'density')
+        slc._repr_html_()
 
-    @parameterized.expand(
-        param.explicit(item)
-        for item in itertools.product(range(3), TEST_FLNMS))
-    def test_projection_plot(self, dim, fname):
-        assert assert_fname(self.projections[dim].save(fname)[0])
+    def test_projection_plot(self):
+        test_ds = fake_random_ds(16)
+        for dim in range(3):
+            proj = ProjectionPlot(test_ds, dim, 'density')
+            for fname in TEST_FLNMS:
+                assert assert_fname(proj.save(fname)[0])
 
-    @parameterized.expand([(0, ), (1, ), (2, )])
-    def test_projection_plot_ds(self, dim):
-        self.projections_ds[dim].save()
+    def test_projection_plot_ds(self):
+        test_ds = fake_random_ds(16)
+        reg = test_ds.region([0.5] * 3, [0.4] * 3, [0.6] * 3)
+        for dim in range(3):
+            proj = ProjectionPlot(test_ds, dim, 'density', data_source=reg)
+            proj.save()
 
-    @parameterized.expand([(i, ) for i in range(len(CENTER_SPECS))])
-    def test_projection_plot_c(self, dim):
-        self.projections_c[dim].save()
+    def test_projection_plot_c(self):
+        test_ds = fake_random_ds(16)
+        for center in CENTER_SPECS:
+            proj = ProjectionPlot(test_ds, 0, 'density', center=center)
+            proj.save()
 
-    @parameterized.expand([(i, ) for i in range(len(WEIGHT_FIELDS))])
-    def test_projection_plot_wf(self, dim):
-        self.projections_wf[dim].save()
+    def test_projection_plot_wf(self):
+        test_ds = fake_random_ds(16)
+        for wf in WEIGHT_FIELDS:
+            proj = ProjectionPlot(test_ds, 0, 'density', weight_field=wf)
+            proj.save()
 
-    @parameterized.expand([(i, ) for i in range(len(PROJECTION_METHODS))])
-    def test_projection_plot_m(self, dim):
-        self.projections_m[dim].save()
+    def test_projection_plot_m(self):
+        test_ds = fake_random_ds(16)
+        for method in PROJECTION_METHODS:
+            proj = ProjectionPlot(test_ds, 0, 'density', method=method)
+            proj.save()
 
-    @parameterized.expand(
-        param.explicit((fname, ))
-        for fname in TEST_FLNMS)
-    def test_offaxis_slice_plot(self, fname):
-        assert assert_fname(self.offaxis_slice.save(fname)[0])
+    def test_offaxis_slice_plot(self):
+        test_ds = fake_random_ds(16)
+        slc = OffAxisSlicePlot(test_ds, [1, 1, 1], "density")
+        for fname in TEST_FLNMS:
+            assert assert_fname(slc.save(fname)[0])
 
-    @parameterized.expand(
-        param.explicit((fname, ))
-        for fname in TEST_FLNMS)
-    def test_offaxis_projection_plot(self, fname):
-        assert assert_fname(self.offaxis_proj.save(fname)[0])
+    def test_offaxis_projection_plot(self):
+        test_ds = fake_random_ds(16)
+        prj = OffAxisProjectionPlot(test_ds, [1, 1, 1], "density")
+        for fname in TEST_FLNMS:
+            assert assert_fname(prj.save(fname)[0])
 
-    def test_ipython_repr(self):
-        self.slices[0]._repr_html_()
+    def test_creation_with_width(self):
+        test_ds = fake_random_ds(16)
+        for width in WIDTH_SPECS:
+            xlim, ylim, pwidth, aun = WIDTH_SPECS[width]
+            plot = ProjectionPlot(test_ds, 0, 'density', width=width)
 
-    @parameterized.expand(
-        param.explicit((width, ))
-        for width in WIDTH_SPECS)
-    def test_creation_with_width(self, width):
-        xlim, ylim, pwidth, aun = WIDTH_SPECS[width]
-        plot = self.projections_w[width]
+            xlim = [plot.ds.quan(el[0], el[1]) for el in xlim]
+            ylim = [plot.ds.quan(el[0], el[1]) for el in ylim]
+            pwidth = [plot.ds.quan(el[0], el[1]) for el in pwidth]
 
-        xlim = [plot.ds.quan(el[0], el[1]) for el in xlim]
-        ylim = [plot.ds.quan(el[0], el[1]) for el in ylim]
-        pwidth = [plot.ds.quan(el[0], el[1]) for el in pwidth]
-
-        [assert_array_almost_equal(px, x, 14) for px, x in zip(plot.xlim, xlim)]
-        [assert_array_almost_equal(py, y, 14) for py, y in zip(plot.ylim, ylim)]
-        [assert_array_almost_equal(pw, w, 14) for pw, w in zip(plot.width, pwidth)]
-        assert_true(aun == plot._axes_unit_names)
+            [assert_array_almost_equal(px, x, 14) for px, x in zip(plot.xlim, xlim)]
+            [assert_array_almost_equal(py, y, 14) for py, y in zip(plot.ylim, ylim)]
+            [assert_array_almost_equal(pw, w, 14) for pw, w in zip(plot.width, pwidth)]
+            assert_true(aun == plot._axes_unit_names)
 
 def test_on_off_compare():
     # fake density field that varies in the x-direction only

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -237,6 +237,8 @@ class TestHideAxesColorbar(unittest.TestCase):
     def tearDown(self):
         os.chdir(self.curdir)
         shutil.rmtree(self.tmpdir)
+        del self.ds
+        del self.slc
 
     def test_hide_show_axes(self):
         self.slc.hide_axes()
@@ -351,6 +353,17 @@ class TestPlotWindowSave(unittest.TestCase):
     def tearDown(self):
         os.chdir(self.curdir)
         shutil.rmtree(self.tmpdir)
+        del self.ds
+        del self.slc
+        del self.slices
+        del self.projections
+        del self.projections_ds
+        del self.projections_c
+        del self.projections_wf
+        del self.projections_w
+        del self.projection_m
+        del self.offaxis_slice
+        del self.offaxis_proj
 
     @parameterized.expand(
         param.explicit(item)

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -12,7 +12,6 @@ Testsuite for PlotWindow class
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-import itertools
 import matplotlib
 import numpy as np
 import os
@@ -23,7 +22,6 @@ import unittest
 from distutils.version import LooseVersion
 from nose.tools import assert_true
 
-from yt.extern.parameterized import parameterized, param
 from yt.testing import \
     fake_random_ds, assert_equal, assert_rel_equal, assert_array_equal, \
     assert_array_almost_equal, assert_raises

--- a/yt/visualization/tests/test_profile_plots.py
+++ b/yt/visualization/tests/test_profile_plots.py
@@ -71,21 +71,25 @@ def test_phase_plot_attributes():
 
 class TestProfilePlotSave(unittest.TestCase):
 
-    @classmethod
-    def setUpClass(cls):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.curdir = os.getcwd()
+        os.chdir(self.tmpdir)
+
+    def tearDown(self):
+        os.chdir(self.curdir)
+        shutil.rmtree(self.tmpdir)
+
+    def test_profile_plot(self):
         fields = ('density', 'temperature', 'velocity_x', 'velocity_y',
                   'velocity_z')
         units = ('g/cm**3', 'K', 'cm/s', 'cm/s', 'cm/s')
-        test_ds = fake_random_ds(64, fields=fields, units=units)
+        test_ds = fake_random_ds(16, fields=fields, units=units)
         regions = [test_ds.region([0.5]*3, [0.4]*3, [0.6]*3), test_ds.all_data()]
-        profiles = []
-        phases = []
         pr_fields = [('density', 'temperature'), ('density', 'velocity_x'),
                      ('temperature', 'cell_mass'), ('density', 'radius'),
                      ('velocity_magnitude', 'cell_mass')]
-        ph_fields = [('density', 'temperature', 'cell_mass'),
-                     ('density', 'velocity_x', 'cell_mass'),
-                     ('radius', 'temperature', 'velocity_magnitude')]
+        profiles = []
         for reg in regions:
             for x_field, y_field in pr_fields:
                 profiles.append(ProfilePlot(reg, x_field, y_field))
@@ -93,6 +97,26 @@ class TestProfilePlotSave(unittest.TestCase):
                                             fractional=True, accumulation=True))
                 p1d = create_profile(reg, x_field, y_field)
                 profiles.append(ProfilePlot.from_profiles(p1d))
+        p1 = create_profile(test_ds.all_data(), 'density', 'temperature')
+        p2 = create_profile(test_ds.all_data(), 'density', 'velocity_x')
+        profiles.append(ProfilePlot.from_profiles(
+            [p1, p2], labels=['temperature', 'velocity']))
+        profiles[0]._repr_html_()
+        for p in profiles:
+            for fname in TEST_FLNMS:
+                assert_fname(p.save(fname)[0])
+
+    def test_phase_plot(self):
+        fields = ('density', 'temperature', 'velocity_x', 'velocity_y',
+                  'velocity_z')
+        units = ('g/cm**3', 'K', 'cm/s', 'cm/s', 'cm/s')
+        test_ds = fake_random_ds(16, fields=fields, units=units)
+        regions = [test_ds.region([0.5]*3, [0.4]*3, [0.6]*3), test_ds.all_data()]
+        phases = []
+        ph_fields = [('density', 'temperature', 'cell_mass'),
+                     ('density', 'velocity_x', 'cell_mass'),
+                     ('radius', 'temperature', 'velocity_magnitude')]
+        for reg in regions:
             for x_field, y_field, z_field in ph_fields:
                 # set n_bins to [16, 16] since matplotlib's postscript
                 # renderer is slow when it has to write a lot of polygons
@@ -113,45 +137,10 @@ class TestProfilePlotSave(unittest.TestCase):
         assert_array_almost_equal(xlim, (0.3, 0.8))
         assert_array_almost_equal(ylim, (0.4, 0.6))
         phases.append(pp)
-
-        p1 = create_profile(test_ds.all_data(), 'density', 'temperature')
-        p2 = create_profile(test_ds.all_data(), 'density', 'velocity_x')
-        profiles.append(ProfilePlot.from_profiles(
-            [p1, p2], labels=['temperature', 'velocity']))
-
-        cls.profiles = profiles
-        cls.phases = phases
-        cls.ds = test_ds
-
-    @classmethod
-    def tearDownClass(cls):
-        del cls.profiles
-        del cls.phases
-        del cls.ds
-
-    def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
-        self.curdir = os.getcwd()
-        os.chdir(self.tmpdir)
-
-    def tearDown(self):
-        os.chdir(self.curdir)
-        shutil.rmtree(self.tmpdir)
-
-    @parameterized.expand(param.explicit((fname, )) for fname in TEST_FLNMS)
-    def test_profile_plot(self, fname):
-        for p in self.profiles:
-            assert_fname(p.save(fname)[0])
-
-    @parameterized.expand(param.explicit((fname, )) for fname in TEST_FLNMS)
-    def test_phase_plot(self, fname):
-        for p in self.phases:
-            assert_fname(p.save(fname)[0])
-
-    def test_ipython_repr(self):
-        self.profiles[0]._repr_html_()
-        self.phases[0]._repr_html_()
-
+        phases[0]._repr_html_()
+        for p in phases:
+            for fname in TEST_FLNMS:
+                assert_fname(p.save(fname)[0])
 
 ETC46 = "enzo_tiny_cosmology/DD0046/DD0046"
 

--- a/yt/visualization/tests/test_profile_plots.py
+++ b/yt/visualization/tests/test_profile_plots.py
@@ -123,6 +123,12 @@ class TestProfilePlotSave(unittest.TestCase):
         cls.phases = phases
         cls.ds = test_ds
 
+    @classmethod
+    def tearDownClass(cls):
+        del cls.profiles
+        del cls.phases
+        del cls.ds
+
     def setUp(self):
         self.tmpdir = tempfile.mkdtemp()
         self.curdir = os.getcwd()

--- a/yt/visualization/tests/test_profile_plots.py
+++ b/yt/visualization/tests/test_profile_plots.py
@@ -18,8 +18,6 @@ import shutil
 import unittest
 import yt
 from yt.data_objects.profiles import create_profile
-from yt.extern.parameterized import\
-    parameterized, param
 from yt.testing import \
     fake_random_ds, \
     assert_array_almost_equal, \

--- a/yt/visualization/volume_rendering/tests/test_scene.py
+++ b/yt/visualization/volume_rendering/tests/test_scene.py
@@ -48,8 +48,8 @@ class RotationTest(TestCase):
             shutil.rmtree(self.tmpdir)
 
     def test_rotation(self):
-        ds = fake_random_ds(64)
-        ds2 = fake_random_ds(64)
+        ds = fake_random_ds(32)
+        ds2 = fake_random_ds(32)
         dd = ds.sphere(ds.domain_center, ds.domain_width[0] / 2)
         dd2 = ds2.sphere(ds2.domain_center, ds2.domain_width[0] / 2)
 

--- a/yt/visualization/volume_rendering/tests/test_varia.py
+++ b/yt/visualization/volume_rendering/tests/test_varia.py
@@ -46,6 +46,7 @@ class VariousVRTests(TestCase):
         if self.use_tmpdir:
             os.chdir(self.curdir)
             shutil.rmtree(self.tmpdir)
+        del self.ds
 
     def test_simple_scene_creation(self):
         yt.create_scene(self.ds)
@@ -72,7 +73,7 @@ class VariousVRTests(TestCase):
         im, sc = yt.volume_render(self.ds)
 
         angle = 2 * np.pi
-        frames = 10
+        frames = 4
         for i in range(frames):
             sc.camera.yaw(angle / frames)
             sc.render()

--- a/yt/visualization/volume_rendering/tests/test_zbuff.py
+++ b/yt/visualization/volume_rendering/tests/test_zbuff.py
@@ -81,7 +81,6 @@ class ZBufferTest(TestCase):
 
         im = sc.render()
         im.write_png("composite.png")
-        return im
 
     def test_nonrectangular_add(self):
         rgba1 = np.ones((64, 1, 4))


### PR DESCRIPTION
This is an attempt to reduce the memory usage of the unit tests. Ideally this will unblock #1356.

Right now the peak memory usage of the unit tests is 4 gigabytes. Most of this is due to the plot window tests, which make use of a pattern where they allocate a bunch of plot objects at class level to avoid recalculating data. It turns out that `nose` deallocates these classes just before the test suite finishes, so this pattern substantially increases the peak memory usage of the test suite.

The fix there is to refactor tests that make use of the `setUpClass` function so that plot objects get allocated and then deallocated as soon as we need them. This drops the peak memory usage of the unit tests to 2 gigabytes or so.

The remaining major source of leaked memory seems to be the volume rendering machinery. I will file a separate issue about that. I have an attempt in here to fix that (all the changes to `ImageSampler.pyx`) but it's not a full fix.

Finally, I added a new feature to `yt.run_nose`. Now you can specify a specific module or path you want to test.