### PR TITLE
[enhancement] Add relativistic component to cosmology calculations

### DIFF
--- a/doc/source/analyzing/analysis_modules/cosmology_calculator.rst
+++ b/doc/source/analyzing/analysis_modules/cosmology_calculator.rst
@@ -51,9 +51,6 @@ redshift and time are available:
    # time between two redshifts
    print("lookback time", co.lookback_time(0, 0.5).in_units("Gyr"))
 
-   # inverse of the Hubble parameter at a given redshift
-   print("hubble time", co.hubble_time(0).in_units("Gyr"))
-
    # critical density
    print("critical density", co.critical_density(0))
 

--- a/doc/source/analyzing/analysis_modules/cosmology_calculator.rst
+++ b/doc/source/analyzing/analysis_modules/cosmology_calculator.rst
@@ -15,7 +15,8 @@ in the following way:
    from yt.utilities.cosmology import Cosmology
 
    co = Cosmology(hubble_constant=0.7, omega_matter=0.3,
-                  omega_lambda=0.7, omega_curvature=0.0)
+                  omega_lambda=0.7, omega_curvature=0.0,
+                  omega_radiation=0.0)
 
 Once created, various distance calculations as well as conversions between
 redshift and time are available:
@@ -24,8 +25,7 @@ redshift and time are available:
 
    from yt.utilities.cosmology import Cosmology
 
-   co = Cosmology(hubble_constant=0.7, omega_matter=0.3,
-                  omega_lambda=0.7, omega_curvature=0.0)
+   co = Cosmology()
 
    # Hubble distance (c / h)
    print("hubble distance", co.hubble_distance())
@@ -51,7 +51,7 @@ redshift and time are available:
    # time between two redshifts
    print("lookback time", co.lookback_time(0, 0.5).in_units("Gyr"))
 
-   # age of the Universe at a given redshift
+   # inverse of the Hubble parameter at a given redshift
    print("hubble time", co.hubble_time(0).in_units("Gyr"))
 
    # critical density
@@ -64,7 +64,7 @@ redshift and time are available:
    my_t = co.quan(8, "Gyr")
    print("z from t", co.z_from_t(my_t))
 
-   # convert redshift to time after Big Bang (same as Hubble time)
+   # convert redshift to time after Big Bang
    print("t from z", co.t_from_z(0.5).in_units("Gyr"))
 
 .. warning::
@@ -76,8 +76,7 @@ redshift and time are available:
    x, x.to("Mpc") and x.to("Mpccm") will be the same.  The user should take
    care to understand which reference frame is correct for the given calculation.
 
-All of the above
-functions accept scalar values and arrays.  The helper functions, `co.quan`
+The helper functions, `co.quan`
 and `co.arr` exist to create unitful `YTQuantities` and `YTArray` with the
 unit registry of the cosmology calculator.  For more information on the usage
 and meaning of each calculation, consult the reference documentation at

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -26,3 +26,4 @@ libconf==1.0.1
 cartopy==0.17.0
 pyaml==17.10.0
 mpi4py==3.0.0
+pyyaml==3.13

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -32,6 +32,7 @@ from yt.fields.derived_field import \
 from yt.funcs import \
     mylog, \
     set_intersection, \
+    setdefaultattr, \
     ensure_list
 from yt.utilities.cosmology import \
     Cosmology
@@ -535,7 +536,7 @@ class Dataset(object):
         if hasattr(self, "cosmological_simulation") and \
            getattr(self, "cosmological_simulation"):
             for a in ["current_redshift", "omega_lambda", "omega_matter",
-                      "hubble_constant"]:
+                      "omega_radiation", "hubble_constant"]:
                 if not hasattr(self, a):
                     mylog.error("Missing %s in parameter file definition!", a)
                     continue
@@ -1025,10 +1026,14 @@ class Dataset(object):
             w_0 = getattr(self, 'w_0', -1.0)
             w_a = getattr(self, 'w_a', 0.0)
 
+            # many frontends do not set this
+            setdefaultattr(self, "omega_radiation", 0.0)
+
             self.cosmology = \
                     Cosmology(hubble_constant=self.hubble_constant,
                               omega_matter=self.omega_matter,
                               omega_lambda=self.omega_lambda,
+                              omega_radiation=self.omega_radiation,
                               use_dark_factor = use_dark_factor,
                               w_0 = w_0, w_a = w_a)
             self.critical_density = \

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -88,7 +88,8 @@ attrs = ("refine_by", "dimensionality", "current_time",
          "domain_dimensions", "domain_left_edge",
          "domain_right_edge", "unique_identifier",
          "current_redshift", "cosmological_simulation",
-         "omega_matter", "omega_lambda", "hubble_constant")
+         "omega_matter", "omega_lambda", "omega_radiation",
+         "hubble_constant")
 
 class TimeSeriesParametersContainer(object):
     def __init__(self, data_object):
@@ -566,8 +567,8 @@ class SimulationTimeSeries(DatasetSeries):
                   "cosmological_simulation"]:
             self._print_attr(a)
         if getattr(self, "cosmological_simulation", False):
