### PR TITLE
Ignore "xyz" fields in clump.save_as_dataset if needs_grid_type is true. Fixes #1566 

### DIFF
--- a/yt/analysis_modules/level_sets/clump_handling.py
+++ b/yt/analysis_modules/level_sets/clump_handling.py
@@ -302,14 +302,18 @@ class Clump(TreeContainer):
             field_data = {}
             need_grid_positions = False
             for f in self.base.data._determine_fields(fields) + contour_fields:
-                field_data[f] = self.base[f]
                 if ds.field_info[f].particle_type:
                     if f[0] not in ptypes:
                         ptypes.append(f[0])
                     ftypes[f] = f[0]
                 else:
                     need_grid_positions = True
+                    if f[1] in 'xyz':
+                        # skip 'xyz' if a user passes that in because they
+                        # will be added to ftypes below
+                        continue
                     ftypes[f] = "grid"
+                field_data[f] = self.base[f]
 
             if len(ptypes) > 0:
                 for ax in "xyz":

--- a/yt/analysis_modules/level_sets/clump_handling.py
+++ b/yt/analysis_modules/level_sets/clump_handling.py
@@ -308,7 +308,7 @@ class Clump(TreeContainer):
                     ftypes[f] = f[0]
                 else:
                     need_grid_positions = True
-                    if f[1] in 'xyz':
+                    if f[1] in ('x', 'y', 'z', 'dx', 'dy', 'dz'):
                         # skip 'xyz' if a user passes that in because they
                         # will be added to ftypes below
                         continue

--- a/yt/analysis_modules/level_sets/tests/test_clump_finding.py
+++ b/yt/analysis_modules/level_sets/tests/test_clump_finding.py
@@ -104,7 +104,8 @@ def test_clump_tree_save():
     find_clumps(master_clump, c_min, c_max, step)
     leaf_clumps = get_lowest_clumps(master_clump)
 
-    fn = master_clump.save_as_dataset(fields=["density", "particle_mass"])
+    fn = master_clump.save_as_dataset(fields=["density", "x", "y", "z",
+                                              "particle_mass"])
     ds2 = load(fn)
 
     # compare clumps in the tree


### PR DESCRIPTION
This fixes #1566 as reported by @Jose-Utreras.

The issue is that if `needs_grid_type` is `True`, the `'x'`, `'y'`, and `'z'`fields are always saved. If a user explicitly asks for them to be saved, then yt tries to save them twice, causing h5py to barf.

The fix is to check for this corner case and remove `'x'`, `'y'`, and `'z'` from the list of user fields to be saved.
