### PR TITLE
Setup improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
 matrix:
   include:
     - python: 2.7
-      env: NUMPY=numpy==1.9.0 CYTHON=cython==0.24 MATPLOTLIB=matplotlib==1.5.3 SYMPY=sympy==1.0 H5PY= SCIPY= FASTCACHE= IPYTHON=ipython==1.0
+      env: NUMPY=numpy==1.10.4 CYTHON=cython==0.24 MATPLOTLIB=matplotlib==1.5.3 SYMPY=sympy==1.0 H5PY= SCIPY= FASTCACHE= IPYTHON=ipython==1.0
     - python: 2.7
     - python: 3.4
     - python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,21 @@ addons:
     packages:
       - libhdf5-serial-dev
 
+env:
+  global:
+    NUMPY=numpy
+    CYTHON=cython
+    MATPLOTLIB=matplotlib
+    SYMPY=sympy
+    H5PY=h5py
+    SCIPY=scipy
+    IPYTHON=ipython
+    FASTCACHE=fastcache
+
 matrix:
   include:
+    - python: 2.7
+      env: NUMPY=numpy==1.9.0 CYTHON=cython==0.24 MATPLOTLIB=matplotlib==1.5.3 SYMPY=sympy==1.0 H5PY= SCIPY= FASTCACHE= IPYTHON=ipython==1.0
     - python: 2.7
     - python: 3.4
     - python: 3.5
@@ -52,7 +65,7 @@ install:
     pip install --upgrade wheel
     pip install --upgrade setuptools
     # Install dependencies
-    pip install mock numpy scipy cython matplotlib sympy fastcache nose flake8 h5py ipython nose-timer
+    pip install mock $NUMPY $SCIPY $H5PY $CYTHON $MATPLOTLIB $SYMPY $FASTCACHE $IPYTHON nose flake8 nose-timer
     # install yt
     pip install -e .
 

--- a/scripts/iyt
+++ b/scripts/iyt
@@ -2,7 +2,6 @@
 from __future__ import print_function
 import os
 import re
-from distutils.version import LooseVersion
 from yt.mods import *
 from yt.data_objects.data_containers import YTDataContainer
 namespace = locals().copy()
@@ -25,38 +24,11 @@ except ImportError:
     code.interact(doc, None, namespace)
     sys.exit()
 
-if LooseVersion(IPython.__version__) <= LooseVersion('0.10'):
-    api_version = '0.10'
-elif LooseVersion(IPython.__version__) <= LooseVersion('1.0'):
-    api_version = '0.11'
-else:
-    api_version = '1.0'
-
-if api_version == "0.10" and "DISPLAY" in os.environ:
-    from matplotlib import rcParams
-    ipbackends = dict(Qt4 = IPython.Shell.IPShellMatplotlibQt4,
-                      WX  = IPython.Shell.IPShellMatplotlibWX,
-                      GTK = IPython.Shell.IPShellMatplotlibGTK,
-                      Qt  = IPython.Shell.IPShellMatplotlibQt)
-    bend = (rcParams["backend"]).rstrip('Agg')
-
-    try:
-        ip_shell = ipbackends[bend](user_ns=namespace)
-    except KeyError:
-        ip_shell = IPython.Shell.IPShellMatplotlib(user_ns=namespace)
-elif api_version == "0.10":
-    ip_shell = IPython.Shell.IPShellMatplotlib(user_ns=namespace)
-else:
-    if api_version == "0.11":
-        from IPython.frontend.terminal.interactiveshell import \
-            TerminalInteractiveShell
-    elif api_version == "1.0":
-        from IPython.terminal.interactiveshell import TerminalInteractiveShell
-    else:
-        raise RuntimeError
-    ip_shell = TerminalInteractiveShell(user_ns=namespace, banner1 = doc,
-                    display_banner = True)
-    if "DISPLAY" in os.environ: ip_shell.enable_pylab(import_all=False)
+from IPython.terminal.interactiveshell import TerminalInteractiveShell
+ip_shell = TerminalInteractiveShell(user_ns=namespace, banner1 = doc,
+                                    display_banner = True)
+if "DISPLAY" in os.environ:
+    ip_shell.enable_pylab(import_all=False)
 
 
 # The rest is a modified version of the IPython default profile code
