### PR TITLE
Two small enhancements to YTArray and YTQuantity

### DIFF
--- a/doc/source/analyzing/units/2)_Fields_and_unit_conversion.ipynb
+++ b/doc/source/analyzing/units/2)_Fields_and_unit_conversion.ipynb
@@ -322,7 +322,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since we have a copy of the data, we can mess with it however we wish without disturbing the original data returned by the yt data object."
+    "Since we have a copy of the data, we can mess with it however we wish without disturbing the original data returned by the yt data object.\n",
+    "\n",
+    "There is yet another way to return a copy of the array data in a `YTArray` or the floating-point value of  a `YTQuantity`, which also allows for the possibility to convert to different units. This is done using the `to_value` method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(dens.to_value()) # Don't change units\n",
+    "print(dens.to_value(\"Msun\")) # Change units to solar masses\n",
+    "print(dens[0].to_value(\"lbm\")) # Pick the first value and change its units to pounds"
    ]
   },
   {
@@ -388,7 +401,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from astropy import units as u\n",
@@ -410,7 +425,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "a = np.random.random(size=10) * u.km/u.s\n",
@@ -437,7 +454,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "temp = dd[\"temperature\"]\n",
@@ -464,7 +483,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from yt.units import kboltz\n",
@@ -496,7 +517,8 @@
    "source": [
     "k1 = kboltz.to_astropy()\n",
     "k2 = yt.YTQuantity.from_astropy(kb)\n",
-    "print (k1 == k2)"
+    "print(k1)\n",
+    "print(k2)"
    ]
   },
   {
@@ -520,7 +542,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from pint import UnitRegistry\n",
@@ -542,7 +566,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "ptemp = temp.to_pint()"
@@ -593,9 +619,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from yt.units import clight\n",
@@ -612,9 +636,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from yt import YTQuantity\n",
@@ -633,7 +655,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -643,9 +665,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "dd = ds.all_data()\n",
@@ -655,23 +675,23 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3.0
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.6.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/doc/source/analyzing/units/6)_Unit_Equivalencies.ipynb
+++ b/doc/source/analyzing/units/6)_Unit_Equivalencies.ipynb
@@ -18,15 +18,13 @@
     "* `\"number_density\"`: conversions between density and number density ($n = \\rho/\\mu{m_p}$)\n",
     "* `\"sound_speed\"`: conversions between temperature and sound speed for an ideal gas ($c_s^2 = \\gamma{k_BT}/\\mu{m_p}$)\n",
     "\n",
-    "A `YTArray` or `YTQuantity` can be converted to an equivalent using `to_equivalent`, where the unit and the equivalence name are provided as arguments:"
+    "A `YTArray` or `YTQuantity` can be converted to an equivalent using `in_units` (previously described in [Fields and Unit Conversion](fields_and_unit_conversion.html)), where the unit and the equivalence name are provided as additional arguments:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import yt\n",
@@ -37,12 +35,12 @@
     "\n",
     "dd = ds.all_data()\n",
     "\n",
-    "print (dd[\"temperature\"].to_equivalent(\"erg\", \"thermal\"))\n",
-    "print (dd[\"temperature\"].to_equivalent(\"eV\", \"thermal\"))\n",
+    "print (dd[\"temperature\"].in_units(\"erg\", equivalence=\"thermal\"))\n",
+    "print (dd[\"temperature\"].in_units(\"eV\", equivalence=\"thermal\"))\n",
     "\n",
     "# Rest energy of the proton\n",
     "from yt.units import mp\n",
-    "E_p = mp.to_equivalent(\"GeV\", \"mass_energy\")\n",
+    "E_p = mp.in_units(\"GeV\", equivalence=\"mass_energy\")\n",
     "print (E_p)"
    ]
   },
@@ -56,16 +54,31 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from yt.units import clight\n",
     "v = 0.1*clight\n",
-    "g = v.to_equivalent(\"dimensionless\", \"lorentz\")\n",
+    "g = v.in_units(\"dimensionless\", equivalence=\"lorentz\")\n",
     "print (g)\n",
