### PR TITLE
Create fixed-resolution rays from region expression

### DIFF
--- a/doc/source/analyzing/objects.rst
+++ b/doc/source/analyzing/objects.rst
@@ -235,6 +235,21 @@ different units can be used. Here's a somewhat convoluted (yet working) example:
     end = ((1.0, "Mpc"), (300.0, "kpc"), (0.0, "kpc"))
     ray = ds.r[start:end]
 
+Making Fixed-Resolution Rays
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Rays can also be constructed to have fixed resolution if an imaginary step value
+is provided, similar to the 2 and 3-dimensional cases described above. This
+works for rays directed along an axis:::
+
+    ortho_ray = ds.r[(0.1:0.6:500j,0.3,0.2]
+    
+or off-axis rays as well:::
+
+    start = [0.1, 0.2, 0.3] # interpreted in code_length
+    end = [0.4, 0.5, 0.6] # interpreted in code_length
+    ray = ds.r[start:end:100j]
+
 Selecting Points
 ^^^^^^^^^^^^^^^^
 

--- a/yt/data_objects/region_expression.py
+++ b/yt/data_objects/region_expression.py
@@ -178,7 +178,7 @@ class RegionExpression(object):
             else:
                 if axis is not None: raise RuntimeError
                 if getattr(v.step, "imag", 0.0) != 0.0:
-                    npoints = new_slice[axis].step
+                    npoints = int(v.step.imag)
                     xi = self._spec_to_value(v.start)
                     xf = self._spec_to_value(v.stop)
                     dx = (xf-xi)/npoints

--- a/yt/data_objects/region_expression.py
+++ b/yt/data_objects/region_expression.py
@@ -157,7 +157,8 @@ class RegionExpression(object):
         start_point = [self._spec_to_value(v) for v in ray_slice.start]
         end_point = [self._spec_to_value(v) for v in ray_slice.stop]
         if getattr(ray_slice.step, "imag", 0.0) != 0.0:
-            return LineBuffer(self.ds, start_point, end_point, ray_slice.step)
+            return LineBuffer(self.ds, start_point, end_point, 
+                              int(ray_slice.step.imag))
         else:
             return self.ds.ray(start_point, end_point)
 

--- a/yt/data_objects/region_expression.py
+++ b/yt/data_objects/region_expression.py
@@ -17,6 +17,7 @@ from yt.extern.six import string_types
 from yt.funcs import obj_length
 from yt.units.yt_array import YTQuantity
 from yt.utilities.exceptions import YTDimensionalityError
+from yt.visualization.line_plot import LineBuffer
 
 class RegionExpression(object):
     _all_data = None
@@ -155,23 +156,42 @@ class RegionExpression(object):
     def _create_ray(self, ray_slice):
         start_point = [self._spec_to_value(v) for v in ray_slice.start]
         end_point = [self._spec_to_value(v) for v in ray_slice.stop]
-        return self.ds.ray(start_point, end_point)
+        if getattr(ray_slice.step, "imag", 0.0) != 0.0:
+            return LineBuffer(self.ds, start_point, end_point, ray_slice.step)
+        else:
+            return self.ds.ray(start_point, end_point)
 
     def _create_ortho_ray(self, ray_tuple):
         axis = None
         new_slice = []
         coord = []
+        npoints = 0
+        start_point = []
+        end_point = []
         for ax, v in enumerate(ray_tuple):
             if not isinstance(v, slice):
-                coord.append(self._spec_to_value(v))
+                val = self._spec_to_value(v)
+                coord.append(val)
                 new_slice.append(slice(None, None, None))
+                start_point.append(val)
+                end_point.append(val)
             else:
                 if axis is not None: raise RuntimeError
-                axis = ax
-                new_slice.append(v)
-        if axis == 1: coord = [coord[1], coord[0]]
-        source = self._create_region(new_slice)
-        ray = self.ds.ortho_ray(axis, coord, data_source=source)
-        if getattr(new_slice[axis].step, "imag", 0.0) != 0.0:
-            raise NotImplementedError
+                if getattr(v.step, "imag", 0.0) != 0.0:
+                    npoints = new_slice[axis].step
+                    xi = self._spec_to_value(v.start)
+                    xf = self._spec_to_value(v.stop)
+                    dx = (xf-xi)/npoints
+                    start_point.append(xi+0.5*dx)
+                    end_point.append(xf-0.5*dx)
+                else:
+                    axis = ax
+                    new_slice.append(v)
+        if npoints > 0:
+            ray = LineBuffer(self.ds, start_point, end_point, npoints)
+        else:
+            if axis == 1:
+                coord = [coord[1], coord[0]]
+            source = self._create_region(new_slice)
+            ray = self.ds.ortho_ray(axis, coord, data_source=source)
         return ray

--- a/yt/data_objects/tests/test_dataset_access.py
+++ b/yt/data_objects/tests/test_dataset_access.py
@@ -8,6 +8,8 @@ from yt.testing import \
     requires_file
 from yt.utilities.answer_testing.framework import \
     data_dir_load
+from yt.visualization.line_plot import \
+    LineBuffer
 
 # This will test the "dataset access" method.
 
@@ -111,6 +113,10 @@ def test_ray_from_r():
     ray6 = ds.ray(start_arr, end_arr)
     assert_equal(ray5["density"], ray6["density"])
 
+    ray7 = ds.r[start:end:500j]
+    ray8 = LineBuffer(ds, [0.1, 0.2, 0.3], [0.5, 0.4, 0.6], 500)
+    assert_equal(ray7["density"], ray8["density"])
+
 def test_ortho_ray_from_r():
     ds = fake_amr_ds(fields = ["density"])
     ray1 = ds.r[:,0.3,0.2]
@@ -127,6 +133,11 @@ def test_ortho_ray_from_r():
     ray5 = ds.r[0.25:0.75,0.3,0.2]
     ray6 = ds.ortho_ray("x", [0.3, 0.2], data_source=box)
     assert_equal(ray5["density"], ray6["density"])
+
+    # Test fixed-resolution rays
+    ray7 = ds.r[0.25:0.75:100j,0.3,0.2]
+    ray8 = LineBuffer(ds, [0.2525,0.3,0.2], [0.7475,0.3,0.2], 100)
+    assert_equal(ray7["density"], ray8["density"])
 
 def test_particle_counts():
     ds = fake_random_ds(16, particles=100)


### PR DESCRIPTION
Thanks to @lindseyad and @ngoldbaum's recent work with `LinePlot` and `LineBuffer`, I was able to incorporate fixed-resolution rays into `ds.r`. This works for both on-axis and off-axis arrays.

Examples:

```python
# orthogonal ray
ortho_ray = ds.r[(0.1:0.6:500j,0.3,0.2]

# off-axis ray
start = [0.1, 0.2, 0.3]
end = [0.4, 0.5, 0.6] 
ray = ds.r[start:end:100j]
```
Tests and docs have been added.