### PR TITLE
Improve OpenMP detection

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -180,17 +180,18 @@ def read_embree_location():
         exit_code = p.returncode
 
         if exit_code != 0:
-            print("Pyembree is installed, but I could not compile Embree test code.")
-            print("The error message was: ")
-            print(err)
-            print(fail_msg)
+            log.warn("Pyembree is installed, but I could not compile Embree "
+                     "test code.")
+            log.warn("The error message was: ")
+            log.warn(err)
+            log.warn(fail_msg)
 
         # Clean up
         file.close()
 
     except OSError:
-        print("read_embree_location() could not find your C compiler. "
-              "Attempted to use '%s'. " % compiler)
+        log.warn("read_embree_location() could not find your C compiler. "
+                 "Attempted to use '%s'. " % compiler)
         return False
 
     finally:

--- a/setupext.py
+++ b/setupext.py
@@ -1,10 +1,52 @@
+import contextlib
+import glob
 import os
-from pkg_resources import resource_filename
 import shutil
-from subprocess import Popen, PIPE
+import subprocess
 import sys
 import tempfile
 
+from distutils import log
+from distutils.ccompiler import new_compiler
+from distutils.sysconfig import customize_compiler
+from distutils.errors import CompileError, LinkError
+from pkg_resources import resource_filename
+from subprocess import Popen, PIPE
+
+
+CCODE = """
+#include <omp.h>
+#include <stdio.h>
+int main() {
+  #pragma omp parallel
+  printf("nthreads=%d\\n", omp_get_num_threads());
+  return 0;
+}
+"""
+
+@contextlib.contextmanager
+def stdchannel_redirected(stdchannel, dest_filename):
+    """
+    A context manager to temporarily redirect stdout or stderr
+
+    e.g.:
+
+    with stdchannel_redirected(sys.stderr, os.devnull):
+        if compiler.has_function('clock_gettime', libraries=['rt']):
+            libraries.append('rt')
+    """
+
+    try:
+        oldstdchannel = os.dup(stdchannel.fileno())
+        dest_file = open(dest_filename, 'w')
+        os.dup2(dest_file.fileno(), stdchannel.fileno())
+
+        yield
+    finally:
+        if oldstdchannel is not None:
+            os.dup2(oldstdchannel, stdchannel.fileno())
+        if dest_file is not None:
+            dest_file.close()
 
 def check_for_openmp():
     """Returns True if local setup supports OpenMP, False otherwise"""
@@ -14,51 +56,65 @@ def check_for_openmp():
         return False
 
     # Create a temporary directory
-    tmpdir = tempfile.mkdtemp()
-    curdir = os.getcwd()
-    exit_code = 1
+    ccompiler = new_compiler()
+    customize_compiler(ccompiler)
+
+    tmp_dir = tempfile.mkdtemp()
+    start_dir = os.path.abspath('.')
+
+    if os.name == 'nt':
+        # TODO: make this work with mingw
+        # AFAICS there's no easy way to get the compiler distutils
+        # will be using until compilation actually happens
+        compile_flag = '-openmp'
+        link_flag = ''
+    else:
+        compile_flag = '-fopenmp'
+        link_flag = '-fopenmp'
 
     try:
-        os.chdir(tmpdir)
+        os.chdir(tmp_dir)
 
-        # Get compiler invocation
-        compiler = os.getenv('CC', 'cc')
-        compiler = compiler.split(' ')
+        with open('test_openmp.c', 'w') as f:
+            f.write(CCODE)
 
-        # Attempt to compile a test script.
-        # See http://openmp.org/wp/openmp-compilers/
-        filename = r'test.c'
-        file = open(filename, 'wt', 1)
-        file.write(
-            "#include <omp.h>\n"
-            "#include <stdio.h>\n"
-            "int main() {\n"
-            "#pragma omp parallel\n"
-            "printf(\"Hello from thread %d, nthreads %d\\n\", omp_get_thread_num(), omp_get_num_threads());\n"
-            "}"
-        )
-        file.flush()
-        p = Popen(compiler + ['-fopenmp', filename],
-                  stdin=PIPE, stdout=PIPE, stderr=PIPE)
-        output, err = p.communicate()
-        exit_code = p.returncode
-        
-        if exit_code != 0:
-            print("Compilation of OpenMP test code failed with the error: ")
-            print(err.decode('utf8'))
-            print("Disabling OpenMP support. ")
+        os.mkdir('objects')
 
