### PR TITLE
Refactor RAMSES age and formation time fields

### DIFF
--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -2027,7 +2027,9 @@ Arguments passed to the load function
 It is possible to provide extra arguments to the load function when loading RAMSES datasets. Here is a list of the ones specific to RAMSES:
 
 ``fields``
-      A list of fields to read from the hydro files. For a hydro simulation with an extra custom field
+    A list of fields to read from the hydro files. For example, in a pure
+    hydro simulation with an extra custom field named ``my-awesome-field``, one
+    would specify the fields argument following this example:
 
       .. code-block:: python
 
@@ -2043,9 +2045,10 @@ It is possible to provide extra arguments to the load function when loading RAMS
       A list of tuples describing extra particles fields to read in. By
       default, yt will try to detect as many fields as possible,
       assuming the extra ones to be double precision floats. This
-      argument is useful if you have extra fields that yt cannot
-      detect. For example, for a dataset containing two integer fields
-      in the particles, one would do
+      argument is useful if you have extra fields besides the particle mass,
+      position, and velocity fields that yt cannot detect automatically. For
+      example, for a dataset containing two extra particle integer fields named
+      ``family`` and ``info``, one would do:
 
       .. code-block:: python
 
@@ -2054,7 +2057,15 @@ It is possible to provide extra arguments to the load function when loading RAMS
           ds = yt.load("output_00001/info_00001.txt", extra_particle_fields=extra_fields)
           # ('all', 'family') and ('all', 'info') now in ds.field_list
 
-      The format of the passed argument is as follow: ``[('field_name_1', 'type_1'), …, ('field_name_n', 'type_n')]`` where the ``type_n`` is as follow `python convention <https://docs.python.org/3.5/library/struct.html#format-characters>`_.
+      The format of the ``extra_particle_fields`` argument is as follows:
+      ``[('field_name_1', 'type_1'), …, ('field_name_n', 'type_n')]`` where
+      the second element of the tuple follows the `python struct format
+      convention
+      <https://docs.python.org/3.5/library/struct.html#format-characters>`_.
+      Note that if ``extra_particle_fields`` is defined, yt will not assume
+      that the ``particle_birth_time`` and ``particle_metallicity`` fields
+      are present in the dataset. If these fields are present, they must be
+      explicitly enumerated in the ``extra_particle_fields`` argument.
 
 ``cosmological``
       Force yt to consider a simulation to be cosmological or
@@ -2062,7 +2073,7 @@ It is possible to provide extra arguments to the load function when loading RAMS
       run down to negative redshifts.
 
 ``bbox``
-      The subbox to load. Yt will only read CPUs intersecting with the
+      The subbox to load. yt will only read CPUs intersecting with the
       subbox. This is especially useful for large simulations or
       zoom-in simulations, where you don't want to have access to data
       outside of a small region of interest. This argument will prevent
@@ -2085,6 +2096,7 @@ It is possible to provide extra arguments to the load function when loading RAMS
 
           bb = ds.box(left_edge=bbox[0], right_edge=bbox[1])
           bb['particle_position_x'].max() < 0.1  # is True
+
       .. note::
          When using the bbox argument, yt will read all the CPUs
          intersecting with the subbox. However it may also read some
@@ -2156,54 +2168,10 @@ There are three way to make yt detect all the particle fields. For example, if y
    The kind (``i``, ``d``, ``I``, ...) of the field follow the `python convention <https://docs.python.org/3.5/library/struct.html#format-characters>`_.
 
 
-Adding custom particle fields
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-There are three way to make yt detect all the particle fields. For example, if you wish to make yt detect the metallicity and a passive field (e.g. for a zoom-in simulation), use one of these methods
-
-1. ``yt.load`` method. Whenever loading a dataset, add the extra particle fields as a keyword argument to the ``yt.load`` call.
-
-   .. code-block:: python
-
-      import yt
-      fields = ["Density",
-                "x-velocity", "y-velocity", "z-velocity",
-                "Pressure", "Metallicity", "Scalar_01"]
-      ds = yt.load('output_00123/info_00123.txt', fields=fields)
-      ('ramses', 'Metallicity') in ds.field_list  # is True
-      ('ramses', 'Scalar_01') in ds.field_list  # is True
-
-2. yt config method. If you don't want to pass the arguments for each call of ``yt.load``, you can add in your configuration
-
-   .. code-block:: none
-
-      [ramses-hydro]
-      fields = Density
-               x-velocity
-               y-velocity
-               z-velocity
-               Pressure
-               Metallicity
-               Scalar_01
-
-3. New RAMSES way. Recent versions of RAMSES automatically write in their output an ``hydro_file_descriptor.txt`` file that gives information about which field is where. If you wish, you can simply create such a file in the folder containing the ``info_xxxxx.txt`` file
-
-   .. code-block:: none
-
-      # version:  1
-      # ivar, variable_name, variable_type
-       1, density, d
-       2, velocity_x, d
-       3, velocity_y, d
-       4, velocity_z, d
-       5, pressure, d
-       6, metallicity, d
-       7, scalar_01
-
-   It is important to note that this file should not end with an empty line (but in this case with ``_7, scalar_01, d``. Note that the ``_`` stands for a space).
 
 Customizing the particle type association
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 In verions of RAMSES more recent than December 2017, particles carry
 along a ``family`` array. The value of this array gives the kind of
 the particle, e.g. 1 for dark matter. It is possible to customize the
