### PR TITLE
Fix Error in Defining Particle Filters in EAGLE

### DIFF
--- a/yt/frontends/owls/fields.py
+++ b/yt/frontends/owls/fields.py
@@ -108,6 +108,9 @@ class OWLSFieldInfo(SPHFieldInfo):
             ftype='BH'
         elif ptype == 'all':
             ftype='all'
+        else:
+            # to avoid errors while creating particle filters
+            ftype=ptype
 
         super(OWLSFieldInfo,self).setup_particle_fields(
             ptype, num_neighbors=self._num_neighbors, ftype=ftype)

--- a/yt/frontends/owls/fields.py
+++ b/yt/frontends/owls/fields.py
@@ -106,8 +106,6 @@ class OWLSFieldInfo(SPHFieldInfo):
             ftype='star'
         elif ptype == 'PartType5':
             ftype='BH'
-        elif ptype == 'all':
-            ftype='all'
         else:
             # to avoid errors while creating particle filters
             ftype=ptype

--- a/yt/frontends/owls/tests/test_outputs.py
+++ b/yt/frontends/owls/tests/test_outputs.py
@@ -23,6 +23,7 @@ from yt.utilities.answer_testing.framework import \
     data_dir_load, \
     sph_answer
 from yt.frontends.owls.api import OWLSDataset
+from yt.data_objects.particle_filters import add_particle_filter
 
 os33 = "snapshot_033/snap_033.0.hdf5"
 
@@ -54,3 +55,23 @@ def test_snapshot_033():
 @requires_file(os33)
 def test_OWLSDataset():
     assert isinstance(data_dir_load(os33), OWLSDataset)
+    
+    
+@requires_ds(os33)
+def test_OWLS_particlefilter(os33):
+    ds = data_dir_load(os33)
+    ad = ds.all_data()
+    def cold_gas(pfilter, data):
+        temperature = data[pfilter.filtered_type, "Temperature"]
+        filter = (temperature.in_units('K') <= 1e5)
+        return filter
+    add_particle_filter("gas_cold", function=cold_gas, filtered_type='PartType0', requires=["Temperature"])
+    ds.add_particle_filter('gas_cold')
+
+    mask = (ad['PartType0','Temperature'] <= 1e5)
+    try:
+        if len(ad['PartType0','Temperature'][mask]) != len(ad['gas_cold','Temperature']):
+            raise NameError('Error in particle selection.')
+    except:
+        raise NameError('Error in setting particle filter.')
+

--- a/yt/frontends/owls/tests/test_outputs.py
+++ b/yt/frontends/owls/tests/test_outputs.py
@@ -58,7 +58,7 @@ def test_OWLSDataset():
     
     
 @requires_ds(os33)
-def test_OWLS_particlefilter(os33):
+def test_OWLS_particlefilter():
     ds = data_dir_load(os33)
     ad = ds.all_data()
     def cold_gas(pfilter, data):

--- a/yt/frontends/owls/tests/test_outputs.py
+++ b/yt/frontends/owls/tests/test_outputs.py
@@ -69,9 +69,5 @@ def test_OWLS_particlefilter(os33):
     ds.add_particle_filter('gas_cold')
 
     mask = (ad['PartType0','Temperature'] <= 1e5)
-    try:
-        if len(ad['PartType0','Temperature'][mask]) != len(ad['gas_cold','Temperature']):
-            raise NameError('Error in particle selection.')
-    except:
-        raise NameError('Error in setting particle filter.')
+    assert ad['PartType0','Temperature'][mask].shape == ad['gas_cold','Temperature'].shape
 


### PR DESCRIPTION
<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

Particle Filter cannot be set while using the EAGLE simulation.  It traces to the error of 'UnboundLocalError: local variable 'ftype' referenced before assignment'  at the following location: yt/frontends/owls/fields.pyc in setup_particle_fields(self, ptype).

This can be solved by adding an else-case, which set ftype=ptype.  This change is submitted to this pull request.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
