### PR TITLE
Two minor IDV fixes for interactivity and non-logged fields

### DIFF
--- a/yt/visualization/volume_rendering/input_events.py
+++ b/yt/visualization/volume_rendering/input_events.py
@@ -333,8 +333,8 @@ def print_help(event_coll, event):
         key_map[glfw.__dict__.get(key)] = key[4:]
     for cb in (f for f in sorted(event_coll.key_callbacks)
                if isinstance(f, tuple)):
-        print("%s - %s" % (key_map[cb[0]],
-                           event_coll.key_callbacks[cb][0].__doc__))
+        for e in event_coll.key_callbacks[cb]:
+            print("%s - %s" % (key_map[cb[0]], e.__doc__))
     return False
 
 @register_event("nplane_closer")

--- a/yt/visualization/volume_rendering/shader_objects.py
+++ b/yt/visualization/volume_rendering/shader_objects.py
@@ -23,6 +23,7 @@ from yt.utilities.exceptions import \
     YTInvalidShaderType, \
     YTUnknownUniformKind, \
     YTUnknownUniformSize
+from yt.units.yt_array import YTQuantity
 
 known_shaders = {}
 
@@ -83,7 +84,7 @@ class ShaderProgram(object):
         # but we will not be using that here.
         if isinstance(value, int):
             return GL.glUniform1i
-        elif isinstance(value, float):
+        elif isinstance(value, (YTQuantity, float)):
             return GL.glUniform1f
         else:
             kind = value.dtype.kind


### PR DESCRIPTION
This changes how the "help" command works in IDV to have it output all of the possible callbacks (usually only one) associated with a given key.  It also adds a check for when setting a uniform that is a `YTQuantity`.  Most commonly, this will happen when *not* taking the log of a field; in that case, the uniform setters get confused and break.  This changes that by knowing that `YTQuantity`'s are castable to floats.