### PR TITLE
temporarily pin numpy version for cloud CI services

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
 
 env:
   global:
-    NUMPY=numpy
+    NUMPY=numpy==1.13.3
     CYTHON=cython
     MATPLOTLIB=matplotlib
     SYMPY=sympy

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ install:
     - "python --version"
 
     # Install specified version of numpy and dependencies
-    - "conda install --yes -c conda-forge numpy scipy nose setuptools ipython Cython sympy fastcache h5py matplotlib flake8 mock"
+    - "conda install --yes -c conda-forge numpy==1.13.3 scipy nose setuptools ipython Cython sympy fastcache h5py matplotlib flake8 mock"
     - "pip install -e ."
 
 # Not a .NET project


### PR DESCRIPTION
This should fix the travis build failures that are happening on master at the moment. We can wait on the resolution of https://github.com/numpy/numpy/issues/10360 to see if fixing this permanently will require changes on the yt side or if we just need to wait for NumPy 1.14.1.