### PR TITLE
Pass in matplotlib arguments to quiver annotations

### DIFF
--- a/doc/source/visualizing/callbacks.rst
+++ b/doc/source/visualizing/callbacks.rst
@@ -208,16 +208,20 @@ Overplot Quivers
 Axis-Aligned Data Sources
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. function:: annotate_quiver(self, field_x, field_y, factor, scale=None, \
-                              scale_units=None, normalize=False)
+.. function:: annotate_quiver(self, field_x, field_y, factor=16, scale=None, \
+                              scale_units=None, normalize=False, plot_args=None)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.QuiverCallback`.)
 
    Adds a 'quiver' plot to any plot, using the ``field_x`` and ``field_y`` from
-   the associated data, skipping every ``factor`` datapoints ``scale`` is the
-   data units per arrow length unit using ``scale_units`` (see
-   matplotlib.axes.Axes.quiver for more info)
+   the associated data, skipping every ``factor`` datapoints in the 
+   discretization. ``scale`` is the data units per arrow length unit using 
+   ``scale_units``. If ``normalize`` is ``True``, the fields will be scaled by 
+   their local (in-plane) length, allowing morphological features to be more 
+   clearly seen for fields with substantial variation in field strength. 
+   Additional arguments can be passed to the ``plot_args`` dictionary, see 
+   matplotlib.axes.Axes.quiver for more info.
 
 .. python-script::
 
@@ -225,26 +229,35 @@ Axis-Aligned Data Sources
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
    p = yt.ProjectionPlot(ds, 'z', 'density', center=[0.5, 0.5, 0.5],
                          weight_field='density', width=(20, 'kpc'))
-   p.annotate_quiver('velocity_x', 'velocity_y', 16)
+   p.annotate_quiver('velocity_x', 'velocity_y', factor=16, 
+                     plot_args={"color":"purple})
    p.save()
 
 Off-Axis Data Sources
 ^^^^^^^^^^^^^^^^^^^^^
 
-.. function:: annotate_cquiver(self, field_x, field_y, factor)
+.. function:: annotate_cquiver(self, field_x, field_y, factor=16, scale=None, \
+                               scale_units=None, normalize=False, plot_args=None)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.CuttingQuiverCallback`.)
 
-   Get a quiver plot on top of a cutting plane, using ``field_x`` and
-   ``field_y``, skipping every ``factor`` datapoint in the discretization.
+   Get a quiver plot on top of a cutting plane, using the ``field_x`` and 
+   ``field_y`` from the associated data, skipping every ``factor`` datapoints in
+   the discretization. ``scale`` is the data units per arrow length unit using 
+   ``scale_units``. If ``normalize`` is ``True``, the fields will be scaled by 
+   their local (in-plane) length, allowing morphological features to be more 
+   clearly seen for fields with substantial variation in field strength. 
+   Additional arguments can be passed to the ``plot_args`` dictionary, see 
+   matplotlib.axes.Axes.quiver for more info.
 
 .. python-script::
 
    import yt
    ds = yt.load("Enzo_64/DD0043/data0043")
    s = yt.OffAxisSlicePlot(ds, [1,1,0], ["density"], center="c")
-   s.annotate_cquiver('cutting_plane_velocity_x', 'cutting_plane_velocity_y', 10)
+   s.annotate_cquiver('cutting_plane_velocity_x', 'cutting_plane_velocity_y', 
+                      factor=10, plot_args={'color':'orange'})
    s.zoom(1.5)
    s.save()
 
