### PR TITLE
Multiple particle types for stream datasets

### DIFF
--- a/doc/source/examining/Loading_Generic_Array_Data.ipynb
+++ b/doc/source/examining/Loading_Generic_Array_Data.ipynb
@@ -163,7 +163,7 @@
     "            particle_position_z = (posz_arr, 'code_length'))\n",
     "bbox = np.array([[-1.5, 1.5], [-1.5, 1.5], [-1.5, 1.5]])\n",
     "ds = yt.load_uniform_grid(data, data[\"density\"][0].shape, length_unit=(1.0, \"Mpc\"), mass_unit=(1.0,\"Msun\"), \n",
-    "                       bbox=bbox, nprocs=4)"
+    "                          bbox=bbox, nprocs=4)"
    ]
   },
   {
@@ -632,6 +632,65 @@
     "slc = yt.SlicePlot(ds, \"z\", [\"density\"])\n",
     "slc.annotate_particles(0.25, p_size=15.0, col=\"Pink\")\n",
     "slc.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Multiple Particle Types"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For both uniform grid data and AMR data, one can specify particle fields with multiple types if the particle field names are given as field tuples instead of strings (the default particle type is `\"io\"`). Make sure that the total number of particles given in the `number_of_particles` key is set to the sum of the number of particles for all types:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "posxr_arr = np.random.uniform(low=-1.5, high=1.5, size=10000)\n",
+    "posyr_arr = np.random.uniform(low=-1.5, high=1.5, size=10000)\n",
+    "poszr_arr = np.random.uniform(low=-1.5, high=1.5, size=10000)\n",
+    "posxb_arr = np.random.uniform(low=-1.5, high=1.5, size=20000)\n",
+    "posyb_arr = np.random.uniform(low=-1.5, high=1.5, size=20000)\n",
+    "poszb_arr = np.random.uniform(low=-1.5, high=1.5, size=20000)\n",
+    "data = {\"density\": (np.random.random(size=(64,64,64)), \"Msun/kpc**3\"), \n",
+    "        \"number_of_particles\": 30000,\n",
+    "        (\"red\", \"particle_position_x\"): (posxr_arr, 'code_length'), \n",
+    "        (\"red\", \"particle_position_y\"): (posyr_arr, 'code_length'),\n",
+    "        (\"red\", \"particle_position_z\"): (poszr_arr, 'code_length'),\n",
+    "        (\"blue\", \"particle_position_x\"): (posxb_arr, 'code_length'), \n",
+    "        (\"blue\", \"particle_position_y\"): (posyb_arr, 'code_length'),\n",
+    "        (\"blue\", \"particle_position_z\"): (poszb_arr, 'code_length')}\n",
+    "bbox = np.array([[-1.5, 1.5], [-1.5, 1.5], [-1.5, 1.5]])\n",
+    "ds = yt.load_uniform_grid(data, data[\"density\"][0].shape, length_unit=(1.0, \"Mpc\"), mass_unit=(1.0,\"Msun\"), \n",
+    "                          bbox=bbox, nprocs=4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now see we have multiple particle types:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dd = ds.all_data()\n",
+    "print (ds.particle_types)\n",
+    "print (dd[\"red\", \"particle_position_x\"].size)\n",
+    "print (dd[\"blue\", \"particle_position_x\"].size)\n",
+    "print (dd[\"all\", \"particle_position_x\"].size)"
    ]
   },
   {

--- a/doc/source/examining/Loading_Generic_Particle_Data.ipynb
+++ b/doc/source/examining/Loading_Generic_Particle_Data.ipynb
@@ -19,7 +19,7 @@
    "source": [
     "import numpy as np\n",
     "\n",
-    "n_particles = 5e6\n",
+    "n_particles = 5000000\n",
     "\n",
     "ppx, ppy, ppz = 1e6*np.random.normal(size=[3, n_particles])\n",
     "\n",
@@ -139,12 +139,63 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "slc = yt.SlicePlot(ds, 2, ('deposit', 'all_cic'))\n",
+    "slc.set_width((8, 'Mpc'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, one can specify multiple particle types in the `data` directory by setting the field names to be field tuples (the default field type for particles is `\"io\"`) if one is not specified:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_star_particles = 1000000\n",
+    "n_dm_particles = 2000000\n",
+    "\n",
+    "ppxd, ppyd, ppzd = 1e6*np.random.normal(size=[3, n_dm_particles])\n",
+    "ppmd = np.ones(n_dm_particles)\n",
+    "\n",
+    "ppxs, ppys, ppzs = 5e5*np.random.normal(size=[3, n_star_particles])\n",
+    "ppms = 0.1*np.ones(n_star_particles)\n",
+    "\n",
+    "data2 = {('dm', 'particle_position_x'): ppxd,\n",
+    "         ('dm', 'particle_position_y'): ppyd,\n",
+    "         ('dm', 'particle_position_z'): ppzd,\n",
+    "         ('dm', 'particle_mass'): ppmd,\n",
+    "         ('star', 'particle_position_x'): ppxs,\n",
+    "         ('star', 'particle_position_y'): ppys,\n",
+    "         ('star', 'particle_position_z'): ppzs,\n",
+    "         ('star', 'particle_mass'): ppms}\n",
+    "\n",
+    "ds2 = yt.load_particles(data2, length_unit=parsec, mass_unit=1e8*Msun, n_ref=256, bbox=bbox)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now have separate `\"dm\"` and `\"star\"` particles, as well as their deposited fields:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
-    "slc = yt.SlicePlot(ds, 2, ('deposit', 'all_cic'))\n",
+    "slc = yt.SlicePlot(ds2, 2, [('deposit', 'dm_cic'), ('deposit', 'star_cic')])\n",
     "slc.set_width((8, 'Mpc'))"
    ]
   }