-            for a in ["box_size", "omega_lambda",
-                      "omega_matter", "hubble_constant",
+            for a in ["box_size", "omega_matter", "omega_lambda",
+                      "omega_radiation", "hubble_constant",
                       "initial_redshift", "final_redshift"]:
                 self._print_attr(a)
         for a in self.key_parameters:

--- a/yt/frontends/ahf/data_structures.py
+++ b/yt/frontends/ahf/data_structures.py
@@ -125,9 +125,10 @@ class AHFHalosDataset(Dataset):
         self.current_redshift = param['z']
         self.omega_lambda = simu['lambda0']
         self.omega_matter = simu['omega0']
-        cosmo = Cosmology(self.hubble_constant,
-                          self.omega_matter, self.omega_lambda)
-        self.current_time = cosmo.hubble_time(param['z']).in_units('s')
+        cosmo = Cosmology(hubble_constant=self.hubble_constant,
+                          omega_matter=self.omega_matter,
+                          omega_lambda=self.omega_lambda)
+        self.current_time = cosmo.lookback_time(param['z'], 1e6).in_units('s')
 
     @classmethod
     def _is_valid(self, *args, **kwargs):

--- a/yt/frontends/enzo/data_structures.py
+++ b/yt/frontends/enzo/data_structures.py
@@ -861,6 +861,8 @@ class EnzoDataset(Dataset):
             self.current_redshift = self.parameters["CosmologyCurrentRedshift"]
             self.omega_lambda = self.parameters["CosmologyOmegaLambdaNow"]
             self.omega_matter = self.parameters["CosmologyOmegaMatterNow"]
+            self.omega_radiation = \
+              self.parameters.get("CosmologyOmegaRadiationNow", 0.0)
             self.hubble_constant = self.parameters["CosmologyHubbleConstantNow"]
         else:
             self.current_redshift = self.omega_lambda = self.omega_matter = \

--- a/yt/frontends/enzo/simulation_handling.py
+++ b/yt/frontends/enzo/simulation_handling.py
@@ -89,6 +89,7 @@ class EnzoSimulation(SimulationTimeSeries):
               EnzoCosmology(self.parameters['CosmologyHubbleConstantNow'],
                             self.parameters['CosmologyOmegaMatterNow'],
                             self.parameters['CosmologyOmegaLambdaNow'],
+                            self.parameters.get('CosmologyOmegaRadiationNow', 0.0),
                             0.0, self.parameters['CosmologyInitialRedshift'],
                             unit_registry=self.unit_registry)
 
@@ -379,6 +380,7 @@ class EnzoSimulation(SimulationTimeSeries):
             cosmo_attr = {'box_size': 'CosmologyComovingBoxSize',
                           'omega_lambda': 'CosmologyOmegaLambdaNow',
                           'omega_matter': 'CosmologyOmegaMatterNow',
+                          'omega_radiation': 'CosmologyOmegaRadiationNow',
                           'hubble_constant': 'CosmologyHubbleConstantNow',
                           'initial_redshift': 'CosmologyInitialRedshift',
                           'final_redshift': 'CosmologyFinalRedshift'}
@@ -635,11 +637,13 @@ class EnzoSimulation(SimulationTimeSeries):
 
 class EnzoCosmology(Cosmology):
     def __init__(self, hubble_constant, omega_matter, omega_lambda,
-                 omega_curvature, initial_redshift, unit_registry = None):
+                 omega_radiation, omega_curvature, initial_redshift,
+                 unit_registry = None):
         Cosmology.__init__(self,
                            hubble_constant=hubble_constant,
                            omega_matter=omega_matter,
                            omega_lambda=omega_lambda,
+                           omega_radiation=omega_radiation,
                            omega_curvature=omega_curvature,
                            unit_registry=unit_registry)
         self.initial_redshift = initial_redshift

--- a/yt/frontends/enzo/simulation_handling.py
+++ b/yt/frontends/enzo/simulation_handling.py
@@ -547,6 +547,7 @@ class EnzoSimulation(SimulationTimeSeries):
         self.parameters['CycleSkipDataDump'] = 0.
         self.parameters['LengthUnits'] = 1.
         self.parameters['TimeUnits'] = 1.
+        self.parameters['CosmologyOmegaRadiationNow'] = 0.
 
     def _find_outputs(self):
         """

--- a/yt/frontends/enzo/tests/test_outputs.py
+++ b/yt/frontends/enzo/tests/test_outputs.py
@@ -46,6 +46,7 @@ toro1d = "ToroShockTube/DD0001/data0001"
 kh2d = "EnzoKelvinHelmholtz/DD0011/DD0011"
 mhdctot = "MHDCTOrszagTang/DD0004/data0004"
 dnz = "DeeplyNestedZoom/DD0025/data0025"
+p3mini = "PopIII_mini/DD0034/DD0034"
 
 def check_color_conservation(ds):
     species_names = ds.field_info.species_names
@@ -228,3 +229,17 @@ def test_2d_grid_shape():
     ds = data_dir_load(kh2d)
     g = ds.index.grids[1]
     assert g['density'].shape == (128, 100, 1)
+
+@requires_file(p3mini)
+def test_nonzero_omega_radiation():
+    """
+    Test support for non-zero omega_radiation cosmologies.
+    """
+    ds = data_dir_load(p3mini)
+
+    assert_equal(ds.omega_radiation, ds.cosmology.omega_radiation)
+
+    tratio = ds.current_time / \
+      ds.cosmology.t_from_z(ds.current_redshift)
+    assert_almost_equal(tratio, 1, 4,
+      err_msg='Simulation time not consistent with cosmology calculator.')

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -352,9 +352,10 @@ class GadgetDataset(SPHDataset):
             # ComovingIntegration hvals["Time"] will in fact be the expansion
             # factor, not the actual integration time, so we re-calculate
             # global time from our Cosmology.
-            cosmo = Cosmology(self.hubble_constant,
-                              self.omega_matter, self.omega_lambda)
-            self.current_time = cosmo.hubble_time(self.current_redshift)
+            cosmo = Cosmology(hubble_constant=self.hubble_constant,
+                              omega_matter=self.omega_matter,
+                              omega_lambda=self.omega_lambda)
+            self.current_time = cosmo.lookback_time(self.current_redshift, 1e6)
             only_on_root(mylog.info, "Calculating time from %0.3e to be %0.3e seconds",
                          hvals["Time"], self.current_time)
         self.parameters = hvals

--- a/yt/frontends/rockstar/data_structures.py
+++ b/yt/frontends/rockstar/data_structures.py
@@ -102,9 +102,11 @@ class RockstarDataset(Dataset):
         self.hubble_constant = hvals['h0']
         self.omega_lambda = hvals['Ol']
         self.omega_matter = hvals['Om']
-        cosmo = Cosmology(self.hubble_constant,
-                          self.omega_matter, self.omega_lambda)
-        self.current_time = cosmo.hubble_time(self.current_redshift).in_units("s")
+        cosmo = Cosmology(hubble_constant=self.hubble_constant,
+                          omega_matter=self.omega_matter,
+                          omega_lambda=self.omega_lambda)
+        self.current_time = cosmo.lookback_time(
+            self.current_redshift, 1e6).in_units("s")
         self.periodicity = (True, True, True)
         self.particle_types = ("halos")
         self.particle_types_raw = ("halos")

--- a/yt/frontends/tipsy/data_structures.py
+++ b/yt/frontends/tipsy/data_structures.py
@@ -267,9 +267,10 @@ class TipsyDataset(SPHDataset):
 
         # Finally, set the dependent units
         if self.cosmological_simulation:
-            cosmo = Cosmology(self.hubble_constant,
-                              self.omega_matter, self.omega_lambda)
-            self.current_time = cosmo.hubble_time(self.current_redshift)
+            cosmo = Cosmology(hubble_constant=self.hubble_constant,
+                              omega_matter=self.omega_matter,
+                              omega_lambda=self.omega_lambda)
+            self.current_time = cosmo.lookback_time(self.current_redshift, 1e6)
             # mass units are rho_crit(z=0) * domain volume
             mu = cosmo.critical_density(0.0) * \
               (1 + self.current_redshift)**3 * self.length_unit**3

--- a/yt/utilities/cosmology.py
+++ b/yt/utilities/cosmology.py
@@ -6,7 +6,7 @@ and featuring time and redshift conversion functions from Enzo.
 """
 
 #-----------------------------------------------------------------------------
