### PR TITLE
use newer miniconda base in appveyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@
 environment:
 
   global:
-      PYTHON: "C:\\Miniconda3-x64"
+      PYTHON: "C:\\Miniconda36-x64"
 
   matrix:
       - PYTHON_VERSION: "2.7"


### PR DESCRIPTION
According to the appveyor docs, `Miniconda3` points to a relatively old base miniconda installation. Let's update to point at a newer one, which should avoid the issue we're seeing.