### PR TITLE
Add ignore rules for new flake8 rules

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,4 +15,4 @@ with-xunit=1
 #      vendored libraries
 exclude = doc,benchmarks,*/api.py,*/__init__.py,*/__config__.py,yt/visualization/_mpl_imports.py,yt/utilities/lodgeit.py,yt/utilities/lru_cache.py,yt/utilities/poster/*,yt/extern/*,yt/mods.py,yt/utilities/fits_image.py
 max-line-length=999
-ignore = E111,E121,E122,E123,E124,E125,E126,E127,E128,E129,E131,E201,E202,E211,E221,E222,E227,E228,E241,E301,E203,E225,E226,E231,E251,E261,E262,E265,E266,E302,E303,E305,E306,E402,E502,E701,E703,E731,W291,W292,W293,W391,W503
+ignore = E111,E121,E122,E123,E124,E125,E126,E127,E128,E129,E131,E201,E202,E211,E221,E222,E227,E228,E241,E301,E203,E225,E226,E231,E251,E261,E262,E265,E266,E302,E303,E305,E306,E402,E502,E701,E703,E722,E741,E731,W291,W292,W293,W391,W503


### PR DESCRIPTION
In principle we could also just fix these but given that our tests are broken right now I'd rather just add ignores for the two new rules that are causing the failures in the flake8 test.

The two new rules we're ignoring are:

* E722 do not use bare except
* E741 ambiguous variable name

I think E722 is probably something worth fixing eventually but it will need a bit of care. I don't think E741 is worth fixing.