### PR TITLE
[bugfix] API Docs for FITSImageData and a bugfix

### DIFF
--- a/doc/source/reference/api/api.rst
+++ b/doc/source/reference/api/api.rst
@@ -48,6 +48,17 @@ Fixed Resolution Pixelization
    ~yt.visualization.fixed_resolution.CylindricalFixedResolutionBuffer
    ~yt.visualization.fixed_resolution.OffAxisProjectionFixedResolutionBuffer
 
+Writing FITS images
+^^^^^^^^^^^^^^^^^^^
+
+.. autosummary::
+
+   ~yt.visualization.fits_image.FITSImageData
+   ~yt.visualization.fits_image.FITSSlice
+   ~yt.visualization.fits_image.FITSProjection
+   ~yt.visualization.fits_image.FITSOffAxisSlice
+   ~yt.visualization.fits_image.FITSOffAxisProjection
+
 Data Sources
 ------------
 

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -295,7 +295,7 @@ class FITSImageData(object):
                    'No.    Name         Type      Cards   Dimensions   Format     Units']
         for line in hinfo:
             units = self.field_units[self.hdulist[line[0]].header['btype']]
-            summary = tuple(line[:-1] + [units])
+            summary = tuple(list(line[:-1]) + [units])
             if output:
                 results.append(format.format(*summary))
             else:


### PR DESCRIPTION
This PR adds the `FITSImageData` classes to the API docs and fixes an issue which was causing the documentation to display errors when calling the `info()` method (and causing an error every time `info()` was called).