### PR TITLE
Register code_specific_energy and correct GadgetDataset's internal energy unit

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -104,7 +104,7 @@ answer_tests:
   local_ytdata_003:
     - yt/frontends/ytdata
 
-  local_absorption_spectrum_005:
+  local_absorption_spectrum_006:
     - yt/analysis_modules/absorption_spectrum/tests/test_absorption_spectrum.py:test_absorption_spectrum_non_cosmo
     - yt/analysis_modules/absorption_spectrum/tests/test_absorption_spectrum.py:test_absorption_spectrum_non_cosmo_novpec
     - yt/analysis_modules/absorption_spectrum/tests/test_absorption_spectrum.py:test_absorption_spectrum_cosmo

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -941,6 +941,8 @@ class Dataset(object):
         self.unit_registry.add("code_length", 1.0, dimensions.length)
         self.unit_registry.add("code_mass", 1.0, dimensions.mass)
         self.unit_registry.add("code_density", 1.0, dimensions.density)
+        # Note that energy is actually energy per unit mass
+        self.unit_registry.add("code_energy", 1.0, dimensions.energy / dimensions.mass)
         self.unit_registry.add("code_time", 1.0, dimensions.time)
         self.unit_registry.add("code_magnetic", 1.0, dimensions.magnetic_field)
         self.unit_registry.add("code_temperature", 1.0, dimensions.temperature)
@@ -1018,10 +1020,12 @@ class Dataset(object):
             self.mass_unit / (self.length_unit * (self.time_unit)**2))
         temperature_unit = getattr(self, "temperature_unit", 1.0)
         density_unit = getattr(self, "density_unit", self.mass_unit / self.length_unit**3)
+        energy_unit = getattr(self, "energy_unit", vel_unit**2)
         self.unit_registry.modify("code_velocity", vel_unit)
         self.unit_registry.modify("code_temperature", temperature_unit)
         self.unit_registry.modify("code_pressure", pressure_unit)
         self.unit_registry.modify("code_density", density_unit)
+        self.unit_registry.modify("code_energy", energy_unit)
         # domain_width does not yet exist
         if (self.domain_left_edge is not None and
             self.domain_right_edge is not None):

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -941,8 +941,8 @@ class Dataset(object):
         self.unit_registry.add("code_length", 1.0, dimensions.length)
         self.unit_registry.add("code_mass", 1.0, dimensions.mass)
         self.unit_registry.add("code_density", 1.0, dimensions.density)
-        # Note that energy is actually energy per unit mass
-        self.unit_registry.add("code_energy", 1.0, dimensions.energy / dimensions.mass)
+        self.unit_registry.add("code_specific_energy", 1.0,
+                               dimensions.energy / dimensions.mass)
         self.unit_registry.add("code_time", 1.0, dimensions.time)
         self.unit_registry.add("code_magnetic", 1.0, dimensions.magnetic_field)
         self.unit_registry.add("code_temperature", 1.0, dimensions.temperature)
@@ -1020,12 +1020,12 @@ class Dataset(object):
             self.mass_unit / (self.length_unit * (self.time_unit)**2))
         temperature_unit = getattr(self, "temperature_unit", 1.0)
         density_unit = getattr(self, "density_unit", self.mass_unit / self.length_unit**3)
-        energy_unit = getattr(self, "energy_unit", vel_unit**2)
+        specific_energy_unit = getattr(self, "specific_energy_unit", vel_unit**2)
         self.unit_registry.modify("code_velocity", vel_unit)
         self.unit_registry.modify("code_temperature", temperature_unit)
         self.unit_registry.modify("code_pressure", pressure_unit)
         self.unit_registry.modify("code_density", density_unit)
-        self.unit_registry.modify("code_energy", energy_unit)
+        self.unit_registry.modify("code_specific_energy", specific_energy_unit)
         # domain_width does not yet exist
         if (self.domain_left_edge is not None and
             self.domain_right_edge is not None):

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -337,14 +337,13 @@ class GadgetDataset(SPHDataset):
             vel_unit = self.velocity_unit
         self.time_unit = self.length_unit / vel_unit
 
-        # Note that energy is actually energy per unit mass
-        if "energy" in unit_base:
-            energy_unit = unit_base["energy"]
+        if "specific_energy" in unit_base:
+            specific_energy_unit = unit_base["specific_energy"]
         else:
             # Sane default
-            energy_unit = (1, "(km/s)**2")
-        energy_unit = _fix_unit_ordering(energy_unit)
-        self.energy_unit = self.quan(energy_unit[0], energy_unit[1])
+            specific_energy_unit = (1, "(km/s) ** 2")
+        specific_energy_unit = _fix_unit_ordering(specific_energy_unit)
+        self.specific_energy_unit = self.quan(*specific_energy_unit)
 
     @staticmethod
     def _validate_header(filename):

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -337,6 +337,15 @@ class GadgetDataset(SPHDataset):
             vel_unit = self.velocity_unit
         self.time_unit = self.length_unit / vel_unit
 
