### PR TITLE
Improvements for FNV hash

### DIFF
--- a/yt/utilities/lib/fnv_hash.pxd
+++ b/yt/utilities/lib/fnv_hash.pxd
@@ -18,4 +18,4 @@ Definitions for fnv_hash
 import numpy as np
 cimport numpy as np
 
-cdef np.int64_t c_fnv_hash(unsigned char[:] octets)
+cdef np.int64_t c_fnv_hash(unsigned unsigned char[:] octets) nogil

--- a/yt/utilities/lib/fnv_hash.pyx
+++ b/yt/utilities/lib/fnv_hash.pyx
@@ -15,13 +15,18 @@ Fast hashing routines
 import numpy as np
 cimport numpy as np
 
-cdef np.int64_t c_fnv_hash(unsigned char[:] octets):
+cimport cython
+
+@cython.wraparound(False)
+@cython.boundscheck(False)
+cdef np.int64_t c_fnv_hash(unsigned char[:] octets) nogil:
     # https://bitbucket.org/yt_analysis/yt/issues/1052/field-access-tests-fail-under-python3
     # FNV hash cf. http://www.isthe.com/chongo/tech/comp/fnv/index.html
     cdef np.int64_t hash_val = 2166136261
-    cdef char octet
-    for octet in octets:
-        hash_val = hash_val ^ octet
+    cdef unsigned char octet
+    cdef int i
+    for i in range(octets.shape[0]):
+        hash_val = hash_val ^ octets[i]
         hash_val = hash_val * 16777619
     return hash_val
 


### PR DESCRIPTION
While trying to repurpose this FNV hash implementation for something in the demeshening, I found a couple of issues.

1. If we pass it non-ascii binary data, there will be values outside of 0-127. This will overflow the signed char we're currently using. The fix is to use unisgned chars. This wasn't an issue until now because we've been passing this function binary-encoded ascii data.

2. There's some python overhead that we can eliminate to improve performance.

I'd keep this in the demeshening for now but I wanted to see if this breaks anything so I'm PRing it separately to get the test suite run against it.