### PR TITLE
add a special case for array scalars in YTArray.__str__

### DIFF
--- a/yt/units/tests/test_ytarray.py
+++ b/yt/units/tests/test_ytarray.py
@@ -815,7 +815,8 @@ def unary_ufunc_comparison(ufunc, a):
     elif ufunc is np.invert:
         assert_raises(TypeError, ufunc, a)
     elif hasattr(np, 'isnat') and ufunc is np.isnat:
-        assert_raises(ValueError, ufunc, a)
+        # numpy 1.13 raises ValueError, numpy 1.14 and newer raise TypeError
+        assert_raises((TypeError, ValueError), ufunc, a)
     else:
         # There shouldn't be any untested ufuncs.
         assert_true(False)

--- a/yt/units/yt_array.py
+++ b/yt/units/yt_array.py
@@ -529,7 +529,11 @@ class YTArray(np.ndarray):
         """
 
         """
-        return super(YTArray, self).__str__()+' '+self.units.__str__()
+        # need to check if we're dealing with a scalar to avoid a recursion
+        # error on NumPy 1.14 and newer
+        if self.shape != ():
+            return super(YTArray, self).__str__()+' '+self.units.__str__()
+        return str(np.asarray(self)) + ' ' + str(self.units)
 
     #
     # Start unit conversion methods

--- a/yt/units/yt_array.py
+++ b/yt/units/yt_array.py
@@ -529,11 +529,7 @@ class YTArray(np.ndarray):
         """
 
         """
-        # need to check if we're dealing with a scalar to avoid a recursion
-        # error on NumPy 1.14 and newer
-        if self.shape != ():
-            return super(YTArray, self).__str__()+' '+self.units.__str__()
-        return str(np.asarray(self)) + ' ' + str(self.units)
+        return str(self.view(np.ndarray)) + ' ' + str(self.units)
 
     #
     # Start unit conversion methods


### PR DESCRIPTION
This fixes the recursion errors that we are seeing on Travis with NumPy 1.14.