### PR TITLE
Allow multiple sampling lines for LinePlot

### DIFF
--- a/doc/source/cookbook/simple_1d_line_plot.py
+++ b/doc/source/cookbook/simple_1d_line_plot.py
@@ -8,7 +8,7 @@ ds = yt.load("SecondOrderTris/RZ_p_no_parts_do_nothing_bcs_cone_out.e", step=-1)
 plot = yt.LinePlot(ds, [('all', 'v'), ('all', 'u')], (0, 0, 0), (0, 1, 0), 1000)
 
 # Add a legend
-plot.add_legend(('all', 'v'))
+plot.annotate_legend(('all', 'v'))
 
 # Save the line plot
 plot.save()

--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -208,7 +208,7 @@ full class description.
 Plots of 2D Datasets
 ~~~~~~~~~~~~~~~~~~~~
 
-If you have a two-dimensional cartesian, cylindrical, or polar dataset, 
+If you have a two-dimensional cartesian, cylindrical, or polar dataset,
 :func:`~yt.visualization.plot_window.plot_2d` is a way to make a plot
 within the dataset's plane without having to specify the axis, which
 in this case is redundant. Otherwise, ``plot_2d`` accepts the same
@@ -1114,7 +1114,7 @@ You can can add a legend to a 1D sampling plot. The legend process takes two ste
 
 1. When instantiating the ``LinePlot``, pass a dictionary of
    labels with keys corresponding to the field names
-2. Call the ``LinePlot`` ``add_legend`` method
+2. Call the ``LinePlot`` ``annotate_legend`` method
 
 X- and Y- axis units can be set with ``set_x_unit`` and ``set_unit`` methods
 respectively. The below code snippet combines all the features we've discussed:
@@ -1126,7 +1126,7 @@ respectively. The below code snippet combines all the features we've discussed:
    ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
 
    plot = yt.LinePlot(ds, 'density', [0, 0, 0], [1, 1, 1], 512)
-   plot.add_legend('density')
+   plot.annotate_legend('density')
    plot.set_x_unit('cm')
    plot.set_unit('density', 'kg/cm**3')
    plot.save()
@@ -1136,7 +1136,7 @@ individual figures equal to the number of different dimensional
 quantities. E.g. if ``LinePlot`` receives two fields with units of "length/time"
 and a field with units of "temperature", two different figures will be created,
 one with plots of the "length/time" fields and another with the plot of the
-"temperature" field. It is only necessary to call ``add_legend``
+"temperature" field. It is only necessary to call ``annotate_legend``
 for one field of a multi-field plot to produce a legend containing all the
 labels passed in the initial construction of the ``LinePlot`` instance. Example:
 
@@ -1147,7 +1147,7 @@ labels passed in the initial construction of the ``LinePlot`` instance. Example:
    ds = yt.load("SecondOrderTris/RZ_p_no_parts_do_nothing_bcs_cone_out.e", step=-1)
    plot = yt.LinePlot(ds, [('all', 'v'), ('all', 'u')], [0, 0, 0], [0, 1, 0],
                       100, labels={('all', 'u') : r"v$_x$", ('all', 'v') : r"v$_y$"})
-   plot.add_legend(('all', 'u'))
+   plot.annotate_legend(('all', 'u'))
    plot.save()
 
 ``LinePlot`` is a bit different from yt ray objects which are data

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -67,12 +67,13 @@ answer_tests:
     - yt/analysis_modules/photon_simulator/tests/test_spectra.py
     - yt/analysis_modules/photon_simulator/tests/test_sloshing.py
 
-  local_unstructured_008:
+  local_unstructured_009:
     - yt/visualization/volume_rendering/tests/test_mesh_render.py
     - yt/visualization/tests/test_mesh_slices.py:test_tri2
     - yt/visualization/tests/test_mesh_slices.py:test_quad2
     - yt/visualization/tests/test_mesh_slices.py:test_multi_region
     - yt/visualization/tests/test_line_plots.py:test_line_plot
