### PR TITLE
Return dimensionless if we can't determine the field units for FITS datasets

### DIFF
--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -109,13 +109,15 @@ class FITSHierarchy(GridIndex):
             # the right case by comparing against known units. This
             # only really works for common units.
             units = set(re.split(regex_pattern, field_units))
-            if '' in units: units.remove('')
+            if '' in units: 
+                units.remove('')
             n = int(0)
             for unit in units:
                 if unit in known_units:
                     field_units = field_units.replace(unit, known_units[unit])
                     n += 1
-            if n != len(units): field_units = "dimensionless"
+            if n != len(units) or n == 0:
+                field_units = "dimensionless"
             if field_units[0] == "/":
                 field_units = "1%s" % field_units
             return field_units

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -2049,7 +2049,7 @@ def plot_2d(ds, fields, center='c', width=None, axes_unit=None,
     """
     if ds.dimensionality != 2:
         raise RuntimeError("plot_2d only plots 2D datasets!")
-    if ds.geometry == "cartesian" or ds.geometry == "polar":
+    if ds.geometry in ["cartesian", "polar", "spectral_cube"]:
         axis = "z"
     elif ds.geometry == "cylindrical":
         axis = "theta"


### PR DESCRIPTION
This PR ensures that if units are not specified for a FITS image that the units are set to dimensionless.

I also fixed a bug that prevented one using `plot_2d` with FITS datasets with celestial coordinates.

Closes Issue #1552.