@@ -2220,6 +2188,88 @@ config (see :ref:`configuration`), adding
 
 
 
+Particle ages and formation times
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For non-cosmological simulations, particle ages are stored in physical units on
+disk. To access the birth time for the particles, use the
+``particle_birth_time`` field. The time recorded in this field is relative to
+the beginning of the simulation. Particles that were present in the initial
+conditions will have negative values for ``particle_birth_time``.
+
+For cosmological simulations that include star particles, RAMSES stores particle
+formation times as conformal times. To access the formation time field data in
+conformal units use the ``conformal_birth_time`` field. This will return the
+formation times of particles in the simulation in conformal units as a
+dimensionless array. To access the formation time in physical units, use the
+``particle_birth_time`` field. Finally, to access the ages of star particles in
+your simulation, use the ``star_age`` field. Note that this field is defined for
+all particle types but will only make sense for star particles.
+
+For simulations conducted in Newtownian coordinates, with no cosmology or
+comoving expansion, the time is equal to zero at the beginning of the
+simulation. That means that particles present in the initial conditions may have
+negative birth times. This can happen, for example, in idealized isolated galaxy
+simulations, where star particles are included in the initial conditions. For
+simulations conducted in cosmological comoving units, the time is equal to zero
+at the big bang, and all particles should have positive values for the
+``particle_birth_time`` field.
+
+To help clarify the above discussion, the following table describes the meaning
+of the various particle formation time and age fields:
+
++------------------+-------------------------+-------------------------------+
+| Simulation type  | Field name              | Description                   |
+|==================|=========================+===============================+
+| cosmological     | `conformal_birth_time`  | Formation time in conformal   |
+|                  |                         | units (dimensionless)         |
++------------------+-------------------------+--------------------------------+
+| any              | `particle_birth_time`   | The time relative to the       |
+|                  |                         | beginning of the simulation    |
+|                  |                         | when the particle was formed.  |
+|                  |                         | For non-cosmological           |
+|                  |                         | simulations, this field will   |
+|                  |                         | have positive values for       |
+|                  |                         | particles formed during the    |
+|                  |                         | simulation and negative for    |
+|                  |                         | particles of finite age in the |
+|                  |                         | initial conditions. For        |
+|                  |                         | cosmological simulations this  |
+|                  |                         | is the time the particle       |
+|                  |                         | formed relative to the big     |
+|                  |                         | bang, therefore the value of   |
+|                  |                         | this field should be between   |
+|                  |                         | 0 and 13.7 Gyr.                |
++------------------+-------------------------+--------------------------------+
+| any              | `star_age`              | Age of the particle.           |
+|                  |                         | Only physically meaningful for |
+|                  |                         | stars and particles that       |
+|                  |                         | formed dynamically during the  |
+|                  |                         | simulation.                    |
++------------------+-------------------------+--------------------------------+
+
+RAMSES datasets produced by a version of the code newer than November 2017
+contain the metadata necessary for yt to automatically distinguish between star
+particles and other particle types. If you are working with a dataset produced
+by a version of RAMSES older than November 2017, yt will only automatically
+recognize a single particle ``io``. It may be convenient to define a particle
+filter in your scripts to distinguish between particles present in the initial
+conditions and particles that formed dynamically during the simulation by
+filtering particles with ``"conformal_birth_time"`` values equal to zero and not
+equal to zero.  An example particle filter definition for dynamically formed
+stars might look like this:
+
+.. code-block:: python
+
+    @yt.particle_filter(requires=["conformal_birth_time"],
+                        filtered_type='io')
+    def stars(pfilter, data):
+        filter = data[(pfilter.filtered_type, "conformal_birth_time"] != 0
+        return filter
+
+For a cosmological simulation, this filter will distinguish between stars and
+dark matter particles.
+        
 .. _loading-sph-data:
 
 SPH Particle Data

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -330,6 +330,11 @@ class RAMSESIndex(OctreeIndex):
                 dsl.update(set(ph.field_offsets.keys()))
 
         self.particle_field_list = list(dsl)
+        cosmo = self.ds.cosmological_simulation
+        for f in self.particle_field_list[:]:
+            if f[1] == 'particle_birth_time' and cosmo:
+                self.particle_field_list.append(
+                    (f[0], 'conformal_birth_time'))
 
         # Get the detected fields
         dsl = set([])

--- a/yt/frontends/ramses/fields.py
+++ b/yt/frontends/ramses/fields.py
@@ -17,6 +17,14 @@ import os
 import numpy as np
 
 from yt import units
+from yt.fields.field_detector import \
+    FieldDetector
+from yt.fields.field_info_container import \
+    FieldInfoContainer
+from yt.frontends.ramses.io import \
+    convert_ramses_ages
+from yt.funcs import \
+    issue_deprecation_warning
 from yt.utilities.physical_constants import \
     boltzmann_constant_cgs, \
     mass_hydrogen_cgs, \
@@ -24,8 +32,6 @@ from yt.utilities.physical_constants import \
 from yt.utilities.linear_interpolators import \
     BilinearFieldInterpolator
 import yt.utilities.fortran_utils as fpu
-from yt.fields.field_info_container import \
-    FieldInfoContainer
 from .field_handlers import RTFieldFileHandler
 
 b_units = "code_magnetic"
@@ -91,8 +97,8 @@ class RAMSESFieldInfo(FieldInfoContainer):
         ("particle_mass", ("code_mass", [], None)),
         ("particle_identity", ("", ["particle_index"], None)),
         ("particle_refinement_level", ("", [], None)),
-        ("particle_age", ("code_time", ['age'], None)),
         ("particle_birth_time", ("code_time", ['age'], None)),
+        ("conformal_birth_time", ("", [], None)),
         ("particle_metallicity", ("", [], None)),
         ("particle_family", ("", [], None)),
         ("particle_tag", ("", [], None))
@@ -107,7 +113,7 @@ class RAMSESFieldInfo(FieldInfoContainer):
         ("particle_velocity_z", (vel_units, [], None)),
         ("particle_mass", ("code_mass", [], None)),
         ("particle_identifier", ("", ["particle_index"], None)),
-        ("particle_age", ("code_time", ['age'], None)),
+        ("particle_birth_time", ("code_time", ['age'], None)),
         ("BH_real_accretion", ("code_mass/code_time", [], None)),
         ("BH_bondi_accretion", ("code_mass/code_time", [], None)),
         ("BH_eddington_accretion", ("code_mass/code_time", [], None)),
@@ -121,6 +127,36 @@ class RAMSESFieldInfo(FieldInfoContainer):
         ("BH_spin", (ang_mom_units, [], None)),
         ("BH_efficiency", ("", [], None))
     )
