### PR TITLE
do a better job of handling global config state for tests that disable the dataset cache

### DIFF
--- a/yt/fields/particle_fields.py
+++ b/yt/fields/particle_fields.py
@@ -173,7 +173,7 @@ def particle_deposition_functions(ptype, coord_name, mass_name, registry):
     for ax in 'xyz':
         for method, name in zip(("cic", "sum"), ("cic", "nn")):
             function = _get_density_weighted_deposit_field(
-                "particle_velocity_%s" % ax, "cm/s", method)
+                "particle_velocity_%s" % ax, "code_velocity", method)
             registry.add_field(
                 ("deposit", ("%s_"+name+"_velocity_%s") % (ptype, ax)), sampling_type="cell",
                 function=function, units=unit_system["velocity"], take_log=False,
@@ -181,7 +181,7 @@ def particle_deposition_functions(ptype, coord_name, mass_name, registry):
 
     for method, name in zip(("cic", "sum"), ("cic", "nn")):
         function = _get_density_weighted_deposit_field(
-            "age", "s", method)
+            "age", "code_time", method)
         registry.add_field(
             ("deposit", ("%s_"+name+"_age") % (ptype)), sampling_type="cell",
             function=function, units=unit_system["time"], take_log=False,

--- a/yt/frontends/athena/tests/test_outputs.py
+++ b/yt/frontends/athena/tests/test_outputs.py
@@ -16,13 +16,13 @@ Athena frontend tests
 from yt.testing import \
     assert_equal, \
     requires_file, \
-    assert_allclose_units
+    assert_allclose_units, \
+    disable_dataset_cache
 from yt.utilities.answer_testing.framework import \
     requires_ds, \
     small_patch_amr, \
     data_dir_load
 from yt.frontends.athena.api import AthenaDataset
-from yt.config import ytcfg
 from yt.convenience import load
 
 import yt.units as u
@@ -85,9 +85,8 @@ uo_sloshing = {"length_unit": (1.0,"Mpc"),
                "mass_unit": (1.0e14,"Msun")}
 
 @requires_file(sloshing)
+@disable_dataset_cache
 def test_nprocs():
-    ytcfg["yt","skip_dataset_cache"] = "True"
-
     ds1 = load(sloshing, units_override=uo_sloshing)
     sp1 = ds1.sphere("c", (100.,"kpc"))
     prj1 = ds1.proj("density",0)
@@ -110,8 +109,6 @@ def test_nprocs():
     assert_allclose_units(sp1.quantities.bulk_velocity(),
                           sp2.quantities.bulk_velocity())
     assert_equal(prj1["density"], prj2["density"])
-
-    ytcfg["yt","skip_dataset_cache"] = "False"
 
 @requires_file(cloud)
 def test_AthenaDataset():

--- a/yt/units/tests/test_unit_systems.py
+++ b/yt/units/tests/test_unit_systems.py
@@ -16,8 +16,7 @@ from yt.units.unit_systems import UnitSystem
 from yt.units import dimensions
 from yt.convenience import load
 from yt.testing import assert_almost_equal, assert_allclose, requires_file, \
-    fake_random_ds
-from yt.config import ytcfg
+    fake_random_ds, disable_dataset_cache
 
 def test_unit_systems():
     goofy_unit_system = UnitSystem("goofy", "ly", "lbm", "hr", temperature_unit="R",
@@ -60,9 +59,8 @@ test_fields = ["density",
 
 gslr = "GasSloshingLowRes/sloshing_low_res_hdf5_plt_cnt_0300"
 @requires_file(gslr)
+@disable_dataset_cache
 def test_fields_diff_systems_sloshing():
-    ytcfg["yt","skip_dataset_cache"] = "True"
-
     ds_cgs = load(gslr)
     dd_cgs = ds_cgs.sphere("c", (15., "kpc"))
 
@@ -77,9 +75,8 @@ def test_fields_diff_systems_sloshing():
 
 etc = "enzo_tiny_cosmology/DD0046/DD0046"
 @requires_file(etc)
+@disable_dataset_cache
 def test_fields_diff_systems_etc():
-    ytcfg["yt","skip_dataset_cache"] = "True"
-
     ds_cgs = load(etc)
     dd_cgs = ds_cgs.sphere("max", (500., "kpc"))
 
@@ -97,8 +94,8 @@ def test_fields_diff_systems_etc():
 
 wdm = 'WDMerger_hdf5_chk_1000/WDMerger_hdf5_chk_1000.hdf5'
 @requires_file(wdm)
+@disable_dataset_cache
 def test_tesla_magnetic_unit():
-    ytcfg["yt", "skip_dataset_cache"] = "True"
     for us in ['cgs', 'mks', 'code']:
         ds = load(wdm, unit_system=us,
                   units_override={'magnetic_unit': (1.0, 'T')})


### PR DESCRIPTION
Currently the default for the `skip_dataset_cache` config variable is `"True"`. However, before it used to be `"False"` and it looks like there are still a couple places in our test suite that assume `skip_dataset_cache` is False by default. This means that some of these tests (`test_units_override`) in particular are re-enabling the dataset cache midway through a run of the test suite, causing mysterious failures (e.g. what hapenned in #1634).

This adds a new decorator to handle the global configuration state. Eventually I'd like to rip out dataset caching entirely but that will be a bigger job.