### PR TITLE
Support tuple argument in save

### DIFF
--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -454,9 +454,11 @@ class PlotContainer(object):
 
         Parameters
         ----------
-        name : string
-           The base of the filename.  If name is a directory or if name is not
-           set, the filename of the dataset is used.
+        name : string or tuple
+           The base of the filename. If name is a directory or if name is not
+           set, the filename of the dataset is used. For a tuple, the
+           resulting path will be given by joining the elements of the
+           tuple
         suffix : string
            Specify the image type by its suffix. If not specified, the output
            type will be inferred from the filename. Defaults to PNG.
@@ -468,6 +470,8 @@ class PlotContainer(object):
         """
         names = []
         if mpl_kwargs is None: mpl_kwargs = {}
+        if isinstance(name, tuple):
+            name = os.path.join(*name)
         if name is None:
             name = str(self.ds)
         name = os.path.expanduser(name)

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -470,7 +470,7 @@ class PlotContainer(object):
         """
         names = []
         if mpl_kwargs is None: mpl_kwargs = {}
-        if isinstance(name, tuple):
+        if isinstance(name, (tuple, list)):
             name = os.path.join(*name)
         if name is None:
             name = str(self.ds)


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

This PR add the possibility to pass a tuple to the `save` method of a plot. This tuple is interpreted as the different components of a path using `os.path.join`. The resulting file name will then follow the same rules as before.
This helps to programatically store outputs in different folders.

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes flake8 checker
- [x] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
