### PR TITLE
RAMSES bbox feature

### DIFF
--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -2061,6 +2061,44 @@ It is possible to provide extra arguments to the load function when loading RAMS
       Force yt to consider a simulation to be cosmological or
       not. This may be useful for some specific simulations e.g. that
       run down to negative redshifts.
+
+``bbox``
+      The subbox to load. Yt will only read CPUs intersecting with the
+      subbox. This is especially useful for large simulations or
+      zoom-in simulations, where you don't want to have access to data
+      outside of a small region of interest. This argument will prevent
+      yt from loading AMR files outside the subbox and will hence
+      spare memory and time.
+      For example, one could used
+
+      .. code-block:: python
+
+          import yt
+	  # Only load a small cube of size (0.1)**3
+	  bbox = [[0., 0., 0.], [0.1, 0.1, 0.1]]
+	  ds = yt.load('output_00001/info_00001.txt', bbox=bbox)
+
+	  # See the note below for the following examples
+	  ds.right_edge == [1, 1, 1]             # is True
+
+	  ad = ds.all_data()
+	  ad['particle_position_x'].max() > 0.1  # _may_ be True
+
+	  bb = ds.box(left_edge=bbox[0], right_edge=bbox[1])
+	  bb['particle_position_x'].max() < 0.1  # is True
+      .. note::
+	 When using the bbox argument, yt will read all the CPUs
+         intersecting with the subbox. However it may also read some
+         data *outside* the selected region. This is due to the fact
+         that domains have a complicated shape when using Hilbert
+         ordering. Internally, yt will hence assume the loaded dataset
+         covers the entire simulation. If you only want the data from
+         the selected region, you may want to use ``ds.box(…)``.
+
+      .. note::
+	 This feature is only available when using Hilbert ordering.
+
+
 .. _loading-sph-data:
 
 SPH Particle Data

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -318,7 +318,7 @@ would have a ``job_info`` file in the plotfile directory.
 * yt does not read the Maestro base state (although you can have Maestro
   map it to a full Cartesian state variable before writing the plotfile
   to get around this).  E-mail the dev list if you need this support.
-* yt supports AMReX/BoxLib particle data stored in the standard format used 
+* yt supports AMReX/BoxLib particle data stored in the standard format used
   by Nyx and WarpX, and optionally Castro. It currently does not support the ASCII particle
   data used by Maestro and Castro.
 * For Maestro, yt aliases either "tfromp" or "tfromh to" ``temperature``
@@ -331,7 +331,7 @@ Viewing raw fields in WarpX
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Most AMReX/BoxLib codes output cell-centered data. If the underlying discretization
-is not cell-centered, then fields are typically averaged to cell centers before 
+is not cell-centered, then fields are typically averaged to cell centers before
 they are written to plot files for visualization. WarpX, however, has the option
 to output the raw (i.e., not averaged to cell centers) data as well.  If you
 run your WarpX simulation with ``warpx.plot_raw_fields = 1`` in your inputs
@@ -348,10 +348,10 @@ defined, with the "raw" field type:
 The raw fields in WarpX are nodal in at least one direction. We define a field
 to be "nodal" in a given direction if the field data is defined at the "low"
 and "high" sides of the cell in that direction, rather than at the cell center.
-Instead of returning one field value per cell selected, nodal fields return a 
+Instead of returning one field value per cell selected, nodal fields return a
 number of values, depending on their centering. This centering is marked by
 a `nodal_flag` that describes whether the fields is nodal in each dimension.
-``nodal_flag = [0, 0, 0]`` means that the field is cell-centered, while 
+``nodal_flag = [0, 0, 0]`` means that the field is cell-centered, while
 ``nodal_flag = [0, 0, 1]`` means that the field is nodal in the z direction
 and cell centered in the others, i.e. it is defined on the z faces of each cell.
 ``nodal_flag = [1, 1, 0]`` would mean that the field is centered in the z direction,
@@ -371,7 +371,7 @@ to the z direction.
 
 Here, the field ``('raw', 'Ex')`` is nodal in two directions, so four values per cell
 are returned, corresponding to the four edges in each cell on which the variable
-is defined. ``('raw', 'Bx')`` is nodal in one direction, so two values are returned 
+is defined. ``('raw', 'Bx')`` is nodal in one direction, so two values are returned
 per cell. The standard, averaged-to-cell-centers fields are still available.
 
 Currently, slices and data selection are implemented for nodal fields. Projections,
@@ -684,7 +684,7 @@ can read FITS image files that have the following (case-insensitive) suffixes:
 * fits.gz
 * fts.gz
 
