### PR TITLE
plot_2d: plot 2d datasets

### DIFF
--- a/doc/source/reference/api/api.rst
+++ b/doc/source/reference/api/api.rst
@@ -18,6 +18,7 @@ SlicePlot and ProjectionPlot
    ~yt.visualization.plot_window.OffAxisProjectionPlot
    ~yt.visualization.plot_window.WindowPlotMPL
    ~yt.visualization.plot_window.PlotWindow
+   ~yt.visualization.plot_window.plot_2d
 
 ProfilePlot and PhasePlot
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -203,6 +203,30 @@ or a :ref:`cut region <cut-regions>`.
 See :class:`~yt.visualization.plot_window.AxisAlignedSlicePlot` for the
 full class description.
 
+.. _plot-2d:
+
+Plots of 2D Datasets
+~~~~~~~~~~~~~~~~~~~~
+
+If you have a two-dimensional cartesian, cylindrical, or polar dataset, 
+:func:`~yt.visualization.plot_window.plot_2d` is a way to make a plot
+within the dataset's plane without having to specify the axis, which
+in this case is redundant. Otherwise, ``plot_2d`` accepts the same
+arguments as ``SlicePlot``. The one other difference is that the
+``center`` keyword argument can be a two-dimensional coordinate instead
+of a three-dimensional one:
+
+.. python-script::
+
+    import yt
+    ds = yt.load("WindTunnel/windtunnel_4lev_hdf5_plt_cnt_0030")
+    p = yt.plot_2d(ds, "density", center=[1.0, 0.4])
+    p.set_log("density", False)
+    p.save()
+
+See :func:`~yt.visualization.plot_window.plot_2d` for the full description
+of the function and its keywords.
+
 .. _off-axis-slices:
 
 Off Axis Slices

--- a/yt/__init__.py
+++ b/yt/__init__.py
@@ -109,7 +109,7 @@ from yt.visualization.api import \
     ProfilePlot, PhasePlot, ParticlePhasePlot, \
     ParticleProjectionPlot, ParticleImageBuffer, ParticlePlot, \
     FITSImageData, FITSSlice, FITSProjection, FITSOffAxisSlice, \
-    FITSOffAxisProjection
+    FITSOffAxisProjection, Plot2DData
 
 from yt.visualization.volume_rendering.api import \
     volume_render, create_scene, ColorTransferFunction, TransferFunction, \

--- a/yt/__init__.py
+++ b/yt/__init__.py
@@ -109,7 +109,7 @@ from yt.visualization.api import \
     ProfilePlot, PhasePlot, ParticlePhasePlot, \
     ParticleProjectionPlot, ParticleImageBuffer, ParticlePlot, \
     FITSImageData, FITSSlice, FITSProjection, FITSOffAxisSlice, \
