### PR TITLE
[BUGFIX] "rad" should have dimensions of angle

### DIFF
--- a/yt/units/unit_lookup_table.py
+++ b/yt/units/unit_lookup_table.py
@@ -133,7 +133,7 @@ default_unit_symbol_lut = {
     "solLum": (luminosity_sun_ergs_per_sec, dimensions.power, 0.0, r"L_\odot"),
     "dyn": (1.0, dimensions.force, 0.0, r"\rm{dyn}"),
     "sr": (1.0, dimensions.solid_angle, 0.0, r"\rm{sr}"),
-    "rad": (1.0, dimensions.solid_angle, 0.0, r"\rm{rad}"),
+    "rad": (1.0, dimensions.angle, 0.0, r"\rm{rad}"),
     "deg": (np.pi/180., dimensions.angle, 0.0, r"\rm{deg}"),
     "Fr":  (1.0, dimensions.charge_cgs, 0.0, r"\rm{Fr}"),
     "G": (1.0, dimensions.magnetic_field_cgs, 0.0, r"\rm{G}"),


### PR DESCRIPTION
`rad` was defined with dimensions of `solid_angle`. But it should be `angle`.

I am not sure why this has not been caught unless my understanding of "rad" has been totally wrong. 