@@ -82,14 +54,9 @@ description on what you could do here.
 # Most of your config files and extensions will probably start with this import
 
 #import IPython.ipapi
-if api_version == "0.10":
-    ip = ip_shell.IP.getapi()
-    try_next = IPython.ipapi.TryNext
-    kwargs = dict(sys_exit=1, banner=doc)
-elif api_version in ("0.11", "1.0"):
-    ip = ip_shell
-    try_next = IPython.core.error.TryNext
-    kwargs = dict()
+ip = ip_shell
+try_next = IPython.core.error.TryNext
+kwargs = dict()
 
 ip.ex("from yt.mods import *")
 ip.ex("import yt")

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,11 @@ from setuptools import setup, find_packages
 from setuptools.extension import Extension
 from setuptools.command.build_ext import build_ext as _build_ext
 from setuptools.command.sdist import sdist as _sdist
-from setuptools.command.build_py import build_py as _build_py
 from setupext import \
-    check_for_openmp, check_for_pyembree, read_embree_location, \
-    get_mercurial_changeset_id, in_conda_env
+    check_for_openmp, \
+    check_for_pyembree, \
+    read_embree_location, \
+    in_conda_env
 from distutils.version import LooseVersion
 import pkg_resources
 
@@ -284,27 +285,6 @@ if os.environ.get("GPERFTOOLS", "no").upper() != "NO":
                   library_dirs=[ldir],
                   include_dirs=[idir]))
 
-class build_py(_build_py):
-    def run(self):
-        # honor the --dry-run flag
-        if not self.dry_run:
-            target_dir = os.path.join(self.build_lib, 'yt')
-            src_dir = os.getcwd()
-            changeset = get_mercurial_changeset_id(src_dir)
-            self.mkpath(target_dir)
-            with open(os.path.join(target_dir, '__hg_version__.py'), 'w') as fobj:
-                fobj.write("hg_version = '%s'\n" % changeset)
-        _build_py.run(self)
-
-    def get_outputs(self):
-        # http://bitbucket.org/yt_analysis/yt/issues/1296
-        outputs = _build_py.get_outputs(self)
-        outputs.append(
-            os.path.join(self.build_lib, 'yt', '__hg_version__.py')
-        )
-        return outputs
-
-
 class build_ext(_build_ext):
     # subclass setuptools extension builder to avoid importing cython and numpy
     # at top level in setup.py. See http://stackoverflow.com/a/21621689/1382869
@@ -380,7 +360,7 @@ setup(
     extras_require = {
         'hub':  ["girder_client"]
     },
-    cmdclass={'sdist': sdist, 'build_ext': build_ext, 'build_py': build_py},
+    cmdclass={'sdist': sdist, 'build_ext': build_ext},
     author="The yt project",
     author_email="yt-dev@lists.spacepope.org",
     url="http://yt-project.org/",

--- a/setup.py
+++ b/setup.py
@@ -295,19 +295,21 @@ class build_ext(_build_ext):
             import numpy
         except ImportError:
             raise ImportError(
-                'Building yt from source requires cython and numpy to be '
-                'installed. Please install these packages using the '
-                'appropriate package manager for your python environment.')
+"""Could not import cython or numpy. Building yt from source requires
+cython and numpy to be installed. Please install these packages using
+the appropriate package manager for your python environment.""")
         if LooseVersion(cython.__version__) < LooseVersion('0.24'):
             raise RuntimeError(
-                'Building yt from source requires Cython 0.24 or newer. Please '
-                'update Cython using the appropriate package manager for your '
-                'python environment.')
+"""Building yt from source requires Cython 0.24 or newer but
+Cython %s is installed. Please update Cython using the appropriate
+package manager for your python environment.""" %
+                cython.__version__)
         if LooseVersion(numpy.__version__) < LooseVersion('1.9'):
             raise RuntimeError(
-                'Building yt from source requires NumPy 1.9 or newer. Please '
-                'update NumPy using the appropriate package manager for your '
-                'python environment.')            
+"""Building yt from source requires NumPy 1.9 or newer but
+NumPy %s is installed. Please update NumPy using the appropriate
+package manager for your python environment.""" %
+                numpy.__version__)
         from Cython.Build import cythonize
         self.distribution.ext_modules[:] = cythonize(
                 self.distribution.ext_modules)

