### PR TITLE
Automatically add particle filter dependencies if already defined

### DIFF
--- a/doc/source/analyzing/filtering.rst
+++ b/doc/source/analyzing/filtering.rst
@@ -127,6 +127,22 @@ In addition, you may specify a name for the newly defined particle type.  If no
 name is specified, the name for the particle type will be inferred from the name
 of the filter definition --- in this case the inferred name will be ``stars``.
 
+As an alternative syntax, you can also define a new particle filter via the
+:func:`~yt.data_objects.particle_filter.add_particle_filter` function.
+
+.. code-block:: python
+
+    def stars(pfilter, data):
+        filter = data[(pfilter.filtered_type, "particle_type")] == 2
+        return filter
+
+    yt.add_particle_filter("stars", function=stars, filtered_type='all',
+                        requires=["particle_type"])
+
+This is equivalent to our use of the ``particle_filter`` decorator above.  The
+choice to use either the ``particle_filter`` decorator or the
+``add_particle_filter`` function is a purely stylistic choice.
+
 Lastly, the filter must be applied to our dataset of choice.  Note that this
 filter can be added to as many datasets as we wish.  It will only actually
 create new filtered fields if the dataset has the required fields, though.
@@ -142,22 +158,34 @@ our dataset ``ds`` and treat them as any other particle field.  In addition,
 it created some ``deposit`` fields, where the particles were deposited on to
 the grid as mesh fields.
 
-As an alternative syntax, you can also define a new particle filter via the
-:func:`~yt.data_objects.particle_filter.add_particle_filter` function.
+We can create additional filters building on top of the filters we have. 
+For example, we can identify the young stars based on their age, which is
+the difference between current time and their creation_time.
 
 .. code-block:: python
 
-
-    def Stars(pfilter, data):
-        filter = data[(pfilter.filtered_type, "particle_type")] == 2
+    def young_stars(pfilter, data):
+        age = data.ds.current_time - data[pfilter.filtered_type, "creation_time"]
+        filter = np.logical_and(age.in_units('Myr') <= 5, age >= 0)
         return filter
 
-    add_particle_filter("stars", function=Stars, filtered_type='all',
-                        requires=["particle_type"])
+    yt.add_particle_filter("young_stars", function=young_stars,
+                        filtered_type='stars', requires=["creation_time"])
 
-This is equivalent to our use of the ``particle_filter`` decorator above.  The
-choice to use either the ``particle_filter`` decorator or the
-``add_particle_filter`` function is a purely stylistic choice.
+If we properly define all the filters using the decorator ``yt.particle_filter`` 
+or the function ``yt.add_particle_filter`` in advance. We can add the filter
+we need to the dataset. If the ``filtered_type`` is already defined but not
+added to the dataset, it will automatically add the filter first. For example,
+if we add the ``young_stars`` filter, which is filtered from ``stars``, 
+to the dataset, it will also add ``stars`` filter to the dataset.
+
+.. code-block:: python
+
+    import yt
+    ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
+    ds.add_particle_filter('young_stars')
+
+
 
 .. notebook:: particle_filter.ipynb
 

--- a/yt/data_objects/particle_filters.py
+++ b/yt/data_objects/particle_filters.py
@@ -87,7 +87,9 @@ def add_particle_filter(name, function, requires=None, filtered_type="all"):
     A particle filter is a short name that corresponds to an algorithm for
     filtering a set of particles into a subset.  This is useful for creating new
     particle types based on a cut on a particle field, such as particle mass, ID
-    or type.
+    or type. After defining a new filter, it still needs to be added to the
+    dataset by calling
+    :func:`~yt.data_objects.static_output.add_particle_filter`.
 
     .. note::
        Alternatively, you can make use of the

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -702,8 +702,10 @@ class Dataset(object):
                 # Now we append the dependencies
                 fd[filter.name, fn[1]] = fd[fn]
         if available:
-            self.particle_types += (filter.name,)
-            self.filtered_particle_types.append(filter.name)
+            if filter.name not in self.particle_types:
+                self.particle_types += (filter.name,)
+            if filter.name not in self.filtered_particle_types:
+                self.filtered_particle_types.append(filter.name)
             new_fields = self._setup_particle_types([filter.name])
             deps, _ = self.field_info.check_derived_fields(new_fields)
             self.field_dependencies.update(deps)

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -677,6 +677,15 @@ class Dataset(object):
         return True
 
     def _setup_filtered_type(self, filter):
+        # Check if the filtered_type of this filter is known, 
+        # otherwise add it first if it is in the filter_registry
+        if filter.filtered_type not in self.known_filters.keys():
+            if filter.filtered_type in filter_registry:
+                add_success = self.add_particle_filter(filter.filtered_type)
+                if add_success:
+                    mylog.info("Added filter dependency '%s' for '%s'",
+                       filter.filtered_type, filter.name)
+
         if not filter.available(self.derived_field_list):
             raise YTIllDefinedParticleFilter(
                 filter, filter.missing(self.derived_field_list))

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -353,7 +353,7 @@ class Dataset(object):
             return hashlib.md5(s.encode('utf-8')).hexdigest()
         except ImportError:
             return s.replace(";", "*")
-   
+
     _checksum = None
     @property
     def checksum(self):
@@ -655,6 +655,12 @@ class Dataset(object):
         return len(new_fields)
 
     def add_particle_filter(self, filter):
+        """Add particle filter to the dataset.
+
+        Add ``filter`` to the dataset and set up relavent derived_field.
+        It will also add any ``filtered_type`` that the ``filter`` depends on.
+
+        """
         # This requires an index
         self.index
         # This is a dummy, which we set up to enable passthrough of "all"

--- a/yt/data_objects/tests/test_particle_filter.py
+++ b/yt/data_objects/tests/test_particle_filter.py
@@ -5,6 +5,7 @@ from yt.testing import \
     requires_file
 from yt.data_objects.particle_filters import \
     add_particle_filter, particle_filter
+import numpy as np
 
 
 # Dataset required for this test

--- a/yt/data_objects/tests/test_particle_filter.py
+++ b/yt/data_objects/tests/test_particle_filter.py
@@ -71,7 +71,6 @@ def test_particle_filter_dependency():
     ds.add_particle_filter('young_stars')
     assert 'young_stars' in ds.particle_types
     assert 'stars' in ds.particle_types
-    print(ds.derived_field_list)
     assert ('deposit', 'young_stars_cic') in ds.derived_field_list
     assert ('deposit', 'stars_cic') in ds.derived_field_list
 


### PR DESCRIPTION
## PR Summary
This PR allows the user to add a particle filter to the dataset without adding all the dependencies of the filter in advance.
Some particle filters depend on other filters (`filtered_type`). When `ds.add_particle_filter` is called, it will look if the `filtered_type` of this filter is in the `filter_registry`, which means the user has already defined the filter through `yt.particle_filter()` decorator or `yt.add_particle_filter()`. It will try to add the filter to the dataset first.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes flake8 checker
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.