### PR TITLE
Transposing octree data for particle octree subsets. Closes #1405.

### DIFF
--- a/yt/data_objects/octree_subset.py
+++ b/yt/data_objects/octree_subset.py
@@ -445,7 +445,7 @@ class OctreeSubsetBlockSlicePosition(object):
 
     def __getitem__(self, key):
         bs = self.block_slice
-        rv = bs.octree_subset[key][:,:,:,self.ind]
+        rv = bs.octree_subset[key][:,:,:,self.ind].T
         if bs.octree_subset._block_reorder:
             rv = rv.copy(order=bs.octree_subset._block_reorder)
         return rv


### PR DESCRIPTION
This addresses #1405 and does so by transposing the arrays returned when iterating over and accessing data inside an octree subset.  This should only affect things that require grid-like access, which I *believe* is exclusively off-axis projections at present.