### PR TITLE
Add python_requires to yt's setup() invocation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from distutils.version import LooseVersion
 import pkg_resources
 
 
-if sys.version_info < (2, 7) or (3, 0) < sys.version_info < (3, 3):
+if sys.version_info < (2, 7) or (3, 0) < sys.version_info < (3, 4):
     print("yt currently supports Python 2.7 or versions newer than Python 3.4")
     print("certain features may fail unexpectedly and silently with older "
           "versions.")
@@ -401,4 +401,5 @@ setup(
     zip_safe=False,
     scripts=["scripts/iyt"],
     ext_modules=cython_extensions + extensions,
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*'
 )


### PR DESCRIPTION
This should prevent people from being able to pip install yt on unsupported versions of python, assuming they have a sufficiently recent verision of pip installed.

When we drop support for Python 2.7 and Python 3.4 having this defined will also make it clearer what changes need to be made to drop support cleanly.

You can read more about python_requires and the version specification format in [PEP 440](https://www.python.org/dev/peps/pep-0440/).