### PR TITLE
Avoid integer overflow issues in RegionSelector. Fixes #1432

### DIFF
--- a/yt/frontends/enzo/tests/test_outputs.py
+++ b/yt/frontends/enzo/tests/test_outputs.py
@@ -20,7 +20,8 @@ from yt.testing import \
     assert_equal, \
     requires_file, \
     units_override_check, \
-    assert_array_equal
+    assert_array_equal, \
+    assert_allclose_units
 from yt.utilities.answer_testing.framework import \
     requires_ds, \
     small_patch_amr, \
@@ -208,3 +209,13 @@ def test_deeply_nested_zoom():
     image = plot.frb['density']
 
     assert (image > 0).all()
+
+    v, c = ds.find_max('density')
+
+    assert_allclose_units(v, ds.quan(0.005879315652144976, 'g/cm**3'))
+
+    c_actual = [0.49150732540021, 0.505260532936791, 0.49058055816398]
+    c_actual = ds.arr(c_actual, 'code_length')
+    assert_allclose_units(c, c_actual)
+
+    assert_equal(max([g['density'].max() for g in ds.index.grids]), v)

--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -920,15 +920,12 @@ cdef class RegionSelector(SelectorObject):
             return 0
         if level == self.max_level:
             this_level = 1
-        cdef int si[3]
-        cdef int ei[3]
-        #print self.left_edge[0], self.left_edge[1], self.left_edge[2],
-        #print self.right_edge[0], self.right_edge[1], self.right_edge[2],
-        #print self.right_edge_shift[0], self.right_edge_shift[1], self.right_edge_shift[2]
+        cdef np.int64_t si[3]
+        cdef np.int64_t ei[3]
         if not self.check_period:
             for i in range(3):
-                si[i] = <int> ((self.left_edge[i] - left_edge[i])/dds[i])
-                ei[i] = <int> ((self.right_edge[i] - left_edge[i])/dds[i])
+                si[i] = <np.int64_t> ((self.left_edge[i] - left_edge[i])/dds[i])
+                ei[i] = <np.int64_t> ((self.right_edge[i] - left_edge[i])/dds[i])
                 si[i] = iclip(si[i] - 1, 0, dim[i])
                 ei[i] = iclip(ei[i] + 1, 0, dim[i])
         else:

--- a/yt/utilities/lib/fp_utils.pxd
+++ b/yt/utilities/lib/fp_utils.pxd
@@ -16,7 +16,7 @@ Shareable definitions for common fp/int Cython utilities
 cimport numpy as np
 cimport cython
 
-cdef inline int imax(int i0, int i1) nogil:
+cdef inline np.int64_t imax(np.int64_t i0, np.int64_t i1) nogil:
     if i0 > i1: return i0
     return i1
 
@@ -24,7 +24,7 @@ cdef inline np.float64_t fmax(np.float64_t f0, np.float64_t f1) nogil:
     if f0 > f1: return f0
     return f1
 
-cdef inline int imin(int i0, int i1) nogil:
+cdef inline np.int64_t imin(np.int64_t i0, np.int64_t i1) nogil:
     if i0 < i1: return i0
     return i1
 
@@ -36,12 +36,12 @@ cdef inline np.float64_t fabs(np.float64_t f0) nogil:
     if f0 < 0.0: return -f0
     return f0
 
-cdef inline int iclip(int i, int a, int b) nogil:
+cdef inline np.int64_t iclip(np.int64_t i, np.int64_t a, np.int64_t b) nogil:
     if i < a: return a
     if i > b: return b
     return i
 
-cdef inline int i64clip(np.int64_t i, np.int64_t a, np.int64_t b) nogil:
+cdef inline np.int64_t i64clip(np.int64_t i, np.int64_t a, np.int64_t b) nogil:
     if i < a: return a
     if i > b: return b
     return i


### PR DESCRIPTION
With these changes, the script in #1432 produces the following image:

![data0025_projection_z_density](https://user-images.githubusercontent.com/3126246/28891119-ff10cee6-778e-11e7-8644-f1a696ac0628.png)

I've asked if we can use the test dataset linked in the issue in our test suite, since right now we don't have any extremely deep zoom-ins.