### PR TITLE
[bugfix] Allow FITS image classes to accept DerivedField objects

### DIFF
--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -154,21 +154,21 @@ class FITSImageData(object):
                 self.fields.append(fd)
 
         first = True
-        for key in fields:
-            if key not in exclude_fields:
-                if hasattr(img_data[key], "units"):
-                    self.field_units[key] = str(img_data[key].units)
+        for name, field in zip(self.fields, fields):
+            if name not in exclude_fields:
+                if hasattr(img_data[field], "units"):
+                    self.field_units[name] = str(img_data[field].units)
                 else:
-                    self.field_units[key] = "dimensionless"
-                mylog.info("Making a FITS image of field %s" % key)
+                    self.field_units[name] = "dimensionless"
+                mylog.info("Making a FITS image of field %s" % name)
                 if first:
-                    hdu = _astropy.pyfits.PrimaryHDU(np.array(img_data[key]))
+                    hdu = _astropy.pyfits.PrimaryHDU(np.array(img_data[field]))
                     first = False
                 else:
-                    hdu = _astropy.pyfits.ImageHDU(np.array(img_data[key]))
-                hdu.name = key
-                hdu.header["btype"] = key
-                hdu.header["bunit"] = re.sub('()', '', self.field_units[key])
+                    hdu = _astropy.pyfits.ImageHDU(np.array(img_data[field]))
+                hdu.name = name
+                hdu.header["btype"] = name
+                hdu.header["bunit"] = re.sub('()', '', self.field_units[name])
                 self.hdulist.append(hdu)
 
         self.shape = self.hdulist[0].shape

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -11,6 +11,7 @@ FITSImageData Class
 #-----------------------------------------------------------------------------
 from yt.extern.six import string_types
 import numpy as np
+from yt.fields.derived_field import DerivedField
 from yt.funcs import mylog, iterable, fix_axis, ensure_list
 from yt.visualization.fixed_resolution import FixedResolutionBuffer
 from yt.data_objects.construction_data_containers import YTCoveringGrid
@@ -147,6 +148,8 @@ class FITSImageData(object):
         for fd in fields:
             if isinstance(fd, tuple):
                 self.fields.append(fd[1])
+            elif isinstance(fd, DerivedField):
+                self.fields.append(fd.name[1])
             else:
                 self.fields.append(fd)
 

--- a/yt/visualization/tests/test_fits_image.py
+++ b/yt/visualization/tests/test_fits_image.py
@@ -44,7 +44,7 @@ def test_fits_image():
     prj_frb = prj.to_frb((0.5, "unitary"), 128)
 
     fid1 = FITSImageData(prj_frb, fields=["density","temperature"], units="cm")
-    fits_prj = FITSProjection(ds, "z", ["density","temperature"], image_res=128,
+    fits_prj = FITSProjection(ds, "z", [ds.fields.gas.density,"temperature"], image_res=128,
                               width=(0.5,"unitary"))
 
     assert_equal(fid1["density"].data, fits_prj["density"].data)
@@ -71,7 +71,7 @@ def test_fits_image():
     slc_frb = slc.to_frb((0.5, "unitary"), 128)
 
     fid2 = FITSImageData(slc_frb, fields=["density","temperature"], units="cm")
-    fits_slc = FITSSlice(ds, "z", ["density","temperature"], image_res=128,
+    fits_slc = FITSSlice(ds, "z", ["density",("gas","temperature")], image_res=128,
                          width=(0.5,"unitary"))
 
     assert_equal(fid2["density"].data, fits_slc["density"].data)
@@ -87,7 +87,7 @@ def test_fits_image():
     cut = ds.cutting([0.1, 0.2, -0.9], [0.5, 0.42, 0.6])
     cut_frb = cut.to_frb((0.5, "unitary"), 128)
 
-    fid3 = FITSImageData(cut_frb, fields=["density","temperature"], units="cm")
+    fid3 = FITSImageData(cut_frb, fields=[("gas","density"), ds.fields.gas.temperature], units="cm")
     fits_cut = FITSOffAxisSlice(ds, [0.1, 0.2, -0.9], ["density","temperature"],
                                 image_res=128, center=[0.5, 0.42, 0.6],
                                 width=(0.5,"unitary"))


### PR DESCRIPTION
The existing API for the various FITS image classes accepts either strings or tuples for field names, but not `DerivedField` objects, e.g. something like this:

```python
import yt
ds = yt.load("GasSloshing/sloshing_nomag2_hdf5_plt_cnt_0100")
fid = yt.FITSProjection(ds, "z", ds.fields.gas.density)
```
This PR changes the internal logic so that these objects are also accepted.