### PR TITLE
Stream frontend: add sanity checks for field shapes and remove number_of_particles requirement

### DIFF
--- a/doc/source/examining/Loading_Generic_Array_Data.ipynb
+++ b/doc/source/examining/Loading_Generic_Array_Data.ipynb
@@ -139,9 +139,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Particle fields are detected as one-dimensional fields. The number of\n",
-    "particles is set by the `number_of_particles` key in\n",
-    "`data`. Particle fields are then added as one-dimensional arrays in\n",
+    "Particle fields are detected as one-dimensional fields. Particle fields are then added as one-dimensional arrays in\n",
     "a similar manner as the three-dimensional grid fields:"
    ]
   },
@@ -157,7 +155,6 @@
     "posy_arr = np.random.uniform(low=-1.5, high=1.5, size=10000)\n",
     "posz_arr = np.random.uniform(low=-1.5, high=1.5, size=10000)\n",
     "data = dict(density = (np.random.random(size=(64,64,64)), \"Msun/kpc**3\"), \n",
-    "            number_of_particles = 10000,\n",
     "            particle_position_x = (posx_arr, 'code_length'), \n",
     "            particle_position_y = (posy_arr, 'code_length'),\n",
     "            particle_position_z = (posz_arr, 'code_length'))\n",
@@ -170,8 +167,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this example only the particle position fields have been assigned. `number_of_particles` must be the same size as the particle\n",
-    "arrays. If no particle arrays are supplied then `number_of_particles` is assumed to be zero. Take a slice, and overlay particle positions:"
+    "In this example only the particle position fields have been assigned. If no particle arrays are supplied, then the number of particles is assumed to be zero. Take a slice, and overlay particle positions:"
    ]
   },
   {
@@ -574,8 +570,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Particle fields are supported by adding 1-dimensional arrays to each `grid` and\n",
-    "setting the `number_of_particles` key in each `grid`'s dict. If a grid has no particles, set `number_of_particles = 0`, but the particle fields still have to be defined since they are defined elsewhere; set them to empty NumPy arrays:"
+    "Particle fields are supported by adding 1-dimensional arrays to each `grid`. If a grid has no particles, the particle fields still have to be defined since they are defined elsewhere; set them to empty NumPy arrays:"
    ]
   },
   {
@@ -586,11 +581,9 @@
    },
    "outputs": [],
    "source": [
-    "grid_data[0][\"number_of_particles\"] = 0 # Set no particles in the top-level grid\n",
     "grid_data[0][\"particle_position_x\"] = (np.array([]), \"code_length\") # No particles, so set empty arrays\n",
     "grid_data[0][\"particle_position_y\"] = (np.array([]), \"code_length\")\n",
     "grid_data[0][\"particle_position_z\"] = (np.array([]), \"code_length\")\n",
-    "grid_data[1][\"number_of_particles\"] = 1000\n",
     "grid_data[1][\"particle_position_x\"] = (np.random.uniform(low=0.25, high=0.75, size=1000), \"code_length\")\n",
     "grid_data[1][\"particle_position_y\"] = (np.random.uniform(low=0.25, high=0.75, size=1000), \"code_length\")\n",
     "grid_data[1][\"particle_position_z\"] = (np.random.uniform(low=0.25, high=0.75, size=1000), \"code_length\")"
@@ -645,7 +638,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For both uniform grid data and AMR data, one can specify particle fields with multiple types if the particle field names are given as field tuples instead of strings (the default particle type is `\"io\"`). Make sure that the total number of particles given in the `number_of_particles` key is set to the sum of the number of particles for all types:"
+    "For both uniform grid data and AMR data, one can specify particle fields with multiple types if the particle field names are given as field tuples instead of strings (the default particle type is `\"io\"`):"
    ]
   },
   {
@@ -661,7 +654,6 @@
     "posyb_arr = np.random.uniform(low=-1.5, high=1.5, size=20000)\n",
     "poszb_arr = np.random.uniform(low=-1.5, high=1.5, size=20000)\n",
     "data = {\"density\": (np.random.random(size=(64,64,64)), \"Msun/kpc**3\"), \n",
-    "        \"number_of_particles\": 30000,\n",
     "        (\"red\", \"particle_position_x\"): (posxr_arr, 'code_length'), \n",
     "        (\"red\", \"particle_position_y\"): (posyr_arr, 'code_length'),\n",
     "        (\"red\", \"particle_position_z\"): (poszr_arr, 'code_length'),\n",

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -1253,13 +1253,11 @@ resolution.
        dict(left_edge=[0.0, 0.0, 0.0],
             right_edge=[1.0, 1.0, 1.0],
             level=0,
-            dimensions=[32, 32, 32],
-            number_of_particles=0)
+            dimensions=[32, 32, 32])
        dict(left_edge=[0.25, 0.25, 0.25],
             right_edge=[0.75, 0.75, 0.75],
             level=1,
-            dimensions=[32, 32, 32],
-            number_of_particles=0)
+            dimensions=[32, 32, 32])
    ]
 
    for g in grid_data:
