### PR TITLE
fix broken links in documentation

### DIFF
--- a/doc/source/cookbook/fits_radio_cubes.ipynb
+++ b/doc/source/cookbook/fits_radio_cubes.ipynb
@@ -402,7 +402,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally, we can also take an existing [ds9](http://ds9.si.edu/site/Home.html) region and use it to create a \"cut region\" as well, using `ds9_region` (the [pyregion](http://leejjoon.github.io/pyregion/) package needs to be installed for this):"
+    "Finally, we can also take an existing [ds9](http://ds9.si.edu/site/Home.html) region and use it to create a \"cut region\" as well, using `ds9_region` (the [pyregion](https://pyregion.readthedocs.io/) package needs to be installed for this):"
    ]
   },
   {

--- a/doc/source/cookbook/fits_xray_images.ipynb
+++ b/doc/source/cookbook/fits_xray_images.ipynb
@@ -213,7 +213,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally, we can also take an existing [ds9](http://ds9.si.edu/site/Home.html) region and use it to create a \"cut region\", using `ds9_region` (the [pyregion](http://leejjoon.github.io/pyregion/) package needs to be installed for this):"
+    "Finally, we can also take an existing [ds9](http://ds9.si.edu/site/Home.html) region and use it to create a \"cut region\", using `ds9_region` (the [pyregion](https://pyregion.readthedocs.io) package needs to be installed for this):"
    ]
   },
   {

--- a/doc/source/help/index.rst
+++ b/doc/source/help/index.rst
@@ -225,7 +225,7 @@ Submit a bug report
 If you have gone through all of the above steps, and you're still encountering
 problems, then you have found a bug.  To submit a bug report, you can either
 directly create one through the GitHub `web interface
-<http://github.org/yt-project/yt/issues/new>`_.  Alternatively, email the
+<https://github.com/yt-project/yt/issues/new>`_.  Alternatively, email the
 ``yt-users`` mailing list and we will construct a new ticket in your stead.
 Remember to include the information about your problem you identified in
 :ref:`this step <isolate_and_document>`.


### PR DESCRIPTION
mfw i saw "github.org":

https://www.youtube.com/watch?v=cdEQmpVIE4A