-yt can currently read two kinds of FITS files: FITS image files and FITS 
+yt can currently read two kinds of FITS files: FITS image files and FITS
 binary table files containing positions, times, and energies of X-ray events.
 
 Though a FITS image is composed of a single array in the FITS file,
@@ -760,14 +760,14 @@ the following dataset types:
 If your data is of the first case, yt will determine the length units based
 on the information in the header. If your data is of the second or third
 cases, no length units will be assigned, but the world coordinate information
-about the axes will be stored in separate fields. If your data is of the 
-fourth type, the coordinates of the first three axes will be determined 
+about the axes will be stored in separate fields. If your data is of the
+fourth type, the coordinates of the first three axes will be determined
 according to cases 1-3.
 
 .. note::
 
-  Linear length-based coordinates (Case 1 above) are only supported if all 
-  dimensions have the same value for ``CUNITx``. WCS coordinates are only 
+  Linear length-based coordinates (Case 1 above) are only supported if all
+  dimensions have the same value for ``CUNITx``. WCS coordinates are only
   supported for Cases 2-4.
 
 FITS Data Decomposition
@@ -791,8 +791,8 @@ upon being loaded into yt it is automatically decomposed into grids:
              512	  981940800
 
 For 3D spectral-cube data, the decomposition into grids will be done along the
-spectral axis since this will speed up many common operations for this 
-particular type of dataset. 
+spectral axis since this will speed up many common operations for this
+particular type of dataset.
 
 yt will generate its own domain decomposition, but the number of grids can be
 set manually by passing the ``nprocs`` parameter to the ``load`` call:
@@ -830,10 +830,10 @@ based on the corresponding ``CTYPEx`` keywords. When queried, these fields
 will be generated from the pixel coordinates in the file using the WCS
 transformations provided by AstroPy.
 
