### PR TITLE
attempt to restore support for very old pickle files

### DIFF
--- a/yt/units/yt_array.py
+++ b/yt/units/yt_array.py
@@ -1438,7 +1438,10 @@ class YTArray(np.ndarray):
         metadata extracted in __reduce__ and then serialized by pickle.
         """
         super(YTArray, self).__setstate__(state[1:])
-        unit, lut = state[0]
+        try:
+            unit, lut = state[0]
+        except TypeError:
+            unit, lut = str(state[0]), default_unit_symbol_lut.copy()
         # need to fix up the lut if the pickle was saved prior to PR #1728
         # when the pickle format changed
         if len(lut['m']) == 2:

--- a/yt/units/yt_array.py
+++ b/yt/units/yt_array.py
@@ -1441,6 +1441,9 @@ class YTArray(np.ndarray):
         try:
             unit, lut = state[0]
         except TypeError:
+            # this case happens when we try to load an old pickle file
+            # created before we serialized the unit symbol lookup table
+            # into the pickle file
             unit, lut = str(state[0]), default_unit_symbol_lut.copy()
         # need to fix up the lut if the pickle was saved prior to PR #1728
         # when the pickle format changed


### PR DESCRIPTION
This is in response to Jason Tumlinson on the mailing list. They supplied a pickle file created with an old version of yt. Apparently on this version there was no unit lookup-table saved at all and instead just a number, which I'm interpreting as the unit name. It's possible that this will break for other old pickle files but this will at least allow yt to load the one example we know of.