### PR TITLE
Use git version for get_yt_version

### DIFF
--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -642,7 +642,7 @@ def get_yt_version():
     import pkg_resources
     yt_provider = pkg_resources.get_provider("yt")
     path = os.path.dirname(yt_provider.module_path)
-    version = get_hg_version(path)
+    version = get_git_version(path)
     if version is None:
         return version
     else:


### PR DESCRIPTION
This should get rid of warnings about installing `python-hglib` when running answer tests.