### PR TITLE
Feature/force cosmo

### DIFF
--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -1922,6 +1922,11 @@ particle fields by supplying the ``extra_particle_fields``:
    # ('all', 'family') and ('all', 'info') now in ds.field_list
 
 
+It is possible to force yt to treat the simulation as a cosmological
+simulation by providing the ``cosmological=True`` parameter (or
+``False`` to force non-cosmology). If left to ``None``, the kind of
+the simulation is inferred from the data.
+
 .. _loading-sph-data:
 
 SPH Particle Data

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -640,13 +640,15 @@ class RAMSESDataset(Dataset):
         self.domain_right_edge = np.ones(3, dtype='float64')
         # This is likely not true, but it's not clear how to determine the boundary conditions
         self.periodicity = (True, True, True)
-        # These conditions seem to always be true for non-cosmological datasets
+
         if self.force_cosmological is not None:
             is_cosmological = self.force_cosmological
         else:
+            # These conditions seem to always be true for non-cosmological datasets
             is_cosmological = not (rheader["time"] >= 0 and
                                    rheader["H0"] == 1 and
                                    rheader["aexp"] == 1)
+
         if not is_cosmological:
             self.cosmological_simulation = 0
             self.current_redshift = 0

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -157,15 +157,15 @@ class RAMSESDomainFile(object):
         self.local_particle_count = hvals['npart']
 
         particle_fields = [
-            ("particle_position_x", "d"),
-            ("particle_position_y", "d"),
-            ("particle_position_z", "d"),
-            ("particle_velocity_x", "d"),
-            ("particle_velocity_y", "d"),
-            ("particle_velocity_z", "d"),
-            ("particle_mass", "d"),
-            ("particle_identifier", "i"),
-            ("particle_refinement_level", "I")]
+                ("particle_position_x", "d"),
+                ("particle_position_y", "d"),
+                ("particle_position_z", "d"),
+                ("particle_velocity_x", "d"),
+                ("particle_velocity_y", "d"),
+                ("particle_velocity_z", "d"),
+                ("particle_mass", "d"),
+                ("particle_identifier", "i"),
+                ("particle_refinement_level", "I")]
         if hvals["nstar_tot"] > 0:
             particle_fields += [("particle_age", "d"),
                                 ("particle_metallicity", "d")]