-    "print (g.to_equivalent(\"c\", \"lorentz\"))"
+    "print (g.in_units(\"c\", equivalence=\"lorentz\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The previously described `to_value` method, which works like `in_units` except that it returns a bare NumPy array or floating-point number, also accepts equivalencies:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print (dd[\"temperature\"].to_value(\"erg\", equivalence=\"thermal\"))\n",
+    "print (mp.to_value(\"GeV\", equivalence=\"mass_energy\"))"
    ]
   },
   {
@@ -85,14 +98,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print (dd[\"density\"].max())\n",
-    "print (dd[\"density\"].to_equivalent(\"cm**-3\", \"number_density\").max())\n",
-    "print (dd[\"density\"].to_equivalent(\"cm**-3\", \"number_density\", mu=0.75).max())"
+    "print (dd[\"density\"].in_units(\"cm**-3\", equivalence=\"number_density\").max())\n",
+    "print (dd[\"density\"].in_units(\"cm**-3\", equivalence=\"number_density\", mu=0.75).max())"
    ]
   },
   {
@@ -105,13 +116,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "print (dd[\"temperature\"].to_equivalent(\"km/s\", \"sound_speed\").mean())\n",
-    "print (dd[\"temperature\"].to_equivalent(\"km/s\", \"sound_speed\", gamma=4./3., mu=0.5).mean())"
+    "print (dd[\"temperature\"].in_units(\"km/s\", equivalence=\"sound_speed\").mean())\n",
+    "print (dd[\"temperature\"].in_units(\"km/s\", equivalence=\"sound_speed\", gamma=4./3., mu=0.5).mean())"
    ]
   },
   {
@@ -138,9 +147,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "Q1 = YTQuantity(1.0,\"C\")\n",
@@ -161,13 +168,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from yt.units import qp # the elementary charge in esu\n",
-    "qp_SI = qp.to_equivalent(\"C\",\"SI\") # convert to Coulombs\n",
+    "qp_SI = qp.in_units(\"C\", equivalence=\"SI\") # convert to Coulombs\n",
     "print (qp)\n",
     "print (qp_SI)"
    ]
@@ -182,13 +187,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "B = YTQuantity(1.0,\"T\") # magnetic field in Tesla\n",
-    "print (B, B.to_equivalent(\"gauss\",\"CGS\")) # convert to Gauss"
+    "print (B, B.in_units(\"gauss\", equivalence=\"CGS\")) # convert to Gauss"
    ]
   },
   {
@@ -201,15 +204,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "I = YTQuantity(1.0,\"A\")\n",
-    "I_cgs = I.to_equivalent(\"statA\",\"CGS\")\n",
+    "I_cgs = I.in_units(\"statA\", equivalence=\"CGS\")\n",
     "R = YTQuantity(1.0,\"ohm\")\n",
-    "R_cgs = R.to_equivalent(\"statohm\",\"CGS\")\n",
+    "R_cgs = R.in_units(\"statohm\", equivalence=\"CGS\")\n",
     "P = I**2*R\n",
     "P_cgs = I_cgs**2*R_cgs"
    ]
@@ -224,9 +225,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print (P_cgs.units.dimensions == P.units.dimensions)\n",
@@ -250,15 +249,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from yt.utilities.exceptions import YTInvalidUnitEquivalence\n",
     "\n",
     "try:\n",
-    "    x = v.to_equivalent(\"angstrom\", \"spectral\")\n",
+    "    x = v.in_units(\"angstrom\", equivalence=\"spectral\")\n",
     "except YTInvalidUnitEquivalence as e:\n",
     "    print (e)"
    ]
