### PR TITLE
Tweak docstrings for surface export operations

### DIFF
--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -1362,26 +1362,23 @@ class YTSurface(YTSelectionContainer3D):
 
         >>> sp = ds.sphere("max", (10, "kpc"))
         >>> trans = 1.0
-        >>> distf = 3.1e18*1e3 # distances into kpc
         >>> surf = ds.surface(sp, "density", 5e-27)
-        >>> surf.export_obj("my_galaxy", transparency=trans, dist_fac = distf)
+        >>> surf.export_obj("my_galaxy", transparency=trans)
 
         >>> sp = ds.sphere("max", (10, "kpc"))
         >>> mi, ma = sp.quantities.extrema('temperature')[0]
         >>> rhos = [1e-24, 1e-25]
         >>> trans = [0.5, 1.0]
-        >>> distf = 3.1e18*1e3 # distances into kpc
         >>> for i, r in enumerate(rhos):
         ...     surf = ds.surface(sp,'density',r)
         ...     surf.export_obj("my_galaxy", transparency=trans[i],
-        ...                      color_field='temperature', dist_fac = distf,
+        ...                      color_field='temperature'
         ...                      plot_index = i, color_field_max = ma,
         ...                      color_field_min = mi)
 
         >>> sp = ds.sphere("max", (10, "kpc"))
         >>> rhos = [1e-24, 1e-25]
         >>> trans = [0.5, 1.0]
-        >>> distf = 3.1e18*1e3 # distances into kpc
         >>> def _Emissivity(field, data):
         ...     return (data['density']*data['density'] *
         ...             np.sqrt(data['temperature']))
@@ -1392,7 +1389,7 @@ class YTSurface(YTSelectionContainer3D):
         ...     surf.export_obj("my_galaxy", transparency=trans[i],
         ...                      color_field='temperature',
         ...                      emit_field='emissivity',
-        ...                      dist_fac = distf, plot_index = i)
+        ...                      plot_index = i)
 
         """
         if color_map is None:
@@ -1617,26 +1614,23 @@ class YTSurface(YTSelectionContainer3D):
 
         >>> sp = ds.sphere("max", (10, "kpc"))
         >>> trans = 1.0
-        >>> distf = 3.1e18*1e3 # distances into kpc
         >>> surf = ds.surface(sp, "density", 5e-27)
-        >>> surf.export_obj("my_galaxy", transparency=trans, dist_fac = distf)
+        >>> surf.export_obj("my_galaxy", transparency=trans)
 
         >>> sp = ds.sphere("max", (10, "kpc"))
         >>> mi, ma = sp.quantities.extrema('temperature')[0]
         >>> rhos = [1e-24, 1e-25]
         >>> trans = [0.5, 1.0]
-        >>> distf = 3.1e18*1e3 # distances into kpc
         >>> for i, r in enumerate(rhos):
         ...     surf = ds.surface(sp,'density',r)
         ...     surf.export_obj("my_galaxy", transparency=trans[i],
-        ...                      color_field='temperature', dist_fac = distf,
+        ...                      color_field='temperature',
         ...                      plot_index = i, color_field_max = ma,
         ...                      color_field_min = mi)
 
         >>> sp = ds.sphere("max", (10, "kpc"))
         >>> rhos = [1e-24, 1e-25]
         >>> trans = [0.5, 1.0]
-        >>> distf = 3.1e18*1e3 # distances into kpc
         >>> def _Emissivity(field, data):
         ...     return (data['density']*data['density']*np.sqrt(data['temperature']))
         >>> ds.add_field("emissivity", function=_Emissivity, units="g / cm**6")
@@ -1644,7 +1638,7 @@ class YTSurface(YTSelectionContainer3D):
         ...     surf = ds.surface(sp,'density',r)
         ...     surf.export_obj("my_galaxy", transparency=trans[i],
         ...                      color_field='temperature', emit_field = 'emissivity',
-        ...                      dist_fac = distf, plot_index = i)
+        ...                      plot_index = i)
 
         """
         if color_map is None:

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -1366,7 +1366,7 @@ class YTSurface(YTSelectionContainer3D):
         >>> surf.export_obj("my_galaxy", transparency=trans)
 
         >>> sp = ds.sphere("max", (10, "kpc"))
-        >>> mi, ma = sp.quantities.extrema('temperature')[0]
+        >>> mi, ma = sp.quantities.extrema('temperature')
         >>> rhos = [1e-24, 1e-25]
         >>> trans = [0.5, 1.0]
         >>> for i, r in enumerate(rhos):


### PR DESCRIPTION
This eliminates usages of `dist_fac` in the examples. I think at one point this was necessary to get a model with a nice normalized size. However, currently this choice of dist_fac produces a model that is much, much bigger than the camera scale. Removing `dist_fac` seems to produce reasonably sized models in sketchfab and meshlab.

I also fixed an error due to an API change we made a while in the derived quantities.