### PR TITLE
Added parallel cython support for calc grav potential.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -178,11 +178,16 @@ cython_extensions = [
     Extension("yt.utilities.lib.alt_ray_tracers",
               ["yt/utilities/lib/alt_ray_tracers.pyx"],
               libraries=std_libs),
+    Extension("yt.utilities.lib.misc_utilities",
+              ["yt/utilities/lib/misc_utilities.pyx"],
+              extra_compile_args=omp_args,
+              extra_link_args=omp_args,
+              libraries=std_libs),
 ]
 
 lib_exts = [
     "particle_mesh_operations", "depth_first_octree", "fortran_reader",
-    "interpolators", "misc_utilities", "basic_octree", "image_utilities",
+    "interpolators", "basic_octree", "image_utilities",
     "points_in_volume", "quad_tree", "mesh_utilities",
     "amr_kdtools", "lenses", "distance_queue", "allocation_container"
 ]

--- a/yt/analysis_modules/level_sets/clump_validators.py
+++ b/yt/analysis_modules/level_sets/clump_validators.py
@@ -43,7 +43,8 @@ class ClumpValidator(object):
         return self.function(clump, *self.args, **self.kwargs)
     
 def _gravitationally_bound(clump, use_thermal_energy=True,
-                           use_particles=True, truncate=True):
+                           use_particles=True, truncate=True,
+                           num_threads=0):
     "True if clump is gravitationally bound."
 
     use_particles &= \
@@ -84,7 +85,7 @@ def _gravitationally_bound(clump, use_thermal_energy=True,
     potential = clump.data.ds.quan(G *
         gravitational_binding_energy(
             m, px, py, pz,
-            truncate, (kinetic / G).in_cgs()),
+            truncate, (kinetic / G).in_cgs(),num_threads=num_threads),
             kinetic.in_cgs().units)
 
     if truncate and potential >= kinetic:

--- a/yt/utilities/lib/misc_utilities.pyx
+++ b/yt/utilities/lib/misc_utilities.pyx
@@ -35,6 +35,9 @@ cdef extern from "platform_dep.h":
     # NOTE that size_t might not be int
     void *alloca(int)
 
+from cython.parallel import prange, parallel, threadid
+cimport openmp 
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
@@ -1021,40 +1024,41 @@ def gravitational_binding_energy(
         np.float64_t[:] y,
         np.float64_t[:] z,
         int truncate,
-        np.float64_t kinetic):
+        np.float64_t kinetic,
+        int num_threads = 0):
 
     cdef int q_outer, q_inner, n_q, i
     cdef np.float64_t mass_o, x_o, y_o, z_o
     cdef np.float64_t mass_i, x_i, y_i, z_i
-    cdef np.float64_t this_potential, total_potential
-    total_potential = 0.
+    cdef np.float64_t total_potential = 0.
+    cdef np.float64_t this_potential
 
-    i = 0
     n_q = mass.size
-    pbar = get_pbar("Calculating potential for %d cells" % n_q,
-                    0.5 * (n_q * n_q - n_q))
-    for q_outer in range(n_q - 1):
+    print("Calculating potential for %d cells using %d threads" % (n_q,num_threads))
+
+    # using reversed iterator in order to make use of guided scheduling 
+    # (inner loop is getting more and more expensive)
+    for q_outer in prange(n_q - 1,-1,-1,
+        nogil=True,schedule='guided',num_threads=num_threads):
         this_potential = 0.
+
         mass_o = mass[q_outer]
         x_o = x[q_outer]
         y_o = y[q_outer]
         z_o = z[q_outer]
-        for q_inner in range(q_outer + 1, n_q):
+        for q_inner in range(q_outer + 1, n_q): 
             mass_i = mass[q_inner]
             x_i = x[q_inner]
             y_i = y[q_inner]
             z_i = z[q_inner]
-            this_potential += mass_o * mass_i / \
+            # not using += operator so that variable is not automatically reduced
+            this_potential = this_potential + mass_o * mass_i / \
               sqrt((x_i - x_o) * (x_i - x_o) +
                    (y_i - y_o) * (y_i - y_o) +
                    (z_i - z_o) * (z_i - z_o))
-        i += n_q - q_outer
-        pbar.update(i)
         total_potential += this_potential
-        if truncate and total_potential / kinetic > 1.:
+        if truncate and this_potential / kinetic > 1.:
             break
-    pbar.finish()
-
     return total_potential
 
 # The OnceIndirect code is from:


### PR DESCRIPTION

## PR Summary

Graviational potential is now calculated using openmp threading.

## PR Checklist

- [x] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

- Remove progress bar in favour of parallel computations.
- Truncation now only works at a thread level as `total_potential` flagged for reduction and thus only accessible after the loop finishes. Please comment on whether this is acceptable or whether it'd be better to introduce a switch to change between parallel and serial calculation)
- Please also comment on the usage of `num_threads`, so that it's in line with general thread parallel coding style in yt