@@ -273,9 +270,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print (mp.has_equivalent(\"compton\"))\n",
@@ -292,9 +287,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "E_p.list_equivalencies()"
@@ -303,7 +296,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python3"
   },
@@ -317,9 +310,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.6.1"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/doc/source/analyzing/units/fields_and_unit_conversion.rst
+++ b/doc/source/analyzing/units/fields_and_unit_conversion.rst
@@ -1,4 +1,4 @@
-.. _data_selection_and_fields:
+.. _fields_and_unit_conversion:
 
 Fields and Unit Conversion
 ==========================

--- a/yt/units/yt_array.py
+++ b/yt/units/yt_array.py
@@ -670,9 +670,13 @@ class YTArray(np.ndarray):
         NumPy array
         """
         if units is None:
-            return self.value
+            v = self.value
         else:
-            return self.in_units(units, equivalence=equivalence, **kwargs).value
+            v = self.in_units(units, equivalence=equivalence, **kwargs).value
+        if isinstance(self, YTQuantity):
+            return float(v)
+        else:
+            return v
 
     def in_base(self, unit_system="cgs"):
         """

--- a/yt/units/yt_array.py
+++ b/yt/units/yt_array.py
@@ -728,6 +728,8 @@ class YTArray(np.ndarray):
         >>> a.to_equivalent("keV", "thermal")
         """
         conv_unit = Unit(unit, registry=self.units.registry)
+        if self.units.same_dimensions_as(conv_unit):
+            return self.in_units(conv_unit)
         this_equiv = equivalence_registry[equiv]()
         oneway_or_equivalent = (
             conv_unit.has_equivalent(equiv) or this_equiv._one_way)

--- a/yt/units/yt_array.py
+++ b/yt/units/yt_array.py
@@ -592,10 +592,12 @@ class YTArray(np.ndarray):
     def in_units(self, units, equivalence=None, **kwargs):
         """
         Creates a copy of this array with the data in the supplied 
-        units, and returns it. Optionally, an equivalence can be 
-        specified to convert to an equivalent quantity which is not 
-        in the same dimensions. All additional keyword arguments are 
-        passed to the equivalency if necessary.
+        units, and returns it.
+
+        Optionally, an equivalence can be specified to convert to an 
+        equivalent quantity which is not in the same dimensions. All 
+        additional keyword arguments are passed to the equivalency if 
+        necessary.
 
         Parameters
         ----------

--- a/yt/units/yt_array.py
+++ b/yt/units/yt_array.py
@@ -589,38 +589,48 @@ class YTArray(np.ndarray):
         """
         return self.convert_to_units(self.units.get_mks_equivalent())
 
-    def in_units(self, units):
+    def in_units(self, units, equivalence=None, **kwargs):
         """
-        Creates a copy of this array with the data in the supplied units, and
-        returns it.
+        Creates a copy of this array with the data in the supplied 
+        units, and returns it. Optionally, an equivalence can be 
+        specified to convert to an equivalent quantity which is not 
+        in the same dimensions. All additional keyword arguments are 
+        passed to the equivalency if necessary.
 
         Parameters
         ----------
         units : Unit object or string
             The units you want to get a new quantity in.
+        equivalence : string, optional
+            The equivalence you wish to use. To see which 
+            equivalencies are supported for this unitful 
+            quantity, try the :meth:`list_equivalencies` 
+            method. Default: None
 
         Returns
         -------
         YTArray
-
         """
-        new_units = _unit_repr_check_same(self.units, units)
-        (conversion_factor, offset) = self.units.get_conversion_factor(new_units)
+        if equivalence is None:
+            new_units = _unit_repr_check_same(self.units, units)
+            (conversion_factor, offset) = self.units.get_conversion_factor(new_units)
 
-        new_array = type(self)(self.ndview * conversion_factor, new_units)
+            new_array = type(self)(self.ndview * conversion_factor, new_units)
 
-        if offset:
-            np.subtract(new_array, offset*new_array.uq, new_array)
+            if offset:
+                np.subtract(new_array, offset*new_array.uq, new_array)
 
-        return new_array
+            return new_array
+        else:
+            return self.to_equivalent(units, equivalence, **kwargs)
 
-    def to(self, units):
+    def to(self, units, equivalence=None, **kwargs):
         """
         An alias for YTArray.in_units().
 
         See the docstrings of that function for details.
         """
-        return self.in_units(units)
+        return self.in_units(units, equivalence=equivalence, **kwargs)
 
     def in_base(self, unit_system="cgs"):
         """

--- a/yt/units/yt_array.py
+++ b/yt/units/yt_array.py
@@ -634,7 +634,7 @@ class YTArray(np.ndarray):
         """
         return self.in_units(units, equivalence=equivalence, **kwargs)
 
-    def to_value(self, units, equivalence=None, **kwargs):
+    def to_value(self, units=None, equivalence=None, **kwargs):
         """
         Creates a copy of this array with the data in the supplied
         units, and returns it without units. Output is therefore a 
@@ -647,8 +647,10 @@ class YTArray(np.ndarray):
 
         Parameters
         ----------
-        units : Unit object or string
-            The units you want to get a new quantity in.
+        units : Unit object or string, optional
+            The units you want to get the bare quantity in. If not
+            specified, the value will be returned in the current units.
+
         equivalence : string, optional
             The equivalence you wish to use. To see which 
             equivalencies are supported for this unitful 
@@ -659,8 +661,11 @@ class YTArray(np.ndarray):
         -------
         NumPy array
         """
-        return self.in_units(units, equivalence=equivalence, **kwargs).value
-    
+        if units is None:
+            return self.value
+        else:
+            return self.in_units(units, equivalence=equivalence, **kwargs).value
+
     def in_base(self, unit_system="cgs"):
         """
         Creates a copy of this array with the data in the specified unit system,

--- a/yt/units/yt_array.py
+++ b/yt/units/yt_array.py
@@ -634,6 +634,33 @@ class YTArray(np.ndarray):
         """
         return self.in_units(units, equivalence=equivalence, **kwargs)
 
+    def to_value(self, units, equivalence=None, **kwargs):
+        """
+        Creates a copy of this array with the data in the supplied
+        units, and returns it without units. Output is therefore a 
+        bare NumPy array.
+
+        Optionally, an equivalence can be specified to convert to an 
+        equivalent quantity which is not in the same dimensions. All 
+        additional keyword arguments are passed to the equivalency if 
+        necessary.
+
+        Parameters
+        ----------
+        units : Unit object or string
+            The units you want to get a new quantity in.
+        equivalence : string, optional
+            The equivalence you wish to use. To see which 
+            equivalencies are supported for this unitful 
+            quantity, try the :meth:`list_equivalencies` 
+            method. Default: None
+
+        Returns
+        -------
+        NumPy array
+        """
+        return self.in_units(units, equivalence=equivalence, **kwargs).value
+    
     def in_base(self, unit_system="cgs"):
         """
         Creates a copy of this array with the data in the specified unit system,

--- a/yt/units/yt_array.py
+++ b/yt/units/yt_array.py
@@ -595,9 +595,13 @@ class YTArray(np.ndarray):
         units, and returns it.
 
         Optionally, an equivalence can be specified to convert to an 
-        equivalent quantity which is not in the same dimensions. All 
-        additional keyword arguments are passed to the equivalency if 
-        necessary.
+        equivalent quantity which is not in the same dimensions. 
+
+        .. note::
+
+            All additional keyword arguments are passed to the 
+            equivalency, which should be used if that particular 
+            equivalency requires them.
 
         Parameters
         ----------
@@ -641,9 +645,13 @@ class YTArray(np.ndarray):
         bare NumPy array.
 
         Optionally, an equivalence can be specified to convert to an 
-        equivalent quantity which is not in the same dimensions. All 
-        additional keyword arguments are passed to the equivalency if 
-        necessary.
+        equivalent quantity which is not in the same dimensions. 
+
+        .. note::
+
+            All additional keyword arguments are passed to the 
+            equivalency, which should be used if that particular 
+            equivalency requires them.
 
         Parameters
         ----------


### PR DESCRIPTION
Both of these small enhancements are inspired in part by AstroPy's units API. 

1. Add the unit equivalency option to the `in_units` and `to` methods. This would basically amount to a consolidation of our API for converting between arrays in equivalent units. So instead of:

```python
kT = yt.YTQuantity(3.0, "keV")
T = kT.to_equivalent("K", "thermal")
```
one could do:

```python
kT = yt.YTQuantity(3.0, "keV")
T = kT.in_units("K", equivalence="thermal")
```
We would keep the original `to_equivalent` method around but change the documentation to use the new API, so this is fully backwards-compatible.

2. Add a `to_value` method that does the same thing as `in_units` but returns a bare NumPy array or floating-point number. 

Once we settle on final details of this API (if folks like these ideas in the first place) I'll change docs and add tests.