@@ -383,17 +396,19 @@ Overplot Magnetic Field Quivers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. function:: annotate_magnetic_field(self, factor=16, scale=None, \
-                                      scale_units=None, normalize=False)
+                                      scale_units=None, normalize=False, \
+                                      plot_args=None)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.MagFieldCallback`.)
 
-   Adds a 'quiver' plot of magnetic field to the plot, skipping all but every
-   ``factor`` datapoint. ``scale`` is the data units per arrow length unit using
-   ``scale_units`` (see matplotlib.axes.Axes.quiver for more info). if
-   ``normalize`` is ``True``, the magnetic fields will be scaled by their local
-   (in-plane) length, allowing morphological features to be more clearly seen
-   for fields with substantial variation in field strength.
+   Adds a 'quiver' plot of magnetic field to the plot, skipping every ``factor`` 
+   datapoints in the discretization. ``scale`` is the data units per arrow 
+   length unit using ``scale_units``. If ``normalize`` is ``True``, the 
+   magnetic fields will be scaled by their local (in-plane) length, allowing 
+   morphological features to be more clearly seen for fields with substantial 
+   variation in field strength. Additional arguments can be passed to the 
+   ``plot_args`` dictionary, see matplotlib.axes.Axes.quiver for more info.
 
 .. python-script::
 
@@ -402,7 +417,7 @@ Overplot Magnetic Field Quivers
                 parameters={"time_unit":(1, 'Myr'), "length_unit":(1, 'Mpc'),
                             "mass_unit":(1e17, 'Msun')})
    p = yt.ProjectionPlot(ds, 'z', 'density', center='c', width=(300, 'kpc'))
-   p.annotate_magnetic_field()
+   p.annotate_magnetic_field(plot_args={"headlength": 3})
    p.save()
 
 .. _annotate-marker:
@@ -578,26 +593,26 @@ Add a Title
 Overplot Quivers for the Velocity Field
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: annotate_velocity(self, factor=16, scale=None, scale_units=None,\
-                                normalize=False)
+.. function:: annotate_velocity(self, factor=16, scale=None, scale_units=None, \
+                                normalize=False, plot_args=None)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.VelocityCallback`.)
 
-   Adds a 'quiver' plot of velocity to the plot, skipping all but every
-   ``factor`` datapoint. ``scale`` is the data units per arrow length unit using
-   ``scale_units`` (see matplotlib.axes.Axes.quiver for more info). if
-   ``normalize`` is ``True``, the velocity fields will be scaled by their local
-   (in-plane) length, allowing morphological features to be more clearly seen
-   for fields with substantial variation in field strength (normalize is not
-   implemented and thus ignored for Cutting Planes).
+   Adds a 'quiver' plot of velocity to the plot, skipping every ``factor`` 
+   datapoints in the discretization. ``scale`` is the data units per arrow 
+   length unit using ``scale_units``. If ``normalize`` is ``True``, the 
+   velocity fields will be scaled by their local (in-plane) length, allowing 
+   morphological features to be more clearly seen for fields with substantial 
+   variation in field strength. Additional arguments can be passed to the 
+   ``plot_args`` dictionary, see matplotlib.axes.Axes.quiver for more info.
 
 .. python-script::
 
    import yt
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
    p = yt.SlicePlot(ds, 'z', 'density', center='m', width=(10, 'kpc'))
-   p.annotate_velocity()
+   p.annotate_velocity(plot_args={"headwidth": 4})
    p.save()
 
 .. _annotate-timestamp:

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -862,7 +862,7 @@ class CuttingQuiverCallback(PlotCallback):
     _supported_geometries = ("cartesian", "spectral_cube")
 
     def __init__(self, field_x, field_y, factor=16, scale=None,
-                 scale_units=None, normalize=None, plot_args=None):
+                 scale_units=None, normalize=False, plot_args=None):
         PlotCallback.__init__(self)
         self.field_x = field_x
         self.field_y = field_y

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -281,7 +281,7 @@ class VelocityCallback(PlotCallback):
     """
     Adds a 'quiver' plot of velocity to the plot, skipping all but
     every *factor* datapoint. *scale* is the data units per arrow
-    length unit using *scale_units* (see
+    length unit using *scale_units* and *color* sets the color (see
     matplotlib.axes.Axes.quiver for more info). if *normalize* is
     True, the velocity fields will be scaled by their local
     (in-plane) length, allowing morphological features to be more
@@ -332,9 +332,9 @@ class MagFieldCallback(PlotCallback):
     """
     Adds a 'quiver' plot of magnetic field to the plot, skipping all but
     every *factor* datapoint. *scale* is the data units per arrow
-    length unit using *scale_units* (see
-    matplotlib.axes.Axes.quiver for more info). if *normalize* is
-    True, the magnetic fields will be scaled by their local
+    length unit using *scale_units* and *color* sets the color of the 
+    arrows (see matplotlib.axes.Axes.quiver for more info). if 
+    *normalize* is True, the magnetic fields will be scaled by their local
     (in-plane) length, allowing morphological features to be more
     clearly seen for fields with substantial variation in field strength.
     """
@@ -372,9 +372,12 @@ class MagFieldCallback(PlotCallback):
 class QuiverCallback(PlotCallback):
     """
     Adds a 'quiver' plot to any plot, using the *field_x* and *field_y*
-    from the associated data, skipping every *factor* datapoints
+    from the associated data, skipping every *factor* datapoints.
     *scale* is the data units per arrow length unit using *scale_units*
