### PR TITLE
Add minorticks for colorbar when symlog is used

### DIFF
--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -982,8 +982,8 @@ class PWViewerMPL(PlotWindow):
             # colorbar minorticks
             if f not in self._cbar_minorticks:
                 self._cbar_minorticks[f] = True
-            if self._cbar_minorticks[f] is True and MPL_VERSION < LooseVersion('2.0.0') \
-                                                or self._field_transform[f] == symlog_transform:
+            if (self._cbar_minorticks[f] is True and MPL_VERSION < LooseVersion('2.0.0')
+                                                 or self._field_transform[f] == symlog_transform):
                 if self._field_transform[f] == linear_transform:
                     self.plots[f].cax.minorticks_on()
                 else:

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -983,7 +983,7 @@ class PWViewerMPL(PlotWindow):
             if f not in self._cbar_minorticks:
                 self._cbar_minorticks[f] = True
             if (self._cbar_minorticks[f] is True and MPL_VERSION < LooseVersion('2.0.0')
-            or self._field_transform[f] == symlog_transform):
+                or self._field_transform[f] == symlog_transform):
                 if self._field_transform[f] == linear_transform:
                     self.plots[f].cax.minorticks_on()
                 else:

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -982,7 +982,8 @@ class PWViewerMPL(PlotWindow):
             # colorbar minorticks
             if f not in self._cbar_minorticks:
                 self._cbar_minorticks[f] = True
-            if self._cbar_minorticks[f] is True and MPL_VERSION < LooseVersion('2.0.0'):
+            if self._cbar_minorticks[f] is True and MPL_VERSION < LooseVersion('2.0.0') \
+                                                or self._field_transform[f] == symlog_transform:
                 if self._field_transform[f] == linear_transform:
                     self.plots[f].cax.minorticks_on()
                 else:

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -983,7 +983,7 @@ class PWViewerMPL(PlotWindow):
             if f not in self._cbar_minorticks:
                 self._cbar_minorticks[f] = True
             if (self._cbar_minorticks[f] is True and MPL_VERSION < LooseVersion('2.0.0')
-                                                 or self._field_transform[f] == symlog_transform):
+            or self._field_transform[f] == symlog_transform):
                 if self._field_transform[f] == linear_transform:
                     self.plots[f].cax.minorticks_on()
                 else:


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

Newer matplotlib versions can handle minor ticks, but only for linear and log scales, not for symlog scales (currently minor ticks are missing with symlog). With this PR, when symlog is used, the code will take over from matplotlib and generate its own minor ticks.

<!--If it fixes an open issue, please link to the issue here.-->



<!-- Note that some of these check boxes may not apply to all pull requests -->



<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->