### PR TITLE
update appveyor config, fix windows test failures

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,19 +4,18 @@
 environment:
 
   global:
-      PYTHON: "C:\\Miniconda-x64"
+      PYTHON: "C:\\Miniconda3-x64"
 
   matrix:
-
-      - PYTHON_VERSION: "2.7"
-
-      - PYTHON_VERSION: "3.5"
-
+      - PYTHON_VERSION: "3.6"
 
 platform:
     -x64
 
 install:
+    - "if not exist \"%userprofile%\\.config\\yt\" mkdir %userprofile%\\.config\\yt"
+    - "echo [yt] > %userprofile%\\.config\\yt\\ytrc"
+    - "echo suppressStreamLogging = True >> %userprofile%\\.config\\yt\\ytrc"
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
     # Install the build and runtime dependencies of the project.
@@ -28,11 +27,11 @@ install:
     - "python --version"
 
     # Install specified version of numpy and dependencies
-    - "conda install -q --yes numpy nose setuptools ipython Cython sympy h5py matplotlib"
-    - "python setup.py develop"
+    - "conda install -q --yes -c conda-forge numpy scipy nose setuptools ipython Cython sympy fastcache h5py matplotlib flake8 "
+    - "pip install -e ."
 
 # Not a .NET project
 build: false
 
 test_script:
-  - "nosetests -e test_all_fields ."
+  - "nosetests --nologcapture -sv yt"

--- a/yt/geometry/coordinates/cartesian_coordinates.py
+++ b/yt/geometry/coordinates/cartesian_coordinates.py
@@ -149,7 +149,7 @@ class CartesianCoordinateHandler(CoordinateHandler):
         return buff
             
     def _oblique_pixelize(self, data_source, field, bounds, size, antialias):
-        indices = np.argsort(data_source['pdx'])[::-1]
+        indices = np.argsort(data_source['pdx'])[::-1].astype(np.int_)
         buff = np.zeros((size[1], size[0]), dtype="f8")
         pixelize_off_axis_cartesian(buff,
                               data_source['x'], data_source['y'],

--- a/yt/utilities/lib/alt_ray_tracers.pyx
+++ b/yt/utilities/lib/alt_ray_tracers.pyx
@@ -95,13 +95,13 @@ def cylindrical_ray_trace(np.ndarray[np.float64_t, ndim=1] p1,
         indexes into the grid cells which the ray crosses in order.
 
     """
-    cdef int i, I
+    cdef np.int_t i, I
     cdef np.float64_t a, b, bsqrd, twoa
     cdef np.ndarray[np.float64_t, ndim=1] p1cart, p2cart, dpcart, t, s, \
                                           rleft, rright, zleft, zright, \
                                           cleft, cright, thetaleft, thetaright, \
                                           tmleft, tpleft, tmright, tpright, tsect
-    cdef np.ndarray[np.int_t, ndim=1, cast=True] inds, tinds, sinds
+    cdef np.ndarray[np.int64_t, ndim=1, cast=True] inds, tinds, sinds
     cdef np.ndarray[np.float64_t, ndim=2] xyz, rztheta, ptemp, b1, b2, dsect
 
     # set up  points

--- a/yt/utilities/lib/misc_utilities.pyx
+++ b/yt/utilities/lib/misc_utilities.pyx
@@ -441,7 +441,7 @@ def zpoints(np.ndarray[np.float64_t, ndim=3] image,
     for j in idx:
         r = radii[j]
         r2 = int((r+0.3)*(r+0.3))  #0.3 to get nicer shape
-        ks = np.arange(-r,r+1,dtype=int)
+        ks = np.arange(-r, r+1, dtype=np.int64)
         z0 = zs[j]
         for kx in ks:
             x0 = xs[j]+kx

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -851,7 +851,7 @@ class CuttingQuiverCallback(PlotCallback):
         yy0, yy1 = plot._axes.get_ylim()
         nx = plot.image._A.shape[1] // self.factor
         ny = plot.image._A.shape[0] // self.factor
-        indices = np.argsort(plot.data['dx'])[::-1]
+        indices = np.argsort(plot.data['dx'])[::-1].astype(np.int_)
 
         pixX = np.zeros((ny, nx), dtype="f8")
         pixY = np.zeros((ny, nx), dtype="f8")


### PR DESCRIPTION
closes #1254

Once this is merged we should be able to turn on automatic windows testing.

I decided to only run tests on Python3.6 because Appveyor only gives us one parallel build.