### PR TITLE
Make scene.save() support saving pdf, ps, and eps files.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
 
   matrix:
       - PYTHON_VERSION: "2.7"
-#      - PYTHON_VERSION: "3.6"
+      - PYTHON_VERSION: "3.6"
 
 platform:
     -x64
@@ -21,6 +21,7 @@ install:
 
     # Install the build and runtime dependencies of the project.
     # Create a conda environment
+    - "conda update -q --yes conda"
     - "conda create -q --yes -n test python=%PYTHON_VERSION%"
     - "activate test"
 
@@ -40,5 +41,5 @@ test_script:
 # Enable this to be able to login to the build worker. You can use the
 # `remmina` program in Ubuntu, use the login information that the line below
 # prints into the log.
-on_finish:
-- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+#on_finish:
+#- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,3 +36,9 @@ build: false
 
 test_script:
   - "nosetests --nologcapture -sv yt"
+
+# Enable this to be able to login to the build worker. You can use the
+# `remmina` program in Ubuntu, use the login information that the line below
+# prints into the log.
+on_finish:
+- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
       PYTHON: "C:\\Miniconda3-x64"
 
   matrix:
-      - PYTHON_VERSION: "3.6"
+#      - PYTHON_VERSION: "3.6"
       - PYTHON_VERSION: "2.7"
 
 platform:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
     - "python --version"
 
     # Install specified version of numpy and dependencies
-    - "conda install -q --yes -c conda-forge numpy scipy nose setuptools ipython Cython sympy fastcache h5py matplotlib flake8 mock"
+    - "conda install --yes -c conda-forge numpy scipy nose setuptools ipython Cython sympy fastcache h5py matplotlib flake8 mock"
     - "pip install -e ."
 
 # Not a .NET project

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,8 @@ environment:
       PYTHON: "C:\\Miniconda3-x64"
 
   matrix:
-#      - PYTHON_VERSION: "3.6"
       - PYTHON_VERSION: "2.7"
+#      - PYTHON_VERSION: "3.6"
 
 platform:
     -x64

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -1019,3 +1019,30 @@ def assert_allclose_units(actual, desired, rtol=1e-7, atol=0, **kwargs):
     at = at.value
 
     return assert_allclose(act, des, rt, at, **kwargs)
+
+def assert_fname(fname):
+    """Function that checks file type using libmagic"""
+    if fname is None:
+        return
+
+    with open(fname, 'rb') as fimg:
+        data = fimg.read()
+    image_type = ''
+
+    # see http://www.w3.org/TR/PNG/#5PNG-file-signature
+    if data.startswith(b'\211PNG\r\n\032\n'):
+        image_type = '.png'
+    # see http://www.mathguide.de/info/tools/media-types/image/jpeg
+    elif data.startswith(b'\377\330'):
+        image_type = '.jpeg'
+    elif data.startswith(b'%!PS-Adobe'):
+        data_str = data.decode("utf-8", "ignore")
+        if 'EPSF' in data_str[:data_str.index('\n')]:
+            image_type = '.eps'
+        else:
+            image_type = '.ps'
+    elif data.startswith(b'%PDF'):
+        image_type = '.pdf'
+
+    return image_type == os.path.splitext(fname)[1]
+

--- a/yt/visualization/tests/test_callbacks.py
+++ b/yt/visualization/tests/test_callbacks.py
@@ -23,9 +23,9 @@ from yt.config import \
 from yt.testing import \
     fake_amr_ds, \
     fake_tetrahedral_ds, \
-    fake_hexahedral_ds
+    fake_hexahedral_ds, \
+    assert_fname
 import yt.units as u
-from .test_plotwindow import assert_fname
 from yt.utilities.exceptions import \
     YTPlotCallbackError, \
     YTDataTypeUnsupported

--- a/yt/visualization/tests/test_particle_plot.py
+++ b/yt/visualization/tests/test_particle_plot.py
@@ -18,10 +18,12 @@ import shutil
 import unittest
 from yt.data_objects.profiles import create_profile
 from yt.visualization.tests.test_plotwindow import \
-    assert_fname, WIDTH_SPECS, ATTR_ARGS
+    WIDTH_SPECS, ATTR_ARGS
 from yt.data_objects.particle_filters import add_particle_filter
 from yt.testing import \
