### PR TITLE
fix issues with adding dimensionless data to data with units

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -42,7 +42,7 @@ answer_tests:
   local_owls_001:
     - yt/frontends/owls/tests/test_outputs.py
 
-  local_pw_015:
+  local_pw_016:
     - yt/visualization/tests/test_plotwindow.py:test_attributes
     - yt/visualization/tests/test_plotwindow.py:test_attributes_wt
     - yt/visualization/tests/test_profile_plots.py:test_phase_plot_attributes

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -64,7 +64,7 @@ answer_tests:
     - yt/analysis_modules/photon_simulator/tests/test_spectra.py
     - yt/analysis_modules/photon_simulator/tests/test_sloshing.py
 
-  local_unstructured_005:
+  local_unstructured_006:
     - yt/visualization/volume_rendering/tests/test_mesh_render.py
     - yt/visualization/tests/test_mesh_slices.py:test_tri2
     - yt/visualization/tests/test_mesh_slices.py:test_quad2

--- a/yt/analysis_modules/absorption_spectrum/absorption_spectrum.py
+++ b/yt/analysis_modules/absorption_spectrum/absorption_spectrum.py
@@ -365,7 +365,7 @@ class AbsorptionSpectrum(object):
                                    this_wavelength[lixel]), \
                               continuum['index']) * \
                     (column_density[lixel] / continuum['normalization'])
-                self.tau_field[left_index[lixel]:right_index[lixel]] += cont_tau
+                self.tau_field[left_index[lixel]:right_index[lixel]] += cont_tau.d
                 pbar.update(i)
             pbar.finish()
 

--- a/yt/analysis_modules/halo_finding/halo_objects.py
+++ b/yt/analysis_modules/halo_finding/halo_objects.py
@@ -1281,7 +1281,7 @@ class GenericHaloFinder(HaloList, ParallelAnalysisInterface):
 
         def haloCmp(h1, h2):
             def cmp(a, b):
-                return (a > b) - (a < b)
+                return (a > b) ^ (a < b)
             c = cmp(h1.total_mass(), h2.total_mass())
             if c != 0:
                 return -1 * c

--- a/yt/analysis_modules/photon_simulator/photon_models.py
+++ b/yt/analysis_modules/photon_simulator/photon_models.py
@@ -224,7 +224,7 @@ class ThermalPhotonModel(PhotonModel):
                         tot_spec *= norm_factor
                         eidxs = self.prng.choice(nchan, size=cn, p=tot_spec)
                         cell_e = emid[eidxs]
-                    energies[ei:ei+cn] = cell_e
+                    energies[int(ei):int(ei + cn)] = cell_e
                     cell_counter += 1
                     pbar.update(cell_counter)
                     ei += cn

--- a/yt/analysis_modules/photon_simulator/photon_simulator.py
+++ b/yt/analysis_modules/photon_simulator/photon_simulator.py
@@ -678,9 +678,9 @@ class PhotonList(object):
             x *= delta
             y *= delta
             z *= delta
-            x += self.photons["x"][obs_cells]
-            y += self.photons["y"][obs_cells]
-            z += self.photons["z"][obs_cells]
+            x += self.photons["x"][obs_cells].d
+            y += self.photons["y"][obs_cells].d
+            z += self.photons["z"][obs_cells].d
 
             xsky = x*x_hat[0] + y*x_hat[1] + z*x_hat[2]
             ysky = x*y_hat[0] + y*y_hat[1] + z*y_hat[2]

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -62,6 +62,7 @@ from yt.utilities.grid_data_format.writer import write_to_gdf
 from yt.fields.field_exceptions import \
     NeedsOriginalGrid
 from yt.frontends.stream.api import load_uniform_grid
+from yt.units.yt_array import YTArray
 import yt.extern.six as six
 
 class YTStreamline(YTSelectionContainer1D):
@@ -1781,6 +1782,11 @@ class YTSurface(YTSelectionContainer3D):
             DLE = self.ds.domain_left_edge
             DRE = self.ds.domain_right_edge
             bounds = [(DLE[i], DRE[i]) for i in range(3)]