@@ -1272,14 +1270,13 @@ resolution.
    yt only supports a block structure where the grid edges on the ``n``-th
    refinement level are aligned with the cell edges on the ``n-1``-th level.
 
-Particle fields are supported by adding 1-dimensional arrays and
-setting the ``number_of_particles`` key to each ``grid``'s dict:
+Particle fields are supported by adding 1-dimensional arrays to each 
+``grid``'s dict:
 
 .. code-block:: python
 
    for g in grid_data:
-       g["number_of_particles"] = 100000
-       g["particle_position_x"] = np.random.random((g["number_of_particles"]))
+       g["particle_position_x"] = np.random.random(size=100000)
 
 .. rubric:: Caveats
 
@@ -1318,26 +1315,22 @@ density field in cubic domain of 3 Mpc edge size (3 * 3.08e24 cm) and
 simultaneously divide the domain into 12 chunks, so that you can take advantage
 of the underlying parallelism.
 
-Particle fields are detected as one-dimensional fields. The number of
-particles is set by the ``number_of_particles`` key in
-``data``. Particle fields are then added as one-dimensional arrays in
-a similar manner as the three-dimensional grid fields:
+Particle fields are added as one-dimensional arrays in a similar manner as the 
+three-dimensional grid fields:
 
 .. code-block:: python
 
    import yt
 
    data = dict(Density = dens,
-               number_of_particles = 1000000,
                particle_position_x = posx_arr,
-	       particle_position_y = posy_arr,
-	       particle_position_z = posz_arr)
+	           particle_position_y = posy_arr,
+	           particle_position_z = posz_arr)
    bbox = np.array([[-1.5, 1.5], [-1.5, 1.5], [1.5, 1.5]])
    ds = yt.load_uniform_grid(data, arr.shape, 3.08e24, bbox=bbox, nprocs=12)
 
