### PR TITLE
RAMSES performance improvement

### DIFF
--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -118,17 +118,19 @@ class RAMSESDomainFile(object):
     def buffered_amr_file(self):
         if hasattr(self, '_buffered_amr_file'):
             return self._buffered_amr_file
-        else:
-            f = IO()
-            with open(self.amr_fn, "rb") as ff:
-                f.write(ff.read())
-            self._buffered_amr_file = f
-            return f
+        f = IO()
+        with open(self.amr_fn, "rb") as ff:
+            f.write(ff.read())
+        self._buffered_amr_file = f
+
+        f.seek(0)
+
+        return f
 
     def _read_amr_header(self):
         hvals = {}
         f = self.buffered_amr_file
-        # f = open(self.amr_fn, "rb")
+
         f.seek(0)
 
         for header in ramses_header(hvals):

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -20,7 +20,7 @@ import numpy as np
 import stat
 import weakref
 
-from yt.extern.six import string_types, PY3
+from yt.extern.six import string_types
 from yt.funcs import \
     mylog, \
     setdefaultattr

--- a/yt/frontends/ramses/definitions.py
+++ b/yt/frontends/ramses/definitions.py
@@ -41,11 +41,6 @@ def ramses_header(hvals):
                  ('timing', 5, 'd'),
                  ('mass_sph', 1, 'd') )
     yield next_set
-    tree_header = ( ('headl', hvals['nlevelmax'] * hvals['ncpu'], 'i'),
-                    ('taill', hvals['nlevelmax'] * hvals['ncpu'], 'i'),
-                    ('numbl', hvals['nlevelmax'] * hvals['ncpu'], 'i'),
-                  )
-    yield tree_header
 
 field_aliases = {
     'standard_five':     ('Density',


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

* Use buffered IO for AMR (as we skim through it a lot)
* Skip reading useless stuff

For a zoom-in cosmological simulation with 4800 cores + 22 level of refinement, this makes the reading of the AMR go from 50s to 0.1s. The improvement comes from the fact that the `fpu.read_attrs` is *very* slow when reading lots of values (in this case 105600). `fpu.read_vector` is much faster at that.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes flake8 checker

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
