### PR TITLE
[show_fields] Only print alias if it's non empty string

### DIFF
--- a/doc/helper_scripts/show_fields.py
+++ b/doc/helper_scripts/show_fields.py
@@ -171,7 +171,7 @@ class FieldInfo:
         u = field[1][0]
         if len(u) > 0:
             self.units = ":math:`\mathrm{%s}`" % fix_units(u)
-        a = ["``%s``" % f for f in field[1][1]]
+        a = ["``%s``" % f for f in field[1][1] if f]
         self.aliases = " ".join(a)
         self.dname = ""
         if field[1][2] is not None:


### PR DESCRIPTION
This gets rid of severe sphinx warnings in `field_list.rst`:

```
--- orig        2017-05-17 10:09:08.942291989 -0500
+++ new 2017-05-17 10:09:38.528315781 -0500
@@ -7342,24 +7342,24 @@
 ('io', 'StarFormationRate')   :math:`\mathrm{M_\odot / \rm{yr}}`                                                      
 ('io', 'FormationTime')       :math:`\mathrm{\rm{code~time}}`                               ``creation_time``         
 ('io', 'Metallicity_00')                                                                    ``metallicity``           
-('io', 'uDotFB')              :math:`\mathrm{\rm{code~mass} \cdot \rm{code~velocity}^{2}}`  ````                      
-('io', 'uDotAV')              :math:`\mathrm{\rm{code~mass} \cdot \rm{code~velocity}^{2}}`  ````                      
-('io', 'uDotPdV')             :math:`\mathrm{\rm{code~mass} \cdot \rm{code~velocity}^{2}}`  ````                      
-('io', 'uDotHydro')           :math:`\mathrm{\rm{code~mass} \cdot \rm{code~velocity}^{2}}`  ````                      
-('io', 'uDotDiff')            :math:`\mathrm{\rm{code~mass} \cdot \rm{code~velocity}^{2}}`  ````                      
-('io', 'uDot')                :math:`\mathrm{\rm{code~mass} \cdot \rm{code~velocity}^{2}}`  ````                      
-('io', 'coolontime')          :math:`\mathrm{\rm{code~time}}`                               ````                      
-('io', 'timeform')            :math:`\mathrm{\rm{code~time}}`                               ````                      
-('io', 'massform')            :math:`\mathrm{\rm{code~mass}}`                               ````                      
+('io', 'uDotFB')              :math:`\mathrm{\rm{code~mass} \cdot \rm{code~velocity}^{2}}`                            
+('io', 'uDotAV')              :math:`\mathrm{\rm{code~mass} \cdot \rm{code~velocity}^{2}}`                            
+('io', 'uDotPdV')             :math:`\mathrm{\rm{code~mass} \cdot \rm{code~velocity}^{2}}`                            
+('io', 'uDotHydro')           :math:`\mathrm{\rm{code~mass} \cdot \rm{code~velocity}^{2}}`                            
+('io', 'uDotDiff')            :math:`\mathrm{\rm{code~mass} \cdot \rm{code~velocity}^{2}}`                            
+('io', 'uDot')                :math:`\mathrm{\rm{code~mass} \cdot \rm{code~velocity}^{2}}`                            
+('io', 'coolontime')          :math:`\mathrm{\rm{code~time}}`                                                         
+('io', 'timeform')            :math:`\mathrm{\rm{code~time}}`                                                         
+('io', 'massform')            :math:`\mathrm{\rm{code~mass}}`                                                         
 ('io', 'HI')                  :math:`\mathrm{}`                                             ``H_fraction``            
 ('io', 'HII')                 :math:`\mathrm{}`                                             ``H_p1_fraction``         
 ('io', 'HeI')                 :math:`\mathrm{}`                                             ``He_fraction``           
 ('io', 'HeII')                :math:`\mathrm{}`                                             ``He_p2_fraction``        
 ('io', 'OxMassFrac')          :math:`\mathrm{}`                                             ``O_fraction``            
 ('io', 'FeMassFrac')          :math:`\mathrm{}`                                             ``Fe_fraction``           
-('io', 'c')                   :math:`\mathrm{\rm{code~velocity}}`                           ````                      
-('io', 'acc')                 :math:`\mathrm{\rm{code~velocity} / \rm{code~time}}`          ````                      
-('io', 'accg')                :math:`\mathrm{\rm{code~velocity} / \rm{code~time}}`          ````                      
+('io', 'c')                   :math:`\mathrm{\rm{code~velocity}}`                                                     
+('io', 'acc')                 :math:`\mathrm{\rm{code~velocity} / \rm{code~time}}`                                    
+('io', 'accg')                :math:`\mathrm{\rm{code~velocity} / \rm{code~time}}`                                    
 ('io', 'smoothlength')        :math:`\mathrm{\rm{code~length}}`                             ``smoothing_length``      
 ============================  ============================================================  =====================  ===
```

