### PR TITLE
Use "origin" and "upstream" as names for remotes in CONTRIBUTING file

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -651,13 +651,14 @@ Here's a more detailed flowchart of how to submit changes.
      git branch -d my-first-pull-request
      git push origin --delete my-first-pull-request
 
-The last two commands will delete your branch name locally and on your
-fork. These commands are optional but are nice for keeping your branch
-list manageable. You can also delete your branch on your fork by clicking
-the "delete branch" button on the pull request you opened.
+The last two commands will delete your branch locally as well as on ``origin``
+(i.e. your fork of the main yt repository on GitHub). These commands are
+optional but are nice for keeping your branch list manageable. You can also
+delete your branch on your fork by clicking the "delete branch" button on the
+page for the merged pull request on GitHub.
 
 During the course of your pull request you may be asked to make changes.  These
-changes may be related to style issues, correctness issues, or even requesting
+changes may be related to style issues, correctness issues, or requesting
 tests.  The process for responding to pull request code review is relatively
 straightforward.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -293,7 +293,7 @@ it locally you must clone it onto your machine from the command line:
 
 .. code-block:: bash
 
-   $ git clone https://github.com/<USER>/yt
+   $ git clone https://github.com/<USER>/yt ./yt-git
 
 This downloads that new forked repository to your local machine, so that you
 can access it, read it, make modifications, etc.  It will put the repository in
@@ -302,7 +302,7 @@ directory.
 
 .. code-block:: bash
 
-   $ cd yt
+   $ cd yt-git
 
 Verify that you are on the master branch of yt by running:
 
@@ -567,8 +567,7 @@ The simplest way to submit changes to yt is to do the following:
 Here's a more detailed flowchart of how to submit changes.
 
 #. Fork yt on GitHub.  (This step only has to be done once.)  You can do
-   this at: https://github.com/yt-project/yt/fork.  Call this repository
-   yt.
+   this at: https://github.com/yt-project/yt/fork.
 #. If you have used the installation script, the source code for yt can be
    found in ``$YT_DEST/src/yt-git``.  Alternatively see
    :ref:`source-installation` for instructions on how to build yt from the
@@ -580,7 +579,6 @@ Here's a more detailed flowchart of how to submit changes.
 
    This will create a local clone of your fork of yt in a folder named
    ``yt-git``.
-
 #. Edit the source file you are interested in and
    test your changes.  (See :ref:`testing` for more information.)
 #. Create a uniquely named branch to track your work. For example: ``git
@@ -602,7 +600,16 @@ Here's a more detailed flowchart of how to submit changes.
    code, add a test.  (See :ref:`testing` for more information.)  Commit
    these changes as well.
 #. Add your remote repository with a unique name identifier. It can be anything
