### PR TITLE
[Bugfix] Fix particle data file names in the Boxlib frontend

### DIFF
--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -579,7 +579,7 @@ class BoxlibHierarchy(GridIndex):
         elif (len(glob.glob(base + "/Level_?/DATA_?????")) > 0):
             base_particle_fn = self.ds.output_dir + '/' + directory_name + "/Level_%d/DATA_%.5d"
         else:
-              raise YTException("Could not find any particle data files.")
+            return
 
         gid = 0
         for lev, data in self.particle_headers[directory_name].data_map.items():

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -572,10 +572,10 @@ class BoxlibHierarchy(GridIndex):
         self.ds._particle_type_counts[directory_name] = num_parts
 
         base = self.ds.output_dir + '/' + directory_name
-        if (len(glob.glob(base + "/Level_?/DATA_????")) > 0):
-            base_particle_fn = self.ds.output_dir + '/' + directory_name + "/Level_%d/DATA_%.4d"
-        elif (len(glob.glob(base + "/Level_?/DATA_?????")) > 0):
-            base_particle_fn = self.ds.output_dir + '/' + directory_name + "/Level_%d/DATA_%.5d"
+        if (len(glob.glob(os.path.join(base, "Level_?", "DATA_????"))) > 0):
+            base_particle_fn = os.path.join(base, "Level_%d", "DATA_%.4d")
+        elif (len(glob.glob(os.path.join(base, "Level_?", "DATA_?????"))) > 0):
+            base_particle_fn = os.path.join(base, "Level_%d", "DATA_%.5d")
         else:
             return
 

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -571,7 +571,7 @@ class BoxlibHierarchy(GridIndex):
             self.ds._particle_type_counts = {}
         self.ds._particle_type_counts[directory_name] = num_parts
 
-        base = self.ds.output_dir + '/' + directory_name
+        base = os.path.join(self.ds.output_dir, directory_name)
         if (len(glob.glob(os.path.join(base, "Level_?", "DATA_????"))) > 0):
             base_particle_fn = os.path.join(base, "Level_%d", "DATA_%.4d")
         elif (len(glob.glob(os.path.join(base, "Level_?", "DATA_?????"))) > 0):

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -37,8 +37,6 @@ from yt.utilities.lib.misc_utilities import \
     get_box_grids_level
 from yt.utilities.io_handler import \
     io_registry
-from yt.utilities.exceptions import \
-    YTException
 
 from .fields import \
     BoxlibFieldInfo, \

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -37,6 +37,8 @@ from yt.utilities.lib.misc_utilities import \
     get_box_grids_level
 from yt.utilities.io_handler import \
     io_registry
+from yt.utilities.exceptions import \
+    YTException
 
 from .fields import \
     BoxlibFieldInfo, \
@@ -571,7 +573,13 @@ class BoxlibHierarchy(GridIndex):
             self.ds._particle_type_counts = {}
         self.ds._particle_type_counts[directory_name] = num_parts
 
-        base_particle_fn = self.ds.output_dir + '/' + directory_name + "/Level_%d/DATA_%.4d"
+        base = self.ds.output_dir + '/' + directory_name
+        if (len(glob.glob(base + "/Level_?/DATA_????")) > 0):
+            base_particle_fn = self.ds.output_dir + '/' + directory_name + "/Level_%d/DATA_%.4d"
+        elif (len(glob.glob(base + "/Level_?/DATA_?????")) > 0):
+            base_particle_fn = self.ds.output_dir + '/' + directory_name + "/Level_%d/DATA_%.5d"
+        else:
+              raise YTException("Could not find any particle data files.")
 
         gid = 0
         for lev, data in self.particle_headers[directory_name].data_map.items():


### PR DESCRIPTION
Due to a change in AMReX, these file names can have either 4 or 5 digits now.
