### PR TITLE
Print a more descriptive error message when defining a particle filter fails with missing fields

### DIFF
--- a/yt/data_objects/particle_filters.py
+++ b/yt/data_objects/particle_filters.py
@@ -69,6 +69,10 @@ class ParticleFilter(object):
         # fields are implicitly "all" or something.
         return all((self.filtered_type, field) in field_list for field in self.requires)
 
+    def missing(self, field_list):
+        return list((self.filtered_type, field) for field in self.requires if
+                    (self.filtered_type, field) not in field_list)
+
     def wrap_func(self, field_name, old_fi):
         new_fi = copy.copy(old_fi)
         new_fi.name = (self.name, field_name[1])

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -37,7 +37,8 @@ from yt.utilities.cosmology import \
 from yt.utilities.exceptions import \
     YTObjectNotImplemented, \
     YTFieldNotFound, \
-    YTGeometryNotSupported
+    YTGeometryNotSupported, \
+    YTIllDefinedParticleFilter
 from yt.utilities.parallel_tools.parallel_analysis_interface import \
     parallel_root_only
 from yt.utilities.parameter_file_storage import \
@@ -675,7 +676,8 @@ class Dataset(object):
 
     def _setup_filtered_type(self, filter):
         if not filter.available(self.derived_field_list):
-            return False
+            raise YTIllDefinedParticleFilter(
+                filter, filter.missing(self.derived_field_list))
         fi = self.field_info
         fd = self.field_dependencies
         available = False

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -392,6 +392,17 @@ class YTIllDefinedFilter(YTException):
         return "Filter '%s' ill-defined.  Applied to shape %s but is shape %s." % (
             self.filter, self.s1, self.s2)
 
+class YTIllDefinedParticleFilter(YTException):
+    def __init__(self, filter, missing):
+        self.filter = filter
+        self.missing = missing
+
+    def __str__(self):
+        msg = ("\nThe fields\n\t{},\nrequired by the \"{}\" particle filter, "
+               "are not defined for this dataset.")
+        f = self.filter
+        return msg.format("\n".join([str(m) for m in self.missing]), f.name)
+
 class YTIllDefinedBounds(YTException):
     def __init__(self, lb, ub):
         self.lb = lb


### PR DESCRIPTION
Closes #1278

~~I'm not sure if this subtly breaks other particle filter behavior so let's see if this causes any test failures.~~

To make that more concrete, with this PR, the following script:

```
import yt

@yt.particle_filter(requires=["myField"], filtered_type='all')
def small_x(pfilter, data):
    filter = data[(pfilter.filtered_type, "myField")] < 0
    return filter

def myField(field, data):
    return data["particle_position_x"]

snap = 'GadgetDiskGalaxy/snapshot_200.hdf5'

ds = yt.load(snap)
ds.add_particle_filter('small_x')
```

Will now error out with the following error message:

```
Traceback (most recent call last):
  File "test.py", line 14, in <module>
    ds.add_particle_filter('small_x')
  File "/Users/goldbaum/Documents/yt-git-fixes/yt/data_objects/static_output.py", line 665, in add_particle_filter
    used = self._setup_filtered_type(f)
  File "/Users/goldbaum/Documents/yt-git-fixes/yt/data_objects/static_output.py", line 680, in _setup_filtered_type
    filter, filter.missing(self.derived_field_list))
yt.utilities.exceptions.YTIllDefinedParticleFilter:
The fields
	('all', 'myField'),
required by the "small_x" particle filter, are not defined.
```

Let me know if you have any issues with the error message or how I'm setting this up.