### PR TITLE
Replace unicode double quotation mark with ascii

### DIFF
--- a/doc/source/analyzing/analysis_modules/halo_catalogs.rst
+++ b/doc/source/analyzing/analysis_modules/halo_catalogs.rst
@@ -309,7 +309,7 @@ Quantities
 ^^^^^^^^^^
 
 A quantity is a call back that returns a value or values. The return values
-are stored within the halo object in a dictionary called “quantities.” At
+are stored within the halo object in a dictionary called "quantities." At
 the end of the analysis, all of these quantities will be written to disk as
 the final form of the generated halo catalog.
 

--- a/doc/source/analyzing/units/3)_Comoving_units_and_code_units.ipynb
+++ b/doc/source/analyzing/units/3)_Comoving_units_and_code_units.ipynb
@@ -171,7 +171,7 @@
     "\n",
     "As an aside, Darren Croton's [research note](http://arxiv.org/abs/1308.4150) on the history, use, and interpretation of $h$ as it appears in the astronomical literature is pretty much required reading for anyone who has to deal with factors of $h$ every now and then.\n",
     "\n",
-    "In yt, comoving length unit symbols are named following the pattern “(length symbol)cm”, i.e. `pccm` for comoving parsec or `mcm` for a comoving meter.  A comoving length unit is different from the normal length unit by a factor of $(1+z)$:"
+    "In yt, comoving length unit symbols are named following the pattern `(length symbol)cm`, i.e. `pccm` for comoving parsec or `mcm` for a comoving meter.  A comoving length unit is different from the normal length unit by a factor of $(1+z)$:"
    ]
   },
   {

--- a/doc/source/reference/changelog.rst
+++ b/doc/source/reference/changelog.rst
@@ -941,7 +941,7 @@ Version 2.2
  * An order of magnitude speed improvement in the RAMSES support
  * Quad-tree projections, speeding up the process of projecting by up to an
    order of magnitude and providing better load balancing
- * “mapserver” for in-browser, Google Maps-style slice and projection
+ * "mapserver" for in-browser, Google Maps-style slice and projection
    visualization (see :ref:`mapserver`)
  * Many bug fixes and performance improvements
  * Halo loader

--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -1146,7 +1146,8 @@ labels passed in the initial construction of the ``LinePlot`` instance. Example:
 
    ds = yt.load("SecondOrderTris/RZ_p_no_parts_do_nothing_bcs_cone_out.e", step=-1)
    plot = yt.LinePlot(ds, [('all', 'v'), ('all', 'u')], [0, 0, 0], [0, 1, 0],
-                      100, labels={('all', 'u') : r"v$_x$", ('all', 'v') : r"v$_y$"})
+                      100, field_labels={('all', 'u') : r"v$_x$",
+                                         ('all', 'v') : r"v$_y$"})
    plot.annotate_legend(('all', 'u'))
    plot.save()
 

--- a/yt/units/yt_array.py
+++ b/yt/units/yt_array.py
@@ -886,7 +886,7 @@ class YTArray(np.ndarray):
             d = g[dataset_name]
             # Overwrite without deleting if we can get away with it.
             if d.shape == self.shape and d.dtype == self.dtype:
-                d[:] = self
+                d[...] = self
                 for k in d.attrs.keys():
                     del d.attrs[k]
             else:

--- a/yt/utilities/grid_data_format/docs/gdf_specification.txt
+++ b/yt/utilities/grid_data_format/docs/gdf_specification.txt
@@ -13,7 +13,7 @@ Caveats and Notes
 #. We avoid having many attributes on many nodes, as access can be quite slow
 #. Cartesian data only for now
 #. All grids must have the same number of ghost zones.
-#. If “/grid_parent” does not exist, parentage relationships will be
+#. If "/grid_parent" does not exist, parentage relationships will be
    reconstructed and assumed to allow multiple grids
 #. No parentage can skip levels
 #. All grids are at the same time
@@ -173,7 +173,7 @@ These attributes will all be associated with ``/simulation_parameters``.
 ``domain_dimensions``
    dimensions in the top grid
 ``current_time``
-   current time in simulation, in seconds, from “start” of simulation
+   current time in simulation, in seconds, from "start" of simulation
 ``domain_left_edge``
    the left edge of the domain, in cm
 ``domain_right_edge``


### PR DESCRIPTION
After recent update of software stack on doc builder builds now hang with:

```
Sphinx parallel build error:
UnicodeEncodeError: 'ascii' codec can't encode character '\u201c' in position 7752: ordinal not in range(128)
```

I updated only `RunNotebook` to version 0.2, but it pulled a lot of new updates in and I have no idea what exactly causes the issue.