+        # Note that energy is actually energy per unit mass
+        if "energy" in unit_base:
+            energy_unit = unit_base["energy"]
+        else:
+            # Sane default
+            energy_unit = (1, "(km/s)**2")
+        energy_unit = _fix_unit_ordering(energy_unit)
+        self.energy_unit = self.quan(energy_unit[0], energy_unit[1])
+
     @staticmethod
     def _validate_header(filename):
         '''

--- a/yt/frontends/gizmo/fields.py
+++ b/yt/frontends/gizmo/fields.py
@@ -37,7 +37,7 @@ class GizmoFieldInfo(GadgetFieldInfo):
         ("Velocity", ("code_velocity", ["particle_velocity"], None)),
         ("Velocities", ("code_velocity", ["particle_velocity"], None)),
         ("ParticleIDs", ("", ["particle_index"], None)),
-        ("InternalEnergy", ("code_velocity ** 2", ["thermal_energy"], None)),
+        ("InternalEnergy", ("code_energy", ["thermal_energy"], None)),
         ("SmoothingLength", ("code_length", ["smoothing_length"], None)),
         ("Density", ("code_mass / code_length**3", ["density"], None)),
         ("MaximumTemperature", ("K", [], None)),

--- a/yt/frontends/gizmo/fields.py
+++ b/yt/frontends/gizmo/fields.py
@@ -37,7 +37,7 @@ class GizmoFieldInfo(GadgetFieldInfo):
         ("Velocity", ("code_velocity", ["particle_velocity"], None)),
         ("Velocities", ("code_velocity", ["particle_velocity"], None)),
         ("ParticleIDs", ("", ["particle_index"], None)),
-        ("InternalEnergy", ("code_energy", ["thermal_energy"], None)),
+        ("InternalEnergy", ("code_specific_energy", ["thermal_energy"], None)),
         ("SmoothingLength", ("code_length", ["smoothing_length"], None)),
         ("Density", ("code_mass / code_length**3", ["density"], None)),
         ("MaximumTemperature", ("K", [], None)),

--- a/yt/frontends/sph/fields.py
+++ b/yt/frontends/sph/fields.py
@@ -30,7 +30,7 @@ class SPHFieldInfo(FieldInfoContainer):
         ("Velocity", ("code_velocity", ["particle_velocity"], None)),
         ("Velocities", ("code_velocity", ["particle_velocity"], None)),
         ("ParticleIDs", ("", ["particle_index"], None)),
-        ("InternalEnergy", ("code_energy", ["thermal_energy"], None)),
+        ("InternalEnergy", ("code_specific_energy", ["thermal_energy"], None)),
         ("SmoothingLength", ("code_length", ["smoothing_length"], None)),
         ("Density", ("code_mass / code_length**3", ["density"], None)),
         ("MaximumTemperature", ("K", [], None)),

--- a/yt/frontends/sph/fields.py
+++ b/yt/frontends/sph/fields.py
@@ -30,7 +30,7 @@ class SPHFieldInfo(FieldInfoContainer):
         ("Velocity", ("code_velocity", ["particle_velocity"], None)),
         ("Velocities", ("code_velocity", ["particle_velocity"], None)),
         ("ParticleIDs", ("", ["particle_index"], None)),
-        ("InternalEnergy", ("code_velocity ** 2", ["thermal_energy"], None)),
+        ("InternalEnergy", ("code_energy", ["thermal_energy"], None)),
         ("SmoothingLength", ("code_length", ["smoothing_length"], None)),
         ("Density", ("code_mass / code_length**3", ["density"], None)),
         ("MaximumTemperature", ("K", [], None)),


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

This PR fixes #1610. As @ngoldbaum and @jzuhone suggested, a new unit `code_specific_energy` is registered and set to a sane default value as the unit for Gadget and Gizmo's internal energy field. There is a side effect that the unit change would propagate into other frontends inherited from `SPHDataset`. The relevant frontends' authors are notified to check if this is the desired behavior.

## Related Issues and PRs

- #971 
- [Bitbucket PR 1392](https://bitbucket.org/yt_analysis/yt/pull-requests/1392)

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes flake8 checker
- [x] Notify relevant frontends' authors
- [x] Confirm relevant frontends are fine
  - [x] GADGET
    - [x] EAGLE
    - [x] GIZMO
    - [x] OWLS
- [x] Update answer tests' answers

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
