### PR TITLE
Add support for Enzo MHDCT fields

### DIFF
--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -358,7 +358,8 @@ and cell centered in the others, i.e. it is defined on the z faces of each cell.
 but nodal in the other two, i.e. it lives on the four cell edges that are normal
 to the z direction.
 
-..code-block:: python
+.. code-block:: python
+
     ad = ds.all_data()
     print(ds.field_info[('raw', 'Ex')].nodal_flag)
     print(ad['raw', 'Ex'].shape)
@@ -458,7 +459,8 @@ cell centered in the others, i.e. it is defined on the z faces of each cell.
 direction, but nodal in the other two, i.e. it lives on the four cell edges that
 are normal to the z direction.
 
-..code-block:: python
+.. code-block:: python
+
     ad = ds.all_data()
     print(ds.field_info[('enzo', 'Ex')].nodal_flag)
     print(ad['raw', 'Ex'].shape)

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -446,19 +446,20 @@ mentioned.
 Enzo MHDCT data
 ^^^^^^^^^^^^^^^
 
-The electric and magnetic fields for Enzo MHDCT simulations are not
-face-centered. In yt, we call fields like this "nodal".  We define a field to be
-"nodal" in a given direction if the field data is defined at the "low" and
-"high" sides of the cell in that direction, rather than at the cell center.
-Instead of returning one field value per cell selected, nodal fields return a
-number of values, depending on their centering. This centering is marked by a
-`nodal_flag` that describes whether the fields is nodal in each dimension.
-``nodal_flag = [0, 0, 0]`` means that the field is cell-centered, while
-``nodal_flag = [0, 0, 1]`` means that the field is nodal in the z direction and
-cell centered in the others, i.e. it is defined on the z faces of each cell.
-``nodal_flag = [1, 1, 0]`` would mean that the field is centered in the z
-direction, but nodal in the other two, i.e. it lives on the four cell edges that
-are normal to the z direction.
+The electric and magnetic fields for Enzo MHDCT simulations are defined on cell
+faces, unlike other Enzo fields which are defined at cell centers. In yt, we
+call face-centered fields like this "nodal".  We define a field to be nodal in
+a given direction if the field data is defined at the "low" and "high" sides of
+the cell in that direction, rather than at the cell center.  Instead of
+returning one field value per cell selected, nodal fields return a number of
+values, depending on their centering. This centering is marked by a `nodal_flag`
+that describes whether the fields is nodal in each dimension.  ``nodal_flag =
+[0, 0, 0]`` means that the field is cell-centered, while ``nodal_flag = [0, 0,
+1]`` means that the field is nodal in the z direction and cell centered in the
+others, i.e. it is defined on the z faces of each cell.  ``nodal_flag = [1, 1,
+0]`` would mean that the field is centered in the z direction, but nodal in the
+other two, i.e. it lives on the four cell edges that are normal to the z
+direction.
 
 .. code-block:: python
 

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -440,6 +440,43 @@ mentioned.
   of length 1.0 in "code length" which may produce strange results for volume
   quantities.
 
+
+Enzo MHDCT data
+^^^^^^^^^^^^^^^
+
+The electric and magnetic fields for Enzo MHDCT simulations are not
+face-centered. In yt, we call fields like this "nodal".  We define a field to be
+"nodal" in a given direction if the field data is defined at the "low" and
+"high" sides of the cell in that direction, rather than at the cell center.
+Instead of returning one field value per cell selected, nodal fields return a
+number of values, depending on their centering. This centering is marked by a
+`nodal_flag` that describes whether the fields is nodal in each dimension.
+``nodal_flag = [0, 0, 0]`` means that the field is cell-centered, while
+``nodal_flag = [0, 0, 1]`` means that the field is nodal in the z direction and
+cell centered in the others, i.e. it is defined on the z faces of each cell.
+``nodal_flag = [1, 1, 0]`` would mean that the field is centered in the z
+direction, but nodal in the other two, i.e. it lives on the four cell edges that
+are normal to the z direction.
+
+..code-block:: python
+    ad = ds.all_data()
+    print(ds.field_info[('enzo', 'Ex')].nodal_flag)
+    print(ad['raw', 'Ex'].shape)
+    print(ds.field_info[('enzo', 'BxF')].nodal_flag)
+    print(ad['raw', 'Bx'].shape)
+    print(ds.field_info[('enzo', 'Bx')].nodal_flag)
+    print(ad['boxlib', 'Bx'].shape)
+
+Here, the field ``('enzo', 'Ex')`` is nodal in two directions, so four values
+per cell are returned, corresponding to the four edges in each cell on which the
+variable is defined. ``('enzo', 'BxF')`` is nodal in one direction, so two
+values are returned per cell. The standard, non-nodal field ``('enzo', 'Bx')``
+is also available.
+
+Currently, slices and data selection are implemented for nodal
+fields. Projections, volume rendering, and many of the analysis modules will not
+work.
+
 .. _loading-exodusii-data:
 
 Exodus II Data

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -360,6 +360,7 @@ to the z direction.
 
 .. code-block:: python
 
