### PR TITLE
Enable a few plot modifications for 2D cylindrical geometry

### DIFF
--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -47,6 +47,9 @@ def _verify_geometry(func):
     @wraps(func)
     def _check_geometry(self, plot):
         geom = plot.data.ds.coordinates.name
+        dims = plot.data.ds.dimensionality
+        # append dimensionality info to cylindrical geometry
+        if geom == "cylindrical": geom = "%s-%dd" % (geom, dims)
         supp = self._supported_geometries
         cs = getattr(self, "coord_system", None)
         if supp is None or geom in supp:
@@ -286,7 +289,7 @@ class VelocityCallback(PlotCallback):
     strength.
     """
     _type_name = "velocity"
-    _supported_geometries = ("cartesian", "spectral_cube")
+    _supported_geometries = ("cartesian", "spectral_cube", "cylindrical-2d")
     def __init__(self, factor=16, scale=None, scale_units=None, normalize=False):
         PlotCallback.__init__(self)
         self.factor = factor
@@ -332,7 +335,7 @@ class MagFieldCallback(PlotCallback):
     clearly seen for fields with substantial variation in field strength.
     """
     _type_name = "magnetic_field"
-    _supported_geometries = ("cartesian", "spectral_cube")
+    _supported_geometries = ("cartesian", "spectral_cube", "cylindrical-2d")
     def __init__(self, factor=16, scale=None, scale_units=None, normalize=False):
         PlotCallback.__init__(self)
         self.factor = factor
@@ -365,7 +368,7 @@ class QuiverCallback(PlotCallback):
     (see matplotlib.axes.Axes.quiver for more info)
     """
     _type_name = "quiver"
-    _supported_geometries = ("cartesian", "spectral_cube")
+    _supported_geometries = ("cartesian", "spectral_cube", "cylindrical-2d")
     def __init__(self, field_x, field_y, factor=16, scale=None,
                  scale_units=None, normalize=False, bv_x=0, bv_y=0):
         PlotCallback.__init__(self)
@@ -435,7 +438,7 @@ class ContourCallback(PlotCallback):
     queried.
     """
     _type_name = "contour"
-    _supported_geometries = ("cartesian", "spectral_cube")
+    _supported_geometries = ("cartesian", "spectral_cube", "cylindrical-2d")
     def __init__(self, field, ncont=5, factor=4, clim=None,
                  plot_args=None, label=False, take_log=None,
                  label_args=None, text_args=None, data_source=None):
@@ -560,7 +563,7 @@ class GridBoundaryCallback(PlotCallback):
     can change the linewidth of the displayed grids.
     """
     _type_name = "grids"
-    _supported_geometries = ("cartesian", "spectral_cube")
+    _supported_geometries = ("cartesian", "spectral_cube", "cylindrical-2d")
 
     def __init__(self, alpha=0.7, min_pix=1, min_pix_ids=20, draw_ids=False,
                  periodic=True, min_level=None, max_level=None,
@@ -671,7 +674,7 @@ class StreamlineCallback(PlotCallback):
     *field_color* is a field to be used to colormap the streamlines.
     """
     _type_name = "streamlines"
-    _supported_geometries = ("cartesian", "spectral_cube")
+    _supported_geometries = ("cartesian", "spectral_cube", "cylindrical-2d")
     def __init__(self, field_x, field_y, factor=16,
                  density=1, field_color=None, plot_args=None):
         PlotCallback.__init__(self)
@@ -772,7 +775,7 @@ class LinePlotCallback(PlotCallback):
 
     """
     _type_name = "line"
-    _supported_geometries = ("cartesian", "spectral_cube")
+    _supported_geometries = ("cartesian", "spectral_cube", "cylindrical-2d")
     def __init__(self, p1, p2, data_coords=False, coord_system="data",
                  plot_args=None):
         PlotCallback.__init__(self)
@@ -809,7 +812,7 @@ class ImageLineCallback(LinePlotCallback):
 
     """
     _type_name = "image_line"
