### PR TITLE
Add missing numpy import to particle_mesh_operations.pyx

### DIFF
--- a/yt/utilities/lib/particle_mesh_operations.pyx
+++ b/yt/utilities/lib/particle_mesh_operations.pyx
@@ -15,6 +15,7 @@ Simple integrators for the radiative transfer equation
 
 cimport numpy as np
 cimport cython
+import numpy as np
 from yt.utilities.lib.fp_utils cimport imax, fmax, imin, fmin, iclip, fclip
 
 @cython.boundscheck(False)


### PR DESCRIPTION
Compiling yt with the latest development version of cython produces the following error:

https://gist.github.com/ngoldbaum/d107a60b1775e97e12b72b29506a822b

The issue is that we only cimport numpy in this file but don't import it.