### PR TITLE
Ensure FLASH field accesses return data as a float64 dtype

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -20,7 +20,7 @@ answer_tests:
   local_fits_002:
     - yt/frontends/fits/tests/test_outputs.py
 
-  local_flash_008:
+  local_flash_009:
     - yt/frontends/flash/tests/test_outputs.py
 
   local_gadget_001:

--- a/yt/frontends/flash/io.py
+++ b/yt/frontends/flash/io.py
@@ -130,7 +130,7 @@ class IOHandlerFLASH(BaseIOHandler):
             data = ds[obj.id - obj._id_offset, :,:,:].transpose()
         else:
             data = ds[offset, :,:,:].transpose()
-        return data
+        return data.astype('=f8')
 
     def _read_chunk_data(self, chunk, fields):
         f = self._handle


### PR DESCRIPTION
If one does something like this:

```
import yt

ds = yt.load('GasSloshing/sloshing_nomag2_hdf5_plt_cnt_0150')

grid = ds.index.grids[-1]

d = grid['flash', 'dens']

print(d.dtype)
```

Right now this will print `float32`. This is a bit surprising because, for example, this:

```
import yt

ds = yt.load('GasSloshing/sloshing_nomag2_hdf5_plt_cnt_0150')

ad = ds.all_data()

print(ad['flash', 'dens'].dtype)
```

will print `float64`.

While this change could lead to some additional memory and CPU overhead, particularly for large FLASH datasets, I think avoiding confusion and floating point underflow means that we should cast data to float64 after reading.