### PR TITLE
Fix volume rendering annotate_axes axes colors.

### DIFF
--- a/yt/visualization/volume_rendering/render_source.py
+++ b/yt/visualization/volume_rendering/render_source.py
@@ -1240,7 +1240,6 @@ class CoordinateVectorSource(OpaqueSource):
             colors[2, 2] = 1.0  # z is blue
             colors[:, 3] = alpha
         self.colors = colors
-        self.color_stride = 2
 
     def render(self, camera, zbuffer=None):
         """Renders an image using the provided camera
@@ -1321,15 +1320,14 @@ class CoordinateVectorSource(OpaqueSource):
         py = py.astype('int64')
 
         if len(px.shape) == 1:
-            zlines(empty, z, px, py, dz, self.colors.astype('float64'),
-                   self.color_stride)
+            zlines(empty, z, px, py, dz, self.colors.astype('float64'))
         else:
             # For stereo-lens, two sets of pos for each eye are contained
             # in px...pz
             zlines(empty, z, px[0, :], py[0, :], dz[0, :],
-                   self.colors.astype('float64'), self.color_stride)
+                   self.colors.astype('float64'))
             zlines(empty, z, px[1, :], py[1, :], dz[1, :],
-                   self.colors.astype('float64'), self.color_stride)
+                   self.colors.astype('float64'))
 
         # Set the new zbuffer
         self.zbuffer = zbuffer

--- a/yt/visualization/volume_rendering/tests/test_scene.py
+++ b/yt/visualization/volume_rendering/tests/test_scene.py
@@ -18,8 +18,12 @@ import tempfile
 import shutil
 from yt.testing import \
     fake_random_ds, \
-    assert_fname
-from yt.visualization.volume_rendering.api import volume_render, VolumeSource
+    assert_fname, \
+    fake_vr_orientation_test_ds
+from yt.visualization.volume_rendering.api import \
+    create_scene, \
+    volume_render, \
+    VolumeSource
 import numpy as np
 from unittest import TestCase
 
@@ -90,3 +94,15 @@ class RotationTest(TestCase):
             sc.camera.pitch(2*np.pi/nrot)
             sc.render()
             sc.save('test_rot_%04i.png' % i, sigma_clip=6.0)
+
+def test_annotations():
+    ds = fake_vr_orientation_test_ds(N=16)
+    sc = create_scene(ds)
+    sc.annotate_axes()
+    sc.annotate_domain(ds)
+    sc.render()
+    # ensure that there are actually red, green, blue, and white pixels
+    # in the image. see Issue #1595
+    im = sc._last_render
+    for c in ([1, 0, 0, 1], [0, 1, 0, 1], [0, 0, 1, 1], [1, 1, 1, 1]):
+        assert np.where((im == c).all(axis=-1))[0].shape[0] > 0


### PR DESCRIPTION
This fixes #1595.

AFAICS this has simply never worked (see e.g. the examples in the yt 3.3.0 docs build). The cause is the use of a non-unit `color_stride` keyword argument to `zlines` in `CoordinateVectorSource`. Since the default stride is 1 and the existing API doesn't expose `color_stride`, we can simply delete it.

I've also added a test to make sure that the line annotations are actually drawing something with the correct color. I could probably add an image comparison test but I'd prefer to avoid that.