--- a/yt/fields/cosmology_fields.py
+++ b/yt/fields/cosmology_fields.py
@@ -107,7 +107,11 @@ def setup_cosmology_fields(registry, ftype = "gas", slice_info = None):
     # r / r_vir
     def _virial_radius_fraction(field, data):
         virial_radius = data.get_field_parameter("virial_radius")
-        return data["radius"] / virial_radius
+        if virial_radius == 0.0:
+            ret = 0.0
+        else:
+            ret = data["radius"] / virial_radius
+        return ret
 
     registry.add_field(("index", "virial_radius_fraction"), sampling_type="cell", 
                        function=_virial_radius_fraction,

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -484,7 +484,8 @@ def assign_particle_data(ds, pdata):
                 start = particle_indices[i]
                 end = particle_indices[i+1]
                 for key in pdata.keys():
-                    grid_pdata[i][key] = pdata[key][idxs][start:end]
+                    if key[0] == ptype:
+                        grid_pdata[i][key] = pdata[key][idxs][start:end]
 
     else:
         grid_pdata = [pdata]
@@ -651,6 +652,7 @@ def load_uniform_grid(data, domain_dimensions, length_unit=None, bbox=None,
     # First we fix our field names
     field_units, data = unitify_data(data)
 
+    """
     for field_name in data:
         fshape = data[field_name].shape
         dshape = tuple(domain_dimensions)
@@ -660,13 +662,14 @@ def load_uniform_grid(data, domain_dimensions, length_unit=None, bbox=None,
                    "domain_dimensions %s or number of particles %s")
             msg = msg % (fshape, field_name, dshape, pshape)
             raise RuntimeError(msg)
+    """
 
     sfh = StreamDictFieldHandler()
 
     if number_of_particles > 0:
         particle_types = set_particle_types(data)
-        pdata = {} # Used much further below.
-        pdata["number_of_particles"] = number_of_particles
+        # Used much further below.
+        pdata = {"number_of_particles": number_of_particles}
         for key in list(data.keys()):
             if len(data[key].shape) == 1 or key[0] == 'io':
                 if not isinstance(key, tuple):

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -255,15 +255,14 @@ class StreamHierarchy(GridIndex):
     def _reset_particle_count(self):
         self.grid_particle_count[:] = self.stream_handler.particle_count
         for i, grid in enumerate(self.grids):
-            grid.NumberOfParticles = self.grid_particle_count[i]
+            grid.NumberOfParticles = self.grid_particle_count[i, 0]
 
     def update_data(self, data):
-
         """
         Update the stream data with a new data dict. If fields already exist,
         they will be replaced, but if they do not, they will be added. Fields
         already in the stream but not part of the data dict will be left
-        alone. 
+        alone.
         """
         particle_types = set_particle_types(data[0])
 

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -652,17 +652,14 @@ def load_uniform_grid(data, domain_dimensions, length_unit=None, bbox=None,
     # First we fix our field names
     field_units, data = unitify_data(data)
 
-    """
+    dshape = tuple(domain_dimensions)
     for field_name in data:
         fshape = data[field_name].shape
-        dshape = tuple(domain_dimensions)
-        pshape = (number_of_particles, )
-        if fshape != dshape and fshape != pshape:
+        if len(fshape) == 3 and fshape != dshape:
             msg = ("Input data shape %s for field %s does not match provided "
-                   "domain_dimensions %s or number of particles %s")
-            msg = msg % (fshape, field_name, dshape, pshape)
+                   "domain_dimensions %s!")
+            msg = msg % (fshape, field_name, dshape)
             raise RuntimeError(msg)
-    """
 
     sfh = StreamDictFieldHandler()
 

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -266,6 +266,7 @@ class StreamHierarchy(GridIndex):
             if key is "number_of_particles":
                 continue
             self.stream_handler.particle_types[key] = particle_types[key]
+        self.ds._find_particle_types()
 
         for i, grid in enumerate(self.grids):
             if "number_of_particles" in data[i]:

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -465,7 +465,7 @@ def assign_particle_data(ds, pdata):
             grid["number_of_particles"] = pcount
             start = particle_indices[i]
             end = particle_indices[i+1]
-            for key in pdata.keys() :
+            for key in pdata.keys():
                 grid[key] = pdata[key][idxs][start:end]
             grid_pdata.append(grid)
 
@@ -951,7 +951,7 @@ def refine_amr(base_ds, refinement_criteria, fluid_operators, max_level,
             if not isinstance(field, tuple):
                 field = ("unknown", field)
             fi = base_ds._get_field_info(*field)
-            if fi.particle_type :
+            if fi.particle_type:
                 pdata[field] = uconcatenate([grid[field]
                                                for grid in base_ds.index.grids])
         pdata["number_of_particles"] = number_of_particles
@@ -969,10 +969,10 @@ def refine_amr(base_ds, refinement_criteria, fluid_operators, max_level,
         if callback is not None: callback(ds)
         grid_data = []
         for g in ds.index.grids:
-            gd = dict( left_edge = g.LeftEdge,
-                       right_edge = g.RightEdge,
-                       level = g.Level,
-                       dimensions = g.ActiveDimensions )
+            gd = dict(left_edge=g.LeftEdge,
+                       right_edge=g.RightEdge,
+                       level=g.Level,
+                       dimensions=g.ActiveDimensions)
             for field in ds.field_list:
                 if not isinstance(field, tuple):
                     field = ("unknown", field)
@@ -987,13 +987,13 @@ def refine_amr(base_ds, refinement_criteria, fluid_operators, max_level,
                 LE = sg.left_index * g.dds + ds.domain_left_edge
                 dims = sg.dimensions * ds.refine_by
                 grid = ds.smoothed_covering_grid(g.Level + 1, LE, dims)
-                gd = dict(left_edge = LE, right_edge = grid.right_edge,
-                          level = g.Level + 1, dimensions = dims)
+                gd = dict(left_edge=LE, right_edge=grid.right_edge,
+                          level=g.Level + 1, dimensions=dims)
                 for field in ds.field_list:
                     if not isinstance(field, tuple):
                         field = ("unknown", field)
                     fi = ds._get_field_info(*field)
-                    if not fi.particle_type :
+                    if not fi.particle_type:
                         gd[field] = grid[field]
                 grid_data.append(gd)
 

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -267,7 +267,7 @@ class StreamHierarchy(GridIndex):
         particle_types = set_particle_types(data[0])
 
         for key in data[0].keys():
-            if key is "number_of_particles":
+            if key == "number_of_particles":
                 continue
             self.stream_handler.particle_types[key] = particle_types[key]
         self.ds._find_particle_types()
@@ -367,11 +367,11 @@ class StreamDataset(Dataset):
         return True
 
     def _find_particle_types(self):
-        particle_types = []
+        particle_types = set([])
         for k, v in self.stream_handler.particle_types.items():
             if v:
-                particle_types.append(k[0])
-        self.particle_types = tuple(set(particle_types))
+                particle_types.add(k[0])
+        self.particle_types = tuple(particle_types)
         self.particle_types_raw = self.particle_types
 
 class StreamDictFieldHandler(dict):

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -294,10 +294,6 @@ class StreamDataset(Dataset):
 
     def __init__(self, stream_handler, storage_filename=None,
                  geometry="cartesian", unit_system="cgs"):
-        #if parameter_override is None: parameter_override = {}
-        #self._parameter_override = parameter_override
-        #if conversion_override is None: conversion_override = {}
-        #self._conversion_override = conversion_override
         self.fluid_types += ("stream",)
         self.geometry = geometry
         self.stream_handler = stream_handler

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -948,7 +948,7 @@ def refine_amr(base_ds, refinement_criteria, fluid_operators, max_level,
             if not isinstance(field, tuple):
                 field = ("unknown", field)
             fi = base_ds._get_field_info(*field)
-            if fi.particle_type:
+            if fi.particle_type and field[0] in base_ds.particle_types_raw:
                 pdata[field] = uconcatenate([grid[field]
                                              for grid in base_ds.index.grids])
         pdata["number_of_particles"] = number_of_particles

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -284,6 +284,9 @@ class StreamHierarchy(GridIndex):
 
         self._reset_particle_count()
         # We only want to create a superset of fields here.
+        for field in self.ds.field_list:
+            if field[0] == "all":
+                self.ds.field_list.remove(field)
         self._detect_output_fields()
         self.ds.create_field_info()
         mylog.debug("Creating Particle Union 'all'")

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -300,12 +300,7 @@ class StreamDataset(Dataset):
         self.fluid_types += ("stream",)
         self.geometry = geometry
         self.stream_handler = stream_handler
-        particle_types = []
-        for k, v in self.stream_handler.particle_types.items():
-            if v:
-                particle_types.append(k[0])
-        self.particle_types = tuple(set(particle_types))
-        self.particle_types_raw = self.particle_types
+        self._find_particle_types()
         name = "InMemoryParameterFile_%s" % uuid.uuid4().hex
         from yt.data_objects.static_output import _cached_datasets
         _cached_datasets[name] = self
@@ -365,6 +360,14 @@ class StreamDataset(Dataset):
     @property
     def _skip_cache(self):
         return True
+
+    def _find_particle_types(self):
+        particle_types = []
+        for k, v in self.stream_handler.particle_types.items():
+            if v:
+                particle_types.append(k[0])
+        self.particle_types = tuple(set(particle_types))
+        self.particle_types_raw = self.particle_types
 
 class StreamDictFieldHandler(dict):
     _additional_fields = ()
@@ -1668,6 +1671,9 @@ class StreamUnstructuredMeshDataset(StreamDataset):
     _index_class = StreamUnstructuredIndex
     _field_info_class = StreamFieldInfo
     _dataset_type = "stream_unstructured"
+
+    def _find_particle_types(self):
+        pass
 
 def load_unstructured_mesh(connectivity, coordinates, node_data=None,
                            elem_data=None, length_unit=None, bbox=None,

--- a/yt/frontends/stream/fields.py
+++ b/yt/frontends/stream/fields.py
@@ -74,8 +74,11 @@ class StreamFieldInfo(FieldInfoContainer):
         from yt.fields.magnetic_field import \
             setup_magnetic_field_aliases
         for field in self.ds.stream_handler.field_units:
+            if field[0] in self.ds.particle_types:
+                continue
             units = self.ds.stream_handler.field_units[field]
-            if units != '': self.add_output_field(field, sampling_type="cell", units=units)
+            if units != '': 
+                self.add_output_field(field, sampling_type="cell", units=units)
         setup_magnetic_field_aliases(self, "stream", ["magnetic_field_%s" % ax for ax in "xyz"])
 
     def add_output_field(self, name, sampling_type, **kwargs):

--- a/yt/frontends/stream/tests/test_stream_particles.py
+++ b/yt/frontends/stream/tests/test_stream_particles.py
@@ -31,7 +31,7 @@ def test_stream_particles():
 
     grid_data = []
 
-    for grid in amr0.index.grids :
+    for grid in amr0.index.grids:
 
         data = dict(left_edge = grid.LeftEdge,
                     right_edge = grid.RightEdge,

--- a/yt/frontends/stream/tests/test_stream_particles.py
+++ b/yt/frontends/stream/tests/test_stream_particles.py
@@ -263,7 +263,7 @@ def test_stream_particles():
 
 def test_load_particles_types():
 
-    num_particles = 100000
+    num_particles = 10000
 
     data1 = {"particle_position_x": np.random.random(size=num_particles),
              "particle_position_y": np.random.random(size=num_particles),

--- a/yt/frontends/stream/tests/test_stream_particles.py
+++ b/yt/frontends/stream/tests/test_stream_particles.py
@@ -15,7 +15,7 @@ def test_stream_particles():
     x = np.random.uniform(size=num_particles)
     y = np.random.uniform(size=num_particles)
     z = np.random.uniform(size=num_particles)
-    m = np.ones((num_particles))
+    m = np.ones(num_particles)
 
     # Field operators and cell flagging methods
 
@@ -33,11 +33,11 @@ def test_stream_particles():
 
     for grid in amr0.index.grids:
 
-        data = dict(left_edge = grid.LeftEdge,
-                    right_edge = grid.RightEdge,
-                    level = grid.Level,
-                    dimensions = grid.ActiveDimensions,
-                    number_of_particles = grid.NumberOfParticles)
+        data = dict(left_edge=grid.LeftEdge,
+                    right_edge=grid.RightEdge,
+                    level=grid.Level,
+                    dimensions=grid.ActiveDimensions,
+                    number_of_particles=grid.NumberOfParticles)
 
         for field in amr0.field_list:
             data[field] = grid[field]
@@ -93,14 +93,13 @@ def test_stream_particles():
 
     for grid in amr1.index.grids:
 
-        data = dict(left_edge = grid.LeftEdge,
-                    right_edge = grid.RightEdge,
-                    level = grid.Level,
-                    dimensions = grid.ActiveDimensions,
-                    number_of_particles = grid.NumberOfParticles)
+        data = dict(left_edge=grid.LeftEdge,
+                    right_edge=grid.RightEdge,
+                    level=grid.Level,
+                    dimensions=grid.ActiveDimensions,
+                    number_of_particles=grid.NumberOfParticles)
 
         for field in amr1.field_list:
-
             data[field] = grid[field]
 
         grid_data.append(data)

--- a/yt/frontends/stream/tests/test_stream_particles.py
+++ b/yt/frontends/stream/tests/test_stream_particles.py
@@ -87,7 +87,7 @@ def test_stream_particles():
 
     amr1 = refine_amr(ug1, rc, fo, 3)
     for field in sorted(ug1.field_list):
-        assert_equal((field in amr1.field_list), True)
+        assert field in amr1.field_list
 
     grid_data = []
 

--- a/yt/frontends/stream/tests/test_update_data.py
+++ b/yt/frontends/stream/tests/test_update_data.py
@@ -6,9 +6,9 @@ def test_update_data():
     ds = fake_random_ds(64, nprocs=8)
     ds.index
     dims = (32,32,32)
-    grid_data = [{"temperature":uniform(size=dims)}
+    grid_data = [{"temperature": uniform(size=dims)}
                  for i in range(ds.index.num_grids)]
-    ds.index.update_data(grid_data, {('gas', 'temperature'):'K'})
+    ds.index.update_data(grid_data)
     prj = ds.proj("temperature", 2)
     prj["temperature"]
     dd = ds.all_data()

--- a/yt/frontends/stream/tests/test_update_data.py
+++ b/yt/frontends/stream/tests/test_update_data.py
@@ -2,7 +2,7 @@ from yt.testing import fake_random_ds
 from yt.data_objects.profiles import create_profile
 from numpy.random import uniform
 
-def test_update_data() :
+def test_update_data():
     ds = fake_random_ds(64, nprocs=8)
     ds.index
     dims = (32,32,32)
@@ -13,4 +13,4 @@ def test_update_data() :
     prj["temperature"]
     dd = ds.all_data()
     profile = create_profile(dd, "density", "temperature", 10)
-    profile["temperature"]                             
+    profile["temperature"]

--- a/yt/utilities/particle_generator.py
+++ b/yt/utilities/particle_generator.py
@@ -17,7 +17,7 @@ class ParticleGenerator(object):
         """
         self.ds = ds
         self.num_particles = num_particles
-        self.field_list = [(ptype, fd) if isinstance(fd,string_types) else fd
+        self.field_list = [(ptype, fd) if isinstance(fd, string_types) else fd
                            for fd in field_list]
         self.field_list.append((ptype, "particle_index"))
         self.field_units = dict(
@@ -168,11 +168,12 @@ class ParticleGenerator(object):
 
     def apply_to_stream(self, clobber=False):
         """
-        Apply the particles to a stream dataset. If particles already exist,
-        and clobber=False, do not overwrite them, but add the new ones to them. 
+        Apply the particles to a grid-based stream dataset. If particles 
+        already exist, and clobber=False, do not overwrite them, but add 
+        the new ones to them.
         """
         grid_data = []
-        for i,g in enumerate(self.ds.index.grids):
+        for i, g in enumerate(self.ds.index.grids):
             data = {}
             if clobber:
                 data["number_of_particles"] = self.NumberOfParticles[i]
@@ -182,22 +183,15 @@ class ParticleGenerator(object):
             grid_particles = self.get_for_grid(g)
             for field in self.field_list:
                 if data["number_of_particles"] > 0:
-                    # We have particles in this grid
-                    if g.NumberOfParticles > 0 and not clobber:
-                        # Particles already exist
-                        if field in self.ds.field_list:
-                            # This field already exists
-                            prev_particles = g[field]
-                        else:
-                            # This one doesn't, set the previous particles' field
-                            # values to zero
-                            prev_particles = np.zeros(g.NumberOfParticles)
-                            prev_particles = self.ds.arr(prev_particles,
-                                                         self.field_units[field])
-                        data[field] = uconcatenate((prev_particles,
-                                                    grid_particles[field]))
+                    if g.NumberOfParticles > 0 and not clobber and \
+                        field in self.ds.field_list:
+                        # We have particles in this grid, we're not
+                        # overwriting them, and the field is in the field
+                        # list already
+                        data[field] = uconcatenate([g[field],
+                                                    grid_particles[field]])
                     else:
-                        # Particles do not already exist or we're clobbering
+                        # Otherwise, simply add the field in
                         data[field] = grid_particles[field]
                 else:
                     # We don't have particles in this grid

--- a/yt/utilities/particle_generator.py
+++ b/yt/utilities/particle_generator.py
@@ -170,13 +170,13 @@ class ParticleGenerator(object):
         grid_data = []
         for i,g in enumerate(self.ds.index.grids):
             data = {}
-            if clobber :
+            if clobber:
                 data["number_of_particles"] = self.NumberOfParticles[i]
-            else :
+            else:
                 data["number_of_particles"] = self.NumberOfParticles[i] + \
                                               g.NumberOfParticles
             grid_particles = self.get_for_grid(g)
-            for field in self.field_list :
+            for field in self.field_list:
                 if data["number_of_particles"] > 0:
                     # We have particles in this grid
                     if g.NumberOfParticles > 0 and not clobber:
@@ -187,9 +187,9 @@ class ParticleGenerator(object):
                         else:
                             # This one doesn't, set the previous particles' field
                             # values to zero
-                            prev_particles = np.zeros((g.NumberOfParticles))
+                            prev_particles = np.zeros(g.NumberOfParticles)
                             prev_particles = self.ds.arr(prev_particles,
-                                input_units = self.field_units[field])
+                                                         self.field_units[field])
                         data[field] = uconcatenate((prev_particles,
                                                     grid_particles[field]))
                     else:

--- a/yt/utilities/particle_generator.py
+++ b/yt/utilities/particle_generator.py
@@ -13,7 +13,8 @@ class ParticleGenerator(object):
         streams. Normally this would not be called directly, since it doesn't
         really do anything except allocate memory. Takes a *ds* to serve as the
         basis for determining grids, the number of particles *num_particles*,
-        and a list of fields, *field_list*.
+        a list of fields, *field_list*, and the particle type *ptype*, which
+        has a default value of "io". 
         """
         self.ds = ds
         self.num_particles = num_particles
@@ -213,6 +214,8 @@ class FromListParticleGenerator(ParticleGenerator):
             The number of particles in the dict.
         data : dict of NumPy arrays
             The particle fields themselves.
+        ptype : string, optional
+            The particle type for these particle fields. Default: "io"
 
         Examples
         --------
@@ -271,6 +274,8 @@ class LatticeParticleGenerator(ParticleGenerator):
              The 'right-most' ending positions of the lattice.
         field_list : list of strings
              A list of particle fields
+        ptype : string, optional
+            The particle type for these particle fields. Default: "io"
 
         Examples
         --------
@@ -336,6 +341,8 @@ class WithDensityParticleGenerator(ParticleGenerator):
         density_field : string, optional
             A density field which will serve as the distribution function for the
             particle positions. Theoretically, this could be any 'per-volume' field. 
+        ptype : string, optional
+            The particle type for these particle fields. Default: "io"
 
         Examples
         --------

--- a/yt/utilities/particle_generator.py
+++ b/yt/utilities/particle_generator.py
@@ -7,11 +7,7 @@ from yt.extern.six import string_types
 
 class ParticleGenerator(object):
 
-    default_fields = [("io", "particle_position_x"),
-                      ("io", "particle_position_y"),
-                      ("io", "particle_position_z")]
-    
-    def __init__(self, ds, num_particles, field_list):
+    def __init__(self, ds, num_particles, field_list, ptype="io"):
         """
         Base class for generating particle fields which may be applied to
         streams. Normally this would not be called directly, since it doesn't
@@ -21,14 +17,17 @@ class ParticleGenerator(object):
         """
         self.ds = ds
         self.num_particles = num_particles
-        self.field_list = [("io",fd) if isinstance(fd,string_types) else fd
+        self.field_list = [(ptype, fd) if isinstance(fd,string_types) else fd
                            for fd in field_list]
-        self.field_list.append(("io", "particle_index"))
+        self.field_list.append((ptype, "particle_index"))
         self.field_units = dict(
-          (('io', 'particle_position_%s' % ax), 'code_length')
+          ((ptype, 'particle_position_%s' % ax), 'code_length')
           for ax in 'xyz')
-        self.field_units['io', 'particle_index'] = ''
-        
+        self.field_units[ptype, 'particle_index'] = ''
+        self.ptype = ptype
+
+        self._set_default_fields()
+
         try:
             self.posx_index = self.field_list.index(self.default_fields[0])
             self.posy_index = self.field_list.index(self.default_fields[1])
@@ -36,35 +35,40 @@ class ParticleGenerator(object):
         except:
             raise KeyError("You must specify position fields: " +
                            " ".join(["particle_position_%s" % ax for ax in "xyz"]))
-        self.index_index = self.field_list.index(("io", "particle_index"))
-        
+        self.index_index = self.field_list.index((ptype, "particle_index"))
+
         self.num_grids = self.ds.index.num_grids
-        self.NumberOfParticles = np.zeros((self.num_grids), dtype='int64')
+        self.NumberOfParticles = np.zeros(self.num_grids, dtype='int64')
         self.ParticleGridIndices = np.zeros(self.num_grids + 1, dtype='int64')
-        
+
         self.num_fields = len(self.field_list)
-        
+
         self.particles = np.zeros((self.num_particles, self.num_fields),
                                   dtype='float64')
+
+    def _set_default_fields(self):
+        self.default_fields = [(self.ptype, "particle_position_x"),
+                               (self.ptype, "particle_position_y"),
+                               (self.ptype, "particle_position_z")]
 
     def has_key(self, key):
         """
         Check to see if *key* is in the particle field list.
         """
         return key in self.field_list
-            
+
     def keys(self):
         """
         Return the list of particle fields.
         """
         return self.field_list
-    
+
     def __getitem__(self, key):
         """
         Get the field associated with key.
         """
         return self.particles[:,self.field_list.index(key)]
-    
+
     def __setitem__(self, key, val):
         """
         Sets a field to be some other value. Note that we assume
@@ -72,7 +76,7 @@ class ParticleGenerator(object):
         make sure the setting of the field is consistent with this.
         """
         self.particles[:,self.field_list.index(key)] = val[:]
-                
+
     def __len__(self):
         """
         The number of particles
@@ -95,17 +99,17 @@ class ParticleGenerator(object):
             else:
                 tr[field] = self.particles[start:end, fi]
         return tr
-    
-    def _setup_particles(self,x,y,z,setup_fields=None):
+
+    def _setup_particles(self, x, y, z, setup_fields=None):
         """
         Assigns grids to particles and sets up particle positions. *setup_fields* is
         a dict of fields other than the particle positions to set up. 
         """
-        particle_grids, particle_grid_inds = self.ds.index._find_points(x,y,z)
+        particle_grids, particle_grid_inds = self.ds.index._find_points(x, y, z)
         idxs = np.argsort(particle_grid_inds)
-        self.particles[:,self.posx_index] = x[idxs]
-        self.particles[:,self.posy_index] = y[idxs]
-        self.particles[:,self.posz_index] = z[idxs]
+        self.particles[:, self.posx_index] = x[idxs]
+        self.particles[:, self.posy_index] = y[idxs]
+        self.particles[:, self.posz_index] = z[idxs]
         self.NumberOfParticles = np.bincount(particle_grid_inds.astype("intp"),
                                              minlength=self.num_grids)
         if self.num_grids > 1:
@@ -115,20 +119,20 @@ class ParticleGenerator(object):
             self.ParticleGridIndices[1] = self.NumberOfParticles.squeeze()
         if setup_fields is not None:
             for key, value in setup_fields.items():
-                field = ("io",key) if isinstance(key, string_types) else key
+                field = (self.ptype, key) if isinstance(key, string_types) else key
                 if field not in self.default_fields:
                     self.particles[:,self.field_list.index(field)] = value[idxs]
-    
+
     def assign_indices(self, function=None, **kwargs):
         """
         Assign unique indices to the particles. The default is to just use
         numpy.arange, but any function may be supplied with keyword arguments.
         """
-        if function is None :
-            self.particles[:,self.index_index] = np.arange((self.num_particles))
-        else :
-            self.particles[:,self.index_index] = function(**kwargs)
-            
+        if function is None:
+            self.particles[:, self.index_index] = np.arange(self.num_particles)
+        else:
+            self.particles[:, self.index_index] = function(**kwargs)
+
     def map_grid_fields_to_particles(self, mapping_dict):
         r"""
         For the fields in  *mapping_dict*, map grid fields to the particles
@@ -203,7 +207,7 @@ class ParticleGenerator(object):
 
 class FromListParticleGenerator(ParticleGenerator):
 
-    def __init__(self, ds, num_particles, data):
+    def __init__(self, ds, num_particles, data, ptype="io"):
         r"""
         Generate particle fields from array-like lists contained in a dict.
 
@@ -233,10 +237,10 @@ class FromListParticleGenerator(ParticleGenerator):
             x = data.pop("particle_position_x")
             y = data.pop("particle_position_y")
             z = data.pop("particle_position_z")
-        elif ("io","particle_position_x") in data:
-            x = data.pop(("io", "particle_position_x"))
-            y = data.pop(("io", "particle_position_y"))
-            z = data.pop(("io", "particle_position_z"))
+        elif (ptype,"particle_position_x") in data:
+            x = data.pop((ptype, "particle_position_x"))
+            y = data.pop((ptype, "particle_position_y"))
+            z = data.pop((ptype, "particle_position_z"))
 
         xcond = np.logical_or(x < ds.domain_left_edge[0],
                               x >= ds.domain_right_edge[0])
@@ -250,13 +254,14 @@ class FromListParticleGenerator(ParticleGenerator):
         if np.any(cond):
             raise ValueError("Some particles are outside of the domain!!!")
 
-        ParticleGenerator.__init__(self, ds, num_particles, field_list)
-        self._setup_particles(x,y,z,setup_fields=data)
-        
+        super(FromListParticleGenerator, self).__init__(ds, num_particles, 
+                                                        field_list, ptype=ptype)
+        self._setup_particles(x, y, z, setup_fields=data)
+
 class LatticeParticleGenerator(ParticleGenerator):
 
     def __init__(self, ds, particles_dims, particles_left_edge,
-                 particles_right_edge, field_list):
+                 particles_right_edge, field_list, ptype="io"):
         r"""
         Generate particles in a lattice arrangement. 
 
@@ -272,7 +277,7 @@ class LatticeParticleGenerator(ParticleGenerator):
              The 'right-most' ending positions of the lattice.
         field_list : list of strings
              A list of particle fields
-             
+
         Examples
         --------
         >>> dims = (128,128,128)
@@ -293,33 +298,34 @@ class LatticeParticleGenerator(ParticleGenerator):
         xmax = particles_right_edge[0]
         ymax = particles_right_edge[1]
         zmax = particles_right_edge[2]
-        DLE = ds.domain_left_edge.in_units("code_length").ndarray_view()
-        DRE = ds.domain_right_edge.in_units("code_length").ndarray_view()
+        DLE = ds.domain_left_edge.in_units("code_length").d
+        DRE = ds.domain_right_edge.in_units("code_length").d
 
         xcond = (xmin < DLE[0]) or (xmax >= DRE[0])
         ycond = (ymin < DLE[1]) or (ymax >= DRE[1])
         zcond = (zmin < DLE[2]) or (zmax >= DRE[2])
         cond = xcond or ycond or zcond
 
-        if cond :
+        if cond:
             raise ValueError("Proposed bounds for particles are outside domain!!!")
 
-        ParticleGenerator.__init__(self, ds, num_x*num_y*num_z, field_list)
+        super(LatticeParticleGenerator, self).__init__(ds, num_x*num_y*num_z, 
+                                                       field_list, ptype=ptype)
 
         dx = (xmax-xmin)/(num_x-1)
         dy = (ymax-ymin)/(num_y-1)
         dz = (zmax-zmin)/(num_z-1)
-        inds = np.indices((num_x,num_y,num_z))
+        inds = np.indices((num_x, num_y, num_z))
         xpos = inds[0]*dx + xmin
         ypos = inds[1]*dy + ymin
         zpos = inds[2]*dz + zmin
-        
+
         self._setup_particles(xpos.flat[:], ypos.flat[:], zpos.flat[:])
-        
+
 class WithDensityParticleGenerator(ParticleGenerator):
 
     def __init__(self, ds, data_source, num_particles, field_list,
-                 density_field="density"):
+                 density_field="density", ptype="io"):
         r"""
         Generate particles based on a density field.
 
@@ -336,7 +342,7 @@ class WithDensityParticleGenerator(ParticleGenerator):
         density_field : string, optional
             A density field which will serve as the distribution function for the
             particle positions. Theoretically, this could be any 'per-volume' field. 
-            
+
         Examples
         --------
         >>> sphere = ds.sphere(ds.domain_center, 0.5)
@@ -348,7 +354,8 @@ class WithDensityParticleGenerator(ParticleGenerator):
         >>>                                          fields, density_field='Dark_Matter_Density')
         """
 
-        ParticleGenerator.__init__(self, ds, num_particles, field_list)
+        super(WithDensityParticleGenerator, self).__init__(ds, num_particles,
+                                                           field_list, ptype=ptype)
 
         num_cells = len(data_source["x"].flat)
         max_mass = (data_source[density_field]*
@@ -357,22 +364,22 @@ class WithDensityParticleGenerator(ParticleGenerator):
         all_x = []
         all_y = []
         all_z = []
-        
+
         pbar = get_pbar("Generating Particles", num_particles)
         tot_num_accepted = int(0)
-        
+
         while num_particles_left > 0:
 
             m = np.random.uniform(high=1.01*max_mass,
                                   size=num_particles_left)
             idxs = np.random.random_integers(low=0, high=num_cells-1,
                                              size=num_particles_left)
-            m_true = (data_source[density_field]*
+            m_true = (data_source[density_field] *
                       data_source["cell_volume"]).flat[idxs]
             accept = m <= m_true
             num_accepted = accept.sum()
             accepted_idxs = idxs[accept]
-            
+
             xpos = data_source["x"].flat[accepted_idxs] + \
                    np.random.uniform(low=-0.5, high=0.5, size=num_accepted) * \
                    data_source["dx"].flat[accepted_idxs]
@@ -397,5 +404,5 @@ class WithDensityParticleGenerator(ParticleGenerator):
         y = uconcatenate(all_y)
         z = uconcatenate(all_z)
 
-        self._setup_particles(x,y,z)
-        
+        self._setup_particles(x, y, z)
+

--- a/yt/utilities/tests/test_particle_generator.py
+++ b/yt/utilities/tests/test_particle_generator.py
@@ -37,7 +37,7 @@ def test_particle_generator():
     particles1 = WithDensityParticleGenerator(ds, sphere, num_particles, field_list)
     particles1.assign_indices()
     particles1.map_grid_fields_to_particles(field_dict)
-    
+
     # Test to make sure we ended up with the right number of particles per grid
     particles1.apply_to_stream()
     particles_per_grid1 = [grid.NumberOfParticles for grid in ds.index.grids]
@@ -49,23 +49,20 @@ def test_particle_generator():
     assert(np.unique(tags).size == num_particles)
 
     del tags
-    
+
     # Set up a lattice of particles
     pdims = np.array([32,32,32])
-    def new_indices() :
+    def new_indices():
         # We just add new indices onto the existing ones
         return np.arange((np.product(pdims)))+num_particles
     le = np.array([0.25,0.25,0.25])
     re = np.array([0.75,0.75,0.75])
-    new_field_list = field_list + [("io", "particle_gas_temperature")]
-    new_field_dict = {("gas", "density"): ("io", "particle_gas_density"),
-                      ("gas", "temperature"): ("io", "particle_gas_temperature")}
 
-    particles2 = LatticeParticleGenerator(ds, pdims, le, re, new_field_list)
+    particles2 = LatticeParticleGenerator(ds, pdims, le, re, field_list)
     particles2.assign_indices(function=new_indices)
-    particles2.map_grid_fields_to_particles(new_field_dict)
+    particles2.map_grid_fields_to_particles(field_dict)
 
-    #Test lattice positions
+    # Test lattice positions
     xpos = np.unique(particles2["io", "particle_position_x"])
     ypos = np.unique(particles2["io", "particle_position_y"])
     zpos = np.unique(particles2["io", "particle_position_z"])
@@ -74,14 +71,14 @@ def test_particle_generator():
     ypred = np.linspace(le[1],re[1],num=pdims[1],endpoint=True)
     zpred = np.linspace(le[2],re[2],num=pdims[2],endpoint=True)
 
-    assert_almost_equal( xpos, xpred)
-    assert_almost_equal( ypos, ypred)
-    assert_almost_equal( zpos, zpred)
+    assert_almost_equal(xpos, xpred)
+    assert_almost_equal(ypos, ypred)
+    assert_almost_equal(zpos, zpred)
 
     del xpos, ypos, zpos
     del xpred, ypred, zpred
 
-    #Test the number of particles again
+    # Test the number of particles again
     particles2.apply_to_stream()
     particles_per_grid2 = [grid.NumberOfParticles for grid in ds.index.grids]
     assert_equal(particles_per_grid2, particles1.NumberOfParticles+particles2.NumberOfParticles)
@@ -90,43 +87,54 @@ def test_particle_generator():
     particles_per_grid2 = [len(grid["particle_position_x"]) for grid in ds.index.grids]
     assert_equal(particles_per_grid2, particles1.NumberOfParticles+particles2.NumberOfParticles)
 
-    #Test the uniqueness of tags
+    # Test the uniqueness of tags
     tags = np.concatenate([grid["particle_index"] for grid in ds.index.grids])
     tags.sort()
     assert_equal(tags, np.arange((np.product(pdims)+num_particles)))
 
     del tags
 
-    # Test that the old particles have zero for the new field
-    old_particle_temps = [grid["particle_gas_temperature"][:particles_per_grid1[i]]
-                          for i, grid in enumerate(ds.index.grids)]
-    test_zeros = [np.zeros((particles_per_grid1[i])) 
-                  for i, grid in enumerate(ds.index.grids)]
-    assert_equal(old_particle_temps, test_zeros)
-
-    del old_particle_temps
-    del test_zeros
-
-    #Now dump all of these particle fields out into a dict
+    # Now dump all of these particle fields out into a dict
     pdata = {}
     dd = ds.all_data()
-    for field in new_field_list :
+    for field in field_list:
         pdata[field] = dd[field]
 
-    #Test the "from-list" generator and particle field clobber
-    particles3 = FromListParticleGenerator(ds, num_particles+np.product(pdims), pdata)
+    # Test the "from-list" generator and particle field clobber
+    num_particles3 = num_particles+np.product(pdims)
+    particles3 = FromListParticleGenerator(ds, num_particles3, pdata)
     particles3.apply_to_stream(clobber=True)
-    
-    #Test the number of particles again
+
+    # Test the number of particles again
     particles_per_grid3 = [grid.NumberOfParticles for grid in ds.index.grids]
     assert_equal(particles_per_grid3, particles1.NumberOfParticles+particles2.NumberOfParticles)
     particles_per_grid2 = [len(grid["particle_position_z"]) for grid in ds.index.grids]
     assert_equal(particles_per_grid3, particles1.NumberOfParticles+particles2.NumberOfParticles)
+    assert_equal(particles_per_grid2, particles_per_grid3)
+
+    # Test adding in particles with a different particle type
+
+    num_star_particles = 100000
+    pdata2 = {("star", "particle_position_x"): np.random.uniform(size=num_star_particles),
+              ("star", "particle_position_y"): np.random.uniform(size=num_star_particles),
+              ("star", "particle_position_z"): np.random.uniform(size=num_star_particles)}
+
+    particles4 = FromListParticleGenerator(ds, num_star_particles, pdata2, ptype="star")
+    particles4.apply_to_stream()
+
+    dd = ds.all_data()
+    assert dd["star", "particle_position_x"].size == num_star_particles
+    assert dd["io", "particle_position_x"].size == num_particles3
+    assert dd["all", "particle_position_x"].size == num_star_particles+num_particles3
+
 
     del pdata
+    del pdata2
     del ds
     del particles1
     del particles2
+    del particles4
     del fields
     del dens
     del temp
+

--- a/yt/utilities/tests/test_particle_generator.py
+++ b/yt/utilities/tests/test_particle_generator.py
@@ -30,7 +30,7 @@ def test_particle_generator():
                   ("io", "particle_position_z"),
                   ("io", "particle_index"),
                   ("io", "particle_gas_density")]
-    num_particles = 1000000
+    num_particles = 10000
     field_dict = {("gas", "density"): ("io", "particle_gas_density")}
     sphere = ds.sphere(ds.domain_center, 0.45)
 
@@ -114,7 +114,7 @@ def test_particle_generator():
 
     # Test adding in particles with a different particle type
 
-    num_star_particles = 100000
+    num_star_particles = 20000
     pdata2 = {("star", "particle_position_x"): np.random.uniform(size=num_star_particles),
               ("star", "particle_position_y"): np.random.uniform(size=num_star_particles),
               ("star", "particle_position_z"): np.random.uniform(size=num_star_particles)}


### PR DESCRIPTION
This PR allows one to specify multiple particle field types when creating a stream dataset, i.e.:

```python
pdata = {}
for i, ax in enumerate("xyz"):
    pdata["PartType0", "particle_position_%s" % ax] = (g["Coordinates"][:,i] / h, "kpc")
    pdata["PartType0", "particle_velocity_%s" % ax] = (g["Velocities"][:,i], "km/s")
    pdata["PartType1", "particle_position_%s" % ax] = (d["Coordinates"][:,i] / h, "kpc")
    pdata["PartType1", "particle_velocity_%s" % ax] = (d["Velocities"][:,i], "km/s")
    pdata["PartType4", "particle_position_%s" % ax] = (s["Coordinates"][:,i] / h, "kpc")
    pdata["PartType4", "particle_velocity_%s" % ax] = (s["Velocities"][:,i], "km/s")

ds = yt.load_particles(pdata, length_unit="kpc", mass_unit="Msun", 
                       time_unit="Gyr", bbox=bbox, n_ref=64)
```
The stream datasets currently only allow for one particle type, `"io"`. It will still be the default if no particle types are specified. These changes will apply to grid and particle-based stream datasets.

- [x] Add tests for new functionality
- [x] Add documentation

UPDATE: This should now be ready to go in, but there are some issues that need to be noted in terms of changes to code behavior that needed to happen in order to get this to work:

1. The old version of `refine_amr` adds particles to the dataset after every refinement step during its creation. In theory this would allow for creating a refinement criterion that refines based on the number of particles. It turns out that it is very hard to maintain this behavior with the code I needed to write for multiple particle types. Since it is not clear that anyone ever used a particle refinement criterion, I think that this is fine and that we should revisit this problem with a rework of the grid-based stream datasets.
2. I also had to remove a check that the size of particle fields for uniform grid datasets was the same as the `number_of_particles` parameter which is passed in, since it was very difficult to maintain it when you can have different particle types. I think we just need to rely on users to be more careful.
3. Finally, the `particle_generators` code enables one to add particle fields to a stream dataset after the dataset is created. Previously, if particles already existed in the dataset, and one added a new set of particles which had a field that was not already in the dataset, zeros would be added to this field to make sure the size of particle arrays was the same for all fields. This is also difficult to maintain in the light of multiple particle fields (and also not really desirable in the first place), so once again the new behavior requires the user to be more careful and not add a new field of the same type.