### PR TITLE
Fix  _switch_ds() use with ParticleProjectionPlots

### DIFF
--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -48,6 +48,7 @@ from yt.utilities.exceptions import \
 from yt.visualization.color_maps import \
     yt_colormaps
 
+
 def invalidate_data(f):
     @wraps(f)
     def newfunc(*args, **kwargs):
@@ -322,10 +323,19 @@ class PlotContainer(object):
                 raise RuntimeError("The data_source keyword argument "
                                    "is only defined for projections.")
             kwargs['data_source'] = data_source
-        new_object = getattr(new_ds, name)(**kwargs)
+
         self.ds = new_ds
+
+        # A _hack_ for ParticleProjectionPlots
+        if name == 'Particle':
+            from yt.visualization.particle_plots import ParticleAxisAlignedDummyDataSource
+            new_object = ParticleAxisAlignedDummyDataSource(ds=self.ds, **kwargs)
+        else:
+            new_object = getattr(new_ds, name)(**kwargs)
+
         self.data_source = new_object
         self._data_valid = self._plot_valid = False
+
         for d in 'xyz':
             lim_name = d+'lim'
             if hasattr(self, lim_name):

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -328,7 +328,8 @@ class PlotContainer(object):
 
         # A _hack_ for ParticleProjectionPlots
         if name == 'Particle':
-            from yt.visualization.particle_plots import ParticleAxisAlignedDummyDataSource
+            from yt.visualization.particle_plots import \
+            ParticleAxisAlignedDummyDataSource
             new_object = ParticleAxisAlignedDummyDataSource(ds=self.ds, **kwargs)
         else:
             new_object = getattr(new_ds, name)(**kwargs)

--- a/yt/visualization/tests/test_particle_plot.py
+++ b/yt/visualization/tests/test_particle_plot.py
@@ -41,7 +41,6 @@ from yt.visualization.api import \
     ParticlePhasePlot
 from yt.units.yt_array import YTArray
 
-
 def setup():
     """Test specific setup."""
     from yt.config import ytcfg
@@ -271,6 +270,26 @@ def test_set_units():
     pp = ParticlePhasePlot(sp, ("Gas", "density"), ("Gas", "temperature"), ("Gas", "particle_mass"))
     # make sure we can set the units using the tuple without erroring out
     pp.set_unit(("Gas", "particle_mass"), "Msun")
+
+@requires_file(tgal)
+def test_switch_ds():
+    """
+    Tests the _switch_ds() method for ParticleProjectionPlots that as of
+    25th October 2017 requires a specific hack in plot_container.py
+    """
+    ds = load(tgal)
+    ds2 = load(tgal)
+
+    plot = ParticlePlot(
+        ds,
+        ("Gas", "particle_position_x"),
+        ("Gas", "particle_position_y"),
+        ("Gas", "density"),
+    )
+
+    plot._switch_ds(ds2)
+
+    return
 
 class TestParticleProjectionPlotSave(unittest.TestCase):
 


### PR DESCRIPTION
## PR Summary

My attempt at solving issue #1582. This implements a 'hack' in the `_switch_ds()` method which enables the data to be swapped when doing a ParticleProjectionPlot. This is incredibly helpful when making movies.

## PR Checklist

- [x] Code passes flake8 checker
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->