### PR TITLE
Correct the temperature calcluation for Gadget snapshot files in fields.py

### DIFF
--- a/yt/frontends/gadget/fields.py
+++ b/yt/frontends/gadget/fields.py
@@ -75,7 +75,8 @@ class GadgetFieldInfo(SPHFieldInfo):
                 x_H = 0.76
                 gamma = 5.0/3.0
                 a_e = data[ptype, 'ElectronAbundance']
-                mu = 4.0 / (3.0 * x_H + 1.0 + 4.0 * x_H * a_e)
+                # mu = 4.0 / (3.0 * x_H + 1.0 + 4.0 * x_H * a_e)
+                mu = 4.0 / (3.0 + x_H + 4.0 * x_H * a_e)  # this should be correct
                 ret = data[ptype, "InternalEnergy"]*(gamma-1)*mu*mp/kb
                 return ret.in_units(self.ds.unit_system["temperature"])
         else:
@@ -87,7 +88,8 @@ class GadgetFieldInfo(SPHFieldInfo):
                     mu = data.get_field_parameter("mean_molecular_weight")
                 else:
                     # Assume zero ionization
-                    mu = 4.0 / (3.0 * x_H + 1.0)
+                    # mu = 4.0 / (3.0 * x_H + 1.0)
+                    mu = 4.0 / (3.0 + 5.0 * x_H)  # this should be correct
                 ret = data[ptype, "InternalEnergy"]*(gamma-1)*mu*mp/kb
                 return ret.in_units(self.ds.unit_system["temperature"])
 

--- a/yt/frontends/gadget/fields.py
+++ b/yt/frontends/gadget/fields.py
@@ -75,8 +75,7 @@ class GadgetFieldInfo(SPHFieldInfo):
                 x_H = 0.76
                 gamma = 5.0/3.0
                 a_e = data[ptype, 'ElectronAbundance']
-                # mu = 4.0 / (3.0 * x_H + 1.0 + 4.0 * x_H * a_e)
-                mu = 4.0 / (3.0 + x_H + 4.0 * x_H * a_e)  # this should be correct
+                mu = 4.0 / (3.0 + x_H + 4.0 * x_H * a_e)
                 ret = data[ptype, "InternalEnergy"]*(gamma-1)*mu*mp/kb
                 return ret.in_units(self.ds.unit_system["temperature"])
         else:
@@ -88,8 +87,7 @@ class GadgetFieldInfo(SPHFieldInfo):
                     mu = data.get_field_parameter("mean_molecular_weight")
                 else:
                     # Assume zero ionization
-                    # mu = 4.0 / (3.0 * x_H + 1.0)
-                    mu = 4.0 / (3.0 + 5.0 * x_H)  # this should be correct
+                    mu = 4.0 / (3.0 + 5.0 * x_H)
                 ret = data[ptype, "InternalEnergy"]*(gamma-1)*mu*mp/kb
                 return ret.in_units(self.ds.unit_system["temperature"])
 


### PR DESCRIPTION
The correct function for gas temperature calculation (at least I was told) in radiative hydro-simulaitons is

```
x_H = 0.76  # hydrogen mass-fraction
yhelium = (1. - x_H) / (4 * x_H)
mean_mol_weight = (1. + 4. * yhelium) / (1. + 3. * yhelium + 1)
mean_mol_weight = (1. + 4. * yhelium) / (1. + 3. * yhelium + a_e)  # if ElectronAbundance is given
```

This gives the mu in field.py as
```
mu = 4.0 / (3.0 + 5.0 * x_H)
or
mu = 4.0 / (3.0 + x_H + 4.0 * x_H * a_e)  # if ElectronAbundance is given.
```

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

The calculation of gas temperature now should be correct. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
