### PR TITLE
Make it possible to access the on-disk ramses particle_age field

### DIFF
--- a/yt/frontends/ramses/fields.py
+++ b/yt/frontends/ramses/fields.py
@@ -25,6 +25,7 @@ from yt.utilities.linear_interpolators import \
 import yt.utilities.fortran_utils as fpu
 from yt.fields.field_info_container import \
     FieldInfoContainer
+from yt.utilities.physical_ratios import cm_per_km, cm_per_mpc
 
 b_units = "code_magnetic"
 ra_units = "code_length / code_time**2"
@@ -80,7 +81,7 @@ class RAMSESFieldInfo(FieldInfoContainer):
         ("particle_mass", ("code_mass", [], None)),
         ("particle_identifier", ("", ["particle_index"], None)),
         ("particle_refinement_level", ("", [], None)),
-        ("particle_age", ("code_time", ['age'], None)),
+        ("particle_age", ("", [""], None)),
         ("particle_metallicity", ("", [], None)),
     )
 
@@ -92,6 +93,10 @@ class RAMSESFieldInfo(FieldInfoContainer):
         self.add_field(("gas", "temperature"), sampling_type="cell",  function=_temperature,
                         units=self.ds.unit_system["temperature"])
         self.create_cooling_fields()
+
+    def setup_particle_fields(self, ptype):
+        super(RAMSESFieldInfo, self).setup_particle_fields(ptype)
+        self.setup_age_fields(ptype)
 
     def create_cooling_fields(self):
         num = os.path.basename(self.ds.parameter_filename).split("."
@@ -131,3 +136,32 @@ class RAMSESFieldInfo(FieldInfoContainer):
                         (avals["lognH"], avals["logT"]),
                         ["lognH", "logT"], truncate = True)
             _create_field(("gas", n), interp)
+
+    def setup_age_fields(self, ptype):
+        ds = self.ds
+        if (ptype, 'particle_age') in self:
+            if ds.cosmological_simulation:
+                def _age(field, data):
+                    tf = ds.t_frw
+                    dtau = ds.dtau
+                    tauf = ds.tau_frw
+                    tsim = ds.time_simu
+                    h100 = ds.hubble_constant
+                    nOver2 = ds.n_frw/2
+                    t_scale = 1./(h100 * 100 * cm_per_km / cm_per_mpc)
+                    t_scale /= ds['unit_t']
+                    ages = data[ptype, 'particle_age']
+                    dage = 1 + (10*ages/dtau)
+                    dage = np.minimum(dage, nOver2 + (dage - nOver2)/10.)
+                    iage = np.array(dage,dtype=np.int32)
+
+                    t = ((tf[iage]*(ages - tauf[iage - 1]) /
+                          (tauf[iage] - tauf[iage - 1])))
+                    t = t + ((tf[iage-1]*(ages-tauf[iage]) /
+                              (tauf[iage-1]-tauf[iage])))
+                    return ds.arr((tsim - t)*t_scale, 'code_time')
+                self.add_field((ptype, 'age'), sampling_type='particle',
+                               function=_age, units=self.ds.unit_system['time'])
+            else:
+                self[ptype, 'particle_age'].units = 'code_time'
+                self.alias((ptype, 'age'), (ptype, 'particle_age'))

--- a/yt/utilities/lib/cosmology_time.pyx
+++ b/yt/utilities/lib/cosmology_time.pyx
@@ -79,24 +79,3 @@ cpdef friedman(double O_mat_0,double O_vac_0,double O_k_0):
 
     return tau_out,t_out,delta_tau,ntable,age_tot
 
-cpdef get_ramses_ages(np.ndarray[double,mode='c'] tf, 
-                     np.ndarray[double,mode='c'] tauf,  
-                     double dtau, 
-                     double tsim, 
-                     double t_scale, 
-                     np.ndarray[double,mode='c'] ages, 
-                     int nOver2, 
-                     int ntot):
-
-    cdef np.ndarray[double,mode='c'] t
-    cdef np.ndarray[double,mode='c'] dage
-    cdef np.ndarray[int,mode='c'] iage
-
-    dage = 1 + (10*ages/dtau)
-    dage = np.minimum(dage, nOver2 + (dage - nOver2)/10.)
-    iage = np.array(dage,dtype=np.int32)
-
-    t = (tf[iage]*(ages - tauf[iage - 1]) / (tauf[iage] - tauf[iage - 1]))
-    t = t + (tf[iage-1]*(ages-tauf[iage]) / (tauf[iage-1]-tauf[iage]))
-    return  (tsim - t)*t_scale
- 


### PR DESCRIPTION
RAMSES uses cornformal time units. To avoid users having to deal with that, currently we apply a conversion at the IO layer to convert the `particle_age` field to proper time units.

However, this makes it difficult to create a particle filter for DM particles (which are written to disk with `particle_age` set to 0).  Due to the nature of the conversion, the DM particles instead end up with some other value that depends on the cosmology and current simulation time. Often this value will be negative, but at z=0 it will probably be a small positive number since RAMSES will integrate slightly past z=0.

In principle one could make a particle filter using the DM mases, but the filter would then need to be updated for every new simulation. Ideally users (or even yt itself) could just create a single filter for dark matter and star particles and reuse it for all their simulations.

This PR proposes making a backward incompatible change. Instead of doing the conversion at the IO layer, it instead does the conversion in the `age` derived field. It also makes the units of the `particle_age` field dimensionless. This means that the `particle_age` field will contain the conformal time data as written to disk by the simulation code.

Unfortunately, this will likely break any script that dealt with the RAMSES `particle_age` field. I'm not sure if there's an alternate way to work around this issue that avoids breakage, feedback is very welcome.