### PR TITLE
Make sure that PPVCube does not fail if there is no temperature field

### DIFF
--- a/yt/analysis_modules/ppv_cube/ppv_cube.py
+++ b/yt/analysis_modules/ppv_cube/ppv_cube.py
@@ -44,10 +44,10 @@ def create_vlos(normal, no_shifting):
             return -vz
     return _v_los
 
-fits_info = {"velocity":("m/s","VOPT","v"),
-             "frequency":("Hz","FREQ","f"),
-             "energy":("eV","ENER","E"),
-             "wavelength":("angstrom","WAVE","lambda")}
+fits_info = {"velocity": ("m/s", "VOPT", "v"),
+             "frequency": ("Hz", "FREQ", "f"),
+             "energy": ("eV", "ENER", "E"),
+             "wavelength": ("angstrom", "WAVE", "lambda")}
 
 class PPVCube(object):
     def __init__(self, ds, normal, field, velocity_bounds, center="c",

--- a/yt/analysis_modules/ppv_cube/ppv_cube.py
+++ b/yt/analysis_modules/ppv_cube/ppv_cube.py
@@ -142,6 +142,10 @@ class PPVCube(object):
             width = ds.coordinates.sanitize_width(normal, width, depth)
             width = tuple(el.in_units('code_length').v for el in width)
 
+        if not hasattr(ds.fields.gas, "temperature") and thermal_broad:
+            raise RuntimeError("thermal_broad cannot be True if there is "
+                               "no 'temperature' field!")
+
         if no_shifting and not thermal_broad:
             raise RuntimeError("no_shifting cannot be True when thermal_broad is False!")
 

--- a/yt/analysis_modules/ppv_cube/ppv_cube.py
+++ b/yt/analysis_modules/ppv_cube/ppv_cube.py
@@ -30,7 +30,7 @@ from yt.extern.six import string_types
 def create_vlos(normal, no_shifting):
     if no_shifting:
         def _v_los(field, data):
-            return data.ds.arr(data["gas", "zeros"], "cm/s")
+            return data.ds.arr(data["index", "zeros"], "cm/s")
     elif isinstance(normal, string_types):
         def _v_los(field, data):
             return -data["gas", "velocity_%s" % normal]

--- a/yt/analysis_modules/ppv_cube/ppv_cube.py
+++ b/yt/analysis_modules/ppv_cube/ppv_cube.py
@@ -30,17 +30,17 @@ from yt.extern.six import string_types
 def create_vlos(normal, no_shifting):
     if no_shifting:
         def _v_los(field, data):
-            return data.ds.arr(data["zeros"], "cm/s")
+            return data.ds.arr(data["gas", "zeros"], "cm/s")
     elif isinstance(normal, string_types):
         def _v_los(field, data):
-            return -data["velocity_%s" % normal]
+            return -data["gas", "velocity_%s" % normal]
     else:
         orient = Orientation(normal)
         los_vec = orient.unit_vectors[2]
         def _v_los(field, data):
-            vz = data["velocity_x"]*los_vec[0] + \
-                data["velocity_y"]*los_vec[1] + \
-                data["velocity_z"]*los_vec[2]
+            vz = data["gas", "velocity_x"]*los_vec[0] + \
+                data["gas", "velocity_y"]*los_vec[1] + \
+                data["gas", "velocity_z"]*los_vec[2]
             return -vz
     return _v_los
 
@@ -326,15 +326,15 @@ class PPVCube(object):
     def _create_intensity(self):
         if self.thermal_broad:
             def _intensity(field, data):
-                v = self.current_v-data["v_los"].in_cgs().v
-                T = data["temperature"].in_cgs().v
+                v = self.current_v-data["gas", "v_los"].in_cgs().v
+                T = data["gas", "temperature"].in_cgs().v
                 w = ppv_utils.compute_weight(self.thermal_broad, self.dv_cgs,
                                              self.particle_mass, v.flatten(), T.flatten())
                 w[np.isnan(w)] = 0.0
                 return data[self.field]*w.reshape(v.shape)
         else:
             def _intensity(field, data):
-                w = 1.-np.fabs(self.current_v-data["v_los"].in_cgs().v)/self.dv_cgs
+                w = 1.-np.fabs(self.current_v-data["gas", "v_los"].in_cgs().v)/self.dv_cgs
                 w[w < 0.0] = 0.0
                 return data[self.field]*w
         return _intensity

--- a/yt/analysis_modules/ppv_cube/ppv_cube.py
+++ b/yt/analysis_modules/ppv_cube/ppv_cube.py
@@ -320,11 +320,17 @@ class PPVCube(object):
         return self.data[item]
 
     def _create_intensity(self):
-        def _intensity(field, data):
-            v = self.current_v-data["v_los"].in_cgs().v
-            T = (data["temperature"]).in_cgs().v
-            w = ppv_utils.compute_weight(self.thermal_broad, self.dv_cgs,
-                                         self.particle_mass, v.flatten(), T.flatten())
-            w[np.isnan(w)] = 0.0
-            return data[self.field]*w.reshape(v.shape)
+        if self.thermal_broad:
+            def _intensity(field, data):
+                v = self.current_v-data["v_los"].in_cgs().v
+                T = data["temperature"].in_cgs().v
+                w = ppv_utils.compute_weight(self.thermal_broad, self.dv_cgs,
+                                             self.particle_mass, v.flatten(), T.flatten())
+                w[np.isnan(w)] = 0.0
+                return data[self.field]*w.reshape(v.shape)
+        else:
+            def _intensity(field, data):
+                w = 1.-np.fabs(self.current_v-data["v_los"].in_cgs().v)/self.dv_cgs
+                w[w < 0.0] = 0.0
+                return data[self.field]*w
         return _intensity

--- a/yt/analysis_modules/ppv_cube/ppv_utils.pyx
+++ b/yt/analysis_modules/ppv_cube/ppv_utils.pyx
@@ -2,7 +2,7 @@ import numpy as np
 cimport numpy as np
 cimport cython
 from yt.utilities.physical_constants import kboltz
-from libc.math cimport exp, fabs, sqrt
+from libc.math cimport exp, sqrt
 
 cdef double kb = kboltz.v
 cdef double pi = np.pi
@@ -24,13 +24,7 @@ def compute_weight(np.uint8_t thermal_broad,
     w = np.zeros(n)
 
     for i in range(n):
-        if thermal_broad:
-            if T[i] > 0.0:
-                v2_th = 2.*kb*T[i]/m_part
-                w[i] = dv*exp(-v[i]*v[i]/v2_th)/sqrt(v2_th*pi)
-        else:
-            x = 1.-fabs(v[i])/dv
-            if x > 0.0:
-                w[i] = x
+        v2_th = 2.*kb*T[i]/m_part
+        w[i] = dv*exp(-v[i]*v[i]/v2_th)/sqrt(v2_th*pi)
                 
     return w


### PR DESCRIPTION
This PR ensures that we can still create a `PPVCube` if there is no temperature field in the dataset, since we can have velocity shifting and broadening without thermal broadening. 

An error will now be thrown if `thermal_broad=True` if there is no temperature field in the dataset.

A new unit test has been added, thanks to @e-koch.

Closes Issue #1539. Thanks to @e-koch for the bug report. 