### PR TITLE
Ensure field accesses on 2D grids keep their dummy dimension

### DIFF
--- a/yt/data_objects/grid_patch.py
+++ b/yt/data_objects/grid_patch.py
@@ -95,8 +95,10 @@ class AMRGridPatch(YTSelectionContainer):
         finfo = self.ds._get_field_info(*fields[0])
         if not finfo.particle_type:
             num_nodes = 2**sum(finfo.nodal_flag)
-            new_shape = list(self.ActiveDimensions) + [num_nodes]
-            return np.squeeze(tr.reshape(new_shape))
+            new_shape = list(self.ActiveDimensions)
+            if num_nodes > 1:
+                new_shape += [num_nodes]
+            return tr.reshape(new_shape)
         return tr
 
     def convert(self, datatype):

--- a/yt/frontends/enzo/tests/test_outputs.py
+++ b/yt/frontends/enzo/tests/test_outputs.py
@@ -219,3 +219,12 @@ def test_deeply_nested_zoom():
     assert_allclose_units(c, c_actual)
 
     assert_equal(max([g['density'].max() for g in ds.index.grids]), v)
+
+@requires_file(kh2d)
+def test_2d_grid_shape():
+    # see issue #1601
+    # we want to make sure that accessing data on a grid object
+    # returns a 3D array with a dummy dimension.
+    ds = data_dir_load(kh2d)
+    g = ds.index.grids[1]
+    assert g['density'].shape == (128, 100, 1)


### PR DESCRIPTION
Fixes #1601.

This fixes a regression that was unintentionally introduced by Andrew in [Bitbucket PR 2575](https://bitbucket.org/yt_analysis/yt/pull-requests/2575) which added support for nodal fields. In particular, there was a call to `np.squeeze` that was added to ensure the return value of field acceses on grid objects would have a dummy dimension added by the nodal field machinery removed.

This was fine for 3D data but for 2D data it changed the shape of the data returned from accessing a grid patch. This in turn broke contour finding in 2D because the contour finding machinery expected 3D grid patches but was handed 2D data.

The fix I've implemented is to avoid use of `np.squeeze` and instead only attach the extra dimensions for nodal fields if they are nontrivial. I'm pretty sure that is the correct thing to do and that there will never be nodal data that is only defined at one location in a cell but please let me know if that's incorrect @atmyers.

While in principle it might make sense for 2D grid data objects to return 2D arrays on field access, we would need to make that change more carefully I think to ensure there isn't breakage elsewhere and also in a major release to avoid breaking someone downstream (although the ship sailed on that already in yt 3.5.0).