### PR TITLE
increment plot answers

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -47,7 +47,7 @@ answer_tests:
   local_owls_001:
     - yt/frontends/owls/tests/test_outputs.py
 
-  local_pw_019:
+  local_pw_020:
     - yt/visualization/tests/test_plotwindow.py:test_attributes
     - yt/visualization/tests/test_plotwindow.py:test_attributes_wt
     - yt/visualization/tests/test_profile_plots.py:test_phase_plot_attributes


### PR DESCRIPTION
I merged #1664 while jenkins was down. Unfortunately I didn't realize that it causes some of the plot answers to fail (there are some plot answer tests that used the contour callback).

The fix is to increment the plot answers.