### PR TITLE
Add imposter syndrome disclaimer to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,26 @@ to have you hang out in our community.
 
 We have developed some [guidelines](CONTRIBUTING.rst) for contributing to yt.
 
+**Imposter syndrome disclaimer**: We want your help. No, really.
+
+There may be a little voice inside your head that is telling you that you're not
+ready to be an open source contributor; that your skills aren't nearly good
+enough to contribute. What could you possibly offer a project like this one?
+
+We assure you - the little voice in your head is wrong. If you can write code at
+all, you can contribute code to open source. Contributing to open source
+projects is a fantastic way to advance one's coding skills. Writing perfect code
+isn't the measure of a good developer (that would disqualify all of us!); it's
+trying to create something, making mistakes, and learning from those
+mistakes. That's how we all improve, and we are happy to help others learn.
+
+Being an open source contributor doesn't just mean writing code, either. You can
+help out by writing documentation, tests, or even giving feedback about the
+project (and yes - that includes giving feedback about the contribution
+process). Some of these contributions may be the most valuable to the project as
+a whole, because you're coming to the project with fresh eyes, so you can see
+the errors and assumptions that seasoned contributors have glossed over.
+
 ## Resources
 
 We have some community and documentation resources available.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,10 @@ process). Some of these contributions may be the most valuable to the project as
 a whole, because you're coming to the project with fresh eyes, so you can see
 the errors and assumptions that seasoned contributors have glossed over.
 
-(This disclaimer was originally part of the README file for the
+(This disclaimer was originally written by
+[Adrienne Lowe](https://github.com/adriennefriend) for a
+[PyCon talk](https://www.youtube.com/watch?v=6Uj746j9Heo), and was adapted by yt
+based on its use in the README file for the
 [MetPy project](https://github.com/Unidata/MetPy))
 
 ## Resources

--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ process). Some of these contributions may be the most valuable to the project as
 a whole, because you're coming to the project with fresh eyes, so you can see
 the errors and assumptions that seasoned contributors have glossed over.
 
+(This disclaimer was originally part of the README file for the
+[MetPy project](https://github.com/Unidata/MetPy))
+
 ## Resources
 
 We have some community and documentation resources available.


### PR DESCRIPTION
This was shamelessly stolen from the [metpy readme](https://github.com/Unidata/MetPy). I really like the gist of it and think it would be a good addition for our readme as well.