+    - yt/visualization/tests/test_line_plots.py:test_multi_line_plot
 
   local_boxlib_004:
     - yt/frontends/boxlib/tests/test_outputs.py:test_radadvect

--- a/yt/__init__.py
+++ b/yt/__init__.py
@@ -104,7 +104,7 @@ from yt.visualization.api import \
     write_bitmap, write_image, \
     apply_colormap, scale_image, write_projection, \
     SlicePlot, AxisAlignedSlicePlot, OffAxisSlicePlot, LinePlot, \
-    ProjectionPlot, OffAxisProjectionPlot, \
+    LineObject, ProjectionPlot, OffAxisProjectionPlot, \
     show_colormaps, add_cmap, make_colormap, \
     ProfilePlot, PhasePlot, ParticlePhasePlot, \
     ParticleProjectionPlot, ParticleImageBuffer, ParticlePlot, \

--- a/yt/__init__.py
+++ b/yt/__init__.py
@@ -104,7 +104,7 @@ from yt.visualization.api import \
     write_bitmap, write_image, \
     apply_colormap, scale_image, write_projection, \
     SlicePlot, AxisAlignedSlicePlot, OffAxisSlicePlot, LinePlot, \
-    LineObject, ProjectionPlot, OffAxisProjectionPlot, \
+    LineBuffer, ProjectionPlot, OffAxisProjectionPlot, \
     show_colormaps, add_cmap, make_colormap, \
     ProfilePlot, PhasePlot, ParticlePhasePlot, \
     ParticleProjectionPlot, ParticleImageBuffer, ParticlePlot, \

--- a/yt/visualization/api.py
+++ b/yt/visualization/api.py
@@ -56,7 +56,7 @@ from .plot_window import \
 
 from .line_plot import \
     LinePlot, \
-    LineObject
+    LineBuffer
 
 from .profile_plotter import \
     ProfilePlot, \

--- a/yt/visualization/api.py
+++ b/yt/visualization/api.py
@@ -55,7 +55,8 @@ from .plot_window import \
     plot_2d
 
 from .line_plot import \
-    LinePlot
+    LinePlot, \
+    LineObject
 
 from .profile_plotter import \
     ProfilePlot, \

--- a/yt/visualization/line_plot.py
+++ b/yt/visualization/line_plot.py
@@ -147,8 +147,9 @@ class LinePlot(PlotContainer):
         """
         self.start_point = _validate_point(start_point, ds, start=True)
         self.end_point = _validate_point(end_point, ds)
+        self.npoints = npoints
 
-        self._initialize_instance(self, ds, fields, npoints, figure_size, fontsize)
+        self._initialize_instance(self, ds, fields, figure_size, fontsize)
 
         if labels is None:
             self.labels = {}
@@ -161,9 +162,7 @@ class LinePlot(PlotContainer):
         self._setup_plots()
 
     @classmethod
-    def _initialize_instance(cls, obj, ds, fields, npoints, figure_size=5.,
-                             fontsize=14.):
-        obj.npoints = npoints
+    def _initialize_instance(cls, obj, ds, fields, figure_size=5., fontsize=14.):
         obj._x_unit = None
         obj._y_units = {}
         obj._titles = {}
@@ -182,8 +181,7 @@ class LinePlot(PlotContainer):
                 obj._field_transform[f] = linear_transform
 
     @classmethod
-    def from_lines(cls, ds, fields, lines, npoints,
-                   figure_size=5., font_size=14.):
+    def from_lines(cls, ds, fields, lines, figure_size=5., font_size=14.):
         """
         A class method for constructing a line plot from multiple sampling lines
 
@@ -195,9 +193,6 @@ class LinePlot(PlotContainer):
             simulation output to be plotted.
         fields : string / tuple, or list of strings / tuples
             The name(s) of the field(s) to be plotted.
-        npoints : int
-            How many points to sample between start_point and end_point for
-            constructing the line plot
         figure_size : int or two-element iterable of ints
             Size in inches of the image.
             Default: 5 (5x5)