+
+    def setup_particle_fields(self, ptype):
+        super(RAMSESFieldInfo, self).setup_particle_fields(ptype)
+        def particle_age(field, data):
+            msg = ("The RAMSES particle_age field has been deprecated since "
+                   "it did not actually represent particle ages in all "
+                   "cases. To get the time when a particle was formed use "
+                   "the particle_birth_time field instead. To get the "
+                   "age of a star particle, use the star_age field")
+            if not isinstance(data, FieldDetector):
+                issue_deprecation_warning(msg, stacklevel=2)
+            if data.ds.cosmological_simulation:
+                conformal_age = data[ptype, 'conformal_birth_time']
+                ret = convert_ramses_ages(data.ds, conformal_age)
+                return data.ds.arr(ret, 'code_time')
+            else:
+                return data[ptype, 'particle_birth_time']
+        self.add_field((ptype, 'particle_age'), sampling_type='particle',
+                       function=particle_age,
+                       units=self.ds.unit_system['time'])
+        def star_age(field, data):
+            if data.ds.cosmological_simulation:
+                conformal_age = data[ptype, 'conformal_birth_time']
+                formation_time = convert_ramses_ages(data.ds, conformal_age)
+                formation_time = data.ds.arr(formation_time, 'code_time')
+            else:
+                formation_time = data['particle_birth_time']
+            return data.ds.current_time - formation_time
+        self.add_field((ptype, 'star_age'), sampling_type='particle',
+                       function=star_age, units=self.ds.unit_system['time'])
 
     def setup_fluid_fields(self):
         def _temperature(field, data):