-    FITSOffAxisProjection, Plot2DData
+    FITSOffAxisProjection, plot_2d
 
 from yt.visualization.volume_rendering.api import \
     volume_render, create_scene, ColorTransferFunction, TransferFunction, \

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -735,7 +735,13 @@ def load_uniform_grid(data, domain_dimensions, length_unit=None, bbox=None,
     handler.domain_left_edge = domain_left_edge
     handler.domain_right_edge = domain_right_edge
     handler.refine_by = 2
-    handler.dimensionality = 3
+    if np.all(domain_dimensions[1:] == 1):
+        dimensionality = 1
+    elif domain_dimensions[2] == 1:
+        dimensionality = 2
+    else:
+        dimensionality = 3
+    handler.dimensionality = dimensionality
     handler.domain_dimensions = domain_dimensions
     handler.simulation_time = sim_time
     handler.cosmology_simulation = 0
@@ -925,7 +931,13 @@ def load_amr_grids(grid_data, domain_dimensions,
     handler.domain_left_edge = domain_left_edge
     handler.domain_right_edge = domain_right_edge
     handler.refine_by = refine_by
-    handler.dimensionality = 3
+    if np.all(domain_dimensions[1:] == 1):
+        dimensionality = 1
+    elif domain_dimensions[2] == 1:
+        dimensionality = 2
+    else:
+        dimensionality = 3
+    handler.dimensionality = dimensionality
     handler.domain_dimensions = domain_dimensions
     handler.simulation_time = sim_time
     handler.cosmology_simulation = 0

--- a/yt/visualization/api.py
+++ b/yt/visualization/api.py
@@ -52,7 +52,7 @@ from .plot_window import \
     OffAxisSlicePlot, \
     ProjectionPlot, \
     OffAxisProjectionPlot, \
-    Plot2DData
+    plot_2d
 
 from .profile_plotter import \
     ProfilePlot, \

--- a/yt/visualization/api.py
+++ b/yt/visualization/api.py
@@ -51,7 +51,8 @@ from .plot_window import \
     AxisAlignedSlicePlot, \
     OffAxisSlicePlot, \
     ProjectionPlot, \
-    OffAxisProjectionPlot
+    OffAxisProjectionPlot, \
+    Plot2DData
 
 from .profile_plotter import \
     ProfilePlot, \

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -2111,7 +2111,7 @@ def plot_2d(ds, fields, center='c', width=None, axes_unit=None,
          region covering the full domain
     """
     if ds.dimensionality != 2:
-        raise RuntimeError("Plot2DData only plots 2D datasets!")
+        raise RuntimeError("plot_2d only plots 2D datasets!")
     if ds.geometry == "cartesian" or ds.geometry == "polar":
         axis = "z"
     elif ds.geometry == "cylindrical":

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -415,7 +415,7 @@ class PlotWindow(ImagePlotContainer):
             is typically represented by a '-' separated string or a tuple of
             strings. In the first index the y-location is given by 'lower',
             'upper', or 'center'. The second index is the x-location, given as
-            'left', 'right', or 'center'. Finally, the whether the origin is
+            'left', 'right', or 'center'. Finally, whether the origin is
             applied in 'domain' space, plot 'window' space or 'native'
             simulation coordinate system is given. For example, both
             'upper-right-domain' and ['upper', 'right', 'domain'] place the
@@ -1240,7 +1240,7 @@ class AxisAlignedSlicePlot(PWViewerMPL):
          is typically represented by a '-' separated string or a tuple of
          strings. In the first index the y-location is given by 'lower',
          'upper', or 'center'. The second index is the x-location, given as
-         'left', 'right', or 'center'. Finally, the whether the origin is
+         'left', 'right', or 'center'. Finally, whether the origin is
          applied in 'domain' space, plot 'window' space or 'native'
          simulation coordinate system is given. For example, both
          'upper-right-domain' and ['upper', 'right', 'domain'] place the
@@ -1268,7 +1268,7 @@ class AxisAlignedSlicePlot(PWViewerMPL):
          ((yloc, '{unit}'), (xloc, '{unit}'), '{space}')    ((0.5, 'm'), (0.4, 'm'), 'window')
          (xloc, yloc, '{space}')                            (0.23, 0.5, 'domain')
          ===============================================    ==================================
-    axes_unit : A string
+    axes_unit : string
          The name of the unit for the tick labels on the x and y axes.
          Defaults to None, which automatically picks an appropriate unit.
          If axes_unit is '1', 'u', or 'unitary', it will not display the
@@ -1385,7 +1385,7 @@ class ProjectionPlot(PWViewerMPL):
          units are assumed, for example (0.2, 0.3) requests a plot that has an
          x width of 0.2 and a y width of 0.3 in code units.  If units are
          provided the resulting plot axis labels will use the supplied units.
-    axes_unit : A string
+    axes_unit : string
          The name of the unit for the tick labels on the x and y axes.
          Defaults to None, which automatically picks an appropriate unit.
          If axes_unit is '1', 'u', or 'unitary', it will not display the
@@ -1395,7 +1395,7 @@ class ProjectionPlot(PWViewerMPL):
          is typically represented by a '-' separated string or a tuple of
          strings. In the first index the y-location is given by 'lower',
          'upper', or 'center'. The second index is the x-location, given as
-         'left', 'right', or 'center'. Finally, the whether the origin is
+         'left', 'right', or 'center'. Finally, whether the origin is
          applied in 'domain' space, plot 'window' space or 'native'
          simulation coordinate system is given. For example, both
          'upper-right-domain' and ['upper', 'right', 'domain'] place the
@@ -1574,7 +1574,7 @@ class OffAxisSlicePlot(PWViewerMPL):
          units are assumed, for example (0.2, 0.3) requests a plot that has an
          x width of 0.2 and a y width of 0.3 in code units.  If units are
          provided the resulting plot axis labels will use the supplied units.
-    axes_unit : A string
+    axes_unit : string
          The name of the unit for the tick labels on the x and y axes.
          Defaults to None, which automatically picks an appropriate unit.
          If axes_unit is '1', 'u', or 'unitary', it will not display the
@@ -1718,7 +1718,7 @@ class OffAxisProjectionPlot(PWViewerMPL):
          The name of the weighting field.  Set to None for no weight.
     max_level: int
          The maximum level to project to.
-    axes_unit : A string
+    axes_unit : string
          The name of the unit for the tick labels on the x and y axes.
          Defaults to None, which automatically picks an appropriate unit.
          If axes_unit is '1', 'u', or 'unitary', it will not display the
@@ -1904,7 +1904,7 @@ def SlicePlot(ds, normal=None, fields=None, axis=None, *args, **kwargs):
          units are assumed, for example (0.2, 0.3) requests a plot that has an
          x width of 0.2 and a y width of 0.3 in code units.  If units are
          provided the resulting plot axis labels will use the supplied units.
-    axes_unit : A string
+    axes_unit : string
          The name of the unit for the tick labels on the x and y axes.
          Defaults to None, which automatically picks an appropriate unit.
          If axes_unit is '1', 'u', or 'unitary', it will not display the
@@ -2068,7 +2068,7 @@ def Plot2DData(ds, fields, center='c', width=None, axes_unit=None,
          is typically represented by a '-' separated string or a tuple of
          strings. In the first index the y-location is given by 'lower',
          'upper', or 'center'. The second index is the x-location, given as
-         'left', 'right', or 'center'. Finally, the whether the origin is
+         'left', 'right', or 'center'. Finally, whether the origin is
          applied in 'domain' space, plot 'window' space or 'native'
          simulation coordinate system is given. For example, both
          'upper-right-domain' and ['upper', 'right', 'domain'] place the
@@ -2096,7 +2096,7 @@ def Plot2DData(ds, fields, center='c', width=None, axes_unit=None,
          ((yloc, '{unit}'), (xloc, '{unit}'), '{space}')    ((0.5, 'm'), (0.4, 'm'), 'window')
          (xloc, yloc, '{space}')                            (0.23, 0.5, 'domain')
          ===============================================    ==================================
-    axes_unit : A string
+    axes_unit : string
          The name of the unit for the tick labels on the x and y axes.
          Defaults to None, which automatically picks an appropriate unit.
          If axes_unit is '1', 'u', or 'unitary', it will not display the

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -2015,9 +2015,9 @@ def SlicePlot(ds, normal=None, fields=None, axis=None, *args, **kwargs):
 
         return AxisAlignedSlicePlot(ds, normal, fields, *args, **kwargs)
 
-def Plot2DData(ds, fields, center='c', width=None, axes_unit=None,
-               origin='center-window', fontsize=18, field_parameters=None, 
-               window_size=8.0, aspect=None, data_source=None):
+def plot_2d(ds, fields, center='c', width=None, axes_unit=None,
+            origin='center-window', fontsize=18, field_parameters=None, 
+            window_size=8.0, aspect=None, data_source=None):
     r"""Creates a plot of a 2D dataset
 
     Given a ds object and a field name string, this will return a

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -2112,7 +2112,11 @@ def plot_2d(ds, fields, center='c', width=None, axes_unit=None,
     """
     if ds.dimensionality != 2:
         raise RuntimeError("Plot2DData only plots 2D datasets!")
-    return AxisAlignedSlicePlot(ds, "z", fields, center=center, width=width,
+    if ds.geometry == "cartesian":
+        axis = "z"
+    elif ds.geometry == "cylindrical":
+        axis = "theta"
+    return AxisAlignedSlicePlot(ds, axis, fields, center=center, width=width,
                                 axes_unit=axes_unit, origin=origin, 
                                 fontsize=fontsize,
                                 field_parameters=field_parameters, 

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -2115,6 +2115,8 @@ def Plot2DData(ds, fields, center='c', width=None, axes_unit=None,
          Object to be used for data selection. Defaults to ds.all_data(), a 
          region covering the full domain
     """
+    if ds.dimensionality != 2:
+        raise RuntimeError("Plot2DData only plots 2D datasets!")
     return AxisAlignedSlicePlot(ds, "z", fields, center=center, width=width,
                                 axes_unit=axes_unit, origin=origin, 
                                 right_handed=right_handed, fontsize=fontsize,

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -2112,7 +2112,7 @@ def plot_2d(ds, fields, center='c', width=None, axes_unit=None,
     """
     if ds.dimensionality != 2:
         raise RuntimeError("Plot2DData only plots 2D datasets!")
-    if ds.geometry == "cartesian":
+    if ds.geometry == "cartesian" or ds.geometry == "polar":
         axis = "z"
     elif ds.geometry == "cylindrical":
         axis = "theta"

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -2014,3 +2014,110 @@ def SlicePlot(ds, normal=None, fields=None, axis=None, *args, **kwargs):
             del kwargs['north_vector']
 
         return AxisAlignedSlicePlot(ds, normal, fields, *args, **kwargs)
+
+def Plot2DData(ds, fields, center='c', width=None, axes_unit=None,
+               origin='center-window', right_handed=True, fontsize=18, 
+               field_parameters=None, window_size=8.0, aspect=None, 
+               data_source=None):
+    r"""Creates a plot of a 2D dataset
+
+    Given a ds object and a field name string, this will return a
+    PWViewerMPL object containing the plot.
+
+    The plot can be updated using one of the many helper functions
+    defined in PlotWindow.
+
+    Parameters
+    ----------
+    ds : `Dataset`
+         This is the dataset object corresponding to the
+         simulation output to be plotted.
+    fields : string
+         The name of the field(s) to be plotted.
+    center : A sequence of floats, a string, or a tuple.
+         The coordinate of the center of the image. If set to 'c', 'center' or
+         left blank, the plot is centered on the middle of the domain. If set to
+         'max' or 'm', the center will be located at the maximum of the
+         ('gas', 'density') field. Centering on the max or min of a specific
+         field is supported by providing a tuple such as ("min","temperature") or
+         ("max","dark_matter_density"). Units can be specified by passing in *center*
+         as a tuple containing a coordinate and string unit name or by passing
+         in a YTArray. If a list or unitless array is supplied, code units are
+         assumed.
+    width : tuple or a float.
+         Width can have four different formats to support windows with variable
+         x and y widths.  They are:
+
+         ==================================     =======================
+         format                                 example
+         ==================================     =======================
+         (float, string)                        (10,'kpc')
+         ((float, string), (float, string))     ((10,'kpc'),(15,'kpc'))
+         float                                  0.2
+         (float, float)                         (0.2, 0.3)
+         ==================================     =======================
+
+         For example, (10, 'kpc') requests a plot window that is 10 kiloparsecs
+         wide in the x and y directions, ((10,'kpc'),(15,'kpc')) requests a
+         window that is 10 kiloparsecs wide along the x axis and 15
+         kiloparsecs wide along the y axis.  In the other two examples, code
+         units are assumed, for example (0.2, 0.3) requests a plot that has an
+         x width of 0.2 and a y width of 0.3 in code units.  If units are
+         provided the resulting plot axis labels will use the supplied units.
+    origin : string or length 1, 2, or 3 sequence.
+         The location of the origin of the plot coordinate system. This
+         is typically represented by a '-' separated string or a tuple of
+         strings. In the first index the y-location is given by 'lower',
+         'upper', or 'center'. The second index is the x-location, given as
+         'left', 'right', or 'center'. Finally, the whether the origin is
+         applied in 'domain' space, plot 'window' space or 'native'
+         simulation coordinate system is given. For example, both
+         'upper-right-domain' and ['upper', 'right', 'domain'] place the
+         origin in the upper right hand corner of domain space. If x or y
+         are not given, a value is inferred. For instance, 'left-domain'
+         corresponds to the lower-left hand corner of the simulation domain,
+         'center-domain' corresponds to the center of the simulation domain,
+         or 'center-window' for the center of the plot window. In the event
+         that none of these options place the origin in a desired location,
+         a sequence of tuples and a string specifying the
+         coordinate space can be given. If plain numeric types are input,
+         units of `code_length` are assumed. Further examples:
+
+         ===============================================    ==================================
+         format                                             example
+         ===============================================    ==================================
+         '{space}'                                          'domain'
+         '{xloc}-{space}'                                   'left-window'
+         '{yloc}-{space}'                                   'upper-domain'
+         '{yloc}-{xloc}-{space}'                            'lower-right-window'
+         ('{space}',)                                       ('window',)
+         ('{xloc}', '{space}')                              ('right', 'domain')
+         ('{yloc}', '{space}')                              ('lower', 'window')
+         ('{yloc}', '{xloc}', '{space}')                    ('lower', 'right', 'window')
+         ((yloc, '{unit}'), (xloc, '{unit}'), '{space}')    ((0.5, 'm'), (0.4, 'm'), 'window')
+         (xloc, yloc, '{space}')                            (0.23, 0.5, 'domain')
+         ===============================================    ==================================
+    axes_unit : A string
+         The name of the unit for the tick labels on the x and y axes.
+         Defaults to None, which automatically picks an appropriate unit.
+         If axes_unit is '1', 'u', or 'unitary', it will not display the
+         units, and only show the axes name.
+    right_handed : boolean
+         Whether the implicit east vector for the image generated is set to make a right
+         handed coordinate system with a normal vector, the direction of the
+         'window' into the data.
+    fontsize : integer
+         The size of the fonts for the axis, colorbar, and tick labels.
+    field_parameters : dictionary
+         A dictionary of field parameters than can be accessed by derived
+         fields.
+    data_source: YTSelectionContainer object
+         Object to be used for data selection. Defaults to ds.all_data(), a 
+         region covering the full domain
+    """
+    return AxisAlignedSlicePlot(ds, "z", fields, center=center, width=width,
+                                axes_unit=axes_unit, origin=origin, 
+                                right_handed=right_handed, fontsize=fontsize,
+                                field_parameters=field_parameters, 
+                                window_size=window_size, aspect=aspect,
+                                data_source=data_source)

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -2016,9 +2016,8 @@ def SlicePlot(ds, normal=None, fields=None, axis=None, *args, **kwargs):
         return AxisAlignedSlicePlot(ds, normal, fields, *args, **kwargs)
 
 def Plot2DData(ds, fields, center='c', width=None, axes_unit=None,
-               origin='center-window', right_handed=True, fontsize=18, 
-               field_parameters=None, window_size=8.0, aspect=None, 
-               data_source=None):
+               origin='center-window', fontsize=18, field_parameters=None, 
+               window_size=8.0, aspect=None, data_source=None):
     r"""Creates a plot of a 2D dataset
 
     Given a ds object and a field name string, this will return a
@@ -2102,10 +2101,6 @@ def Plot2DData(ds, fields, center='c', width=None, axes_unit=None,
          Defaults to None, which automatically picks an appropriate unit.
          If axes_unit is '1', 'u', or 'unitary', it will not display the
          units, and only show the axes name.
-    right_handed : boolean
-         Whether the implicit east vector for the image generated is set to make a right
-         handed coordinate system with a normal vector, the direction of the
-         'window' into the data.
     fontsize : integer
          The size of the fonts for the axis, colorbar, and tick labels.
     field_parameters : dictionary
@@ -2119,7 +2114,7 @@ def Plot2DData(ds, fields, center='c', width=None, axes_unit=None,
         raise RuntimeError("Plot2DData only plots 2D datasets!")
     return AxisAlignedSlicePlot(ds, "z", fields, center=center, width=width,
                                 axes_unit=axes_unit, origin=origin, 
-                                right_handed=right_handed, fontsize=fontsize,
+                                fontsize=fontsize,
                                 field_parameters=field_parameters, 
                                 window_size=window_size, aspect=aspect,
                                 data_source=data_source)

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -30,7 +30,8 @@ from yt.utilities.answer_testing.framework import \
 from yt.utilities.exceptions import \
     YTInvalidFieldType
 from yt.visualization.api import \
-    SlicePlot, ProjectionPlot, OffAxisSlicePlot, OffAxisProjectionPlot
+    SlicePlot, ProjectionPlot, OffAxisSlicePlot, OffAxisProjectionPlot, \
+    plot_2d
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.units import kboltz
 from yt.frontends.stream.api import load_uniform_grid
@@ -532,3 +533,10 @@ def test_set_unit():
     slc.set_unit('temperature', 'keV', equivalency='thermal')
     assert str(slc.frb['gas', 'temperature'].units) == 'keV'
 
+def test_plot_2d():
+    ds = fake_random_ds((32,32,1), fields=('temperature',), units=('K',))
+    slc = SlicePlot(ds, "z", ["temperature"], width=(0.2,"unitary"),
+                    center=[0.4, 0.3, 0.5])
+    slc2 = plot_2d(ds, "temperature", width=(0.2,"unitary"),
+                   center=[0.4, 0.3, 0.5])
+    assert_array_equal(slc.frb['temperature'], slc2.frb['temperature'])

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -542,10 +542,15 @@ def test_plot_2d():
     slc = SlicePlot(ds, "z", ["temperature"], width=(0.2,"unitary"),
                     center=[0.4, 0.3, 0.5])
     slc2 = plot_2d(ds, "temperature", width=(0.2,"unitary"),
-                   center=[0.4, 0.3, 0.5])
+                   center=[0.4, 0.3])
     assert_array_equal(slc.frb['temperature'], slc2.frb['temperature'])
     # Cylindrical
     ds = data_dir_load(WD)
-    slc = SlicePlot(ds, "theta", ["density"], width=(0.2, "unitary"))
-    slc2 = plot_2d(ds, "density", width=(0.2, "unitary"))
+    slc = SlicePlot(ds, "theta", ["density"], width=(1000.0, "km"),
+                    center=[2.0e9, 2.0e9, 3.141592655])
+    slc2 = plot_2d(ds, "density", width=(1000.0, "km"),
+                   center=[2.0e9, 2.0e9])
+    slc3 = plot_2d(ds, "density", width=(1000.0, "km"),
+                   center=ds.arr([2.0e4]*2, "km"))
     assert_array_equal(slc.frb['density'], slc2.frb['density'])
+    assert_array_equal(slc.frb['density'], slc3.frb['density'])

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -543,14 +543,12 @@ def test_plot_2d():
                     center=[0.4, 0.3, 0.5])
     slc2 = plot_2d(ds, "temperature", width=(0.2,"unitary"),
                    center=[0.4, 0.3])
+    slc3 = plot_2d(ds, "temperature", width=(0.2,"unitary"),
+                   center=ds.arr([0.4, 0.3], "cm"))
     assert_array_equal(slc.frb['temperature'], slc2.frb['temperature'])
+    assert_array_equal(slc.frb['temperature'], slc3.frb['temperature'])
     # Cylindrical
     ds = data_dir_load(WD)
-    slc = SlicePlot(ds, "theta", ["density"], width=(1000.0, "km"),
-                    center=[2.0e9, 2.0e9, 3.141592655])
-    slc2 = plot_2d(ds, "density", width=(1000.0, "km"),
-                   center=[2.0e9, 2.0e9])
-    slc3 = plot_2d(ds, "density", width=(1000.0, "km"),
-                   center=ds.arr([2.0e4]*2, "km"))
+    slc = SlicePlot(ds, "theta", ["density"], width=(30000.0, "km"))
+    slc2 = plot_2d(ds, "density", width=(30000.0, "km"))
     assert_array_equal(slc.frb['density'], slc2.frb['density'])
-    assert_array_equal(slc.frb['density'], slc3.frb['density'])

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -533,10 +533,19 @@ def test_set_unit():
     slc.set_unit('temperature', 'keV', equivalency='thermal')
     assert str(slc.frb['gas', 'temperature'].units) == 'keV'
 
+WD = "WDMerger_hdf5_chk_1000/WDMerger_hdf5_chk_1000.hdf5"
+
+@requires_ds(WD)
 def test_plot_2d():
+    # Cartesian
     ds = fake_random_ds((32,32,1), fields=('temperature',), units=('K',))
     slc = SlicePlot(ds, "z", ["temperature"], width=(0.2,"unitary"),
                     center=[0.4, 0.3, 0.5])
     slc2 = plot_2d(ds, "temperature", width=(0.2,"unitary"),
                    center=[0.4, 0.3, 0.5])
     assert_array_equal(slc.frb['temperature'], slc2.frb['temperature'])
+    # Cylindrical
+    ds = data_dir_load(WD)
+    slc = SlicePlot(ds, "theta", ["density"], width=(0.2, "unitary"))
+    slc2 = plot_2d(ds, "density", width=(0.2, "unitary"))
+    assert_array_equal(slc.frb['density'], slc2.frb['density'])


### PR DESCRIPTION
This PR doesn't do much, but it provides a wrapper function for `AxisAlignedSlicePlot` which sets the `axis` argument to `"z"`, so that one can plot 2D datasets without having to set an axis (`"z"` is the only one worth setting). 

It's almost too trivial to add, but I thought having a convenience function like this might be nice. 

Need to add to the documentation and (maybe) add a test.