### PR TITLE
Setting fixed # OMP threads in test function to get around frontend policies.

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -18,6 +18,7 @@ CCODE = """
 #include <omp.h>
 #include <stdio.h>
 int main() {
+  omp_set_num_threads(2);
   #pragma omp parallel
   printf("nthreads=%d\\n", omp_get_num_threads());
   return 0;
@@ -68,15 +69,8 @@ def check_for_openmp():
     tmp_dir = tempfile.mkdtemp()
     start_dir = os.path.abspath('.')
 
-    if os.name == 'nt':
-        # TODO: make this work with mingw
-        # AFAICS there's no easy way to get the compiler distutils
-        # will be using until compilation actually happens
-        compile_flag = '-openmp'
-        link_flag = ''
-    else:
-        compile_flag = '-fopenmp'
-        link_flag = '-fopenmp'
+    compile_flag = '-fopenmp'
+    link_flag = '-fopenmp'
 
     try:
         os.chdir(tmp_dir)

--- a/setupext.py
+++ b/setupext.py
@@ -69,8 +69,15 @@ def check_for_openmp():
     tmp_dir = tempfile.mkdtemp()
     start_dir = os.path.abspath('.')
 
-    compile_flag = '-fopenmp'
-    link_flag = '-fopenmp'
+    if os.name == 'nt':
+        # TODO: make this work with mingw
+        # AFAICS there's no easy way to get the compiler distutils
+        # will be using until compilation actually happens
+        compile_flag = '-openmp'
+        link_flag = ''
+    else:
+        compile_flag = '-fopenmp'
+        link_flag = '-fopenmp'
 
     try:
         os.chdir(tmp_dir)


### PR DESCRIPTION
## PR Summary

On Comet frontend the default policy seems to restrict the maximum thread spawned by openmp, which lead to a failed openmp test:
```
./test_openmp 
libgomp: Thread creation failed: Resource temporarily unavailable
```
In order for the simple check to be successful, two threads are sufficient.