-X-ray event data will be loaded as particle fields in yt, but a grid will be 
-constructed from the WCS information in the FITS header. There is a helper 
-function, ``setup_counts_fields``, which may be used to make deposited image 
-fields from the event data for different energy bands (for an example see 
+X-ray event data will be loaded as particle fields in yt, but a grid will be
+constructed from the WCS information in the FITS header. There is a helper
+function, ``setup_counts_fields``, which may be used to make deposited image
+fields from the event data for different energy bands (for an example see
 :ref:`xray_fits`).
 
 .. note::
@@ -848,7 +848,7 @@ fields from the event data for different energy bands (for an example see
 Additional Options
 ^^^^^^^^^^^^^^^^^^
 
-The following are additional options that may be passed to the ``load`` command 
+The following are additional options that may be passed to the ``load`` command
 when analyzing FITS data:
 
 ``nan_mask``
@@ -888,9 +888,9 @@ plane.
 Miscellaneous Tools for Use with FITS Data
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A number of tools have been prepared for use with FITS data that enhance yt's 
-visualization and analysis capabilities for this particular type of data. These 
-are included in the ``yt.frontends.fits.misc`` module, and can be imported like 
+A number of tools have been prepared for use with FITS data that enhance yt's
+visualization and analysis capabilities for this particular type of data. These
+are included in the ``yt.frontends.fits.misc`` module, and can be imported like
 so:
 
 .. code-block:: python
@@ -900,7 +900,7 @@ so:
 ``setup_counts_fields``
 """""""""""""""""""""""
 
-This function can be used to create image fields from X-ray counts data in 
+This function can be used to create image fields from X-ray counts data in
 different energy bands:
 
 .. code-block:: python
@@ -914,9 +914,9 @@ and add them to the field registry for the dataset ``ds``.
 ``ds9_region``
 """"""""""""""
 
-This function takes a `ds9 <http://ds9.si.edu/site/Home.html>`_ region and 
-creates a "cut region" data container from it, that can be used to select 
-the cells in the FITS dataset that fall within the region. To use this 
+This function takes a `ds9 <http://ds9.si.edu/site/Home.html>`_ region and
+creates a "cut region" data container from it, that can be used to select
+the cells in the FITS dataset that fall within the region. To use this
 functionality, the `pyregion <https://github.com/astropy/pyregion/>`_
 package must be installed.
 
@@ -930,8 +930,8 @@ package must be installed.
 ``PlotWindowWCS``
 """""""""""""""""
 
-This class takes a on-axis ``SlicePlot`` or ``ProjectionPlot`` of FITS 
-data and adds celestial coordinates to the plot axes. To use it, a 
+This class takes a on-axis ``SlicePlot`` or ``ProjectionPlot`` of FITS
+data and adds celestial coordinates to the plot axes. To use it, a
 version of AstroPy >= 1.3 must be installed.
 
 .. code-block:: python
@@ -940,7 +940,7 @@ version of AstroPy >= 1.3 must be installed.
   wcs_slc.show() # for the IPython notebook
   wcs_slc.save()
 
-``WCSAxes`` is still in an experimental state, but as its functionality 
+``WCSAxes`` is still in an experimental state, but as its functionality
 improves it will be utilized more here.
 
 ``create_spectral_slabs``
@@ -948,14 +948,14 @@ improves it will be utilized more here.
 
 .. note::
 
-  The following functionality requires the 
-  `spectral-cube <http://spectral-cube.readthedocs.org>`_ library to be 
+  The following functionality requires the
+  `spectral-cube <http://spectral-cube.readthedocs.org>`_ library to be
   installed.
 
 If you have a spectral intensity dataset of some sort, and would like to
-extract emission in particular slabs along the spectral axis of a certain 
-width, ``create_spectral_slabs`` can be used to generate a dataset with 
-these slabs as different fields. In this example, we use it to extract 
+extract emission in particular slabs along the spectral axis of a certain
+width, ``create_spectral_slabs`` can be used to generate a dataset with
+these slabs as different fields. In this example, we use it to extract
 individual lines from an intensity cube:
 
 .. code-block:: python
@@ -968,12 +968,12 @@ individual lines from an intensity cube:
                                     slab_centers, slab_width,
                                     nan_mask=0.0)
 
-All keyword arguments to ``create_spectral_slabs`` are passed on to ``load`` when 
-creating the dataset (see :ref:`additional_fits_options` above). In the 
-returned dataset, the different slabs will be different fields, with the field 
-names taken from the keys in ``slab_centers``. The WCS coordinates on the 
-spectral axis are reset so that the center of the domain along this axis is 
-zero, and the left and right edges of the domain along this axis are 
+All keyword arguments to ``create_spectral_slabs`` are passed on to ``load`` when
+creating the dataset (see :ref:`additional_fits_options` above). In the
+returned dataset, the different slabs will be different fields, with the field
+names taken from the keys in ``slab_centers``. The WCS coordinates on the
+spectral axis are reset so that the center of the domain along this axis is
+zero, and the left and right edges of the domain along this axis are
 :math:`\pm` ``0.5*slab_width``.
 
 Examples of Using FITS Data
@@ -991,10 +991,10 @@ FLASH Data
 ----------
 
 FLASH HDF5 data is *mostly* supported and cared for by John ZuHone.  To load a
-FLASH dataset, you can use the ``yt.load`` command and provide it the file name of 
+FLASH dataset, you can use the ``yt.load`` command and provide it the file name of
 a plot file, checkpoint file, or particle file. Particle files require special handling
-depending on the situation, the main issue being that they typically lack grid information. 
-The first case is when you have a plotfile and a particle file that you would like to 
+depending on the situation, the main issue being that they typically lack grid information.
+The first case is when you have a plotfile and a particle file that you would like to
 load together. In the simplest case, this occurs automatically. For instance, if you
 were in a directory with the following files:
 
@@ -1003,8 +1003,8 @@ were in a directory with the following files:
    radio_halo_1kpc_hdf5_plt_cnt_0100 # plotfile
    radio_halo_1kpc_hdf5_part_0100 # particle file
 
-where the plotfile and the particle file were created at the same time (therefore having 
-particle data consistent with the grid structure of the former). Notice also that the 
+where the plotfile and the particle file were created at the same time (therefore having
+particle data consistent with the grid structure of the former). Notice also that the
 prefix ``"radio_halo_1kpc_"`` and the file number ``100`` are the same. In this special case,
 the particle file will be loaded automatically when ``yt.load`` is called on the plotfile.
 This also works when loading a number of files in a time series.
@@ -1018,10 +1018,10 @@ grid structure and are at the same simulation time, the particle data may be loa
     import yt
     ds = yt.load("radio_halo_1kpc_hdf5_plt_cnt_0100", particle_filename="radio_halo_1kpc_hdf5_part_0100")
 
-However, if you don't have a corresponding plotfile for a particle file, but would still 
-like to load the particle data, you can still call ``yt.load`` on the file. However, the 
+However, if you don't have a corresponding plotfile for a particle file, but would still
+like to load the particle data, you can still call ``yt.load`` on the file. However, the
 grid information will not be available, and the particle data will be loaded in a fashion
-similar to SPH data. 
+similar to SPH data.
 
 .. rubric:: Caveats
 
@@ -1349,7 +1349,7 @@ resolution.
    yt only supports a block structure where the grid edges on the ``n``-th
    refinement level are aligned with the cell edges on the ``n-1``-th level.
 
-Particle fields are supported by adding 1-dimensional arrays to each 
+Particle fields are supported by adding 1-dimensional arrays to each
 ``grid``'s dict:
 
 .. code-block:: python
@@ -1394,7 +1394,7 @@ density field in cubic domain of 3 Mpc edge size (3 * 3.08e24 cm) and
 simultaneously divide the domain into 12 chunks, so that you can take advantage
 of the underlying parallelism.
 
-Particle fields are added as one-dimensional arrays in a similar manner as the 
+Particle fields are added as one-dimensional arrays in a similar manner as the
 three-dimensional grid fields:
 
 .. code-block:: python
@@ -1562,7 +1562,7 @@ To load multiple meshes, you can do:
 
    # only plot the second
    sl = yt.SlicePlot(ds, 'z', ('connect2', 'test'))
-   
+
    # plot both
    sl = yt.SlicePlot(ds, 'z', ('all', 'test'))
 
@@ -1631,10 +1631,10 @@ The ``load_particles`` function also accepts the following keyword parameters:
 Gizmo Data
 ----------
 
-Gizmo datasets, including FIRE outputs, can be loaded into yt in the usual 
-manner.  Like other SPH data formats, yt loads Gizmo data as particle fields 
-and then uses smoothing kernels to deposit those fields to an underlying 
-grid structure as spatial fields as described in :ref:`loading-gadget-data`.  
+Gizmo datasets, including FIRE outputs, can be loaded into yt in the usual
+manner.  Like other SPH data formats, yt loads Gizmo data as particle fields
+and then uses smoothing kernels to deposit those fields to an underlying
+grid structure as spatial fields as described in :ref:`loading-gadget-data`.
 To load Gizmo datasets using the standard HDF5 output format::
 
    import yt
@@ -1642,11 +1642,11 @@ To load Gizmo datasets using the standard HDF5 output format::
 
 Because the Gizmo output format is similar to the Gadget format, yt
 may load Gizmo datasets as Gadget depending on the circumstances, but this
-should not pose a problem in most situations.  FIRE outputs will be loaded 
-accordingly due to the number of metallicity fields found (11 or 17).  
+should not pose a problem in most situations.  FIRE outputs will be loaded
+accordingly due to the number of metallicity fields found (11 or 17).
 
 For Gizmo outputs written as raw binary outputs, you may have to specify
-a bounding box, field specification, and units as are done for standard 
+a bounding box, field specification, and units as are done for standard
 Gadget outputs.  See :ref:`loading-gadget-data` for more information.
 
 .. _halo-catalog-data:
@@ -2001,27 +2001,19 @@ You would feed it the filename ``output_00007/info_00007.txt``:
    import yt
    ds = yt.load("output_00007/info_00007.txt")
 
-yt will attempt to guess the fields in the file.  You may also specify
-a list of hydro fields by supplying the ``fields`` keyword in your
-call to ``load``. It is also possible to provide a list of *extra*
-particle fields by supplying the ``extra_particle_fields``:
-
-.. code-block:: python
-
-   import yt
-   extra_fields = [('family', 'I'), ('info', 'I')]
-   ds = yt.load("output_00001/info_00001.txt", extra_particle_fields=extra_fields)
-   # ('all', 'family') and ('all', 'info') now in ds.field_list
+yt will attempt to guess the fields in the file. For more control over the hydro fields or the particle fields, see :ref:`loading-ramses-data-args`.
 
 yt supports outputs made by the mainline ``RAMSES`` code as well as the
 ``RAMSES-RT`` fork. Files produces by ``RAMSES-RT`` are recognized as such
 based on the presence of a ``info_rt_*.txt`` file in the output directory.
 
+.. note::
+   for backward compatibility, particles from the
+   ``part_XXXXX.outYYYYY`` files have the particle type ``io`` by
+   default (including dark matter, stars, tracer particles, …). Sink
+   particles have the particle type ``sink``.
 
-Note: for backward compatibility, particles from the
-``particle_XXXXX.outYYYYY`` files have the particle type ``io`` by
-default (including dark matter, stars, tracer particles, …). Sink
-particles have the particle type ``sink``.
+.. _loading-ramses-data-args:
 
 Arguments passed to the load function
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -2029,7 +2029,7 @@ It is possible to provide extra arguments to the load function when loading RAMS
                     "x-velocity", "y-velocity", "z-velocity",
                     "Pressure", "my-awesome-field"]
 	  ds = yt.load('output_00123/info_00123.txt', fields=fields)
