### PR TITLE
add a few classes from the halo finder frontends to the API docs

### DIFF
--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -1654,7 +1654,7 @@ Gadget outputs.  See :ref:`loading-gadget-data` for more information.
 Halo Catalog Data
 -----------------
 
-yt has support for reading halo catalogs produced by AHF, Rockstar and the inline
+yt has support for reading halo catalogs produced by the Amiga Halo Finder (AHF), Rockstar and the inline
 FOF/SUBFIND halo finders of Gadget and OWLS.  The halo catalogs are treated as
 particle datasets where each particle represents a single halo.  For example,
 this means that the `particle_mass` field refers to the mass of the halos.  For
@@ -1669,13 +1669,13 @@ to the other halo catalogs shown here.
 
 .. _ahf:
 
-AHF
-^^^
+Amiga Halo Finder
+^^^^^^^^^^^^^^^^^
 
-AHF halo catalogs are loaded by providing the path to the .parameter files.
-The corresponding .log and .AHF_halos files must exist for data loading to
-succeed. The field type for all fields is "halos". Some fields of note available
-from AHF are:
+Amiga Halo Finder (AHF) halo catalogs are loaded by providing the path to the
+.parameter files.  The corresponding .log and .AHF_halos files must exist for
+data loading to succeed. The field type for all fields is "halos". Some fields
+of note available from AHF are:
 
 +----------------+---------------------------+
 | AHF field      | yt field name             |

--- a/doc/source/reference/api/api.rst
+++ b/doc/source/reference/api/api.rst
@@ -294,6 +294,16 @@ Halo Catalogs
 
 .. autosummary::
 
+   ~yt.frontends.ahf.data_structures.AHFHalosDataset
+   ~yt.frontends.ahf.fields.AHFHalosFieldInfo
+   ~yt.frontends.ahf.io.IOHandlerAHFHalos
+   ~yt.frontends.gadget_fof.data_structures.GadgetFOFDataset
+   ~yt.frontends.gadget_fof.data_structures.GadgetFOFHDF5File
+   ~yt.frontends.gadget_fof.data_structures.GadgetFOFHaloDataset
+   ~yt.frontends.gadget_fof.io.IOHandlerGadgetFOFHDF5
+   ~yt.frontends.gadget_fof.io.IOHandlerGadgetFOFHaloHDF5
+   ~yt.frontends.gadget_fof.fields.GadgetFOFFieldInfo
+   ~yt.frontends.gadget_fof.fields.GadgetFIFHaloFieldInfo
    ~yt.frontends.halo_catalog.data_structures.HaloCatalogHDF5File
    ~yt.frontends.halo_catalog.data_structures.HaloCatalogDataset
    ~yt.frontends.halo_catalog.fields.HaloCatalogFieldInfo


### PR DESCRIPTION
@saethlin pointed out on Slack today that the AHF frontend doens't show up in the API docs. It looks like adding that was missed in #1477. I've also added references to classes from the Gadget FOF frontend, which were also missing.

Lastly, I reworded the documentation to spell out AHF as Amiga Halo Finder, this makes the docs searchable for the phrase "Amiga" as well as "AHF".