### PR TITLE
RAMSES Fix bug when passing np.array

### DIFF
--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -470,7 +470,7 @@ class RAMSESIndex(OctreeIndex):
         super(RAMSESIndex, self).__init__(ds, dataset_type)
 
     def _initialize_oct_handler(self):
-        if self.ds._bbox:
+        if self.ds._bbox is not None:
             cpu_list = get_cpu_list(self.dataset, self.dataset._bbox)
         else:
             cpu_list = range(self.dataset['ncpu'])


### PR DESCRIPTION
# Bug report
When calling 
```python
ds = yt.load('path/to/my/ramses/dataset', bbox=np.array([[x1, x2, x3], [y1, y2, y3]])
```
the code would crash, complaining about 
```
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```

This is fixed by this PR.