### PR TITLE
[bugfix] Properly create curvilinear magnetic fields

### DIFF
--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -153,6 +153,7 @@ class YTDataContainer(object):
         self._default_field_parameters = {
             'center': self.ds.arr(np.zeros(3, dtype='float64'), 'cm'),
             'bulk_velocity': self.ds.arr(np.zeros(3, dtype='float64'), 'cm/s'),
+            'bulk_magnetic_field': self.ds.arr(np.zeros(3, dtype='float64'), 'cm/s'),
             'normal': self.ds.arr([0.0, 0.0, 1.0], ''),
         }
         if field_parameters is None: field_parameters = {}

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -153,7 +153,7 @@ class YTDataContainer(object):
         self._default_field_parameters = {
             'center': self.ds.arr(np.zeros(3, dtype='float64'), 'cm'),
             'bulk_velocity': self.ds.arr(np.zeros(3, dtype='float64'), 'cm/s'),
-            'bulk_magnetic_field': self.ds.arr(np.zeros(3, dtype='float64'), 'cm/s'),
+            'bulk_magnetic_field': self.ds.arr(np.zeros(3, dtype='float64'), 'G'),
             'normal': self.ds.arr([0.0, 0.0, 1.0], ''),
         }
         if field_parameters is None: field_parameters = {}


### PR DESCRIPTION
There is a call to `create_vector_fields` in `setup_fluid_fields` which is supposed to set up the magnetic fields in spherical and cylindrical coordinates. However, it does not happen, and this is because these fields expect a `bulk_magnetic_field` field parameter to exist and it does not. This PR adds this parameter.