### PR TITLE
support active particle fields that map to arrays

### DIFF
--- a/yt/frontends/enzo/data_structures.py
+++ b/yt/frontends/enzo/data_structures.py
@@ -384,6 +384,9 @@ class EnzoHierarchy(GridIndex):
                 if ptype not in _fields: continue
                 for field in (str(f) for f in node[ptype]):
                     _fields[ptype].append(field)
+                    sh = node[ptype][field].shape
+                    if len(sh) > 1:
+                        self.io._array_fields[field] = (sh[1], )
                 fields += [(ptype, field) for field in _fields.pop(ptype)]
             handle.close()
         return set(fields)


### PR DESCRIPTION
This makes it possible to read in active particle fields that represent arrays. With this change I'm able to run the script from @john-regan's e-mail to the mailing list.