### PR TITLE
Refactor volume rendering to eliminate need for ImageContainer struct

### DIFF
--- a/yt/utilities/lib/grid_traversal.pxd
+++ b/yt/utilities/lib/grid_traversal.pxd
@@ -17,7 +17,7 @@ Definitions for the traversal code
 import numpy as np
 cimport numpy as np
 cimport cython
-from .image_samplers cimport ImageContainer, ImageSampler
+from .image_samplers cimport ImageSampler
 from .volume_container cimport VolumeContainer, vc_index, vc_pos_index
 
 ctypedef void sampler_function(

--- a/yt/utilities/lib/grid_traversal.pyx
+++ b/yt/utilities/lib/grid_traversal.pyx
@@ -28,11 +28,6 @@ from fixed_interpolator cimport *
 
 from cython.parallel import prange, parallel, threadid
 
-from .image_samplers cimport \
-    ImageSampler, \
-    ImageContainer, \
-    VolumeRenderAccumulator
-
 DEF Nch = 4
 
 @cython.boundscheck(False)

--- a/yt/utilities/lib/image_samplers.pxd
+++ b/yt/utilities/lib/image_samplers.pxd
@@ -19,10 +19,6 @@ cimport numpy as np
 cimport cython
 cimport kdtree_utils
 from .volume_container cimport VolumeContainer
-from .lenses cimport \
-    calculate_extent_function, \
-    generate_vector_info_function, \
-    ImageContainer
 from .partitioned_grid cimport PartitionedGrid
 
 DEF Nch = 4
@@ -32,12 +28,32 @@ DEF Nch = 4
 # declare.
 cdef struct VolumeRenderAccumulator
 
+ctypedef int calculate_extent_function(ImageSampler image,
+            VolumeContainer *vc, np.int64_t rv[4]) nogil except -1
+
+ctypedef void generate_vector_info_function(ImageSampler im,
+            np.int64_t vi, np.int64_t vj,
+            np.float64_t width[2],
+            np.float64_t v_dir[3], np.float64_t v_pos[3]) nogil
+
 cdef struct ImageAccumulator:
     np.float64_t rgba[Nch]
     void *supp_data
 
 cdef class ImageSampler:
-    cdef ImageContainer *image
+    cdef np.float64_t[:,:,:] vp_pos
+    cdef np.float64_t[:,:,:] vp_dir
+    cdef np.float64_t *center
+    cdef np.float64_t[:,:,:] image
+    cdef np.float64_t[:,:] zbuffer
+    cdef np.int64_t[:,:] image_used
+    cdef np.int64_t[:,:] mesh_lines
+    cdef np.float64_t pdx, pdy
+    cdef np.float64_t bounds[4]
+    cdef np.float64_t[:,:] camera_data   # position, width, unit_vec[0,2]
+    cdef int nv[2]
+    cdef np.float64_t *x_vec
+    cdef np.float64_t *y_vec
     cdef public object acenter, aimage, ax_vec, ay_vec
     cdef public object azbuffer
     cdef public object aimage_used

--- a/yt/utilities/lib/image_samplers.pyx
+++ b/yt/utilities/lib/image_samplers.pyx
@@ -68,16 +68,11 @@ cdef class ImageSampler:
                   np.ndarray[np.float64_t, ndim=1] y_vec,
                   np.ndarray[np.float64_t, ndim=1] width,
                   *args, **kwargs):
-        self.image = <ImageContainer *> calloc(sizeof(ImageContainer), 1)
-        cdef np.float64_t[:,:] zbuffer
-        cdef np.int64_t[:,:] image_used
-        cdef np.int64_t[:,:] mesh_lines
-        cdef np.float64_t[:,:] camera_data
         cdef int i
 
         camera_data = kwargs.pop("camera_data", None)
         if camera_data is not None:
-            self.image.camera_data = camera_data
+            self.camera_data = camera_data
 
         zbuffer = kwargs.pop("zbuffer", None)
         if zbuffer is None:
@@ -110,26 +105,26 @@ cdef class ImageSampler:
         # de-allocation from reference counts.  Note that we do this to the
         # "atleast_3d" versions.  Also, note that we re-assign the input
         # arguments.
-        self.image.vp_pos = vp_pos
-        self.image.vp_dir = vp_dir
-        self.image.image = self.aimage = image
+        self.vp_pos = vp_pos
+        self.vp_dir = vp_dir
+        self.image = self.aimage = image
         self.acenter = center
-        self.image.center = <np.float64_t *> center.data
+        self.center = <np.float64_t *> center.data
         self.ax_vec = x_vec
-        self.image.x_vec = <np.float64_t *> x_vec.data
+        self.x_vec = <np.float64_t *> x_vec.data
         self.ay_vec = y_vec
