### PR TITLE
Fix incorrect vector field components in cylindrical and spherical cordinates

### DIFF
--- a/yt/fields/tests/test_vector_fields.py
+++ b/yt/fields/tests/test_vector_fields.py
@@ -1,0 +1,43 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2016, yt Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+import numpy as np
+
+from yt.testing import \
+    assert_allclose_units, \
+    fake_random_ds
+
+def test_vector_component_conversions():
+    ds = fake_random_ds(16)
+
+    ad = ds.all_data()
+
+    vmag = ad['velocity_magnitude']
+    vmag_cart = np.sqrt(
+        ad['velocity_x']**2 +
+        ad['velocity_y']**2 +
+        ad['velocity_z']**2
+    )
+
+    assert_allclose_units(vmag, vmag_cart)
+
+    vmag_cyl = np.sqrt(
+        ad['velocity_cylindrical_radius']**2 +
+        ad['velocity_cylindrical_theta']**2 +
+        ad['velocity_cylindrical_z']**2
+    )
+
+    assert_allclose_units(vmag, vmag_cyl)
+
+    vmag_sph = np.sqrt(
+        ad['velocity_spherical_radius']**2 +
+        ad['velocity_spherical_theta']**2 +
+        ad['velocity_spherical_phi']**2
+    )
+
+    assert_allclose_units(vmag, vmag_sph)

--- a/yt/fields/vector_operations.py
+++ b/yt/fields/vector_operations.py
@@ -23,8 +23,7 @@ from yt.utilities.math_utils import \
     get_sph_phi_component, \
     get_cyl_r_component, \
     get_cyl_z_component, \
-    get_cyl_theta_component, \
-    resize_vector
+    get_cyl_theta_component
 
 from yt.funcs import just_one
 
@@ -150,8 +149,8 @@ def create_vector_fields(registry, basename, field_units,
         normal = data.get_field_parameter("normal")
         vectors = obtain_rv_vec(data, (xn, yn, zn),
                                 "bulk_%s" % basename)
-        theta = resize_vector(data["index", "spherical_theta"], vectors)
-        phi = resize_vector(data["index", "spherical_phi"], vectors)
+        theta = data["index", "spherical_theta"]
+        phi = data["index", "spherical_phi"]
         return get_sph_theta_component(vectors, theta, phi, normal)
 
     registry.add_field((ftype, "%s_spherical_theta" % basename), sampling_type="cell", 
@@ -170,7 +169,7 @@ def create_vector_fields(registry, basename, field_units,
         normal = data.get_field_parameter("normal")
         vectors = obtain_rv_vec(data, (xn, yn, zn),
                                 "bulk_%s" % basename)
-        phi = resize_vector(data["index", "spherical_phi"], vectors)
+        phi = data["index", "spherical_phi"]
         return get_sph_phi_component(vectors, phi, normal)
 
     registry.add_field((ftype, "%s_spherical_phi" % basename), sampling_type="cell", 
@@ -249,7 +248,7 @@ def create_vector_fields(registry, basename, field_units,
         normal = data.get_field_parameter("normal")
         vectors = obtain_rv_vec(data, (xn, yn, zn),
                                 "bulk_%s" % basename)
-        theta = resize_vector(data["index", 'cylindrical_theta'], vectors)
+        theta = data["index", 'cylindrical_theta']
         return get_cyl_r_component(vectors, theta, normal)
 
     registry.add_field((ftype, "%s_cylindrical_radius" % basename), sampling_type="cell", 


### PR DESCRIPTION
As pointed out on slack today by @pgrete, currently some of the vector field components in curvilinear coordinates are incorrect. This is easiest to verify by computing the velocity magnitude in those coordinate systems and comparing with the answer in cartesian coordinates.

It turns out that for the past few years as far as I can see, the fields representing the spherical theta, spherical phi, and cylindrical theta coordinates of vector fields in yt have been incorrect.

The ultimate cause is the use of `resize_vector` on the coordinate arrays. This function strips data from the coordinate arrays, causing the wrong coordinate data to be fed into the functions that calculate the components of vectors in cylindrical and spherical coordinates.

The fix is to remove the use of `resize_vector` in `vector_operations.py`. I've also added a test to make sure that the velocity magnitude comes out to be the same answer no matter which coordinate system we use to calculate it.