### PR TITLE
Remove grid edge rounding in FLASH frontend. Fixes #1361

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -20,7 +20,7 @@ answer_tests:
   local_fits_001:
     - yt/frontends/fits/tests/test_outputs.py
 
-  local_flash_007:
+  local_flash_008:
     - yt/frontends/flash/tests/test_outputs.py
 
   local_gadget_001:
@@ -45,7 +45,7 @@ answer_tests:
   local_owls_001:
     - yt/frontends/owls/tests/test_outputs.py
 
-  local_pw_016:
+  local_pw_017:
     - yt/visualization/tests/test_plotwindow.py:test_attributes
     - yt/visualization/tests/test_plotwindow.py:test_attributes_wt
     - yt/visualization/tests/test_profile_plots.py:test_phase_plot_attributes
@@ -57,13 +57,13 @@ answer_tests:
   local_tipsy_002:
     - yt/frontends/tipsy/tests/test_outputs.py
 
-  local_varia_008:
+  local_varia_009:
     - yt/analysis_modules/radmc3d_export
     - yt/frontends/moab/tests/test_c5.py
     - yt/visualization/volume_rendering/tests/test_vr_orientation.py
     - yt/fields/tests/test_xray_fields.py
 
-  local_photon_001:
+  local_photon_002:
     - yt/analysis_modules/photon_simulator/tests/test_spectra.py
     - yt/analysis_modules/photon_simulator/tests/test_sloshing.py
 

--- a/yt/frontends/flash/data_structures.py
+++ b/yt/frontends/flash/data_structures.py
@@ -153,12 +153,6 @@ class FLASHHierarchy(GridIndex):
             gre[:,2] = 2.0 * np.pi
             return
 
-        # Now, for cartesian data.
-        for i in range(self.num_grids):
-            dx = dxs[self.grid_levels[i],:]
-            gle[i][:ND] = np.rint(gle[i][:ND]/dx[0][:ND])*dx[0][:ND]
-            gre[i][:ND] = np.rint(gre[i][:ND]/dx[0][:ND])*dx[0][:ND]
-
     def _populate_grid_objects(self):
         ii = np.argsort(self.grid_levels.flat)
         gid = self._handle["/gid"][:]


### PR DESCRIPTION
This code dates back to January 2012, specifically git commit a471742895. The commit message for that change includes the following description:

> Sam suggested this fix to "finesse" the roundoff error when reading in FLASH bounding boxes. It's somewhat hackish, so if someone has a more elegant solution feel free to change it.

I *think* that the base issue @jzuhone was working around was fixed relatively recently by #1433, although I'm not 100% sure.

With this change, we now have the correct volume (up to round-off error?) for the FLASH dataset that had issues and no longer have artifacts in the slice visualizations:

```
In [2]: ad['cell_volume'].sum()
Out[2]: 0.01820000019222498 code_length**3

In [3]: ds.domain_width.prod()
Out[3]: 0.0182 code_length**3
```

![nogrids_slice_z_density](https://user-images.githubusercontent.com/3126246/28241150-7a42a4a2-6954-11e7-836a-14a7a5d7844c.png)

This may change answers for some FLASH datasets. Let's see what the tests say.
