### PR TITLE
Fix parallel projections when there are less than nprocs io chunks. 

### DIFF
--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -342,6 +342,10 @@ class YTQuadTreeProj(YTSelectionContainer2D):
                     self._initialize_projected_units(fields, chunk)
                     _units_initialized = True
                 self._handle_chunk(chunk, fields, tree)
+        # if there's less than nprocs chunks, units won't be initialized
+        # on all processors, so sync with _projected_units on rank 0
+        projected_units = self.comm.mpi_bcast(self._projected_units)
+        self._projected_units = projected_units
         # Note that this will briefly double RAM usage
         if self.method == "mip":
             merge_style = -1


### PR DESCRIPTION
Closes #1483.

As the inline comment says, if there are less than n_procs io chunks, we only initialize the `_projected_units` dict on the root processor. The fix is to broadcast the units to all MPI ranks.

I didn't add a test because we don't have a parallel testing framework.