### PR TITLE
Phase plot and ParticlePlot fixes and improvements

### DIFF
--- a/doc/source/cookbook/particle_xvz_plot.py
+++ b/doc/source/cookbook/particle_xvz_plot.py
@@ -11,9 +11,5 @@ p.set_unit('particle_position_x', 'Mpc')
 p.set_unit('particle_velocity_z', 'km/s')
 p.set_unit('particle_mass', 'Msun')
 
-# We want to plot position and velocity in linear scale
-p.set_log('particle_position_x', False)
-p.set_log('particle_velocity_z', False)
-
 # save result
 p.save()

--- a/doc/source/cookbook/particle_xvz_plot.py
+++ b/doc/source/cookbook/particle_xvz_plot.py
@@ -11,5 +11,9 @@ p.set_unit('particle_position_x', 'Mpc')
 p.set_unit('particle_velocity_z', 'km/s')
 p.set_unit('particle_mass', 'Msun')
 
+# We want to plot position and velocity in linear scale
+p.set_log('particle_position_x', False)
+p.set_log('particle_velocity_z', False)
+
 # save result
 p.save()

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -45,7 +45,7 @@ answer_tests:
   local_owls_001:
     - yt/frontends/owls/tests/test_outputs.py
 
-  local_pw_017:
+  local_pw_018:
     - yt/visualization/tests/test_plotwindow.py:test_attributes
     - yt/visualization/tests/test_plotwindow.py:test_attributes_wt
     - yt/visualization/tests/test_profile_plots.py:test_phase_plot_attributes

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -674,8 +674,8 @@ class ParticleProfile(Profile2D):
         if deposition not in ['ngp', 'cic']:
             raise NotImplementedError(deposition)
         elif (x_log or y_log) and deposition != 'ngp':
