### PR TITLE
[bug] Fix cleanup error

### DIFF
--- a/yt/utilities/parallel_tools/parallel_analysis_interface.py
+++ b/yt/utilities/parallel_tools/parallel_analysis_interface.py
@@ -676,7 +676,8 @@ class Communicator(object):
         self._distributed = comm is not None and self.comm.size > 1
 
     def __del__(self):
-        self.comm.Free()
+        if self.comm is not None:
+            self.comm.Free()
     """
     This is an interface specification providing several useful utility
     functions for analyzing something in parallel.


### PR DESCRIPTION
This fixes an error that happens when yt improperly shuts down. I usually see it when I introduce a SyntaxError somewhere that only gets triggered when yt is partially imported.

Here's an example traceback:

```
Traceback (most recent call last):
  File "/usr/local/bin/iyt", line 6, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "/Users/goldbaum/Documents/yt-git/scripts/iyt", line 5, in <module>
    from yt.mods import *
  File "/Users/goldbaum/Documents/yt-git/yt/__init__.py", line 131, in <module>
    from yt.data_objects.api import \
  File "/Users/goldbaum/Documents/yt-git/yt/data_objects/api.py", line 46, in <module>
    from . import construction_data_containers as __cdc
  File "/Users/goldbaum/Documents/yt-git/yt/data_objects/construction_data_containers.py", line 65, in <module>
    from yt.frontends.sph.data_structures import ParticleDataset
  File "/Users/goldbaum/Documents/yt-git/yt/frontends/sph/data_structures.py", line 36
    kdtree_filename)
               ^
SyntaxError: positional argument follows keyword argument
Exception ignored in: <bound method Communicator.__del__ of <yt.utilities.parallel_tools.parallel_analysis_interface.Communicator object at 0x111582f98>>
Traceback (most recent call last):
  File "/Users/goldbaum/Documents/yt-git/yt/utilities/parallel_tools/parallel_analysis_interface.py", line 679, in __del__
AttributeError: 'NoneType' object has no attribute 'Free'
```

Having two errors in the traceback makes debugging needlessly confusing.

The fix is thankfully easy, we just need to make sure that `self.comm` is not `None` before calling `comm.free`.