### PR TITLE
Make boilerplate consistent and pep8 compliant

### DIFF
--- a/yt/frontends/_skeleton/__init__.py
+++ b/yt/frontends/_skeleton/__init__.py
@@ -1,5 +1,5 @@
 """
-API for yt.frontends.skeleton
+API for yt.frontends._skeleton
 
 
 

--- a/yt/frontends/_skeleton/api.py
+++ b/yt/frontends/_skeleton/api.py
@@ -22,4 +22,4 @@ from .fields import \
       SkeletonFieldInfo
 
 from .io import \
-      IOHandlerSkeleton
+      SkeletonIOHandler

--- a/yt/frontends/_skeleton/data_structures.py
+++ b/yt/frontends/_skeleton/data_structures.py
@@ -25,8 +25,10 @@ from yt.data_objects.static_output import \
     Dataset
 from .fields import SkeletonFieldInfo
 
+
 class SkeletonGrid(AMRGridPatch):
     _id_offset = 0
+
     def __init__(self, id, index, level):
         AMRGridPatch.__init__(self, id, filename=index.index_filename,
                               index=index)
@@ -36,6 +38,7 @@ class SkeletonGrid(AMRGridPatch):
 
     def __repr__(self):
         return "SkeletonGrid_%04i (%s)" % (self.id, self.ActiveDimensions)
+
 
 class SkeletonHierarchy(GridIndex):
     grid = SkeletonGrid
@@ -84,6 +87,7 @@ class SkeletonHierarchy(GridIndex):
         # This is handled by the frontend because often the children must be
         # identified.
         pass
+
 
 class SkeletonDataset(Dataset):
     _index_class = SkeletonHierarchy
@@ -146,5 +150,3 @@ class SkeletonDataset(Dataset):
         # This accepts a filename or a set of arguments and returns True or
         # False depending on if the file is of the type requested.
         return False
-
-

--- a/yt/frontends/_skeleton/fields.py
+++ b/yt/frontends/_skeleton/fields.py
@@ -20,6 +20,7 @@ from yt.fields.field_info_container import \
 # container subclass here will define which fields it knows about.  There are
 # optionally methods on it that get called which can be subclassed.
 
+
 class SkeletonFieldInfo(FieldInfoContainer):
     known_other_fields = (
         # Each entry here is of the form

--- a/yt/frontends/_skeleton/io.py
+++ b/yt/frontends/_skeleton/io.py
@@ -16,9 +16,10 @@ Skeleton-specific IO functions
 from yt.utilities.io_handler import \
     BaseIOHandler
 
-class IOHandlerSkeleton(BaseIOHandler):
+
+class SkeletonIOHandler(BaseIOHandler):
     _particle_reader = False
-    _dataset_type = "skeleton"
+    _dataset_type = 'skeleton'
 
     def _read_particle_coords(self, chunks, ptf):
         # This needs to *yield* a series of tuples of (ptype, (x, y, z)).
@@ -33,7 +34,6 @@ class IOHandlerSkeleton(BaseIOHandler):
         # Selector objects have a .select_points(x,y,z) that returns a mask, so
         # you need to do your masking here.
         pass
-
 
     def _read_fluid_selection(self, chunks, selector, fields, size):
         # This needs to allocate a set of arrays inside a dictionary, where the


### PR DESCRIPTION
## PR Summary

As I copied the contents of `yt/frontends/_skeleton/` to create a new frontend, I noticed some minor naming and styling inconsistencies.  I thought I would make all files pass `pep8` at the same time.  This way, warnings and errors won't propagate as we copy this boilerplate code.

Somehow `flake8` does not seem to detect anything...  Maybe that's my new install--yet another one.

## PR Checklist

- [x] Code passes flake8 checker