### PR TITLE
tweak travis config to not capture logs and to print timing info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,10 +52,10 @@ install:
     pip install --upgrade wheel
     pip install --upgrade setuptools
     # Install dependencies
-    pip install mock numpy scipy cython matplotlib sympy fastcache nose flake8 h5py ipython
+    pip install mock numpy scipy cython matplotlib sympy fastcache nose flake8 h5py ipython nose-timer
     # install yt
     pip install -e .
 
 script:
   - |
-    nosetests -sv yt
+    nosetests --nologcapture --with-timer -sv yt


### PR DESCRIPTION
This makes error tracebacks on travis a bit nicer. It also makes it so that nose prints out the time each test takes to execute.