### PR TITLE
[RAMSES] Change name of extra hydro variable to `hydro_...`

### DIFF
--- a/yt/frontends/ramses/io.py
+++ b/yt/frontends/ramses/io.py
@@ -298,7 +298,7 @@ def _read_fluid_file_descriptor(fname):
                 if varname in mapping:
                     varname = mapping[varname]
                 else:
-                    varname = 'particle_%s' % varname
+                    varname = 'hydro_%s' % varname
 
                 fields.append((varname, dtype))
         else:


### PR DESCRIPTION
This changes the name of extra hydro fields to `hydro_xxx` instead of `particle_xxx`.