### PR TITLE
Update yt configuration path

### DIFF
--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -1858,7 +1858,7 @@ class YTSurface(YTSelectionContainer3D):
         SketchFab.com.  It requires an API key, which can be found on your
         SketchFab.com dashboard.  You can either supply the API key to this
         routine directly or you can place it in the variable
-        "sketchfab_api_key" in your ~/.yt/config file.  This function is
+        "sketchfab_api_key" in your ~/.config/yt/ytrc file.  This function is
         parallel-safe.
 
         Parameters

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -1000,7 +1000,7 @@ class YTNotebookCmd(YTCommand):
             pw = IPython.lib.passwd()
             print("If you would like to use this password in the future,")
             print("place a line like this inside the [yt] section in your")
-            print("yt configuration file at ~/.yt/config")
+            print("yt configuration file at ~/.config/yt/ytrc")
             print()
             print("notebook_password = %s" % pw)
             print()

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -321,7 +321,7 @@ class YTNoAPIKey(YTException):
         self.config_name = config_name
 
     def __str__(self):
-        return "You need to set an API key for %s in ~/.yt/config as %s" % (
+        return "You need to set an API key for %s in ~/.config/yt/ytrc as %s" % (
             self.service, self.config_name)
 
 class YTTooManyVertices(YTException):


### PR DESCRIPTION
## PR Summary

This change spares us `UserWarning: The configuration file ~/.yt/config is deprecated.  Please migrate your config to ~/.config/yt/ytrc by running: 'yt config migrate'` and a fail when launching `yt notebook`.

I admit that I did not bother running `yt config migrate` but edited my already existing `~/.config/yt/ytrc` file (and removed `~/.yt/config`).

Now `yt notebook` launches smoothly!