### PR TITLE
Travis fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,12 @@ env:
     SCIPY=scipy
     IPYTHON=ipython
     FASTCACHE=fastcache
+    FLAKE8=flake8
 
 matrix:
   include:
     - python: 2.7
-      env: NUMPY=numpy==1.10.4 CYTHON=cython==0.24 MATPLOTLIB=matplotlib==1.5.3 SYMPY=sympy==1.0 H5PY= SCIPY= FASTCACHE= IPYTHON=ipython==1.0
+      env: NUMPY=numpy==1.10.4 CYTHON=cython==0.24 MATPLOTLIB=matplotlib==1.5.3 SYMPY=sympy==1.0 H5PY= SCIPY= FASTCACHE= FLAKE8= IPYTHON=ipython==1.0
     - python: 2.7
     - python: 3.4
     - python: 3.5
@@ -65,7 +66,7 @@ install:
     pip install --upgrade wheel
     pip install --upgrade setuptools
     # Install dependencies
-    pip install mock $NUMPY $SCIPY $H5PY $CYTHON $MATPLOTLIB $SYMPY $FASTCACHE $IPYTHON nose flake8 nose-timer
+    pip install mock $NUMPY $SCIPY $H5PY $CYTHON $MATPLOTLIB $SYMPY $FASTCACHE $IPYTHON $FLAKE8 nose nose-timer
     # install yt
     pip install -e .
 

--- a/yt/frontends/ytdata/tests/test_outputs.py
+++ b/yt/frontends/ytdata/tests/test_outputs.py
@@ -28,7 +28,8 @@ from yt.testing import \
     assert_allclose_units, \
     assert_equal, \
     assert_fname, \
-    fake_random_ds
+    fake_random_ds, \
+    requires_module
 from yt.utilities.answer_testing.framework import \
     requires_ds, \
     data_dir_load, \
@@ -229,6 +230,7 @@ def test_nonspatial_data():
     os.chdir(curdir)
     shutil.rmtree(tmpdir)
 
+@requires_module('h5py')
 def test_plot_data():
     tmpdir = tempfile.mkdtemp()
     curdir = os.getcwd()

--- a/yt/utilities/grid_data_format/tests/test_writer.py
+++ b/yt/utilities/grid_data_format/tests/test_writer.py
@@ -17,7 +17,9 @@ import shutil
 import os
 from yt.utilities.on_demand_imports import _h5py as h5
 from yt.testing import \
-    fake_random_ds, assert_equal
+    fake_random_ds, \
+    assert_equal, \
+    requires_module
 from yt.utilities.grid_data_format.writer import \
     write_to_gdf
 from yt.frontends.gdf.data_structures import \
@@ -35,6 +37,7 @@ def setup():
     ytcfg["yt", "__withintesting"] = "True"
 
 
+@requires_module('h5py')
 def test_write_gdf():
     """Main test suite for write_gdf"""
     tmpdir = tempfile.mkdtemp()


### PR DESCRIPTION
This is an attempt to fix our travis builds, which are currently failing due to two separate issues:

* Some tests need h5py to run but are not decorated with `requires_module('h5py')`. The fix is to add the decorator. We don't always assume h5py is installed because it's now an optional dependency.
* For some reason flake8 is failing on the travis build with minimal dependencies. I have no idea why it's failing and can't reproduce locally. It has something to do with flake8 not parsing our `setup.cfg` file for some reason. Rather than struggling to debug why this is happening, I've elected to disable flake8 on the minimal travis build. Flake8 will still run under python2.7 on the other python2.7 travis build.