### PR TITLE
Allow OpenMP support on Windows

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -58,7 +58,7 @@ def check_for_openmp():
     """
 
     # See https://bugs.python.org/issue25150
-    if sys.version_info[:3] == (3, 5, 0) or os.name == 'nt':
+    if sys.version_info[:3] == (3, 5, 0):
         return False
 
     # Create a temporary directory


### PR DESCRIPTION
This was missed when I added support for OpenMP on Windows in #1591. Thanks to @pgrete for pointing this out.