-# Copyright (c) 2013-2014, yt Development Team.
+# Copyright (c) yt Development Team. All rights reserved.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -24,8 +24,8 @@ from yt.units.yt_array import \
      YTQuantity
 
 from yt.utilities.physical_constants import \
-    gravitational_constant_cgs as G, \
-    speed_of_light_cgs
+     gravitational_constant_cgs as G, \
+     speed_of_light_cgs
 
 class Cosmology(object):
     r"""
@@ -49,6 +49,8 @@ class Cosmology(object):
     omega_matter : the fraction of the energy density of the Universe in 
         matter at redshift zero.
         Default: 0.27.
+    omega_radiation : the fraction of the energy density of the Universe in
+        relativistic matter at redshift zero.
     omega_lambda : the fraction of the energy density of the Universe in 
         a cosmological constant.
         Default: 0.73.
@@ -80,6 +82,7 @@ class Cosmology(object):
     """
     def __init__(self, hubble_constant = 0.71,
                  omega_matter = 0.27,
+                 omega_radiation = 0.0,
                  omega_lambda = 0.73,
                  omega_curvature = 0.0,
                  unit_registry = None,
@@ -88,6 +91,7 @@ class Cosmology(object):
                  w_0 = -1.0,
                  w_a = 0.0):
         self.omega_matter = float(omega_matter)
+        self.omega_radiation = float(omega_radiation)
         self.omega_lambda = float(omega_lambda)
         self.omega_curvature = float(omega_curvature)
         if unit_registry is None:
@@ -319,9 +323,9 @@ class Cosmology(object):
         return (trapzint(self.age_integrand, z_i, z_f) / \
                 self.hubble_constant).in_base(self.unit_system)
     
