### PR TITLE
Superclass init for grid objects

### DIFF
--- a/yt/data_objects/grid_patch.py
+++ b/yt/data_objects/grid_patch.py
@@ -58,8 +58,7 @@ class AMRGridPatch(YTSelectionContainer):
     OverlappingSiblings = None
 
     def __init__(self, id, filename=None, index=None):
-        self.field_data = YTFieldData()
-        self.field_parameters = {}
+        super(AMRGridPatch, self).__init__(index.dataset, None)
         self.id = id
         self._child_mask = self._child_indices = self._child_index_mask = None
         self.ds = index.dataset
@@ -69,8 +68,6 @@ class AMRGridPatch(YTSelectionContainer):
         self._last_mask = None
         self._last_count = -1
         self._last_selector_id = None
-        self._current_particle_type = 'all'
-        self._current_fluid_type = self.ds.default_fluid_type
 
     def get_global_startindex(self):
         """

--- a/yt/data_objects/grid_patch.py
+++ b/yt/data_objects/grid_patch.py
@@ -21,8 +21,6 @@ from six import string_types
 from yt.config import ytcfg
 from yt.data_objects.data_containers import \
     YTSelectionContainer
-from yt.data_objects.field_data import \
-    YTFieldData
 from yt.funcs import iterable
 from yt.geometry.selection_routines import convert_mask_to_indices
 import yt.geometry.particle_deposit as particle_deposit

--- a/yt/data_objects/octree_subset.py
+++ b/yt/data_objects/octree_subset.py
@@ -55,10 +55,9 @@ class OctreeSubset(YTSelectionContainer):
     _block_reorder = None
 
     def __init__(self, base_region, domain, ds, over_refine_factor = 1):
+        super(OctreeSubset, self).__init__(ds, None)
         self._num_zones = 1 << (over_refine_factor)
         self._oref = over_refine_factor
-        self.field_data = YTFieldData()
-        self.field_parameters = {}
         self.domain = domain
         self.domain_id = domain.domain_id
         self.ds = domain.ds
@@ -66,8 +65,6 @@ class OctreeSubset(YTSelectionContainer):
         self.oct_handler = domain.oct_handler
         self._last_mask = None
         self._last_selector_id = None
-        self._current_particle_type = 'all'
-        self._current_fluid_type = self.ds.default_fluid_type
         self.base_region = base_region
         self.base_selector = base_region.selector
 

--- a/yt/data_objects/unstructured_mesh.py
+++ b/yt/data_objects/unstructured_mesh.py
@@ -39,9 +39,8 @@ class UnstructuredMesh(YTSelectionContainer):
 
     def __init__(self, mesh_id, filename, connectivity_indices,
                  connectivity_coords, index):
-        self.field_data = YTFieldData()
+        super(UnstructuredMesh, self).__init__(index.dataset, None)
         self.filename = filename
-        self.field_parameters = {}
         self.mesh_id = mesh_id
         # This is where we set up the connectivity information
         self.connectivity_indices = connectivity_indices
@@ -56,8 +55,6 @@ class UnstructuredMesh(YTSelectionContainer):
         self._last_mask = None
         self._last_count = -1
         self._last_selector_id = None
-        self._current_particle_type = 'all'
-        self._current_fluid_type = self.ds.default_fluid_type
 
     def _check_consistency(self):
         if self.connectivity_indices.shape[1] != self._connectivity_length:

--- a/yt/data_objects/unstructured_mesh.py
+++ b/yt/data_objects/unstructured_mesh.py
@@ -23,8 +23,6 @@ from yt.utilities.lib.mesh_utilities import \
 
 from yt.data_objects.data_containers import \
     YTSelectionContainer
-from yt.data_objects.field_data import \
-    YTFieldData
 import yt.geometry.particle_deposit as particle_deposit
 
 class UnstructuredMesh(YTSelectionContainer):


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary
Use the ```__init__``` function on the superclass to ensure proper initialization and remove redundant inits in ```AMRGridPatch```, ```OctreeSubset``` and ```UnstructureMesh```. Closes #1571.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
