### PR TITLE
Let NetCDF-4 Classic files trigger warn_netcdf() as well

### DIFF
--- a/yt/utilities/file_handler.py
+++ b/yt/utilities/file_handler.py
@@ -105,7 +105,7 @@ def warn_netcdf(fn):
     classic = valid_netcdf_classic_signature(fn)
     # NetCDF-4 Classic files are HDF5 files constrained to the Classic
     # data model used by netCDF-3.
-    netcdf4_classic = valid_hdf5_signature(fn) and fn.endswith('.nc')
+    netcdf4_classic = valid_hdf5_signature(fn) and fn.endswith(('.nc', '.nc4'))
     needs_netcdf = classic or netcdf4_classic
     from yt.utilities.on_demand_imports import _netCDF4 as netCDF4
     if needs_netcdf and isinstance(netCDF4.Dataset, NotAModule):

--- a/yt/utilities/file_handler.py
+++ b/yt/utilities/file_handler.py
@@ -99,7 +99,12 @@ def valid_netcdf_classic_signature(filename):
 
 
 def warn_netcdf(fn):
-    needs_netcdf = valid_netcdf_classic_signature(fn)
+    # There are a few variants of the netCDF format.
+    classic = valid_netcdf_classic_signature(fn)
+    # NetCDF-4 Classic files are HDF5 files constrained to the Classic
+    # data model used by netCDF-3.
+    netcdf4_classic = valid_hdf5_signature(fn) and fn.endswith('.nc')
+    needs_netcdf = classic or netcdf4_classic
     from yt.utilities.on_demand_imports import _netCDF4 as netCDF4
     if needs_netcdf and isinstance(netCDF4.Dataset, NotAModule):
         raise RuntimeError("This appears to be a netCDF file, but the "

--- a/yt/utilities/file_handler.py
+++ b/yt/utilities/file_handler.py
@@ -17,6 +17,7 @@ from yt.utilities.on_demand_imports import _h5py as h5py
 from yt.utilities.on_demand_imports import NotAModule
 from contextlib import contextmanager
 
+
 def valid_hdf5_signature(fn):
     signature = b'\x89HDF\r\n\x1a\n'
     try:
@@ -62,6 +63,7 @@ class HDF5FileHandler(object):
     def close(self):
         if self.handle is not None:
             self.handle.close()
+
 
 class FITSFileHandler(HDF5FileHandler):
     def __init__(self, filename):


### PR DESCRIPTION
As I commented in the code I added, there are different variants of the netCDF format.
Reference: https://www.loc.gov/preservation/digital/formats/fdd/fdd000339.shtml

## PR Summary

Now netCDF-4 Classic files can trigger `warn_netcdf()` too, if the `netcdf4` Python package is not installed.  If `h5py` is not installed either, `warn_h5py()` will get triggered first, since netCDF-4 files are HDF5 files.  That's all good, you want to install `h5py` and (then) `netcdf4`.

I need this change so that I can call `warn_netcdf()` in the future `netcdf` frontend and have it work for more netCDF files.

I'm not very comfortable with the absence of tests...  But I'm not sure where to start, since there are currently no tests for `warn_h5py()` or `warn_netcdf()`.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
