### PR TITLE
Validate AMR structure in load_amr_grids. Fixes #1295

### DIFF
--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -446,6 +446,7 @@ Exodus II Data
 --------------
 
 .. note::
+
    To load Exodus II data, you need to have the `netcdf4 <http://unidata.github.io/
    netcdf4-python/>`_ python interface installed.
 
@@ -1207,22 +1208,27 @@ resolution.
    import yt
 
    grid_data = [
-       dict(left_edge = [0.0, 0.0, 0.0],
-            right_edge = [1.0, 1.0, 1.],
-            level = 0,
-            dimensions = [32, 32, 32],
-            number_of_particles = 0)
-       dict(left_edge = [0.25, 0.25, 0.25],
-            right_edge = [0.75, 0.75, 0.75],
-            level = 1,
-            dimensions = [32, 32, 32],
-            number_of_particles = 0)
+       dict(left_edge=[0.0, 0.0, 0.0],
+            right_edge=[1.0, 1.0, 1.0],
+            level=0,
+            dimensions=[32, 32, 32],
+            number_of_particles=0)
+       dict(left_edge=[0.25, 0.25, 0.25],
+            right_edge=[0.75, 0.75, 0.75],
+            level=1,
+            dimensions=[32, 32, 32],
+            number_of_particles=0)
    ]
 
    for g in grid_data:
-       g["density"] = np.random.random(g["dimensions"]) * 2**g["level"]
+       g["density"] = np.random.random(g["dimensions"]) * 2 ** g["level"]
 
    ds = yt.load_amr_grids(grid_data, [32, 32, 32], 1.0)
+
+.. note::
+
+   yt only supports a block structure where the grid edges on the ``n``-th
+   refinement level are aligned with the cell edges on the ``n-1``-th level.
 
 Particle fields are supported by adding 1-dimensional arrays and
 setting the ``number_of_particles`` key to each ``grid``'s dict:

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -61,6 +61,8 @@ from yt.geometry.grid_container import \
     MatchPointsToGrids
 from yt.utilities.decompose import \
     decompose_array, get_psize
+from yt.utilities.exceptions import \
+    YTIllDefinedAMR
 from yt.units.yt_array import \
     YTQuantity, \
     uconcatenate
@@ -856,6 +858,17 @@ def load_amr_grids(grid_data, domain_dimensions,
         ids = np.where(mask.astype("bool"))
         for ci in ids:
             parent_ids[ci] = gi
+
+    # Check if the grid structure is properly aligned (bug #1295)
+    for lvl in range(grid_levels.min() + 1, grid_levels.max() + 1):
+        idx = grid_levels.flatten() == lvl
+        dims = domain_dimensions * refine_by ** (lvl - 1)
+        for iax, ax in enumerate('xyz'):
+            cell_edges = np.linspace(domain_left_edge[iax],
+                                     domain_right_edge[iax],
+                                     dims[iax], endpoint=False)
+            if set(grid_left_edges[idx, iax]) - set(cell_edges):
+                raise YTIllDefinedAMR(lvl, ax)
 
     if length_unit is None:
         length_unit = 'code_length'

--- a/yt/frontends/stream/tests/test_stream_amrgrids.py
+++ b/yt/frontends/stream/tests/test_stream_amrgrids.py
@@ -1,5 +1,7 @@
 import numpy as np
-from yt.utilities.exceptions import YTIntDomainOverflow
+from yt.utilities.exceptions import \
+    YTIllDefinedAMR, \
+    YTIntDomainOverflow
 
 from yt import load_amr_grids, ProjectionPlot
 
@@ -49,3 +51,21 @@ def test_refine_by():
     domain_dimensions = np.array([8, 8, 8])
 
     load_amr_grids(grid_data, domain_dimensions, refine_by=ref_by)
+
+def test_validation():
+    dims = np.array([4, 2, 4])
+    grid_data = [
+        dict(left_edge = [0.0, 0.0, 0.0],
+             right_edge = [1.0, 1.0, 1.0],
+             level = 0,
+             dimensions = dims),
+        dict(left_edge = [0.25, 0.25, 0.25],
+             right_edge = [0.75, 0.75, 0.75],
+             level = 1,
+             dimensions = dims),
+       ]
+    bbox = np.array([[0, 1], [0, 1], [0, 1]])
+    def load_grids():
+        load_amr_grids(grid_data, dims, bbox=bbox, periodicity=(0, 0, 0),
+                       length_unit=1.0, refine_by=2)
+    assert_raises(YTIllDefinedAMR, load_grids)

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -649,3 +649,15 @@ class YTBooleanObjectsWrongDataset(YTException):
 
     def __str__(self):
         return "Boolean data objects must share a common dataset object."
+
+class YTIllDefinedAMR(YTException):
+    def __init__(self, level, axis):
+        self.level = level
+        self.axis = axis
+
+    def __str__(self):
+        msg = (
+            "Grids on the level {} are not properly aligned with cell edges "
+            "on the parent level ({} axis)"
+        ).format(self.level, self.axis)
+        return msg


### PR DESCRIPTION
## PR Summary

Don't allow to create Stream dataset with an invalid grid structure, i.e. when the grid edges on the *n*-th
refinement level are **not** aligned with the cell edges on the *n-1*-th level.

Fixes #1295 