### PR TITLE
fix warnings generated by the plotting tests

### DIFF
--- a/yt/utilities/on_demand_imports.py
+++ b/yt/utilities/on_demand_imports.py
@@ -134,6 +134,18 @@ class astropy_imports(object):
             self._wcsaxes = wcsaxes
         return self._wcsaxes
 
+    _version = None
+    @property
+    def __version__(self):
+        if self._version is None:
+            try:
+                import astropy
+                version = astropy.__version__
+            except ImportError:
+                version = NotAModule(self._name)
+            self._version = version
+        return self._version
+
 _astropy = astropy_imports()
 
 class scipy_imports(object):

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -11,6 +11,7 @@ FITSImageData Class
 #-----------------------------------------------------------------------------
 from yt.extern.six import string_types
 import numpy as np
+from distutils.version import LooseVersion
 from yt.fields.derived_field import DerivedField
 from yt.funcs import mylog, iterable, fix_axis, ensure_list
 from yt.visualization.fixed_resolution import FixedResolutionBuffer
@@ -339,7 +340,10 @@ class FITSImageData(object):
             hdus = _astropy.pyfits.HDUList()
             for field in fields:
                 hdus.append(self.hdulist[field])
-        hdus.writeto(fileobj, clobber=clobber, **kwargs)
+        if LooseVersion(_astropy.__version__) < LooseVersion('2.0.0'):
+            hdus.writeto(fileobj, clobber=clobber, **kwargs)
+        else:
+            hdus.writeto(fileobj, overwrite=clobber, **kwargs)
 
     def to_glue(self, label="yt", data_collection=None):
         """

--- a/yt/visualization/tests/test_callbacks.py
+++ b/yt/visualization/tests/test_callbacks.py
@@ -471,7 +471,7 @@ def test_contour_callback():
         p = SlicePlot(ds, "x", "density")
         p.annotate_contour("temperature", ncont=10, factor=8,
             take_log=False, clim=(0.4, 0.6),
-            plot_args={'lw':2.0}, label=True,
+            plot_args={'linewidths':2.0}, label=True,
             text_args={'text-size':'x-large'})
         p.save(prefix)
 
@@ -479,7 +479,7 @@ def test_contour_callback():
         s2 = ds.slice(0, 0.2)
         p.annotate_contour("temperature", ncont=10, factor=8,
             take_log=False, clim=(0.4, 0.6),
-            plot_args={'lw':2.0}, label=True,
+            plot_args={'linewidths':2.0}, label=True,
             text_args={'text-size':'x-large'},
             data_source=s2)
         p.save(prefix)
@@ -503,7 +503,7 @@ def test_contour_callback():
         p = SlicePlot(ds, "r", "density")
         p.annotate_contour("temperature", ncont=10, factor=8,
             take_log=False, clim=(0.4, 0.6),
-            plot_args={'lw':2.0}, label=True,
+            plot_args={'linewidths':2.0}, label=True,
             text_args={'text-size':'x-large'})
         assert_raises(YTDataTypeUnsupported, p.save, prefix)
 


### PR DESCRIPTION
Fixes some warnings generated by the plotting tests. Also adds a wrapper around `astropy.__version__` I needed because of an astropy deprecation.