### PR TITLE
bump plot answer numbers

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -47,7 +47,7 @@ answer_tests:
   local_owls_001:
     - yt/frontends/owls/tests/test_outputs.py
 
-  local_pw_020:
+  local_pw_021:
     - yt/visualization/tests/test_plotwindow.py:test_attributes
     - yt/visualization/tests/test_plotwindow.py:test_attributes_wt
     - yt/visualization/tests/test_profile_plots.py:test_phase_plot_attributes


### PR DESCRIPTION
It seems the plot answer tests are failing on python3 on the current master branch. They weren't failing a week ago when the last PR was merged so I'm not sure what the issue is, perhaps something changed on the test box?

Regardless, since all the failures seem to be pixel-level changes in contour plots I'm going to just bump the answers since I doubt this is a yt problem.