### PR TITLE
Update the docstring for the yt module. Closes #1362

### DIFF
--- a/yt/__init__.py
+++ b/yt/__init__.py
@@ -1,66 +1,10 @@
 """
-YT is a package written primarily in Python designed to make the task of
-running Enzo easier.  It contains facilities for creating Enzo data (currently
-in prototype form) as well as runnning Enzo simulations, simulating the actions
-of Enzo on various existing data, and analyzing output from Enzo in a
-wide-variety of methods.
+yt is a toolkit for analyzing and visualizing volumetric data.
 
-An ever-growing collection of documentation is also available at
-http://yt-project.org/doc/ . Additionally, there is a
-project site at http://yt-project.org/ with recipes, a wiki, a variety of
-ways of peering into the version control, and a bug-reporting system.
-
-YT is divided into several packages.
-
-frontends
----------
-
-This is where interfaces to codes are created.  Within each subdirectory of
-yt/frontends/ there must exist the following files, even if empty:
-
-* data_structures.py, where subclasses of AMRGridPatch, Dataset and
-  AMRHierarchy are defined.
-* io.py, where a subclass of IOHandler is defined.
-* misc.py, where any miscellaneous functions or classes are defined.
-* definitions.py, where any definitions specific to the frontend are
-  defined.  (i.e., header formats, etc.)
-
-visualization
--------------
-
-This is where all visualization modules are stored.  This includes plot
-collections, the volume rendering interface, and pixelization frontends.
-
-data_objects
-------------
-
-All objects that handle data, processed or unprocessed, not explicitly
-defined as visualization are located in here.  This includes the base
-classes for data regions, covering grids, time series, and so on.  This
-also includes derived fields and derived quantities.
-
-analysis_modules
-----------------
-
-This is where all mechanisms for processing data live.  This includes
-things like clump finding, halo profiling, halo finding, and so on.  This
-is something of a catchall, but it serves as a level of greater
-abstraction that simply data selection and modification.
-
-gui
----
-
-This is where all GUI components go.  Typically this will be some small
-tool used for one or two things, which contains a launching mechanism on
-the command line.
-
-utilities
----------
-
-All broadly useful code that doesn't clearly fit in one of the other
-categories goes here.
-
-
+* Website: http://yt-project.org
+* Documentation: http://yt-project.org/doc
+* Data hub: http://hub.yt
+* Contribute: http://github.com/yt-project/yt
 
 """
 


### PR DESCRIPTION
Currently these docstrings are hilariously out of date. It's also clear that they're not commonly read. Rather than attempting to update all the detailed content in the docstring to reflect the way the code is currently structured I've opted to just delete most of it.

Looking at other packages, the docstring for the main package is generally quite short:

* Astropy: https://github.com/astropy/astropy/blob/master/astropy/__init__.py#L2
* IPython: https://github.com/ipython/ipython/blob/master/IPython/__init__.py#L2

In case anyone looking for information consults the docstring I've included a number of resources that are not likely to change often.