@@ -206,7 +201,7 @@ class LinePlot(PlotContainer):
             Default: 14
         """
         obj = cls.__new__(cls)
-        cls._initialize_instance(obj, ds, fields, npoints, figure_size, font_size)
+        cls._initialize_instance(obj, ds, fields, figure_size, font_size)
 
         for line in lines:
             dimensions_counter = defaultdict(int)
@@ -219,7 +214,7 @@ class LinePlot(PlotContainer):
             for field in obj.fields:
                 plot = obj._get_plot_instance(field)
                 x, y = obj.ds.coordinates.pixelize_line(
-                    field, line.start_point, line.end_point, npoints)
+                    field, line.start_point, line.end_point, line.npoints)
                 finfo = obj.ds.field_info[field]
                 dimensions = Unit(finfo.units,
                                   registry=obj.ds.unit_registry).dimensions
@@ -340,7 +335,7 @@ class LinePlot(PlotContainer):
 
 
     @invalidate_plot
-    def add_field_legend(self, field):
+    def annotate_legend(self, field):
         """Adds a legend to the `LinePlot` instance"""
         self.include_legend[field] = True
 

--- a/yt/visualization/line_plot.py
+++ b/yt/visualization/line_plot.py
@@ -344,19 +344,23 @@ class LinePlot(PlotContainer):
                 # set x and y axis labels
                 axes_unit_labels = self._get_axes_unit_labels(unit_x, unit_y)
 
-                finfo = self.ds.field_info[field]
-
-                x_label = r'$\rm{Path\ Length' + axes_unit_labels[0]+'}$'
-
-                finfo = self.ds.field_info[field]
-                dimensions = Unit(finfo.units,
-                                  registry=self.ds.unit_registry).dimensions
-                if dimensions_counter[dimensions] > 1:
-                    y_label = (r'$\rm{Multiple\ Fields}$' + r'$\rm{' +
-                               axes_unit_labels[1]+'}$')
+                if self._xlabel is not None:
+                    x_label = self._xlabel
                 else:
-                    y_label = (finfo.get_latex_display_name() + r'$\rm{' +
-                               axes_unit_labels[1]+'}$')
+                    x_label = r'$\rm{Path\ Length' + axes_unit_labels[0]+'}$'
+
+                if self._ylabel is not None:
+                    y_label = self._ylabel
+                else:
+                    finfo = self.ds.field_info[field]
+                    dimensions = Unit(finfo.units,
+                                      registry=self.ds.unit_registry).dimensions
+                    if dimensions_counter[dimensions] > 1:
+                        y_label = (r'$\rm{Multiple\ Fields}$' + r'$\rm{' +
+                                   axes_unit_labels[1]+'}$')
+                    else:
+                        y_label = (finfo.get_latex_display_name() + r'$\rm{' +
+                                   axes_unit_labels[1]+'}$')
 
                 plot.axes.set_xlabel(x_label)
                 plot.axes.set_ylabel(y_label)

--- a/yt/visualization/line_plot.py
+++ b/yt/visualization/line_plot.py
@@ -370,16 +370,22 @@ class LinePlot(PlotContainer):
                     plot.axes.set_title(self._titles[field])
 
                 # apply legend
-                if self.include_legend[field]:
+                dim_field = self.plots._sanitize_dimensions(field)
+                if self.include_legend[dim_field]:
                     plot.axes.legend()
 
-                self._plot_valid = True
+        self._plot_valid = True
 
 
     @invalidate_plot
     def annotate_legend(self, field):
-        """Adds a legend to the `LinePlot` instance"""
-        self.include_legend[field] = True
+        """
+        Adds a legend to the `LinePlot` instance. The `_sanitize_dimensions`
+        call ensures that a legend label will be added for every field of
+        a multi-field plot
+        """
+        dim_field = self.plots._sanitize_dimensions(field)
+        self.include_legend[dim_field] = True
 
     @invalidate_plot
     def set_x_unit(self, unit_name):

--- a/yt/visualization/line_plot.py
+++ b/yt/visualization/line_plot.py
@@ -33,6 +33,35 @@ from yt.visualization.plot_container import \
     invalidate_plot
 
 class LineBuffer(object):
+    r"""
+    LineBuffer(ds, start_point, end_point, npoints, label = None)
+
+    This takes a data source and implements a protocol for generating a
+    'pixelized', fixed-resolution line buffer. In other words, LineBuffer
+    takes a starting point, ending point, and number of sampling points and
+    can subsequently generate YTArrays of field values along the sample points.
+
+    Parameters
+    ----------
+    ds : :class:`yt.data_objects.static_output.Dataset`
+        This is the dataset object holding the data that can be sampled by the
+        LineBuffer
+    start_point : n-element list, tuple, ndarray, or YTArray
+        Contains the coordinates of the first point for constructing the LineBuffer.
+        Must contain n elements where n is the dimensionality of the dataset.
+    end_point : n-element list, tuple, ndarray, or YTArray
+        Contains the coordinates of the first point for constructing the LineBuffer.
+        Must contain n elements where n is the dimensionality of the dataset.
+    npoints : int
+        How many points to sample between start_point and end_point
+
+    Examples
+    --------
+    >>> lb = yt.LineBuffer(ds, (.25, 0, 0), (.25, 1, 0), 100)
+    >>> lb[('all', 'u')].max()
+    0.11562424257143075 dimensionless
+
+    """
     def __init__(self, ds, start_point, end_point, npoints, label=None):
         self.ds = ds
         self.start_point = _validate_point(start_point, ds, start=True)
@@ -193,12 +222,25 @@ class LinePlot(PlotContainer):
             simulation output to be plotted.
         fields : string / tuple, or list of strings / tuples
             The name(s) of the field(s) to be plotted.
+        lines : a list of :class:`yt.visualization.line_plot.LineBuffer`s
+            The lines from which to sample data
         figure_size : int or two-element iterable of ints
             Size in inches of the image.
             Default: 5 (5x5)
         fontsize : int
             Font size for all text in the plot.
             Default: 14
+
+        Example
+        --------
+        >>> ds = yt.load('SecondOrderTris/RZ_p_no_parts_do_nothing_bcs_cone_out.e', step=-1)
+        >>> fields = [field for field in ds.field_list if field[0] == 'all']
+        >>> lines = []
+        >>> lines.append(yt.LineBuffer(ds, [0.25, 0, 0], [0.25, 1, 0], 100, label='x = 0.25'))
+        >>> lines.append(yt.LineBuffer(ds, [0.5, 0, 0], [0.5, 1, 0], 100, label='x = 0.5'))
+        >>> plot = yt.LinePlot.from_lines(ds, fields, lines)
+        >>> plot.save()
+
         """
         obj = cls.__new__(cls)
         cls._initialize_instance(obj, ds, fields, figure_size, font_size)

