### PR TITLE
Use AstroPy version of WCSAxes for plotting FITS datasets

### DIFF
--- a/doc/source/cookbook/fits_radio_cubes.ipynb
+++ b/doc/source/cookbook/fits_radio_cubes.ipynb
@@ -18,7 +18,7 @@
    "source": [
     "This notebook demonstrates some of the capabilties of yt on some FITS \"position-position-spectrum\" cubes of radio data.\n",
     "\n",
-    "Note that it depends on some external dependencies, including `astropy`, `wcsaxes`, and `pyregion`."
+    "Note that it depends on some external dependencies, including `astropy` and `pyregion`."
    ]
   },
   {
@@ -69,7 +69,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The x and y axes are in units of the image pixel. When making plots of FITS data, to see the image coordinates as they are in the file, it is helpful to set the keyword `origin = \"native\"`. If you want to see the celestial coordinates along the axes, you can import the `PlotWindowWCS` class and feed it the `SlicePlot`. For this to work, the [WCSAxes](http://wcsaxes.readthedocs.org/en/latest/) package needs to be installed."
+    "The x and y axes are in units of the image pixel. When making plots of FITS data, to see the image coordinates as they are in the file, it is helpful to set the keyword `origin = \"native\"`. If you want to see the celestial coordinates along the axes, you can import the `PlotWindowWCS` class and feed it the `SlicePlot`. For this to work, a version of AstroPy >= 1.3 needs to be installed."
    ]
   },
   {

--- a/doc/source/cookbook/fits_xray_images.ipynb
+++ b/doc/source/cookbook/fits_xray_images.ipynb
@@ -71,15 +71,15 @@
     "def _counts(field, data):\n",
     "    exposure_time = data.get_field_parameter(\"exposure_time\")\n",
     "    return data[\"flux\"]*data[\"pixel\"]*exposure_time\n",
-    "ds.add_field((\"gas\",\"counts\"), function=_counts, units=\"counts\", take_log=False)\n",
+    "ds.add_field((\"gas\",\"counts\"), function=_counts, sampling_type=\"cell\", units=\"counts\", take_log=False)\n",
     "\n",
     "def _pp(field, data):\n",
     "    return np.sqrt(data[\"counts\"])*data[\"projected_temperature\"]\n",
-    "ds.add_field((\"gas\",\"pseudo_pressure\"), function=_pp, units=\"sqrt(counts)*keV\", take_log=False)\n",
+    "ds.add_field((\"gas\",\"pseudo_pressure\"), function=_pp, sampling_type=\"cell\", units=\"sqrt(counts)*keV\", take_log=False)\n",
     "\n",
     "def _pe(field, data):\n",
     "    return data[\"projected_temperature\"]*data[\"counts\"]**(-1./3.)\n",
-    "ds.add_field((\"gas\",\"pseudo_entropy\"), function=_pe, units=\"keV*(counts)**(-1/3)\", take_log=False)"
+    "ds.add_field((\"gas\",\"pseudo_entropy\"), function=_pe, sampling_type=\"cell\", units=\"keV*(counts)**(-1/3)\", take_log=False)"
    ]
   },
   {
@@ -129,7 +129,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To add the celestial coordinates to the image, we can use `PlotWindowWCS`, if you have the [WCSAxes](http://wcsaxes.readthedocs.org/en/latest/) package installed:"
+    "To add the celestial coordinates to the image, we can use `PlotWindowWCS`, if you have a recent version of AstroPy (>= 1.3) installed:"
    ]
   },
   {

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -687,14 +687,6 @@ can read FITS image files that have the following (case-insensitive) suffixes:
 yt can read two kinds of FITS files: FITS image files and FITS binary table files containing
 positions, times, and energies of X-ray events.
 
-.. note::
-
-  AstroPy is necessary due to the requirements of both FITS file reading and
-  WCS coordinates. Since new releases of `PyFITS <http://www.stsci
-  .edu/institute/software_hardware/pyfits>`_ are to be discontinued, individual
-  installations of this package and the `PyWCS <http://stsdas.stsci
-  .edu/astrolib/pywcs/>`_ package are not supported.
-
 Though a FITS image is composed of a single array in the FITS file,
 upon being loaded into yt it is automatically decomposed into grids:
 
@@ -908,8 +900,7 @@ package must be installed.
 """""""""""""""""
 
 This class takes a on-axis ``SlicePlot`` or ``ProjectionPlot`` of FITS data and adds celestial
-coordinates to the plot axes. To use it, the `WCSAxes <http://wcsaxes.readthedocs.org>`_
-package must be installed.
+coordinates to the plot axes. To use it, a version of AstroPy >= 1.3 must be installed.
 
 .. code-block:: python
 

--- a/yt/frontends/fits/misc.py
+++ b/yt/frontends/fits/misc.py
@@ -192,8 +192,10 @@ def ds9_region(ds, reg, obj=None, field_parameters=None):
 
 class PlotWindowWCS(object):
     r"""
-    Use the wcsaxes library to plot celestial coordinates on the axes of a
-    on-axis PlotWindow plot. See http://wcsaxes.readthedocs.org for details.
+    Use AstroPy's WCSAxes class to plot celestial coordinates on the axes of a
+    on-axis PlotWindow plot. See 
+    http://docs.astropy.org/en/stable/visualization/wcsaxes/ for more details
+    on how it works under the hood.
 
     Parameters
     ----------
@@ -201,7 +203,13 @@ class PlotWindowWCS(object):
         The PlotWindow instance to add celestial axes to.
     """
     def __init__(self, pw):
-        from wcsaxes import WCSAxes
+        try:
+            # Attempt import from the old WCSAxes package first
+            from wcsaxes import WCSAxes
+        except ImportError:
+            # Try to use the AstroPy version
+            WCSAxes = _astropy.visualization.wcsaxes.WCSAxes
+
         if pw.oblique:
             raise NotImplementedError("WCS axes are not implemented for oblique plots.")
         if not hasattr(pw.ds, "wcs_2d"):

--- a/yt/frontends/fits/misc.py
+++ b/yt/frontends/fits/misc.py
@@ -14,7 +14,7 @@ import numpy as np
 import base64
 from yt.extern.six import PY3
 from yt.fields.derived_field import ValidateSpatial
-from yt.funcs import mylog
+from yt.funcs import mylog, issue_deprecation_warning
 from yt.utilities.on_demand_imports import _astropy
 from yt.units.yt_array import YTQuantity, YTArray
 if PY3:
@@ -207,6 +207,13 @@ class PlotWindowWCS(object):
         try:
             # Attempt import from the old WCSAxes package first
             from wcsaxes import WCSAxes
+            issue_deprecation_warning("Support for the standalone 'wcsaxes' "
+                                      "package is deprecated since its"
+                                      "functionality has been merged into"
+                                      "AstroPy, and will be removed in a "
+                                      "future release. It is recommended to "
+                                      "use the version bundled with AstroPy "
+                                      ">= 1.3.") 
         except ImportError:
             # Try to use the AstroPy version
             WCSAxes = _astropy.wcsaxes.WCSAxes

--- a/yt/frontends/fits/misc.py
+++ b/yt/frontends/fits/misc.py
@@ -195,7 +195,8 @@ class PlotWindowWCS(object):
     Use AstroPy's WCSAxes class to plot celestial coordinates on the axes of a
     on-axis PlotWindow plot. See 
     http://docs.astropy.org/en/stable/visualization/wcsaxes/ for more details
-    on how it works under the hood.
+    on how it works under the hood. This functionality requires a version of 
+    AstroPy >= 1.3. 
 
     Parameters
     ----------

--- a/yt/frontends/fits/misc.py
+++ b/yt/frontends/fits/misc.py
@@ -208,7 +208,7 @@ class PlotWindowWCS(object):
             from wcsaxes import WCSAxes
         except ImportError:
             # Try to use the AstroPy version
-            WCSAxes = _astropy.visualization.wcsaxes.WCSAxes
+            WCSAxes = _astropy.wcsaxes.WCSAxes
 
         if pw.oblique:
             raise NotImplementedError("WCS axes are not implemented for oblique plots.")

--- a/yt/utilities/on_demand_imports.py
+++ b/yt/utilities/on_demand_imports.py
@@ -122,6 +122,18 @@ class astropy_imports(object):
             self._time = time
         return self._time
 
+    _visualization = None
+    @property
+    def visualization(self):
+        if self._visualization is None:
+            try:
+                import astropy.visualization as visualization
+                self.log
+            except ImportError:
+                visualization = NotAModule(self._name)
+            self._visualization = visualization
+        return self._visualization
+
 _astropy = astropy_imports()
 
 class scipy_imports(object):

--- a/yt/utilities/on_demand_imports.py
+++ b/yt/utilities/on_demand_imports.py
@@ -122,17 +122,17 @@ class astropy_imports(object):
             self._time = time
         return self._time
 
-    _visualization = None
+    _wcsaxes = None
     @property
-    def visualization(self):
-        if self._visualization is None:
+    def wcsaxes(self):
+        if self._wcsaxes is None:
             try:
-                import astropy.visualization as visualization
+                import astropy.visualization.wcsaxes as wcsaxes
                 self.log
             except ImportError:
-                visualization = NotAModule(self._name)
-            self._visualization = visualization
-        return self._visualization
+                wcsaxes = NotAModule(self._name)
+            self._wcsaxes = wcsaxes
+        return self._wcsaxes
 
 _astropy = astropy_imports()
 


### PR DESCRIPTION
Currently, there is a miscellaneous function, `PlotWindowWCS`, which uses the `wcsaxes` package to add celestial coordinates to a `PlotWindow` plot of a FITS dataset.

As of AstroPy version 1.3 (the current stable version of AstroPy is 2.0.2), this functionality has been moved into AstroPy proper, and the separate package itself is no longer being supported. This PR allows us to import `wcsaxes` from AstroPy instead, but allows for the old import of `wcsaxes` as well. 

Eventually, we will handle these plots in a more seamless way, but for now this is the best we can do. 