### PR TITLE
[bugfix] fix clump-finding corner case

### DIFF
--- a/yt/analysis_modules/level_sets/clump_handling.py
+++ b/yt/analysis_modules/level_sets/clump_handling.py
@@ -87,9 +87,6 @@ class Clump(TreeContainer):
         if parent is not None:
             self.data.parent = self.parent.data
 
-        if parent is not None:
-            self.data.parent = self.parent.data
-
         if validators is None:
             validators = []
         self.validators = validators
@@ -457,6 +454,9 @@ def find_clumps(clump, min_val, max_val, d_clump):
                         "children to parent.") % 
                         (len(these_children),len(clump.children)))
             clump.children = these_children[0].children
+            for child in clump.children:
+                child.parent = clump
+                child.data.parent = clump.data
         else:
             mylog.info("%d of %d children survived, erasing children." %
                        (len(these_children),len(clump.children)))


### PR DESCRIPTION
This fixes a corner case in clump finding where a child clump has no siblings, and so it is removed and its children are attached to its parent.  This already happens but the pointer from a child clump to its new parent was not being updated.  This issue manifests when the clumps are saved with `save_as_dataset` and reloaded.  The parent ids are not saved correctly and a `KeyError` occurs.

I also removed a duplicate line that probably appeared because of a bad merge a long time ago.