-        self.image.y_vec = <np.float64_t *> y_vec.data
-        self.image.zbuffer = zbuffer
+        self.y_vec = <np.float64_t *> y_vec.data
+        self.zbuffer = zbuffer
         self.azbuffer = np.asarray(zbuffer)
-        self.image.image_used = image_used
+        self.image_used = image_used
         self.aimage_used = np.asarray(image_used)
-        self.image.mesh_lines = mesh_lines
+        self.mesh_lines = mesh_lines
         self.amesh_lines = np.asarray(mesh_lines)
-        self.image.nv[0] = image.shape[0]
-        self.image.nv[1] = image.shape[1]
-        for i in range(4): self.image.bounds[i] = bounds[i]
-        self.image.pdx = (bounds[1] - bounds[0])/self.image.nv[0]
-        self.image.pdy = (bounds[3] - bounds[2])/self.image.nv[1]
+        self.nv[0] = image.shape[0]
+        self.nv[1] = image.shape[1]
+        for i in range(4): self.bounds[i] = bounds[i]
+        self.pdx = (bounds[1] - bounds[0])/self.nv[0]
+        self.pdy = (bounds[3] - bounds[2])/self.nv[1]
         for i in range(3):
             self.width[i] = width[i]
 
@@ -143,18 +138,17 @@ cdef class ImageSampler:
         cdef int vi, vj, hit, i, j
         cdef np.int64_t iter[4]
         cdef VolumeContainer *vc = pg.container
-        cdef ImageContainer *im = self.image
         self.setup(pg)
         cdef np.float64_t *v_pos
         cdef np.float64_t *v_dir
         cdef np.float64_t max_t
         hit = 0
         cdef np.int64_t nx, ny, size
-        self.extent_function(self.image, vc, iter)
-        iter[0] = i64clip(iter[0]-1, 0, im.nv[0])
-        iter[1] = i64clip(iter[1]+1, 0, im.nv[0])
-        iter[2] = i64clip(iter[2]-1, 0, im.nv[1])
-        iter[3] = i64clip(iter[3]+1, 0, im.nv[1])
+        self.extent_function(self, vc, iter)
+        iter[0] = i64clip(iter[0]-1, 0, self.nv[0])
+        iter[1] = i64clip(iter[1]+1, 0, self.nv[0])
+        iter[2] = i64clip(iter[2]-1, 0, self.nv[1])
+        iter[3] = i64clip(iter[3]+1, 0, self.nv[1])
         nx = (iter[1] - iter[0])
         ny = (iter[3] - iter[2])
         size = nx * ny
@@ -173,17 +167,18 @@ cdef class ImageSampler:
                 vi = (j - vj) / ny + iter[0]
                 vj = vj + iter[2]
                 # Dynamically calculate the position
-                self.vector_function(im, vi, vj, width, v_dir, v_pos)
+                self.vector_function(self, vi, vj, width, v_dir, v_pos)
                 for i in range(Nch):
-                    idata.rgba[i] = im.image[vi, vj, i]
-                max_t = fclip(im.zbuffer[vi, vj], 0.0, 1.0)
+                    idata.rgba[i] = self.image[vi, vj, i]
+                max_t = fclip(self.zbuffer[vi, vj], 0.0, 1.0)
                 walk_volume(vc, v_pos, v_dir, self.sample,
                             (<void *> idata), NULL, max_t)
                 if (j % (10*chunksize)) == 0:
                     with gil:
                         PyErr_CheckSignals()
                 for i in range(Nch):
-                    im.image[vi, vj, i] = idata.rgba[i]
+                    self.image[vi, vj, i] = idata.rgba[i]
+            idata.supp_data = NULL
             free(idata)
             free(v_pos)
             free(v_dir)
@@ -213,23 +208,6 @@ cdef class ImageSampler:
             params['bounds'] = tuple(b.in_units('code_length').d for b in bounds)
 
         return params
-
-    def __dealloc__(self):
-        self.image.image = None
-        self.image.vp_pos = None
-        self.image.vp_dir = None
-        self.image.zbuffer = None
-        self.image.image_used = None
-        self.image.mesh_lines = None
-        self.image.camera_data = None
-        self.aimage = None
-        self.acenter = None
-        self.ax_vec = None
-        self.ay_vec = None
-        self.azbuffer = None
-        self.aimage_used = None
-        self.amesh_lines = None
-        free(self.image)
 
 cdef class ProjectionSampler(ImageSampler):
 

