### PR TITLE
Isocontour fixes and enhancements

### DIFF
--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -1294,6 +1294,22 @@ class YTSurface(YTSelectionContainer3D):
                 vv[:,i,j] = self.vertices[j,i::3]
         return vv
 
+    _surface_area = None
+    @property
+    def surface_area(self):
+        if self._surface_area is not None:
+            return self._surface_area
+        tris = self.triangles
+        x = tris[:, 1, :] - tris[:, 0, :]
+        y = tris[:, 2, :] - tris[:, 0, :]
+        areas = 0.5*np.sqrt(
+            (x[:, 1]*y[:, 2] - x[:, 2]*y[:, 1])**2 +
+            (x[:, 2]*y[:, 0] - x[:, 0]*y[:, 2])**2 +
+            (x[:, 0]*y[:, 1] - x[:, 1]*y[:, 0])**2
+        )
+        self._surface_area = areas.sum()
+        return self._surface_area
+
     def export_obj(self, filename, transparency = 1.0, dist_fac = None,
                    color_field = None, emit_field = None, color_map = None,
                    color_log = True, emit_log = True, plot_index = None,

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -1302,12 +1302,11 @@ class YTSurface(YTSelectionContainer3D):
         tris = self.triangles
         x = tris[:, 1, :] - tris[:, 0, :]
         y = tris[:, 2, :] - tris[:, 0, :]
-        areas = 0.5*np.sqrt(
-            (x[:, 1]*y[:, 2] - x[:, 2]*y[:, 1])**2 +
-            (x[:, 2]*y[:, 0] - x[:, 0]*y[:, 2])**2 +
-            (x[:, 0]*y[:, 1] - x[:, 1]*y[:, 0])**2
-        )
-        self._surface_area = areas.sum()
+        areas = (x[:, 1]*y[:, 2] - x[:, 2]*y[:, 1])**2
+        np.add(areas, (x[:, 2]*y[:, 0] - x[:, 0]*y[:, 2])**2, out=areas)
+        np.add(areas, (x[:, 0]*y[:, 1] - x[:, 1]*y[:, 0])**2, out=areas)
+        np.sqrt(areas, out=areas)
+        self._surface_area = 0.5*areas.sum()
         return self._surface_area
 
     def export_obj(self, filename, transparency = 1.0, dist_fac = None,

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -1144,7 +1144,8 @@ class YTSurface(YTSelectionContainer3D):
         elif isinstance(fields, list):
             fields = fields[0]
         # Now we have a "fields" value that is either a string or None
-        mylog.info("Extracting (sampling: %s)" % (fields,))
+        if fields is not None:
+            mylog.info("Extracting (sampling: %s)" % (fields,))
         verts = []
         samples = []
         for io_chunk in parallel_objects(self.data_source.chunks([], "io")):

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1166,9 +1166,12 @@ class YTDataContainer(object):
                 # For grids this will be a grid object, and for octrees it will
                 # be an OctreeSubset.  Note that we delegate to the sub-object.
                 o = self._current_chunk.objs[0]
+                cache_fp = o.field_parameters.copy()
+                o.field_parameters.update(self.field_parameters)
                 for b, m in o.select_blocks(self.selector):
                     if m is None: continue
                     yield b, m
+                o.field_parameters = cache_fp
 
 class GenerationInProgress(Exception):
     def __init__(self, fields):

--- a/yt/data_objects/tests/test_fluxes.py
+++ b/yt/data_objects/tests/test_fluxes.py
@@ -111,3 +111,21 @@ def test_correct_output_unit():
     Nmax = sp1.max('HI_Density')
     sur = ds.surface(sp1,"HI_Density", .5*Nmax)
     sur['x'][0]
+
+@requires_file(ISOGAL)
+def test_radius_surface():
+    # see #1407
+    ds = load(ISOGAL)
+    reg = ds.all_data()
+    sp = ds.sphere(ds.domain_center, (0.5, 'code_length'))
+    for obj in [reg, sp]:
+        for rad in [0.05, .1, .4]:
+            surface = ds.surface(obj, 'radius', (rad, 'code_length'))
+            assert_almost_equal(
+                surface.surface_area.v, 4*np.pi*rad**2, decimal=2)
+            verts = surface.vertices
+            for i in range(3):
+                assert_almost_equal(
+                    verts[i, :].min().v, 0.5-rad, decimal=2)
+                assert_almost_equal(
+                    verts[i, :].max().v, 0.5+rad, decimal=2)


### PR DESCRIPTION
Fixes #1406 and #1407

This ensures the field value of an iscontour is interpreted in the units expected by the low-level isocontour machinery. In addition, this fixes another issue with field parameters not being correctly applied to volumetric blocks, which we use to generate ghost zones needed for the marching cubes algorithm.

I also added a new `surface_area` property of the `YTSurface` which returns the combined surface area of all of the polygons that make up the surface. In addition I made the `vertices` attribute of `YTSurface` a cached property which simplifies some logic.