-    (see matplotlib.axes.Axes.quiver for more info)
+    and *color* sets the color of the arrows (see matplotlib.axes.Axes.quiver
+    for more info). if *normalize* is True, the fields will be scaled by
+    their local (in-plane) length, allowing morphological features to be more
+    clearly seen for fields with substantial variation in field strength.
     """
     _type_name = "quiver"
     _supported_geometries = ("cartesian", "spectral_cube", "cylindrical-2d")
@@ -840,6 +843,11 @@ class CuttingQuiverCallback(PlotCallback):
     """
     Get a quiver plot on top of a cutting plane, using *field_x* and
     *field_y*, skipping every *factor* datapoint in the discretization.
+    *scale* is the data units per arrow length unit using *scale_units*
+    and *color* sets the color of the arrows (see matplotlib.axes.Axes.quiver
+    for more info). if *normalize* is True, the fields will be scaled by 
+    their local (in-plane) length, allowing morphological features to be more
+    clearly seen for fields with substantial variation in field strength.
     """
     _type_name = "cquiver"
     _supported_geometries = ("cartesian", "spectral_cube")

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -290,12 +290,14 @@ class VelocityCallback(PlotCallback):
     """
     _type_name = "velocity"
     _supported_geometries = ("cartesian", "spectral_cube")
-    def __init__(self, factor=16, scale=None, scale_units=None, normalize=False):
+    def __init__(self, factor=16, scale=None, scale_units=None, 
+                 normalize=False, color=None):
         PlotCallback.__init__(self)
         self.factor = factor
         self.scale  = scale
         self.scale_units = scale_units
         self.normalize = normalize
+        self.color = color
 
     def __call__(self, plot):
         # Instantiation of these is cheap
@@ -304,7 +306,8 @@ class VelocityCallback(PlotCallback):
                                         "cutting_plane_velocity_y",
                                         self.factor, scale=self.scale,
                                         normalize=self.normalize,
-                                        scale_units=self.scale_units)
+                                        scale_units=self.scale_units,
+                                        color=self.color)
         else:
             ax = plot.data.axis
             (xi, yi) = (plot.data.ds.coordinates.x_axis[ax],
@@ -321,7 +324,8 @@ class VelocityCallback(PlotCallback):
 
             qcb = QuiverCallback(xv, yv, self.factor, scale=self.scale,
                                  scale_units=self.scale_units,
-                                 normalize=self.normalize, bv_x=bv_x, bv_y=bv_y)
+                                 normalize=self.normalize, bv_x=bv_x, 
+                                 bv_y=bv_y, color=self.color)
         return qcb(plot)
 
 class MagFieldCallback(PlotCallback):
