### PR TITLE
RAMSES new particles

### DIFF
--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -2038,22 +2038,6 @@ Note: for backward compatibility, particles from the
 default (including dark matter, stars, tracer particles, …). Sink
 particles have the particle type ``sink``.
 
-Particle automatic filtering
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-If your RAMSES version is more recent than `stable_17_09`, it is
-possible to tell yt to filter the particles in your dataset. This is
-not done by default is it requires to read all the particles and may
-be small. To use this feature, run
-
-.. code-block:: python
-
-   ds = yt.load('ramses_new_format/output_00011/info_00011.txt')
-
-   # This will load the particle types automatically
-   ds.add_ptypes()
-
-
 Adding custom particle fields
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -2015,8 +2015,8 @@ particle fields by supplying the ``extra_particle_fields``:
    # ('all', 'family') and ('all', 'info') now in ds.field_list
 
 yt also support the new way particles are handled introduced after
-version `stable_17_09` (the version introduced after the 2017 Ramses
-User Meeting). In this case, the file `part_file_descriptor.txt`
+version ``stable_17_091` (the version introduced after the 2017 Ramses
+User Meeting). In this case, the file ``part_file_descriptor.txt``
 containing the different fields in the particle files will be read. If
 you use a custom version of RAMSES, make sure this file is up-to-date
 and reflects the true layout of the particles.
@@ -2048,7 +2048,7 @@ the field as well as its data type to the assoc list, following the
 convention from
 `python struct module <https://docs.python.org/3.5/library/struct.html#format-characters>`_.
 For example, to add support for a longint field named
-`my_custom_field`, one would add `('my_custom_field', 'l')` to `assoc`.
+``my_custom_field``, one would add ``('my_custom_field', 'l')`` to ``assoc``.
 
 
 .. _loading-sph-data:

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -2015,7 +2015,7 @@ particle fields by supplying the ``extra_particle_fields``:
    # ('all', 'family') and ('all', 'info') now in ds.field_list
 
 yt also support the new way particles are handled introduced after
-version ``stable_17_091` (the version introduced after the 2017 Ramses
+version ``stable_17_091`` (the version introduced after the 2017 Ramses
 User Meeting). In this case, the file ``part_file_descriptor.txt``
 containing the different fields in the particle files will be read. If
 you use a custom version of RAMSES, make sure this file is up-to-date

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -2038,7 +2038,8 @@ Note: for backward compatibility, particles from the
 default (including dark matter, stars, tracer particles, …). Sink
 particles have the particle type ``sink``.
 
-.. rubric:: Particle automatic filtering
+Particle automatic filtering
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If your RAMSES version is more recent than `stable_17_09`, it is
 possible to tell yt to filter the particles in your dataset. This is
@@ -2051,6 +2052,19 @@ be small. To use this feature, run
 
    # This will load the particle types automatically
    ds.add_ptypes()
+
+
+Adding custom particle fields
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+It is possible to add support for particle fields. For this, one
+should tweak
+:func:`~yt.frontends.ramses.io._read_part_file_descriptor` to include
+the field as well as its data type to the assoc list, following the
+convention from
+`python struct module <https://docs.python.org/3.5/library/struct.html#format-characters>`_.
+For example, to add support for a longint field named
+`my_custom_field`, one would add `('my_custom_field', 'l')` to `assoc`.
 
 
 .. _loading-sph-data:

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -318,7 +318,7 @@ would have a ``job_info`` file in the plotfile directory.
 * yt does not read the Maestro base state (although you can have Maestro
   map it to a full Cartesian state variable before writing the plotfile
   to get around this).  E-mail the dev list if you need this support.
-* yt supports AMReX/BoxLib particle data stored in the standard format used 
+* yt supports AMReX/BoxLib particle data stored in the standard format used
   by Nyx and WarpX, and optionally Castro. It currently does not support the ASCII particle
   data used by Maestro and Castro.
 * For Maestro, yt aliases either "tfromp" or "tfromh to" ``temperature``
@@ -331,7 +331,7 @@ Viewing raw fields in WarpX
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Most AMReX/BoxLib codes output cell-centered data. If the underlying discretization
-is not cell-centered, then fields are typically averaged to cell centers before 
+is not cell-centered, then fields are typically averaged to cell centers before
 they are written to plot files for visualization. WarpX, however, has the option
 to output the raw (i.e., not averaged to cell centers) data as well.  If you
 run your WarpX simulation with ``warpx.plot_raw_fields = 1`` in your inputs
@@ -348,10 +348,10 @@ defined, with the "raw" field type:
 The raw fields in WarpX are nodal in at least one direction. We define a field
 to be "nodal" in a given direction if the field data is defined at the "low"
 and "high" sides of the cell in that direction, rather than at the cell center.
-Instead of returning one field value per cell selected, nodal fields return a 
+Instead of returning one field value per cell selected, nodal fields return a
 number of values, depending on their centering. This centering is marked by
 a `nodal_flag` that describes whether the fields is nodal in each dimension.
-``nodal_flag = [0, 0, 0]`` means that the field is cell-centered, while 
+``nodal_flag = [0, 0, 0]`` means that the field is cell-centered, while
 ``nodal_flag = [0, 0, 1]`` means that the field is nodal in the z direction
 and cell centered in the others, i.e. it is defined on the z faces of each cell.
 ``nodal_flag = [1, 1, 0]`` would mean that the field is centered in the z direction,
@@ -371,7 +371,7 @@ to the z direction.
 
 Here, the field ``('raw', 'Ex')`` is nodal in two directions, so four values per cell
 are returned, corresponding to the four edges in each cell on which the variable
-is defined. ``('raw', 'Bx')`` is nodal in one direction, so two values are returned 
+is defined. ``('raw', 'Bx')`` is nodal in one direction, so two values are returned
 per cell. The standard, averaged-to-cell-centers fields are still available.
 
 Currently, slices and data selection are implemented for nodal fields. Projections,
