### PR TITLE
Ensure grid edges are consistent with edges computed by masks

### DIFF
--- a/doc/source/reference/configuration.rst
+++ b/doc/source/reference/configuration.rst
@@ -91,6 +91,12 @@ used internally.
 * ``test_data_dir`` (default: ``'/does/not/exist'``): The default path the
   ``load()`` function searches for datasets when it cannot find a dataset in the
   current directory.
+* ``reconstruct_index`` (default: True): If True, grid edges for patch AMR
+  datasets will be adjusted such that they fall as close as possible to an
+  integer multiple of the local cell width. If you are working with a dataset
+  with a large number of grids, setting this to False can speed up loading
+  your dataset possibly at the cost of grid-aligned artifacts showing up in
+  slice visualizations.
 * ``notebook_password`` (default: empty): If set, this will be fed to the
   IPython notebook created by ``yt notebook``.  Note that this should be an
   sha512 hash, not a plaintext password.  Starting ``yt notebook`` with no

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -17,7 +17,7 @@ answer_tests:
   local_fits_001:
     - yt/frontends/fits/tests/test_outputs.py
 
-  local_flash_005:
+  local_flash_006:
     - yt/frontends/flash/tests/test_outputs.py
 
   local_gadget_001:
@@ -42,7 +42,7 @@ answer_tests:
   local_owls_001:
     - yt/frontends/owls/tests/test_outputs.py
 
-  local_pw_014:
+  local_pw_015:
     - yt/visualization/tests/test_plotwindow.py:test_attributes
     - yt/visualization/tests/test_plotwindow.py:test_attributes_wt
     - yt/visualization/tests/test_profile_plots.py:test_phase_plot_attributes
@@ -104,7 +104,7 @@ answer_tests:
     - yt/analysis_modules/absorption_spectrum/tests/test_absorption_spectrum.py:test_absorption_spectrum_cosmo_sph
     - yt/analysis_modules/absorption_spectrum/tests/test_absorption_spectrum.py:test_absorption_spectrum_with_continuum
 
-  local_axialpix_001:
+  local_axialpix_002:
     - yt/geometry/coordinates/tests/test_axial_pixelization.py:test_axial_pixelization
 
   local_particle_trajectory_000:

