### PR TITLE
[bugfix] fix units in light cone projection

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -117,6 +117,9 @@ answer_tests:
   local_particle_trajectory_000:
     - yt/data_objects/tests/test_particle_trajectories.py
 
+  local_light_cone_001:
+    - yt/analysis_modules/cosmological_observation/light_cone/tests/test_light_cone.py
+
 other_tests:
   unittests:
      - '--exclude=test_mesh_slices'  # disable randomly failing test

--- a/yt/analysis_modules/cosmological_observation/light_cone/light_cone_projection.py
+++ b/yt/analysis_modules/cosmological_observation/light_cone/light_cone_projection.py
@@ -17,6 +17,8 @@ import numpy as np
 
 from yt.funcs import \
      mylog
+from yt.units.yt_array import \
+    uconcatenate
 from yt.visualization.fixed_resolution import \
     FixedResolutionBuffer
 from yt.utilities.parallel_tools.parallel_analysis_interface import \
@@ -198,25 +200,25 @@ def _light_cone_projection(my_slice, field, pixels, weight_field=None,
     del add_y_left
 
     # Add the hanging cells back to the projection data.
-    proj.field_data["px"] = proj.field_data["px"].unit_quantity * \
-      np.concatenate([proj.field_data["px"].d, add_x_px.d, add_y_px.d,
-                      add2_x_px.d, add2_y_px.d])
-    proj.field_data["py"] = proj.field_data["py"].unit_quantity * \
-        np.concatenate([proj.field_data["py"].d, add_x_py.d, add_y_py.d,
-                        add2_x_py.d, add2_y_py.d])
-    proj.field_data["pdx"] = proj.field_data["pdx"].unit_quantity * \
-        np.concatenate([proj.field_data["pdx"].d, add_x_pdx.d, add_y_pdx.d,
-                        add2_x_pdx.d, add2_y_pdx.d])
-    proj.field_data["pdy"] = proj.field_data["pdy"].unit_quantity * \
-        np.concatenate([proj.field_data["pdy"].d, add_x_pdy.d, add_y_pdy.d,
-                        add2_x_pdy.d, add2_y_pdy.d])
-    proj.field_data[proj_field] = proj.field_data[proj_field].unit_quantity * \
-        np.concatenate([proj.field_data[proj_field].d, add_x_field.d, add_y_field.d,
-                        add2_x_field.d, add2_y_field.d])
-    proj.field_data["weight_field"] = proj.field_data["weight_field"].unit_quantity * \
-        np.concatenate([proj.field_data["weight_field"].d,
-                        add_x_weight_field.d, add_y_weight_field.d,
-                        add2_x_weight_field.d, add2_y_weight_field.d])
+    proj.field_data["px"] = uconcatenate(
+        [proj.field_data["px"], add_x_px,
+         add_y_px, add2_x_px, add2_y_px])
+    proj.field_data["py"] = uconcatenate(
+        [proj.field_data["py"], add_x_py,
+         add_y_py, add2_x_py, add2_y_py])
+    proj.field_data["pdx"] = uconcatenate(
+        [proj.field_data["pdx"], add_x_pdx,
+         add_y_pdx, add2_x_pdx, add2_y_pdx])
+    proj.field_data["pdy"] = uconcatenate(
+        [proj.field_data["pdy"], add_x_pdy,
+         add_y_pdy, add2_x_pdy, add2_y_pdy])
+    proj.field_data[proj_field] = uconcatenate(
+        [proj.field_data[proj_field], add_x_field,
+         add_y_field, add2_x_field, add2_y_field])
+    proj.field_data["weight_field"] = uconcatenate(
+        [proj.field_data["weight_field"],
+         add_x_weight_field, add_y_weight_field,
+         add2_x_weight_field, add2_y_weight_field])
 
     # Delete original copies of hanging cells.
     del add_x_px, add_y_px, add2_x_px, add2_y_px

--- a/yt/analysis_modules/cosmological_observation/light_cone/light_cone_projection.py
+++ b/yt/analysis_modules/cosmological_observation/light_cone/light_cone_projection.py
@@ -210,7 +210,7 @@ def _light_cone_projection(my_slice, field, pixels, weight_field=None,
     proj.field_data["pdy"] = proj.field_data["pdy"].unit_quantity * \
         np.concatenate([proj.field_data["pdy"].d, add_x_pdy.d, add_y_pdy.d,
                         add2_x_pdy.d, add2_y_pdy.d])
-    proj.field_data[proj_field] = proj.field_data["pdy"].unit_quantity * \
+    proj.field_data[proj_field] = proj.field_data[proj_field].unit_quantity * \
         np.concatenate([proj.field_data[proj_field].d, add_x_field.d, add_y_field.d,
                         add2_x_field.d, add2_y_field.d])
     proj.field_data["weight_field"] = proj.field_data["weight_field"].unit_quantity * \

--- a/yt/analysis_modules/cosmological_observation/light_cone/tests/test_light_cone.py
+++ b/yt/analysis_modules/cosmological_observation/light_cone/tests/test_light_cone.py
@@ -13,7 +13,8 @@ light cone generator test
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-import h5py
+from yt.utilities.on_demand_imports import \
+    _h5py as h5py
 import numpy as np
 import os
 import shutil
@@ -22,13 +23,15 @@ import tempfile
 from yt.analysis_modules.cosmological_observation.api import \
      LightCone
 from yt.testing import \
-    assert_equal
+    assert_equal, \
+    requires_module
 from yt.utilities.answer_testing.framework import \
     AnswerTestingTest, \
     requires_sim
 
 ETC = "enzo_tiny_cosmology/32Mpc_32.enzo"
-    
+
+@requires_module("h5py")
 class LightConeProjectionTest(AnswerTestingTest):
     _type_name = "LightConeProjection"
     _attrs = ()

--- a/yt/analysis_modules/cosmological_observation/light_cone/tests/test_light_cone.py
+++ b/yt/analysis_modules/cosmological_observation/light_cone/tests/test_light_cone.py
@@ -25,7 +25,6 @@ from yt.testing import \
     assert_equal
 from yt.utilities.answer_testing.framework import \
     AnswerTestingTest, \
-    data_dir_load, \
     requires_sim
 
 ETC = "enzo_tiny_cosmology/32Mpc_32.enzo"

--- a/yt/analysis_modules/cosmological_observation/light_cone/tests/test_light_cone.py
+++ b/yt/analysis_modules/cosmological_observation/light_cone/tests/test_light_cone.py
@@ -1,0 +1,81 @@
+"""
+light cone generator test
+
+
+
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) 2017, yt Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+import h5py
+import numpy as np
+import os
+import shutil
+import tempfile
+
+from yt.analysis_modules.cosmological_observation.api import \
+     LightCone
+from yt.testing import \
+    assert_equal
+from yt.utilities.answer_testing.framework import \
+    AnswerTestingTest, \
+    data_dir_load, \
+    requires_sim
+
+ETC = "enzo_tiny_cosmology/32Mpc_32.enzo"
+    
+class LightConeProjectionTest(AnswerTestingTest):
+    _type_name = "LightConeProjection"
+    _attrs = ()
+ 
+    def __init__(self, parameter_file, simulation_type):
+        self.parameter_file = parameter_file
+        self.simulation_type = simulation_type
+        self.ds = os.path.basename(self.parameter_file)
+
+    @property
+    def storage_name(self):
+        return os.path.basename(self.parameter_file)
+
+    def run(self):
+        # Set up in a temp dir
+        tmpdir = tempfile.mkdtemp()
+        curdir = os.getcwd()
+        os.chdir(tmpdir)
+
+        lc = LightCone(
+            self.parameter_file, self.simulation_type, 0., 0.1,
+            observer_redshift=0.0, time_data=False)
+        lc.calculate_light_cone_solution(
+            seed=123456789, filename="LC/solution.txt")
+        lc.project_light_cone(
+            (600.0, "arcmin"), (60.0, "arcsec"), "density",
+            weight_field=None, save_stack=True)
+
+        fh = h5py.File("LC/LightCone.h5")
+        data = fh["density_None"].value
+        units = fh["density_None"].attrs["units"]
+        assert units == "g/cm**2"
+        fh.close()
+
+        # clean up
+        os.chdir(curdir)
+        shutil.rmtree(tmpdir)
+
+        mean = data.mean()
+        mi = data[data.nonzero()].min()
+        ma = data.max()
+        return np.array([mean, mi, ma])
+
+    def compare(self, new_result, old_result):
+        assert_equal(new_result, old_result, verbose=True)
+
+@requires_sim(ETC, "Enzo")
+def test_light_cone_projection():
+    yield LightConeProjectionTest(ETC, "Enzo")


### PR DESCRIPTION
This fixes a typo in the light cone projection routine where we were applying the wrong units to the projection array.  The fix itself can be see in [this commit](https://github.com/yt-project/yt/commit/10a349a3441218285d5c40efde0c07a92d7fee73).  I then simplify this code to use the `uconcatenate` function instead.  This was never caught because the units of this array get lost again later and because there are not any tests for the light cone generator.  However, this will produce an error in some circumstances.  I've added a relatively simple answer test so this module at least has something.