### PR TITLE
Make arbitrary grid support filling multiple fields.

### DIFF
--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -848,16 +848,15 @@ class YTArbitraryGrid(YTCoveringGrid):
     def _fill_fields(self, fields):
         fields = [f for f in fields if f not in self.field_data]
         if len(fields) == 0: return
-        assert(len(fields) == 1)
-        field = fields[0]
-        dest = np.zeros(self.ActiveDimensions, dtype="float64")
-        for chunk in self._data_source.chunks(fields, "io"):
-            fill_region_float(chunk.fcoords, chunk.fwidth, chunk[field],
-                              self.left_edge, self.right_edge, dest, 1,
-                              self.ds.domain_width,
-                              int(any(self.ds.periodicity)))
-        fi = self.ds._get_field_info(field)
-        self[field] = self.ds.arr(dest, fi.units)
+        for field in fields:
+            dest = np.zeros(self.ActiveDimensions, dtype="float64")
+            for chunk in self._data_source.chunks(fields, "io"):
+                fill_region_float(chunk.fcoords, chunk.fwidth, chunk[field],
+                                  self.left_edge, self.right_edge, dest, 1,
+                                  self.ds.domain_width,
+                                  int(any(self.ds.periodicity)))
+            fi = self.ds._get_field_info(field)
+            self[field] = self.ds.arr(dest, fi.units)
 
 
 class LevelState(object):

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -848,6 +848,8 @@ class YTArbitraryGrid(YTCoveringGrid):
     def _fill_fields(self, fields):
         fields = [f for f in fields if f not in self.field_data]
         if len(fields) == 0: return
+        # It may be faster to adapt fill_region_float to fill multiple fields
+        # instead of looping here
         for field in fields:
             dest = np.zeros(self.ActiveDimensions, dtype="float64")
             for chunk in self._data_source.chunks(fields, "io"):

--- a/yt/data_objects/tests/test_covering_grid.py
+++ b/yt/data_objects/tests/test_covering_grid.py
@@ -149,3 +149,18 @@ def test_smoothed_covering_grid_2d_dataset():
     ds.periodicity = (True, True, True)
     scg = ds.smoothed_covering_grid(1, [0, 0, 0], [128, 128, 1])
     assert_equal(scg['density'].shape, [128, 128, 1])
+
+isogal = "IsolatedGalaxy/galaxy0030/galaxy0030"
+@requires_file(isogal)
+def test_arbitrary_grid_derived_field():
+    def _tracerf(field, data):
+        return data['Metal_Density']/data['gas', 'density']
+
+    ds = load(isogal)
+
+    ds.add_field(("gas", "tracerf"), function=_tracerf, units="dimensionless",
+                 take_log=False)
+
+    galgas = ds.arbitrary_grid([0.4, 0.4, 0.4], [0.99, 0.99, 0.99],
+                               dims=[32, 32, 32])
+    galgas['tracerf']


### PR DESCRIPTION
Fixes #1527.

This fixes the test script in #1527. I'm not sure offhand why the restriction to only fill one field was added to `ArbitraryGrid._fill_fields`, but this seems to work.