@@ -684,7 +684,7 @@ can read FITS image files that have the following (case-insensitive) suffixes:
 * fits.gz
 * fts.gz
 
-yt can currently read two kinds of FITS files: FITS image files and FITS 
+yt can currently read two kinds of FITS files: FITS image files and FITS
 binary table files containing positions, times, and energies of X-ray events.
 
 Though a FITS image is composed of a single array in the FITS file,
@@ -760,14 +760,14 @@ the following dataset types:
 If your data is of the first case, yt will determine the length units based
 on the information in the header. If your data is of the second or third
 cases, no length units will be assigned, but the world coordinate information
-about the axes will be stored in separate fields. If your data is of the 
-fourth type, the coordinates of the first three axes will be determined 
+about the axes will be stored in separate fields. If your data is of the
+fourth type, the coordinates of the first three axes will be determined
 according to cases 1-3.
 
 .. note::
 
-  Linear length-based coordinates (Case 1 above) are only supported if all 
-  dimensions have the same value for ``CUNITx``. WCS coordinates are only 
+  Linear length-based coordinates (Case 1 above) are only supported if all
+  dimensions have the same value for ``CUNITx``. WCS coordinates are only
   supported for Cases 2-4.
 
 FITS Data Decomposition
@@ -791,8 +791,8 @@ upon being loaded into yt it is automatically decomposed into grids:
              512	  981940800
 
 For 3D spectral-cube data, the decomposition into grids will be done along the
-spectral axis since this will speed up many common operations for this 
-particular type of dataset. 
+spectral axis since this will speed up many common operations for this
+particular type of dataset.
 
 yt will generate its own domain decomposition, but the number of grids can be
 set manually by passing the ``nprocs`` parameter to the ``load`` call:
@@ -830,10 +830,10 @@ based on the corresponding ``CTYPEx`` keywords. When queried, these fields
 will be generated from the pixel coordinates in the file using the WCS
 transformations provided by AstroPy.
 