+    ds.index
     ad = ds.all_data()
     print(ds.field_info[('raw', 'Ex')].nodal_flag)
     print(ad['raw', 'Ex'].shape)
@@ -461,6 +462,7 @@ are normal to the z direction.
 
 .. code-block:: python
 
+    ds.index
     ad = ds.all_data()
     print(ds.field_info[('enzo', 'Ex')].nodal_flag)
     print(ad['raw', 'Ex'].shape)

--- a/yt/frontends/boxlib/io.py
+++ b/yt/frontends/boxlib/io.py
@@ -21,6 +21,7 @@ from yt.utilities.io_handler import \
     BaseIOHandler
 from yt.funcs import mylog
 from yt.frontends.chombo.io import parse_orion_sinks
+from yt.geometry.selection_routines import GridSelector
 
 def _remove_raw(all_fields, raw_fields):
     centered_fields = set(all_fields)
@@ -232,7 +233,7 @@ class IOHandlerOrion(IOHandlerBoxlib):
         rv = {}
         chunks = list(chunks)
 
-        if selector.__class__.__name__ == "GridSelector":
+        if isinstance(selector, GridSelector):
 
             if not (len(chunks) == len(chunks[0].objs) == 1):
                 raise RuntimeError

--- a/yt/frontends/chombo/io.py
+++ b/yt/frontends/chombo/io.py
@@ -15,8 +15,10 @@ The data-file handling functions
 
 import re
 import numpy as np
-from yt.utilities.logger import ytLogger as mylog
-
+from yt.geometry.selection_routines import \
+    GridSelector
+from yt.utilities.logger import \
+    ytLogger as mylog
 from yt.utilities.io_handler import \
     BaseIOHandler
 
@@ -116,7 +118,7 @@ class IOHandlerChomboHDF5(BaseIOHandler):
         rv = {}
         chunks = list(chunks)
         fields.sort(key=lambda a: self.field_dict[a[1]])
-        if selector.__class__.__name__ == "GridSelector":
+        if isinstance(selector, GridSelector):
             if not (len(chunks) == len(chunks[0].objs) == 1):
                 raise RuntimeError
             grid = chunks[0].objs[0]
@@ -149,7 +151,7 @@ class IOHandlerChomboHDF5(BaseIOHandler):
         rv = {}
         chunks = list(chunks)
 
-        if selector.__class__.__name__ == "GridSelector":
+        if isinstance(selector, GridSelector):
 
             if not (len(chunks) == len(chunks[0].objs) == 1):
                 raise RuntimeError

--- a/yt/frontends/enzo/fields.py
+++ b/yt/frontends/enzo/fields.py
@@ -13,6 +13,7 @@ Fields specific to Enzo
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
+import numpy as np
 from yt.fields.field_info_container import \
     FieldInfoContainer
 from yt.utilities.physical_constants import \
@@ -20,6 +21,7 @@ from yt.utilities.physical_constants import \
     mp
 
 b_units = "code_magnetic"
+e_units = "code_magnetic/c"
 ra_units = "code_length / code_time**2"
 rho_units = "code_mass / code_length**3"
 vel_units = "code_velocity"
@@ -49,6 +51,18 @@ known_species_names = {
     'OIX'     : 'O_p8',
 }
 
