### PR TITLE
Adding FRB generation to ds.r

### DIFF
--- a/doc/source/analyzing/objects.rst
+++ b/doc/source/analyzing/objects.rst
@@ -199,6 +199,21 @@ This accepts arguments the same way:::
 
 .. _available-objects:
 
+Making Image Buffers
+^^^^^^^^^^^^^^^^^^^^
+
+Using the slicing syntax above for choosing a slice, if you also provide an
+imaginary step value you can obtain a
+:class:`~yt.visualization.api.FixedResolutionBuffer` of the chosen resolution.
+
+For instance, to obtain a 1024 by 1024 buffer covering the entire
+domain but centered at 0.5 in code units, you can do:::
+
+   frb = ds.r[0.5, ::1024j, ::1024j]
+
+This `frb` object then can be queried like a normal fixed resolution buffer,
+and it will return arrays of shape (1024, 1024).
+
 Available Objects
 -----------------
 
@@ -650,7 +665,7 @@ Here are some examples:
    cutout = sp1 - sp3
    sp4 = sp1 ^ sp2
    sp5 = sp1 & sp2
-   
+
 
 Note that the ``+`` operation and the ``|`` operation are identical.  For when
 multiple objects are to be combined in an intersection or a union, there are

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -495,16 +495,16 @@ class YTDataContainer(object):
     def save_as_dataset(self, filename=None, fields=None):
         r"""Export a data object to a reloadable yt dataset.
 
-        This function will take a data object and output a dataset 
-        containing either the fields presently existing or fields 
+        This function will take a data object and output a dataset
+        containing either the fields presently existing or fields
         given in the ``fields`` list.  The resulting dataset can be
         reloaded as a yt dataset.
 
         Parameters
         ----------
         filename : str, optional
-            The name of the file to be written.  If None, the name 
-            will be a combination of the original dataset and the type 
+            The name of the file to be written.  If None, the name
+            will be a combination of the original dataset and the type
             of data container.
         fields : list of string or tuple field names, optional
             If this is supplied, it is the list of fields to be saved to
@@ -1628,6 +1628,8 @@ class YTSelectionContainer2D(YTSelectionContainer):
         elif iterable(height):
             h, u = height
             height = self.ds.quan(h, input_units = u)
+        elif not isinstance(height, YTArray):
+            height = self.ds.quan(height, 'code_length')
         if not iterable(resolution):
             resolution = (resolution, resolution)
         from yt.visualization.fixed_resolution import FixedResolutionBuffer
@@ -1857,7 +1859,7 @@ class YTSelectionContainer3D(YTSelectionContainer):
 
     def _calculate_flux_in_grid(self, grid, mask, field, value,
                     field_x, field_y, field_z, fluxing_field = None):
-        
+
         vc_fields = [field, field_x, field_y, field_z]
         if fluxing_field is not None:
             vc_fields.append(fluxing_field)

--- a/yt/data_objects/tests/test_dataset_access.py
+++ b/yt/data_objects/tests/test_dataset_access.py
@@ -66,6 +66,16 @@ def test_accessing_all_data():
     assert_equal(dd["density"]*2.0, ds.r["density"])
     assert_equal(dd["gas", "density"]*2.0, ds.r["gas", "density"])
 
+def test_slice_from_r():
+    ds = fake_amr_ds(fields = ["density"])
+    sl1 = ds.r[0.5, :, :]
+    sl2 = ds.slice("x", 0.5)
+    assert_equal(sl1["density"], sl2["density"])
+
+    frb1 = sl1.to_frb(width = 1.0, height = 1.0, resolution = (1024, 512))
+    frb2 = ds.r[0.5, ::1024j, ::512j]
+    assert_equal(frb1["density"], frb2["density"])
+
 def test_particle_counts():
     ds = fake_random_ds(16, particles=100)
     assert ds.particle_type_counts == {'io': 100}


### PR DESCRIPTION
This allows you to use `ds.r` to get back FRB objects.  For instance, it is
natural to do something like:

```
ds.r[0.5, ::256j, ::256j]
```

and expect to get back a fixed resolution buffer.  Currently, this doesn't
work.  This adds that, along with tests and some more comments.