### PR TITLE
[Bugfix] Calculation of tangential vector components

### DIFF
--- a/yt/fields/vector_operations.py
+++ b/yt/fields/vector_operations.py
@@ -124,8 +124,8 @@ def create_vector_fields(registry, basename, field_units,
         return np.abs(data[ftype, "%s_spherical_radius" % basename])
 
     def _tangential(field, data):
-        return np.sqrt(data[ftype, "%s_magnitude" % basename]**2.0 -
-                       data[ftype, "%s_spherical_radius" % basename]**2.0)
+        return np.sqrt(data[ftype, "%s_spherical_theta" % basename]**2.0 +
+                       data[ftype, "%s_spherical_phi" % basename]**2.0)
 
     registry.add_field((ftype, "radial_%s" % basename), sampling_type="cell", 
                        function=_radial,
@@ -234,7 +234,9 @@ def create_vector_fields(registry, basename, field_units,
 
     def _tangential_over_magnitude(field, data):
         tr = data[ftype, "tangential_%s" % basename] / \
-             data[ftype, "%s_magnitude" % basename]
+             np.sqrt(data[ftype, "%s_spherical_radius" % basename]**2.0 +
+                     data[ftype, "%s_spherical_theta" % basename]**2.0 +
+                     data[ftype, "%s_spherical_phi" % basename]**2.0)
         return np.abs(tr)
     registry.add_field((ftype, "tangential_over_%s_magnitude" % basename), sampling_type="cell", 
              function=_tangential_over_magnitude,


### PR DESCRIPTION
## PR Summary

Tangential vector components are currently incorrect when calculated for an object with a bulk velocity given that the magnitude does not include the bulk velocity whereas the _spherical terms are.

This is only an quick fix for the two mentioned functions. Generally, this affects more parts of the code, see #1686

Moreover, this fix relies on #1687 to give correct results as the theta and phi components are otherwise off.

