### PR TITLE
Fix the name of the colors keyword to matplotlib contour

### DIFF
--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -466,7 +466,7 @@ class ContourCallback(PlotCallback):
                  plot_args=None, label=False, take_log=None,
                  label_args=None, text_args=None, data_source=None):
         PlotCallback.__init__(self)
-        def_plot_args = {'color':'k'}
+        def_plot_args = {'colors':'k'}
         def_text_args = {'color':'w'}
         self.ncont = ncont
         self.field = field


### PR DESCRIPTION
## PR Summary

The annotate_contour callback passes 'color' as a keyword to contour from matplotlib, but this is not a known keyword. This appears to be the result of a typo in commit 9a2f4ff4a5; prior to then, the correct keyword (colors) was passed to the contour plot. This commit will have the effect of making all contours be black in color by default. As a result, it will change the behavior of, for example, the "[Overplotting Contours](http://yt-project.org/doc/cookbook/complex_plots.html?highlight=annotate_contour#overplotting-contours)" example from the cookbook. If the current behavior is desired, which ends up being the use of the default colormap provided by mpl's contour, then instead we could just empty out def_plot_args.

## PR Checklist

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
