### PR TITLE
Adding deprecation warnings for LightRay and AbsorptionSpectrum

### DIFF
--- a/doc/source/analyzing/analysis_modules/absorption_spectrum.rst
+++ b/doc/source/analyzing/analysis_modules/absorption_spectrum.rst
@@ -1,5 +1,12 @@
 .. _absorption_spectrum:
 
+.. note::
+
+    Development of the AbsorptionSpectrum module has been moved to the
+    Trident package. This version is deprecated and will be removed from yt
+    in a future release. See https://github.com/trident-project/trident
+    for further information.
+
 Creating Absorption Spectra
 ===========================
 

--- a/doc/source/analyzing/analysis_modules/light_ray_generator.rst
+++ b/doc/source/analyzing/analysis_modules/light_ray_generator.rst
@@ -1,5 +1,12 @@
 .. _light-ray-generator:
 
+.. note::
+
+    Development of the LightRay module has been moved to the Trident
+    package. This version is deprecated and will be removed from yt
+    in a future release. See https://github.com/trident-project/trident
+    for further information.
+
 Light Ray Generator
 ===================
 

--- a/yt/analysis_modules/absorption_spectrum/api.py
+++ b/yt/analysis_modules/absorption_spectrum/api.py
@@ -13,6 +13,14 @@ API for absorption_spectrum
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
+from yt.funcs import issue_deprecation_warning
+
+issue_deprecation_warning(
+    "Development of the AbsorptionSpectrum module has been moved to the "
+    "Trident package. This version is deprecated and will be removed from yt "
+    "in a future release. See https://github.com/trident-project/trident "
+    "for further information.")
+
 from .absorption_spectrum import \
     AbsorptionSpectrum
 

--- a/yt/analysis_modules/cosmological_observation/light_ray/api.py
+++ b/yt/analysis_modules/cosmological_observation/light_ray/api.py
@@ -13,5 +13,13 @@ API for light_ray
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
+from yt.funcs import issue_deprecation_warning
+
+issue_deprecation_warning(
+    "Development of the LightRay module has been moved to the Trident "
+    "package. This version is deprecated and will be removed from yt "
+    "in a future release. See https://github.com/trident-project/trident "
+    "for further information.")
+
 from .light_ray import \
     LightRay

--- a/yt/analysis_modules/halo_mass_function/api.py
+++ b/yt/analysis_modules/halo_mass_function/api.py
@@ -18,7 +18,7 @@ from yt.funcs import issue_deprecation_warning
 issue_deprecation_warning(
     "The halo_mass_function module does not function correctly and has been "
     "deprecated. This code has been moved to the yt attic "
-    "(https://bitbucket.org/yt_analysis/yt_attic) and will be removed in a "
+    "(https://github.com/yt-project/yt_attic) and will be removed in a "
     "future release.")
 
 from .halo_mass_function import \

--- a/yt/analysis_modules/star_analysis/api.py
+++ b/yt/analysis_modules/star_analysis/api.py
@@ -17,7 +17,7 @@ from yt.funcs import issue_deprecation_warning
 
 issue_deprecation_warning(
     "The star_analysis module has been deprecated. This code has been moved "
-    "to the yt attic (https://bitbucket.org/yt_analysis/yt_attic) and will "
+    "to the yt attic (https://github.com/yt-project/yt_attic) and will "
     "be removed in a future release.")
 
 from .sfr_spectrum import \

--- a/yt/analysis_modules/sunrise_export/api.py
+++ b/yt/analysis_modules/sunrise_export/api.py
@@ -17,7 +17,7 @@ from yt.funcs import issue_deprecation_warning
 
 issue_deprecation_warning(
     "The sunrise_exporter module has been deprecated. This code has been "
-    "moved to the yt attic (https://bitbucket.org/yt_analysis/yt_attic) and "
+    "moved to the yt attic (https://github.com/yt-project/yt_attic) and "
     "will be removed in a future release.")
 
 from .sunrise_exporter import \

--- a/yt/analysis_modules/two_point_functions/api.py
+++ b/yt/analysis_modules/two_point_functions/api.py
@@ -18,7 +18,7 @@ from yt.funcs import issue_deprecation_warning
 
 issue_deprecation_warning(
     "The two_point_functions module has been deprecated. This code has been "
-    "moved to the yt attic (https://bitbucket.org/yt_analysis/yt_attic) and "
+    "moved to the yt attic (https://github.com/yt-project/yt_attic) and "
     "will be removed in a future release.")
 
 from .two_point_functions import \


### PR DESCRIPTION
These modules have been moved to the Trident package.

Also, update the links to the yt_attic.