### PR TITLE
Extend region expression to return points and rays

### DIFF
--- a/doc/source/analyzing/objects.rst
+++ b/doc/source/analyzing/objects.rst
@@ -197,7 +197,6 @@ This accepts arguments the same way:::
              (900.1, 'm')]
    sl.plot()
 
-.. _available-objects:
 
 Making Image Buffers
 ^^^^^^^^^^^^^^^^^^^^
@@ -213,6 +212,34 @@ domain but centered at 0.5 in code units, you can do:::
 
 This `frb` object then can be queried like a normal fixed resolution buffer,
 and it will return arrays of shape (1024, 1024).
+
+Making Rays
+^^^^^^^^^^^
+
+The slicing syntax can also be used select 1D rays of points, whether along 
+an axis or off-axis. To create a ray along an axis:::
+
+    ortho_ray = ds.r[(500.0, "kpc"), (200, "kpc"):(300.0, "kpc"), (-2.0, "Mpc")]
+
+To create a ray off-axis, use a single slice between the start and end points
+of the ray:::
+
+    start = ((500.0, "kpc"), (0.2, "Mpc"), (100.0, "kpc"))
+    end = ((1.0, "Mpc"), (300.0, "kpc"), (0.0, "kpc"))
+    ray = ds.r[start:end]
+
+Selecting Points
+^^^^^^^^^^^^^^^^
+
+Finally, you can quickly select a single point within the domain by providing
+a single coordinate for every axis:::
+
+    pt = ds.r[(10.0, 'km'), (200, 'm'), (1.0,'km')]
+
+Querying this object for fields will give you the value of the field at that
+point.
+
+.. _available-objects:
 
 Available Objects
 -----------------

--- a/doc/source/analyzing/objects.rst
+++ b/doc/source/analyzing/objects.rst
@@ -224,8 +224,8 @@ an axis or off-axis. To create a ray along an axis:::
 To create a ray off-axis, use a single slice between the start and end points
 of the ray:::
 
-    start = [0.1, 0.2, 0.3]
-    end = [0.4, 0.5, 0.6]
+    start = [0.1, 0.2, 0.3] # interpreted in code_length
+    end = [0.4, 0.5, 0.6] # interpreted in code_length
     ray = ds.r[start:end]
 
 As for the other slicing options, combinations of unitful quantities with even

--- a/doc/source/analyzing/objects.rst
+++ b/doc/source/analyzing/objects.rst
@@ -224,6 +224,13 @@ an axis or off-axis. To create a ray along an axis:::
 To create a ray off-axis, use a single slice between the start and end points
 of the ray:::
 
+    start = [0.1, 0.2, 0.3]
+    end = [0.4, 0.5, 0.6]
+    ray = ds.r[start:end]
+
+As for the other slicing options, combinations of unitful quantities with even
+different units can be used. Here's a somewhat convoluted (yet working) example:::
+
     start = ((500.0, "kpc"), (0.2, "Mpc"), (100.0, "kpc"))
     end = ((1.0, "Mpc"), (300.0, "kpc"), (0.0, "kpc"))
     ray = ds.r[start:end]

--- a/yt/data_objects/region_expression.py
+++ b/yt/data_objects/region_expression.py
@@ -71,9 +71,10 @@ class RegionExpression(object):
     def _spec_to_value(self, input_tuple):
         if not isinstance(input_tuple, tuple):
             # We now assume that it's in code_length
-            return self.ds.quan(input_tuple, 'code_length')
-        v, u = input_tuple
-        value = self.ds.quan(v, u)
+            value = self.ds.quan(input_tuple, 'code_length')
+        else:
+            v, u = input_tuple
+            value = self.ds.quan(v, u).in_units("code_length")
         return value
 
     def _create_slice(self, slice_tuple):

--- a/yt/data_objects/region_expression.py
+++ b/yt/data_objects/region_expression.py
@@ -14,7 +14,7 @@ An object that can live on the dataset to facilitate data access.
 import weakref
 
 from yt.extern.six import string_types
-from yt.funcs import iterable
+from yt.funcs import iterable, obj_length
 from yt.units.yt_array import YTQuantity
 from yt.utilities.exceptions import YTDimensionalityError
 
