### PR TITLE
[bugfix] properly set attributes for reloaded arbitrary grids

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -100,7 +100,7 @@ answer_tests:
   local_ramses_001:
     - yt/frontends/ramses/tests/test_outputs.py
 
-  local_ytdata_002:
+  local_ytdata_003:
     - yt/frontends/ytdata
 
   local_absorption_spectrum_005:

--- a/yt/frontends/ytdata/data_structures.py
+++ b/yt/frontends/ytdata/data_structures.py
@@ -68,7 +68,7 @@ from yt.fields.field_exceptions import \
 from yt.data_objects.data_containers import \
     GenerationInProgress
 
-_grid_data_containers = ["abritrary_grid",
+_grid_data_containers = ["arbitrary_grid",
                          "covering_grid",
                          "smoothed_covering_grid"]
 
@@ -472,12 +472,17 @@ class YTGridDataset(YTDataset):
         self.base_domain_right_edge = self.domain_right_edge
         self.base_domain_dimensions = self.domain_dimensions
         if self.container_type in _grid_data_containers:
-            dx = (self.domain_right_edge - self.domain_left_edge) / \
-              (self.domain_dimensions *
-               self.refine_by**self.parameters["level"])
             self.domain_left_edge = self.parameters["left_edge"]
-            self.domain_right_edge = self.domain_left_edge + \
-              self.parameters["ActiveDimensions"] * dx
+            if "level" in self.parameters["con_args"]:
+                dx = (self.domain_right_edge - self.domain_left_edge) / \
+                  (self.domain_dimensions *
+                   self.refine_by**self.parameters["level"])
+                self.domain_right_edge = self.domain_left_edge + \
+                  self.parameters["ActiveDimensions"] * dx
+            else:
+                self.domain_right_edge = self.parameters["right_edge"]
+                dx = (self.domain_right_edge - self.domain_left_edge) / \
+                  self.parameters["ActiveDimensions"]
             self.domain_dimensions = self.parameters["ActiveDimensions"]
             self.periodicity = \
               np.abs(self.domain_left_edge -

--- a/yt/frontends/ytdata/data_structures.py
+++ b/yt/frontends/ytdata/data_structures.py
@@ -471,25 +471,33 @@ class YTGridDataset(YTDataset):
         self.base_domain_left_edge = self.domain_left_edge
         self.base_domain_right_edge = self.domain_right_edge
         self.base_domain_dimensions = self.domain_dimensions
+
         if self.container_type in _grid_data_containers:
             self.domain_left_edge = self.parameters["left_edge"]
+
             if "level" in self.parameters["con_args"]:
-                dx = (self.domain_right_edge - self.domain_left_edge) / \
+                dx = (self.base_domain_right_edge -
+                      self.base_domain_left_edge) / \
                   (self.domain_dimensions *
                    self.refine_by**self.parameters["level"])
                 self.domain_right_edge = self.domain_left_edge + \
                   self.parameters["ActiveDimensions"] * dx
+                self.domain_dimensions = \
+                  ((self.domain_right_edge -
+                    self.domain_left_edge) / dx).astype(int)
             else:
                 self.domain_right_edge = self.parameters["right_edge"]
+                self.domain_dimensions = self.parameters["ActiveDimensions"]
                 dx = (self.domain_right_edge - self.domain_left_edge) / \
-                  self.parameters["ActiveDimensions"]
-            self.domain_dimensions = self.parameters["ActiveDimensions"]
+                  self.domain_dimensions
+
             self.periodicity = \
               np.abs(self.domain_left_edge -
                      self.base_domain_left_edge) < 0.5 * dx
             self.periodicity &= \
             np.abs(self.domain_right_edge -
                    self.base_domain_right_edge) < 0.5 * dx
+
         elif self.data_type == "yt_frb":
             self.domain_left_edge = \
               np.concatenate([self.parameters["left_edge"], [0.]])

--- a/yt/frontends/ytdata/tests/test_outputs.py
+++ b/yt/frontends/ytdata/tests/test_outputs.py
@@ -120,15 +120,26 @@ def test_grid_datacontainer_data():
     curdir = os.getcwd()
     os.chdir(tmpdir)
     ds = data_dir_load(enzotiny)
+
     cg = ds.covering_grid(level=0, left_edge=[0.25]*3, dims=[16]*3)
     fn = cg.save_as_dataset(fields=["density", "particle_mass"])
     full_fn = os.path.join(tmpdir, fn)
     cg_ds = load(full_fn)
     compare_unit_attributes(ds, cg_ds)
     assert isinstance(cg_ds, YTGridDataset)
-
     yield YTDataFieldTest(full_fn, ("grid", "density"))
     yield YTDataFieldTest(full_fn, ("all", "particle_mass"))
+
+    ag = ds.arbitrary_grid(left_edge=[0.25]*3, right_edge=[0.75]*3,
+                           dims=[16]*3)
+    fn = ag.save_as_dataset(fields=["density", "particle_mass"])
+    full_fn = os.path.join(tmpdir, fn)
+    ag_ds = load(full_fn)
+    compare_unit_attributes(ds, ag_ds)
+    assert isinstance(ag_ds, YTGridDataset)
+    yield YTDataFieldTest(full_fn, ("grid", "density"))
+    yield YTDataFieldTest(full_fn, ("all", "particle_mass"))
+
     my_proj = ds.proj("density", "x", weight_field="density")
     frb = my_proj.to_frb(1.0, (800, 800))
     fn = frb.save_as_dataset(fields=["density"])


### PR DESCRIPTION
This fixes a bug in reloading arbitrary grids saved with `save_as_dataset`.  There was a small typo and some of the dataset attributes were not being set correctly.  I've added a test as well.  I'll wait to make sure the old tests are correct before incrementing the answer version.