### PR TITLE
Ensuring plot annotations are in code_length units prior to plotting.

### DIFF
--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -93,6 +93,7 @@ class PlotCallback(object):
         if len(coord) == 3:
             if not isinstance(coord, YTArray):
                 coord = plot.data.ds.arr(coord, 'code_length')
+            coord.convert_to_units('code_length')
             ax = plot.data.axis
             # if this is an on-axis projection or slice, then
             # just grab the appropriate 2 coords for the on-axis view
@@ -167,7 +168,7 @@ class PlotCallback(object):
 
         Parameters
         ----------
-        
+
         plot: a PlotMPL subclass
            The plot that we are converting coordinates for
 


### PR DESCRIPTION
An error was reported on the Trident mailing list by Kezman Saboi that a FLASH dataset was unable to generate an `annotate_ray()` on a `ProjectionPlot`.  After investigating, I found that we don't fully sanitize data coordinates in the plot_modifications (i.e. annotations).  The assumption is made that specified data coordinates are in `code_length`, when this particular coordinate was in `unitary` units, leading to the user's error.  This change explicitly forces the coordinates to be in `code_length` for coordinates used by the annotation machinery.