### PR TITLE
[bugfix] make halo finders work in parallel in python3

### DIFF
--- a/yt/utilities/parallel_tools/parallel_analysis_interface.py
+++ b/yt/utilities/parallel_tools/parallel_analysis_interface.py
@@ -21,7 +21,6 @@ import numpy as np
 import sys
 import os
 import traceback
-import types
 from functools import wraps
 
 from yt.funcs import \

--- a/yt/utilities/parallel_tools/parallel_analysis_interface.py
+++ b/yt/utilities/parallel_tools/parallel_analysis_interface.py
@@ -271,7 +271,7 @@ class ParallelDummy(type):
             if attrname.startswith("_") or attrname in skip:
                 if attrname not in extra: continue
             attr = getattr(cls, attrname)
-            if isinstance(attr, types.MethodType):
+            if callable(attr):
                 setattr(cls, attrname, parallel_simple_proxy(attr))
 
 def parallel_passthrough(func):


### PR DESCRIPTION
This will close [Issue #19](https://github.com/yt-project/yt_astro_analysis/issues/19) in `yt_astro_analysis`.

The `ParallelDummy` class was identifying class methods by checking if they were of type `MethodType`, which works in python 2.  In python 3, they are of type `function`, so the class object wasn't getting setup correctly.  This change works in both python 2 and 3.