### PR TITLE
Decode units given as bytes object

### DIFF
--- a/yt/fields/derived_field.py
+++ b/yt/fields/derived_field.py
@@ -144,6 +144,8 @@ class DerivedField(object):
                 self.units = units
         elif isinstance(units, Unit):
             self.units = str(units)
+        elif isinstance(units, bytes):
+            self.units = units.decode("utf-8")
         else:
             raise FieldUnitsError("Cannot handle units '%s' (type %s)." \
                                   "Please provide a string or Unit " \


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

Reading hdf5 files of stored `Ray` objects in python 3 can result in feeding yt unit information as `bytes` objects instead of strings. This is due to an [issue](https://github.com/h5py/h5py/issues/379) where h5py parses hdf5 attributes incorrectly.

This PR does a simple check to ensure unit information provided as a `bytes` object gets properly decoded.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes flake8 checker
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