@@ -209,7 +209,7 @@ class RAMSESDomainFile(object):
 
     def _read_amr(self):
         """Open the oct file, read in octs level-by-level.
-           For each oct, only the position, index, level and domain
+           For each oct, only the position, index, level and domain 
            are needed - its position in the octree is found automatically.
            The most important is finding all the information to feed
            oct_handler.add
@@ -235,7 +235,7 @@ class RAMSESDomainFile(object):
         min_level = self.ds.min_level
         # yt max level is not the same as the RAMSES one.
         # yt max level is the maximum number of additional refinement levels
-        # so for a uni grid run with no refinement, it would be 0.
+        # so for a uni grid run with no refinement, it would be 0. 
         # So we initially assume that.
         max_level = 0
         nx, ny, nz = (((i-1.0)/2.0) for i in self.amr_header['nx'])
@@ -372,7 +372,7 @@ class RAMSESIndex(OctreeIndex):
             dsl.update(set(domain.particle_field_offsets.keys()))
         self.particle_field_list = list(dsl)
         self.field_list = [("ramses", f) for f in self.fluid_field_list] \
-                          + self.particle_field_list
+                        + self.particle_field_list
 
     def _setup_auto_fields(self):
         '''
@@ -380,7 +380,7 @@ class RAMSESIndex(OctreeIndex):
         '''
         # TODO: SUPPORT RT - THIS REQUIRES IMPLEMENTING A NEW FILE READER!
         # Find nvar
-
+        
 
         # TODO: copy/pasted from DomainFile; needs refactoring!
         num = os.path.basename(self.dataset.parameter_filename).split("."
@@ -414,25 +414,25 @@ class RAMSESIndex(OctreeIndex):
             raise ValueError
         # Basic hydro runs
         if nvar == 5:
-            fields = ["Density",
-                      "x-velocity", "y-velocity", "z-velocity",
+            fields = ["Density", 
+                      "x-velocity", "y-velocity", "z-velocity", 
                       "Pressure"]
         if nvar > 5 and nvar < 11:
-            fields = ["Density",
-                      "x-velocity", "y-velocity", "z-velocity",
+            fields = ["Density", 
+                      "x-velocity", "y-velocity", "z-velocity", 
                       "Pressure", "Metallicity"]
         # MHD runs - NOTE: THE MHD MODULE WILL SILENTLY ADD 3 TO THE NVAR IN THE MAKEFILE
         if nvar == 11:
-            fields = ["Density",
-                      "x-velocity", "y-velocity", "z-velocity",
-                      "x-Bfield-left", "y-Bfield-left", "z-Bfield-left",
-                      "x-Bfield-right", "y-Bfield-right", "z-Bfield-right",
+            fields = ["Density", 
+                      "x-velocity", "y-velocity", "z-velocity", 
+                      "x-Bfield-left", "y-Bfield-left", "z-Bfield-left", 
+                      "x-Bfield-right", "y-Bfield-right", "z-Bfield-right", 
                       "Pressure"]
         if nvar > 11:
-            fields = ["Density",
-                      "x-velocity", "y-velocity", "z-velocity",
-                      "x-Bfield-left", "y-Bfield-left", "z-Bfield-left",
-                      "x-Bfield-right", "y-Bfield-right", "z-Bfield-right",
+            fields = ["Density", 
+                      "x-velocity", "y-velocity", "z-velocity", 
+                      "x-Bfield-left", "y-Bfield-left", "z-Bfield-left", 
+                      "x-Bfield-right", "y-Bfield-right", "z-Bfield-right", 
                       "Pressure","Metallicity"]
         while len(fields) < nvar:
             fields.append("var"+str(len(fields)))
@@ -490,9 +490,9 @@ class RAMSESIndex(OctreeIndex):
         return {'io': npart}
 
     def print_stats(self):
-
+        
         # This function prints information based on the fluid on the grids,
-        # and therefore does not work for DM only runs.
+        # and therefore does not work for DM only runs. 
         if not self.fluid_field_list:
             print("This function is not implemented for DM only runs")
             return
@@ -532,11 +532,11 @@ class RAMSESDataset(Dataset):
     _index_class = RAMSESIndex
     _field_info_class = RAMSESFieldInfo
     gamma = 1.4 # This will get replaced on hydro_fn open
-
+    
     def __init__(self, filename, dataset_type='ramses',
-                 fields = None, storage_filename = None,
+                 fields=None, storage_filename=None,
                  units_override=None, unit_system="cgs",
-                 extra_particle_fields=None):
+                 extra_particle_fields=None, cosmological=None):
         # Here we want to initiate a traceback, if the reader is not built.
         if isinstance(fields, string_types):
             fields = field_aliases[fields]
@@ -544,13 +544,17 @@ class RAMSESDataset(Dataset):
         fields: An array of hydro variable fields in order of position in the hydro_XXXXX.outYYYYY file
                 If set to None, will try a default set of fields
         extra_particle_fields: An array of extra particle variables in order of position in the particle_XXXXX.outYYYYY file.
+        cosmological: If set to None, automatically detect cosmological simulation. If a boolean, force 
+                      its value.
         '''
         self.fluid_types += ("ramses",)
         self._fields_in_file = fields
         self._extra_particle_fields = extra_particle_fields
+        self.force_cosmological = cosmological
         Dataset.__init__(self, filename, dataset_type, units_override=units_override,
                          unit_system=unit_system)
         self.storage_filename = storage_filename
+
 
     def __repr__(self):
         return self.basename.rsplit(".", 1)[0]
@@ -566,7 +570,7 @@ class RAMSESDataset(Dataset):
         time_unit = self.parameters['unit_t']
 
         # calculating derived units (except velocity and temperature, done below)
-        mass_unit = density_unit * length_unit**3
+        mass_unit = density_unit * length_unit**3     
         magnetic_unit = np.sqrt(4*np.pi * mass_unit /
                                 (time_unit**2 * length_unit))
         pressure_unit = density_unit * (length_unit / time_unit)**2
@@ -637,7 +641,13 @@ class RAMSESDataset(Dataset):
         # This is likely not true, but it's not clear how to determine the boundary conditions
         self.periodicity = (True, True, True)
         # These conditions seem to always be true for non-cosmological datasets
-        if rheader["time"] >= 0 and rheader["H0"] == 1 and rheader["aexp"] == 1:
+        if self.force_cosmological is not None:
+            is_cosmological = self.force_cosmological
+        else:
+            is_cosmological = (rheader["time"] >= 0 and
+                               rheader["H0"] == 1 and
+                               rheader["aexp"] == 1)
+        if not is_cosmological:
             self.cosmological_simulation = 0
             self.current_redshift = 0
             self.hubble_constant = 0
@@ -665,7 +675,7 @@ class RAMSESDataset(Dataset):
 
             self.time_simu = self.t_frw[iage  ]*(age-self.tau_frw[iage-1])/(self.tau_frw[iage]-self.tau_frw[iage-1])+ \
                              self.t_frw[iage-1]*(age-self.tau_frw[iage  ])/(self.tau_frw[iage-1]-self.tau_frw[iage])
-
+ 
             self.current_time = (self.time_tot + self.time_simu)/(self.hubble_constant*1e7/3.08e24)/self.parameters['unit_t']
 
 

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -644,9 +644,9 @@ class RAMSESDataset(Dataset):
         if self.force_cosmological is not None:
             is_cosmological = self.force_cosmological
         else:
-            is_cosmological = (rheader["time"] >= 0 and
-                               rheader["H0"] == 1 and
-                               rheader["aexp"] == 1)
+            is_cosmological = not (rheader["time"] >= 0 and
+                                   rheader["H0"] == 1 and
+                                   rheader["aexp"] == 1)
         if not is_cosmological:
             self.cosmological_simulation = 0
             self.current_redshift = 0

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -62,14 +62,54 @@ def test_units_override():
 
 ramsesNonCosmo = 'DICEGalaxyDisk_nonCosmological/output_00002'
 @requires_file(ramsesNonCosmo)
+def test_non_cosmo_detection():
+    path = os.path.join(ramsesNonCosmo, 'info_00002.txt')
+    ds = yt.load(path, cosmological=False)
+    assert_equal(ds.cosmological_simulation, 0)
+
+    ds = yt.load(path, cosmological=None)
+    assert_equal(ds.cosmological_simulation, 0)
+
+    ds = yt.load(path)
+    assert_equal(ds.cosmological_simulation, 0)
+
+
+@requires_file(ramsesNonCosmo)
 def test_unit_non_cosmo():
-    ds = yt.load(os.path.join(ramsesNonCosmo, 'info_00002.txt'))
+    for force_cosmo in [False, None]:
+        ds = yt.load(os.path.join(ramsesNonCosmo, 'info_00002.txt'), cosmological=force_cosmo)
 
-    expected_raw_time = 0.0299468077820411 # in ramses unit
-    assert_equal(ds.current_time.value, expected_raw_time)
+        expected_raw_time = 0.0299468077820411 # in ramses unit
+        assert_equal(ds.current_time.value, expected_raw_time)
 
-    expected_time = 14087886140997.336 # in seconds
-    assert_equal(ds.current_time.in_units('s').value, expected_time)
+        expected_time = 14087886140997.336 # in seconds
+        assert_equal(ds.current_time.in_units('s').value, expected_time)
+
+
+ramsesCosmo = 'output_00080/info_00080.txt'
+@requires_file(ramsesCosmo)
+def test_cosmo_detection():
+    ds = yt.load(ramsesCosmo, cosmological=True)
+    assert_equal(ds.cosmological_simulation, 1)
+
+    ds = yt.load(ramsesCosmo, cosmological=None)
+    assert_equal(ds.cosmological_simulation, 1)
+
+    ds = yt.load(ramsesCosmo)
+    assert_equal(ds.cosmological_simulation, 1)
+
+
+@requires_file(ramsesCosmo)
+def test_unit_cosmo():
+    for force_cosmo in [True, None]:
+        ds = yt.load(ramsesCosmo, cosmological=force_cosmo)
+
+        expected_raw_time = 1.119216564055017 # in ramses unit
+        assert_equal(ds.current_time.value, expected_raw_time)
+
+        expected_time = 3.756241729312462e+17 # in seconds
+        assert_equal(ds.current_time.in_units('s').value, expected_time)
+
 
 ramsesExtraFieldsSmall = 'ramses_extra_fields_small/output_00001'
 @requires_file(ramsesExtraFieldsSmall)


### PR DESCRIPTION
## PR Summary

Solves issue #1311 by providing a way to force cosmological simulation detection. This is useful in cases where the conformal time of a cosmological simulation becomes positive. The simulation would then be detected as being non cosmological.=

## PR Checklist

- [x] Code passes flake8 checker
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.