-	  'my-awesome-field' in ds.field  # is True
+	  'my-awesome-field' in ds.field_list  # is True
 
 
 ``extra_particle_fields``
@@ -2047,7 +2047,7 @@ It is possible to provide extra arguments to the load function when loading RAMS
           ds = yt.load("output_00001/info_00001.txt", extra_particle_fields=extra_fields)
           # ('all', 'family') and ('all', 'info') now in ds.field_list
 
-      The format of the passed argument is as follow: ``[('field_name_1', 'type_1'), …, ('field_name_n', 'type_n')]`` where the ``type_n`` should follow the `python convention <https://docs.python.org/3.5/library/struct.html#format-characters>`_.
+      The format of the passed argument is as follow: ``[('field_name_1', 'type_1'), …, ('field_name_n', 'type_n')]`` where the ``type_n`` is as follow `python convention <https://docs.python.org/3.5/library/struct.html#format-characters>`_.
 
 ``cosmological``
       Force yt to consider a simulation to be cosmological or
@@ -2061,7 +2061,7 @@ It is possible to provide extra arguments to the load function when loading RAMS
       outside of a small region of interest. This argument will prevent
       yt from loading AMR files outside the subbox and will hence
       spare memory and time.
-      For example, one could used
+      For example, one could use
 
       .. code-block:: python
 

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -2017,19 +2017,50 @@ yt supports outputs made by the mainline ``RAMSES`` code as well as the
 ``RAMSES-RT`` fork. Files produces by ``RAMSES-RT`` are recognized as such
 based on the presence of a ``info_rt_*.txt`` file in the output directory.
 