-        # Clean up
-        file.close()
-    except OSError:
-        print("check_for_openmp() could not find your C compiler. "
-              "Attempted to use '%s'. " % compiler)
-        return False
+        # Compile, link, and run test program
+        with stdchannel_redirected(sys.stderr, os.devnull):
+            ccompiler.compile(['test_openmp.c'], output_dir='objects',
+                              extra_postargs=[compile_flag])
+            ccompiler.link_executable(
+                glob.glob(os.path.join('objects', '*')), 'test_openmp',
+                extra_postargs=[link_flag])
+            output = subprocess.check_output('./test_openmp').decode(
+                sys.stdout.encoding or 'utf-8').splitlines()
+
+        if 'nthreads=' in output[0]:
+            nthreads = int(output[0].strip().split('=')[1])
+            if len(output) == nthreads:
+                using_openmp = True
+            else:
+                log.warn("Unexpected number of lines from output of test "
+                         "OpenMP program (output was {0})".format(output))
+                using_openmp = False
+        else:
+            log.warn("Unexpected output from test OpenMP "
+                     "program (output was {0})".format(output))
+            using_openmp = False
+
+    except (CompileError, LinkError):
+        using_openmp = False
     finally:
-        os.chdir(curdir)
-        shutil.rmtree(tmpdir)
+        os.chdir(start_dir)
 
-    return exit_code == 0
+    if using_openmp:
+        log.warn("Using OpenMP to compile parallel extensions")
+    else:
+        log.warn("Unable to compile OpenMP test program so Cython\n"
+                 "extensions will be compiled without parallel support")
+
+    return using_openmp
 
 
 def check_for_pyembree():

--- a/setupext.py
+++ b/setupext.py
@@ -34,6 +34,8 @@ def stdchannel_redirected(stdchannel, dest_filename):
     with stdchannel_redirected(sys.stderr, os.devnull):
         if compiler.has_function('clock_gettime', libraries=['rt']):
             libraries.append('rt')
+
+    Code adapted from https://stackoverflow.com/a/17752455/1382869
     """
 
     try:
@@ -49,7 +51,11 @@ def stdchannel_redirected(stdchannel, dest_filename):
             dest_file.close()
 
 def check_for_openmp():
-    """Returns True if local setup supports OpenMP, False otherwise"""
+    """Returns True if local setup supports OpenMP, False otherwise
+
+    Code adapted from astropy_helpers, originally written by Tom 
+    Robitaille and Curtis McCully.
+    """
 
     # See https://bugs.python.org/issue25150
     if sys.version_info[:3] == (3, 5, 0) or os.name == 'nt':


### PR DESCRIPTION
This is inspired by https://github.com/astropy/astropy-helpers/pull/346, which added detection for OpenMP support to astropy. Their approach is better than ours in that it:

* Links the program and tests to make sure it actually runs correctly
* Uses the distutils compiler API instead of relying on the `'CC'` environment variable
* Adds support for OpenMP on windows with MSVC

I've also added a small context manager to suppress the compiler output to stdout from the OpenMP test to avoid adding noise to the output from compiling yt. If compilation fails, we will still print the compiler output so I think this is fine.

Rather than using their exact approach, which manipulates the Extension objects after creating them, I'm instead just modifying the `check_for_openmp` function that already exists in yt to use the compilation logic used by astropy's `add_openmp_options_if_available`.

One corner case is that the way this is written right now, if someone compiles yt with MinGW on Windows they won't get OpenMP support. I can't find a way to easily detect whether distutils will use MSVC or MinGW so I'm just assuming all windows users are using MSVC since that is the most popular use case.

I tested this on MacOS and Linux where it works correctly. If someone (@jzuhone?) could test this on Windows that would be very much appreciated.