--- a/yt/visualization/tests/test_line_plots.py
+++ b/yt/visualization/tests/test_line_plots.py
@@ -25,14 +25,12 @@ def setup():
     from yt.config import ytcfg
     ytcfg["yt", "__withintesting"] = "True"
 
-def compare(ds, fields, point1, point2, resolution, test_prefix, decimals=12):
-    def line_plot(filename_prefix):
-        ln = yt.LinePlot(ds, fields, point1, point2, resolution)
-        image_file = ln.save(filename_prefix)
-        return image_file
+def compare(ds, plot, test_prefix, decimals=12):
+    def image_from_plot(filename_prefix):
+        return plot.save(filename_prefix)
 
-    line_plot.__name__ = "line_{}".format(test_prefix)
-    test = GenericImageTest(ds, line_plot, decimals)
+    image_from_plot.__name__ = "line_{}".format(test_prefix)
+    test = GenericImageTest(ds, image_from_plot, decimals)
     test.prefix = test_prefix
     return test
 
@@ -42,7 +40,18 @@ tri2 = "SecondOrderTris/RZ_p_no_parts_do_nothing_bcs_cone_out.e"
 def test_line_plot():
     ds = data_dir_load(tri2, kwargs={'step':-1})
     fields = [field for field in ds.field_list if field[0] == 'all']