--- a/yt/utilities/lib/lenses.pxd
+++ b/yt/utilities/lib/lenses.pxd
@@ -22,36 +22,16 @@ from vec3_ops cimport dot, subtract, L2_norm, fma
 from libc.math cimport exp, floor, log2, \
     fabs, atan, atan2, asin, cos, sin, sqrt, acos, M_PI
 from yt.utilities.lib.fp_utils cimport imax, fmax, imin, fmin, iclip, fclip, i64clip
+from .image_samplers cimport \
+    ImageSampler, \
+    calculate_extent_function, \
+    generate_vector_info_function
 
 cdef extern from "platform_dep.h":
     long int lrint(double x) nogil
 
 cdef extern from "limits.h":
     cdef int SHRT_MAX
-
-cdef struct ImageContainer:
-    np.float64_t[:,:,:] vp_pos
-    np.float64_t[:,:,:] vp_dir
-    np.float64_t *center
-    np.float64_t[:,:,:] image
-    np.float64_t[:,:] zbuffer
-    np.int64_t[:,:] image_used
-    np.int64_t[:,:] mesh_lines
-    np.float64_t pdx, pdy
-    np.float64_t bounds[4]
-    np.float64_t[:,:] camera_data   # position, width, unit_vec[0,2]
-    int nv[2]
-    np.float64_t *x_vec
-    np.float64_t *y_vec
-
-
-ctypedef int calculate_extent_function(ImageContainer *image,
-            VolumeContainer *vc, np.int64_t rv[4]) nogil except -1
-
-ctypedef void generate_vector_info_function(ImageContainer *im,
-            np.int64_t vi, np.int64_t vj,
-            np.float64_t width[2],
-            np.float64_t v_dir[3], np.float64_t v_pos[3]) nogil
 
 cdef generate_vector_info_function generate_vector_info_plane_parallel
 cdef generate_vector_info_function generate_vector_info_null

--- a/yt/utilities/lib/lenses.pyx
+++ b/yt/utilities/lib/lenses.pyx
@@ -16,12 +16,12 @@ Functions for computing the extent of lenses and whatnot
 import numpy as np
 cimport numpy as np
 cimport cython