@@ -336,12 +340,14 @@ class MagFieldCallback(PlotCallback):
     """
     _type_name = "magnetic_field"
     _supported_geometries = ("cartesian", "spectral_cube", "cylindrical-2d")
-    def __init__(self, factor=16, scale=None, scale_units=None, normalize=False):
+    def __init__(self, factor=16, scale=None, scale_units=None, 
+                 normalize=False, color=None):
         PlotCallback.__init__(self)
         self.factor = factor
         self.scale  = scale
         self.scale_units = scale_units
         self.normalize = normalize
+        self.color = color
 
     def __call__(self, plot):
         # Instantiation of these is cheap
@@ -350,14 +356,17 @@ class MagFieldCallback(PlotCallback):
                                         "cutting_plane_magnetic_field_y",
                                         self.factor, scale=self.scale, 
                                         scale_units=self.scale_units, 
-                                        normalize=self.normalize)
+                                        normalize=self.normalize,
+                                        color=self.color)
         else:
             xax = plot.data.ds.coordinates.x_axis[plot.data.axis]
             yax = plot.data.ds.coordinates.y_axis[plot.data.axis]
             axis_names = plot.data.ds.coordinates.axis_name
             xv = "magnetic_field_%s" % (axis_names[xax])
             yv = "magnetic_field_%s" % (axis_names[yax])
-            qcb = QuiverCallback(xv, yv, self.factor, scale=self.scale, scale_units=self.scale_units, normalize=self.normalize)
+            qcb = QuiverCallback(xv, yv, self.factor, scale=self.scale, 
+                                 scale_units=self.scale_units, 
+                                 normalize=self.normalize, color=self.color)
         return qcb(plot)
 
 class QuiverCallback(PlotCallback):
@@ -370,7 +379,8 @@ class QuiverCallback(PlotCallback):
     _type_name = "quiver"
     _supported_geometries = ("cartesian", "spectral_cube", "cylindrical-2d")
     def __init__(self, field_x, field_y, factor=16, scale=None,
-                 scale_units=None, normalize=False, bv_x=0, bv_y=0):
+                 scale_units=None, color=None, normalize=False, 
+                 bv_x=0, bv_y=0):
         PlotCallback.__init__(self)
         self.field_x = field_x
         self.field_y = field_y
@@ -380,6 +390,7 @@ class QuiverCallback(PlotCallback):
         self.scale = scale
         self.scale_units = scale_units
         self.normalize = normalize
+        self.color = color
 
     def __call__(self, plot):
         x0, x1 = [p.to('code_length') for p in plot.xlim]
@@ -424,7 +435,8 @@ class QuiverCallback(PlotCallback):
             nn = np.sqrt(pixX**2 + pixY**2)
             pixX /= nn
             pixY /= nn
-        plot._axes.quiver(X,Y, pixX, pixY, scale=self.scale, scale_units=self.scale_units)
+        plot._axes.quiver(X,Y, pixX, pixY, scale=self.scale, 
+                          color=self.color, scale_units=self.scale_units)
         plot._axes.set_xlim(xx0,xx1)
         plot._axes.set_ylim(yy0,yy1)
 
@@ -833,7 +845,7 @@ class CuttingQuiverCallback(PlotCallback):
     _supported_geometries = ("cartesian", "spectral_cube")
 
     def __init__(self, field_x, field_y, factor=16, scale=None,
-                 scale_units=None, normalize=None):
+                 scale_units=None, normalize=None, color=None):
         PlotCallback.__init__(self)
         self.field_x = field_x
         self.field_y = field_y
@@ -841,6 +853,7 @@ class CuttingQuiverCallback(PlotCallback):
         self.scale = scale
         self.scale_units = scale_units
         self.normalize = normalize
+        self.color = color
 
     def __call__(self, plot):
         x0, x1 = [p.to('code_length') for p in plot.xlim]
@@ -875,7 +888,8 @@ class CuttingQuiverCallback(PlotCallback):
             pixX /= nn
             pixY /= nn
 
-        plot._axes.quiver(X,Y, pixX, pixY, scale=self.scale, scale_units=self.scale_units)
+        plot._axes.quiver(X,Y, pixX, pixY, scale=self.scale, 
+                          scale_units=self.scale_units, color=self.color)
         plot._axes.set_xlim(xx0,xx1)
         plot._axes.set_ylim(yy0,yy1)
 

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -281,23 +281,25 @@ class VelocityCallback(PlotCallback):
     """
     Adds a 'quiver' plot of velocity to the plot, skipping all but
     every *factor* datapoint. *scale* is the data units per arrow
-    length unit using *scale_units* and *color* sets the color (see
-    matplotlib.axes.Axes.quiver for more info). if *normalize* is
-    True, the velocity fields will be scaled by their local
-    (in-plane) length, allowing morphological features to be more
-    clearly seen for fields with substantial variation in field
-    strength.
+    length unit using *scale_units* and *plot_args* allows you to 
+    pass in matplotlib arguments (see matplotlib.axes.Axes.quiver 
+    for more info). if *normalize* is True, the velocity fields 
+    will be scaled by their local (in-plane) length, allowing 
+    morphological features to be more clearly seen for fields 
+    with substantial variation in field strength.
     """
     _type_name = "velocity"
     _supported_geometries = ("cartesian", "spectral_cube")
     def __init__(self, factor=16, scale=None, scale_units=None, 
-                 normalize=False, color="k"):
+                 normalize=False, plot_args=None):
         PlotCallback.__init__(self)
         self.factor = factor
         self.scale  = scale
         self.scale_units = scale_units
         self.normalize = normalize
-        self.color = color
+        if plot_args is None:
+            plot_args = {}
+        self.plot_args = plot_args
 
     def __call__(self, plot):
         # Instantiation of these is cheap
@@ -307,7 +309,7 @@ class VelocityCallback(PlotCallback):
                                         self.factor, scale=self.scale,
                                         normalize=self.normalize,
                                         scale_units=self.scale_units,
-                                        color=self.color)
+                                        plot_args=self.plot_args)
         else:
             ax = plot.data.axis
             (xi, yi) = (plot.data.ds.coordinates.x_axis[ax],
@@ -325,29 +327,31 @@ class VelocityCallback(PlotCallback):
             qcb = QuiverCallback(xv, yv, self.factor, scale=self.scale,
                                  scale_units=self.scale_units,
                                  normalize=self.normalize, bv_x=bv_x, 
-                                 bv_y=bv_y, color=self.color)
+                                 bv_y=bv_y, plot_args=self.plot_args)
         return qcb(plot)
 
 class MagFieldCallback(PlotCallback):
     """
     Adds a 'quiver' plot of magnetic field to the plot, skipping all but
     every *factor* datapoint. *scale* is the data units per arrow