-    _supported_geometries = ("cartesian", "spectral_cube")
+    _supported_geometries = ("cartesian", "spectral_cube", "cylindrical-2d")
     def __init__(self, p1, p2, data_coords=False, coord_system='axis',
                  plot_args=None):
         super(ImageLineCallback, self).__init__(p1, p2, data_coords,
@@ -881,7 +884,7 @@ class ClumpContourCallback(PlotCallback):
     Take a list of *clumps* and plot them as a set of contours.
     """
     _type_name = "clumps"
-    _supported_geometries = ("cartesian", "spectral_cube")
+    _supported_geometries = ("cartesian", "spectral_cube", "cylindrical-2d")
     def __init__(self, clumps, plot_args=None):
         self.clumps = clumps
         if plot_args is None: plot_args = {}
@@ -1003,7 +1006,7 @@ class ArrowCallback(PlotCallback):
 
     """
     _type_name = "arrow"
-    _supported_geometries = ("cartesian", "spectral_cube")
+    _supported_geometries = ("cartesian", "spectral_cube", "cylindrical-2d")
     def __init__(self, pos, code_size=None, length=0.03, width=0.0001,
                  head_width=0.01, head_length=0.01,
                  starting_pos=None, coord_system='data', plot_args=None):
@@ -1115,7 +1118,7 @@ class MarkerAnnotateCallback(PlotCallback):
 
     """
     _type_name = "marker"
-    _supported_geometries = ("cartesian", "spectral_cube")
+    _supported_geometries = ("cartesian", "spectral_cube", "cylindrical-2d")
     def __init__(self, pos, marker='x', coord_system="data", plot_args=None):
         def_plot_args = {'color':'w', 's':50}
         self.pos = pos
@@ -1184,7 +1187,7 @@ class SphereCallback(PlotCallback):
 
     """
     _type_name = "sphere"
-    _supported_geometries = ("cartesian", "spectral_cube")
+    _supported_geometries = ("cartesian", "spectral_cube", "cylindrical-2d")
     def __init__(self, center, radius, circle_args=None,
                  text=None, coord_system='data', text_args=None):
         def_text_args = {'color':'white'}
@@ -1295,7 +1298,7 @@ class TextLabelCallback(PlotCallback):
     >>> s.save()
     """
     _type_name = "text"
-    _supported_geometries = ("cartesian", "spectral_cube")
+    _supported_geometries = ("cartesian", "spectral_cube", "cylindrical-2d")
     def __init__(self, pos, text, data_coords=False, coord_system='data',
                  text_args=None, inset_box_args=None):
         def_text_args = {'color':'white'}
@@ -1335,7 +1338,7 @@ class PointAnnotateCallback(TextLabelCallback):
 
     """
     _type_name = "point"
-    _supported_geometries = ("cartesian", "spectral_cube")
+    _supported_geometries = ("cartesian", "spectral_cube", "cylindrical-2d")
     def __init__(self, pos, text, data_coords=False, coord_system='data',
                  text_args=None, inset_box_args=None):
         super(PointAnnotateCallback, self).__init__(pos, text, data_coords,
@@ -1506,7 +1509,7 @@ class ParticleCallback(PlotCallback):
     _type_name = "particles"
     region = None
     _descriptor = None
-    _supported_geometries = ("cartesian", "spectral_cube")
+    _supported_geometries = ("cartesian", "spectral_cube", "cylindrical-2d")
     def __init__(self, width, p_size=1.0, col='k', marker='o', stride=1,
                  ptype='all', minimum_mass=None, alpha=1.0):
         PlotCallback.__init__(self)
@@ -1818,7 +1821,7 @@ class TimestampCallback(PlotCallback):
     >>> s.annotate_timestamp()
     """
     _type_name = "timestamp"
-    _supported_geometries = ("cartesian", "spectral_cube")
+    _supported_geometries = ("cartesian", "spectral_cube", "cylindrical-2d")
     def __init__(self, x_pos=None, y_pos=None, corner='lower_left', time=True,
                  redshift=False, time_format="t = {time:.1f} {units}",
                  time_unit=None, redshift_format="z = {redshift:.2f}",
@@ -2315,7 +2318,7 @@ class LineIntegralConvolutionCallback(PlotCallback):
                                              lim=(0.5,0.65))
     """
     _type_name = "line_integral_convolution"
-    _supported_geometries = ("cartesian", "spectral_cube")
+    _supported_geometries = ("cartesian", "spectral_cube", "cylindrical-2d")
     def __init__(self, field_x, field_y, texture=None, kernellen=50.,
                  lim=(0.5,0.6), cmap='binary', alpha=0.8, const_alpha=False):
         PlotCallback.__init__(self)
@@ -2411,7 +2414,7 @@ class CellEdgesCallback(PlotCallback):
     >>> s.save()
     """
     _type_name = "cell_edges"
-    _supported_geometries = ("cartesian", "spectral_cube")
+    _supported_geometries = ("cartesian", "spectral_cube", "cylindrical-2d")
     def __init__(self, line_width=0.002, alpha = 1.0, color='black'):
         from matplotlib.colors import ColorConverter
         conv = ColorConverter()

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -48,7 +48,7 @@ def _verify_geometry(func):
     def _check_geometry(self, plot):
         geom = plot.data.ds.coordinates.name
         # append dimensionality info to cylindrical geometry
-        if geom is "cylindrical":
+        if geom == "cylindrical":
             geom = "%s-%dd" % (geom, plot.data.ds.dimensionality)
         supp = self._supported_geometries
         cs = getattr(self, "coord_system", None)

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -289,7 +289,7 @@ class VelocityCallback(PlotCallback):
     strength.
     """
     _type_name = "velocity"
-    _supported_geometries = ("cartesian", "spectral_cube", "cylindrical-2d")
+    _supported_geometries = ("cartesian", "spectral_cube")
     def __init__(self, factor=16, scale=None, scale_units=None, normalize=False):
         PlotCallback.__init__(self)
         self.factor = factor

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -49,7 +49,7 @@ def _verify_geometry(func):
         geom = plot.data.ds.coordinates.name
         dims = plot.data.ds.dimensionality
         # append dimensionality info to cylindrical geometry
-        if geom == "cylindrical": geom = "%s-%dd" % (geom, dims)
+        if geom is "cylindrical": geom = "%s-%dd" % (geom, dims)
         supp = self._supported_geometries
         cs = getattr(self, "coord_system", None)
         if supp is None or geom in supp:

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -47,9 +47,9 @@ def _verify_geometry(func):
     @wraps(func)
     def _check_geometry(self, plot):
         geom = plot.data.ds.coordinates.name
-        dims = plot.data.ds.dimensionality
         # append dimensionality info to cylindrical geometry
-        if geom is "cylindrical": geom = "%s-%dd" % (geom, dims)
+        if geom is "cylindrical":
+            geom = "%s-%dd" % (geom, plot.data.ds.dimensionality)
         supp = self._supported_geometries
         cs = getattr(self, "coord_system", None)
         if supp is None or geom in supp:

--- a/yt/visualization/tests/test_callbacks.py
+++ b/yt/visualization/tests/test_callbacks.py
@@ -24,13 +24,15 @@ from yt.testing import \
     fake_amr_ds, \
     fake_tetrahedral_ds, \
     fake_hexahedral_ds, \
-    assert_fname
+    assert_fname, \
+    requires_file
 import yt.units as u
 from yt.utilities.exceptions import \
     YTPlotCallbackError, \
     YTDataTypeUnsupported
 from yt.visualization.api import \
     SlicePlot, ProjectionPlot, OffAxisSlicePlot
+from yt.convenience import load
 import contextlib
 
 # These are a very simple set of tests that verify that each callback is or is
@@ -345,7 +347,7 @@ def test_text_callback():
                         text_args={'color':'red'})
         assert_fname(p.save(prefix)[0])
 
-@requires_ds(cyl_2d)
+@requires_file(cyl_2d)
 def test_velocity_callback():
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields =
@@ -368,7 +370,7 @@ def test_velocity_callback():
         assert_fname(p.save(prefix)[0])
 
     with _cleanup_fname() as prefix:
-        ds = yt.load(cyl_2d)
+        ds = load(cyl_2d)
         slc = SlicePlot(ds, "theta", "density")
         slc.annotate_velocity()
         assert_fname(slc.save(prefix)[0])
@@ -381,7 +383,7 @@ def test_velocity_callback():
         p.annotate_velocity(factor=40, normalize=True)
         assert_raises(YTDataTypeUnsupported, p.save, prefix)
 
-@requires_ds(cyl_2d)
+@requires_file(cyl_2d)
 def test_magnetic_callback():
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields = ("density", "magnetic_field_x",
@@ -404,7 +406,7 @@ def test_magnetic_callback():
         assert_fname(p.save(prefix)[0])
 
     with _cleanup_fname() as prefix:
-        ds = yt.load(cyl_2d)
+        ds = load(cyl_2d)
         slc = ProjectionPlot(ds, "theta", "density")
         slc.annotate_magnetic_field()
         assert_fname(slc.save(prefix)[0])
@@ -418,7 +420,7 @@ def test_magnetic_callback():
             scale_units="inches", normalize = True)
         assert_raises(YTDataTypeUnsupported, p.save, prefix)
 
-@requires_ds(cyl_2d)
+@requires_file(cyl_2d)
 def test_quiver_callback():
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields =
@@ -442,7 +444,7 @@ def test_quiver_callback():
         assert_fname(p.save(prefix)[0])
 
     with _cleanup_fname() as prefix:
-        ds = yt.load(cyl_2d)
+        ds = load(cyl_2d)
         slc = SlicePlot(ds, "theta", "density")
         slc.annotate_quiver("velocity_x", "velocity_y")
         assert_fname(slc.save(prefix)[0])
@@ -458,7 +460,7 @@ def test_quiver_callback():
             bv_y = 0.5 * u.cm / u.s)
         assert_raises(YTDataTypeUnsupported, p.save, prefix)
 
