### PR TITLE
[bugfix] Check for units before converting quantities in HaloCatalog

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -35,8 +35,9 @@ answer_tests:
   local_gizmo_002:
     - yt/frontends/gizmo/tests/test_outputs.py
 
-  local_halos_004:
+  local_halos_005:
     - yt/analysis_modules/halo_analysis/tests/test_halo_finders.py  # [py2]
+    - yt/analysis_modules/halo_analysis/tests/test_halo_catalog.py
     - yt/analysis_modules/halo_finding/tests/test_rockstar.py  # [py2]
     - yt/frontends/ahf/tests/test_outputs.py
     - yt/frontends/owls_subfind/tests/test_outputs.py

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -35,7 +35,7 @@ answer_tests:
   local_gizmo_002:
     - yt/frontends/gizmo/tests/test_outputs.py
 
-  local_halos_005:
+  local_halos_006:
     - yt/analysis_modules/halo_analysis/tests/test_halo_finders.py  # [py2]
     - yt/analysis_modules/halo_analysis/tests/test_halo_catalog.py
     - yt/analysis_modules/halo_finding/tests/test_rockstar.py  # [py2]

--- a/yt/analysis_modules/halo_analysis/halo_catalog.py
+++ b/yt/analysis_modules/halo_analysis/halo_catalog.py
@@ -449,7 +449,8 @@ class HaloCatalog(ParallelAnalysisInterface):
 
             if halo_filter:
                 for quantity in new_halo.quantities.values():
-                    quantity.convert_to_base()
+                    if hasattr(quantity, "units"):
+                        quantity.convert_to_base()
                 self.catalog.append(new_halo.quantities)
 
             if save_halos and halo_filter:

--- a/yt/analysis_modules/halo_analysis/tests/test_halo_catalog.py
+++ b/yt/analysis_modules/halo_analysis/tests/test_halo_catalog.py
@@ -1,0 +1,83 @@
+"""
+HaloCatalog answer tests
+
+
+
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) 2017, yt Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+import numpy as np
+import os
+import shutil
+import tempfile
+
+from yt.analysis_modules.halo_analysis.api import \
+    HaloCatalog, \
+    add_quantity
+from yt.convenience import \
+    load
+from yt.testing import \
+    assert_equal
+from yt.utilities.answer_testing.framework import \
+    AnswerTestingTest, \
+    data_dir_load, \
+    requires_ds
+
+def _nstars(halo):
+    sp = halo.data_object
+    return (sp["all", "creation_time"] > 0).sum()
+add_quantity("nstars", _nstars)
+
+class HaloQuantityTest(AnswerTestingTest):
+    _type_name = "HaloQuantity"
+    _attrs = ()
+
+    def __init__(self, data_ds, halos_ds):
+        self.data_ds = data_dir_load(data_ds)
+        self.halos_ds = data_dir_load(halos_ds)
+        self.ds = data_ds
+
+    def run(self):
+        curdir = os.getcwd()
+        tmpdir = tempfile.mkdtemp()
+        os.chdir(tmpdir)
+
+        hc = HaloCatalog(
+            data_ds=self.data_ds, halos_ds=self.halos_ds,
+            output_dir=os.path.join(tmpdir, str(self.data_ds)))
+        hc.add_callback("sphere")
+        hc.add_quantity("nstars")
+        hc.create()
+
+        fn = os.path.join(tmpdir, str(self.data_ds),
+                          "%s.0.h5" % str(self.data_ds))
+        ds = load(fn)
+        ad = ds.all_data()
+        mi, ma = ad.quantities.extrema("nstars")
+        mean = ad.quantities.weighted_average_quantity(
+            "nstars", "particle_ones")
+
+        os.chdir(curdir)
+        shutil.rmtree(tmpdir)
+    
+        return np.array([mean, mi, ma])
+
+    def compare(self, new_result, old_result):
+        assert_equal(new_result, old_result, verbose=True)
+
+rh0 = "rockstar_halos/halos_0.0.bin"
+e64 = "Enzo_64/DD0043/data0043"
+
+@requires_ds(rh0)
+@requires_ds(e64)
+def test_halo_quantity():
+    hds = data_dir_load(rh0)
+    dds = data_dir_load(e64)
+    yield HaloQuantityTest(dds, hds)

--- a/yt/analysis_modules/halo_analysis/tests/test_halo_catalog.py
+++ b/yt/analysis_modules/halo_analysis/tests/test_halo_catalog.py
@@ -39,25 +39,27 @@ class HaloQuantityTest(AnswerTestingTest):
     _type_name = "HaloQuantity"
     _attrs = ()
 
-    def __init__(self, data_ds, halos_ds):
-        self.data_ds = data_dir_load(data_ds)
-        self.halos_ds = data_dir_load(halos_ds)
-        self.ds = data_ds
+    def __init__(self, data_ds_fn, halos_ds_fn):
+        self.data_ds_fn = data_ds_fn
+        self.halos_ds_fn = halos_ds_fn
+        self.ds = data_dir_load(data_ds_fn)
 
     def run(self):
         curdir = os.getcwd()
         tmpdir = tempfile.mkdtemp()
         os.chdir(tmpdir)
 
+        dds = data_dir_load(self.data_ds_fn)
+        hds = data_dir_load(self.halos_ds_fn)
         hc = HaloCatalog(
-            data_ds=self.data_ds, halos_ds=self.halos_ds,
-            output_dir=os.path.join(tmpdir, str(self.data_ds)))
+            data_ds=dds, halos_ds=hds,
+            output_dir=os.path.join(tmpdir, str(dds)))
         hc.add_callback("sphere")
         hc.add_quantity("nstars")
         hc.create()
 
-        fn = os.path.join(tmpdir, str(self.data_ds),
-                          "%s.0.h5" % str(self.data_ds))
+        fn = os.path.join(tmpdir, str(dds),
+                          "%s.0.h5" % str(dds))
         ds = load(fn)
         ad = ds.all_data()
         mi, ma = ad.quantities.extrema("nstars")
@@ -78,6 +80,4 @@ e64 = "Enzo_64/DD0043/data0043"
 @requires_ds(rh0)
 @requires_ds(e64)
 def test_halo_quantity():
-    hds = data_dir_load(rh0)
-    dds = data_dir_load(e64)
-    yield HaloQuantityTest(dds, hds)
+    yield HaloQuantityTest(e64, rh0)


### PR DESCRIPTION
This fixes a bug where halo quantities returned without units will fail because of a forced unit conversion when compiling results.  I also added a test for this.