### PR TITLE
[cleanup] Remove references to overlap_proj in Dataset initialization

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -764,8 +764,6 @@ class Dataset(object):
                 setattr(self, name,
                     _unsupported_object(self, name))
                 continue
-            cname = cls.__name__
-            if cname.endswith("Base"): cname = cname[:-4]
             self._add_object_class(name, cls)
         self.object_types.sort()
 

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -767,16 +767,6 @@ class Dataset(object):
             cname = cls.__name__
             if cname.endswith("Base"): cname = cname[:-4]
             self._add_object_class(name, cls)
-        if not np.all(self.refine_by == 2) and hasattr(self, 'proj') and \
-            hasattr(self, 'overlap_proj'):
-            mylog.warning("Refine by something other than two: reverting to"
-                        + " overlap_proj")
-            self.proj = self.overlap_proj
-        if self.dimensionality < 3 and hasattr(self, 'proj') and \
-            hasattr(self, 'overlap_proj'):
-            mylog.warning("Dimensionality less than 3: reverting to"
-                        + " overlap_proj")
-            self.proj = self.overlap_proj
         self.object_types.sort()
 
     def _add_object_class(self, name, base):


### PR DESCRIPTION
We used to fall back to `ds.overlap_proj` for low-dimensionality data and data with refine_by different than a factor of 2. However, since 320c51b66 `overlap_proj` has not been present in the codebase.

This removes the code that falls back to `overlap_proj` since it is unconditionally dead code now (i.e. the `hasattr` checks in the code I've deleted will never be `True`).