--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,10 @@ from distutils.version import LooseVersion
 import pkg_resources
 
 
-if sys.version_info < (2, 7):
-    print("yt currently requires Python version 2.7")
-    print("certain features may fail unexpectedly and silently with older versions.")
+if sys.version_info < (2, 7) or (3, 0) < sys.version_info < (3, 3):
+    print("yt currently supports Python 2.7 or versions newer than Python 3.4")
+    print("certain features may fail unexpectedly and silently with older "
+          "versions.")
     sys.exit(1)
 
 try:

--- a/setup.py
+++ b/setup.py
@@ -377,7 +377,7 @@ setup(
     author="The yt project",
     author_email="yt-dev@lists.spacepope.org",
     url="http://yt-project.org/",
-    license="BSD",
+    license="BSD 3-Clause",
     zip_safe=False,
     scripts=["scripts/iyt"],
     ext_modules=cython_extensions + extensions,

--- a/setup.py
+++ b/setup.py
@@ -290,6 +290,24 @@ class build_ext(_build_ext):
     # subclass setuptools extension builder to avoid importing cython and numpy
     # at top level in setup.py. See http://stackoverflow.com/a/21621689/1382869
     def finalize_options(self):
+        try:
+            import cython
+            import numpy
+        except ImportError:
+            raise ImportError(
+                'Building yt from source requires cython and numpy to be '
+                'installed. Please install these packages using the '
+                'appropriate package manager for your python environment.')
+        if LooseVersion(cython.__version__) < LooseVersion('0.24'):
+            raise RuntimeError(
+                'Building yt from source requires Cython 0.24 or newer. Please '
+                'update Cython using the appropriate package manager for your '
+                'python environment.')
+        if LooseVersion(numpy.__version__) < LooseVersion('1.9'):
+            raise RuntimeError(
+                'Building yt from source requires NumPy 1.9 or newer. Please '
+                'update NumPy using the appropriate package manager for your '
+                'python environment.')            
         from Cython.Build import cythonize
         self.distribution.ext_modules[:] = cythonize(
                 self.distribution.ext_modules)
@@ -302,7 +320,6 @@ class build_ext(_build_ext):
             __builtins__["__NUMPY_SETUP__"] = False
         else:
             __builtins__.__NUMPY_SETUP__ = False
-        import numpy
         self.include_dirs.append(numpy.get_include())
 
 class sdist(_sdist):
@@ -346,10 +363,6 @@ setup(
     },
     packages=find_packages(),
     include_package_data = True,
-    setup_requires=[
-        'numpy',
-        'cython>=0.24',
-    ],
     install_requires=[
         'matplotlib',
         'setuptools>=19.6',

--- a/setup.py
+++ b/setup.py
@@ -364,12 +364,11 @@ setup(
     packages=find_packages(),
     include_package_data = True,
     install_requires=[
-        'matplotlib',
+        'matplotlib>=1.5.3',
         'setuptools>=19.6',
-        'sympy',
-        'numpy',
-        'IPython',
-        'cython',
+        'sympy>=1.0',
+        'numpy>=1.9',
+        'IPython>=1.0',
     ],
     extras_require = {
         'hub':  ["girder_client"]

--- a/setup.py
+++ b/setup.py
@@ -304,9 +304,9 @@ the appropriate package manager for your python environment.""")
 Cython %s is installed. Please update Cython using the appropriate
 package manager for your python environment.""" %
                 cython.__version__)
-        if LooseVersion(numpy.__version__) < LooseVersion('1.9'):
+        if LooseVersion(numpy.__version__) < LooseVersion('1.10.4'):
             raise RuntimeError(
-"""Building yt from source requires NumPy 1.9 or newer but
+"""Building yt from source requires NumPy 1.10.4 or newer but
 NumPy %s is installed. Please update NumPy using the appropriate
 package manager for your python environment.""" %
                 numpy.__version__)
@@ -369,7 +369,7 @@ setup(
         'matplotlib>=1.5.3',
         'setuptools>=19.6',
         'sympy>=1.0',
-        'numpy>=1.9',
+        'numpy>=1.10.4',
         'IPython>=1.0',
     ],
     extras_require = {

--- a/setupext.py
+++ b/setupext.py
@@ -142,20 +142,3 @@ def read_embree_location():
         shutil.rmtree(tmpdir)
 
     return rd
-
-
-def get_mercurial_changeset_id(target_dir):
-    '''
-    Returns changeset and branch using hglib
-    '''
-    try:
-        import hglib
-    except ImportError:
-        return None
-    try:
-        with hglib.open(target_dir) as repo:
-            changeset = repo.identify(
-                id=True, branch=True).strip().decode('utf8')
-    except hglib.error.ServerError:
-        return None
-    return changeset

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -736,33 +736,21 @@ class YTLoadCmd(YTCommand):
         import yt
 
         import IPython
-        from distutils import version
-        if version.LooseVersion(IPython.__version__) <= version.LooseVersion('0.10'):
-            api_version = '0.10'
-        else:
-            api_version = '0.11'
 
         local_ns = yt.mods.__dict__.copy()
         local_ns['ds'] = args.ds
         local_ns['pf'] = args.ds
         local_ns['yt'] = yt
 
-        if api_version == '0.10':
-            shell = IPython.Shell.IPShellEmbed()
-            shell(local_ns = local_ns,
-                  header =
-                  "\nHi there!  Welcome to yt.\n\nWe've loaded your dataset as 'ds'.  Enjoy!"
-                  )
-        else:
-            try:
-                from traitlets.config.loader import Config
-            except ImportError:
-                from IPython.config.loader import Config
-            import sys
-            cfg = Config()
-            # prepend sys.path with current working directory
-            sys.path.insert(0,'')
-            IPython.embed(config=cfg,user_ns=local_ns)
+        try:
+            from traitlets.config.loader import Config
+        except ImportError:
+            from IPython.config.loader import Config
+        import sys
+        cfg = Config()
+        # prepend sys.path with current working directory
+        sys.path.insert(0,'')
+        IPython.embed(config=cfg,user_ns=local_ns)
 
 class YTMapserverCmd(YTCommand):
     args = ("proj", "field", "weight",

--- a/yt/utilities/png_writer.py
+++ b/yt/utilities/png_writer.py
@@ -10,7 +10,6 @@ Writing PNGs
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-import matplotlib
 import matplotlib._png as _png
 from yt.extern.six import PY2
 
@@ -18,17 +17,9 @@ if PY2:
     from cStringIO import StringIO
 else:
     from io import BytesIO as StringIO
-from distutils.version import LooseVersion
 
-MPL_VERSION = LooseVersion(matplotlib.__version__)
-MPL_API_2_VERSION = LooseVersion("1.5.0")
-
-if MPL_VERSION < MPL_API_2_VERSION:
-    def call_png_write_png(buffer, width, height, filename, dpi):
-        _png.write_png(buffer, width, height, filename, dpi)
-else:
-    def call_png_write_png(buffer, width, height, filename, dpi):
-        _png.write_png(buffer, filename, dpi)
+def call_png_write_png(buffer, width, height, filename, dpi):
+    _png.write_png(buffer, filename, dpi)
 
 def write_png(buffer, filename, dpi=100):
     width = buffer.shape[1]

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -32,7 +32,7 @@ from yt.config import \
     ytcfg
 from yt.funcs import \
     get_image_suffix, \
-    get_ipython_api_version, iterable, \
+    iterable, \
     ensure_dir, \
     ensure_list
 from yt.utilities.exceptions import \
@@ -655,12 +655,8 @@ class ImagePlotContainer(object):
                 v.show()
         else:
             if "__IPYTHON__" in dir(builtins):
-                api_version = get_ipython_api_version()
-                if api_version in ('0.10', '0.11'):
-                    self._send_zmq()
-                else:
-                    from IPython.display import display
-                    display(self)
+                from IPython.display import display
+                display(self)
 
     @validate_plot
     def display(self, name=None, mpl_kwargs=None):

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -21,7 +21,6 @@ import matplotlib
 import numpy as np
 import re
 
-from distutils.version import LooseVersion
 from functools import wraps
 
 from yt.funcs import \
@@ -460,6 +459,8 @@ class ContourCallback(PlotCallback):
         self.data_source = data_source
 
     def __call__(self, plot):
+        from matplotlib.tri import Triangulation, LinearTriInterpolator
+
         # These need to be in code_length
         x0, x1 = (v.in_units("code_length") for v in plot.xlim)
         y0, y1 = (v.in_units("code_length") for v in plot.ylim)
@@ -517,14 +518,8 @@ class ContourCallback(PlotCallback):
 
             # Both the input and output from the triangulator are in plot
             # coordinates
-            if LooseVersion(matplotlib.__version__) < LooseVersion("1.4.0"):
-                from matplotlib.delaunay.triangulate import Triangulation as \
-                    triang
-                zi = triang(x,y).nn_interpolator(z)(xi,yi)
-            else:
-                from matplotlib.tri import Triangulation, LinearTriInterpolator
-                triangulation = Triangulation(x, y)
-                zi = LinearTriInterpolator(triangulation, z)(xi,yi)
+            triangulation = Triangulation(x, y)
+            zi = LinearTriInterpolator(triangulation, z)(xi,yi)
         elif plot._type_name == 'OffAxisProjection':
             zi = plot.frb[self.field][::self.factor,::self.factor].transpose()
 

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -72,15 +72,11 @@ MPL_VERSION = LooseVersion(matplotlib.__version__)
 
 # Some magic for dealing with pyparsing being included or not
 # included in matplotlib (not in gentoo, yes in everything else)
-# Also accounting for the fact that in 1.2.0, pyparsing got renamed.
 try:
-    if MPL_VERSION < LooseVersion("1.2.0"):
-        from matplotlib.pyparsing import ParseFatalException
+    if sys.version_info[0] == 3:
+        from matplotlib.pyparsing_py3 import ParseFatalException
     else:
-        if sys.version_info[0] == 3:
-            from matplotlib.pyparsing_py3 import ParseFatalException
-        else:
-            from matplotlib.pyparsing_py2 import ParseFatalException
+        from matplotlib.pyparsing_py2 import ParseFatalException
 except ImportError:
     from pyparsing import ParseFatalException
 

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -41,7 +41,6 @@ from yt.utilities.logger import ytLogger as mylog
 from yt.funcs import \
     ensure_list, \
     get_image_suffix, \
-    get_ipython_api_version, \
     matplotlib_style_context
 
 def get_canvas(name):
@@ -313,12 +312,8 @@ class ProfilePlot(object):
 
         """
         if "__IPYTHON__" in dir(builtins):
-            api_version = get_ipython_api_version()
-            if api_version in ('0.10', '0.11'):
-                self._send_zmq()
-            else:
-                from IPython.display import display
-                display(self)
+            from IPython.display import display
+            display(self)
         else:
             raise YTNotInsideNotebook
 


### PR DESCRIPTION
This includes a number of cleanups and improvements for our setup.py script.

* removes some now defunct logic related to the `__hg_version__.py` file. Rather than update this logic to work with git, I've opted to simply delete it. Please let me know if you want this to be updated to work with git.

* the setup.py script will now bail if you try to install yt on python 3.0, 3.1, 3.2, or 3.3.

* Makes the license description more accurate

* Defines minimum supported versions of our runtime dependencies. Thankfully `install_requires` works correctly with `pip` to install wheels if these requirements are not satisfied. I've chosen versions of these libraries from the past year or two to support.

* Adds a travis job to test that we still build and the unit tests pass for the minimum supported versions of our dependencies.

* Removes compatibility code for unsupported versions of dependencies

* Finally, removed usage of the `setup_requires` argument to the `setup` function. 

This last bit deserved a bit more discussion. This was originally added a year or two ago by @Xarthisius in an attempt to make it easier to install yt out of the box with no required dependencies already installed. For our runtime dependencies `install_requires` already takes care of this. Unfortunately for our build dependencies the available solution from `setuptools`,  `setup_requires`, uses `easy_install` under the hood and thus if it gets triggered must always build `cython` and `numpy` from source. This is unfortunate given the availability of wheels and conda packages for both of these packages. I think it's better to simply bail from the `setup.py` with an error message admonishing the user to install cython or numpy from a package manager if they're not installed or the installed version is too old.
