### PR TITLE
[bugfix] Create the particle_ones field even if we don't have a particle mass field

### DIFF
--- a/yt/fields/particle_fields.py
+++ b/yt/fields/particle_fields.py
@@ -190,7 +190,7 @@ def particle_deposition_functions(ptype, coord_name, mass_name, registry):
     # Now some translation functions.
 
     def particle_ones(field, data):
-        v = np.ones(data[ptype, mass_name].shape, dtype="float64")
+        v = np.ones(data[ptype, coord_name].shape[0], dtype="float64")
         return data.apply_units(v, field.units)
 
     registry.add_field((ptype, "particle_ones"),


### PR DESCRIPTION
On rare occasions, it may be the case that a dataset has particles without having a mass field for the particles. 

We use the shape of the particle mass field to create the `particle_ones` field. However, if a mass field doesn't exist, then the `particle_ones` field never gets created. This PR bases the creation of the `particle_ones` field off of the coordinate field just as the `mesh_id` below it. 