### PR TITLE
remove unnecessary loop over 'xyz' in phase plot answer tests

### DIFF
--- a/yt/visualization/tests/test_profile_plots.py
+++ b/yt/visualization/tests/test_profile_plots.py
@@ -59,13 +59,12 @@ def test_phase_plot_attributes():
     z_field = 'cell_mass'
     decimals = 12
     ds = data_dir_load(g30)
-    for ax in 'xyz':
-        for attr_name in ATTR_ARGS.keys():
-            for args in ATTR_ARGS[attr_name]:
-                test = PhasePlotAttributeTest(ds, x_field, y_field, z_field, 
-                                               attr_name, args, decimals)
-                test_phase_plot_attributes.__name__ = test.description
-                yield test
+    for attr_name in ATTR_ARGS.keys():
+        for args in ATTR_ARGS[attr_name]:
+            test = PhasePlotAttributeTest(ds, x_field, y_field, z_field, 
+                                          attr_name, args, decimals)
+            test_phase_plot_attributes.__name__ = test.description
+            yield test
 
 class TestProfilePlotSave(unittest.TestCase):
 


### PR DESCRIPTION
This loop doesn't actually do anything. I think it just causes these tests to run three times. Let's see if deleting it causes the answer tests to fail...