@@ -40,8 +40,7 @@ class RegionExpression(object):
         if isinstance(item, tuple) and isinstance(item[1], string_types):
             return self.all_data[item]
         if isinstance(item, slice):
-            if iterable(item.start) and len(item.start) == 3 and \
-                iterable(item.stop) and len(item.stop) == 3:
+            if obj_length(item.start) == 3 and obj_length(item.stop) == 3:
                 # This is for a ray that is not orthogonal to an axis.
                 # it's straightforward to do this, so we create a ray
                 # and drop out here.

--- a/yt/data_objects/region_expression.py
+++ b/yt/data_objects/region_expression.py
@@ -14,7 +14,7 @@ An object that can live on the dataset to facilitate data access.
 import weakref
 
 from yt.extern.six import string_types
-from yt.funcs import iterable, obj_length
+from yt.funcs import obj_length
 from yt.units.yt_array import YTQuantity
 from yt.utilities.exceptions import YTDimensionalityError
 

--- a/yt/data_objects/region_expression.py
+++ b/yt/data_objects/region_expression.py
@@ -15,6 +15,7 @@ import weakref
 
 from yt.extern.six import string_types
 from yt.funcs import iterable
+from yt.units.yt_array import YTQuantity
 from yt.utilities.exceptions import YTDimensionalityError
 
 class RegionExpression(object):
@@ -76,14 +77,14 @@ class RegionExpression(object):
                 return self.all_data
             return self._create_region(item)
 
-    def _spec_to_value(self, input_tuple):
-        if not isinstance(input_tuple, tuple):
-            # We now assume that it's in code_length
-            value = self.ds.quan(input_tuple, 'code_length')
+    def _spec_to_value(self, input):
+        if isinstance(input, tuple):
+            v = self.ds.quan(input[0], input[1]).to("code_length")
+        elif isinstance(input, YTQuantity):
+            v = self.ds.quan(input.value, input.units).to('code_length')
         else:
-            v, u = input_tuple
-            value = self.ds.quan(v, u).in_units("code_length")
-        return value
+            v = self.ds.quan(input, "code_length")
+        return v
 
     def _create_slice(self, slice_tuple):
         # This is somewhat more complex because we want to allow for slicing

--- a/yt/data_objects/region_expression.py
+++ b/yt/data_objects/region_expression.py
@@ -64,7 +64,7 @@ class RegionExpression(object):
         # OK, now we need to look at our slices.  How many are a specific
         # coordinate?
 
-        nslices = sum([isinstance(v, slice) for v in item])
+        nslices = sum(isinstance(v, slice) for v in item)
         if nslices == 0:
             return self._create_point(item)
         elif nslices == 1:

--- a/yt/data_objects/region_expression.py
+++ b/yt/data_objects/region_expression.py
@@ -80,7 +80,7 @@ class RegionExpression(object):
         if isinstance(input, tuple):
             v = self.ds.quan(input[0], input[1]).to("code_length")
         elif isinstance(input, YTQuantity):
-            v = self.ds.quan(input.value, input.units).to('code_length')
+            v = self.ds.quan(input).to('code_length')
         else:
             v = self.ds.quan(input, "code_length")
         return v

--- a/yt/data_objects/region_expression.py
+++ b/yt/data_objects/region_expression.py
@@ -158,4 +158,6 @@ class RegionExpression(object):
         if axis == 1: coord = [coord[1], coord[0]]
         source = self._create_region(new_slice)
         ray = self.ds.ortho_ray(axis, coord, data_source=source)
+        if getattr(new_slice[axis].step, "imag", 0.0) != 0.0:
+            raise NotImplementedError
         return ray

--- a/yt/data_objects/selection_data_containers.py
+++ b/yt/data_objects/selection_data_containers.py
@@ -23,7 +23,8 @@ from yt.funcs import \
     ensure_list, \
     iterable, \
     validate_width_tuple, \
-    fix_length
+    fix_length, \
+    fix_axis
 from yt.geometry.selection_routines import \
     points_in_cells
 from yt.units.yt_array import \
