### PR TITLE
check if eps is larger than the domain when building halo catalog fro…

### DIFF
--- a/yt/frontends/rockstar/io.py
+++ b/yt/frontends/rockstar/io.py
@@ -105,7 +105,7 @@ class IOHandlerRockstarBinary(BaseIOHandler):
                 eps = eps*self.ds.domain_right_edge
                 dx = np.abs(eps).max()
             else:
-                dx = 2.0*self.ds.quan(dx, "code_length")
+                dx = 2.0*self.ds.quan(eps, "code_length")
             pos[:,0] = halos["particle_position_x"]
             pos[:,1] = halos["particle_position_y"]
             pos[:,2] = halos["particle_position_z"]

--- a/yt/frontends/rockstar/io.py
+++ b/yt/frontends/rockstar/io.py
@@ -103,7 +103,7 @@ class IOHandlerRockstarBinary(BaseIOHandler):
             # Make sure eps is not larger than the domain itself
             if(eps>np.max(abs(self.ds.domain_right_edge))):
                 eps = eps*self.ds.domain_right_edge
-                dx = eps
+                dx = np.abs(eps).max()
 	    else:
                 dx = 2.0*self.ds.quan(dx, "code_length")
             pos[:,0] = halos["particle_position_x"]

--- a/yt/frontends/rockstar/io.py
+++ b/yt/frontends/rockstar/io.py
@@ -99,8 +99,13 @@ class IOHandlerRockstarBinary(BaseIOHandler):
             pos = np.empty((halos.size, 3), dtype="float64")
             # These positions are in Mpc, *not* "code" units
             pos = data_file.ds.arr(pos, "code_length")
-            dx = np.finfo(halos['particle_position_x'].dtype).eps
-            dx = 2.0*self.ds.quan(dx, "code_length")
+            eps = np.finfo(halos['particle_position_x'].dtype).eps
+            # Make sure eps is not larger than the domain itself
+            if(eps>np.max(abs(self.ds.domain_right_edge))):
+                eps = eps*self.ds.domain_right_edge
+                dx = eps
+	    else:
+                dx = 2.0*self.ds.quan(dx, "code_length")
             pos[:,0] = halos["particle_position_x"]
             pos[:,1] = halos["particle_position_y"]
             pos[:,2] = halos["particle_position_z"]
@@ -130,3 +135,4 @@ class IOHandlerRockstarBinary(BaseIOHandler):
         fields = [("halos", f) for f in self._halo_dt.fields if
                   "padding" not in f]
         return fields, {}
+

--- a/yt/frontends/rockstar/io.py
+++ b/yt/frontends/rockstar/io.py
@@ -101,11 +101,8 @@ class IOHandlerRockstarBinary(BaseIOHandler):
             pos = data_file.ds.arr(pos, "code_length")
             eps = np.finfo(halos['particle_position_x'].dtype).eps
             # Make sure eps is not larger than the domain itself
-            if(eps>np.max(abs(self.ds.domain_right_edge))):
-                eps = eps*self.ds.domain_right_edge
-                dx = np.abs(eps).max()
-            else:
-                dx = 2.0*self.ds.quan(eps, "code_length")
+            eps = eps*self.ds.domain_right_edge
+            dx = np.abs(eps).max()
             pos[:,0] = halos["particle_position_x"]
             pos[:,1] = halos["particle_position_y"]
             pos[:,2] = halos["particle_position_z"]

--- a/yt/frontends/rockstar/io.py
+++ b/yt/frontends/rockstar/io.py
@@ -104,7 +104,7 @@ class IOHandlerRockstarBinary(BaseIOHandler):
             if(eps>np.max(abs(self.ds.domain_right_edge))):
                 eps = eps*self.ds.domain_right_edge
                 dx = np.abs(eps).max()
-	    else:
+            else:
                 dx = 2.0*self.ds.quan(dx, "code_length")
             pos[:,0] = halos["particle_position_x"]
             pos[:,1] = halos["particle_position_y"]
@@ -135,4 +135,3 @@ class IOHandlerRockstarBinary(BaseIOHandler):
         fields = [("halos", f) for f in self._halo_dt.fields if
                   "padding" not in f]
         return fields, {}
-


### PR DESCRIPTION
…m rockstar input, addresses Issue #1678

## PR Summary
Fixes this issue:
https://github.com/yt-project/yt/issues/1678
When creating a halo catalog from Rockstar data, yt will die if the box size used in the halo finder is smaller than 1e-7. This is because yt tries to shift halo positions to be well inside the domain walls, by clipping them to the domain walls +- eps, where eps is the eps of the float32 datatype. To avoid this, we check if eps is larger than the right domain wall, and scale eps accordingly.

