### PR TITLE
Update cython version for INST_CONDA=0

### DIFF
--- a/doc/install_script.sh
+++ b/doc/install_script.sh
@@ -694,6 +694,26 @@ else
      PYTHON_EXEC='python2.7'
 fi
 
+function do_setup_py_zip
+{
+    [ -e $1/done ] && return
+    LIB=$1
+    shift
+    if [ -z "$@" ]
+    then
+        echo "Installing $LIB"
+    else
+        echo "Installing $LIB (arguments: '$@')"
+    fi
+    [ ! -e $LIB/extracted ] && unzip $LIB.zip
+    touch $LIB/extracted
+    PYEXE=${PYTHON_EXEC}
+    cd $LIB
+    ( ${DEST_DIR}/bin/${PYEXE} setup.py install 2>&1 ) 1>> ${LOG_FILE} || do_exit
+    touch done
+    cd ..
+}
+
 function do_setup_py
 {
     [ -e $1/done ] && return
@@ -849,7 +869,7 @@ then
     SQLITE='sqlite-autoconf-3071700'
     SYMPY='sympy-1.0'
     ZLIB='zlib-1.2.8'
-    SETUPTOOLS='setuptools-20.6.7'
+    SETUPTOOLS='setuptools-36.0.1'
     ASTROPY='astropy-1.1.2'
     
     # Now we dump all our SHA512 files out.
@@ -878,7 +898,7 @@ then
     echo '96f3e51b46741450bc6b63779c10ebb4a7066860fe544385d64d1eda52592e376a589ef282ace2e1df73df61c10eab1a0d793abbdaf770e60289494d4bf3bcb4  sqlite-autoconf-3071700.tar.gz' > sqlite-autoconf-3071700.tar.gz.sha512
     echo '977db6e9bc6a5918cceb255981a57e85e7060c0922aefd2968b004d25d704e25a5cb5bbe09eb387e8695581e23e2825d9c40310068fe25ece7e9c23037a21f39  sympy-1.0.tar.gz' > sympy-1.0.tar.gz.sha512
     echo 'ece209d4c7ec0cb58ede791444dc754e0d10811cbbdebe3df61c0fd9f9f9867c1c3ccd5f1827f847c005e24eef34fb5bf87b5d3f894d75da04f1797538290e4a  zlib-1.2.8.tar.gz' > zlib-1.2.8.tar.gz.sha512
-    echo '91a212b5007f9fdfacb4341e06dc0355c5c29897eb8ea407dd4864091f845ba1417bb0d33b5ed6897869d0233e2d0ec6548898d3dbe9eda23f751829bd51a104  setuptools-20.6.7.tar.gz' > setuptools-20.6.7.tar.gz.sha512
+    echo 'cbcd2591d0d8a7591c5d9a1d4173814afa0b984af29f2e34d26a37c357474b043f371978ac224cea12f50834d91babd9f14b137488c4edcd62594e91aff903d8 setuptools-36.0.1.zip' > setuptools-36.0.1.zip.sha512
     # Individual processes
     [ -z "$HDF5_DIR" ] && get_ytproject $HDF5.tar.gz
     [ $INST_ZLIB -eq 1 ] && get_ytproject $ZLIB.tar.gz
@@ -1070,7 +1090,7 @@ then
     export PYTHONPATH=${DEST_DIR}/lib/${PYTHON_EXEC}/site-packages/
 
     # Install setuptools
-    do_setup_py $SETUPTOOLS
+    do_setup_py_zip $SETUPTOOLS
 
     if type -P git &>/dev/null
     then

--- a/doc/install_script.sh
+++ b/doc/install_script.sh
@@ -827,7 +827,7 @@ then
 
     PYTHON2='Python-2.7.11'
     PYTHON3='Python-3.5.1'
-    CYTHON='Cython-0.23.5'
+    CYTHON='Cython-0.25.2'
     if [ $INST_PY3 -eq 0 ]
     then
         PYX='PyX-0.12.1'
@@ -853,7 +853,7 @@ then
     ASTROPY='astropy-1.1.2'
     
     # Now we dump all our SHA512 files out.
-    echo '9052d74bbd0c93757fd916939cc3c39eb1aba6c9692b48887ae577256bec64b39b1fd25b6c751e6c8fe723de4c0ddf9a1a207de39f75b0839500dfcdde69f925  Cython-0.23.5.tar.gz' > Cython-0.23.5.tar.gz.sha512
+    echo '1974b9374aeedb030307dc95aa6560ce9d5e1652783cd4552e96ef11663c73dd263e3521b68e7712abbb31628011e2e66320c5ee2577968684e2679eb80726e1  Cython-0.25.2.tar.gz' > Cython-0.25.2.tar.gz.sha512
     if [ $INST_PY3 -eq 0 ]
     then
         echo '4941f5aa21aff3743546495fb073c10d2657ff42b2aff401903498638093d0e31e344cce778980f28a7170c6d29eab72ac074277b9d4088376e8692dc71e55c1  PyX-0.12.1.tar.gz' > PyX-0.12.1.tar.gz.sha512


### PR DESCRIPTION
We recently increased the minimum required cython version. This updates the install script for the `INST_CONDA=0` case to match that.