-@requires_ds(cyl_2d)
+@requires_file(cyl_2d)
 def test_contour_callback():
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields = ("density", "temperature"))
@@ -490,7 +492,7 @@ def test_contour_callback():
         p.save(prefix)
 
     with _cleanup_fname() as prefix:
-        ds = yt.load(cyl_2d)
+        ds = load(cyl_2d)
         slc = SlicePlot(ds, "theta", "plasma_beta")
         slc.annotate_contour(field,
                              ncont=2,
@@ -513,7 +515,7 @@ def test_contour_callback():
         assert_raises(YTDataTypeUnsupported, p.save, prefix)
 
 
-@requires_ds(cyl_2d)
+@requires_file(cyl_2d)
 def test_grids_callback():
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields = ("density",))
@@ -535,7 +537,7 @@ def test_grids_callback():
         p.save(prefix)
 
     with _cleanup_fname() as prefix:
-        ds = yt.load(cyl_2d)
+        ds = load(cyl_2d)
         slc = SlicePlot(ds, "theta", "density")
         slc.annotate_grids()
         assert_fname(slc.save(prefix)[0])
@@ -549,7 +551,7 @@ def test_grids_callback():
         assert_raises(YTDataTypeUnsupported, p.save, prefix)
 
 
-@requires_ds(cyl_2d)
+@requires_file(cyl_2d)
 def test_cell_edges_callback():
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields = ("density",))
@@ -570,7 +572,7 @@ def test_cell_edges_callback():
         p.save(prefix)
 
     with _cleanup_fname() as prefix:
