### PR TITLE
Use CGS units to calculate Gadget specific energy units if available

### DIFF
--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -339,6 +339,10 @@ class GadgetDataset(SPHDataset):
 
         if "specific_energy" in unit_base:
             specific_energy_unit = unit_base["specific_energy"]
+        elif "UnitEnergy_in_cgs" in unit_base and "UnitMass_in_g" in unit_base:
+            specific_energy_unit = \
+                unit_base["UnitEnergy_in_cgs"] / unit_base["UnitMass_in_g"]
+            specific_energy_unit = (specific_energy_unit, "(cm/s)**2")
         else:
             # Sane default
             specific_energy_unit = (1, "(km/s) ** 2")


### PR DESCRIPTION
While looking at #1675 I noticed that we weren't being consistent in looking for the Gadget CGS unit constants for the specific energy units like we do for the other units. This fixes that. Note that this is independent of #1675.