### PR TITLE
Add non-cartesian dataset support to the GAMER frontend

### DIFF
--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -101,6 +101,8 @@ class GAMERHierarchy(GridIndex):
                 = (grid_corner[ gid0:gid0 + num_grids_level ] + patch_scale)*convert2physical
 
             gid0 += num_grids_level
+        self.grid_left_edge += self.dataset.domain_left_edge
+        self.grid_right_edge += self.dataset.domain_left_edge
 
         # allocate all grid objects
         self.grids = np.empty(self.num_grids, dtype='object')
@@ -272,8 +274,10 @@ class GAMERDataset(Dataset):
         # simulation time and domain
         self.current_time      = parameters['Time'][0]
         self.dimensionality    = 3  # always 3D
-        self.domain_left_edge  = np.array([0.,0.,0.], dtype='float64')
-        self.domain_right_edge = parameters['BoxSize'].astype('float64')
+        self.domain_left_edge  = parameters.get("BoxEdgeL",
+                np.array([0.,0.,0.])).astype("f8")
+        self.domain_right_edge  = parameters.get("BoxEdgeR",
+                parameters["BoxSize"]).astype("f8")
         self.domain_dimensions = parameters['NX0'].astype('int64')
 
         # periodicity

--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -304,6 +304,12 @@ class GAMERDataset(Dataset):
         # old data format (version < 2210) does not contain any information of code units
         self.parameters.setdefault('Opt__Unit', 0)
 
+        self.geometry = {1: "cartesian",
+                         2: ("cylindrical", ("r", "theta", "z")),
+                         3: ("spherical", ("r", "theta", "phi"))}[
+                             parameters.get("Coordinate", 1)]
+
+
     @classmethod
     def _is_valid(self, *args, **kwargs):
         try:

--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -30,6 +30,7 @@ from yt.data_objects.static_output import \
 from yt.utilities.file_handler import \
     HDF5FileHandler
 from .fields import GAMERFieldInfo
+from .definitions import geometry_parameters
 from yt.testing import assert_equal
 
 
@@ -308,11 +309,7 @@ class GAMERDataset(Dataset):
         # old data format (version < 2210) does not contain any information of code units
         self.parameters.setdefault('Opt__Unit', 0)
 
-        self.geometry = {1: "cartesian",
-                         2: ("cylindrical", ("r", "theta", "z")),
-                         3: ("spherical", ("r", "theta", "phi"))}[
-                             parameters.get("Coordinate", 1)]
-
+        self.geometry = geometry_parameters[parameters.get("Coordinate", 1)]
 
     @classmethod
     def _is_valid(self, *args, **kwargs):

--- a/yt/frontends/gamer/definitions.py
+++ b/yt/frontends/gamer/definitions.py
@@ -1,0 +1,3 @@
+geometry_parameters = {1: "cartesian",
+                       2: ("cylindrical", ("r", "theta", "z")),
+                       3: ("spherical", ("r", "theta", "phi"))}


### PR DESCRIPTION
This adds support for auto-detecting non-cartesian datasets in the GAMER frontend; note that it uses r-theta-z for cylindrical, which we make explicit here.