### PR TITLE
Improve docstrings for coloring of opaque sources in VR

### DIFF
--- a/yt/visualization/volume_rendering/render_source.py
+++ b/yt/visualization/volume_rendering/render_source.py
@@ -1047,6 +1047,7 @@ class BoxSource(LineSource):
         The right edge coordinates of the box.
     color : array-like of shape (4,), float, optional
         The colors (including alpha) to use for the lines.
+        Default is black with an alpha of 1.0.
 
     Examples
     --------
@@ -1205,7 +1206,10 @@ class CoordinateVectorSource(OpaqueSource):
     Parameters
     ----------
     colors: array-like of shape (3,4), optional
-        The x, y, z RGBA values to use to draw the vectors.
+        The RGBA values to use to draw the x, y, and z vectors. The default is 
+        [[1, 0, 0, alpha], [0, 1, 0, alpha], [0, 0, 1, alpha]]  where ``alpha``
+        is set by the parameter below. If ``colors`` is set then ``alpha`` is 
+        ignored.
     alpha : float, optional
         The opacity of the vectors.
 

--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -645,7 +645,9 @@ class Scene(object):
         ds : :class:`yt.data_objects.static_output.Dataset`
             This is the dataset object corresponding to the
             simulation being rendered. Used to get the domain bounds.
-
+        color : array_like of shape (4,), optional
+            The RGBA value to use to draw the domain boundaries.
+            Default is black with an alpha of 1.0.
 
         Examples
         --------
@@ -713,9 +715,9 @@ class Scene(object):
 
         Parameters
         ----------
-        colors: array_like of shape (4,), optional
+        color : array_like of shape (4,), optional
             The RGBA value to use to draw the mesh lines.
-            Default is black.
+            Default is black with an alpha of 1.0.
         alpha : float, optional
             The opacity of the mesh lines. Default is 255 (solid).
 
@@ -735,7 +737,10 @@ class Scene(object):
         Parameters
         ----------
         colors: array-like of shape (3,4), optional
-            The x, y, z RGBA values to use to draw the axes.
+            The RGBA values to use to draw the x, y, and z vectors. The default 
+            is  [[1, 0, 0, alpha], [0, 1, 0, alpha], [0, 0, 1, alpha]] where
+            ``alpha`` is set by the parameter below. If ``colors`` is set then 
+            ``alpha`` is ignored.
         alpha : float, optional
             The opacity of the vectors.
 


### PR DESCRIPTION
After noticing that `color` wasn't documented at all for `annotate_domain` I realized that the docstrings for other similar keyword arguments could be improved as well. This does that.