### PR TITLE
[bugfix] Fix precision issues for X-ray related fields

### DIFF
--- a/yt/fields/astro_fields.py
+++ b/yt/fields/astro_fields.py
@@ -97,8 +97,8 @@ def setup_astro_fields(registry, ftype = "gas", slice_info = None):
             X_H = data.get_field_parameter("X_H")
         else:
             X_H = 0.76
-        nenh = data["density"]*data["density"]
-        nenh /= mh*mh
+        nenh = data["density"]/mh
+        nenh *= nenh
         nenh *= 0.5*(1.+X_H)*X_H*data["cell_volume"]
         return nenh
     
@@ -119,7 +119,9 @@ def setup_astro_fields(registry, ftype = "gas", slice_info = None):
     def _mazzotta_weighting(field, data):
         # Spectroscopic-like weighting field for galaxy clusters
         # Only useful as a weight_field for temperature, metallicity, velocity
-        return data["density"]*data["density"]*data["kT"]**-0.25/mh/mh
+        ret = data["density"]/mh
+        ret *= ret*data["kT"]**-0.25
+        return ret
 
     registry.add_field((ftype,"mazzotta_weighting"), sampling_type="cell", 
                        function=_mazzotta_weighting,


### PR DESCRIPTION
There are a couple of astro fields that have a density-squared dependence and have a division by the proton mass to get a number density: `mazzotta_weighting` and `emission_measure`.

If the density is very small in cgs units, it is sometimes the case that the field itself is zero. I've altered the computation of the fields so that we divide the density by the proton mass first before doing anything else. 