-        ds = yt.load(cyl_2d)
+        ds = load(cyl_2d)
         slc = SlicePlot(ds, "theta", "density")
         slc.annotate_cell_edges()
         assert_fname(slc.save(prefix)[0])
@@ -597,7 +599,7 @@ def test_mesh_lines_callback():
             assert_fname(sl.save(prefix)[0])
                 
 
-@requires_ds(cyl_2d)
+@requires_file(cyl_2d)
 def test_line_integral_convolution_callback():
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields =
@@ -621,7 +623,7 @@ def test_line_integral_convolution_callback():
         p.save(prefix)
 
     with _cleanup_fname() as prefix:
-        ds = yt.load(cyl_2d)
+        ds = load(cyl_2d)
         slc = SlicePlot(ds, "theta", "density")
         slc.annotate_line_integral_convolution("magnetic_field_r", "magnetic_field_z")
         assert_fname(slc.save(prefix)[0])

--- a/yt/visualization/tests/test_callbacks.py
+++ b/yt/visualization/tests/test_callbacks.py
@@ -65,6 +65,9 @@ import contextlib
 #  X ray
 #  X line_integral_convolution
 
+# 2D cylindrical data for callback test
+cyl_2d = "WDMerger_hdf5_chk_1000"
+
 @contextlib.contextmanager
 def _cleanup_fname():
     tmpdir = tempfile.mkdtemp()