-    length unit using *scale_units* and *color* sets the color of the 
-    arrows (see matplotlib.axes.Axes.quiver for more info). if 
-    *normalize* is True, the magnetic fields will be scaled by their local
-    (in-plane) length, allowing morphological features to be more
+    length unit using *scale_units* and *plot_args* allows you to pass 
+    in matplotlib arguments (see matplotlib.axes.Axes.quiver for more info).
+    if *normalize* is True, the magnetic fields will be scaled by their 
+    local (in-plane) length, allowing morphological features to be more
     clearly seen for fields with substantial variation in field strength.
     """
     _type_name = "magnetic_field"
     _supported_geometries = ("cartesian", "spectral_cube", "cylindrical-2d")
     def __init__(self, factor=16, scale=None, scale_units=None, 
-                 normalize=False, color="k"):
+                 normalize=False, plot_args=None):
         PlotCallback.__init__(self)
         self.factor = factor
         self.scale  = scale
         self.scale_units = scale_units
         self.normalize = normalize
-        self.color = color
+        if plot_args is None:
+            plot_args = {}
+        self.plot_args = plot_args
 
     def __call__(self, plot):
         # Instantiation of these is cheap
@@ -357,7 +361,7 @@ class MagFieldCallback(PlotCallback):
                                         self.factor, scale=self.scale, 
                                         scale_units=self.scale_units, 
                                         normalize=self.normalize,
-                                        color=self.color)
+                                        plot_args=self.plot_args)
         else:
             xax = plot.data.ds.coordinates.x_axis[plot.data.axis]
             yax = plot.data.ds.coordinates.y_axis[plot.data.axis]
@@ -365,8 +369,9 @@ class MagFieldCallback(PlotCallback):
             xv = "magnetic_field_%s" % (axis_names[xax])
             yv = "magnetic_field_%s" % (axis_names[yax])
             qcb = QuiverCallback(xv, yv, self.factor, scale=self.scale, 
-                                 scale_units=self.scale_units, 
-                                 normalize=self.normalize, color=self.color)
+                                 scale_units=self.scale_units,
+                                 normalize=self.normalize, 
+                                 plot_args=self.plot_args)
         return qcb(plot)
 
 class QuiverCallback(PlotCallback):
@@ -374,16 +379,17 @@ class QuiverCallback(PlotCallback):
     Adds a 'quiver' plot to any plot, using the *field_x* and *field_y*
     from the associated data, skipping every *factor* datapoints.
     *scale* is the data units per arrow length unit using *scale_units*
-    and *color* sets the color of the arrows (see matplotlib.axes.Axes.quiver
-    for more info). if *normalize* is True, the fields will be scaled by
-    their local (in-plane) length, allowing morphological features to be more
-    clearly seen for fields with substantial variation in field strength.
+    and *plot_args* allows you to pass in matplotlib arguments (see 
+    matplotlib.axes.Axes.quiver for more info). if *normalize* is True, 
+    the fields will be scaled by their local (in-plane) length, allowing 
+    morphological features to be more clearly seen for fields with 
+    substantial variation in field strength.
     """
     _type_name = "quiver"
     _supported_geometries = ("cartesian", "spectral_cube", "cylindrical-2d")
     def __init__(self, field_x, field_y, factor=16, scale=None,
-                 scale_units=None, color="k", normalize=False, 
-                 bv_x=0, bv_y=0):
+                 scale_units=None, normalize=False, bv_x=0, bv_y=0,
+                 plot_args=None):
         PlotCallback.__init__(self)
         self.field_x = field_x
         self.field_y = field_y
@@ -393,7 +399,9 @@ class QuiverCallback(PlotCallback):
         self.scale = scale
         self.scale_units = scale_units
         self.normalize = normalize
-        self.color = color
+        if plot_args is None:
+            plot_args = {}
+        self.plot_args = plot_args
 
     def __call__(self, plot):
         x0, x1 = [p.to('code_length') for p in plot.xlim]