-It is possible to force yt to treat the simulation as a cosmological
-simulation by providing the ``cosmological=True`` parameter (or
-``False`` to force non-cosmology). If left to ``None``, the kind of
-the simulation is inferred from the data.
-
-yt also support outputs that include sinks (RAMSES' name for black
-holes) when the folder contains files like ``sink_XXXXX.outYYYYY``.
 
 Note: for backward compatibility, particles from the
 ``particle_XXXXX.outYYYYY`` files have the particle type ``io`` by
 default (including dark matter, stars, tracer particles, …). Sink
 particles have the particle type ``sink``.
 
+Arguments passed to the load function
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+It is possible to provide extra arguments to the load function when loading RAMSES datasets. Here is a list of the ones specific to RAMSES:
+
+``fields``
+      A list of fields to read from the hydro files. For a hydro simulation with an extra custom field
+
+      .. code-block:: python
+
+          import yt
+          fields = ["Density",
+                    "x-velocity", "y-velocity", "z-velocity",
+                    "Pressure", "my-awesome-field"]
+	  ds = yt.load('output_00123/info_00123.txt', fields=fields)
+	  'my-awesome-field' in ds.field  # is True
+
+
+``extra_particle_fields``
+      A list of tuples describing extra particles fields to read in. By
+      default, yt will try to detect as many fields as possible,
+      assuming the extra ones to be double precision floats. This
+      argument is useful if you have extra fields that yt cannot
+      detect. For example, for a dataset containing two integer fields
+      in the particles, one would do
+
+      .. code-block:: python
+
+          import yt
+          extra_fields = [('family', 'I'), ('info', 'I')]
+          ds = yt.load("output_00001/info_00001.txt", extra_particle_fields=extra_fields)
+          # ('all', 'family') and ('all', 'info') now in ds.field_list
+
+      The format of the passed argument is as follow: ``[('field_name_1', 'type_1'), …, ('field_name_n', 'type_n')]`` where the ``type_n`` should follow the `python convention <https://docs.python.org/3.5/library/struct.html#format-characters>`_.
+
+``cosmological``
+      Force yt to consider a simulation to be cosmological or
+      not. This may be useful for some specific simulations e.g. that
+      run down to negative redshifts.
 .. _loading-sph-data:
 
 SPH Particle Data
@@ -2113,6 +2144,3 @@ non-default cosmological parameters, you may pass an empty dictionary.
 
     import yt
     ds = yt.load(filename, cosmology_parameters={})
-
-
-

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -317,9 +317,8 @@ class RAMSESDomainFile(object):
                 self.ds.domain_left_edge, self.ds.domain_right_edge)
         root_nodes = self.amr_header['numbl'][self.ds.min_level,:].sum()
         self.oct_handler.allocate_domains(self.total_oct_count, root_nodes)
-        fb = open(self.amr_fn, "rb")
-        fb.seek(self.amr_offset)
-        f = fb
+        f = open(self.amr_fn, "rb")
+        f.seek(self.amr_offset)
         mylog.debug("Reading domain AMR % 4i (%0.3e, %0.3e)",
             self.domain_id, self.total_oct_count.sum(), self.ngridbound.sum())
         def _ng(c, l):
@@ -751,7 +750,9 @@ class RAMSESDataset(Dataset):
                 self.hilbert_indices[int(dom)] = (float(mi), float(ma))
 
         if rheader['ordering type'] != 'hilbert' and self.bbox:
-            raise NotImplementedError('The ordering %s is not compatible with the `bbox` argument.' % rheader['ordering type'])
+            raise NotImplementedError(
+                'The ordering %s is not compatible with the `bbox` argument.'
+                % rheader['ordering type'])
         self.parameters.update(rheader)
         self.domain_left_edge = np.zeros(3, dtype='float64')
         self.domain_dimensions = np.ones(3, dtype='int32') * \

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -20,7 +20,6 @@ import os
 import numpy as np
 import stat
 import weakref
-from io import BytesIO
 
 from yt.extern.six import string_types
 from yt.funcs import \
@@ -320,9 +319,7 @@ class RAMSESDomainFile(object):
         self.oct_handler.allocate_domains(self.total_oct_count, root_nodes)
         fb = open(self.amr_fn, "rb")
         fb.seek(self.amr_offset)
-        f = BytesIO()
-        f.write(fb.read())
-        f.seek(0)
+        f = fb
         mylog.debug("Reading domain AMR % 4i (%0.3e, %0.3e)",
             self.domain_id, self.total_oct_count.sum(), self.ngridbound.sum())
         def _ng(c, l):

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -723,9 +723,9 @@ class RAMSESDataset(Dataset):
         rheader = {}
         f = open(self.parameter_filename)
         def read_rhs(cast):
-            line = f.readline()
+            line = f.readline().replace('\n', '')
             p, v = line.split("=")
-            rheader[p.strip()] = cast(v)
+            rheader[p.strip()] = cast(v.strip())
         for i in range(6): read_rhs(int)
         f.readline()
         for i in range(11): read_rhs(float)

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -749,6 +749,9 @@ class RAMSESDataset(Dataset):
             for n in range(rheader['ncpu']):
                 dom, mi, ma = f.readline().split()
                 self.hilbert_indices[int(dom)] = (float(mi), float(ma))
+
+        if rheader['ordering type'] != 'hilbert' and self.bbox:
+            raise NotImplementedError('The ordering %s is not compatible with the `bbox` argument.' % rheader['ordering type'])
         self.parameters.update(rheader)
         self.domain_left_edge = np.zeros(3, dtype='float64')
         self.domain_dimensions = np.ones(3, dtype='int32') * \

--- a/yt/frontends/ramses/hilbert.py
+++ b/yt/frontends/ramses/hilbert.py
@@ -1,3 +1,21 @@
+"""
+RAMSES-specific hilbert ordering routines.
+
+These functions were translated from their original files from the
+RAMSES project. See https://bitbucket.org/rteyssie/ramses.
+
+
+"""
+from __future__ import print_function, absolute_import
+
+#-----------------------------------------------------------------------------
+# Copyright (c) yt Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
 import numpy as np
 
 def hilbert3d(X, bit_length):

--- a/yt/frontends/ramses/hilbert.py
+++ b/yt/frontends/ramses/hilbert.py
@@ -2,7 +2,8 @@
 RAMSES-specific hilbert ordering routines.
 
 These functions were translated from their original files from the