@@ -88,8 +89,8 @@ class YTOrthoRay(YTSelectionContainer1D):
 
     Parameters
     ----------
-    axis : int
-        The axis along which to cast the ray.  Can be 0, 1, or 2 for x, y, z.
+    axis : int or char
+        The axis along which to slice.  Can be 0, 1, or 2 for x, y, z.
     coords : tuple of floats
         The (plane_x, plane_y) coordinates at which to cast the ray.  Note
         that this is in the plane coordinates: so if you are casting along
@@ -129,7 +130,7 @@ class YTOrthoRay(YTSelectionContainer1D):
     def __init__(self, axis, coords, ds=None, 
                  field_parameters=None, data_source=None):
         super(YTOrthoRay, self).__init__(ds, field_parameters, data_source)
-        self.axis = axis
+        self.axis = fix_axis(axis, self.ds)
         xax = self.ds.coordinates.x_axis[self.axis]
         yax = self.ds.coordinates.y_axis[self.axis]
         self.px_ax = xax

--- a/yt/data_objects/selection_data_containers.py
+++ b/yt/data_objects/selection_data_containers.py
@@ -28,7 +28,8 @@ from yt.funcs import \
 from yt.geometry.selection_routines import \
     points_in_cells
 from yt.units.yt_array import \
-    YTArray
+    YTArray, \
+    YTQuantity
 from yt.utilities.exceptions import \
     YTSphereTooSmall, \
     YTIllDefinedCutRegion, \
@@ -138,9 +139,15 @@ class YTOrthoRay(YTSelectionContainer1D):
         # Even though we may not be using x,y,z we use them here.
         self.px_dx = 'd%s'%('xyz'[self.px_ax])
         self.py_dx = 'd%s'%('xyz'[self.py_ax])
-        # Convert coordinates to code length. 
-        self.px = self.ds.quan(coords[0], "code_length")
-        self.py = self.ds.quan(coords[1], "code_length")
+        # Convert coordinates to code length.
+        if isinstance(coords[0], YTQuantity):
+            self.px = self.ds.quan(coords[0]).to("code_length")
+        else:
+            self.px = self.ds.quan(coords[0], "code_length")
+        if isinstance(coords[1], YTQuantity):
+            self.py = self.ds.quan(coords[1]).to("code_length")
+        else:
+            self.py = self.ds.quan(coords[1], "code_length")
         self.sort_by = 'xyz'[self.axis]
 
     @property

--- a/yt/data_objects/selection_data_containers.py
+++ b/yt/data_objects/selection_data_containers.py
@@ -137,7 +137,9 @@ class YTOrthoRay(YTSelectionContainer1D):
         # Even though we may not be using x,y,z we use them here.
         self.px_dx = 'd%s'%('xyz'[self.px_ax])
         self.py_dx = 'd%s'%('xyz'[self.py_ax])
-        self.px, self.py = coords
+        # Convert coordinates to code length. 
+        self.px = self.ds.quan(coords[0], "code_length")
+        self.py = self.ds.quan(coords[1], "code_length")
         self.sort_by = 'xyz'[self.axis]
 
     @property

--- a/yt/data_objects/tests/test_dataset_access.py
+++ b/yt/data_objects/tests/test_dataset_access.py
@@ -93,6 +93,24 @@ def test_point_from_r():
     pt2 = ds.point([0.5,0.3,0.1])
     assert_equal(pt1["density"], pt2["density"])
 
+def test_ray_from_r():
+    ds = fake_amr_ds(fields = ["density"])
+    ray1 = ds.r[(0.1,0.2,0.3):(0.4,0.5,0.6)]
+    ray2 = ds.ray((0.1,0.2,0.3), (0.4,0.5,0.6))
+    assert_equal(ray1["density"], ray2["density"])
+
+    ray3 = ds.r[0.5*ds.domain_left_edge:0.5*ds.domain_right_edge]
+    ray4 = ds.ray(0.5*ds.domain_left_edge, 0.5*ds.domain_right_edge)
+    assert_equal(ray3["density"], ray4["density"])
+
+    start = [(0.1,"cm"), 0.2, (0.3,"cm")]
+    end = [(0.5,"cm"), (0.4,"cm"), 0.6]
+    ray5 = ds.r[start:end]
+    start_arr = [ds.quan(0.1,"cm"), 0.2, ds.quan(0.3,"cm")]
+    end_arr = [ds.quan(0.5,"cm"), ds.quan(0.4,"cm"), 0.6]
+    ray6 = ds.ray(start_arr, end_arr)
+    assert_equal(ray5["density"], ray6["density"])
+
 def test_ortho_ray_from_r():
     ds = fake_amr_ds(fields = ["density"])
     ray1 = ds.r[:,0.3,0.2]