+NODAL_FLAGS = {
+    'BxF': [1, 0, 0],
+    'ByF': [0, 1, 0],
+    'BzF': [0, 0, 1],
+    'Ex': [0, 1, 1],
+    'Ey': [1, 0, 1],
+    'Ez': [1, 1, 0],
+    'AvgElec0': [0, 1, 1],
+    'AvgElec1': [1, 0, 1],
+    'AvgElec2': [1, 1, 0],
+}
+
 class EnzoFieldInfo(FieldInfoContainer):
     known_other_fields = (
         ("Cooling_Time", ("s", ["cooling_time"], None)),
@@ -63,6 +77,15 @@ class EnzoFieldInfo(FieldInfoContainer):
         ("Bx", (b_units, [], None)),
         ("By", (b_units, [], None)),
         ("Bz", (b_units, [], None)),
+        ("BxF", (b_units, [], None)),
+        ("ByF", (b_units, [], None)),
+        ("BzF", (b_units, [], None)),
+        ("Ex", (e_units, [], None)),
+        ("Ey", (e_units, [], None)),
+        ("Ez", (e_units, [], None)),
+        ("AvgElec0", (e_units, [], None)),
+        ("AvgElec1", (e_units, [], None)),
+        ("AvgElec2", (e_units, [], None)),
         ("RadAccel1", (ra_units, ["radiation_acceleration_x"], None)),
         ("RadAccel2", (ra_units, ["radiation_acceleration_y"], None)),
         ("RadAccel3", (ra_units, ["radiation_acceleration_z"], None)),
@@ -115,6 +138,15 @@ class EnzoFieldInfo(FieldInfoContainer):
             div_fac = 2.0
         slice_info = (sl_left, sl_right, div_fac)
         super(EnzoFieldInfo, self).__init__(ds, field_list, slice_info)
+
+        # setup nodal flag information
+        for field in NODAL_FLAGS:
+            try:
+                finfo = self['enzo', field]
+                finfo.nodal_flag = np.array(NODAL_FLAGS[field])
+            except KeyError:
+                pass
+
 
     def add_species_field(self, species):
         # This is currently specific to Enzo.  Hopefully in the future we will

--- a/yt/frontends/enzo/fields.py
+++ b/yt/frontends/enzo/fields.py
@@ -141,12 +141,9 @@ class EnzoFieldInfo(FieldInfoContainer):
 
         # setup nodal flag information
         for field in NODAL_FLAGS:
-            try:
+            if ('enzo', field) in self:
                 finfo = self['enzo', field]
                 finfo.nodal_flag = np.array(NODAL_FLAGS[field])
-            except KeyError:
-                pass
-
 
     def add_species_field(self, species):
         # This is currently specific to Enzo.  Hopefully in the future we will

--- a/yt/frontends/enzo/io.py
+++ b/yt/frontends/enzo/io.py
@@ -18,7 +18,7 @@ from yt.utilities.io_handler import \
 from yt.utilities.logger import ytLogger as mylog
 from yt.extern.six import b, iteritems
 from yt.utilities.on_demand_imports import _h5py as h5py
-
+from yt.geometry.selection_routines import GridSelector
 import numpy as np
 
 
@@ -212,7 +212,7 @@ class IOHandlerInMemory(BaseIOHandler):
         rv = {}
         # Now we have to do something unpleasant
         chunks = list(chunks)
-        if selector.__class__.__name__ == "GridSelector":
+        if isinstance(selector, GridSelector):
             if not (len(chunks) == len(chunks[0].objs) == 1):
                 raise RuntimeError
             g = chunks[0].objs[0]
@@ -294,7 +294,7 @@ class IOHandlerPacked2D(IOHandlerPackedHDF5):
         rv = {}
         # Now we have to do something unpleasant
         chunks = list(chunks)
-        if selector.__class__.__name__ == "GridSelector":
+        if isinstance(selector, GridSelector):
             if not (len(chunks) == len(chunks[0].objs) == 1):
                 raise RuntimeError
             g = chunks[0].objs[0]

--- a/yt/frontends/enzo/io.py
+++ b/yt/frontends/enzo/io.py
@@ -131,9 +131,7 @@ class IOHandlerPackedHDF5(BaseIOHandler):
                     filename = obj.filename
                 for field in fields:
                     nodal_flag = self.ds.field_info[field].nodal_flag
-                    dims = obj.ActiveDimensions[::-1].copy()
-                    if np.any(nodal_flag):
-                        dims += nodal_flag[::-1]
+                    dims = obj.ActiveDimensions[::-1] + nodal_flag[::-1]
                     data = np.empty(dims, dtype=h5_dtype)
                     yield field, obj, self._read_obj_field(
                         obj, field, (fid, data))

--- a/yt/frontends/enzo/io.py
+++ b/yt/frontends/enzo/io.py
@@ -129,13 +129,18 @@ class IOHandlerPackedHDF5(BaseIOHandler):
                         fid.close()
                     fid = h5py.h5f.open(b(obj.filename), h5py.h5f.ACC_RDONLY)
                     filename = obj.filename
-                data = np.empty(obj.ActiveDimensions[::-1], dtype=h5_dtype)
                 for field in fields:
-                    yield field, obj, self._read_obj_field(obj, field, (fid, data))
+                    nodal_flag = self.ds.field_info[field].nodal_flag
+                    dims = obj.ActiveDimensions[::-1].copy()
+                    if np.any(nodal_flag):
+                        dims += nodal_flag[::-1]
+                    data = np.empty(dims, dtype=h5_dtype)
+                    yield field, obj, self._read_obj_field(
+                        obj, field, (fid, data))
         if fid is not None:
             fid.close()
         
-    def _read_obj_field(self, obj, field, fid_data = None):
+    def _read_obj_field(self, obj, field, fid_data):
         if fid_data is None: fid_data = (None, None)
         fid, data = fid_data
         if fid is None:

--- a/yt/frontends/enzo/tests/test_outputs.py
+++ b/yt/frontends/enzo/tests/test_outputs.py
@@ -29,6 +29,7 @@ from yt.utilities.answer_testing.framework import \
     AnalyticHaloMassFunctionTest, \
     SimulatedHaloMassFunctionTest
 from yt.frontends.enzo.api import EnzoDataset
+from yt.frontends.enzo.fields import NODAL_FLAGS
 
 _fields = ("temperature", "density", "velocity_magnitude",
            "velocity_divergence")
@@ -40,6 +41,7 @@ g30 = "IsolatedGalaxy/galaxy0030/galaxy0030"
 enzotiny = "enzo_tiny_cosmology/DD0046/DD0046"
 toro1d = "ToroShockTube/DD0001/data0001"
 kh2d = "EnzoKelvinHelmholtz/DD0011/DD0011"
+mhdctot = "MHDCTOrszagTang/DD0004/data0004"
 
 def check_color_conservation(ds):
     species_names = ds.field_info.species_names
@@ -172,3 +174,20 @@ def test_active_particle_datasets():
 
     assert_equal(apcos.particle_type_counts,
                  {'CenOstriker': 899755, 'DarkMatter': 32768})
+
+@requires_file(mhdctot)
+def test_face_centered_mhdct_fields():
+    ds = data_dir_load(mhdctot)
+
+    ad = ds.all_data()
+    grid = ds.index.grids[0]
+
+    for field, flag in NODAL_FLAGS.items():
+        dims = ds.domain_dimensions
+        assert_equal(ad[field].shape, (dims.prod(), 2*sum(flag)))
+        assert_equal(grid[field].shape, tuple(dims) + (2*sum(flag),))
+
+    # Average of face-centered fields should be the same as cell-centered field
+    assert (ad['BxF'].sum(axis=-1)/2 == ad['Bx']).all()
+    assert (ad['ByF'].sum(axis=-1)/2 == ad['By']).all()
+    assert (ad['BzF'].sum(axis=-1)/2 == ad['Bz']).all()

--- a/yt/frontends/gdf/io.py
+++ b/yt/frontends/gdf/io.py
@@ -17,6 +17,7 @@ import numpy as np
 from yt.utilities.on_demand_imports import _h5py as h5py
 from yt.funcs import \
     mylog
+from yt.geometry.selection_routines import GridSelector
 from yt.utilities.io_handler import \
     BaseIOHandler
 
@@ -40,7 +41,7 @@ class IOHandlerGDFHDF5(BaseIOHandler):
         rv = {}
         chunks = list(chunks)
 
-        if selector.__class__.__name__ == "GridSelector":
+        if isinstance(selector, GridSelector):
             if not (len(chunks) == len(chunks[0].objs) == 1):
                 raise RuntimeError
             grid = chunks[0].objs[0]

--- a/yt/frontends/open_pmd/io.py
+++ b/yt/frontends/open_pmd/io.py
@@ -22,6 +22,7 @@ import numpy as np
 from yt.frontends.open_pmd.misc import \
     is_const_component, \
     get_component
+from yt.geometry.selection_routines import GridSelector
 from yt.utilities.io_handler import BaseIOHandler
 
 
@@ -178,7 +179,7 @@ class IOHandlerOpenPMDHDF5(BaseIOHandler):
         rv = {}
         ind = {}
 
-        if selector.__class__.__name__ == "GridSelector":
+        if isinstance(selector, GridSelector):
             if not (len(chunks) == len(chunks[0].objs) == 1):
                 raise RuntimeError
 

--- a/yt/frontends/ytdata/io.py
+++ b/yt/frontends/ytdata/io.py
@@ -20,6 +20,8 @@ from yt.extern.six import \
     u
 from yt.funcs import \
     mylog
+from yt.geometry.selection_routines import \
+    GridSelector
 from yt.utilities.exceptions import \
     YTDomainOverflow
 from yt.utilities.io_handler import \
@@ -36,7 +38,7 @@ class IOHandlerYTNonspatialhdf5(BaseIOHandler):
 
     def _read_fluid_selection(self, g, selector, fields):
         rv = {}
-        if selector.__class__.__name__ == "GridSelector":
+        if isinstance(selector, GridSelector):
             if g.id in self._cached_fields:
                 gf = self._cached_fields[g.id]
                 rv.update(gf)
@@ -68,7 +70,7 @@ class IOHandlerYTGridHDF5(BaseIOHandler):
         rv = {}
         # Now we have to do something unpleasant
         chunks = list(chunks)
-        if selector.__class__.__name__ == "GridSelector":
+        if isinstance(selector, GridSelector):
             if not (len(chunks) == len(chunks[0].objs) == 1):
                 raise RuntimeError
             g = chunks[0].objs[0]

--- a/yt/utilities/io_handler.py
+++ b/yt/utilities/io_handler.py
@@ -22,6 +22,7 @@ import numpy as np
 from yt.extern.six import add_metaclass
 from yt.utilities.lru_cache import \
     local_lru_cache, _make_key
+from yt.geometry.selection_routines import GridSelector
 
 _axis_ids = {0:2,1:1,2:0}
 
@@ -128,8 +129,9 @@ class BaseIOHandler(object):
         rv = {field: np.empty(size, dtype="=f8") for field in fields} 
         ind = {field: 0 for field in fields}
         for field, obj, data in self.io_iter(chunks, fields):
-            if data is None: continue
-            if selector.__class__.__name__ == "GridSelector":
+            if data is None:
+                continue
+            if selector.__class__ is GridSelector and field not in nodal_fields:
                 ind[field] += data.size
                 rv[field] = data.copy()
                 continue

--- a/yt/utilities/io_handler.py
+++ b/yt/utilities/io_handler.py
@@ -126,7 +126,17 @@ class BaseIOHandler(object):
         # rewrite a whole bunch of IO handlers all at once, and to allow a
         # better abstraction for grid-based frontends, we're now defining it in
         # the base class.
-        rv = {field: np.empty(size, dtype="=f8") for field in fields} 
+        rv = {}
+        nodal_fields = []
+        for field in fields:
+            finfo = self.ds.field_info[field]
+            nodal_flag = finfo.nodal_flag
+            if np.any(nodal_flag):
+                num_nodes = 2**sum(nodal_flag)
+                rv[field] = np.empty((size, num_nodes), dtype="=f8")
+                nodal_fields.append(field)
+            else:
+                rv[field] = np.empty(size, dtype="=f8")
         ind = {field: 0 for field in fields}
         for field, obj, data in self.io_iter(chunks, fields):
             if data is None:
@@ -134,8 +144,8 @@ class BaseIOHandler(object):
             if selector.__class__ is GridSelector and field not in nodal_fields:
                 ind[field] += data.size
                 rv[field] = data.copy()
-                continue
-            ind[field] += obj.select(selector, data, rv[field], ind[field])
+            else:
+                ind[field] += obj.select(selector, data, rv[field], ind[field])
         return rv
 
     def _read_data_slice(self, grid, field, axis, coord):

--- a/yt/utilities/io_handler.py
+++ b/yt/utilities/io_handler.py
@@ -141,7 +141,7 @@ class BaseIOHandler(object):
         for field, obj, data in self.io_iter(chunks, fields):
             if data is None:
                 continue
-            if selector.__class__ is GridSelector and field not in nodal_fields:
+            if isinstance(selector, GridSelector) and field not in nodal_fields:
                 ind[field] += data.size
                 rv[field] = data.copy()
             else:


### PR DESCRIPTION
This adds support for Enzo MHDCT fields, following the support @atmyers added for nodal WarpX data.

The implementation is relatively straightforward. I just needed to add support for I/O on these fields following more or less what the boxlib frontend does. I also needed to teach the enzo frontend which fields are expected to be nodal and what their expected nodal flags are. In principle we could read these data off disk like the boxlib frotend does but as far as I'm aware that data is currently not written out by Enzo so it needs to be hardcoded in the Enzo frontend.

While working on this I noticed a pattern where we do something like:

```
if selector.__class__.__name__ == "GridSelector":
```

many places in the codebase. Since this is arcane and wordy, I decided to globally replace it with

```
isinstance(selector, GridSelector)
```

which is a bit less arcane. Let me know if you'd prefer to have that change as a separate pull request.