-RAMSES project. See https://bitbucket.org/rteyssie/ramses.
+RAMSES project with the agreement of the original developer. See
+https://bitbucket.org/rteyssie/ramses.
 
 
 """

--- a/yt/frontends/ramses/hilbert.py
+++ b/yt/frontends/ramses/hilbert.py
@@ -1,0 +1,180 @@
+import numpy as np
+
+def hilbert3d(X, bit_length):
+    '''Compute the order using Hilbert indexing.
+
+    Arguments
+    ---------
+    * X: (N, ndim) float array
+      The positions
+    * bit_length: integer
+      The bit_length for the indexing.
+    '''
+    X = np.atleast_2d(X)
+    state_diagram = np.array([
+        1, 2, 3, 2, 4, 5, 3, 5,
+        0, 1, 3, 2, 7, 6, 4, 5,
+        2, 6, 0, 7, 8, 8, 0, 7,
+        0, 7, 1, 6, 3, 4, 2, 5,
+        0, 9,10, 9, 1, 1,11,11,
+        0, 3, 7, 4, 1, 2, 6, 5,
+        6, 0, 6,11, 9, 0, 9, 8,
+        2, 3, 1, 0, 5, 4, 6, 7,
+        11,11, 0, 7, 5, 9, 0, 7,
+        4, 3, 5, 2, 7, 0, 6, 1,
+        4, 4, 8, 8, 0, 6,10, 6,
+        6, 5, 1, 2, 7, 4, 0, 3,
+        5, 7, 5, 3, 1, 1,11,11,
+        4, 7, 3, 0, 5, 6, 2, 1,
+        6, 1, 6,10, 9, 4, 9,10,
+        6, 7, 5, 4, 1, 0, 2, 3,
+        10, 3, 1, 1,10, 3, 5, 9,
+        2, 5, 3, 4, 1, 6, 0, 7,
+        4, 4, 8, 8, 2, 7, 2, 3,
+        2, 1, 5, 6, 3, 0, 4, 7,
+        7, 2,11, 2, 7, 5, 8, 5,
+        4, 5, 7, 6, 3, 2, 0, 1,
+        10, 3, 2, 6,10, 3, 4, 4,
+        6, 1, 7, 0, 5, 2, 4, 3]).reshape(12, 2, 8).T
+
+    x_bit_mask, y_bit_mask, z_bit_mask = [np.zeros(bit_length, dtype=bool) for _ in range(3)]
+    i_bit_mask = np.zeros(3*bit_length, dtype=bool)
+
+    npoint = X.shape[0]
+    order = np.zeros(npoint)
+
+    # Convert positions to binary
+    for ip in range(npoint):
+        for i in range(bit_length):
+            mask = 0b01 << i
+            x_bit_mask[i] = X[ip, 0] & mask
+            y_bit_mask[i] = X[ip, 1] & mask
+            z_bit_mask[i] = X[ip, 2] & mask
+
+        for i in range(bit_length):
+            # Interleave bits
+            i_bit_mask[3*i+2] = x_bit_mask[i]
+            i_bit_mask[3*i+1] = y_bit_mask[i]
+            i_bit_mask[3*i  ] = z_bit_mask[i]
+
+        # Build Hilbert ordering using state diagram
+        cstate = 0
+        for i in range(bit_length-1, -1, -1):
+            sdigit = (4 * i_bit_mask[3*i+2] +
+                      2 * i_bit_mask[3*i+1] +
+                      1 * i_bit_mask[3*i  ])
+            nstate = state_diagram[sdigit, 0, cstate]
+            hdigit = state_diagram[sdigit, 1, cstate]
+
+            i_bit_mask[3*i+2] = hdigit & 0b100
+            i_bit_mask[3*i+1] = hdigit & 0b010
+            i_bit_mask[3*i  ] = hdigit & 0b001
+
+            cstate = nstate
+
+        # Compute ordering
+        for i in range(3*bit_length):
+            order[ip] = order[ip] + i_bit_mask[i]*2**i
+
+    return order
+
+def get_cpu_list(ds, X):
+    '''
+    Return the list of the CPU intersecting with the positions
+    given. Note that it will be 0-indexed.
+
+    Parameters
+    ----------
+    * ds: Dataset
+      The dataset containing the information
+    * X: (N, ndim) float array
+      An array containing positions. They should be between 0 and 1.
+    '''
+    X = np.atleast_2d(X)
+    if X.shape[1] != 3:
+        raise NotImplementedError('This function is only implemented in 3D.')
+
+    levelmax = ds.parameters['levelmax']
+    ncpu = ds.parameters['ncpu']
+    ndim = ds.parameters['ndim']
+
+    xmin, ymin, zmin = X.min(axis=0)
+    xmax, ymax, zmax = X.max(axis=0)
+
+    dmax = max(xmax-xmin, ymax-ymin, zmax-zmin)
+    ilevel = 0
+    deltax = dmax * 2
+
+    while deltax >= dmax:
+        ilevel += 1
+        deltax = 0.5**ilevel
+
+    lmin = ilevel
+    bit_length = lmin - 1
+    maxdom = 2**bit_length
+
+    imin, imax, jmin, jmax, kmin, kmax = 0, 0, 0, 0, 0, 0
+    if bit_length > 0:
+        imin = int(xmin * maxdom)
+        imax = imin + 1
+        jmin = int(ymin * maxdom)
+        jmax = jmin + 1
+        kmin = int(zmin * maxdom)
+        kmax = kmin + 1
+
+
+    dkey = (2**(levelmax+1) / maxdom)**ndim
+    ndom = 1
+    if (bit_length > 0): ndom = 8
+
+    idom, jdom, kdom = [np.zeros(8, dtype=int) for _ in range(3)]
+
+    idom[0], idom[1] = imin, imax
+    idom[2], idom[3] = imin, imax
+    idom[4], idom[5] = imin, imax
+    idom[6], idom[7] = imin, imax
+
+    jdom[0], jdom[1] = jmin, jmin
+    jdom[2], jdom[3] = jmax, jmax
+    jdom[4], jdom[5] = jmin, jmin
+    jdom[6], jdom[7] = jmax, jmax
+
+    kdom[0], kdom[1] = kmin, kmin
+    kdom[2], kdom[3] = kmin, kmin
+    kdom[4], kdom[5] = kmax, kmax
+    kdom[6], kdom[7] = kmax, kmax
+
+    bounding_min, bounding_max = np.zeros(ndom), np.zeros(ndom)
+    for i in range(ndom):
+        if bit_length > 0:
+            order_min = hilbert3d([idom[i], jdom[i], kdom[i]], bit_length)
+        else:
+            order_min = 0
+        bounding_min[i] = (order_min  )*dkey
+        bounding_max[i] = (order_min+1)*dkey
+
+    bound_key = {}
+    for icpu in range(1, ncpu+1):
+        bound_key[icpu-1], bound_key[icpu] = ds.hilbert_indices[icpu]
+
+    cpu_min, cpu_max = [np.zeros(ncpu + 1, dtype=np.int) for _ in range(2)]
+    for icpu in range(1, ncpu+1):
+        for i in range(ndom):
+            if (bound_key[icpu - 1] <= bounding_min[i] and
+                bound_key[icpu    ] >  bounding_min[i]):
+                cpu_min[i] = icpu-1
+            if (bound_key[icpu - 1] <  bounding_max[i] and
+                bound_key[icpu    ] >= bounding_max[i]):
+                cpu_max[i] = icpu
+
+    ncpu_read = 0
+    cpu_list = []
+    cpu_read = np.zeros(ncpu, dtype=np.bool)
+    for i in range(ndom):
+        for j in range(cpu_min[i], cpu_max[i]):
+            if not cpu_read[j]:
+                ncpu_read += 1
+                cpu_list.append(j)
+                cpu_read[j] = True
+
+    return sorted(cpu_list)

--- a/yt/frontends/ramses/tests/test_hilbert.py
+++ b/yt/frontends/ramses/tests/test_hilbert.py
@@ -6,6 +6,7 @@ import numpy as np
 import yt
 
 def test_hilbert3d():
+    # 8 different cases, checked against RAMSES' own implementation
     inputs = [[0, 0, 0],
               [1, 0, 0],
               [0, 1, 0],

--- a/yt/frontends/ramses/tests/test_hilbert.py
+++ b/yt/frontends/ramses/tests/test_hilbert.py
@@ -1,0 +1,48 @@
+from yt.frontends.ramses.hilbert import get_cpu_list, hilbert3d
+from yt.testing import \
+    assert_equal, \
+    requires_file
+import numpy as np
+import yt
+
+def test_hilbert3d():
+    inputs = [[0, 0, 0],
+              [1, 0, 0],
+              [0, 1, 0],
+              [1, 1, 0],
+              [0, 0, 1],
+              [1, 0, 1],
+              [0, 1, 1],
+              [1, 1, 1]]
+    outputs = [0, 1, 7, 6, 3, 2, 4, 5]
+
+    for i, o in zip(inputs, outputs):
+        assert_equal(int(hilbert3d(i, 3)), o)
+
+
+output_00080 = "output_00080/info_00080.txt"
+@requires_file(output_00080)
+def test_get_cpu_list():
+    ds = yt.load(output_00080)
+
+    np.random.seed(16091992)
+    # These are randomly generated outputs, checked against RAMSES' own implementation
+    inputs = (
+        [[ 0.27747276,  0.30018937,  0.17916189], [ 0.42656026,  0.40509483,  0.29927838]],
+        [[ 0.90660856,  0.44201328,  0.22770587], [ 1.09175462,  0.58017918,  0.2836648 ]],
+        [[ 0.98542323,  0.58543376,  0.45858327], [ 1.04441105,  0.62079207,  0.58919283]],
+        [[ 0.42274841,  0.44887745,  0.87793679], [ 0.52066634,  0.58936331,  1.00666222]],
+        [[ 0.69964803,  0.65893669,  0.03660775], [ 0.80565696,  0.67409752,  0.11434604]])
+    outputs = (
+        [0, 15],
+        [0, 15],
+        [0, 1, 15],
+        [0, 13, 14, 15],
+        [0]
+    )
+
+    for i, o in zip(inputs, outputs):
+        bbox = i
+        ls = get_cpu_list(ds, bbox)
+        assert(len(ls) > 0)
+        assert(all(np.array(o) == np.array(ls)))


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

Provide a new argument to the `yt.load` for ramses datasets to only load a subset of a simulation.

The drawback is that once you loaded your dataset, you cannot access any of the skipped domains.

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

The new argument won't change the dataset itself (same domain width, …) but only which domains are red from disk. This is useful for people doing zoom-in simulations (like me) or cosmological simulations (like me), as it prevents yt from loading the entire AMR structure and can result in significantly faster access to small parts of simulations.

It would be good to have a bit more tests, but I didn't have time until now, any help is welcome!
<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes flake8 checker
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
