### PR TITLE
fix compilation on windows python2.7

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
     - "python --version"
 
     # Install specified version of numpy and dependencies
-    - "conda install -q --yes -c conda-forge numpy scipy nose setuptools ipython Cython sympy fastcache h5py matplotlib flake8 "
+    - "conda install -q --yes -c conda-forge numpy scipy nose setuptools ipython Cython sympy fastcache h5py matplotlib flake8 mock"
     - "pip install -e ."
 
 # Not a .NET project

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ environment:
 
   matrix:
       - PYTHON_VERSION: "3.6"
+      - PYTHON_VERSION: "2.7"
 
 platform:
     -x64

--- a/yt/geometry/grid_container.pyx
+++ b/yt/geometry/grid_container.pyx
@@ -16,7 +16,6 @@ Matching points on the grid to specific grids
 import numpy as np
 cimport numpy as np
 cimport cython
-from libc.math cimport rint
 from yt.utilities.lib.bitarray cimport bitarray
 
 @cython.boundscheck(False)

--- a/yt/utilities/lib/mesh_utilities.pyx
+++ b/yt/utilities/lib/mesh_utilities.pyx
@@ -17,9 +17,11 @@ import numpy as np
 cimport numpy as np
 cimport cython
 from libc.stdlib cimport malloc, free, abs
-from libc.math cimport rint
 from yt.utilities.lib.fp_utils cimport imax, fmax, imin, fmin, iclip, fclip, i64clip
 from yt.units.yt_array import YTArray
+
+cdef extern from "platform_dep.h":
+    double rint(double x)
 
 @cython.boundscheck(False)
 @cython.wraparound(False)


### PR DESCRIPTION
MSVC didn't add support for rint in `math.h` until 2013, so python2.7 needs a fallback.