### PR TITLE
Minor update for the cookbook of calculating SFR

### DIFF
--- a/doc/source/cookbook/particle_filter_sfr.py
+++ b/doc/source/cookbook/particle_filter_sfr.py
@@ -24,7 +24,7 @@ hist, bins = np.histogram(formation_time, bins=n_bins, range=time_range,)
 inds = np.digitize(formation_time, bins=bins)
 time = (bins[:-1] + bins[1:])/2
 
-sfr = np.array([masses[inds == j].sum()/(bins[j+1]-bins[j])
+sfr = np.array([masses[inds == j+1].sum()/(bins[j+1]-bins[j])
                 for j in range(len(time))])
 sfr[sfr == 0] = np.nan
 


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

Minor fix to the cookbook of calculating SFR. If I understand it correctly, the array index should be `j+1` instead of `j` since np.digitize returns the **right** bin of the data to be digitized.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