-            mylog.info('cic deposition is only supported for linear axis '
-                       'scales, falling back to ngp deposition')
+            mylog.warning('cic deposition is only supported for linear axis '
+                          'scales, falling back to ngp deposition')
             deposition = 'ngp'
 
         self.deposition = deposition

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -1058,6 +1058,9 @@ def create_profile(data_source, bin_fields, fields, n_bins=64,
                 for i, exi in enumerate(field_ex):
                     if exi is None:
                         field_ex[i] = ds_extrema[i]
+                        # pad extrema by epsilon so cells at bin edges are
+                        # not excluded
+                        field_ex[i] -= (-1)**i*np.spacing(field_ex[i])
             if units is not None and bin_field in units:
                 for i, exi in enumerate(field_ex):
                     if hasattr(exi, 'units'):

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -1059,7 +1059,10 @@ def create_profile(data_source, bin_fields, fields, n_bins=64,
                         field_ex[i] = data_source.ds.quan(exi, units[bin_field])
                 fe = data_source.ds.arr(field_ex)
             else:
-                fe = data_source.ds.arr(field_ex)
+                if hasattr(field_ex, 'units'):
+                    fe = field_ex.to(bf_units)
+                else:
+                    fe = data_source.ds.arr(field_ex, bf_units)
             fe.convert_to_units(bf_units)
             field_ex = [fe[0].v, fe[1].v]
             if iterable(field_ex[0]):

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -1046,7 +1046,7 @@ def create_profile(data_source, bin_fields, fields, n_bins=64,
                 field_ex = list(extrema[bin_field])
             if isinstance(field_ex[0], tuple):
                 field_ex = [data_source.ds.quan(*f) for f in field_ex]
-            if any([ex is None for ex in field_ex]):
+            if any([exi is None for exi in field_ex]):
                 ds_extrema = data_source.quantities.extrema(bin_field)
                 for i, exi in enumerate(field_ex):
                     if exi is None:

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -997,15 +997,14 @@ def create_profile(data_source, bin_fields, fields, n_bins=64,
                     raise RuntimeError(
                         "CIC deposition is only implemented for linear-scaled "
                         "axes")
-                else:
-                    logs[bin_fields[0]] = False
-                    logs[bin_fields[1]] = False
             else:
                 logs = {bin_fields[0]: False, bin_fields[1]: False}
             if any(accumulation) or fractional:
                 raise RuntimeError(
                     'The accumulation and fractional keyword arguments must be '
                     'False for CIC deposition')
+        elif logs is None:
+            logs = {bin_fields[0]: False, bin_fields[1]: False}
         cls = ParticleProfile
     elif len(bin_fields) == 2:
         cls = Profile2D

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -257,7 +257,7 @@ been deprecated, use profile.standard_deviation instead."""
             units = chunk.ds.field_info[self.weight_field].output_units
             weight_data = chunk[self.weight_field].in_units(units)
         else:
-            weight_data = np.ones(filter.size, dtype="float64")
+            weight_data = np.ones(filter.shape, dtype="float64")
         weight_data = weight_data[filter]
         # So that we can pass these into
         return arr, weight_data, bin_fields

--- a/yt/data_objects/tests/test_profiles.py
+++ b/yt/data_objects/tests/test_profiles.py
@@ -231,6 +231,9 @@ def test_particle_profile_negative_field():
         ad,
         ["particle_position_x", "particle_position_y"],
         "particle_velocity_x",
+        logs = {'particle_position_x': True,
+                'particle_position_y': True,
+                'particle_position_z': True},
         weight_field=None)
     assert profile['particle_velocity_x'].min() < 0
     assert profile.x_bins.min() > 0
@@ -240,9 +243,6 @@ def test_particle_profile_negative_field():
         ad,
         ["particle_position_x", "particle_position_y"],
         "particle_velocity_x",
-        logs = {'particle_position_x': False,
-                'particle_position_y': False,
-                'particle_position_z': False},
         weight_field=None)
     assert profile['particle_velocity_x'].min() < 0
     assert profile.x_bins.min() < 0

--- a/yt/data_objects/tests/test_profiles.py
+++ b/yt/data_objects/tests/test_profiles.py
@@ -127,14 +127,14 @@ def test_profiles():
         p2d = create_profile(dd, ('gas', 'density'), ('gas', 'temperature'),
                              weight_field=('gas', 'cell_mass'),
                              extrema={'density': (None, rma*e2)})
-        assert_equal(p2d.x_bins[0], rmi)
+        assert_equal(p2d.x_bins[0], rmi - np.spacing(rmi))
         assert_equal(p2d.x_bins[-1], rma*e2)
 
         p2d = create_profile(dd, ('gas', 'density'), ('gas', 'temperature'),
                              weight_field=('gas', 'cell_mass'),
                              extrema={'density': (rmi*e2, None)})
         assert_equal(p2d.x_bins[0], rmi*e2)
-        assert_equal(p2d.x_bins[-1], rma)
+        assert_equal(p2d.x_bins[-1], rma + np.spacing(rma))
 
 
 extrema_s = {'particle_position_x': (0, 1)}

--- a/yt/utilities/lib/particle_mesh_operations.pyx
+++ b/yt/utilities/lib/particle_mesh_operations.pyx
@@ -97,8 +97,8 @@ def CICDeposit_2(np.float64_t[:] posx,
     cdef np.float64_t edgex, edgey
     cdef np.float64_t dx, dy, ddx, ddy, ddx2, ddy2
 
-    edgex = (<np.float64_t> x_bin_edges.shape[0]) + 0.5001
-    edgey = (<np.float64_t> y_bin_edges.shape[0]) + 0.5001
+    edgex = (<np.float64_t> x_bin_edges.shape[0] - 1) + 0.5001
+    edgey = (<np.float64_t> y_bin_edges.shape[0] - 1) + 0.5001
 
     # We are always dealing with uniformly spaced bins for CiC
     dx = x_bin_edges[1] - x_bin_edges[0]

--- a/yt/visualization/particle_plots.py
+++ b/yt/visualization/particle_plots.py
@@ -347,8 +347,8 @@ class ParticlePhasePlot(PhasePlot):
                                         figure_size)
 
 
-def ParticlePlot(ds, x_field, y_field, z_fields=None, color='b', *args, **
-                 kwargs):
+def ParticlePlot(ds, x_field, y_field, z_fields=None, color='b', *args,
+                 **kwargs):
     r"""
     A factory function for
     :class:`yt.visualization.particle_plots.ParticleProjectionPlot`
@@ -357,13 +357,15 @@ def ParticlePlot(ds, x_field, y_field, z_fields=None, color='b', *args, **
     plots, the distinction being determined by the fields passed in.
 
     If the x_field and y_field combination corresponds to a valid, right-handed
-    spatial plot, an 'ParticleProjectionPlot` will be returned. This plot
+    spatial plot, an ``ParticleProjectionPlot`` will be returned. This plot
     object can be updated using one of the many helper functions defined in
-    PlotWindow.
+    ``PlotWindow``.
 
     If the x_field and y_field combo do not correspond to a valid
-    'ParticleProjectionPlot`, then a `ParticlePhasePlot`. This object can be
-    modified by its own set of  helper functions defined in PhasePlot.
+    ``ParticleProjectionPlot``, then a ``ParticlePhasePlot``. This object can be
+    modified by its own set of  helper functions defined in PhasePlot. We note
+    below which arguments are only accepted by ``ParticleProjectionPlot`` and
+    which arguments are only accepted by ``ParticlePhasePlot``.
 
     Parameters
     ----------
@@ -386,6 +388,103 @@ def ParticlePlot(ds, x_field, y_field, z_fields=None, color='b', *args, **
          The color that will indicate the particle locations
          on the plot. This argument is ignored if z_fields is
          not None. Default is 'b'.
+    weight_field : string
+         The name of the weighting field.  Set to None for no weight.
+    fontsize : integer
+         The size of the fonts for the axis, colorbar, and tick labels.
+    data_source : YTSelectionContainer Object
+         Object to be used for data selection.  Defaults to a region covering
+         the entire simulation.
+    center : A sequence of floats, a string, or a tuple.
+         The coordinate of the center of the image. If set to 'c', 'center' or
+         left blank, the plot is centered on the middle of the domain. If set to
+         'max' or 'm', the center will be located at the maximum of the
+         ('gas', 'density') field. Centering on the max or min of a specific
+         field is supported by providing a tuple such as ("min","temperature") or
+         ("max","dark_matter_density"). Units can be specified by passing in *center*
+         as a tuple containing a coordinate and string unit name or by passing
+         in a YTArray. If a list or unitless array is supplied, code units are
+         assumed. This argument is only accepted by ``ParticleProjectionPlot``.
+    width : tuple or a float.
+         Width can have four different formats to support windows with variable
+         x and y widths.  They are:
+
+         ==================================     =======================
+         format                                 example
+         ==================================     =======================
+         (float, string)                        (10,'kpc')
+         ((float, string), (float, string))     ((10,'kpc'),(15,'kpc'))
+         float                                  0.2
+         (float, float)                         (0.2, 0.3)
+         ==================================     =======================
+
+         For example, (10, 'kpc') requests a plot window that is 10 kiloparsecs
+         wide in the x and y directions, ((10,'kpc'),(15,'kpc')) requests a
+         window that is 10 kiloparsecs wide along the x axis and 15
+         kiloparsecs wide along the y axis.  In the other two examples, code
+         units are assumed, for example (0.2, 0.3) requests a plot that has an
+         x width of 0.2 and a y width of 0.3 in code units.  If units are
+         provided the resulting plot axis labels will use the supplied units.
+         This argument is only accepted by ``ParticleProjectionPlot``.
+    depth : A tuple or a float
+         A tuple containing the depth to project through and the string
+         key of the unit: (width, 'unit').  If set to a float, code units
+         are assumed. Defaults to the entire domain. This argument is only 
+         accepted by ``ParticleProjectionPlot``.
+    axes_unit : A string
+         The name of the unit for the tick labels on the x and y axes.
+         Defaults to None, which automatically picks an appropriate unit.
+         If axes_unit is '1', 'u', or 'unitary', it will not display the
+         units, and only show the axes name.
+    origin : string or length 1, 2, or 3 sequence of strings
+         The location of the origin of the plot coordinate system.  This is
+         represented by '-' separated string or a tuple of strings.  In the
+         first index the y-location is given by 'lower', 'upper', or 'center'.
+         The second index is the x-location, given as 'left', 'right', or
+         'center'.  Finally, the whether the origin is applied in 'domain'
+         space, plot 'window' space or 'native' simulation coordinate system
+         is given. For example, both 'upper-right-domain' and ['upper',
+         'right', 'domain'] both place the origin in the upper right hand
+         corner of domain space. If x or y are not given, a value is inffered.
+         For instance, 'left-domain' corresponds to the lower-left hand corner
+         of the simulation domain, 'center-domain' corresponds to the center
+         of the simulation domain, or 'center-window' for the center of the
+         plot window. Further examples:
+
+         ==================================     ============================
+         format                                 example
+         ==================================     ============================
+         '{space}'                              'domain'
+         '{xloc}-{space}'                       'left-window'
+         '{yloc}-{space}'                       'upper-domain'
+         '{yloc}-{xloc}-{space}'                'lower-right-window'
+         ('{space}',)                           ('window',)
+         ('{xloc}', '{space}')                  ('right', 'domain')
+         ('{yloc}', '{space}')                  ('lower', 'window')
+         ('{yloc}', '{xloc}', '{space}')        ('lower', 'right', 'window')
+         ==================================     ============================
+
+         This argument is only accepted by ``ParticleProjectionPlot``.
+    window_size : float
+         The size of the window on the longest axis (in units of inches),
+         including the margins but not the colorbar. This argument is only 
+         accepted by ``ParticleProjectionPlot``.
+    aspect : float
+         The aspect ratio of the plot.  Set to None for 1. This argument is 
+         only accepted by ``ParticleProjectionPlot``.
+    x_bins : int
+        The number of bins in x field for the mesh. Defaults to 800. This
+        argument is only accepted by ``ParticlePhasePlot``.
+    y_bins : int
+        The number of bins in y field for the mesh. Defaults to 800. This
+        argument is only accepted by ``ParticlePhasePlot``.
+    deposition : str
+        Either 'ngp' or 'cic'. Controls what type of interpolation will be 
+        used to deposit the particle z_fields onto the mesh. Defaults to 'ngp'.
+        This argument is only accepted by ``ParticlePhasePlot``.
+    figure_size : int
+        Size in inches of the image. Defaults to 8 (product an 8x8 inch figure).
+        This argument is only accepted by ``ParticlePhasePlot``.
 
     Examples
     --------

--- a/yt/visualization/particle_plots.py
+++ b/yt/visualization/particle_plots.py
@@ -175,6 +175,11 @@ class ParticleProjectionPlot(PWViewerMPL):
     field_parameters : dictionary
          A dictionary of field parameters than can be accessed by derived
          fields.
+    window_size : float
+        The size of the window on the longest axis (in units of inches),
+        including the margins but not the colorbar.
+    aspect : float
+         The aspect ratio of the plot.  Set to None for 1.
     data_source : YTSelectionContainer Object
          Object to be used for data selection.  Defaults to a region covering
          the entire simulation.

--- a/yt/visualization/particle_plots.py
+++ b/yt/visualization/particle_plots.py
@@ -498,10 +498,11 @@ def ParticlePlot(ds, x_field, y_field, z_fields=None, color='b', *args,
     ...                     color='g')
 
     """
-
-    ad = ds.all_data()
-    x_field = ad._determine_fields(x_field)[0]
-    y_field = ad._determine_fields(y_field)[0]
+    dd = kwargs.get('data_source', None)
+    if dd is None:
+        dd = ds.all_data()
+    x_field = dd._determine_fields(x_field)[0]
+    y_field = dd._determine_fields(y_field)[0]
 
     direction = 3
     # try potential axes for a ParticleProjectionPlot:
@@ -523,5 +524,5 @@ def ParticlePlot(ds, x_field, y_field, z_fields=None, color='b', *args,
     # Does not correspond to any valid PlotWindow-style plot,
     # use ParticlePhasePlot instead
     else:
-        return ParticlePhasePlot(ad, x_field, y_field,
+        return ParticlePhasePlot(dd, x_field, y_field,
                                  z_fields, color, *args, **kwargs)

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -85,6 +85,9 @@ def validate_plot(f):
         if hasattr(args[0], '_data_valid'):
             if not args[0]._data_valid:
                 args[0]._recreate_frb()
+        if hasattr(args[0], '_profile_valid'):
+            if not args[0]._profile_valid:
+                args[0]._recreate_profile()
         if not args[0]._plot_valid:
             # it is the responsibility of _setup_plots to
             # call args[0].run_callbacks()

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -163,6 +163,9 @@ class PlotWindow(ImagePlotContainer):
     window_size : float
         The size of the window on the longest axis (in units of inches),
         including the margins but not the colorbar.
+    window_size : float
+        The size of the window on the longest axis (in units of inches),
+        including the margins but not the colorbar.
     right_handed : boolean
         Whether the implicit east vector for the image generated is set to make a right
         handed coordinate system with a north vector and the normal vector, the

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -20,10 +20,10 @@ from yt.extern.six import string_types, iteritems
 from collections import OrderedDict
 import base64
 import os
+from functools import wraps
 
 import matplotlib
 import numpy as np
-
 
 from .base_plot_types import \
     PlotMPL, ImagePlotMPL
@@ -60,6 +60,14 @@ def get_canvas(name):
         mylog.warning("Unknown suffix %s, defaulting to Agg", suffix)
         canvas_cls = mpl.FigureCanvasAgg
     return canvas_cls
+
+def invalidate_profile(f):
+    @wraps(f)
+    def newfunc(*args, **kwargs):
+        rv = f(*args, **kwargs)
+        args[0]._profile_valid = False
+        return rv
+    return newfunc
 
 class PlotContainerDict(OrderedDict):
     def __missing__(self, key):
@@ -729,6 +737,7 @@ class PhasePlot(ImagePlotContainer):
     y_log = None
     plot_title = None
     _plot_valid = False
+    _profile_valid = False
     _plot_type = 'Phase'
     _xlim = (None, None)
     _ylim = (None, None)
@@ -766,7 +775,9 @@ class PhasePlot(ImagePlotContainer):
         obj._text_xpos = {}
         obj._text_ypos = {}
         obj._text_kwargs = {}
-        obj.profile = profile
+        obj._profile = profile
+        obj._xlim = (None, None)
+        obj._ylim = (None, None)
         super(PhasePlot, obj).__init__(data_source, figure_size, fontsize)
         obj._setup_plots()
         obj._initfinished = True
@@ -827,6 +838,12 @@ class PhasePlot(ImagePlotContainer):
     def _recreate_frb(self):
         # needed for API compatibility with PlotWindow
         pass
+
+    @property
+    def profile(self):
+        if not self._profile_valid:
+            self._recreate_profile()
+        return self._profile
 
     def _setup_plots(self):
         if self._plot_valid:
@@ -1190,11 +1207,14 @@ class PhasePlot(ImagePlotContainer):
             self.y_log = log
             for field in self.profile.field_data:
                 self.z_log[field] = log
+            self._profile_valid = False
         else:
             if field == self.profile.x_field[1]:
                 self.x_log = log
+                self._profile_valid = False
             elif field == self.profile.y_field[1]:
                 self.y_log = log
+                self._profile_valid = False
             elif field in self.profile.field_map:
                 self.z_log[self.profile.field_map[field]] = log
             else:
@@ -1226,6 +1246,7 @@ class PhasePlot(ImagePlotContainer):
         return self
 
     @invalidate_plot
+    @invalidate_profile
     def set_xlim(self, xmin=None, xmax=None):
         """Sets the limits of the x bin field
 
@@ -1233,12 +1254,12 @@ class PhasePlot(ImagePlotContainer):
         ----------
 
         xmin : float or None
-          The new x minimum.  Defaults to None, which leaves the xmin
-          unchanged.
+          The new x minimum in the current x-axis units.  Defaults to None,
+          which leaves the xmin unchanged.
 
         xmax : float or None
-          The new x maximum.  Defaults to None, which leaves the xmax
-          unchanged.
+          The new x maximum in the current x-axis units.  Defaults to None,
+          which leaves the xmax unchanged.
 
         Examples
         --------
@@ -1253,44 +1274,17 @@ class PhasePlot(ImagePlotContainer):
         p = self.profile
         if xmin is None:
             xmin = p.x_bins.min()
+        elif not hasattr(xmin, 'units'):
+            xmin = self.ds.quan(xmin, p.y_bins.units)
         if xmax is None:
             xmax = p.x_bins.max()
-        units = {p.x_field: str(p.x.units),
-                 p.y_field: str(p.y.units)}
-        zunits = dict((field, str(p.field_units[field])) for field in p.field_units)
-        extrema = {p.x_field: ((xmin, str(p.x.units)), (xmax, str(p.x.units))),
-                   p.y_field: ((p.y_bins.min(), str(p.y.units)),
-                               (p.y_bins.max(), str(p.y.units)))}
-        if self.x_log is not None or self.y_log is not None:
-            logs = {}
-        else:
-            logs = None
-        if self.x_log is not None:
-            logs[p.x_field] = self.x_log
-        if self.y_log is not None:
-            logs[p.y_field] = self.y_log
-        deposition = getattr(self.profile, "deposition", None)
-        if deposition is None:
-            additional_kwargs = {'accumulation': p.accumulation,
-                                 'fractional': p.fractional}
-        else:
-            additional_kwargs = {'deposition': p.deposition}
-        self.profile = create_profile(
-            p.data_source,
-            [p.x_field, p.y_field],
-            list(p.field_map.values()),
-            n_bins=[len(p.x_bins)-1, len(p.y_bins)-1],
-            weight_field=p.weight_field,
-            units=units,
-            extrema=extrema,
-            logs=logs,
-            **additional_kwargs)
-        for field in zunits:
-            self.profile.set_field_unit(field, zunits[field])
+        elif not hasattr(xmax, 'units'):
+            xmax = self.ds.quan(xmax, p.y_bins.units)
         self._xlim = (xmin, xmax)
         return self
 
     @invalidate_plot
+    @invalidate_profile
     def set_ylim(self, ymin=None, ymax=None):
         """Sets the plot limits for the y bin field.
 
@@ -1298,12 +1292,12 @@ class PhasePlot(ImagePlotContainer):
         ----------
 
         ymin : float or None
-          The new y minimum.  Defaults to None, which leaves the ymin
-          unchanged.
+          The new y minimum in the current y-axis units.  Defaults to None,
+          which leaves the ymin unchanged.
 
         ymax : float or None
-          The new y maximum.  Defaults to None, which leaves the ymax
-          unchanged.
+          The new y maximum in the current y-axis units.  Defaults to None,
+          which leaves the ymax unchanged.
 
         Examples
         --------
@@ -1318,14 +1312,21 @@ class PhasePlot(ImagePlotContainer):
         p = self.profile
         if ymin is None:
             ymin = p.y_bins.min()
+        elif not hasattr(ymin, 'units'):
+            ymin = self.ds.quan(ymin, p.y_bins.units)
         if ymax is None:
             ymax = p.y_bins.max()
+        elif not hasattr(ymax, 'units'):
+            ymax = self.ds.quan(ymax, p.y_bins.units)
+        self._ylim = (ymin, ymax)
+        return self
+
+    def _recreate_profile(self):
+        p = self._profile
         units = {p.x_field: str(p.x.units),
                  p.y_field: str(p.y.units)}
         zunits = dict((field, str(p.field_units[field])) for field in p.field_units)
-        extrema = {p.x_field: ((p.x_bins.min(), str(p.x.units)),
-                               (p.x_bins.max(), str(p.x.units))),
-                   p.y_field: ((ymin, str(p.y.units)), (ymax, str(p.y.units)))}
+        extrema = {p.x_field: self._xlim, p.y_field: self._ylim}
         if self.x_log is not None or self.y_log is not None:
             logs = {}
         else:
@@ -1334,13 +1335,11 @@ class PhasePlot(ImagePlotContainer):
             logs[p.x_field] = self.x_log
         if self.y_log is not None:
             logs[p.y_field] = self.y_log
-        deposition = getattr(self.profile, "deposition", None)
-        if deposition is None:
-            additional_kwargs = {'accumulation': p.accumulation,
-                                 'fractional': p.fractional}
-        else:
-            additional_kwargs = {'deposition': p.deposition}
-        self.profile = create_profile(
+        deposition = getattr(p, "deposition", None)
+        additional_kwargs = {'accumulation': p.accumulation,
+                             'fractional': p.fractional,
+                             'deposition': deposition}
+        self._profile = create_profile(
             p.data_source,
             [p.x_field, p.y_field],
             list(p.field_map.values()),
@@ -1351,9 +1350,8 @@ class PhasePlot(ImagePlotContainer):
             logs=logs,
             **additional_kwargs)
         for field in zunits:
-            self.profile.set_field_unit(field, zunits[field])
-        self._ylim = (ymin, ymax)
-        return self
+            self._profile.set_field_unit(field, zunits[field])
+
 
 
 class PhasePlotMPL(ImagePlotMPL):

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -776,6 +776,7 @@ class PhasePlot(ImagePlotContainer):
         obj._text_ypos = {}
         obj._text_kwargs = {}
         obj._profile = profile
+        obj._profile_valid = True
         obj._xlim = (None, None)
         obj._ylim = (None, None)
         super(PhasePlot, obj).__init__(data_source, figure_size, fontsize)
@@ -1180,7 +1181,7 @@ class PhasePlot(ImagePlotContainer):
         >>> plot.annotate_title("This is a phase plot")
 
         """
-        for f in self.profile.field_data:
+        for f in self._profile.field_data:
             if isinstance(f, tuple):
                 f = f[1]
             self.plot_title[self.data_source._determine_fields(f)[0]] = title
@@ -1202,21 +1203,22 @@ class PhasePlot(ImagePlotContainer):
         log : boolean
             Log on/off.
         """
+        p = self._profile
         if field == "all":
             self.x_log = log
             self.y_log = log
-            for field in self.profile.field_data:
+            for field in p.field_data:
                 self.z_log[field] = log
             self._profile_valid = False
         else:
-            if field == self.profile.x_field[1]:
+            if field == p.x_field[1]:
                 self.x_log = log
                 self._profile_valid = False
-            elif field == self.profile.y_field[1]:
+            elif field == p.y_field[1]:
                 self.y_log = log
                 self._profile_valid = False
-            elif field in self.profile.field_map:
-                self.z_log[self.profile.field_map[field]] = log
+            elif field in p.field_map:
+                self.z_log[p.field_map[field]] = log
             else:
                 raise KeyError("Field %s not in phase plot!" % (field))
         return self
@@ -1271,15 +1273,15 @@ class PhasePlot(ImagePlotContainer):
         >>> pp.save()
 
         """
-        p = self.profile
+        p = self._profile
         if xmin is None:
             xmin = p.x_bins.min()
         elif not hasattr(xmin, 'units'):
-            xmin = self.ds.quan(xmin, p.y_bins.units)
+            xmin = self.ds.quan(xmin, p.x_bins.units)
         if xmax is None:
             xmax = p.x_bins.max()
         elif not hasattr(xmax, 'units'):
-            xmax = self.ds.quan(xmax, p.y_bins.units)
+            xmax = self.ds.quan(xmax, p.x_bins.units)
         self._xlim = (xmin, xmax)
         return self
 
@@ -1309,7 +1311,7 @@ class PhasePlot(ImagePlotContainer):
         >>> pp.save()
 
         """
-        p = self.profile
+        p = self._profile
         if ymin is None:
             ymin = p.y_bins.min()
         elif not hasattr(ymin, 'units'):
@@ -1351,7 +1353,7 @@ class PhasePlot(ImagePlotContainer):
             **additional_kwargs)
         for field in zunits:
             self._profile.set_field_unit(field, zunits[field])
-
+        self._profile_valid = True
 
 
 class PhasePlotMPL(ImagePlotMPL):

--- a/yt/visualization/tests/test_particle_plot.py
+++ b/yt/visualization/tests/test_particle_plot.py
@@ -23,7 +23,6 @@ from yt.data_objects.profiles import create_profile
 from yt.visualization.tests.test_plotwindow import \
     WIDTH_SPECS, ATTR_ARGS
 from yt.convenience import load
-    WIDTH_SPECS, ATTR_ARGS
 from yt.data_objects.particle_filters import add_particle_filter
 from yt.testing import \
     fake_particle_ds, \
@@ -264,7 +263,6 @@ def test_particle_phase_plot_semantics():
 
     dybins = p.y_bins[1:] - p.y_bins[:-1]
     assert_allclose(dybins, dybins[0])
-    import pdb; pdb.set_trace()
 
 class TestParticleProjectionPlotSave(unittest.TestCase):
 

--- a/yt/visualization/tests/test_particle_plot.py
+++ b/yt/visualization/tests/test_particle_plot.py
@@ -233,10 +233,10 @@ def test_particle_phase_plot_semantics():
     p = plot.profile
 
     # bin extrema are field extrema
-    assert dens_ex[0] == p.x_bins[0]
-    assert dens_ex[-1] == p.x_bins[-1]
-    assert temp_ex[0] == p.y_bins[0]
-    assert temp_ex[-1] == p.y_bins[-1]
+    assert dens_ex[0] - np.spacing(dens_ex[0]) == p.x_bins[0]
+    assert dens_ex[-1] + np.spacing(dens_ex[-1]) == p.x_bins[-1]
+    assert temp_ex[0] - np.spacing(temp_ex[0]) == p.y_bins[0]
+    assert temp_ex[-1] + np.spacing(temp_ex[-1]) == p.y_bins[-1]
 
     # bins are evenly spaced in log space
     logxbins = np.log10(p.x_bins)
@@ -252,10 +252,10 @@ def test_particle_phase_plot_semantics():
     p = plot.profile
 
     # bin extrema are field extrema
-    assert dens_ex[0] == p.x_bins[0]
-    assert dens_ex[-1] == p.x_bins[-1]
-    assert temp_ex[0] == p.y_bins[0]
-    assert temp_ex[-1] == p.y_bins[-1]
+    assert dens_ex[0] - np.spacing(dens_ex[0]) == p.x_bins[0]
+    assert dens_ex[-1] + np.spacing(dens_ex[-1]) == p.x_bins[-1]
+    assert temp_ex[0] - np.spacing(temp_ex[0]) == p.y_bins[0]
+    assert temp_ex[-1] + np.spacing(temp_ex[-1]) == p.y_bins[-1]
 
     # bins are evenly spaced in log space
     dxbins = p.x_bins[1:] - p.x_bins[:-1]

--- a/yt/visualization/tests/test_particle_plot.py
+++ b/yt/visualization/tests/test_particle_plot.py
@@ -16,19 +16,28 @@ import os
 import tempfile
 import shutil
 import unittest
+
+import numpy as np
+
 from yt.data_objects.profiles import create_profile
 from yt.visualization.tests.test_plotwindow import \
     assert_fname, WIDTH_SPECS, ATTR_ARGS
+from yt.convenience import load
 from yt.data_objects.particle_filters import add_particle_filter
 from yt.testing import \
-    fake_particle_ds, assert_array_almost_equal
+    fake_particle_ds, \
+    assert_array_almost_equal, \
+    requires_file, \
+    assert_allclose
 from yt.utilities.answer_testing.framework import \
     requires_ds, \
     data_dir_load, \
     PlotWindowAttributeTest, \
     PhasePlotAttributeTest
 from yt.visualization.api import \
-    ParticleProjectionPlot, ParticlePhasePlot
+    ParticlePlot, \
+    ParticleProjectionPlot, \
+    ParticlePhasePlot
 from yt.units.yt_array import YTArray
 
 
@@ -207,6 +216,53 @@ class TestParticlePhasePlotSave(unittest.TestCase):
             for fname in TEST_FLNMS:
                 assert assert_fname(p.save(fname)[0])
 
+tgal = 'TipsyGalaxy/galaxy.00300'
+@requires_file(tgal)
+def test_particle_phase_plot_semantics():
+    ds = load(tgal)
+    ad = ds.all_data()
+    dens_ex = ad.quantities.extrema(('Gas', 'density'))
+    temp_ex = ad.quantities.extrema(('Gas', 'temperature'))
+    plot = ParticlePlot(ds,
+                        ('Gas', 'density'),
+                        ('Gas', 'temperature'),
+                        ('Gas', 'particle_mass'))
+    plot.set_log('density', True)
+    plot.set_log('temperature', True)
+    p = plot.profile
+
+    # bin extrema are field extrema
+    assert dens_ex[0] == p.x_bins[0]
+    assert dens_ex[-1] == p.x_bins[-1]
+    assert temp_ex[0] == p.y_bins[0]
+    assert temp_ex[-1] == p.y_bins[-1]
+
+    # bins are evenly spaced in log space
+    logxbins = np.log10(p.x_bins)
+    dxlogxbins = logxbins[1:] - logxbins[:-1]
+    assert_allclose(dxlogxbins, dxlogxbins[0])
+
+    logybins = np.log10(p.y_bins)
+    dylogybins = logybins[1:] - logybins[:-1]
+    assert_allclose(dylogybins, dylogybins[0])
+
+    plot.set_log('density', False)
+    plot.set_log('temperature', False)
+    p = plot.profile
+
+    # bin extrema are field extrema
+    assert dens_ex[0] == p.x_bins[0]
+    assert dens_ex[-1] == p.x_bins[-1]
+    assert temp_ex[0] == p.y_bins[0]
+    assert temp_ex[-1] == p.y_bins[-1]
+
+    # bins are evenly spaced in log space
+    dxbins = p.x_bins[1:] - p.x_bins[:-1]
+    assert_allclose(dxbins, dxbins[0])
+
+    dybins = p.y_bins[1:] - p.y_bins[:-1]
+    assert_allclose(dybins, dybins[0])
+    import pdb; pdb.set_trace()
 
 class TestParticleProjectionPlotSave(unittest.TestCase):
 


### PR DESCRIPTION
Currently the `ParticleProfile` object is hard-coded to always use linearly spaced bins. It turns out that this requirement only needs to be imposed for CIC deposition, so I've relaxed it. This fixed #1448.

While adding improvements to `ParticleProfile` I noticed a number of issues with `PhasePlot` and `create_profile` that I also fix here. In particular:

* `PhasePlot` will now recreate profile objects only as needed when someone accesses the `profile` attribute or when we're about to save a plot to disk. This avoids unnecessary calls to `create_profile` when a user successively applies several customizations.
* `create_profile` will now do the right thing if you pass it an `extrema` dict like `{'density': (None, 1e-31)}` (the `None` will be interpreted as a request to find the minimum of the `density` field).
* `create_profile` will error out if you try to create a particle profile using CIC deposition and log-scaled bin fields.
* I've changed the API of `ParticleProfile`, `CICDeposit_2`, and `NGPDeposit_2` to avoid computing unnecessary intermediate values (e.g. `DomainDimensions` and `LeftEdge`) and instead use properties of the profile class to get the same information. This simplifies the API somewhat and clarifies the implementations of `CICDeposit_2`, and `NGPDeposit_2`.
* Added tests for the above behaviors.

With this pull request I feel like `ParticlePhasePlot` ends up in a much more robust state.