-where in this example the particle position fields have been assigned.
-``number_of_particles`` must be the same size as the particle arrays. If no
-particle arrays are supplied then ``number_of_particles`` is assumed to be
+where in this example the particle position fields have been assigned. If no
+particle fields are supplied, then the number of particles is assumed to be
 zero.
 
 .. rubric:: Caveats

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -1022,21 +1022,15 @@ def refine_amr(base_ds, refinement_criteria, fluid_operators, max_level,
 
         ds = load_amr_grids(grid_data, ds.domain_dimensions, bbox=bbox)
 
+        ds.particle_types_raw = base_ds.particle_types_raw
+        ds.particle_types = ds.particle_types_raw
+
+        # Now figure out where the particles go
+        if number_of_particles > 0:
+            # This will update the stream handler too
+            assign_particle_data(ds, pdata)
+
         cur_gc = ds.index.num_grids
-
-    ds.particle_types_raw = base_ds.particle_types_raw
-    ds.particle_types = ds.particle_types_raw
-
-    # Now figure out where the particles go
-    if number_of_particles > 0:
-        # This will update the stream handler too
-        assign_particle_data(ds, pdata)
-        # Because we've already used the index, we
-        # have to re-create the field info because
-        # we added particle data after the fact
-        ds.index._reset_particle_count()
-        ds.index._detect_output_fields()
-        ds.create_field_info()
 
     return ds
 

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -28,7 +28,8 @@ from numbers import Number as numeric_type
 
 from yt.funcs import \
     iterable, \
-    ensure_list
+    ensure_list, \
+    issue_deprecation_warning
 from yt.utilities.io_handler import io_registry
 from yt.data_objects.field_data import \
     YTFieldData
@@ -662,7 +663,13 @@ def load_uniform_grid(data, domain_dimensions, length_unit=None, bbox=None,
     domain_right_edge = np.array(bbox[:, 1], 'float64')
     grid_levels = np.zeros(nprocs, dtype='int32').reshape((nprocs,1))
     # If someone included this throw it away--old API
-    data.pop("number_of_particles", 0)
+    if "number_of_particles" in data:
+        issue_deprecation_warning("It is no longer necessary to include "
+                                  "the number of particles in the data "
+                                  "dict. The number of particles is "
+                                  "determined from the sizes of the "
+                                  "particle fields.")
+        data.pop("number_of_particles")
     # First we fix our field names, apply units to data
     # and check for consistency of field shapes
     field_units, data, number_of_particles = process_data(
@@ -857,7 +864,13 @@ def load_amr_grids(grid_data, domain_dimensions,
         grid_dimensions[i,:] = g.pop("dimensions")
         grid_levels[i,:] = g.pop("level")
         # If someone included this throw it away--old API
-        g.pop("number_of_particles", None)
+        if "number_of_particles" in g:
+            issue_deprecation_warning("It is no longer necessary to include "
+                                      "the number of particles in the data "
+                                      "dict. The number of particles is "
+                                      "determined from the sizes of the "
+                                      "particle fields.")
+            g.pop("number_of_particles")
         field_units, data, n_particles = process_data(
             g, grid_dims=tuple(grid_dimensions[i,:]))
         number_of_particles[i, :] = n_particles

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -269,10 +269,7 @@ class StreamHierarchy(GridIndex):
         """
         particle_types = set_particle_types(data[0])
 
-        for key in data[0].keys():
-            if key == "number_of_particles":
-                continue
-            self.stream_handler.particle_types[key] = particle_types[key]
+        self.stream_handler.particle_types.update(particle_types)
         self.ds._find_particle_types()
 
         for i, grid in enumerate(self.grids):

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -560,8 +560,9 @@ def process_data(data, grid_dims=None):
             g_shapes.append(f_shape)
     if len(g_shapes) > 0 and not np.all(np.array(g_shapes) == g_shapes[0]):
         raise RuntimeError("Not all grid-based fields have the same shape!")
-    if grid_dims is not None and not np.all(np.array(g_shapes) == grid_dims):
-        raise RuntimeError("Not all grid-based fields match the grid dimensions!")
+    if len(g_shapes) > 0 and grid_dims is not None: 
+        if not np.all(np.array(g_shapes) == grid_dims):
+            raise RuntimeError("Not all grid-based fields match the grid dimensions!")
     if len(p_shapes) > 0:
         for ptype, p_shape in p_shapes.items():
             if not np.all(np.array(p_shape) == p_shape[0]):

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -568,12 +568,13 @@ def process_data(data, grid_dims=None):
                 raise YTInconsistentGridFieldShapeGridDims(g_shapes, grid_dims)
     if len(p_shapes) > 0:
         for ptype, p_shape in p_shapes.items():
-            if not np.all(np.array(p_shape) == p_shape[0]):
+            p_s = np.array([s[1] for s in p_shape])
+            if not np.all(p_s == p_s[0]):
                 raise YTInconsistentParticleFieldShape(ptype, p_shape)
     # Now that we know the particle fields are consistent, determine the number
     # of particles.
     if len(p_shapes) > 0:
-        number_of_particles = np.sum([s[0] for s in p_shapes.values()])
+        number_of_particles = np.sum([s[0][1] for s in p_shapes.values()])
     else:
         number_of_particles = 0
     return field_units, data, number_of_particles

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -63,7 +63,9 @@ from yt.geometry.grid_container import \
 from yt.utilities.decompose import \
     decompose_array, get_psize
 from yt.utilities.exceptions import \
-    YTIllDefinedAMR
+    YTIllDefinedAMR, \
+    YTInconsistentGridFieldShape, \
+    YTInconsistentParticleFieldShape
 from yt.units.yt_array import \
     YTQuantity, \
     uconcatenate
@@ -556,15 +558,14 @@ def process_data(data, grid_dims=None):
         elif n_shape == 3:
             g_shapes.append(f_shape)
     if len(g_shapes) > 0 and not np.all(np.array(g_shapes) == g_shapes[0]):
-        raise RuntimeError("Not all grid-based fields have the same shape!")
-    if len(g_shapes) > 0 and grid_dims is not None: 
+        raise YTInconsistentGridFieldShape(False)
+    if len(g_shapes) > 0 and grid_dims is not None:
         if not np.all(np.array(g_shapes) == grid_dims):
-            raise RuntimeError("Not all grid-based fields match the grid dimensions!")
+            raise YTInconsistentGridFieldShape(True)
     if len(p_shapes) > 0:
         for ptype, p_shape in p_shapes.items():
             if not np.all(np.array(p_shape) == p_shape[0]):
-                raise RuntimeError("Not all fields with field type '%s' " % ptype +
-                                   "have the same shape!")
+                raise YTInconsistentParticleFieldShape(ptype)
     # Now that we know the particle fields are consistent, determine the number
     # of particles.
     if len(p_shapes) > 0:

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -665,8 +665,8 @@ def load_uniform_grid(data, domain_dimensions, length_unit=None, bbox=None,
     data.pop("number_of_particles", 0)
     # First we fix our field names, apply units to data
     # and check for consistency of field shapes
-    field_units, data, number_of_particles = process_data(data,
-                                                          grid_dims=tuple(domain_dimensions))
+    field_units, data, number_of_particles = process_data(
+        data, grid_dims=tuple(domain_dimensions))
 
     sfh = StreamDictFieldHandler()
 
@@ -858,8 +858,8 @@ def load_amr_grids(grid_data, domain_dimensions,
         grid_levels[i,:] = g.pop("level")
         # If someone included this throw it away--old API
         g.pop("number_of_particles", None)
-        field_units, data, n_particles = process_data(g,
-                                                      grid_dims=tuple(grid_dimensions[i,:]))
+        field_units, data, n_particles = process_data(
+            g, grid_dims=tuple(grid_dimensions[i,:]))
         number_of_particles[i, :] = n_particles
         sfh[i] = data
 

--- a/yt/frontends/stream/tests/test_outputs.py
+++ b/yt/frontends/stream/tests/test_outputs.py
@@ -25,9 +25,11 @@ from yt.testing import \
     assert_equal, \
     assert_raises
 from yt.convenience import load
-from yt.utilities.exceptions import YTOutputNotIdentified, \
+from yt.utilities.exceptions import \
+    YTOutputNotIdentified, \
     YTInconsistentGridFieldShape, \
-    YTInconsistentParticleFieldShape
+    YTInconsistentParticleFieldShape, \
+    YTInconsistentGridFieldShapeGridDims
 
 class TestEmptyLoad(unittest.TestCase):
 
@@ -80,7 +82,7 @@ def test_inconsistent_field_shape():
         data = {"density": d, "temperature": t}
         load_uniform_grid(data, (32,64,32))
 
-    assert_raises(YTInconsistentGridFieldShape,
+    assert_raises(YTInconsistentGridFieldShapeGridDims,
                   load_field_grid_mismatch)
 
     def load_particle_fields_mismatch():

--- a/yt/frontends/stream/tests/test_outputs.py
+++ b/yt/frontends/stream/tests/test_outputs.py
@@ -19,12 +19,15 @@ import shutil
 import tempfile
 import unittest
 
-from yt.frontends.stream.data_structures import load_uniform_grid
+from yt.frontends.stream.data_structures import load_uniform_grid, \
+    load_particles
 from yt.testing import \
     assert_equal, \
     assert_raises
 from yt.convenience import load
-from yt.utilities.exceptions import YTOutputNotIdentified
+from yt.utilities.exceptions import YTOutputNotIdentified, \
+    YTInconsistentGridFieldShape, \
+    YTInconsistentParticleFieldShape
 
 class TestEmptyLoad(unittest.TestCase):
 
@@ -59,3 +62,35 @@ def test_dimensionless_field_units():
     dd = ds.all_data()
 
     assert_equal(Z.max(), dd["metallicity"].max())
+
+def test_inconsistent_field_shape():
+
+    def load_field_field_mismatch():
+        d = np.random.uniform(size=(32, 32, 32))
+        t = np.random.uniform(size=(32, 64, 32))
+        data = {"density": d, "temperature": t}
+        load_uniform_grid(data, (32,32,32))
+
+    assert_raises(YTInconsistentGridFieldShape,
+                  load_field_field_mismatch)
+
+    def load_field_grid_mismatch():
+        d = np.random.uniform(size=(32, 32, 32))
+        t = np.random.uniform(size=(32, 32, 32))
+        data = {"density": d, "temperature": t}
+        load_uniform_grid(data, (32,64,32))
+
+    assert_raises(YTInconsistentGridFieldShape,
+                  load_field_grid_mismatch)
+
+    def load_particle_fields_mismatch():
+        x = np.random.uniform(size=100)
+        y = np.random.uniform(size=100)
+        z = np.random.uniform(size=200)
+        data = {"particle_position_x": x,
+                "particle_position_y": y,
+                "particle_position_z": z}
+        load_particles(data)
+
+    assert_raises(YTInconsistentParticleFieldShape,
+                  load_particle_fields_mismatch)

--- a/yt/frontends/stream/tests/test_stream_particles.py
+++ b/yt/frontends/stream/tests/test_stream_particles.py
@@ -109,7 +109,8 @@ def test_stream_particles():
                     number_of_particles=grid.NumberOfParticles)
 
         for field in amr1.field_list:
-            data[field] = grid[field]
+            if field[0] != "all":
+                data[field] = grid[field]
 
         grid_data.append(data)
 
@@ -124,14 +125,14 @@ def test_stream_particles():
     assert_equal(number_of_particles1, number_of_particles2)
 
     for grid in amr1.index.grids:
-        tot_parts = grid["io","particle_position_x"].size
-        tot_all_parts = grid["all","particle_position_x"].size
+        tot_parts = grid["io", "particle_position_x"].size
+        tot_all_parts = grid["all", "particle_position_x"].size
         assert tot_parts == grid.NumberOfParticles
         assert tot_all_parts == grid.NumberOfParticles
 
     for grid in amr2.index.grids:
-        tot_parts = grid["io","particle_position_x"].size
-        tot_all_parts = grid["all","particle_position_x"].size
+        tot_parts = grid["io", "particle_position_x"].size
+        tot_all_parts = grid["all", "particle_position_x"].size
         assert tot_parts == grid.NumberOfParticles
         assert tot_all_parts == grid.NumberOfParticles
 
@@ -188,9 +189,9 @@ def test_stream_particles():
     assert_equal(number_of_particles3, number_of_particles4)
 
     for grid in ug4.index.grids:
-        tot_parts = grid["dm","particle_position_x"].size
-        tot_parts += grid["star","particle_position_x"].size
-        tot_all_parts = grid["all","particle_position_x"].size
+        tot_parts = grid["dm", "particle_position_x"].size
+        tot_parts += grid["star", "particle_position_x"].size
+        tot_all_parts = grid["all", "particle_position_x"].size
         assert tot_parts == grid.NumberOfParticles
         assert tot_all_parts == grid.NumberOfParticles
 
@@ -223,7 +224,8 @@ def test_stream_particles():
                     number_of_particles=grid.NumberOfParticles)
 
         for field in amr3.field_list:
-            data[field] = grid[field]
+            if field[0] != "all":
+                data[field] = grid[field]
 
         grid_data.append(data)
 
@@ -248,9 +250,9 @@ def test_stream_particles():
         assert amr4._get_field_info(ptype, "particle_mass").particle_type
 
     for grid in amr3.index.grids:
-        tot_parts = grid["dm","particle_position_x"].size
-        tot_parts += grid["star","particle_position_x"].size
-        tot_all_parts = grid["all","particle_position_x"].size
+        tot_parts = grid["dm", "particle_position_x"].size
+        tot_parts += grid["star", "particle_position_x"].size
+        tot_all_parts = grid["all", "particle_position_x"].size
         assert tot_parts == grid.NumberOfParticles
         assert tot_all_parts == grid.NumberOfParticles
 

--- a/yt/frontends/stream/tests/test_stream_particles.py
+++ b/yt/frontends/stream/tests/test_stream_particles.py
@@ -39,8 +39,7 @@ def test_stream_particles():
         data = dict(left_edge=grid.LeftEdge,
                     right_edge=grid.RightEdge,
                     level=grid.Level,
-                    dimensions=grid.ActiveDimensions,
-                    number_of_particles=grid.NumberOfParticles)
+                    dimensions=grid.ActiveDimensions)
 
         for field in amr0.field_list:
             data[field] = grid[field]
@@ -54,8 +53,7 @@ def test_stream_particles():
                "particle_position_x": x,
                "particle_position_y": y,
                "particle_position_z": z,
-               "particle_mass": m,
-               "number_of_particles": num_particles}
+               "particle_mass": m}
 
     fields2 = fields1.copy()
 
@@ -105,8 +103,7 @@ def test_stream_particles():
         data = dict(left_edge=grid.LeftEdge,
                     right_edge=grid.RightEdge,
                     level=grid.Level,
-                    dimensions=grid.ActiveDimensions,
-                    number_of_particles=grid.NumberOfParticles)
+                    dimensions=grid.ActiveDimensions)
 
         for field in amr1.field_list:
             if field[0] != "all":
@@ -172,8 +169,7 @@ def test_stream_particles():
                ("star", "particle_position_x"): xs,
                ("star", "particle_position_y"): ys,
                ("star", "particle_position_z"): zs,
-               ("star", "particle_mass"): ms,
-               "number_of_particles": num_dm_particles+num_star_particles}
+               ("star", "particle_mass"): ms}
 
     fields4 = fields3.copy()
 
@@ -220,8 +216,7 @@ def test_stream_particles():
         data = dict(left_edge=grid.LeftEdge,
                     right_edge=grid.RightEdge,
                     level=grid.Level,
-                    dimensions=grid.ActiveDimensions,
-                    number_of_particles=grid.NumberOfParticles)
+                    dimensions=grid.ActiveDimensions)
 
         for field in amr3.field_list:
             if field[0] != "all":

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -663,22 +663,39 @@ class YTIllDefinedAMR(YTException):
         return msg
 
 class YTInconsistentGridFieldShape(YTException):
-    def __init__(self, grid_dims_check):
-        self.grid_dims_check = grid_dims_check
+    def __init__(self, shapes):
+        self.shapes = shapes
 
     def __str__(self):
-        if self.grid_dims_check:
-            msg = "Not all grid-based fields match the grid dimensions!"
-        else:
-            msg = "Not all grid-based fields have the same shape!"
+        msg = "Not all grid-based fields have the same shape!\n"
+        for name, shape in self.shapes:
+            msg += "    Field {} has shape {}.\n".format(name, shape)
         return msg
 
 class YTInconsistentParticleFieldShape(YTException):
-    def __init__(self, ptype):
+    def __init__(self, ptype, shapes):
         self.ptype = ptype
+        self.shapes = shapes
 
     def __str__(self):
         msg = (
-            "Not all fields with field type {} have the same shape!"
+            "Not all fields with field type '{}' have the same shape!\n"
         ).format(self.ptype)
+        for name, shape in self.shapes:
+            field = (self.ptype, name)
+            msg += "    Field {} has shape {}.\n".format(field, shape)
+        return msg
+
+class YTInconsistentGridFieldShapeGridDims(YTException):
+    def __init__(self, shapes, grid_dims):
+        self.shapes = shapes
+        self.grid_dims = grid_dims
+
+    def __str__(self):
+        msg = "Not all grid-based fields match the grid dimensions! "
+        msg += "Grid dims are {}, ".format(self.grid_dims)
+        msg += "and the following fields have shapes that do not match them:\n"
+        for name, shape in self.shapes:
+            if shape != self.grid_dims:
+                msg += "    Field {} has shape {}.\n".format(name, shape)
         return msg

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -661,3 +661,24 @@ class YTIllDefinedAMR(YTException):
             "on the parent level ({} axis)"
         ).format(self.level, self.axis)
         return msg
+
+class YTInconsistentGridFieldShape(YTException):
+    def __init__(self, grid_dims_check):
+        self.grid_dims_check = grid_dims_check
+
+    def __str__(self):
+        if self.grid_dims_check:
+            msg = "Not all grid-based fields match the grid dimensions!"
+        else:
+            msg = "Not all grid-based fields have the same shape!"
+        return msg
+
+class YTInconsistentParticleFieldShape(YTException):
+    def __init__(self, ptype):
+        self.ptype = ptype
+
+    def __str__(self):
+        msg = (
+            "Not all fields with field type {} have the same shape!"
+        ).format(self.ptype)
+        return msg

--- a/yt/utilities/particle_generator.py
+++ b/yt/utilities/particle_generator.py
@@ -176,14 +176,12 @@ class ParticleGenerator(object):
         grid_data = []
         for i, g in enumerate(self.ds.index.grids):
             data = {}
-            if clobber:
-                data["number_of_particles"] = self.NumberOfParticles[i]
-            else:
-                data["number_of_particles"] = self.NumberOfParticles[i] + \
-                                              g.NumberOfParticles
+            number_of_particles = self.NumberOfParticles[i]
+            if not clobber:
+                number_of_particles += g.NumberOfParticles
             grid_particles = self.get_for_grid(g)
             for field in self.field_list:
-                if data["number_of_particles"] > 0:
+                if number_of_particles > 0:
                     if g.NumberOfParticles > 0 and not clobber and \
                         field in self.ds.field_list:
                         # We have particles in this grid, we're not


### PR DESCRIPTION
This PR refactors the stream frontend and adds one feature and simplifies the API:

* Add sanity checks to make sure that every particle field for a given type is the same shape, and that all grid-based fields for a given grid are all the same shape and have the same shape as the grid dimensions.
* Once we have convinced ourselves that the particle fields all have the same shape, use them to determine the number of particles for a given grid. This removes the need to supply `number_of_particles` as a field to the data dictionary for grid-based stream frontends. If someone supplies this key, it will be harmlessly discarded.

The `unitify_data` function, where all of this action occurs, has been renamed to `process_data`.

I've updated the docs and tests.