### PR TITLE
Symlog zeroes catches passed to np.log10()

### DIFF
--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -229,7 +229,15 @@ class ImagePlotMPL(PlotMPL):
                 **formatter_kwargs)
             self.cb = self.figure.colorbar(
                 self.image, self.cax, format=formatter)
-            yticks = list(-10**np.arange(np.floor(np.log10(-data.min())),\
+            if data.min().v >= 0.0:
+                yticks = [data.min().v] + list(10**np.arange(
+                                          np.rint(np.log10(cblinthresh)),\
+                          np.ceil(np.log10(data.max()))+1))
+            elif data.max().v <= 0.0:
+                yticks = list(-10**np.arange(np.floor(np.log10(-data.min())),\
+                         np.rint(np.log10(cblinthresh))-1, -1)) + [data.max().v]
+            else:
+                yticks = list(-10**np.arange(np.floor(np.log10(-data.min())),\
                           np.rint(np.log10(cblinthresh))-1, -1)) + [0] + \
                      list(10**np.arange(np.rint(np.log10(cblinthresh)),\
                           np.ceil(np.log10(data.max()))+1))

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -229,18 +229,23 @@ class ImagePlotMPL(PlotMPL):
                 **formatter_kwargs)
             self.cb = self.figure.colorbar(
                 self.image, self.cax, format=formatter)
-            if data.min().v >= 0.0:
-                yticks = [data.min().v] + list(10**np.arange(
-                                          np.rint(np.log10(cblinthresh)),\
-                          np.ceil(np.log10(data.max()))+1))
-            elif data.max().v <= 0.0:
-                yticks = list(-10**np.arange(np.floor(np.log10(-data.min())),\
-                         np.rint(np.log10(cblinthresh))-1, -1)) + [data.max().v]
+            if data.min() >= 0.0:
+                yticks = [data.min().v] + list(
+                    10**np.arange(np.rint(np.log10(cblinthresh)),
+                                  np.ceil(np.log10(data.max())) + 1))
+            elif data.max() <= 0.0:
+                yticks = list(
+                    -10**np.arange(
+                        np.floor(np.log10(-data.min())),
+                        np.rint(np.log10(cblinthresh)) - 1, -1)) + \
+                    [data.max().v]
             else:
-                yticks = list(-10**np.arange(np.floor(np.log10(-data.min())),\
-                          np.rint(np.log10(cblinthresh))-1, -1)) + [0] + \
-                     list(10**np.arange(np.rint(np.log10(cblinthresh)),\
-                          np.ceil(np.log10(data.max()))+1))
+                yticks = list(
+                    -10**np.arange(np.floor(np.log10(-data.min())),
+                                   np.rint(np.log10(cblinthresh))-1, -1)) + \
+                    [0] + \
+                    list(10**np.arange(np.rint(np.log10(cblinthresh)),
+                                       np.ceil(np.log10(data.max()))+1))
             self.cb.set_ticks(yticks)
         else:
             self.cb = self.figure.colorbar(self.image, self.cax)

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -145,12 +145,12 @@ def get_symlog_minorticks(linthresh, vmin, vmax):
     if vmin > 0 or vmax < 0:
         return get_log_minorticks(vmin, vmax)
     elif vmin == 0:
-        return np.hstack( (0, get_log_minorticks(linthresh, vmax)) )
+        return np.hstack((0, get_log_minorticks(linthresh, vmax)))
     elif vmax == 0:
-        return np.hstack( (-get_log_minorticks(linthresh,-vim)[::-1], 0) )
+        return np.hstack((-get_log_minorticks(linthresh,-vmin)[::-1], 0) )
     else:
-        return np.hstack( (-get_log_minorticks(linthresh,-vmin)[::-1], 0,
-                            get_log_minorticks(linthresh, vmax)) )
+        return np.hstack((-get_log_minorticks(linthresh,-vmin)[::-1], 0,
+                          get_log_minorticks(linthresh, vmax)))
 
 field_transforms = {}
 

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -142,8 +142,12 @@ def get_symlog_minorticks(linthresh, vmin, vmax):
         the maximum value in the colorbar
 
     """
-    if vmin >= 0 or vmax <= 0:
+    if vmin > 0 or vmax < 0:
         return get_log_minorticks(vmin, vmax)
+    elif vmin == 0:
+        return np.hstack( (0, get_log_minorticks(linthresh, vmax)) )
+    elif vmax == 0:
+        return np.hstack( (-get_log_minorticks(linthresh,-vim)[::-1], 0) )
     else:
         return np.hstack( (-get_log_minorticks(linthresh,-vmin)[::-1], 0,
                             get_log_minorticks(linthresh, vmax)) )

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -525,3 +525,26 @@ def test_plot_2d():
     slc = SlicePlot(ds, "theta", ["density"], width=(30000.0, "km"))
     slc2 = plot_2d(ds, "density", width=(30000.0, "km"))
     assert_array_equal(slc.frb['density'], slc2.frb['density'])
+
+def test_symlog_colorbar():
+    ds = fake_random_ds(16)
+
+    def _thresh_density(field, data):
+        wh = data['density'] < 0.5
+        ret = data['density']
+        ret[wh] = 0
+        return ret
+
+    def _neg_density(field, data):
+        return -data['threshold_density']
+
+    ds.add_field('threshold_density', function=_thresh_density,
+                 units='g/cm**3', sampling_type='cell')
+    ds.add_field('negative_density', function=_neg_density, units='g/cm**3',
+                 sampling_type='cell')
+
+    for field in ['density', 'threshold_density', 'negative_density']:
+        plot = SlicePlot(ds, 2, field)
+        plot.set_log(field, True, linthresh=0.1)
+        with tempfile.NamedTemporaryFile(suffix='png') as f:
+            plot.save(f.name)


### PR DESCRIPTION
## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request i
detail.  Why is this change required?  What problem does it solve?-->

If your data has zero as the extrema values yt crashes when it tries to take a `np.log10(data.min())` in `_init_image()` from `yt/visualization/base_plot_types.py`. This is fixed in the first commit about major ticks. Additionally `get_symlog_minorticks()` of `yt/visualization/plot_container.py`, needed a similar catch to properly added minor ticks, second commit.

Reproduction of the bugs are outlined in issue #1501.

Fixes #1501 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes flake8 checker
- [x] Adds a test for any bugs fixed. 