-    fake_particle_ds, assert_array_almost_equal
+    fake_particle_ds, \
+    assert_array_almost_equal, \
+    assert_fname
 from yt.utilities.answer_testing.framework import \
     requires_ds, \
     data_dir_load, \

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -24,7 +24,7 @@ from nose.tools import assert_true
 
 from yt.testing import \
     fake_random_ds, assert_equal, assert_rel_equal, assert_array_equal, \
-    assert_array_almost_equal, assert_raises
+    assert_array_almost_equal, assert_raises, assert_fname
 from yt.utilities.answer_testing.framework import \
     requires_ds, data_dir_load, PlotWindowAttributeTest
 from yt.utilities.exceptions import \
@@ -41,33 +41,6 @@ def setup():
     """Test specific setup."""
     from yt.config import ytcfg
     ytcfg["yt", "__withintesting"] = "True"
-
-
-def assert_fname(fname):
-    """Function that checks file type using libmagic"""
-    if fname is None:
-        return
-
-    with open(fname, 'rb') as fimg:
-        data = fimg.read()
-    image_type = ''
-
-    # see http://www.w3.org/TR/PNG/#5PNG-file-signature
-    if data.startswith(b'\211PNG\r\n\032\n'):
-        image_type = '.png'
-    # see http://www.mathguide.de/info/tools/media-types/image/jpeg
-    elif data.startswith(b'\377\330'):
-        image_type = '.jpeg'
-    elif data.startswith(b'%!PS-Adobe'):
-        data_str = data.decode("utf-8", "ignore")
-        if 'EPSF' in data_str[:data_str.index('\n')]:
-            image_type = '.eps'
-        else:
-            image_type = '.ps'
-    elif data.startswith(b'%PDF'):
-        image_type = '.pdf'
-
-    return image_type == os.path.splitext(fname)[1]
 
 
 TEST_FLNMS = [None, 'test', 'test.png', 'test.eps',

--- a/yt/visualization/tests/test_profile_plots.py
+++ b/yt/visualization/tests/test_profile_plots.py
@@ -21,11 +21,12 @@ from yt.data_objects.profiles import create_profile
 from yt.testing import \
     fake_random_ds, \
     assert_array_almost_equal, \
-    requires_file
+    requires_file, \
+    assert_fname
 from yt.visualization.profile_plotter import \
     ProfilePlot, PhasePlot
 from yt.visualization.tests.test_plotwindow import \
-    assert_fname, TEST_FLNMS
+    TEST_FLNMS
 from yt.utilities.answer_testing.framework import \
     PhasePlotAttributeTest, \
     requires_ds, \

--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -309,11 +309,21 @@ class Scene(object):
         if suffix == '.png':
             self._last_render.write_png(fname, sigma_clip=sigma_clip)
         else:
-            from matplotlib import pyplot as plt
-            fig, ax = plt.subplots()
+            from matplotlib.figure import Figure
+            from matplotlib.backends.backend_pdf import \
+                FigureCanvasPdf
+            from matplotlib.backends.backend_ps import \
+                FigureCanvasPS
             shape = self._last_render.shape
-            fig.set_size_inches(shape[0]/100., shape[1]/100.)
-            fig.subplots_adjust(left=0, bottom=0, right=1, top=1)
+            fig = Figure((shape[0]/100., shape[1]/100.))
+            if suffix == '.pdf':
+                canvas = FigureCanvasPdf(fig)
+            elif suffix in ('.eps', '.ps'):
+                canvas = FigureCanvasPS(fig)
+            else:
+                raise NotImplementedError(
+                    "Unknown file suffix '{}'".format(suffix))
+            ax = fig.add_axes([0, 0, 1, 1])
             ax.set_axis_off()
             out = self._last_render
             nz = out[:, :, :3][out[:, :, :3].nonzero()]
@@ -325,8 +335,7 @@ class Scene(object):
             # not sure why we need rot90, but this makes the orentation
             # match the png writer
             ax.imshow(np.rot90(out), origin='lower')
-            plt.savefig(fname, dpi=100)
-
+            canvas.print_figure(fname, dpi=100)
 
     def save_annotated(self, fname=None, label_fmt=None,
                        text_annotate=None, dpi=100, sigma_clip=None):

--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -241,8 +241,10 @@ class Scene(object):
         Parameters
         ----------
         fname: string, optional
-            If specified, save the rendering as a bitmap to the file "fname".
+            If specified, save the rendering as to the file "fname".
             If unspecified, it creates a default based on the dataset filename.
+            The file format is inferred from the filename's suffix. Supported
+            fomats are png, pdf, eps, and ps.
             Default: None
         sigma_clip: float, optional
             Image values greater than this number times the standard deviation
@@ -302,7 +304,28 @@ class Scene(object):
         self.render()
 
         mylog.info("Saving render %s", fname)
-        self._last_render.write_png(fname, sigma_clip=sigma_clip)
+        # We can render pngs natively but for other formats we defer to
+        # matplotlib.
+        if suffix == '.png':
+            self._last_render.write_png(fname, sigma_clip=sigma_clip)
+        else:
+            from matplotlib import pyplot as plt
+            fig, ax = plt.subplots()
+            shape = self._last_render.shape
+            fig.set_size_inches(shape[0]/100., shape[1]/100.)
+            fig.subplots_adjust(left=0, bottom=0, right=1, top=1)
+            ax.set_axis_off()
+            out = self._last_render
+            nz = out[:, :, :3][out[:, :, :3].nonzero()]
+            max_val = nz.mean() + sigma_clip * nz.std()
+            alpha = 255 * out[:, :, 3].astype('uint8')
+            out = np.clip(out[:, :, :3] / max_val, 0.0, 1.0) * 255
+            out = np.concatenate(
+                [out.astype('uint8'), alpha[..., None]], axis=-1)
+            # not sure why we need rot90, but this makes the orentation
+            # match the png writer
+            ax.imshow(np.rot90(out), origin='lower')
+            plt.savefig(fname, dpi=100)
 
 
     def save_annotated(self, fname=None, label_fmt=None,

--- a/yt/visualization/volume_rendering/tests/test_scene.py
+++ b/yt/visualization/volume_rendering/tests/test_scene.py
@@ -16,7 +16,9 @@ Test for Volume Rendering Scene, and their movement.
 import os
 import tempfile
 import shutil
-from yt.testing import fake_random_ds
+from yt.testing import \
+    fake_random_ds, \
+    assert_fname
 from yt.visualization.volume_rendering.api import volume_render, VolumeSource
 import numpy as np
 from unittest import TestCase
@@ -78,7 +80,10 @@ class RotationTest(TestCase):
         ma_bound = ((ma-mi)*(0.90))+mi
         tf.map_to_colormap(mi_bound, ma_bound,  scale=0.01, colormap='Reds_r')
         sc.render()
-        sc.save('test_scene.png', sigma_clip=6.0)
+        for suffix in ['png', 'eps', 'ps', 'pdf']:
+            fname = 'test_scene.{}'.format(suffix)
+            sc.save(fname, sigma_clip=6.0)
+            assert_fname(fname)
 
         nrot = 2 
         for i in range(nrot):

--- a/yt/visualization/volume_rendering/tests/test_vr_cameras.py
+++ b/yt/visualization/volume_rendering/tests/test_vr_cameras.py
@@ -18,14 +18,14 @@ import os.path
 import tempfile
 import shutil
 from yt.testing import \
-    fake_random_ds
+    fake_random_ds, \
+    assert_fname
 import numpy as np
 from yt.visualization.volume_rendering.old_camera import \
     PerspectiveCamera, StereoPairCamera, InteractiveCamera, ProjectionCamera, \
     FisheyeCamera
 from yt.visualization.volume_rendering.api import ColorTransferFunction, \
     ProjectionTransferFunction
-from yt.visualization.tests.test_plotwindow import assert_fname
 from unittest import TestCase
 
 


### PR DESCRIPTION
This makes it so you can save pdf, eps, and ps files directly from the scene object, making use of matplotlib to handle the file format conversion issues. I made sure that if you save an image as a pdf and a png, the images you get back match orientation and appearance as closely as possible.

This is technically a new feature but it was simple enough to add that I went ahead and did it. Given the bug report (#1503) and the vagueness of the current docstrings I don't think it's crazy to expect yt to do the right thing if you tell it to save a pdf instead of a png.

~~Let me know if my use of pyplot is objectionable - it was easier to implement this using pyplot rather than using the OO interface. The pyplot import only happens if you tell yt to save something that's not a png so I think it should be safe for existing scripts. I could probably rewrite it to use the matplotlib OO interface if anyone sees using pyplot as a possible issue.~~

EDIT: It looks like travis doesn't like using pyplot without a DISPLAY variable set. That was enough to kick me in the pants and remove the pyplot usage.