--- a/yt/data_objects/tests/test_dataset_access.py
+++ b/yt/data_objects/tests/test_dataset_access.py
@@ -76,6 +76,40 @@ def test_slice_from_r():
     frb2 = ds.r[0.5, ::1024j, ::512j]
     assert_equal(frb1["density"], frb2["density"])
 
+    # Test slice which doesn't cover the whole domain
+    box = ds.box([0.0, 0.25, 0.25], [1.0, 0.75, 0.75])
+
+    sl3 = ds.r[0.5, 0.25:0.75, 0.25:0.75]
+    sl4 = ds.slice("x", 0.5, data_source=box)
+    assert_equal(sl3["density"], sl4["density"])
+
+    frb3 = sl3.to_frb(width = 0.5, height = 0.5, resolution = (1024, 512))
+    frb4 = ds.r[0.5, 0.25:0.75:1024j, 0.25:0.75:512j]
+    assert_equal(frb3["density"], frb4["density"])
+
+def test_point_from_r():
+    ds = fake_amr_ds(fields = ["density"])
+    pt1 = ds.r[0.5,0.3,0.1]
+    pt2 = ds.point([0.5,0.3,0.1])
+    assert_equal(pt1["density"], pt2["density"])
+
+def test_ortho_ray_from_r():
+    ds = fake_amr_ds(fields = ["density"])
+    ray1 = ds.r[:,0.3,0.2]
+    ray2 = ds.ortho_ray("x",[0.3, 0.2])
+    assert_equal(ray1["density"], ray2["density"])
+
+    # the y-coord is funny so test it too
+    ray3 = ds.r[0.3,:,0.2]
+    ray4 = ds.ortho_ray("y", [0.2, 0.3])
+    assert_equal(ray3["density"], ray4["density"])
+
+    # Test ray which doesn't cover the whole domain
+    box = ds.box([0.25, 0.0, 0.0], [0.75, 1.0, 1.0])
+    ray5 = ds.r[0.25:0.75,0.3,0.2]
+    ray6 = ds.ortho_ray("x", [0.3, 0.2], data_source=box)
+    assert_equal(ray5["density"], ray6["density"])
+
 def test_particle_counts():
     ds = fake_random_ds(16, particles=100)
     assert ds.particle_type_counts == {'io': 100}

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -1141,3 +1141,9 @@ def parse_h5_attr(f, attr):
 def issue_deprecation_warning(msg):
     from numpy import VisibleDeprecationWarning
     warnings.warn(msg, VisibleDeprecationWarning, stacklevel=3)
+
+def obj_length(v):
+    if iterable(v):
+        return len(v)
+    else:
+        return 0

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -1146,4 +1146,6 @@ def obj_length(v):
     if iterable(v):
         return len(v)
     else:
+        # If something isn't iterable, we return 0 
+        # to signify zero length (aka a scalar).
         return 0


### PR DESCRIPTION
This PR extends `ds.r` to allow it to return 0 and 1-dimensional data objects. For example:

```python
p = ds.r[0.1,0.3,0.5]
```
returns a `YTPoint` object, and 

```python
ray = ds.r[(300.0,"kpc"),:,(-200.0,"kpc")]
```
returns a `YTOrthoRay`.

Currently, I'm having trouble getting the rays to work, because for some reason composition of a `YTOrthoRay` with a region does not work (it yields empty arrays when querying fields).

- [x] Fix composition of rays with regions
- [x] Add tests
- [x] Update docs
