### PR TITLE
Updated PartilcePlot axis configuration (fix for Issue #1680)

### DIFF
--- a/yt/visualization/particle_plots.py
+++ b/yt/visualization/particle_plots.py
@@ -512,7 +512,8 @@ def ParticlePlot(ds, x_field, y_field, z_fields=None, color='b', *args,
         ax_field_template = 'particle_position_%s'
         xf = ax_field_template % ds.coordinates.axis_name[xax]
         yf = ax_field_template % ds.coordinates.axis_name[yax]
-        if (x_field[1], y_field[1]) == (xf, yf):
+        if (x_field[1], y_field[1]) == (xf, yf) \
+                or (x_field[1], y_field[1]) == (yf, xf):
             direction = axis
             break
 

--- a/yt/visualization/particle_plots.py
+++ b/yt/visualization/particle_plots.py
@@ -512,8 +512,7 @@ def ParticlePlot(ds, x_field, y_field, z_fields=None, color='b', *args,
         ax_field_template = 'particle_position_%s'
         xf = ax_field_template % ds.coordinates.axis_name[xax]
         yf = ax_field_template % ds.coordinates.axis_name[yax]
-        if (x_field[1], y_field[1]) == (xf, yf) \
-                or (x_field[1], y_field[1]) == (yf, xf):
+        if (x_field[1], y_field[1]) in [(xf, yf), (yf, xf)]:
             direction = axis
             break
 

--- a/yt/visualization/tests/test_particle_plot.py
+++ b/yt/visualization/tests/test_particle_plot.py
@@ -346,3 +346,26 @@ class TestParticleProjectionPlotSave(unittest.TestCase):
             [assert_array_almost_equal(px, x, 14) for px, x in zip(plot.xlim, xlim)]
             [assert_array_almost_equal(py, y, 14) for py, y in zip(plot.ylim, ylim)]
             [assert_array_almost_equal(pw, w, 14) for pw, w in zip(plot.width, pwidth)]
+
+def test_particle_plot_instance():
+    """
+    Tests the type of plot instance returned by ParticlePlot.
+
+    If x_field and y_field are any combination of valid particle_position in x,
+    y or z axis,then ParticleProjectionPlot instance is expected.
+
+
+    """
+    ds = fake_particle_ds()
+    x_field = ('all', 'particle_position_x')
+    y_field = ('all', 'particle_position_y')
+    z_field = ('all', 'particle_velocity_x')
+
+    plot = ParticlePlot(ds, x_field, y_field)
+    assert isinstance(plot, ParticleProjectionPlot)
+
+    plot = ParticlePlot(ds, y_field, x_field)
+    assert isinstance(plot, ParticleProjectionPlot)
+
+    plot = ParticlePlot(ds, x_field, z_field)
+    assert isinstance(plot, ParticlePhasePlot)


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->
When doing a `ParticlePlot` with positions, one expects that the outcome of it is a `ParticleProjectionPlot` object. However, depending on the order of the arguments, the user either get a `ParticleProjectionPlot` or a `ParticlePhasePlot`.
<!--If it fixes an open issue, please link to the issue here.-->
https://github.com/yt-project/yt/issues/1680
## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] All test cases passed for particle_plot

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
