### PR TITLE
Improve gadget loading fallback when some items are not present in the Header

### DIFF
--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -202,10 +202,25 @@ class GadgetDataset(SPHDataset):
 
         self.cosmological_simulation = 1
 
-        self.current_redshift = hvals["Redshift"]
-        self.omega_lambda = hvals["OmegaLambda"]
-        self.omega_matter = hvals["Omega0"]
-        self.hubble_constant = hvals["HubbleParam"]
+        try:
+            self.current_redshift = hvals["Redshift"]
+        except KeyError:
+            # Probably not a cosmological dataset, we should just set
+            # z = 0 and let the user know
+            self.current_redshift = 0.0
+            only_on_root(
+                mylog.info, "Redshift is not set in Header. Assuming z=0.")
+
+        try:
+            self.omega_lambda = hvals["OmegaLambda"]
+            self.omega_matter = hvals["Omega0"]
+            self.hubble_constant = hvals["HubbleParam"]
+        except KeyError:
+            # If these are not set it is definitely not a cosmological dataset.
+            self.omega_lambda = 0.0
+            self.omega_matter = 1.0  # Just in case somebody asks for it.
+            # Hubble is set below for Omega Lambda = 0.
+
         # According to the Gadget manual, OmegaLambda will be zero for
         # non-cosmological datasets.  However, it may be the case that
         # individuals are running cosmological simulations *without* Lambda, in

--- a/yt/frontends/gadget/tests/test_outputs.py
+++ b/yt/frontends/gadget/tests/test_outputs.py
@@ -49,7 +49,7 @@ iso_kwargs = dict(bounding_box=[[-3, 3], [-3, 3], [-3, 3]])
 @requires_file(isothermal_bin)
 @requires_file(BE_Gadget)
 @requires_file(LE_SnapFormat2)
-def test_GadgetDataset():
+def test_gadget_dataset():
     assert isinstance(data_dir_load(isothermal_h5, kwargs=iso_kwargs),
                       GadgetHDF5Dataset)
     assert isinstance(data_dir_load(isothermal_bin, kwargs=iso_kwargs),
@@ -59,7 +59,7 @@ def test_GadgetDataset():
 
 
 @requires_file(keplerian_ring)
-def test_NonCosmoDataset():
+def test_non_cosmo_dataset():
     """
     Non-cosmological datasets may not have the cosmological parametrs in the
     Header. The code should fall back gracefully when they are not present,

--- a/yt/frontends/gadget/tests/test_outputs.py
+++ b/yt/frontends/gadget/tests/test_outputs.py
@@ -27,6 +27,7 @@ isothermal_h5 = "IsothermalCollapse/snap_505.hdf5"
 isothermal_bin = "IsothermalCollapse/snap_505"
 BE_Gadget = "BigEndianGadgetBinary/BigEndianGadgetBinary"
 LE_SnapFormat2 = "Gadget3-snap-format2/Gadget3-snap-format2"
+keplerian_ring = "KeplerianRing/keplerian_ring_test_data.hdf5"
 
 # This maps from field names to weight field names to use for projections
 iso_fields = OrderedDict(
@@ -55,6 +56,18 @@ def test_GadgetDataset():
                       GadgetDataset)
     assert isinstance(data_dir_load(BE_Gadget), GadgetDataset)
     assert isinstance(data_dir_load(LE_SnapFormat2), GadgetDataset)
+
+
+@requires_file(keplerian_ring)
+def test_NonCosmoDataset():
+    """
+    Non-cosmological datasets may not have the cosmological parametrs in the
+    Header. The code should fall back gracefully when they are not present,
+    with the Redshift set to 0.
+    """
+    data = data_dir_load(keplerian_ring)
+    assert data.current_redshift == 0.0
+    assert data.cosmological_simulation == 0
 
 
 @requires_ds(isothermal_h5)

--- a/yt/geometry/particle_geometry_handler.py
+++ b/yt/geometry/particle_geometry_handler.py
@@ -75,9 +75,7 @@ class ParticleIndex(Index):
         cls = self.dataset._file_class
         self.data_files = \
           [cls(self.dataset, self.io, template % {'num':i}, i)
-           for i in range(ndoms[0])]
-        # This [0] index is required as newer versions of numpy do not like
-        # using single-length arrays for indexing.
+           for i in range(int(ndoms))]
 
     def _initialize_particle_handler(self):
         self._setup_data_io()

--- a/yt/geometry/particle_geometry_handler.py
+++ b/yt/geometry/particle_geometry_handler.py
@@ -75,7 +75,9 @@ class ParticleIndex(Index):
         cls = self.dataset._file_class
         self.data_files = \
           [cls(self.dataset, self.io, template % {'num':i}, i)
-           for i in range(ndoms)]
+           for i in range(ndoms[0])]
+        # This [0] index is required as newer versions of numpy do not like
+        # using single-length arrays for indexing.
 
     def _initialize_particle_handler(self):
         self._setup_data_io()


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

Some newer codes don't include everything that the original GADGET did
in their Header. This is not currently handled very gracefully in yt, and is a
particular issue for non-cosmological runs. If a hdf5 file is loaded that does
not have a Header/Redshift attribute yt crashes and can't continue (by default)
, whereas it should fall back gracefully.

Also, whilst doing this I noticed an error where a single-length array was being
used as a scalar. This is fixed also here, however I can submit that separately
if you would prefer.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [X] Code passes flake8 checker
- [N/A] New features are documented, with docstrings and narrative docs
- [N/A] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