@@ -342,6 +345,7 @@ def test_text_callback():
                         text_args={'color':'red'})
         assert_fname(p.save(prefix)[0])
 
+@requires_ds(cyl_2d)
 def test_velocity_callback():
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields =
@@ -364,6 +368,12 @@ def test_velocity_callback():
         assert_fname(p.save(prefix)[0])
 
     with _cleanup_fname() as prefix:
+        ds = yt.load(cyl_2d)
+        slc = SlicePlot(ds, "theta", "density")
+        slc.annotate_velocity()
+        assert_fname(slc.save(prefix)[0])
+
+    with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields = 
             ("density", "velocity_r", "velocity_theta", "velocity_phi"),
             geometry="spherical")
@@ -371,6 +381,7 @@ def test_velocity_callback():
         p.annotate_velocity(factor=40, normalize=True)
         assert_raises(YTDataTypeUnsupported, p.save, prefix)
 
+@requires_ds(cyl_2d)
 def test_magnetic_callback():
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields = ("density", "magnetic_field_x",
@@ -393,6 +404,12 @@ def test_magnetic_callback():
         assert_fname(p.save(prefix)[0])
 
     with _cleanup_fname() as prefix:
+        ds = yt.load(cyl_2d)
+        slc = ProjectionPlot(ds, "theta", "density")
+        slc.annotate_magnetic_field()
+        assert_fname(slc.save(prefix)[0])
+
+    with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields = ("density", "magnetic_field_r",
           "magnetic_field_theta", "magnetic_field_phi"),
           geometry="spherical")
@@ -401,6 +418,7 @@ def test_magnetic_callback():
             scale_units="inches", normalize = True)
         assert_raises(YTDataTypeUnsupported, p.save, prefix)
 
+@requires_ds(cyl_2d)
 def test_quiver_callback():
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields =
@@ -424,6 +442,12 @@ def test_quiver_callback():
         assert_fname(p.save(prefix)[0])
 
     with _cleanup_fname() as prefix:
+        ds = yt.load(cyl_2d)
+        slc = SlicePlot(ds, "theta", "density")
+        slc.annotate_quiver("velocity_x", "velocity_y")
+        assert_fname(slc.save(prefix)[0])
+
+    with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields = 
             ("density", "velocity_x", "velocity_theta", "velocity_phi"),
             geometry="spherical")
@@ -434,6 +458,7 @@ def test_quiver_callback():
             bv_y = 0.5 * u.cm / u.s)
         assert_raises(YTDataTypeUnsupported, p.save, prefix)
 
+@requires_ds(cyl_2d)
 def test_contour_callback():
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields = ("density", "temperature"))
@@ -465,6 +490,19 @@ def test_contour_callback():
         p.save(prefix)
 
     with _cleanup_fname() as prefix:
+        ds = yt.load(cyl_2d)
+        slc = SlicePlot(ds, "theta", "plasma_beta")
+        slc.annotate_contour(field,
+                             ncont=2,
+                             factor=7.,
+                             take_log=False,
+                             clim=(1.e-1,1.e1),
+                             label=True, 
+                             plot_args={"colors": ("c","w"), "linewidths": 1},
+                             text_args={"fmt": "%1.1f"})
+        assert_fname(slc.save(prefix)[0])
+
+    with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields = ("density", "temperature"),
                          geometry="spherical")
         p = SlicePlot(ds, "r", "density")
@@ -475,6 +513,7 @@ def test_contour_callback():
         assert_raises(YTDataTypeUnsupported, p.save, prefix)
 
 
