### PR TITLE
Do covering grid and arbitrary grid particle deposition on F order arrays

### DIFF
--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -741,12 +741,15 @@ class YTCoveringGrid(YTSelectionContainer3D):
         cls = getattr(particle_deposit, "deposit_%s" % method, None)
         if cls is None:
             raise YTParticleDepositionNotImplemented(method)
-        # We allocate number of zones, not number of octs
-        op = cls(self.ActiveDimensions, kernel_name)
+        # We allocate number of zones, not number of octs. Everything inside
+        # this is fortran ordered because of the ordering in the octree deposit
+        # routines, so we reverse it here to match the convention there
+        op = cls(tuple(self.ActiveDimensions)[::-1], kernel_name)
         op.initialize()
         op.process_grid(self, positions, fields)
         vals = op.finalize()
-        return vals.copy(order="C")
+        # Fortran-ordered, so transpose.
+        return vals.transpose()
 
     def write_to_gdf(self, gdf_path, fields, nprocs=1, field_units=None,
                      **kwargs):

--- a/yt/data_objects/grid_patch.py
+++ b/yt/data_objects/grid_patch.py
@@ -351,14 +351,16 @@ class AMRGridPatch(YTSelectionContainer):
         cls = getattr(particle_deposit, "deposit_%s" % method, None)
         if cls is None:
             raise YTParticleDepositionNotImplemented(method)
-        # We allocate number of zones, not number of octs
-        # Everything inside this is fortran ordered, so we reverse it here.
-        op = cls(tuple(self.ActiveDimensions)[::-1], kernel_name)
+        # We allocate number of zones, not number of octs. Everything inside
+        # this is Fortran ordered because of the ordering in the octree deposit
+        # routines, so we reverse it here to match the convention there
+        op = cls(tuple(self.ActiveDimensions[::-1]), kernel_name)
         op.initialize()
         op.process_grid(self, positions, fields)
         vals = op.finalize()
         if vals is None: return
-        return vals.transpose() # Fortran-ordered, so transpose.
+        # Fortran-ordered, so transpose.
+        return vals.transpose()
 
     def select_blocks(self, selector):
         mask = self._get_selector_mask(selector)

--- a/yt/data_objects/tests/test_covering_grid.py
+++ b/yt/data_objects/tests/test_covering_grid.py
@@ -101,28 +101,27 @@ def test_arbitrary_grid():
 
             ds = load_particles(particle_data)
 
-            LE = np.array([0.05, 0.05, 0.05])
-            RE = np.array([0.95, 0.95, 0.95])
-            dims = np.array([ncells, ncells, ncells])
+            for dims in ([ncells]*3, [ncells, ncells/2, ncells/4]):
+                LE = np.array([0.05, 0.05, 0.05])
+                RE = np.array([0.95, 0.95, 0.95])
+                dims = np.array(dims)
 
-            dds = (RE - LE) / dims
-            volume = ds.quan(np.product(dds), 'cm**3')
+                dds = (RE - LE) / dims
+                volume = ds.quan(np.product(dds), 'cm**3')
 
-            obj = ds.arbitrary_grid(LE, RE, dims)
-            deposited_mass = obj["deposit", "all_density"].sum() * volume
+                obj = ds.arbitrary_grid(LE, RE, dims)
+                deposited_mass = obj["deposit", "all_density"].sum() * volume
 
-            assert_equal(deposited_mass, ds.quan(1.0, 'g'))
+                assert_equal(deposited_mass, ds.quan(1.0, 'g'))
 
-            LE = np.array([0.00, 0.00, 0.00])
-            RE = np.array([0.05, 0.05, 0.05])
-            dims = np.array([ncells, ncells, ncells])
+                LE = np.array([0.00, 0.00, 0.00])
+                RE = np.array([0.05, 0.05, 0.05])
 
-            obj = ds.arbitrary_grid(LE, RE, dims)
+                obj = ds.arbitrary_grid(LE, RE, dims)
 
-            deposited_mass = obj["deposit", "all_density"].sum()
+                deposited_mass = obj["deposit", "all_density"].sum()
 
-            assert_equal(deposited_mass, 0)
-
+                assert_equal(deposited_mass, 0)
 
     # Test that we get identical results to the covering grid for unigrid data.
     # Testing AMR data is much harder.

--- a/yt/fields/tests/test_fields.py
+++ b/yt/fields/tests/test_fields.py
@@ -11,6 +11,7 @@ from yt.testing import \
     assert_array_almost_equal_nulp, \
     assert_array_equal, \
     assert_raises, \
+    assert_allclose_units, \
     requires_file
 from yt.utilities.cosmology import \
     Cosmology
@@ -347,3 +348,13 @@ def test_field_inference():
     # If this is not true this means the result of field inference depends
     # on the order we did field detection, which is random in Python3
     assert_equal(ds._last_freq, (None, None))
+
+ISOGAL = 'IsolatedGalaxy/galaxy0030/galaxy0030'
+
+@requires_file(ISOGAL)
+def test_deposit_amr():
+    ds = load(ISOGAL)
+    for i, g in enumerate(ds.index.grids):
+        gpm = g['particle_mass'].sum()
+        dpm = g['deposit', 'all_mass'].sum()
+        assert_allclose_units(gpm, dpm)

--- a/yt/geometry/particle_deposit.pyx
+++ b/yt/geometry/particle_deposit.pyx
@@ -340,11 +340,11 @@ cdef class CICDeposit(ParticleDepositOperation):
     cdef np.float64_t[:,:,:,:] field
     cdef public object ofield
     def initialize(self):
-        if not all(_ > 1 for _ in self.nvals[:-1]):
+        if not all(_ > 1 for _ in self.nvals):
             from yt.utilities.exceptions import YTBoundsDefinitionError
             raise YTBoundsDefinitionError(
                 "CIC requires minimum of 2 zones in all spatial dimensions",
-                self.nvals[:-1])
+                self.nvals)
         self.field = append_axes(
             np.zeros(self.nvals, dtype="float64", order='F'), 4)
 


### PR DESCRIPTION
closes #1379

Suoqing triggered this by creating an `arbitrary_grid` object with non-uniform dimensions. This exposed an inconsistency in how the particle deposit operations work. Due to an assumption that grids are fortran-ordered in `grid_patch.py`, all particle deposit operations are done in a fortran ordered manner. However, the other ways we let users create grids (e.g. `arbitrary_grid`) are not assumed to be fortran ordered.

The fix would either be to make everything fortran ordered or, ~~as I've done here,~~ relax the assumption that grid data are fortran ordered in `grid_patch.py` and then update all the deposit operations to work with C ordered data.

~~I've checked and I'm pretty sure this won't trigger any user-visible changes, it was purely an internal bookkeeping thing.~~

EDIT: Initially I thought it would be easy to go back to C order. This is wrong. It turns out it's much easier to make arbitrary grid and covering grid use fortran order.

I've added tests both for accessing a deposit field on a non-unformly shaped `arbitrary_grid` and also via direct grid IO in an Enzo dataset.