-   but it is conventional to call it ``origin``::
+   but it is conventional to call it ``origin``.  You can see names and URLs of
+   all the remotes you currently have configured with::
+
+     git remote -v
+
+   If you already have an ``origin` remote, you can set it to your fork with::
+
+     git remote set-url origin https://github.com/<USER>/yt
+
+   If you do not have an ``origin`` remote you will need to add it::
 
      git remote add origin https://github.com/<USER>/yt
 
@@ -612,10 +619,7 @@ Here's a more detailed flowchart of how to submit changes.
      git remote add upstream https://github.com/yt-project/yt
 
    Note that if your forked the yt repository on github and then cloned from
-   there you will not need to add the ``origin`` remote. You can see names and
-   URLS of all the remotes you currently have configured with::
-
-     git remote -v
+   there you will not need to add the ``origin`` remote.
 
 #. Push your changes to your remote fork using the unique identifier you just
    created and the command::
@@ -698,7 +702,7 @@ And then navigate to the root of the yt repository and run ``flake8`` on the
 
 .. code-block:: bash
 
-    $ cd yt
+    $ cd yt-git
     $ flake8 ./yt
 
 This will print out any ``flake8`` errors or warnings that your newly added code

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -566,16 +566,23 @@ The simplest way to submit changes to yt is to do the following:
 
 Here's a more detailed flowchart of how to submit changes.
 
+#. Fork yt on GitHub.  (This step only has to be done once.)  You can do
+   this at: https://github.com/yt-project/yt/fork.  Call this repository
+   yt.
 #. If you have used the installation script, the source code for yt can be
    found in ``$YT_DEST/src/yt-git``.  Alternatively see
    :ref:`source-installation` for instructions on how to build yt from the
    git repository. (Below, in :ref:`reading-source`, we describe how to
-   find items of interest.)
+   find items of interest.) If you have already forked the repository then
+   you can clone your fork locally::
+
+     git clone https://github.com/<USER>/yt ./yt-git
+
+   This will create a local clone of your fork of yt in a folder named
+   ``yt-git``.
+
 #. Edit the source file you are interested in and
    test your changes.  (See :ref:`testing` for more information.)
-#. Fork yt on GitHub.  (This step only has to be done once.)  You can do
-   this at: https://github.com/yt-project/yt/fork.  Call this repository
-   yt.
 #. Create a uniquely named branch to track your work. For example: ``git
    checkout -b my-first-pull-request``
 #. Stage your changes using ``git add <paths>``.  This command take an argument
@@ -594,15 +601,26 @@ Here's a more detailed flowchart of how to submit changes.
 #. If your changes include new functionality or cover an untested area of the
    code, add a test.  (See :ref:`testing` for more information.)  Commit
    these changes as well.
-#. Add your remote repository with a unique name identifier. It can be anything;
-   your GitHub user name is one possible choice::
+#. Add your remote repository with a unique name identifier. It can be anything
+   but it is conventional to call it ``origin``::
 
-      git remote add <YourUniqueIdentifier> https://github.com/<USER>/yt
-  
+     git remote add origin https://github.com/<USER>/yt
+
+   In addition, it is also useful to add a remote for the main yt repository.
+   By convention we name this remote ``upstream``::
+
+     git remote add upstream https://github.com/yt-project/yt
+
+   Note that if your forked the yt repository on github and then cloned from
+   there you will not need to add the ``origin`` remote. You can see names and
+   URLS of all the remotes you currently have configured with::
+
+     git remote -v
+
 #. Push your changes to your remote fork using the unique identifier you just
    created and the command::
 
-      git push <YourUniqueIdentifier> my-first-pull-request
+      git push origin my-first-pull-request
 
    Where you should substitute the name of the feature branch you are working on for
    ``my-first-pull-request``.
@@ -624,6 +642,12 @@ Here's a more detailed flowchart of how to submit changes.
    A pull request is essentially just asking people to review and accept the
    modifications you have made to your personal version of the code.
 
+#. Once you pull request is merged, stay up to date with the main yt repository
+   by pulling from the ``upstream`` remote::
+
+     git checkout master
+     git pull upstream master
+
 During the course of your pull request you may be asked to make changes.  These
 changes may be related to style issues, correctness issues, or even requesting
 tests.  The process for responding to pull request code review is relatively
@@ -634,7 +658,7 @@ straightforward.
 #. Commit those changes to your local repository.
 #. Push the changes to your fork::
 
-      git push <YourRemoteIdentifier> <YourBranchName>
+      git push origin <YourBranchName>
 
 #. Your pull request will be automatically updated.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -643,19 +643,6 @@ Here's a more detailed flowchart of how to submit changes.
 #. Issue a pull request at https://github.com/yt-project/yt/pull/new/master A
    pull request is essentially just asking people to review and accept the
    modifications you have made to your personal version of the code.
-#. Once your pull request is merged, sync up with the main yt repository by
-   pulling from the ``upstream`` remote::
-
-     git checkout master
-     git pull upstream master
-     git branch -d my-first-pull-request
-     git push origin --delete my-first-pull-request
-
-The last two commands will delete your branch locally as well as on ``origin``
-(i.e. your fork of the main yt repository on GitHub). These commands are
-optional but are nice for keeping your branch list manageable. You can also
-delete your branch on your fork by clicking the "delete branch" button on the
-page for the merged pull request on GitHub.
 
 During the course of your pull request you may be asked to make changes.  These
 changes may be related to style issues, correctness issues, or requesting
@@ -668,6 +655,28 @@ straightforward.
 #. Push the changes to your fork::
       git push origin my-first-pull-request
 #. Your pull request will be automatically updated.
+
+Once your pull request is merged, sync up with the main yt repository by pulling
+from the ``upstream`` remote::
+
+     git checkout master
+     git pull upstream master
+
+You might also want to sync your fork of yt on GitHub::
+
+     # sync my fork of yt with upstream
+     git push origin master
+
+And delete the branch for the merged pull request::
+
+     # delete branch for merged pull request
+     git branch -d my-first-pull-request
+     git push origin --delete my-first-pull-request
+
+These commands are optional but are nice for keeping your branch list
+manageable. You can also delete the branch on your fork of yt on GitHub by
+clicking the "delete branch" button on the page for the merged pull request on
+GitHub.
 
 .. _multiple-PRs:
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -605,7 +605,7 @@ Here's a more detailed flowchart of how to submit changes.
 
      git remote -v
 
-   If you already have an ``origin` remote, you can set it to your fork with::
+   If you already have an ``origin`` remote, you can set it to your fork with::
 
      git remote set-url origin https://github.com/<USER>/yt
 
@@ -618,7 +618,7 @@ Here's a more detailed flowchart of how to submit changes.
 
      git remote add upstream https://github.com/yt-project/yt
 
-   Note that if your forked the yt repository on github and then cloned from
+   Note that if you forked the yt repository on GitHub and then cloned from
    there you will not need to add the ``origin`` remote.
 
 #. Push your changes to your remote fork using the unique identifier you just
@@ -640,17 +640,21 @@ Here's a more detailed flowchart of how to submit changes.
      protocol.
 
      .. _SSH key: https://help.github.com/articles/connecting-to-github-with-ssh/
-
-#. Issue a pull request at
-   https://github.com/yt-project/yt/pull/new/master
-   A pull request is essentially just asking people to review and accept the
+#. Issue a pull request at https://github.com/yt-project/yt/pull/new/master A
+   pull request is essentially just asking people to review and accept the
    modifications you have made to your personal version of the code.
-
-#. Once you pull request is merged, stay up to date with the main yt repository
-   by pulling from the ``upstream`` remote::
+#. Once your pull request is merged, sync up with the main yt repository by
+   pulling from the ``upstream`` remote::
 
      git checkout master
      git pull upstream master
+     git branch -d my-first-pull-request
+     git push origin --delete my-first-pull-request
+
+The last two commands will delete your branch name locally and on your
+fork. These commands are optional but are nice for keeping your branch
+list manageable. You can also delete your branch on your fork by clicking
+the "delete branch" button on the pull request you opened.
 
 During the course of your pull request you may be asked to make changes.  These
 changes may be related to style issues, correctness issues, or even requesting
@@ -661,9 +665,7 @@ straightforward.
    they should be made.
 #. Commit those changes to your local repository.
 #. Push the changes to your fork::
-
-      git push origin <YourBranchName>
-
+      git push origin my-first-pull-request
 #. Your pull request will be automatically updated.
 
 .. _multiple-PRs:


### PR DESCRIPTION
This incorporates suggestions that @mkcor made on Slack. These names are the "canonical" names for the roles they play in our workflow.