### PR TITLE
Restore support for visualizing YTSpatialPlotDataset instances. Fixes #1444

### DIFF
--- a/yt/frontends/ytdata/tests/test_outputs.py
+++ b/yt/frontends/ytdata/tests/test_outputs.py
@@ -26,7 +26,9 @@ from yt.frontends.ytdata.api import \
     save_as_dataset
 from yt.testing import \
     assert_allclose_units, \
-    assert_equal
+    assert_equal, \
+    assert_fname, \
+    fake_random_ds
 from yt.utilities.answer_testing.framework import \
     requires_ds, \
     data_dir_load, \
@@ -34,6 +36,9 @@ from yt.utilities.answer_testing.framework import \
 from yt.units.yt_array import \
     YTArray, \
     YTQuantity
+from yt.visualization.plot_window import \
+    SlicePlot, \
+    ProjectionPlot
 from yt.visualization.profile_plotter import \
     ProfilePlot, \
     PhasePlot
@@ -221,5 +226,35 @@ def test_nonspatial_data():
     new_ds = load(full_fn)
     assert isinstance(new_ds, YTNonspatialDataset)
     yield YTDataFieldTest(full_fn, "density", geometric=False)
+    os.chdir(curdir)
+    shutil.rmtree(tmpdir)
+
+def test_plot_data():
+    tmpdir = tempfile.mkdtemp()
+    curdir = os.getcwd()
+    os.chdir(tmpdir)
+    ds = fake_random_ds(16)
+
+    plot = SlicePlot(ds, 'z', 'density')
+    plot.data_source.save_as_dataset('slice.h5')
+    ds_slice = load('slice.h5')
+    p = SlicePlot(ds_slice, 'z', 'density')
+    fn = p.save()
+    assert_fname(fn[0])
+
+    plot = ProjectionPlot(ds, 'z', 'density')
+    plot.data_source.save_as_dataset('proj.h5')
+    ds_proj = load('slice.h5')
+    p = ProjectionPlot(ds_proj, 'z', 'density')
+    fn = p.save()
+    assert_fname(fn[0])
+
+    plot = SlicePlot(ds, [1, 1, 1], 'density')
+    plot.data_source.save_as_dataset('oas.h5')
+    ds_oas = load('oas.h5')
+    p = SlicePlot(ds_oas, [1, 1, 1], 'density')
+    fn = p.save()
+    assert_fname(fn[0])
+
     os.chdir(curdir)
     shutil.rmtree(tmpdir)

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -124,6 +124,11 @@ def get_axes_unit(width, ds):
     return axes_unit
 
 def validate_mesh_fields(data_source, fields):
+    # this check doesn't make sense for ytdata plot datasets, which
+    # load mesh data as a particle field but nonetheless can still
+    # make plots with it
+    if isinstance(data_source.ds, YTSpatialPlotDataset):
+        return
     canonical_fields = data_source._determine_fields(fields)
     invalid_fields = []
     for field in canonical_fields:
@@ -1438,7 +1443,10 @@ class ProjectionPlot(PWViewerMPL):
             if proj.axis != ds.parameters["axis"]:
                 raise RuntimeError("Original projection axis is %s." %
                                    ds.parameters["axis"])
-            proj.weight_field = proj._determine_fields(weight_field)[0]
+            if weight_field is not None:
+                proj.weight_field = proj._determine_fields(weight_field)[0]
+            else:
+                proj.weight_field = weight_field
         else:
             proj = ds.proj(fields, axis, weight_field=weight_field,
                            center=center, data_source=data_source,


### PR DESCRIPTION
This functionality was unintentionally broken last year by me. The problem is that the `ytdata` frontend reloads plot datasets as particle fields, which broke the logic of the guard I added that gives a nice error message if someone tries to plot a particle field in a grid dataset.

The fix is to not perform this check for `ytdata` plot datasets.

I also added tests to avoid future regressions.

This fixes #1444.