+@requires_ds(cyl_2d)
 def test_grids_callback():
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields = ("density",))
@@ -496,6 +535,12 @@ def test_grids_callback():
         p.save(prefix)
 
     with _cleanup_fname() as prefix:
+        ds = yt.load(cyl_2d)
+        slc = SlicePlot(ds, "theta", "density")
+        slc.annotate_grids()
+        assert_fname(slc.save(prefix)[0])
+
+    with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields = ("density",), geometry="spherical")
         p = SlicePlot(ds, "r", "density")
         p.annotate_grids(alpha=0.7, min_pix=10, min_pix_ids=30,
@@ -504,6 +549,7 @@ def test_grids_callback():
         assert_raises(YTDataTypeUnsupported, p.save, prefix)
 
 
+@requires_ds(cyl_2d)
 def test_cell_edges_callback():
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields = ("density",))
@@ -522,6 +568,12 @@ def test_cell_edges_callback():
         p.annotate_cell_edges(alpha=0.7, line_width=0.9,
                               color=(0.0, 1.0, 1.0))
         p.save(prefix)
+
+    with _cleanup_fname() as prefix:
+        ds = yt.load(cyl_2d)
+        slc = SlicePlot(ds, "theta", "density")
+        slc.annotate_cell_edges()
+        assert_fname(slc.save(prefix)[0])
 
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields = ("density",), geometry="spherical")
@@ -545,6 +597,7 @@ def test_mesh_lines_callback():
             assert_fname(sl.save(prefix)[0])
                 
 
+@requires_ds(cyl_2d)
 def test_line_integral_convolution_callback():
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields =
@@ -566,6 +619,12 @@ def test_line_integral_convolution_callback():
                                              cmap=ytcfg.get("yt", "default_colormap"),
                                              alpha=0.9, const_alpha=True)
         p.save(prefix)
+
+    with _cleanup_fname() as prefix:
+        ds = yt.load(cyl_2d)
+        slc = SlicePlot(ds, "theta", "density")
+        slc.annotate_line_integral_convolution("magnetic_field_r", "magnetic_field_z")
+        assert_fname(slc.save(prefix)[0])
 
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields = 

--- a/yt/visualization/tests/test_callbacks.py
+++ b/yt/visualization/tests/test_callbacks.py
@@ -494,7 +494,7 @@ def test_contour_callback():
     with _cleanup_fname() as prefix:
         ds = load(cyl_2d)
         slc = SlicePlot(ds, "theta", "plasma_beta")
-        slc.annotate_contour(field,
+        slc.annotate_contour("plasma_beta",
                              ncont=2,
                              factor=7.,
                              take_log=False,

--- a/yt/visualization/tests/test_callbacks.py
+++ b/yt/visualization/tests/test_callbacks.py
@@ -68,7 +68,7 @@ import contextlib
 #  X line_integral_convolution
 
 # 2D cylindrical data for callback test
-cyl_2d = "WDMerger_hdf5_chk_1000"
+cyl_2d = "WDMerger_hdf5_chk_1000/WDMerger_hdf5_chk_1000.hdf5"
 
 @contextlib.contextmanager
 def _cleanup_fname():

--- a/yt/visualization/tests/test_callbacks.py
+++ b/yt/visualization/tests/test_callbacks.py
@@ -347,7 +347,6 @@ def test_text_callback():
                         text_args={'color':'red'})
         assert_fname(p.save(prefix)[0])
 
-@requires_file(cyl_2d)
 def test_velocity_callback():
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields =
@@ -368,12 +367,6 @@ def test_velocity_callback():
         p.annotate_velocity(factor=8, scale=0.5, scale_units="inches",
                             normalize = True)
         assert_fname(p.save(prefix)[0])
-
-    with _cleanup_fname() as prefix:
-        ds = load(cyl_2d)
-        slc = SlicePlot(ds, "theta", "density")
-        slc.annotate_velocity()
-        assert_fname(slc.save(prefix)[0])
 
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields = 


### PR DESCRIPTION
A few plot modifications do work for 2D cylindrical geometry, but now they are excluded from support geometries.