+        elif any([not all([isinstance(be, YTArray) for be in b])
+                  for b in bounds]):
+            bounds = [tuple(be if isinstance(be, YTArray) else
+                            self.ds.quan(be, 'code_length') for be in b)
+                      for b in bounds]
         nv = self.vertices.shape[1]
         vs = [("x", "<f"), ("y", "<f"), ("z", "<f"),
               ("red", "uint8"), ("green", "uint8"), ("blue", "uint8") ]

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -354,8 +354,8 @@ class YTQuadTreeProj(YTSelectionContainer2D):
         # TODO: Add the combine operation
         xax = self.ds.coordinates.x_axis[self.axis]
         yax = self.ds.coordinates.y_axis[self.axis]
-        ox = self.ds.domain_left_edge[xax]
-        oy = self.ds.domain_left_edge[yax]
+        ox = self.ds.domain_left_edge[xax].v
+        oy = self.ds.domain_left_edge[yax].v
         px, py, pdx, pdy, nvals, nwvals = tree.get_all(False, merge_style)
         nvals = self.comm.mpi_allreduce(nvals, op=op)
         nwvals = self.comm.mpi_allreduce(nwvals, op=op)

--- a/yt/frontends/owls_subfind/io.py
+++ b/yt/frontends/owls_subfind/io.py
@@ -105,7 +105,7 @@ class IOHandlerOWLSSubfindHDF5(BaseIOHandler):
                                 field_data = f[ptype][fname].value.astype("float64")
                                 my_div = field_data.size / pcount
                                 if my_div > 1:
-                                    field_data = np.resize(field_data, (pcount, my_div))
+                                    field_data = np.resize(field_data, (int(pcount), int(my_div)))
                                     findex = int(field[field.rfind("_") + 1:])
                                     field_data = field_data[:, findex]
                         data = field_data[mask]

--- a/yt/units/tests/test_ytarray.py
+++ b/yt/units/tests/test_ytarray.py
@@ -119,9 +119,19 @@ def test_addition():
     # Catch the different dimensions error
     a1 = YTArray([1, 2, 3], 'm')
     a2 = YTArray([4, 5, 6], 'kg')
+    a3 = [7, 8, 9]
+    a4 = YTArray([10, 11, 12], '')
 
     assert_raises(YTUnitOperationError, operator.add, a1, a2)
     assert_raises(YTUnitOperationError, operator.iadd, a1, a2)
+    assert_raises(YTUnitOperationError, operator.add, a1, a3)
+    assert_raises(YTUnitOperationError, operator.iadd, a1, a3)
+    assert_raises(YTUnitOperationError, operator.add, a3, a1)
+    assert_raises(YTUnitOperationError, operator.iadd, a3, a1)
+    assert_raises(YTUnitOperationError, operator.add, a1, a4)
+    assert_raises(YTUnitOperationError, operator.iadd, a1, a4)
+    assert_raises(YTUnitOperationError, operator.add, a4, a1)
+    assert_raises(YTUnitOperationError, operator.iadd, a4, a1)
 
     # adding with zero is allowed irrespective of the units
     zeros = np.zeros(3)
@@ -200,9 +210,19 @@ def test_subtraction():
     # Catch the different dimensions error
     a1 = YTArray([1, 2, 3], 'm')
     a2 = YTArray([4, 5, 6], 'kg')
+    a3 = [7, 8, 9]
+    a4 = YTArray([10, 11, 12], '')
 
     assert_raises(YTUnitOperationError, operator.sub, a1, a2)
     assert_raises(YTUnitOperationError, operator.isub, a1, a2)
+    assert_raises(YTUnitOperationError, operator.sub, a1, a3)
+    assert_raises(YTUnitOperationError, operator.isub, a1, a3)
+    assert_raises(YTUnitOperationError, operator.sub, a3, a1)
+    assert_raises(YTUnitOperationError, operator.isub, a3, a1)
+    assert_raises(YTUnitOperationError, operator.sub, a1, a4)
+    assert_raises(YTUnitOperationError, operator.isub, a1, a4)
+    assert_raises(YTUnitOperationError, operator.sub, a4, a1)
+    assert_raises(YTUnitOperationError, operator.isub, a4, a1)
 
     # subtracting with zero is allowed irrespective of the units
     zeros = np.zeros(3)


### PR DESCRIPTION
This is a followup to #1422. I missed the following case:

```
from yt.units import cm
[1, 1, 1]*cm + [1, 1, 1]
```

This *should* raise a `YTUnitOperationError` but currently does not. It looks like I broke that behavior in #1422 because we didn't have an explicit test.

This PR restores that behavior and adds explicit tests for addition and subtraction between arrays with units and dimensionless arrays.