--- a/yt/config.py
+++ b/yt/config.py
@@ -45,6 +45,7 @@ ytcfg_defaults = dict(
     pluginfilename = 'my_plugins.py',
     parallel_traceback = 'False',
     pasteboard_repo = '',
+    reconstruct_index = 'True',
     test_storage_dir = '/does/not/exist',
     test_data_dir = '/does/not/exist',
     requires_ds_strict = 'False',

--- a/yt/config.py
+++ b/yt/config.py
@@ -45,7 +45,6 @@ ytcfg_defaults = dict(
     pluginfilename = 'my_plugins.py',
     parallel_traceback = 'False',
     pasteboard_repo = '',
-    reconstruct_index = 'False',
     test_storage_dir = '/does/not/exist',
     test_data_dir = '/does/not/exist',
     requires_ds_strict = 'False',

--- a/yt/data_objects/grid_patch.py
+++ b/yt/data_objects/grid_patch.py
@@ -184,11 +184,11 @@ class AMRGridPatch(YTSelectionContainer):
         # This can be expensive so we allow people to disable this behavior
         # via a config option
         if bool(ytcfg.get('yt', 'reconstruct_index')):
-            if iterable(self.Parent):
+            if iterable(self.Parent) and len(self.Parent) > 0:
                 p = self.Parent[0]
             else:
                 p = self.Parent
-            if p is not None:
+            if p is not None and p != []:
                 # clamp grid edges to an integer multiple of the parent cell
                 # width
                 self.LeftEdge.view(np.ndarray)[:] = clamp_edges(

--- a/yt/data_objects/grid_patch.py
+++ b/yt/data_objects/grid_patch.py
@@ -22,8 +22,7 @@ from yt.data_objects.data_containers import \
     YTSelectionContainer
 from yt.data_objects.field_data import \
     YTFieldData
-from yt.funcs import \
-    iterable
+from yt.funcs import iterable
 from yt.geometry.selection_routines import convert_mask_to_indices
 import yt.geometry.particle_deposit as particle_deposit
 from yt.utilities.exceptions import \
@@ -31,6 +30,8 @@ from yt.utilities.exceptions import \
     YTParticleDepositionNotImplemented
 from yt.utilities.lib.interpolators import \
     ghost_zone_interpolate
+from yt.utilities.lib.mesh_utilities import \
+    clamp_edges
 from yt.utilities.nodal_data_utils import \
     get_nodal_slices
 
@@ -173,31 +174,21 @@ class AMRGridPatch(YTSelectionContainer):
         h = self.index # cache it
         my_ind = self.id - self._id_offset
         self.ActiveDimensions = h.grid_dimensions[my_ind]
-        self.LeftEdge, self.RightEdge = self._clamp_edges(
-            h.grid_left_edge[my_ind], h.grid_right_edge[my_ind])
-        h.grid_levels[my_ind, 0] = self.Level
-        # This might be needed for streaming formats
-        #self.Time = h.gridTimes[my_ind,0]
-        self.NumberOfParticles = h.grid_particle_count[my_ind, 0]
-
-    def _clamp_edges(self, left_edge, right_edge):
-        if self.Parent is None or self.Parent == []:
-            return left_edge, right_edge
-        start_index = np.zeros((2, 3))
+        self.LeftEdge = h.grid_left_edge[my_ind]
+        self.RightEdge = h.grid_right_edge[my_ind]
         if iterable(self.Parent):
             p = self.Parent[0]
         else:
             p = self.Parent
-        pdx = p.dds
-        start_index[0, :] = (left_edge - p.LeftEdge) / pdx
-        start_index[1, :] = (right_edge - p.LeftEdge) / pdx
-        integer_index = np.rint(start_index)
-        need_adjustment = (start_index != integer_index).any(axis=1)
-        if need_adjustment[0]:
-            left_edge = (integer_index[0, :] * pdx + p.LeftEdge)
-        elif need_adjustment[1]:
-            right_edge = (integer_index[1, :] * pdx + p.LeftEdge)
-        return left_edge, right_edge
+        if p is not None:
+            self.LeftEdge[:] = clamp_edges(
+                self.LeftEdge.d, p.LeftEdge.d, p.dds.d)
+            self.RightEdge[:] = clamp_edges(
+                self.RightEdge.d, p.LeftEdge.d, p.dds.d)
+        h.grid_levels[my_ind, 0] = self.Level
+        # This might be needed for streaming formats
+        #self.Time = h.gridTimes[my_ind,0]
+        self.NumberOfParticles = h.grid_particle_count[my_ind, 0]
 
     def get_position(self, index):
         """ Returns center position of an *index*. """

--- a/yt/data_objects/grid_patch.py
+++ b/yt/data_objects/grid_patch.py
@@ -193,10 +193,8 @@ class AMRGridPatch(YTSelectionContainer):
             if p is not None and p != []:
                 # clamp grid edges to an integer multiple of the parent cell
                 # width
-                self.LeftEdge.view(np.ndarray)[:] = clamp_edges(
-                    self.LeftEdge, p.LeftEdge, p.dds)
-                self.RightEdge.view(np.ndarray)[:] = clamp_edges(
-                    self.RightEdge, p.LeftEdge, p.dds)
+                clamp_edges(self.LeftEdge, p.LeftEdge, p.dds)
+                clamp_edges(self.RightEdge, p.LeftEdge, p.dds)
         h.grid_levels[my_ind, 0] = self.Level
         # This might be needed for streaming formats
         #self.Time = h.gridTimes[my_ind,0]

--- a/yt/data_objects/grid_patch.py
+++ b/yt/data_objects/grid_patch.py
@@ -69,6 +69,7 @@ class AMRGridPatch(YTSelectionContainer):
         self._last_selector_id = None
         self._current_particle_type = 'all'
         self._current_fluid_type = self.ds.default_fluid_type
+        self._reconstruct_index = bool(ytcfg.get('yt', 'reconstruct_index'))
 
     def get_global_startindex(self):
         """
@@ -183,7 +184,7 @@ class AMRGridPatch(YTSelectionContainer):
         self.RightEdge = h.grid_right_edge[my_ind]
         # This can be expensive so we allow people to disable this behavior
         # via a config option
-        if bool(ytcfg.get('yt', 'reconstruct_index')):
+        if self._reconstruct_index:
             if iterable(self.Parent) and len(self.Parent) > 0:
                 p = self.Parent[0]
             else:

--- a/yt/data_objects/grid_patch.py
+++ b/yt/data_objects/grid_patch.py
@@ -37,6 +37,8 @@ from yt.utilities.lib.mesh_utilities import \
 from yt.utilities.nodal_data_utils import \
     get_nodal_slices
 
+RECONSTRUCT_INDEX = bool(ytcfg.get('yt', 'reconstruct_index'))
+
 class AMRGridPatch(YTSelectionContainer):
     _spatial = True
     _num_ghost_zones = 0
@@ -69,7 +71,6 @@ class AMRGridPatch(YTSelectionContainer):
         self._last_selector_id = None
         self._current_particle_type = 'all'
         self._current_fluid_type = self.ds.default_fluid_type
-        self._reconstruct_index = bool(ytcfg.get('yt', 'reconstruct_index'))
 
     def get_global_startindex(self):
         """
@@ -184,7 +185,7 @@ class AMRGridPatch(YTSelectionContainer):
         self.RightEdge = h.grid_right_edge[my_ind]
         # This can be expensive so we allow people to disable this behavior
         # via a config option
-        if self._reconstruct_index:
+        if RECONSTRUCT_INDEX:
             if iterable(self.Parent) and len(self.Parent) > 0:
                 p = self.Parent[0]
             else:

--- a/yt/frontends/enzo/data_structures.py
+++ b/yt/frontends/enzo/data_structures.py
@@ -30,7 +30,6 @@ from yt.funcs import \
     ensure_tuple, \
     get_pbar, \
     setdefaultattr
-from yt.config import ytcfg
 from yt.data_objects.grid_patch import \
     AMRGridPatch
 from yt.geometry.grid_geometry_handler import \

--- a/yt/frontends/enzo/data_structures.py
+++ b/yt/frontends/enzo/data_structures.py
@@ -66,28 +66,6 @@ class EnzoGrid(AMRGridPatch):
         self._parent_id = -1
         self.Level = -1
 
-    def _guess_properties_from_parent(self):
-        """
-        We know that our grid boundary occurs on the cell boundary of our
-        parent.  This can be a very expensive process, but it is necessary
-        in some indexs, where yt is unable to generate a completely
-        space-filling tiling of grids, possibly due to the finite accuracy in a
-        standard Enzo index file.
-        """
-        rf = self.ds.refine_by
-        my_ind = self.id - self._id_offset
-        self.dds = self.Parent.dds/rf
-        ParentLeftIndex = np.rint((self.LeftEdge-self.Parent.LeftEdge)/self.Parent.dds)
-        self.start_index = rf*(ParentLeftIndex + self.Parent.get_global_startindex()).astype('int64')
-        self.LeftEdge = self.Parent.LeftEdge + self.Parent.dds * ParentLeftIndex
-        self.RightEdge = self.LeftEdge + self.ActiveDimensions*self.dds
-        self.index.grid_left_edge[my_ind,:] = self.LeftEdge
-        self.index.grid_right_edge[my_ind,:] = self.RightEdge
-        self._child_mask = None
-        self._child_index_mask = None
-        self._child_indices = None
-        self._setup_dx()
-
     def set_filename(self, filename):
         """
         Intelligently set the filename.

--- a/yt/frontends/enzo/data_structures.py
+++ b/yt/frontends/enzo/data_structures.py
@@ -380,13 +380,10 @@ class EnzoHierarchy(GridIndex):
         mylog.info("Finished rebuilding")
 
     def _populate_grid_objects(self):
-        reconstruct = ytcfg.getboolean("yt","reconstruct_index")
         for g,f in izip(self.grids, self.filenames):
             g._prepare_grid()
             g._setup_dx()
             g.set_filename(f[0])
-            if reconstruct:
-                if g.Parent is not None: g._guess_properties_from_parent()
         del self.filenames # No longer needed.
         self.max_level = self.grid_levels.max()
 

--- a/yt/frontends/enzo/tests/test_outputs.py
+++ b/yt/frontends/enzo/tests/test_outputs.py
@@ -28,6 +28,8 @@ from yt.utilities.answer_testing.framework import \
     data_dir_load, \
     AnalyticHaloMassFunctionTest, \
     SimulatedHaloMassFunctionTest
+from yt.visualization.plot_window import \
+    SlicePlot
 from yt.frontends.enzo.api import EnzoDataset
 from yt.frontends.enzo.fields import NODAL_FLAGS
 
@@ -42,6 +44,7 @@ enzotiny = "enzo_tiny_cosmology/DD0046/DD0046"
 toro1d = "ToroShockTube/DD0001/data0001"
 kh2d = "EnzoKelvinHelmholtz/DD0011/DD0011"
 mhdctot = "MHDCTOrszagTang/DD0004/data0004"
+dnz = "DeeplyNestedZoom/DD0025/data0025"
 
 def check_color_conservation(ds):
     species_names = ds.field_info.species_names
@@ -191,3 +194,17 @@ def test_face_centered_mhdct_fields():
     assert (ad['BxF'].sum(axis=-1)/2 == ad['Bx']).all()
     assert (ad['ByF'].sum(axis=-1)/2 == ad['By']).all()
     assert (ad['BzF'].sum(axis=-1)/2 == ad['Bz']).all()
+
+@requires_file(dnz)
+def test_deeply_nested_zoom():
+    ds = data_dir_load(dnz)
+
+    # carefully chosen to just barely miss a grid in the middle of the image
+    center = [0.4915073260199302, 0.5052605316800006, 0.4905805557500548]
+    
+    plot = SlicePlot(ds, 'z', 'density', width=(0.001, 'pc'),
+                     center=center)
+
+    image = plot.frb['density']
+
+    assert (image > 0).all()

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -97,21 +97,6 @@ class StreamGrid(AMRGridPatch):
         self._parent_id = -1
         self.Level = -1
 
-    def _guess_properties_from_parent(self):
-        rf = self.ds.refine_by
-        my_ind = self.id - self._id_offset
-        self.dds = self.Parent.dds/rf
-        ParentLeftIndex = np.rint((self.LeftEdge-self.Parent.LeftEdge)/self.Parent.dds)
-        self.start_index = rf*(ParentLeftIndex + self.Parent.get_global_startindex()).astype('int64')
-        self.LeftEdge = self.Parent.LeftEdge + self.Parent.dds * ParentLeftIndex
-        self.RightEdge = self.LeftEdge + self.ActiveDimensions*self.dds
-        self.index.grid_left_edge[my_ind,:] = self.LeftEdge
-        self.index.grid_right_edge[my_ind,:] = self.RightEdge
-        self._child_mask = None
-        self._child_index_mask = None
-        self._child_indices = None
-        self._setup_dx()
-
     def set_filename(self, filename):
         pass
 

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -191,6 +191,7 @@ class StreamHierarchy(GridIndex):
             if (i%1e4) == 0: mylog.debug("Prepared % 7i / % 7i grids", i, self.num_grids)
             grid.filename = None
             grid._prepare_grid()
+            grid._setup_dx()
             grid.proc_num = self.grid_procs[i]
             temp_grids[i] = grid
         self.grids = temp_grids

--- a/yt/geometry/grid_geometry_handler.py
+++ b/yt/geometry/grid_geometry_handler.py
@@ -53,9 +53,6 @@ class GridIndex(Index):
         mylog.debug("Constructing grid objects.")
         self._populate_grid_objects()
 
-        mylog.debug("Adjusting grids")
-        self._clamp_grid_edges()
-
         mylog.debug("Re-examining index")
         self._initialize_level_stats()
 
@@ -107,35 +104,6 @@ class GridIndex(Index):
                                     self.float_type), 'code_length')
         self.grid_levels = np.zeros((self.num_grids,1), 'int32')
         self.grid_particle_count = np.zeros((self.num_grids,1), 'int32')
-
-    def _clamp_grid_edges(self):
-        for g in self.grids:
-            start_index = np.zeros((2, 3))
-            if g.Parent is None:
-                left = g.LeftEdge - self.ds.domain_left_edge
-                start_index[0, :] = left/g.dds
-                right = g.RightEdge - self.ds.domain_left_edge
-                start_index[1, :] = right/g.dds
-            else:
-                pdx = g.Parent.dds
-                start_index[0, :] = (g.LeftEdge - g.Parent.LeftEdge) / pdx
-                start_index[1, :] = (g.RightEdge - g.Parent.LeftEdge) / pdx
-            integer_index = np.rint(start_index)
-            need_adjustment = (start_index != integer_index).any(axis=1)
-            if np.any(need_adjustment):
-                wh = np.where(need_adjustment)[0]
-                for d in wh:
-                    if g.Parent is None:
-                        new_edge = (integer_index[d, :] * g.dds +
-                                    self.ds.domain_left_edge)
-                    else:
-                        new_edge = (integer_index[d, :] * pdx +
-                                    g.Parent.LeftEdge)
-                    if d == 0:
-                        g.LeftEdge = new_edge
-                    elif d == 1:
-                        g.RightEdge = new_edge
-
 
     def clear_all_data(self):
         """

--- a/yt/geometry/grid_geometry_handler.py
+++ b/yt/geometry/grid_geometry_handler.py
@@ -53,6 +53,9 @@ class GridIndex(Index):
         mylog.debug("Constructing grid objects.")
         self._populate_grid_objects()
 
+        mylog.debug("Adjusting grids")
+        self._clamp_grid_edges()
+
         mylog.debug("Re-examining index")
         self._initialize_level_stats()
 
@@ -104,6 +107,35 @@ class GridIndex(Index):
                                     self.float_type), 'code_length')
         self.grid_levels = np.zeros((self.num_grids,1), 'int32')
         self.grid_particle_count = np.zeros((self.num_grids,1), 'int32')
+
+    def _clamp_grid_edges(self):
+        for g in self.grids:
+            start_index = np.zeros((2, 3))
+            if g.Parent is None:
+                left = g.LeftEdge - self.ds.domain_left_edge
+                start_index[0, :] = left/g.dds
+                right = g.RightEdge - self.ds.domain_left_edge
+                start_index[1, :] = right/g.dds
+            else:
+                pdx = g.Parent.dds
+                start_index[0, :] = (g.LeftEdge - g.Parent.LeftEdge) / pdx
+                start_index[1, :] = (g.RightEdge - g.Parent.LeftEdge) / pdx
+            integer_index = np.rint(start_index)
+            need_adjustment = (start_index != integer_index).any(axis=1)
+            if np.any(need_adjustment):
+                wh = np.where(need_adjustment)[0]
+                for d in wh:
+                    if g.Parent is None:
+                        new_edge = (integer_index[d, :] * g.dds +
+                                    self.ds.domain_left_edge)
+                    else:
+                        new_edge = (integer_index[d, :] * pdx +
+                                    g.Parent.LeftEdge)
+                    if d == 0:
+                        g.LeftEdge = new_edge
+                    elif d == 1:
+                        g.RightEdge = new_edge
+
 
     def clear_all_data(self):
         """

--- a/yt/utilities/lib/mesh_utilities.pyx
+++ b/yt/utilities/lib/mesh_utilities.pyx
@@ -17,6 +17,7 @@ import numpy as np
 cimport numpy as np
 cimport cython
 from libc.stdlib cimport malloc, free, abs
+from libc.math cimport rint
 from yt.utilities.lib.fp_utils cimport imax, fmax, imin, fmin, iclip, fclip, i64clip
 
 @cython.boundscheck(False)
@@ -97,4 +98,22 @@ def smallest_fwidth(np.ndarray[np.float64_t, ndim=2] coords,
         for j in range(3):
             fwidth = fmin(fwidth, RE[j] - LE[j])
     return fwidth
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.cdivision(True)
+cpdef np.float64_t[:] clamp_edges(np.float64_t[:] edge, np.float64_t[:] pleft,
+                                  np.float64_t[:] pdx):
+    cdef np.float64_t start_index
+    cdef np.float64_t integer_index
+    cdef np.intp_t shape = edge.shape[0]
+    cdef np.float64_t[:] ret = np.empty(shape)
+    for i in range(shape):
+        start_index = (edge[i] - pleft[i]) / pdx[i]
+        integer_index = rint(start_index)
+        if start_index != integer_index:
+            ret[i] = integer_index * pdx[i] + pleft[i]
+        else:
+            ret[i] = edge[i]
+    return ret
 

--- a/yt/utilities/lib/mesh_utilities.pyx
+++ b/yt/utilities/lib/mesh_utilities.pyx
@@ -19,6 +19,7 @@ cimport cython
 from libc.stdlib cimport malloc, free, abs
 from libc.math cimport rint
 from yt.utilities.lib.fp_utils cimport imax, fmax, imin, fmin, iclip, fclip, i64clip
+from yt.units.yt_array import YTArray
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
@@ -102,8 +103,9 @@ def smallest_fwidth(np.ndarray[np.float64_t, ndim=2] coords,
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-cpdef np.float64_t[:] clamp_edges(np.float64_t[:] edge, np.float64_t[:] pleft,
-                                  np.float64_t[:] pdx):
+def clamp_edges(np.float64_t[:] edge, np.float64_t[:] pleft,
+                np.float64_t[:] pdx):
+    """Clamp edge to pleft + pdx*n where n is the closest integer"""
     cdef np.float64_t start_index
     cdef np.float64_t integer_index
     cdef np.intp_t shape = edge.shape[0]
@@ -116,4 +118,3 @@ cpdef np.float64_t[:] clamp_edges(np.float64_t[:] edge, np.float64_t[:] pleft,
         else:
             ret[i] = edge[i]
     return ret
-

--- a/yt/utilities/lib/mesh_utilities.pyx
+++ b/yt/utilities/lib/mesh_utilities.pyx
@@ -105,16 +105,14 @@ def smallest_fwidth(np.ndarray[np.float64_t, ndim=2] coords,
 @cython.cdivision(True)
 def clamp_edges(np.float64_t[:] edge, np.float64_t[:] pleft,
                 np.float64_t[:] pdx):
-    """Clamp edge to pleft + pdx*n where n is the closest integer"""
+    """Clamp edge to pleft + pdx*n where n is the closest integer
+
+    Note that edge is modified in-place.
+    """
     cdef np.float64_t start_index
     cdef np.float64_t integer_index
     cdef np.intp_t shape = edge.shape[0]
-    cdef np.float64_t[:] ret = np.empty(shape)
     for i in range(shape):
         start_index = (edge[i] - pleft[i]) / pdx[i]
         integer_index = rint(start_index)
-        if start_index != integer_index:
-            ret[i] = integer_index * pdx[i] + pleft[i]
-        else:
-            ret[i] = edge[i]
-    return ret
+        edge[i] = integer_index * pdx[i] + pleft[i]


### PR DESCRIPTION
This is an attempt to fix #1431. I'm PRing now to see if this causes any test breakage.

There is an existing fix for this issue that is specific to the Enzo frontend that's already in the code. Unfortunately, It's hidden behind an undocumented configuration variable. I also suspect that it's doing too much work and that all we need to do is adjust the grid edges. I've opted to delete that old fix in favor of a solution that will work for all grid frontends and is always turned on.

TODO:

- [x] Benchmark on a dataset with lots of grids
- [x] Add a test
