### PR TITLE
Make force_override work for on-disk fields (#1511)

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1177,12 +1177,16 @@ class Dataset(object):
            Describes the dimensionality of the field.  Currently unused.
         display_name : str
            A name used in the plots
+        force_override : bool
+           Whether to override an existing derived field. Does not work with
+           on-disk fields.
 
         """
         self.index
         override = kwargs.get("force_override", False)
         if override and name in self.index.field_list:
-            self.index.field_list.remove(name)
+            raise RuntimeError("force_override is only meant to be used with "
+                               "derived fields, not on-disk fields.")
         # Handle the case where the field has already been added.
         if not override and name in self.field_info:
             mylog.warning("Field %s already exists. To override use " +

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1181,6 +1181,8 @@ class Dataset(object):
         """
         self.index
         override = kwargs.get("force_override", False)
+        if override and name in self.index.field_list:
+            self.index.field_list.remove(name)
         # Handle the case where the field has already been added.
         if not override and name in self.field_info:
             mylog.warning("Field %s already exists. To override use " +

--- a/yt/fields/tests/test_fields.py
+++ b/yt/fields/tests/test_fields.py
@@ -358,13 +358,3 @@ def test_deposit_amr():
         gpm = g['particle_mass'].sum()
         dpm = g['deposit', 'all_mass'].sum()
         assert_allclose_units(gpm, dpm)
-
-def test_on_disk_override():
-    def _test(field, data):
-        return data[('stream', 'velocity_x')]
-
-    ds = fake_random_ds(16)
-    ds.add_field(('stream', 'density'), function=_test, units='cm/s', force_override=True)
-    density = ds.all_data()[('stream', 'density')]
-    vel_x = ds.all_data()[('stream', 'velocity_x')]
-    assert_equal(density, vel_x)

--- a/yt/fields/tests/test_fields.py
+++ b/yt/fields/tests/test_fields.py
@@ -358,3 +358,13 @@ def test_deposit_amr():
         gpm = g['particle_mass'].sum()
         dpm = g['deposit', 'all_mass'].sum()
         assert_allclose_units(gpm, dpm)
+
+def test_on_disk_override():
+    def _test(field, data):
+        return data[('stream', 'velocity_x')]
+
+    ds = fake_random_ds(16)
+    ds.add_field(('stream', 'density'), function=_test, units='cm/s', force_override=True)
+    density = ds.all_data()[('stream', 'density')]
+    vel_x = ds.all_data()[('stream', 'velocity_x')]
+    assert_equal(density, vel_x)


### PR DESCRIPTION
## PR Summary

In order to override an on-disk field, it seems to be enough to remove it from the index's `field_list`. Let's see how many tests this breaks...