-X-ray event data will be loaded as particle fields in yt, but a grid will be 
-constructed from the WCS information in the FITS header. There is a helper 
-function, ``setup_counts_fields``, which may be used to make deposited image 
-fields from the event data for different energy bands (for an example see 
+X-ray event data will be loaded as particle fields in yt, but a grid will be
+constructed from the WCS information in the FITS header. There is a helper
+function, ``setup_counts_fields``, which may be used to make deposited image
+fields from the event data for different energy bands (for an example see
 :ref:`xray_fits`).
 
 .. note::
@@ -848,7 +848,7 @@ fields from the event data for different energy bands (for an example see
 Additional Options
 ^^^^^^^^^^^^^^^^^^
 
-The following are additional options that may be passed to the ``load`` command 
+The following are additional options that may be passed to the ``load`` command
 when analyzing FITS data:
 
 ``nan_mask``
@@ -888,9 +888,9 @@ plane.
 Miscellaneous Tools for Use with FITS Data
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A number of tools have been prepared for use with FITS data that enhance yt's 
-visualization and analysis capabilities for this particular type of data. These 
-are included in the ``yt.frontends.fits.misc`` module, and can be imported like 
+A number of tools have been prepared for use with FITS data that enhance yt's
+visualization and analysis capabilities for this particular type of data. These
+are included in the ``yt.frontends.fits.misc`` module, and can be imported like
 so:
 
 .. code-block:: python
@@ -900,7 +900,7 @@ so:
 ``setup_counts_fields``
 """""""""""""""""""""""
 
-This function can be used to create image fields from X-ray counts data in 
+This function can be used to create image fields from X-ray counts data in
 different energy bands:
 
 .. code-block:: python
@@ -914,9 +914,9 @@ and add them to the field registry for the dataset ``ds``.
 ``ds9_region``
 """"""""""""""
 
-This function takes a `ds9 <http://ds9.si.edu/site/Home.html>`_ region and 
-creates a "cut region" data container from it, that can be used to select 
-the cells in the FITS dataset that fall within the region. To use this 
+This function takes a `ds9 <http://ds9.si.edu/site/Home.html>`_ region and
+creates a "cut region" data container from it, that can be used to select
+the cells in the FITS dataset that fall within the region. To use this
 functionality, the `pyregion <https://github.com/astropy/pyregion/>`_
 package must be installed.
 
@@ -930,8 +930,8 @@ package must be installed.
 ``PlotWindowWCS``
 """""""""""""""""
 
-This class takes a on-axis ``SlicePlot`` or ``ProjectionPlot`` of FITS 
-data and adds celestial coordinates to the plot axes. To use it, a 
+This class takes a on-axis ``SlicePlot`` or ``ProjectionPlot`` of FITS
+data and adds celestial coordinates to the plot axes. To use it, a
 version of AstroPy >= 1.3 must be installed.
 
 .. code-block:: python
@@ -940,7 +940,7 @@ version of AstroPy >= 1.3 must be installed.
   wcs_slc.show() # for the IPython notebook
   wcs_slc.save()
 
-``WCSAxes`` is still in an experimental state, but as its functionality 
+``WCSAxes`` is still in an experimental state, but as its functionality
 improves it will be utilized more here.
 
 ``create_spectral_slabs``
@@ -948,14 +948,14 @@ improves it will be utilized more here.
 
 .. note::
 
-  The following functionality requires the 
-  `spectral-cube <http://spectral-cube.readthedocs.org>`_ library to be 
+  The following functionality requires the
+  `spectral-cube <http://spectral-cube.readthedocs.org>`_ library to be
   installed.
 
 If you have a spectral intensity dataset of some sort, and would like to
-extract emission in particular slabs along the spectral axis of a certain 
-width, ``create_spectral_slabs`` can be used to generate a dataset with 
-these slabs as different fields. In this example, we use it to extract 
+extract emission in particular slabs along the spectral axis of a certain
+width, ``create_spectral_slabs`` can be used to generate a dataset with
+these slabs as different fields. In this example, we use it to extract
 individual lines from an intensity cube:
 
 .. code-block:: python
@@ -968,12 +968,12 @@ individual lines from an intensity cube:
                                     slab_centers, slab_width,
                                     nan_mask=0.0)
 
-All keyword arguments to ``create_spectral_slabs`` are passed on to ``load`` when 
-creating the dataset (see :ref:`additional_fits_options` above). In the 
-returned dataset, the different slabs will be different fields, with the field 
-names taken from the keys in ``slab_centers``. The WCS coordinates on the 
-spectral axis are reset so that the center of the domain along this axis is 
-zero, and the left and right edges of the domain along this axis are 
+All keyword arguments to ``create_spectral_slabs`` are passed on to ``load`` when
+creating the dataset (see :ref:`additional_fits_options` above). In the
+returned dataset, the different slabs will be different fields, with the field
+names taken from the keys in ``slab_centers``. The WCS coordinates on the
+spectral axis are reset so that the center of the domain along this axis is
+zero, and the left and right edges of the domain along this axis are
 :math:`\pm` ``0.5*slab_width``.
 
 Examples of Using FITS Data
@@ -991,10 +991,10 @@ FLASH Data
 ----------
 
 FLASH HDF5 data is *mostly* supported and cared for by John ZuHone.  To load a
-FLASH dataset, you can use the ``yt.load`` command and provide it the file name of 
+FLASH dataset, you can use the ``yt.load`` command and provide it the file name of
 a plot file, checkpoint file, or particle file. Particle files require special handling
-depending on the situation, the main issue being that they typically lack grid information. 
-The first case is when you have a plotfile and a particle file that you would like to 
+depending on the situation, the main issue being that they typically lack grid information.
+The first case is when you have a plotfile and a particle file that you would like to
 load together. In the simplest case, this occurs automatically. For instance, if you
 were in a directory with the following files:
 
@@ -1003,8 +1003,8 @@ were in a directory with the following files:
    radio_halo_1kpc_hdf5_plt_cnt_0100 # plotfile
    radio_halo_1kpc_hdf5_part_0100 # particle file
 
-where the plotfile and the particle file were created at the same time (therefore having 
-particle data consistent with the grid structure of the former). Notice also that the 
+where the plotfile and the particle file were created at the same time (therefore having
+particle data consistent with the grid structure of the former). Notice also that the
 prefix ``"radio_halo_1kpc_"`` and the file number ``100`` are the same. In this special case,
 the particle file will be loaded automatically when ``yt.load`` is called on the plotfile.
 This also works when loading a number of files in a time series.
@@ -1018,10 +1018,10 @@ grid structure and are at the same simulation time, the particle data may be loa
     import yt
     ds = yt.load("radio_halo_1kpc_hdf5_plt_cnt_0100", particle_filename="radio_halo_1kpc_hdf5_part_0100")
 
-However, if you don't have a corresponding plotfile for a particle file, but would still 
-like to load the particle data, you can still call ``yt.load`` on the file. However, the 
+However, if you don't have a corresponding plotfile for a particle file, but would still
+like to load the particle data, you can still call ``yt.load`` on the file. However, the
 grid information will not be available, and the particle data will be loaded in a fashion
-similar to SPH data. 
+similar to SPH data.
 
 .. rubric:: Caveats
 
@@ -1349,7 +1349,7 @@ resolution.
    yt only supports a block structure where the grid edges on the ``n``-th
    refinement level are aligned with the cell edges on the ``n-1``-th level.
 
-Particle fields are supported by adding 1-dimensional arrays to each 
+Particle fields are supported by adding 1-dimensional arrays to each
 ``grid``'s dict:
 
 .. code-block:: python
@@ -1394,7 +1394,7 @@ density field in cubic domain of 3 Mpc edge size (3 * 3.08e24 cm) and
 simultaneously divide the domain into 12 chunks, so that you can take advantage
 of the underlying parallelism.
 
-Particle fields are added as one-dimensional arrays in a similar manner as the 
+Particle fields are added as one-dimensional arrays in a similar manner as the
 three-dimensional grid fields:
 
 .. code-block:: python
@@ -1562,7 +1562,7 @@ To load multiple meshes, you can do:
 
    # only plot the second
    sl = yt.SlicePlot(ds, 'z', ('connect2', 'test'))
-   
+
    # plot both
    sl = yt.SlicePlot(ds, 'z', ('all', 'test'))
 
@@ -1631,10 +1631,10 @@ The ``load_particles`` function also accepts the following keyword parameters:
 Gizmo Data
 ----------
 
-Gizmo datasets, including FIRE outputs, can be loaded into yt in the usual 
-manner.  Like other SPH data formats, yt loads Gizmo data as particle fields 
-and then uses smoothing kernels to deposit those fields to an underlying 
-grid structure as spatial fields as described in :ref:`loading-gadget-data`.  
+Gizmo datasets, including FIRE outputs, can be loaded into yt in the usual
+manner.  Like other SPH data formats, yt loads Gizmo data as particle fields
+and then uses smoothing kernels to deposit those fields to an underlying
+grid structure as spatial fields as described in :ref:`loading-gadget-data`.
 To load Gizmo datasets using the standard HDF5 output format::
 
    import yt
@@ -1642,11 +1642,11 @@ To load Gizmo datasets using the standard HDF5 output format::
 
 Because the Gizmo output format is similar to the Gadget format, yt
 may load Gizmo datasets as Gadget depending on the circumstances, but this
-should not pose a problem in most situations.  FIRE outputs will be loaded 
-accordingly due to the number of metallicity fields found (11 or 17).  
+should not pose a problem in most situations.  FIRE outputs will be loaded
+accordingly due to the number of metallicity fields found (11 or 17).
 
 For Gizmo outputs written as raw binary outputs, you may have to specify
-a bounding box, field specification, and units as are done for standard 
+a bounding box, field specification, and units as are done for standard
 Gadget outputs.  See :ref:`loading-gadget-data` for more information.
 
 .. _halo-catalog-data:
@@ -2001,7 +2001,8 @@ You would feed it the filename ``output_00007/info_00007.txt``:
    import yt
    ds = yt.load("output_00007/info_00007.txt")
 
-yt will attempt to guess the fields in the file.  You may also specify
+
+yt will attempt to guess the fields in the file. You may also specify
 a list of hydro fields by supplying the ``fields`` keyword in your
 call to ``load``. It is also possible to provide a list of *extra*
 particle fields by supplying the ``extra_particle_fields``:
@@ -2012,6 +2013,13 @@ particle fields by supplying the ``extra_particle_fields``:
    extra_fields = [('family', 'I'), ('info', 'I')]
    ds = yt.load("output_00001/info_00001.txt", extra_particle_fields=extra_fields)
    # ('all', 'family') and ('all', 'info') now in ds.field_list
+
+yt also support the new way particles are handled introduced after
+version `stable_17_09` (the version introduced after the 2017 Ramses
+User Meeting). In this case, the file `part_file_descriptor.txt`
+containing the different fields in the particle files will be read. If
+you use a custom version of RAMSES, make sure this file is up-to-date
+and reflects the true layout of the particles.
 
 yt supports outputs made by the mainline ``RAMSES`` code as well as the
 ``RAMSES-RT`` fork. Files produces by ``RAMSES-RT`` are recognized as such
@@ -2029,6 +2037,21 @@ Note: for backward compatibility, particles from the
 ``particle_XXXXX.outYYYYY`` files have the particle type ``io`` by
 default (including dark matter, stars, tracer particles, …). Sink
 particles have the particle type ``sink``.
+
+.. rubric:: Particle automatic filtering
+
+If your RAMSES version is more recent than `stable_17_09`, it is
+possible to tell yt to filter the particles in your dataset. This is
+not done by default is it requires to read all the particles and may
+be small. To use this feature, run
+
+.. code-block:: python
+
+   ds = yt.load('ramses_new_format/output_00011/info_00011.txt')
+
+   # This will load the particle types automatically
+   ds.add_ptypes()
+
 
 .. _loading-sph-data:
 
@@ -2113,6 +2136,3 @@ non-default cosmological parameters, you may pass an empty dictionary.
 
     import yt
     ds = yt.load(filename, cosmology_parameters={})
-
-
-

--- a/yt/data_objects/particle_filters.py
+++ b/yt/data_objects/particle_filters.py
@@ -22,6 +22,7 @@ from contextlib import contextmanager
 from yt.fields.field_info_container import \
     NullFunc, TranslationFunc
 from yt.utilities.exceptions import YTIllDefinedFilter
+from yt.funcs import mylog
 
 # One to many mapping
 filter_registry = defaultdict(None)
@@ -131,6 +132,8 @@ def add_particle_filter(name, function, requires=None, filtered_type="all"):
     if requires is None:
         requires = []
     filter = ParticleFilter(name, function, requires, filtered_type)
+    if filter_registry[name] is not None:
+        mylog.warning('The %s particle filter already exists. Overriding.' % name)
     filter_registry[name] = filter
 
 

--- a/yt/data_objects/particle_filters.py
+++ b/yt/data_objects/particle_filters.py
@@ -24,7 +24,7 @@ from yt.fields.field_info_container import \
 from yt.utilities.exceptions import YTIllDefinedFilter
 
 # One to many mapping
-filter_registry = defaultdict(list)
+filter_registry = defaultdict(None)
 
 class DummyFieldInfo(object):
     particle_type = True
@@ -131,7 +131,7 @@ def add_particle_filter(name, function, requires=None, filtered_type="all"):
     if requires is None:
         requires = []
     filter = ParticleFilter(name, function, requires, filtered_type)
-    filter_registry[name].append(filter)
+    filter_registry[name] = filter
 
 
 def particle_filter(name=None, requires=None, filtered_type='all'):

--- a/yt/data_objects/particle_filters.py
+++ b/yt/data_objects/particle_filters.py
@@ -15,7 +15,6 @@ This is a library for defining and using particle filters.
 #-----------------------------------------------------------------------------
 
 import copy
-from collections import defaultdict
 
 from contextlib import contextmanager
 
@@ -24,8 +23,8 @@ from yt.fields.field_info_container import \
 from yt.utilities.exceptions import YTIllDefinedFilter
 from yt.funcs import mylog
 
-# One to many mapping
-filter_registry = defaultdict(None)
+# One to one mapping
+filter_registry = {}
 
 class DummyFieldInfo(object):
     particle_type = True
@@ -132,7 +131,7 @@ def add_particle_filter(name, function, requires=None, filtered_type="all"):
     if requires is None:
         requires = []
     filter = ParticleFilter(name, function, requires, filtered_type)
-    if filter_registry[name] is not None:
+    if filter_registry.get(name, None) is not None:
         mylog.warning('The %s particle filter already exists. Overriding.' % name)
     filter_registry[name] = filter
 

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -663,11 +663,10 @@ class Dataset(object):
         self.known_filters[n] = None
         if isinstance(filter, string_types):
             used = False
-            for f in filter_registry[filter]:
-                used = self._setup_filtered_type(f)
-                if used:
-                    filter = f
-                    break
+            f = filter_registry[filter]
+            used = self._setup_filtered_type(f)
+            if used:
+                filter = f
         else:
             used = self._setup_filtered_type(filter)
         if not used:

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -663,7 +663,9 @@ class Dataset(object):
         self.known_filters[n] = None
         if isinstance(filter, string_types):
             used = False
-            f = filter_registry[filter]
+            f = filter_registry.get(filter, None)
+            if f is None:
+                return False
             used = self._setup_filtered_type(f)
             if used:
                 filter = f

--- a/yt/data_objects/tests/test_particle_filter.py
+++ b/yt/data_objects/tests/test_particle_filter.py
@@ -48,7 +48,6 @@ def test_add_particle_filter_overriding():
     # Use a closure to store whether the warning was called
     def closure(status):
         def warning_patch(*args, **kwargs):
-            print('I am called!')
             status[0] = True
 
         def was_called():
@@ -106,7 +105,7 @@ def test_covering_grid_particle_filter():
 
     for grid in ds.index.grids[20:31]:
         cg = ds.covering_grid(grid.Level, grid.LeftEdge, grid.ActiveDimensions)
-        
+
         assert_equal(cg['stars', 'particle_ones'].shape[0],
                      grid['stars', 'particle_ones'].shape[0])
         assert_equal(cg['stars', 'particle_mass'].shape[0],

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -698,7 +698,12 @@ class RAMSESDataset(Dataset):
                                 filtered_type='io', requires=['particle_family'])
 
 
-    def add_ptypes(self):
+    def create_field_info(self, *args, **kwa):
+        """Extend create_field_info to add the particles types."""
+        Dataset.create_field_info(self, *args, **kwa)
+        self._add_ptypes()
+
+    def _add_ptypes(self):
         for k in particle_families.keys():
             mylog.info('Adding particle_type: %s' % k)
             self.add_particle_filter('%s' % k)

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -687,15 +687,16 @@ class RAMSESDataset(Dataset):
         self.storage_filename = storage_filename
 
         # Add particles filters
-        for fname, value in particle_families.items():
-            def loc(val):
-                def closure(pfilter, data):
-                    filter = data[(pfilter.filtered_type, "particle_family")] == val
-                    return filter
+        if ('io', 'particle_family') in self.field_list:
+            for fname, value in particle_families.items():
+                def loc(val):
+                    def closure(pfilter, data):
+                        filter = data[(pfilter.filtered_type, "particle_family")] == val
+                        return filter
 
-                return closure
-            add_particle_filter(fname, loc(value),
-                                filtered_type='io', requires=['particle_family'])
+                    return closure
+                add_particle_filter(fname, loc(value),
+                                    filtered_type='io', requires=['particle_family'])
 
 
     def create_field_info(self, *args, **kwa):
@@ -704,9 +705,10 @@ class RAMSESDataset(Dataset):
         self._add_ptypes()
 
     def _add_ptypes(self):
-        for k in particle_families.keys():
-            mylog.info('Adding particle_type: %s' % k)
-            self.add_particle_filter('%s' % k)
+        if ('io', 'particle_family') in self.field_list:
+            for k in particle_families.keys():
+                mylog.info('Adding particle_type: %s' % k)
+                self.add_particle_filter('%s' % k)
 
     def __repr__(self):
         return self.basename.rsplit(".", 1)[0]

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -686,7 +686,11 @@ class RAMSESDataset(Dataset):
 
         self.storage_filename = storage_filename
 
-        # Add particles filters
+
+    def create_field_info(self, *args, **kwa):
+        """Extend create_field_info to add the particles types."""
+        super(RAMSESDataset, self).create_field_info(*args, **kwa)
+        # Register particle filters
         if ('io', 'particle_family') in self.field_list:
             for fname, value in particle_families.items():
                 def loc(val):
@@ -698,14 +702,6 @@ class RAMSESDataset(Dataset):
                 add_particle_filter(fname, loc(value),
                                     filtered_type='io', requires=['particle_family'])
 
-
-    def create_field_info(self, *args, **kwa):
-        """Extend create_field_info to add the particles types."""
-        Dataset.create_field_info(self, *args, **kwa)
-        self._add_ptypes()
-
-    def _add_ptypes(self):
-        if ('io', 'particle_family') in self.field_list:
             for k in particle_families.keys():
                 mylog.info('Adding particle_type: %s' % k)
                 self.add_particle_filter('%s' % k)

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -246,8 +246,7 @@ class RAMSESDomainFile(object):
         self.local_particle_count = hvals['npart']
 
         # Try reading particle file descriptor
-        if self._has_part_descriptor and \
-           self.ds._extra_particle_fields is None:
+        if self._has_part_descriptor:
             particle_fields = (
                 _read_part_file_descriptor(self._part_file_descriptor))
             ptype = 'io'

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -34,7 +34,7 @@ from yt.data_objects.static_output import \
     Dataset
 from yt.data_objects.octree_subset import \
     OctreeSubset
-from yt import add_particle_filter
+from yt.data_objects.particle_filters import add_particle_filter
 
 from .definitions import ramses_header, field_aliases, particle_families
 from .io import _read_part_file_descriptor

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -249,7 +249,6 @@ class RAMSESDomainFile(object):
         if self._has_part_descriptor:
             particle_fields = (
                 _read_part_file_descriptor(self._part_file_descriptor))
-            ptype = 'io'
         else:
             particle_fields = [
                 ("particle_position_x", "d"),
@@ -265,8 +264,7 @@ class RAMSESDomainFile(object):
             if self.ds._extra_particle_fields is not None:
                 particle_fields += self.ds._extra_particle_fields
 
-            ptype = 'io'
-
+        ptype = 'io'
 
         field_offsets = {}
         _pfields = {}

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -35,7 +35,7 @@ from yt.data_objects.static_output import \
 from yt.data_objects.octree_subset import \
     OctreeSubset
 
-from .definitions import ramses_header, field_aliases
+from .definitions import ramses_header, field_aliases, particle_families
 from .io import _read_part_file_descriptor
 from yt.utilities.physical_constants import mp, kb
 from .fields import \
@@ -240,7 +240,9 @@ class RAMSESDomainFile(object):
         # Try reading particle file descriptor
         if os.path.exists(self._part_file_descriptor) and \
            self.ds._extra_particle_fields is None:
-            particle_fields = _read_part_file_descriptor(self._part_file_descriptor)
+            particle_fields = (
+                _read_part_file_descriptor(self._part_file_descriptor))
+            ptype = 'io'
         else:
             particle_fields = [
                 ("particle_position_x", "d"),
@@ -256,10 +258,12 @@ class RAMSESDomainFile(object):
             if self.ds._extra_particle_fields is not None:
                 particle_fields += self.ds._extra_particle_fields
 
+            ptype = 'io'
+
+
         field_offsets = {}
         _pfields = {}
 
-        ptype = 'io'
 
         # Read offsets
         for field, vtype in particle_fields:

--- a/yt/frontends/ramses/definitions.py
+++ b/yt/frontends/ramses/definitions.py
@@ -63,12 +63,12 @@ field_aliases = {
 }
 
 particle_families = {
-    1: 'DM',
-    2: 'star',
-    3: 'cloud',
-    4: 'dust',
-    -2: 'star_tracer',
-    -3: 'cloud_tracer',
-    -4: 'dust_tracer',
-    0: 'gas_tracer',
+    'DM': 1,
+    'star': 2,
+    'cloud': 3,
+    'dust': 4,
+    'star_tracer': -2,
+    'cloud_tracer': -3,
+    'dust_tracer': -4,
+    'gas_tracer': 0
 }

--- a/yt/frontends/ramses/definitions.py
+++ b/yt/frontends/ramses/definitions.py
@@ -61,3 +61,14 @@ field_aliases = {
                           'Metallicity'),
 
 }
+
+particle_families = {
+    1: 'DM',
+    2: 'star',
+    3: 'cloud',
+    4: 'dust',
+    -2: 'star_tracer',
+    -3: 'cloud_tracer',
+    -4: 'dust_tracer',
+    0: 'gas_tracer',
+}

--- a/yt/frontends/ramses/fields.py
+++ b/yt/frontends/ramses/fields.py
@@ -88,6 +88,7 @@ class RAMSESFieldInfo(FieldInfoContainer):
         ("particle_identifier", ("", ["particle_index"], None)),
         ("particle_refinement_level", ("", [], None)),
         ("particle_age", ("code_time", ['age'], None)),
+        ("particle_birth_time", ("code_time", ['age'], None)),
         ("particle_metallicity", ("", [], None)),
     )
 

--- a/yt/frontends/ramses/fields.py
+++ b/yt/frontends/ramses/fields.py
@@ -64,6 +64,20 @@ _cool_species = ("Electron_number_density",
 _X = 0.76 # H fraction, hardcoded
 _Y = 0.24 # He fraction, hardcoded
 
+
+# Association between particles types and families, hardcoded
+_families = {
+    1: 'DM',
+    2: 'star',
+    3: 'cloud',
+    4: 'dust',
+    -2: 'star_tracer',
+    -3: 'cloud_tracer',
+    -4: 'dust_tracer',
+    0: 'gas_tracer',
+}
+
+
 class RAMSESFieldInfo(FieldInfoContainer):
     known_other_fields = (
         ("Density", (rho_units, ["density"], None)),
@@ -90,6 +104,8 @@ class RAMSESFieldInfo(FieldInfoContainer):
         ("particle_age", ("code_time", ['age'], None)),
         ("particle_birth_time", ("code_time", ['age'], None)),
         ("particle_metallicity", ("", [], None)),
+        ("particle_family", ("", [], None)),
+        ("particle_tag", ("", [], None))
     )
 
     known_sink_fields = (

--- a/yt/frontends/ramses/fields.py
+++ b/yt/frontends/ramses/fields.py
@@ -17,7 +17,6 @@ import glob
 import os
 import numpy as np
 
-import yt
 from yt.utilities.physical_constants import \
     boltzmann_constant_cgs, \
     mass_hydrogen_cgs, \
@@ -27,7 +26,6 @@ from yt.utilities.linear_interpolators import \
 import yt.utilities.fortran_utils as fpu
 from yt.fields.field_info_container import \
     FieldInfoContainer
-from .definitions import particle_families
 
 b_units = "code_magnetic"
 ra_units = "code_length / code_time**2"

--- a/yt/frontends/ramses/fields.py
+++ b/yt/frontends/ramses/fields.py
@@ -17,6 +17,7 @@ import glob
 import os
 import numpy as np
 
+import yt
 from yt.utilities.physical_constants import \
     boltzmann_constant_cgs, \
     mass_hydrogen_cgs, \
@@ -26,6 +27,7 @@ from yt.utilities.linear_interpolators import \
 import yt.utilities.fortran_utils as fpu
 from yt.fields.field_info_container import \
     FieldInfoContainer
+from .definitions import particle_families
 
 b_units = "code_magnetic"
 ra_units = "code_length / code_time**2"
@@ -63,19 +65,6 @@ _cool_species = ("Electron_number_density",
 
 _X = 0.76 # H fraction, hardcoded
 _Y = 0.24 # He fraction, hardcoded
-
-
-# Association between particles types and families, hardcoded
-_families = {
-    1: 'DM',
-    2: 'star',
-    3: 'cloud',
-    4: 'dust',
-    -2: 'star_tracer',
-    -3: 'cloud_tracer',
-    -4: 'dust_tracer',
-    0: 'gas_tracer',
-}
 
 
 class RAMSESFieldInfo(FieldInfoContainer):

--- a/yt/frontends/ramses/io.py
+++ b/yt/frontends/ramses/io.py
@@ -23,6 +23,7 @@ from yt.utilities.physical_ratios import cm_per_km, cm_per_mpc
 import yt.utilities.fortran_utils as fpu
 from yt.utilities.lib.cosmology_time import \
     get_ramses_ages
+from yt.utilities.exceptions import YTFieldTypeNotFound
 from yt.extern.six import PY3
 import re
 
@@ -157,7 +158,7 @@ class IOHandlerRAMSES(BaseIOHandler):
 
             else:
                 # Raise here an exception
-                raise Exception('Unknown particle type %s' % ptype)
+                raise YTFieldTypeNotFound(ptype)
 
             tr.update(_ramses_particle_file_handler(
                 fname, foffsets, data_types, subset, subs_fields))

--- a/yt/frontends/ramses/io.py
+++ b/yt/frontends/ramses/io.py
@@ -174,7 +174,7 @@ def _read_part_file_descriptor(fname):
     assoc = [('position_%s' % k, 'd') for k in 'xyz'] + \
             [('velocity_%s' % k, 'd') for k in 'xyz'] + \
             [('mass', 'd'), ('identity', 'i'), ('levelp', 'i'),
-            ('family', 'i'), ('tag', 'i'), ('birth_time', 'd'),
+            ('family', 'b'), ('tag', 'b'), ('birth_time', 'd'),
             ('metallicity', 'd')]
 
     assoc = {k: v for k, v in assoc}
@@ -182,6 +182,7 @@ def _read_part_file_descriptor(fname):
         f = open(fname, 'r')
         line = f.readline()
         tmp = VERSION_RE.match(line)
+        mylog.info('Reading part file descriptor.')
         if not tmp:
             print(line)
             raise Exception('File format not understood')

--- a/yt/frontends/ramses/io.py
+++ b/yt/frontends/ramses/io.py
@@ -24,7 +24,7 @@ import yt.utilities.fortran_utils as fpu
 from yt.utilities.lib.cosmology_time import \
     get_ramses_ages
 from yt.utilities.exceptions import YTFieldTypeNotFound, YTParticleOutputFormatNotImplemented, \
-    YTNotParsableFile
+    YTFileNotParseable
 from yt.extern.six import PY3
 import re
 
@@ -206,7 +206,7 @@ def _read_part_file_descriptor(fname):
             for i, line in enumerate(f.readlines()):
                 tmp = VAR_DESC_RE.match(line)
                 if not tmp:
-                    raise YTNotParsableFile(fname, i+1)
+                    raise YTFileNotParseable(fname, i+1)
 
                 # ivar = tmp.group(1)
                 varname = tmp.group(2)

--- a/yt/frontends/ramses/io.py
+++ b/yt/frontends/ramses/io.py
@@ -166,12 +166,13 @@ class IOHandlerRAMSES(BaseIOHandler):
 
         return tr
 
-VERSION_RE = re.compile('# version: *(\d+)')
-VAR_DESC_RE = re.compile(r'\s*(\d+),\s*(\w+),\s*(\w+)')
 def _read_part_file_descriptor(fname):
     """
     Read the particle file descriptor and returns the array of the fields found.
     """
+    VERSION_RE = re.compile('# version: *(\d+)')
+    VAR_DESC_RE = re.compile(r'\s*(\d+),\s*(\w+),\s*(\w+)')
+
     # Mapping
     mapping = [
         ('position_x', 'particle_position_x'),

--- a/yt/frontends/ramses/io.py
+++ b/yt/frontends/ramses/io.py
@@ -23,7 +23,8 @@ from yt.utilities.physical_ratios import cm_per_km, cm_per_mpc
 import yt.utilities.fortran_utils as fpu
 from yt.utilities.lib.cosmology_time import \
     get_ramses_ages
-from yt.utilities.exceptions import YTFieldTypeNotFound
+from yt.utilities.exceptions import YTFieldTypeNotFound, YTOutputFormatNotImplemented, \
+    YTNotParsableFile
 from yt.extern.six import PY3
 import re
 
@@ -195,7 +196,7 @@ def _read_part_file_descriptor(fname):
             for i, line in enumerate(f.readlines()):
                 tmp = VAR_DESC_RE.match(line)
                 if not tmp:
-                    raise Exception('Error while reading %s at line %s' % (fname, i+1))
+                    raise YTNotParsableFile(fname, i+1)
 
                 # ivar = tmp.group(1)
                 varname = tmp.group(2)
@@ -207,6 +208,6 @@ def _read_part_file_descriptor(fname):
 
                 fields.append(("particle_%s" % varname, dtype))
         else:
-            raise Exception('Unrecognized particle file descriptor version: %s' % version)
+            raise YTOutputFormatNotImplemented()
 
     return fields

--- a/yt/frontends/ramses/io.py
+++ b/yt/frontends/ramses/io.py
@@ -190,7 +190,6 @@ def _read_part_file_descriptor(fname):
     mapping = {k: v for k, v in mapping}
 
     with open(fname, 'r') as f:
-        f = open(fname, 'r')
         line = f.readline()
         tmp = VERSION_RE.match(line)
         mylog.info('Reading part file descriptor.')

--- a/yt/frontends/ramses/io.py
+++ b/yt/frontends/ramses/io.py
@@ -189,7 +189,7 @@ def _read_part_file_descriptor(fname):
     # Convert in dictionary
     mapping = {k: v for k, v in mapping}
 
-    if True: #with open(fname, 'r') as f:
+    with open(fname, 'r') as f:
         f = open(fname, 'r')
         line = f.readline()
         tmp = VERSION_RE.match(line)

--- a/yt/frontends/ramses/io.py
+++ b/yt/frontends/ramses/io.py
@@ -174,8 +174,8 @@ def _read_part_file_descriptor(fname):
     assoc = [('position_%s' % k, 'd') for k in 'xyz'] + \
             [('velocity_%s' % k, 'd') for k in 'xyz'] + \
             [('mass', 'd'), ('identity', 'i'), ('levelp', 'i'),
-            ('family', 'b'), ('tag', 'b'), ('birth_time', 'd'),
-            ('metallicity', 'd')]
+             ('family', 'b'), ('tag', 'b'), ('birth_time', 'd'),
+             ('metallicity', 'd')]
 
     assoc = {k: v for k, v in assoc}
     if True: #with open(fname, 'r') as f:

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -206,32 +206,31 @@ def test_ramses_sink():
         assert(('sink', 'field') not in ds.field_list)
 
 
-ramses_new_format = "ramses_new_format/output_00011/info_00011.txt"
+ramses_new_format = "ramses_new_format/output_00002/info_00002.txt"
 @requires_file(ramses_new_format)
 def test_new_format():
     expected_particle_fields = [
-        ('io', 'particle_birth_time'),
-        ('io', 'particle_family'),
-        ('io', 'particle_identity'),
-        ('io', 'particle_levelp'),
-        ('io', 'particle_mass'),
-        ('io', 'particle_metallicity'),
-        ('io', 'particle_position_x'),
-        ('io', 'particle_position_y'),
-        ('io', 'particle_position_z'),
-        ('io', 'particle_tag'),
-        ('io', 'particle_velocity_x'),
-        ('io', 'particle_velocity_y'),
-        ('io', 'particle_velocity_z')]
+        ('star', 'particle_identity'),
+        ('star', 'particle_level'),
+        ('star', 'particle_mass'),
+        ('star', 'particle_metallicity'),
+        ('star', 'particle_position_x'),
+        ('star', 'particle_position_y'),
+        ('star', 'particle_position_z'),
+        ('star', 'particle_tag'),
+        ('star', 'particle_velocity_x'),
+        ('star', 'particle_velocity_y'),
+        ('star', 'particle_velocity_z')]
 
     ds = yt.load(ramses_new_format)
     ad = ds.all_data()
 
     # Check all the expected fields exist and can be accessed
     for f in expected_particle_fields:
-        assert(f in ds.field_list)
+        assert(f in ds.derived_field_list)
         ad[f]
 
     # Check there is only stars with tag 0 (it should be right)
-    assert(all(ad['particle_family'] == 2))
-    assert(all(ad['particle_tag'] == 0))
+    assert(all(ad['star', 'particle_family'] == 2))
+    assert(all(ad['star', 'particle_tag'] == 0))
+    assert(len(ad['star', 'particle_tag']) == 600)

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -204,3 +204,34 @@ def test_ramses_sink():
 
     for field in expected_fields:
         assert(('sink', 'field') not in ds.field_list)
+
+
+ramses_new_format = "ramses_new_format/output_00011/info_00011.txt"
+@requires_file(ramses_new_format)
+def test_new_format():
+    expected_particle_fields = [
+        ('io', 'particle_birth_time'),
+        ('io', 'particle_family'),
+        ('io', 'particle_identity'),
+        ('io', 'particle_levelp'),
+        ('io', 'particle_mass'),
+        ('io', 'particle_metallicity'),
+        ('io', 'particle_position_x'),
+        ('io', 'particle_position_y'),
+        ('io', 'particle_position_z'),
+        ('io', 'particle_tag'),
+        ('io', 'particle_velocity_x'),
+        ('io', 'particle_velocity_y'),
+        ('io', 'particle_velocity_z')]
+
+    ds = yt.load(ramses_new_format)
+    ad = ds.all_data()
+
+    # Check all the expected fields exist and can be accessed
+    for f in expected_particle_fields:
+        assert(f in ds.field_list)
+        ad[f]
+
+    # Check there is only stars with tag 0 (it should be right)
+    assert(all(ad['particle_family'] == 2))
+    assert(all(ad['particle_tag'] == 0))

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -424,6 +424,19 @@ class YTObjectNotImplemented(YTException):
         v += r"'%s'."
         return v % (self.obj_name, self.ds)
 
+class YTParticleOutputFormatNotImplemented(YTException):
+    def __str__(self):
+        return "The particle output format is not supported."
+
+class YTNotParsableFile(YTException):
+    def __init__(self, fname, line):
+        self.fname = fname
+        self.line = line
+
+    def __str__(self):
+        v = r"Error while parsing file %s at line %s"
+        return v % (self.fname, self.line)
+
 class YTRockstarMultiMassNotSupported(YTException):
     def __init__(self, mi, ma, ptype):
         self.mi = mi

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -428,7 +428,7 @@ class YTParticleOutputFormatNotImplemented(YTException):
     def __str__(self):
         return "The particle output format is not supported."
 
-class YTNotParsableFile(YTException):
+class YTFileNotParseable(YTException):
     def __init__(self, fname, line):
         self.fname = fname
         self.line = line


### PR DESCRIPTION
At the yearly Ramses User Meeting, it was decided to implement particle families in RAMSES. This includes a non-backward compatible change in the structure of the particle outputs, namely two 1-byte extra fields are included: a `particle_family` (the kind of the particle, e.g. stars, DM, …) and a `particle_tag` (the subtype of the particle, e.g. pop III stars, pop II stars, …).
The change is autocratically detectable because a new file `part_file_descriptor.txt` file is now outputted with the following structure:

```
# version:    X
# ivar, variable_name, variable_type
1, variable_name_1, data_type
…
n, variable_name_n, data_type
```
The nice thing is that `data_type` is directly given using the table of https://docs.python.org/3.5/library/struct.html#format-characters, so it can be used to unpack the data.

## PR Summary

This PR adds support for the automatic detection of this new format, without breaking previous versions (hence it is backward compatible). Please note however that this prevents the use of `extra_particle_fields`, any feedback of how to notify the user about this is welcome!

## PR Checklist

- [x] Code passes flake8 checker
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

An example dataset can be found here:
[ramses_new_format.tar.gz](https://github.com/yt-project/yt/files/1463763/ramses_new_format.tar.gz)


