### PR TITLE
fix cython warning

### DIFF
--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -1573,7 +1573,8 @@ cdef class RaySelector(SelectorObject):
         cdef VolumeContainer vc
         cdef IntegrationAccumulator *ia
         ia = <IntegrationAccumulator *> malloc(sizeof(IntegrationAccumulator))
-        cdef np.float64_t dt[1], t[1]
+        cdef np.float64_t dt[1]
+        cdef np.float64_t t[1]
         cdef np.uint8_t cm[1]
         for i in range(3):
             vc.left_edge[i] = left_edge[i]


### PR DESCRIPTION
Cython complains about having these two declarations on the same line:

```
[ 7/33] Cythonizing yt/geometry/selection_routines.pyx
warning: yt/geometry/selection_routines.pyx:1576:28: Non-trivial type declarators in shared declaration (e.g. mix of pointers and values). Each pointer declaration should be on its own line.
warning: yt/geometry/selection_routines.pyx:1576:34: Non-trivial type declarators in shared declaration (e.g. mix of pointers and values). Each pointer declaration should be on its own line.
```

It's a silly rule but the warning is annoying, so let's just fix it.