@@ -439,7 +447,7 @@ class QuiverCallback(PlotCallback):
             pixX /= nn
             pixY /= nn
         plot._axes.quiver(X,Y, pixX, pixY, scale=self.scale, 
-                          color=self.color, scale_units=self.scale_units)
+                          scale_units=self.scale_units, **self.plot_args)
         plot._axes.set_xlim(xx0,xx1)
         plot._axes.set_ylim(yy0,yy1)
 
@@ -844,16 +852,17 @@ class CuttingQuiverCallback(PlotCallback):
     Get a quiver plot on top of a cutting plane, using *field_x* and
     *field_y*, skipping every *factor* datapoint in the discretization.
     *scale* is the data units per arrow length unit using *scale_units*
-    and *color* sets the color of the arrows (see matplotlib.axes.Axes.quiver
-    for more info). if *normalize* is True, the fields will be scaled by 
-    their local (in-plane) length, allowing morphological features to be more
-    clearly seen for fields with substantial variation in field strength.
+    and *plot_args* allows you to pass in matplotlib arguments (see 
+    matplotlib.axes.Axes.quiver for more info). if *normalize* is True, 
+    the fields will be scaled by their local (in-plane) length, allowing 
+    morphological features to be more clearly seen for fields with 
+    substantial variation in field strength.
     """
     _type_name = "cquiver"
     _supported_geometries = ("cartesian", "spectral_cube")
 
     def __init__(self, field_x, field_y, factor=16, scale=None,
-                 scale_units=None, normalize=None, color="k"):
+                 scale_units=None, normalize=None, plot_args=None):
         PlotCallback.__init__(self)
         self.field_x = field_x
         self.field_y = field_y
@@ -861,7 +870,9 @@ class CuttingQuiverCallback(PlotCallback):
         self.scale = scale
         self.scale_units = scale_units
         self.normalize = normalize
-        self.color = color
+        if plot_args is None:
+            plot_args = {}
+        self.plot_args = plot_args
 
     def __call__(self, plot):
         x0, x1 = [p.to('code_length') for p in plot.xlim]
@@ -897,7 +908,7 @@ class CuttingQuiverCallback(PlotCallback):
             pixY /= nn
 
         plot._axes.quiver(X,Y, pixX, pixY, scale=self.scale, 
-                          scale_units=self.scale_units, color=self.color)
+                          scale_units=self.scale_units, **self.plot_args)
         plot._axes.set_xlim(xx0,xx1)
         plot._axes.set_ylim(yy0,yy1)
 

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -291,7 +291,7 @@ class VelocityCallback(PlotCallback):
     _type_name = "velocity"
     _supported_geometries = ("cartesian", "spectral_cube")
     def __init__(self, factor=16, scale=None, scale_units=None, 
-                 normalize=False, color=None):
+                 normalize=False, color="k"):
         PlotCallback.__init__(self)
         self.factor = factor
         self.scale  = scale
@@ -341,7 +341,7 @@ class MagFieldCallback(PlotCallback):
     _type_name = "magnetic_field"
     _supported_geometries = ("cartesian", "spectral_cube", "cylindrical-2d")
     def __init__(self, factor=16, scale=None, scale_units=None, 
-                 normalize=False, color=None):
+                 normalize=False, color="k"):
         PlotCallback.__init__(self)
         self.factor = factor
         self.scale  = scale
@@ -379,7 +379,7 @@ class QuiverCallback(PlotCallback):
     _type_name = "quiver"
     _supported_geometries = ("cartesian", "spectral_cube", "cylindrical-2d")
     def __init__(self, field_x, field_y, factor=16, scale=None,
-                 scale_units=None, color=None, normalize=False, 
+                 scale_units=None, color="k", normalize=False, 
                  bv_x=0, bv_y=0):
         PlotCallback.__init__(self)
         self.field_x = field_x
@@ -845,7 +845,7 @@ class CuttingQuiverCallback(PlotCallback):
     _supported_geometries = ("cartesian", "spectral_cube")
 
     def __init__(self, field_x, field_y, factor=16, scale=None,
-                 scale_units=None, normalize=None, color=None):
+                 scale_units=None, normalize=None, color="k"):
         PlotCallback.__init__(self)
         self.field_x = field_x
         self.field_y = field_y


### PR DESCRIPTION
This PR adds the option to pass in matplotlib arguments to quiver annotations (such as changing the color of the arrows), whether for the generic quiver annotation methods or for the specific velocity or magnetic field annotation methods. 

I've updated docstrings, still need to update the docs themselves. 