-from .image_samplers cimport ImageContainer
+from .image_samplers cimport ImageSampler
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-cdef int calculate_extent_plane_parallel(ImageContainer *image,
+cdef int calculate_extent_plane_parallel(ImageSampler image,
             VolumeContainer *vc, np.int64_t rv[4]) nogil except -1:
     # We do this for all eight corners
     cdef np.float64_t temp
@@ -59,7 +59,7 @@ cdef int calculate_extent_plane_parallel(ImageContainer *image,
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-cdef int calculate_extent_perspective(ImageContainer *image,
+cdef int calculate_extent_perspective(ImageSampler image,
             VolumeContainer *vc, np.int64_t rv[4]) nogil except -1:
 
     cdef np.float64_t cam_pos[3]
@@ -168,7 +168,7 @@ cdef int calculate_extent_perspective(ImageContainer *image,
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-cdef int calculate_extent_null(ImageContainer *image,
+cdef int calculate_extent_null(ImageSampler image,
             VolumeContainer *vc, np.int64_t rv[4]) nogil except -1:
     rv[0] = 0
     rv[1] = image.nv[0]
@@ -178,7 +178,7 @@ cdef int calculate_extent_null(ImageContainer *image,
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef void generate_vector_info_plane_parallel(ImageContainer *im,
+cdef void generate_vector_info_plane_parallel(ImageSampler im,
             np.int64_t vi, np.int64_t vj,
             np.float64_t width[2],
             # Now outbound
@@ -195,7 +195,7 @@ cdef void generate_vector_info_plane_parallel(ImageContainer *im,
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef void generate_vector_info_null(ImageContainer *im,
+cdef void generate_vector_info_null(ImageSampler im,
             np.int64_t vi, np.int64_t vj,
             np.float64_t width[2],
             # Now outbound

--- a/yt/utilities/lib/mesh_traversal.pyx
+++ b/yt/utilities/lib/mesh_traversal.pyx
@@ -23,8 +23,6 @@ cimport pyembree.rtcore_geometry as rtcg
 cimport pyembree.rtcore_scene as rtcs
 from .image_samplers cimport \
     ImageSampler
-from .lenses cimport \
-    ImageContainer
 from cython.parallel import prange, parallel, threadid
 from yt.visualization.image_writer import apply_colormap
 from yt.utilities.lib.bounding_volume_hierarchy cimport BVH, Ray
@@ -63,15 +61,14 @@ cdef class EmbreeMeshSampler(ImageSampler):
 
         rtcs.rtcCommit(scene.scene_i)
         cdef int vi, vj, i, j
-        cdef ImageContainer *im = self.image
         cdef np.float64_t *v_pos
         cdef np.float64_t *v_dir
         cdef np.int64_t nx, ny, size
         cdef np.float64_t width[3]
         for i in range(3):
             width[i] = self.width[i]
-        nx = im.nv[0]
-        ny = im.nv[1]
+        nx = self.nv[0]
+        ny = self.nv[1]
         size = nx * ny
         cdef rtcr.RTCRay ray
         v_pos = <np.float64_t *> malloc(3 * sizeof(np.float64_t))
@@ -93,9 +90,9 @@ cdef class EmbreeMeshSampler(ImageSampler):
             ray.time = 0
             ray.Ng[0] = 1e37  # we use this to track the hit distance
             rtcs.rtcIntersect(scene.scene_i, ray)
-            im.image[vi, vj, 0] = ray.time
-            im.image_used[vi, vj] = ray.primID
-            im.mesh_lines[vi, vj] = ray.instID
-            im.zbuffer[vi, vj] = ray.tfar
+            self.image[vi, vj, 0] = ray.time
+            self.image_used[vi, vj] = ray.primID
+            self.mesh_lines[vi, vj] = ray.instID
+            self.zbuffer[vi, vj] = ray.tfar
         free(v_pos)
         free(v_dir)

--- a/yt/utilities/lib/mesh_traversal.pyx
+++ b/yt/utilities/lib/mesh_traversal.pyx
@@ -77,7 +77,7 @@ cdef class EmbreeMeshSampler(ImageSampler):
             vj = j % ny
             vi = (j - vj) / ny
             vj = vj
-            self.vector_function(im, vi, vj, width, v_dir, v_pos)
+            self.vector_function(self, vi, vj, width, v_dir, v_pos)
             for i in range(3):
                 ray.org[i] = v_pos[i]
                 ray.dir[i] = v_dir[i]


### PR DESCRIPTION
Closes #1374

To evaluate this PR consider the following script:

```python
import yt
from yt.testing import fake_random_ds

from pympler import tracker

tracker = tracker.SummaryTracker()

ds = fake_random_ds(16)
sc = yt.create_scene(ds)
sc.render()
del sc
del ds

tracker.print_diff()
```

This is a little bit different from the script in #1374 in that it has the nice feature that the stuff between the creation of the `SummaryTracker` and the call to `tracker.print_diff` should in principle have no side effects.

Before this PR I get the following output:

```
                                                   types |   # objects |   total size
========================================================= | =========== | ============
                                    <class 'numpy.ndarray |          10 |      6.01 MB
                                             <class 'list |       12003 |      1.11 MB
                                              <class 'str |       12509 |    904.12 KB
                                             <class 'dict |         151 |    117.38 KB
                                              <class 'int |        3028 |     84.93 KB
                                            <class 'tuple |         895 |     73.38 KB
                 <class 'sympy.core.assumptions.StdFactKB |         114 |     59.72 KB
                         <class 'functools._lru_list_elem |         614 |     47.97 KB
                        <class 'yt.units.yt_array.YTArray |           9 |     33.15 KB
                        <class 'yt.units.unit_object.Unit |         133 |     15.59 KB
                                             <class 'type |           0 |     12.00 KB
                               <class 'sympy.core.mul.Mul |         126 |      8.86 KB
                             <class 'sympy.core.power.Pow |          89 |      6.26 KB
                                            <class 'float |         127 |      2.98 KB
  <class 'yt.data_objects.static_output.RegisteredDataset |           0 |      2.91 KB
```

And after, I get:

```
                                                    types |   # objects |   total size
========================================================= | =========== | ============
                                             <class 'list |       11996 |      1.11 MB
                                              <class 'str |       12509 |    904.12 KB
                                             <class 'dict |         140 |    115.78 KB
                                              <class 'int |        3004 |     84.18 KB
                                            <class 'tuple |         857 |     70.23 KB
                 <class 'sympy.core.assumptions.StdFactKB |         108 |     53.44 KB
                         <class 'functools._lru_list_elem |         588 |     45.94 KB
                        <class 'yt.units.yt_array.YTArray |           7 |     32.88 KB
                        <class 'yt.units.unit_object.Unit |         133 |     15.59 KB
                                    <class 'numpy.ndarray |           5 |     12.62 KB
                                             <class 'type |           0 |     12.00 KB
                               <class 'sympy.core.mul.Mul |         123 |      8.65 KB
                             <class 'sympy.core.power.Pow |          89 |      6.26 KB
                                            <class 'float |         127 |      2.98 KB
  <class 'yt.data_objects.static_output.RegisteredDataset |           0 |      2.91 KB
```

The major difference here is that we're no longer leaking 6 MB of ndarray data. The rest of the "leaked" memory are I suspect in global caches in the yt module or in sympy.