-    yield compare(ds, fields, (0, 0, 0), (1, 1, 0), 1000, "answers_line_plot")
+    plot = yt.LinePlot(ds, fields, (0, 0, 0), (1, 1, 0), 1000)
+    yield compare(ds, plot, "answers_line_plot")
+
+@requires_ds(tri2)
+def test_multi_line_plot():
+    ds = data_dir_load(tri2, kwargs={'step':-1})
+    fields = [field for field in ds.field_list if field[0] == 'all']
+    lines = []
+    lines.append(yt.LineBuffer(ds, [0.25, 0, 0], [0.25, 1, 0], 100, label='x = 0.25'))
+    lines.append(yt.LineBuffer(ds, [0.5, 0, 0], [0.5, 1, 0], 100, label='x = 0.5'))
+    plot = yt.LinePlot.from_lines(ds, fields, lines)
+    yield compare(ds, plot, "answers_multi_line_plot")
 
 def test_line_plot_methods():
     # Perform I/O in safe place instead of yt main dir
@@ -53,7 +62,7 @@ def test_line_plot_methods():
     ds = fake_random_ds(32)
 
     plot = yt.LinePlot(ds, 'density', [0, 0, 0], [1, 1, 1], 512)
-    plot.add_legend('density')
+    plot.annotate_legend('density')
     plot.set_x_unit('cm')
     plot.set_unit('density', 'kg/cm**3')
     plot.save()
@@ -61,3 +70,12 @@ def test_line_plot_methods():
     os.chdir(curdir)
     # clean up
     shutil.rmtree(tmpdir)
+
+def test_line_buffer():
+    ds = fake_random_ds(32)
+    lb = yt.LineBuffer(ds, (0, 0, 0), (1, 1, 1), 512, label='diag')
+    density = lb['density']
+    lb['density'] = 0
+    vx = lb['velocity_x']
+    keys = lb.keys()
+    del lb['velocity_x']

--- a/yt/visualization/tests/test_line_plots.py
+++ b/yt/visualization/tests/test_line_plots.py
@@ -74,8 +74,8 @@ def test_line_plot_methods():
 def test_line_buffer():
     ds = fake_random_ds(32)
     lb = yt.LineBuffer(ds, (0, 0, 0), (1, 1, 1), 512, label='diag')
-    density = lb['density']
+    lb['density']
     lb['density'] = 0
-    vx = lb['velocity_x']
-    keys = lb.keys()
+    lb['velocity_x']
+    lb.keys()
     del lb['velocity_x']


### PR DESCRIPTION
## PR Summary

Creates an alternative `LinePlot` initializer for creating a `LinePlot` from a series of `LineObject`s. To reduce code duplication, some of the previous code in `_setup_plots` has been split into more atomic methods. 

A demonstration script (some unimportant parts removed):
```python
import yt

ds = yt.load("/home/lindsayad/projects/moose/modules/navier_stokes/tests/ins/lid_driven/gold/lid_driven_out.e", step=-1)
lines = []
lines.append(yt.LineObject([0, 0.5, 0], [1, 0.5, 0], ds, label='y = 0.5'))
lines.append(yt.LineObject([0, 0.25, 0], [1, 0.25, 0], ds, label='y = 0.25'))
plt = yt.LinePlot.from_lines(ds, [('all', 'vel_x'), ('all', 'vel_y')], lines, 100)
plt.save("multi_lines.png")
```
produces this image:
![multi_lines](https://user-images.githubusercontent.com/10248304/28628396-24a4a92a-71ea-11e7-96fa-7306e24d96ab.png)

Documentation and a test are in progress.

Addresses #1505 
