### PR TITLE
[bugfix] Keep units when setting domain edges for frb datasets.

### DIFF
--- a/yt/frontends/ytdata/data_structures.py
+++ b/yt/frontends/ytdata/data_structures.py
@@ -52,6 +52,7 @@ from yt.units import \
 from yt.units.unit_registry import \
     UnitRegistry
 from yt.units.yt_array import \
+    uconcatenate, \
     YTQuantity
 from yt.utilities.logger import \
     ytLogger as mylog
@@ -500,11 +501,11 @@ class YTGridDataset(YTDataset):
 
         elif self.data_type == "yt_frb":
             dle = self.domain_left_edge
-            left = self.parameters["left_edge"].to(dle.units)
-            dle[0:2] = left
+            self.domain_left_edge = uconcatenate(
+                [self.parameters["left_edge"].to(dle.units), [0] * dle.uq])
             dre = self.domain_right_edge
-            right = self.parameters["right_edge"].to(dre.units)
-            dre[0:2] = right
+            self.domain_right_edge = uconcatenate(
+                [self.parameters["right_edge"].to(dre.units), [1] * dre.uq])
             self.domain_dimensions = \
               np.concatenate([self.parameters["ActiveDimensions"], [1]])
 

--- a/yt/frontends/ytdata/data_structures.py
+++ b/yt/frontends/ytdata/data_structures.py
@@ -499,10 +499,12 @@ class YTGridDataset(YTDataset):
                    self.base_domain_right_edge) < 0.5 * dx
 
         elif self.data_type == "yt_frb":
-            self.domain_left_edge = \
-              np.concatenate([self.parameters["left_edge"], [0.]])
-            self.domain_right_edge = \
-              np.concatenate([self.parameters["right_edge"], [1.]])
+            dle = self.domain_left_edge
+            left = self.parameters["left_edge"].to(dle.units)
+            dle[0:2] = left
+            dre = self.domain_right_edge
+            right = self.parameters["right_edge"].to(dre.units)
+            dre[0:2] = right
             self.domain_dimensions = \
               np.concatenate([self.parameters["ActiveDimensions"], [1]])
 

--- a/yt/frontends/ytdata/tests/test_outputs.py
+++ b/yt/frontends/ytdata/tests/test_outputs.py
@@ -25,6 +25,7 @@ from yt.frontends.ytdata.api import \
     YTProfileDataset, \
     save_as_dataset
 from yt.testing import \
+    assert_array_equal, \
     assert_allclose_units, \
     assert_equal, \
     assert_fname, \
@@ -145,6 +146,7 @@ def test_grid_datacontainer_data():
     frb = my_proj.to_frb(1.0, (800, 800))
     fn = frb.save_as_dataset(fields=["density"])
     frb_ds = load(fn)
+    assert_array_equal(frb["density"], frb_ds.data["density"])
     compare_unit_attributes(ds, frb_ds)
     assert isinstance(frb_ds, YTGridDataset)
     yield YTDataFieldTest(full_fn, "density", geometric=False)


### PR DESCRIPTION
This fixes a bug that shows up when you do:
```
ds = yt.load("enzo_tiny_cosmology/DD0046/DD0046")
proj = ds.proj("density", "x")
frb = proj.to_frb(1, (1000, 1000))
fn = frb.save_as_dataset(fields=["density"])
nds = yt.load(fn)
print (nds.data["density"])
```

The units of the domain right/left edges were being clobbered.  The added assert tests this functionality.
  