### PR TITLE
Allow negative indexes when reading RAMSES outputs.

### DIFF
--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -162,7 +162,7 @@ class RAMSESDomainFile(object):
                 ("particle_velocity_y", "d"),
                 ("particle_velocity_z", "d"),
                 ("particle_mass", "d"),
-                ("particle_identifier", "I"),
+                ("particle_identifier", "i"),
                 ("particle_refinement_level", "I")]
         if hvals["nstar_tot"] > 0:
             particle_fields += [("particle_age", "d"),


### PR DESCRIPTION
Sink particles in ramses are stored in a particular output file, but they need 'cloud particles' to compute the accretion.
These cloud particles are stored in the particle file, but they have no physical meaning. The way to determine that a particle is a cloud particle (and not a star or a DM particle) is that it has a negative index.
Thus we must be able to read negative indexes, which explains the change.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes flake8 checker
- [x] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