--- a/yt/frontends/ramses/io.py
+++ b/yt/frontends/ramses/io.py
@@ -21,8 +21,6 @@ from yt.utilities.io_handler import \
 from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.physical_ratios import cm_per_km, cm_per_mpc
 import yt.utilities.fortran_utils as fpu
-from yt.utilities.lib.cosmology_time import \
-    get_ramses_ages
 from yt.utilities.exceptions import YTFieldTypeNotFound, YTParticleOutputFormatNotImplemented, \
     YTFileNotParseable
 from yt.extern.six import PY3
@@ -32,6 +30,31 @@ if PY3:
     from io import BytesIO as IO
 else:
     from cStringIO import StringIO as IO
+
+def convert_ramses_ages(ds, conformal_ages):
+    tf = ds.t_frw
+    dtau = ds.dtau
+    tauf = ds.tau_frw
+    tsim = ds.time_simu
+    h100 = ds.hubble_constant
+    nOver2 = ds.n_frw/2
+    unit_t = ds.parameters['unit_t']
+    t_scale = 1./(h100 * 100 * cm_per_km / cm_per_mpc) / unit_t
+
+    # calculate index into lookup table (n_frw elements in
+    # lookup table)
+    dage =  1 + (10*conformal_ages/dtau)
+    dage = np.minimum(dage, nOver2 + (dage - nOver2)/10.)
+    iage = np.array(dage, dtype=np.int32)
+
+    # linearly interpolate physical times from tf and tauf lookup
+    # tables.
+    t = ((tf[iage]*(conformal_ages - tauf[iage - 1]) /
+          (tauf[iage] - tauf[iage - 1])))
+    t = t + ((tf[iage-1]*(conformal_ages - tauf[iage]) /
+              (tauf[iage-1]-tauf[iage])))
+    return (tsim - t)*t_scale
+
 
 def _ramses_particle_file_handler(fname, foffsets, data_types,
                                   subset, fields, count):
