### PR TITLE
only rotate volume rendering images after compositing all sources

### DIFF
--- a/yt/utilities/lib/image_samplers.pyx
+++ b/yt/utilities/lib/image_samplers.pyx
@@ -119,9 +119,12 @@ cdef class ImageSampler:
         self.image.x_vec = <np.float64_t *> x_vec.data
         self.ay_vec = y_vec
         self.image.y_vec = <np.float64_t *> y_vec.data
-        self.image.zbuffer = self.azbuffer = zbuffer
-        self.image.image_used = self.aimage_used = image_used
-        self.image.mesh_lines = self.amesh_lines = mesh_lines
+        self.image.zbuffer = zbuffer
+        self.azbuffer = np.asarray(zbuffer)
+        self.image.image_used = image_used
+        self.aimage_used = np.asarray(image_used)
+        self.image.mesh_lines = mesh_lines
+        self.amesh_lines = np.asarray(mesh_lines)
         self.image.nv[0] = image.shape[0]
         self.image.nv[1] = image.shape[1]
         for i in range(4): self.image.bounds[i] = bounds[i]

--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -501,7 +501,9 @@ class Scene(object):
             im = source.render(camera, zbuffer=opaque)
             opaque.rgba = im
 
-        return im
+        # rotate image 180 degrees so orientation agrees with e.g.
+        # a PlotWindow plot
+        return np.rot90(im, k=2)
 
     def add_camera(self, data_source=None, lens_type='plane-parallel',
                    auto=False):


### PR DESCRIPTION
closes #1410

Up until now, each VolumeSource and MeshSource was rotating volume rendering images for each source by 180 degrees. This is find when you're only dealing with one source but is completely wrong with multiple sources. Rather than doing the rotation in the source, we instead to do the rotation in the scene object after compositing all the images together. I *think* that this still gives the correct answer when annotating lines and grids, but we should manually verify.