### PR TITLE
fix I/O issue with little endian Gadget snap format 2 data

### DIFF
--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -353,11 +353,10 @@ class GadgetDataset(SPHDataset):
             endianswap = '<'
         elif rhead == 65536:
             endianswap = '>'
-        # Enabled Format2 here
-        elif rhead == 8:
-            f.close()
-            return True, 'f8'
-        elif rhead == 134217728:
+        elif rhead in (8, 134217728):
+            # This is only true for snapshot format 2
+            # we do not currently support double precision
+            # snap format 2 data
             f.close()
             return True, 'f4'
         else:

--- a/yt/frontends/gadget/tests/test_outputs.py
+++ b/yt/frontends/gadget/tests/test_outputs.py
@@ -26,6 +26,7 @@ from yt.frontends.gadget.api import GadgetHDF5Dataset, GadgetDataset
 isothermal_h5 = "IsothermalCollapse/snap_505.hdf5"
 isothermal_bin = "IsothermalCollapse/snap_505"
 BE_Gadget = "BigEndianGadgetBinary/BigEndianGadgetBinary"
+LE_SnapFormat2 = "Gadget3-snap-format2/Gadget3-snap-format2"
 
 # This maps from field names to weight field names to use for projections
 iso_fields = OrderedDict(
@@ -46,13 +47,14 @@ iso_kwargs = dict(bounding_box=[[-3, 3], [-3, 3], [-3, 3]])
 @requires_file(isothermal_h5)
 @requires_file(isothermal_bin)
 @requires_file(BE_Gadget)
+@requires_file(LE_SnapFormat2)
 def test_GadgetDataset():
     assert isinstance(data_dir_load(isothermal_h5, kwargs=iso_kwargs),
                       GadgetHDF5Dataset)
     assert isinstance(data_dir_load(isothermal_bin, kwargs=iso_kwargs),
                       GadgetDataset)
-    assert isinstance(data_dir_load(BE_Gadget, kwargs=''),
-                      GadgetDataset)
+    assert isinstance(data_dir_load(BE_Gadget), GadgetDataset)
+    assert isinstance(data_dir_load(LE_SnapFormat2), GadgetDataset)
 
 
 @requires_ds(isothermal_h5)


### PR DESCRIPTION
Thanks to @weiguangcui for pointing out this issue which I unintentionally introduced.

I've added a test using a dataset that would have caught this issue if it were in our tests. @Xarthisius can you make sure the dataset I've added to the Gadget tests is staged with the correct path on the test box? So far we haven't added this dataset to the tests so it might not have been downloaded yet.