-    def hubble_time(self, z, z_inf=1e6):
+    def hubble_time(self, z, z_inf=1e7):
         r"""
-        The age of the Universe at a given redshift.
+        The inverse of the Hubble parameter.
 
         Parameters
         ----------
@@ -337,11 +341,6 @@ class Cosmology(object):
         >>> from yt.utilities.cosmology import Cosmology
         >>> co = Cosmology()
         >>> print(co.hubble_time(0.).in_units("Gyr"))
-
-        See Also
-        --------
-
-        t_from_z
 
         """
         return (trapzint(self.age_integrand, z, z_inf) /
@@ -366,10 +365,8 @@ class Cosmology(object):
         >>> print(co.critical_density(0).in_units("Msun/Mpc**3"))
         
         """
-        return (3.0 / 8.0 / np.pi * 
-                self.hubble_constant**2 / G *
-                ((1 + z)**3.0 * self.omega_matter + 
-                 self.omega_lambda)).in_base(self.unit_system)
+        return (3.0 * self.hubble_parameter(z)**2 /
+                8.0 / np.pi / G).in_base(self.unit_system)
 
     def hubble_parameter(self, z):
         r"""
@@ -388,10 +385,11 @@ class Cosmology(object):
         >>> print(co.hubble_parameter(1.0).in_units("km/s/Mpc"))
 
         """
-        return self.hubble_constant.in_base(self.unit_system) * self.expansion_factor(z)
+        return self.hubble_constant.in_base(self.unit_system) * \
+          self.expansion_factor(z)
 
     def age_integrand(self, z):
-        return (1 / (z + 1) / self.expansion_factor(z))
+        return 1 / (z + 1) / self.expansion_factor(z)
 
     def expansion_factor(self, z):
         r"""
@@ -411,9 +409,11 @@ class Cosmology(object):
         else:
             dark_factor = 1.0
 
-        return np.sqrt(self.omega_matter * ((1 + z)**3.0) + 
-                       self.omega_curvature * ((1 + z)**2.0) + 
-                       (self.omega_lambda * dark_factor))
+        zp1 = 1 + z
+        return np.sqrt(self.omega_matter    * zp1**3 +
+                       self.omega_curvature * zp1**2 +
+                       self.omega_radiation * zp1**4 +
+                       self.omega_lambda    * dark_factor)
 
     def inverse_expansion_factor(self, z):
         return 1 / self.expansion_factor(z)
@@ -424,103 +424,29 @@ class Cosmology(object):
     def path_length(self, z_i, z_f):
         return trapzint(self.path_length_function, z_i, z_f)
 
-    def z_from_t(self, my_time):
-        """
-        Compute the redshift from time after the big bang.  This is based on
-        Enzo's CosmologyComputeExpansionFactor.C, but altered to use physical
-        units.
+    _tz = None
+    @property
+    def _tz_table(self):
+        if self._tz is not None:
+            return self._tz
 
-        Parameters
-        ----------
-        my_time : float
-            Age of the Universe in seconds.
-
-        Examples
-        --------
-
-        >>> from yt.utilities.cosmology import Cosmology
-        >>> co = Cosmology()
-        >>> print(co.z_from_t(4.e17))
-
-        """
-
-        omega_curvature = 1.0 - self.omega_matter - self.omega_lambda
-
-        OMEGA_TOLERANCE = 1e-5
-        ETA_TOLERANCE = 1.0e-10
-
-        # Convert the time to Time * H0.
-
-        if not isinstance(my_time, YTArray):
-            my_time = self.quan(my_time, "s")
-
-        t0 = (my_time.in_units("s") *
-              self.hubble_constant.in_units("1/s")).to_ndarray()
- 
-        # 1) For a flat universe with omega_matter = 1, it's easy.
- 
-        if ((np.fabs(self.omega_matter-1) < OMEGA_TOLERANCE) and
-            (self.omega_lambda < OMEGA_TOLERANCE)):
-            a = np.power(my_time/self.initial_time, 2.0/3.0)
- 
-        # 2) For omega_matter < 1 and omega_lambda == 0 see
-        #    Peebles 1993, eq. 13-3, 13-10.
-        #    Actually, this is a little tricky since we must solve an equation
-        #    of the form eta - np.sinh(eta) + x = 0..
- 
-        if ((self.omega_matter < 1) and 
-            (self.omega_lambda < OMEGA_TOLERANCE)):
-            x = 2*t0*np.power(1.0 - self.omega_matter, 1.5) / \
-                self.omega_matter;
- 
-            # Compute eta in a three step process, first from a third-order
-            # Taylor expansion of the formula above, then use that in a fifth-order
-            # approximation.  Then finally, iterate on the formula itself, solving for
-            # eta.  This works well because parts 1 & 2 are an excellent approximation
-            # when x is small and part 3 converges quickly when x is large. 
- 
-            eta = np.power(6*x, 1.0/3.0)                # part 1
-            eta = np.power(120*x/(20+eta*eta), 1.0/3.0) # part 2
-            for i in range(40):                      # part 3
-                eta_old = eta
-                eta = np.arcsinh(eta + x)
-                if (np.fabs(eta-eta_old) < ETA_TOLERANCE): 
-                    break
-                if (i == 39):
-                    print("No convergence after %d iterations." % i)
- 
-            # Now use eta to compute the expansion factor (eq. 13-10, part 2).
- 
-            a = self.omega_matter/(2.0*(1.0 - self.omega_matter))*\
-                (np.cosh(eta) - 1.0)
-
-        # 3) For omega_matter > 1 and omega_lambda == 0, use sin/cos.
-        #    Easy, but skip it for now.
- 
-        if ((self.omega_matter > 1) and 
-            (self.omega_lambda < OMEGA_TOLERANCE)):
-            print("Never implemented in Enzo, not implemented here.")
-            return 0
- 
-        # 4) For flat universe, with non-zero omega_lambda, see eq. 13-20.
- 
-        if ((np.fabs(omega_curvature) < OMEGA_TOLERANCE) and
-            (self.omega_lambda > OMEGA_TOLERANCE)):
-            a = np.power(self.omega_matter / 
-                         (1 - self.omega_matter), 1.0/3.0) * \
-                np.power(np.sinh(1.5 * np.sqrt(1.0 - self.omega_matter)*\
-                                     t0), 2.0/3.0)
-
-
-        redshift = (1.0/a) - 1.0
-
-        return redshift
+        # Create a table of log(a) vs. log(t).
+        la_i = -6
+        la_f = 6
+        bins_per_dex = 100
+        n_bins = (la_f - la_i) * bins_per_dex + 1
+        la = np.linspace(la_i, la_f, n_bins)
+        # Integrate in redshift-space.
+        z = 1 / np.power(10, la) - 1
+        integ = IntegralTable(self.age_integrand, z)
+        # Store table of log(a)/log(t).
+        # Add a minus sign because we've switched the integration limits.
+        self._tz = InterpTable(la[1:], np.log10(-integ.y))
+        return self._tz
 
     def t_from_z(self, z):
         """
-        Compute the age of the Universe from redshift.  This is based on Enzo's
-        CosmologyComputeTimeFromRedshift.C, but altered to use physical units.  
-        Similar to hubble_time, but using an analytical function.
+        Compute the age of the Universe for a given redshift.
 
         Parameters
         ----------
@@ -534,48 +460,44 @@ class Cosmology(object):
         >>> co = Cosmology()
         >>> print(co.t_from_z(0.).in_units("Gyr"))
 
-        See Also
+        """
+
+        la = np.log10(1 / (1 + z))
+        t = np.power(10, self._tz_table(la))
+
+        return (t / self.hubble_constant).in_base(self.unit_system)
+
+    _zt = None
+    @property
+    def _zt_table(self):
+        if self._zt is None:
+            self._zt = InterpTable(self._tz_table.y, self._tz_table.x)
+        return self._zt
+
+    def z_from_t(self, t):
+        """
+        Compute the redshift for a given age of the Universe.
+
+        Parameters
+        ----------
+        t : YTQuantity or float
+            Time since the Big Bang.  If a float is given, units are
+            assumed to be seconds.
+
+        Examples
         --------
 
-        hubble_time
-        
+        >>> from yt.utilities.cosmology import Cosmology
+        >>> co = Cosmology()
+        >>> print(co.z_from_t(4.e17))
+
         """
-        omega_curvature = 1.0 - self.omega_matter - self.omega_lambda
- 
-        # 1) For a flat universe with omega_matter = 1, things are easy.
- 
-        if ((self.omega_matter == 1.0) and (self.omega_lambda == 0.0)):
-            t0 = 2.0/3.0/np.power(1+z, 1.5)
- 
-        # 2) For omega_matter < 1 and omega_lambda == 0 see
-        #    Peebles 1993, eq. 13-3, 13-10.
- 
-        if ((self.omega_matter < 1) and (self.omega_lambda == 0)):
-            eta = np.arccosh(1 + 
-                             2*(1-self.omega_matter)/self.omega_matter/(1+z))
-            t0 = self.omega_matter/ \
-              (2*np.power(1.0-self.omega_matter, 1.5))*\
-              (np.sinh(eta) - eta)
- 
-        # 3) For omega_matter > 1 and omega_lambda == 0, use sin/cos.
- 
-        if ((self.omega_matter > 1) and (self.omega_lambda == 0)):
-            eta = np.arccos(1 - 2*(1-self.omega_matter)/self.omega_matter/(1+z))
-            t0 = self.omega_matter/(2*np.power(1.0-self.omega_matter, 1.5))*\
-                (eta - np.sin(eta))
- 
-        # 4) For flat universe, with non-zero omega_lambda, see eq. 13-20.
- 
-        if ((np.fabs(omega_curvature) < 1.0e-3) and (self.omega_lambda != 0)):
-            t0 = 2.0/3.0/np.sqrt(1-self.omega_matter)*\
-                np.arcsinh(np.sqrt((1-self.omega_matter)/self.omega_matter)/ \
-                               np.power(1+z, 1.5))
-  
-        # Now convert from Time * H0 to time.
-  
-        my_time = t0 / self.hubble_constant
-    
-        return my_time.in_base(self.unit_system)
+
+        if not isinstance(t, YTArray):
+            t = self.arr(t, 's')
+        lt = np.log10((t * self.hubble_constant).to(""))
+        la = self._zt_table(lt)
+        return 1 / np.power(10, la) - 1
 
     def get_dark_factor(self, z):
         """
@@ -619,6 +541,40 @@ class Cosmology(object):
                 registry = self.unit_registry)
         return self._quan
 
-def trapzint(f, a, b, bins=10000):
+def trapzint(f, a, b, bins=1000):
     zbins = np.logspace(np.log10(a + 1), np.log10(b + 1), bins) - 1
     return np.trapz(f(zbins[:-1]), x=zbins[:-1], dx=np.diff(zbins))
+
+class IntegralTable(object):
+    """
+    Generate a table of the integral of the provided function over the
+    specified range of values.
+    """
+    def __init__(self, f, x):
+        self.f = f
+        self.x = x
+
+    _y = None
+    @property
+    def y(self):
+        """
+        Use the trapezoid rule to integrate.
+        """
+        if self._y is None:
+            fy = self.f(self.x)
+            self._y = (0.5 * (fy[:-1] + fy[1:]) * \
+                np.diff(self.x)).cumsum()
+        return self._y
+
+class InterpTable(object):
+    """
+    Generate a function to linearly interpolate from provided tables.
+    """
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+
+    def __call__(self, val):
+        i = np.clip(np.digitize(val, self.x) - 1, 0, self.x.size - 2)
+        slope = (self.y[i+1] - self.y[i]) / (self.x[i+1] - self.x[i])
+        return slope * (val - self.x[i]) + self.y[i]

--- a/yt/utilities/cosmology.py
+++ b/yt/utilities/cosmology.py
@@ -51,11 +51,11 @@ class Cosmology(object):
     omega_matter : the fraction of the energy density of the Universe in 
         matter at redshift zero.
         Default: 0.27.
-    omega_radiation : the fraction of the energy density of the Universe in
-        relativistic matter at redshift zero.
     omega_lambda : the fraction of the energy density of the Universe in 
         a cosmological constant.
         Default: 0.73.
+    omega_radiation : the fraction of the energy density of the Universe in
+        relativistic matter at redshift zero.
     omega_curvature : the fraction of the energy density of the Universe in 
         curvature.
         Default: 0.0.
@@ -84,8 +84,8 @@ class Cosmology(object):
     """
     def __init__(self, hubble_constant = 0.71,
                  omega_matter = 0.27,
-                 omega_radiation = 0.0,
                  omega_lambda = 0.73,
+                 omega_radiation = 0.0,
                  omega_curvature = 0.0,
                  unit_registry = None,
                  unit_system = "cgs",

--- a/yt/utilities/cosmology.py
+++ b/yt/utilities/cosmology.py
@@ -119,7 +119,8 @@ class Cosmology(object):
         The distance corresponding to c / h, where c is the speed of light 
         and h is the Hubble parameter in units of 1 / time.
         """
-        return self.quan((speed_of_light_cgs / self.hubble_constant)).in_base(self.unit_system)
+        return self.quan(speed_of_light_cgs /
+                         self.hubble_constant).in_base(self.unit_system)
 
     def comoving_radial_distance(self, z_i, z_f):
         r"""

--- a/yt/utilities/cosmology.py
+++ b/yt/utilities/cosmology.py
@@ -465,7 +465,7 @@ class Cosmology(object):
         bins_per_dex = 1000
         n_bins = int((la_f - la_i) * bins_per_dex + 1)
         la_bins = np.linspace(la_i, la_f, n_bins)
-        z_bins = 1 / np.power(10, la_bins) - 1
+        z_bins = 1. / np.power(10, la_bins) - 1
 
         # Integrate in redshift.
         lt = trapezoid_cumulative_integral(self.age_integrand, z_bins)
@@ -494,7 +494,7 @@ class Cosmology(object):
 
         """
 
-        return self.t_from_a(1 / (1 + z))
+        return self.t_from_a(1. / (1. + z))
 
     def a_from_t(self, t):
         """
@@ -530,7 +530,7 @@ class Cosmology(object):
             good = True
             n_bins = int((la_f - la_i) * bins_per_dex + 1)
             la_bins = np.linspace(la_i, la_f, n_bins)
-            z_bins = 1 / np.power(10, la_bins) - 1
+            z_bins = 1. / np.power(10, la_bins) - 1
 
             # Integrate in redshift.
             lt_bins = trapezoid_cumulative_integral(
@@ -579,7 +579,7 @@ class Cosmology(object):
         """
 
         a = self.a_from_t(t)
-        return 1 / a - 1
+        return 1. / a - 1.
 
     def get_dark_factor(self, z):
         """

--- a/yt/utilities/cosmology.py
+++ b/yt/utilities/cosmology.py
@@ -201,8 +201,8 @@ class Cosmology(object):
         >>> print(co.comoving_volume(0., 1.).in_units("Gpccm**3"))
 
         """
-        if (self.omega_curvature > 0):
-             return (2 * np.pi * np.power(self.hubble_distance(), 3) /
+        if (self.omega_curvature > 1e-10):
+            return (2 * np.pi * np.power(self.hubble_distance(), 3) /
                      self.omega_curvature * 
                      (self.comoving_transverse_distance(z_i, z_f) /
                       self.hubble_distance() * 
@@ -213,8 +213,8 @@ class Cosmology(object):
                             self.comoving_transverse_distance(z_i, z_f) /
                             self.hubble_distance()) /
                             np.sqrt(self.omega_curvature))).in_base(self.unit_system)
-        elif (self.omega_curvature < 0):
-             return (2 * np.pi * np.power(self.hubble_distance(), 3) /
+        elif (self.omega_curvature < -1e-10):
+            return (2 * np.pi * np.power(self.hubble_distance(), 3) /
                      np.fabs(self.omega_curvature) * 
                      (self.comoving_transverse_distance(z_i, z_f) /
                       self.hubble_distance() * 
@@ -226,7 +226,7 @@ class Cosmology(object):
                            self.hubble_distance()) /
                       np.sqrt(np.fabs(self.omega_curvature)))).in_base(self.unit_system)
         else:
-             return (4 * np.pi *
+            return (4 * np.pi *
                      np.power(self.comoving_transverse_distance(z_i, z_f), 3) /\
                      3).in_base(self.unit_system)
 

--- a/yt/utilities/cosmology.py
+++ b/yt/utilities/cosmology.py
@@ -343,8 +343,7 @@ class Cosmology(object):
         >>> print(co.hubble_time(0.).in_units("Gyr"))
 
         """
-        return (trapzint(self.age_integrand, z, z_inf) /
-                self.hubble_constant).in_base(self.unit_system)
+        return (1 / self.hubble_parameter(z)).in_base(self.unit_system)
 
     def critical_density(self, z):
         r"""

--- a/yt/utilities/cosmology.py
+++ b/yt/utilities/cosmology.py
@@ -405,7 +405,7 @@ class Cosmology(object):
                 self.expansion_factor(z))
 
     def age_integrand(self, z):
-        return 1 / (z + 1) / self.expansion_factor(z)
+        return 1. / (z + 1) / self.expansion_factor(z)
 
     def expansion_factor(self, z):
         r"""
@@ -432,7 +432,7 @@ class Cosmology(object):
                        self.omega_lambda    * dark_factor)
 
     def inverse_expansion_factor(self, z):
-        return 1 / self.expansion_factor(z)
+        return 1. / self.expansion_factor(z)
 
     def path_length_function(self, z):
         return ((1 + z)**2) * self.inverse_expansion_factor(z)

--- a/yt/utilities/cosmology.py
+++ b/yt/utilities/cosmology.py
@@ -463,7 +463,7 @@ class Cosmology(object):
         la_i = min(-6, np.asarray(la).min() - 3)
         la_f = np.asarray(la).max()
         bins_per_dex = 1000
-        n_bins = (la_f - la_i) * bins_per_dex + 1
+        n_bins = int((la_f - la_i) * bins_per_dex + 1)
         la_bins = np.linspace(la_i, la_f, n_bins)
         z_bins = 1 / np.power(10, la_bins) - 1
 
@@ -528,7 +528,7 @@ class Cosmology(object):
 
         while True:
             good = True
-            n_bins = (la_f - la_i) * bins_per_dex + 1
+            n_bins = int((la_f - la_i) * bins_per_dex + 1)
             la_bins = np.linspace(la_i, la_f, n_bins)
             z_bins = 1 / np.power(10, la_bins) - 1
 

--- a/yt/utilities/cosmology.py
+++ b/yt/utilities/cosmology.py
@@ -623,7 +623,7 @@ class Cosmology(object):
                 registry = self.unit_registry)
         return self._quan
 
-def trapzint(f, a, b, bins=1000):
+def trapzint(f, a, b, bins=10000):
     zbins = np.logspace(np.log10(a + 1), np.log10(b + 1), bins) - 1
     return np.trapz(f(zbins[:-1]), x=zbins[:-1], dx=np.diff(zbins))
 

--- a/yt/utilities/cosmology.py
+++ b/yt/utilities/cosmology.py
@@ -326,7 +326,7 @@ class Cosmology(object):
         return (trapzint(self.age_integrand, z_i, z_f) / \
                 self.hubble_constant).in_base(self.unit_system)
     
-    def hubble_time(self, z, z_inf=1e7):
+    def hubble_time(self, z, z_inf=1e6):
         r"""
         The inverse of the Hubble parameter.
 
@@ -355,7 +355,7 @@ class Cosmology(object):
 
         """
         issue_deprecation_warning(
-            'This function is incorrect and has been deprecated! ' +
+            'The hubble_time function is incorrect and has been deprecated! ' +
             'Instead, do the following:\n' +
             '>>> print (1 / co.hubble_parameter(z)).to(\'Gyr\')\n' +
             'If you want the age of the Universe, use the t_from_z function.')

--- a/yt/utilities/on_demand_imports.py
+++ b/yt/utilities/on_demand_imports.py
@@ -460,3 +460,18 @@ class libconf_imports(object):
         return self._load
 
 _libconf = libconf_imports()
+
+class yaml_imports(object):
+    _name = "yaml"
+    _load = None
+    @property
+    def load(self):
+        if self._load is None:
+            try:
+                from yaml import load
+            except ImportError:
+                load = NotAModule(self._name)
+            self._load = load
+        return self._load
+
+_yaml = yaml_imports()

--- a/yt/utilities/tests/cosmology_answers.yml
+++ b/yt/utilities/tests/cosmology_answers.yml
@@ -1,0 +1,76 @@
+cosmologies:
+  EdS: {hubble_constant: 0.7, omega_lambda: 0.0, omega_matter: 1.0, omega_radiation: 0.0}
+  LCDM: {hubble_constant: 0.7, omega_lambda: 0.7, omega_matter: 0.3, omega_radiation: 0.0}
+  omega_radiation: {hubble_constant: 0.7, omega_lambda: 0.7, omega_matter: 0.2999,
+    omega_radiation: 0.0001}
+  open: {hubble_constant: 0.7, omega_lambda: 0.0, omega_matter: 0.3, omega_radiation: 0.0}
+functions:
+  age_integrand:
+    answers: {EdS: 0.17677669529663687, LCDM: 0.28398091712353246, omega_radiation: 0.2839442815151592,
+      open: 0.21926450482675733}
+    args: [1]
+  angular_diameter_distance:
+    answers: {EdS: -47.63859400006291, LCDM: 74.71628440466395, omega_radiation: 74.61156201248941,
+      open: 114.42229537588507}
+    args: [1, 2]
+    units: Mpc
+  angular_scale:
+    answers: {EdS: -47.63859400006291, LCDM: 74.71628440466395, omega_radiation: 74.61156201248941,
+      open: 114.42229537588507}
+    args: [1, 2]
+    units: Mpc/radian
+  comoving_radial_distance:
+    answers: {EdS: 1111.3289801408714, LCDM: 1875.857637458183, omega_radiation: 1875.4640874252457,
+      open: 1448.958605095395}
+    args: [1, 2]
+    units: Mpc
+  comoving_transverse_distance:
+    answers: {EdS: 1111.3289801408714, LCDM: 1875.857637458183, omega_radiation: 1875.4640874252457,
+      open: 1468.3857559045264}
+    args: [1, 2]
+    units: Mpc
+  comoving_volume:
+    answers: {EdS: 5.749320615429804, LCDM: 27.64956077763837, omega_radiation: 27.632162011458195,
+      open: 82.84024895030079}
+    args: [1, 2]
+    units: Gpc**3
+  critical_density:
+    answers: {EdS: 1088.0152888198547, LCDM: 421.6059244176937, omega_radiation: 421.7147259465755,
+      open: 707.2099377329054}
+    args: [1]
+    units: Msun/kpc**3
+  expansion_factor:
+    answers: {EdS: 2.8284271247461903, LCDM: 1.7606816861659007, omega_radiation: 1.7609088562444108,
+      open: 2.2803508501982757}
+    args: [1]
+  hubble_distance:
+    answers: {EdS: 4282.749400000001, LCDM: 4282.749400000001, omega_radiation: 4282.749400000001,
+      open: 4282.749400000001}
+    units: Mpc
+  hubble_parameter:
+    answers: {EdS: 197.98989873223329, LCDM: 123.24771803161306, omega_radiation: 123.26361993710874,
+      open: 159.6245595138793}
+    args: [1]
+    units: km/s/Mpc
+  inverse_expansion_factor:
+    answers: {EdS: 0.35355339059327373, LCDM: 0.5679618342470649, omega_radiation: 0.5678885630303184,
+      open: 0.43852900965351466}
+    args: [1]
+  lookback_time:
+    answers: {EdS: 1500.1343648374723, LCDM: 2524.828936828046, omega_radiation: 2524.3141825048465,
+      open: 1949.3932768737345}
+    args: [1, 2]
+    units: Myr
+  luminosity_distance:
+    answers: {EdS: 5842.669112528931, LCDM: 8931.175468218224, omega_radiation: 8929.836295237686,
+      open: 8369.418267416617}
+    args: [1, 2]
+    units: Mpc
+  path_length:
+    answers: {EdS: 1.5782728314065704, LCDM: 2.679181396559161, omega_radiation: 2.6785873459658784,
+      open: 2.0714508064868244}
+    args: [1, 2]
+  path_length_function:
+    answers: {EdS: 1.414213562373095, LCDM: 2.2718473369882597, omega_radiation: 2.2715542521212737,
+      open: 1.7541160386140586}
+    args: [1]

--- a/yt/utilities/tests/test_cosmology.py
+++ b/yt/utilities/tests/test_cosmology.py
@@ -16,12 +16,12 @@ Test cosmology calculator.
 
 import numpy as np
 import os
-import yaml
 
 from yt.testing import \
      assert_almost_equal, \
      assert_rel_equal, \
-     assert_equal
+     assert_equal, \
+     requires_module
 from yt.units.yt_array import \
      YTArray, \
      YTQuantity
@@ -213,6 +213,7 @@ def test_dark_factor():
     co.use_dark_factor = True
     assert_equal(co.get_dark_factor(0), 1.0)
 
+@requires_module('yaml')
 def test_cosmology_calculator_answers():
     """
     Test cosmology calculator functions against previously calculated values.

--- a/yt/utilities/tests/test_cosmology.py
+++ b/yt/utilities/tests/test_cosmology.py
@@ -16,11 +16,132 @@ Test cosmology calculator.
 
 import numpy as np
 
-from yt.testing import assert_rel_equal
+from yt.testing import \
+     assert_rel_equal
+from yt.units.yt_array import \
+     YTArray, \
+     YTQuantity
 from yt.utilities.cosmology import \
      Cosmology
 
-def test_z_t_conversion():
+def z_from_t_analytic(my_time, hubble_constant=0.7,
+                      omega_matter=0.3, omega_lambda=0.7):
+    """
+    Compute the redshift from time after the big bang.  This is based on
+    Enzo's CosmologyComputeExpansionFactor.C, but altered to use physical
+    units.
+    """
+
+    hubble_constant = YTQuantity(hubble_constant, "100*km/s/Mpc")
+    omega_curvature = 1.0 - omega_matter - omega_lambda
+
+    OMEGA_TOLERANCE = 1e-5
+    ETA_TOLERANCE = 1.0e-10
+
+    # Convert the time to Time * H0.
+
+    if not isinstance(my_time, YTArray):
+        my_time = YTArray(my_time, "s")
+
+    t0 = (my_time.in_units("s") *
+          hubble_constant.in_units("1/s")).to_ndarray()
+
+    # For a flat universe with omega_matter = 1, it's easy.
+
+    if np.fabs(omega_matter-1) < OMEGA_TOLERANCE and \
+      omega_lambda < OMEGA_TOLERANCE:
+        a = np.power(1.5 * t0, 2.0/3.0)
+
+    # For omega_matter < 1 and omega_lambda == 0 see
+    # Peebles 1993, eq. 13-3, 13-10.
+    # Actually, this is a little tricky since we must solve an equation
+    # of the form eta - np.sinh(eta) + x = 0..
+
+    elif omega_matter < 1 and omega_lambda < OMEGA_TOLERANCE:
+        x = 2*t0*np.power(1.0 - omega_matter, 1.5) / omega_matter
+
+        # Compute eta in a three step process, first from a third-order
+        # Taylor expansion of the formula above, then use that in a fifth-order
+        # approximation.  Then finally, iterate on the formula itself, solving for
+        # eta.  This works well because parts 1 & 2 are an excellent approximation
+        # when x is small and part 3 converges quickly when x is large.
+
+        eta = np.power(6*x, 1.0/3.0)                # part 1
+        eta = np.power(120*x/(20+eta*eta), 1.0/3.0) # part 2
+        mask = np.ones(eta.size, dtype=bool)
+        max_iter = 1000
+        for i in range(max_iter):                   # part 3
+            eta_old = eta[mask]
+            eta[mask] = np.arcsinh(eta[mask] + x[mask])
+            mask[mask] = np.fabs(eta[mask]-eta_old) >= ETA_TOLERANCE
+            if not mask.any():
+                break
+            if (i == max_iter-1):
+                raise RuntimeError(
+                    "No convergence after %d iterations." % i)
+
+        # Now use eta to compute the expansion factor (eq. 13-10, part 2).
+
+        a = omega_matter/(2.0*(1.0 - omega_matter))*\
+            (np.cosh(eta) - 1.0)
+
+    # For flat universe, with non-zero omega_lambda, see eq. 13-20.
+
+    elif np.fabs(omega_curvature) < OMEGA_TOLERANCE and \
+      omega_lambda > OMEGA_TOLERANCE:
+        a = np.power(omega_matter / (1 - omega_matter), 1.0/3.0) * \
+          np.power(np.sinh(1.5 * np.sqrt(1.0 - omega_matter) * \
+                           t0), 2.0/3.0)
+
+    else:
+        raise NotImplementedError
+
+    redshift = (1.0/a) - 1.0
+
+    return redshift
+
+def t_from_z_analytic(z, hubble_constant=0.7,
+                      omega_matter=0.3, omega_lambda=0.7):
+    """
+    Compute the age of the Universe from redshift.  This is based on Enzo's
+    CosmologyComputeTimeFromRedshift.C, but altered to use physical units.
+    """
+
+    hubble_constant = YTQuantity(hubble_constant, "100*km/s/Mpc")
+    omega_curvature = 1.0 - omega_matter - omega_lambda
+
+    # For a flat universe with omega_matter = 1, things are easy.
+
+    if omega_matter == 1.0 and omega_lambda == 0.0:
+        t0 = 2.0/3.0/np.power(1+z, 1.5)
+
+    # For omega_matter < 1 and omega_lambda == 0 see
+    # Peebles 1993, eq. 13-3, 13-10.
+
+    elif omega_matter < 1 and omega_lambda == 0:
+        eta = np.arccosh(1 + 2*(1-omega_matter)/omega_matter/(1+z))
+        t0 = omega_matter/ \
+          (2*np.power(1.0-omega_matter, 1.5))*\
+          (np.sinh(eta) - eta)
+
+    # For flat universe, with non-zero omega_lambda, see eq. 13-20.
+
+    elif np.fabs(omega_curvature) < 1.0e-3 and omega_lambda != 0:
+        t0 = 2.0/3.0/np.sqrt(1-omega_matter)*\
+          np.arcsinh(np.sqrt((1-omega_matter)/omega_matter)/ \
+                     np.power(1+z, 1.5))
+
+    else:
+        raise NotImplementedError("%s, %s, %s" %
+                                  (hubble_constant, omega_matter, omega_lambda))
+
+    # Now convert from Time * H0 to time.
+
+    my_time = t0 / hubble_constant
+
+    return my_time
+
+def test_z_t_roundtrip():
     """
     Make sure t_from_z and z_from_t are consistent.
 
@@ -28,9 +149,47 @@ def test_z_t_conversion():
 
     co = Cosmology()
     # random sample in log(a) from -6 to 6
-    my_random = np.random.RandomState(2419)
+    my_random = np.random.RandomState(6132305)
     la = 12 * my_random.random_sample(10000) - 6
     z1 = 1 / np.power(10, la) - 1
     t = co.t_from_z(z1)
     z2 = co.z_from_t(t)
     assert_rel_equal(z1, z2, 4)
+
+def test_z_t_analytic():
+    """
+    Test z/t conversions against analytic solutions.
+    """
+
+    cosmos = [
+        {'hubble_constant': 0.7, 'omega_matter': 0.3, 'omega_lambda': 0.7},
+        {'hubble_constant': 0.7, 'omega_matter': 1.0, 'omega_lambda': 0.0},
+        {'hubble_constant': 0.7, 'omega_matter': 0.3, 'omega_lambda': 0.0},
+    ]
+
+    for cosmo in cosmos:
+        omega_curvature = 1 - cosmo['omega_matter'] - cosmo['omega_lambda']
+        co = Cosmology(omega_curvature=omega_curvature, **cosmo)
+        # random sample in log(a) from -6 to 6
+        my_random = np.random.RandomState(10132324)
+        la = 12 * my_random.random_sample(1000) - 6
+        z = 1 / np.power(10, la) - 1
+
+        t_an = t_from_z_analytic(z, **cosmo).to('Gyr')
+        t_co = co.t_from_z(z).to('Gyr')
+
+        assert_rel_equal(
+            t_an, t_co, 4,
+            err_msg='t_from_z does not match analytic version for cosmology %s.' % cosmo)
+
+        # random sample in log(t/t0) from -3 to 1
+        t0 = np.power(10, 4 * my_random.random_sample(1000) - 3)
+        t = (t0 / co.hubble_constant).to('Gyr')
+
+        z_an = z_from_t_analytic(t, **cosmo)
+        z_co = co.z_from_t(t)
+
+        # compare scale factors since z approaches 0
+        assert_rel_equal(
+            1 / (1 + z_an), 1 / (1 + z_co), 5,
+            err_msg='z_from_t does not match analytic version for cosmology %s.' % cosmo)

--- a/yt/utilities/tests/test_cosmology.py
+++ b/yt/utilities/tests/test_cosmology.py
@@ -18,7 +18,8 @@ import numpy as np
 
 from yt.testing import \
      assert_almost_equal, \
-     assert_rel_equal
+     assert_rel_equal, \
+     assert_equal
 from yt.units.yt_array import \
      YTArray, \
      YTQuantity
@@ -243,3 +244,16 @@ def test_cosmology_calculator_answers():
 
         for value, answer in zip(values, answers):
             assert_almost_equal(value.d, answer, 8)
+
+def test_dark_factor():
+    """
+    Test that dark factor returns same value for when not
+    being used and when w_0 = -1 and w_z = 0.
+    """
+
+    co = Cosmology(w_0=-1, w_a=0,
+                   use_dark_factor=False)
+
+    assert_equal(co.get_dark_factor(0), 1.0)
+    co.use_dark_factor = True
+    assert_equal(co.get_dark_factor(0), 1.0)

--- a/yt/utilities/tests/test_cosmology.py
+++ b/yt/utilities/tests/test_cosmology.py
@@ -16,12 +16,14 @@ Test cosmology calculator.
 
 import numpy as np
 import os
-import yaml
+from yt.utilities.on_demand_imports import \
+    _yaml as yaml
 
 from yt.testing import \
      assert_almost_equal, \
      assert_rel_equal, \
-     assert_equal
+     assert_equal, \
+     requires_module
 from yt.units.yt_array import \
      YTArray, \
      YTQuantity
@@ -213,6 +215,7 @@ def test_dark_factor():
     co.use_dark_factor = True
     assert_equal(co.get_dark_factor(0), 1.0)
 
+@requires_module('yaml')
 def test_cosmology_calculator_answers():
     """
     Test cosmology calculator functions against previously calculated values.

--- a/yt/utilities/tests/test_cosmology.py
+++ b/yt/utilities/tests/test_cosmology.py
@@ -20,28 +20,17 @@ from yt.testing import assert_rel_equal
 from yt.utilities.cosmology import \
      Cosmology
 
-def test_hubble_time():
-    """
-    Make sure hubble_time and t_from_z functions agree.
-
-    """
-
-    for i in range(10):
-        co = Cosmology()
-        # random sample over interval (-1,100]
-        z = -101 * np.random.random() + 100
-        assert_rel_equal(co.hubble_time(z), co.t_from_z(z), 5)
-
 def test_z_t_conversion():
     """
     Make sure t_from_z and z_from_t are consistent.
 
     """
 
-    for i in range(10):
-        co = Cosmology()
-        # random sample over interval (-1,100]
-        z1 = -101 * np.random.random() + 100
-        t = co.t_from_z(z1)
-        z2 = co.z_from_t(t)
-        assert_rel_equal(z1, z2, 10)
+    co = Cosmology()
+    # random sample in log(a) from -6 to 6
+    my_random = np.random.RandomState(2419)
+    la = 12 * my_random.random_sample(10000) - 6
+    z1 = 1 / np.power(10, la) - 1
+    t = co.t_from_z(z1)
+    z2 = co.z_from_t(t)
+    assert_rel_equal(z1, z2, 4)

--- a/yt/utilities/tests/test_cosmology.py
+++ b/yt/utilities/tests/test_cosmology.py
@@ -16,12 +16,12 @@ Test cosmology calculator.
 
 import numpy as np
 import os
+import yaml
 
 from yt.testing import \
      assert_almost_equal, \
      assert_rel_equal, \
-     assert_equal, \
-     requires_module
+     assert_equal
 from yt.units.yt_array import \
      YTArray, \
      YTQuantity
@@ -213,7 +213,6 @@ def test_dark_factor():
     co.use_dark_factor = True
     assert_equal(co.get_dark_factor(0), 1.0)
 
-@requires_module('yaml')
 def test_cosmology_calculator_answers():
     """
     Test cosmology calculator functions against previously calculated values.


### PR DESCRIPTION
Update: I've finally come back to this and it should now be in a finished state.

This adds the relativistic component of the energy density of the universe, `omega_radiation`, to the cosmology calculations.  Since there is no analytic solution to the Friedmann equations when `omega_radiation` > 0, we now numerically integrate using the trapezoid rule and then linearly interpolate in log(a) vs. log(t).

To get `z_from_t`, we reverse that table and interpolate. In this case, I also iteratively adjust the bounds of the log(a) table to be outside of the calculated log(a) values. This makes sure the integration is accurate and the ends of the table. This is most important at the high redshift end.

It's also important to note that the previous `z_from_t` and `t_from_z` calculations did not support all cosmologies, whereas this does.

In response to @jzuhone's comment about the hubble_time calculation, I've switched it to the correct formulation. @jzuhone was definitely right all along about that.

Differences of redshift/time conversions (`t_from_z` and `z_from_t`) are maximally about 1e-5.  It's not nothing, but I think quite acceptable.

This is now supported in the Enzo code, so that frontend is updated to include it.  I have added it as a standard dataset attribute for cosmology simulations.