### PR TITLE
cache dataset args and kwargs in dataset cache keys

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -24,6 +24,7 @@ import warnings
 
 from collections import defaultdict
 from yt.extern.six import add_metaclass, string_types
+from six.moves import cPickle
 
 from yt.config import ytcfg
 from yt.fields.derived_field import \
@@ -252,14 +253,15 @@ class Dataset(object):
                 obj.__init__(filename, *args, **kwargs)
             return obj
         apath = os.path.abspath(filename)
+        cache_key = (apath, cPickle.dumps(args), cPickle.dumps(kwargs))
         if ytcfg.getboolean("yt","skip_dataset_cache"):
             obj = object.__new__(cls)
-        elif apath not in _cached_datasets:
+        elif cache_key not in _cached_datasets:
             obj = object.__new__(cls)
             if obj._skip_cache is False:
-                _cached_datasets[apath] = obj
+                _cached_datasets[cache_key] = obj
         else:
-            obj = _cached_datasets[apath]
+            obj = _cached_datasets[cache_key]
         return obj
 
     def __init__(self, filename, dataset_type=None, file_style=None,


### PR DESCRIPTION
Currently the dataset caching system does not store the args and kwargs passed to the dataset initializer when storing datasets for caching. This means that if a dataset is loaded multiple times with different arguments or keyword arguments, the dataset initializer will silently ignore the arguments and keyword arguments passed after the first call to `yt.load()`. This can cause issues in user scripts as well as the yt test suite, where we commonly try loading the same dataset multiple times in the same session.

Ultimately I'd like to get rid of the dataset caching system. Unfortunately, that's a bit difficult because dataset caching enables functionality elsewhere in the library, so we'd need to figure out how to maintain that functionality after removing the dataset cache. Definitely doable, just harder than a one-off fix.

My fix here is to save pickled versions of the args and kwargs that get passed to the dataset initializer in the key used to populate the dataset cache dictionary. I can't use the raw args and kwargs because the key needs to be immutable. I also can't use something more human-readable like json because we pass non-serializable data to dataset initializers (mostly numpy arrays).

Pickle does seem to work, but I haven't tried running the full test suite yet. If the tests pass here that's a good indication this fix will work in general.

I'd love to hear alternative ideas for how to deal with this issue.