@@ -53,6 +76,7 @@ def _ramses_particle_file_handler(fname, foffsets, data_types,
         The number of elements to count
     '''
     tr = {}
+    ds = subset.domain.ds
     with open(fname, "rb") as f:
         # We do *all* conversion into boxlen here.
         # This means that no other conversions need to be applied to convert
@@ -65,18 +89,13 @@ def _ramses_particle_file_handler(fname, foffsets, data_types,
             dt = data_types[field]
             tr[field] = fpu.read_vector(f, dt)
             if field[1].startswith("particle_position"):
-                np.divide(tr[field], subset.domain.ds["boxlen"], tr[field])
-            cosmo = subset.domain.ds.cosmological_simulation
-            if cosmo == 1 and field[1] == "particle_age":
-                tf = subset.domain.ds.t_frw
-                dtau = subset.domain.ds.dtau
-                tauf = subset.domain.ds.tau_frw
-                tsim = subset.domain.ds.time_simu
-                h100 = subset.domain.ds.hubble_constant
-                nOver2 = subset.domain.ds.n_frw/2
-                t_scale = 1./(h100 * 100 * cm_per_km / cm_per_mpc)/subset.domain.ds['unit_t']
-                ages = tr[field]
-                tr[field] = get_ramses_ages(tf,tauf,dtau,tsim,t_scale,ages,nOver2,len(ages))
+                np.divide(tr[field], ds["boxlen"], tr[field])
+            if ds.cosmological_simulation and field[1] == "particle_birth_time":
+                conformal_age = tr[field]
+                tr[field] = convert_ramses_ages(ds, conformal_age)
+                # arbitrarily set particles with zero conformal_age to zero
+                # particle_age. This corresponds to DM particles.
+                tr[field][conformal_age == 0] = 0
     return tr
 
 
@@ -188,6 +207,13 @@ class IOHandlerRAMSES(BaseIOHandler):
                     break
             if not ok:
                 raise YTFieldTypeNotFound(ptype)
+
+            cosmo = self.ds.cosmological_simulation
+            if (ptype, 'particle_birth_time') in foffsets and cosmo:
+                foffsets[ptype, 'conformal_birth_time'] = \
+                    foffsets[ptype, 'particle_birth_time']
+                data_types[ptype, 'conformal_birth_time'] = \
+                    data_types[ptype, 'particle_birth_time']
 
             tr.update(_ramses_particle_file_handler(
                 fname, foffsets, data_types, subset, subs_fields,

--- a/yt/frontends/ramses/particle_handlers.py
+++ b/yt/frontends/ramses/particle_handlers.py
@@ -203,6 +203,7 @@ class DefaultParticleFileHandler(ParticleFileHandler):
         hvals.update(fpu.read_attrs(f, attrs))
         self.header = hvals
         self.local_particle_count = hvals['npart']
+        extra_particle_fields = self.ds._extra_particle_fields
 
         if self.has_part_descriptor:
             particle_fields = (
@@ -211,8 +212,12 @@ class DefaultParticleFileHandler(ParticleFileHandler):
         else:
             particle_fields = list(self.known_fields)
 
-            if self.ds._extra_particle_fields is not None:
-                particle_fields += self.ds._extra_particle_fields
+            if extra_particle_fields is not None:
+                particle_fields += extra_particle_fields
+
+        if hvals["nstar_tot"] > 0 and extra_particle_fields is not None:
+            particle_fields += [("particle_birth_time", "d"),
+                                ("particle_metallicity", "d")]
 
         field_offsets = {}
         _pfields = {}
@@ -266,7 +271,7 @@ class SinkParticleFileHandler(ParticleFileHandler):
         ("particle_velocity_x", "d"),
         ("particle_velocity_y", "d"),
         ("particle_velocity_z", "d"),
-        ("particle_age", "d"),
+        ("particle_birth_time", "d"),
         ("BH_real_accretion", "d"),
         ("BH_bondi_accretion", "d"),
         ("BH_eddington_accretion", "d"),

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -1142,9 +1142,9 @@ def parse_h5_attr(f, attr):
     else:
         return val
 
-def issue_deprecation_warning(msg):
+def issue_deprecation_warning(msg, stacklevel=3):
     from numpy import VisibleDeprecationWarning
-    warnings.warn(msg, VisibleDeprecationWarning, stacklevel=3)
+    warnings.warn(msg, VisibleDeprecationWarning, stacklevel=stacklevel)
 
 def obj_length(v):
     if iterable(v):

--- a/yt/utilities/lib/cosmology_time.pyx
+++ b/yt/utilities/lib/cosmology_time.pyx
@@ -78,25 +78,4 @@ cpdef friedman(double O_mat_0,double O_vac_0,double O_k_0):
     tau_out[n_out] = tau
 
     return tau_out,t_out,delta_tau,ntable,age_tot
-
-cpdef get_ramses_ages(np.ndarray[double,mode='c'] tf, 
-                     np.ndarray[double,mode='c'] tauf,  
-                     double dtau, 
-                     double tsim, 
-                     double t_scale, 
-                     np.ndarray[double,mode='c'] ages, 
-                     int nOver2, 
-                     int ntot):
-
-    cdef np.ndarray[double,mode='c'] t
-    cdef np.ndarray[double,mode='c'] dage
-    cdef np.ndarray[int,mode='c'] iage
-
-    dage = 1 + (10*ages/dtau)
-    dage = np.minimum(dage, nOver2 + (dage - nOver2)/10.)
-    iage = np.array(dage,dtype=np.int32)
-
-    t = (tf[iage]*(ages - tauf[iage - 1]) / (tauf[iage] - tauf[iage - 1]))
-    t = t + (tf[iage-1]*(ages-tauf[iage]) / (tauf[iage-1]-tauf[iage]))
-    return  (tsim - t)*t_scale
  


### PR DESCRIPTION
This supersedes #1463 and #1545.

This pull request makes the following changes:

 * Restores the `particle_age` and `particle_metallicity` fields, which were unintentionally removed during the particle i/o refactoring that was recently merged.
 * Deprecates the `particle_age` field. This field is actually the formation time of particles and shouldn't have ever been called an "age".
 * Adds a `particle_formation_time` field. This is distinct from the values in the old `particle_age` in that particles present in the initial conditions will always have a `particle_formation_time` equal to zero. This makes it a bit easier to write particle filters for particles present in the initial conditions and avoids presenting negative formation times to the user, which doesn't make much sense.
 * Adds a `star_age` field that contains the actual ages of star particles.

As a minor refactoring, I've eliminated the cython `get_ramses_ages`. This function doesn't get any particular speedup by being written in cython so to ease debugging I've put its functionality into a `convert_ramses_ages` python function.

I'd appreciate eyes on this by one or more of @ari_maller, @HugoPfister, @cphyc, @mlarichardson, or @ruggiero, who have all participated in discussions about issues that this PR hopes to address.