### PR TITLE
Incorrect Velocity Unit with Reading EAGLE

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -44,7 +44,7 @@ answer_tests:
     - yt/frontends/gadget_fof/tests/test_outputs.py:test_fields_g5
     - yt/frontends/gadget_fof/tests/test_outputs.py:test_fields_g42
 
-  local_owls_001:
+  local_owls_002:
     - yt/frontends/owls/tests/test_outputs.py
 
   local_pw_020:

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -491,11 +491,12 @@ class GadgetHDF5Dataset(GadgetDataset):
 
         # note the contents of the HDF5 Units group are in _unit_base
         # note the velocity stored on disk is sqrt(a) dx/dt
+        # physical velocity [cm/s] = a dx/dt = sqrt(a) * velocity_on_disk * UnitVelocity_in_cm_per_s
         self.length_unit = self.quan(
             self._unit_base["UnitLength_in_cm"], 'cmcm/h')
-        self.mass_unit = self.quan(self._unit_base["UnitMass_in_g"], 'g/h')
+        self.mass_unit = self.quan(self._unit_base["UnitMass_in_g"], 'g/h')      
         self.velocity_unit = self.quan(
-            self._unit_base["UnitVelocity_in_cm_per_s"], 'cm/s')
+            self._unit_base["UnitVelocity_in_cm_per_s"], 'cm/s * sqrt(a)')
         self.time_unit = self.quan(self._unit_base["UnitTime_in_s"], 's/h')
 
     @classmethod

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -498,6 +498,9 @@ class GadgetHDF5Dataset(GadgetDataset):
         self.velocity_unit = self.quan(
             self._unit_base["UnitVelocity_in_cm_per_s"], 'cm/s * sqrt(a)')
         self.time_unit = self.quan(self._unit_base["UnitTime_in_s"], 's/h')
+        
+        specific_energy_unit_cgs = self._unit_base["UnitEnergy_in_cgs"] / self._unit_base["UnitMass_in_g"]
+        self.specific_energy_unit = self.quan(specific_energy_unit_cgs, '(cm/s)**2')
 
     @classmethod
     def _is_valid(self, *args, **kwargs):


### PR DESCRIPTION
## PR Summary

While reading the EAGLE simulation, the original yt output physical velocity (in cgs, or km/s, etc.) misses a factor of sqrt(a).
Expected: physical velocity [cm/s] = sqrt(a) * velocity_on_disk * 1e5
where 1e5 is the unit velocity in cm per second.

For details, please see the discussion in the mailing list.   I have also included the output before and after editing the code, which uses an EAGLE simulation with z=0.271. 
https://mail.python.org/mm3/archives/list/yt-users@python.org/thread/RP2FYIRCBAOYOYDS7WIATBYVH2TIK5NT/


## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
