### PR TITLE
Error out early if user doesn't have an API key

### DIFF
--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -138,7 +138,7 @@ def _get_girder_client():
         print("this command requires girder_client to be installed")
         print("Please install them using your python package manager, e.g.:")
         print("   pip install girder_client --user")
-        exit()
+        sys.exit()
     if not ytcfg.get("yt", "hub_api_key"):
         print("Before you can access the yt Hub you need an API key")
         print("In order to obtain one, either register by typing:")
@@ -622,12 +622,12 @@ class YTHubRegisterCmd(YTCommand):
             print("yt {} requires requests to be installed".format(self.name))
             print("Please install them using your python package manager, e.g.:")
             print("   pip install requests --user")
-            exit()
+            sys.exit()
         if ytcfg.get("yt", "hub_api_key") != "":
             print("You seem to already have an API key for the hub in")
             print("{} . Delete this if you want to force a".format(CURRENT_CONFIG_FILE))
             print("new user registration.")
-            exit()
+            sys.exit()
         print("Awesome!  Let's start by registering a new user for you.")
         print("Here's the URL, for reference: http://hub.yt/ ")
         print()

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -139,7 +139,13 @@ def _get_girder_client():
         print("Please install them using your python package manager, e.g.:")
         print("   pip install girder_client --user")
         exit()
-
+    if not ytcfg.get("yt", "hub_api_key"):
+        print("Before you can access the yt Hub you need an API key")
+        print("In order to obtain one, either register by typing:")
+        print("  yt hub register")
+        print("or follow the instruction on:")
+        print("  http://yt-project.org/docs/dev/sharing_data.html#obtaining-an-api-key")
+        sys.exit()
     hub_url = urlparse(ytcfg.get("yt", "hub_url"))
     gc = girder_client.GirderClient(apiUrl=hub_url.geturl())
     gc.authenticate(apiKey=ytcfg.get("yt", "hub_api_key"))


### PR DESCRIPTION
Before:

```
 $ yt upload_notebook ~/Untitled0.ipynb 
Traceback (most recent call last):
  File "/home/xarth/local/bin/yt", line 11, in <module>
    load_entry_point('yt', 'console_scripts', 'yt')()
  File "/home/xarth/codes/xarthisius/yt/yt/utilities/command_line.py", line 1391, in run_main
    args.func(args)
  File "/home/xarth/codes/xarthisius/yt/yt/utilities/command_line.py", line 214, in run
    self(args)
  File "/home/xarth/codes/xarthisius/yt/yt/utilities/command_line.py", line 886, in __call__
    gc = _get_girder_client()
  File "/home/xarth/codes/xarthisius/yt/yt/utilities/command_line.py", line 145, in _get_girder_client
    gc.authenticate(apiKey=ytcfg.get("yt", "hub_api_key"))
  File "/home/xarth/codes/girder/clients/python/girder_client/__init__.py", line 310, in authenticate
    raise Exception('A user name and password are required')
```

after:

```
$ yt upload_notebook ~/Untitled0.ipynb 
Before you can access the yt Hub you need an API key
In order to obtain one, either register by typing:
  yt hub register
or follow the instruction on:
  http://yt-project.org/docs/dev/sharing_data.html#obtaining-an-api-key
```