### PR TITLE
Make it possible to hide axes and set an axes background color

### DIFF
--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -719,6 +719,21 @@ value of the color map.
    slc.set_background_color('density', color='black')
    slc.save('black_background')
 
+If you would like to change the background for a plot and also hide the axes,
+you will need to make use of the ``draw_frame`` keyword argument for the ``hide_axes`` function. If you do not use this keyword argument, the call to
+``set_background_color`` will have no effect. Here is an example illustrating how to use the ``draw_frame`` keyword argument for ``hide_axes``:
+
+.. python-script::
+
+   import yt
+   ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
+   field = ('deposit', 'all_density')
+   slc = yt.ProjectionPlot(ds, 'z', field, width=(1.5, 'Mpc'))
+   slc.set_background_color(field)
+   slc.hide_axes(draw_frame=True)
+   slc.hide_colorbar()
+   slc.save('just_image')
+
 Lastly, the :meth:`~yt.visualization.plot_window.AxisAlignedSlicePlot.set_zlim`
 function makes it possible to set a custom colormap range.
 

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -325,7 +325,11 @@ class ImagePlotMPL(PlotMPL):
         """
         Turn on/off displaying the axis ticks and labels for a plot.
 
-        choice = True or False
+        Parameters
+        ----------
+        choice : boolean
+            If True, set the axes to be drawn. If False, set the axes to not be
+            drawn.
         """
         if draw_frame is None:
             draw_frame = choice

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -321,15 +321,17 @@ class ImagePlotMPL(PlotMPL):
 
         return size, axrect, caxrect
 
-    def _toggle_axes(self, choice):
+    def _toggle_axes(self, choice, draw_frame=None):
         """
         Turn on/off displaying the axis ticks and labels for a plot.
 
         choice = True or False
         """
-
+        if draw_frame is None:
+            draw_frame = choice
         self._draw_axes = choice
-        self.axes.set_frame_on(choice)
+        self._draw_frame = draw_frame
+        self.axes.set_frame_on(draw_frame)
         self.axes.get_xaxis().set_visible(choice)
         self.axes.get_yaxis().set_visible(choice)
         size, axrect, caxrect = self._get_best_layout()
@@ -357,11 +359,11 @@ class ImagePlotMPL(PlotMPL):
         labels += [cbax.yaxis.label, cbax.yaxis.get_offset_text()]
         return labels
 
-    def hide_axes(self):
+    def hide_axes(self, draw_frame=None):
         """
         Hide the axes for a plot including ticks and labels
         """
-        self._toggle_axes(False)
+        self._toggle_axes(False, draw_frame)
         return self
 
     def show_axes(self):

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1083,6 +1083,7 @@ class PWViewerMPL(PlotWindow):
 
         draw_frame : boolean
             If True, the axes frame will still be drawn. Defaults to False.
+            See note below for more details.
 
         Examples
         --------
@@ -1103,6 +1104,13 @@ class PWViewerMPL(PlotWindow):
         >>> s.hide_axes()
         >>> s.hide_colorbar()
         >>> s.save()
+
+        Note
+        ----
+        By default, when removing the axes, the patch on which the axes are
+        drawn is disabled, making it impossible to later change e.g. the
+        background colour. To force the axes patch to be displayed while still 
+        hiding the axes, set the ``draw_frame`` keyword argument to ``True``.
         """
         if field is None:
             field = self.fields

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -813,9 +813,11 @@ class PWViewerMPL(PlotWindow):
             cax = None
             draw_colorbar = True
             draw_axes = True
+            draw_frame = draw_axes
             if f in self.plots:
                 draw_colorbar = self.plots[f]._draw_colorbar
                 draw_axes = self.plots[f]._draw_axes
+                draw_frame = self.plots[f]._draw_frame
                 if self.plots[f].figure is not None:
                     fig = self.plots[f].figure
                     axes = self.plots[f].axes
@@ -939,7 +941,7 @@ class PWViewerMPL(PlotWindow):
                 self.plots[f].cax.minorticks_off()
 
             if draw_axes is False:
-                self.plots[f]._toggle_axes(draw_axes)
+                self.plots[f]._toggle_axes(draw_axes, draw_frame)
 
             if draw_colorbar is False:
                 self.plots[f]._toggle_colorbar(draw_colorbar)
@@ -1067,7 +1069,7 @@ class PWViewerMPL(PlotWindow):
             self.plots[f].show_colorbar()
         return self
 
-    def hide_axes(self, field=None):
+    def hide_axes(self, field=None, draw_frame=False):
         """
         Hides the axes for a plot and updates the size of the
         plot accordingly.  Defaults to operating on all fields for a
@@ -1078,6 +1080,9 @@ class PWViewerMPL(PlotWindow):
 
         field : string, field tuple, or list of strings or field tuples (optional)
             The name of the field(s) that we want to hide the axes.
+
+        draw_frame : boolean
+            If True, the axes frame will still be drawn. Defaults to False.
 
         Examples
         --------
@@ -1103,7 +1108,7 @@ class PWViewerMPL(PlotWindow):
             field = self.fields
         field = ensure_list(field)
         for f in field:
-            self.plots[f].hide_axes()
+            self.plots[f].hide_axes(draw_frame)
         return self
 
     def show_axes(self, field=None):
@@ -1739,6 +1744,7 @@ class WindowPlotMPL(ImagePlotMPL):
         from matplotlib.ticker import ScalarFormatter
         self._draw_colorbar = True
         self._draw_axes = True
+        self._draw_frame = True
         self._fontsize = fontsize
         self._figure_size = figure_size
 


### PR DESCRIPTION
This makes it possible to write scripts like the one I've added to the documentation. Before this PR it was not possible to simultaneously hide the plot axes *and* set the plot background color. I think we want to retain the default behavior of removing the axes frame to avoid changing existing plots.

However, we still want to provide an escape hatch if someone explicitly sets the plot background color. This implements that escape hatch.

This was motivated by a question from sheagk on freenode.