### PR TITLE
[enhancement] Speeding up yt fof/hop halo finding.

### DIFF
--- a/yt/analysis_modules/halo_finding/halo_objects.py
+++ b/yt/analysis_modules/halo_finding/halo_objects.py
@@ -19,7 +19,6 @@ import math
 import numpy as np
 import os.path as path
 from functools import cmp_to_key
-from yt.extern.six import add_metaclass
 from yt.extern.six.moves import zip as izip
 
 from yt.config import ytcfg

--- a/yt/analysis_modules/halo_finding/halo_objects.py
+++ b/yt/analysis_modules/halo_finding/halo_objects.py
@@ -37,12 +37,10 @@ from .hop.EnzoHop import RunHOP
 from .fof.EnzoFOF import RunFOF
 
 from yt.utilities.parallel_tools.parallel_analysis_interface import \
-    ParallelDummy, \
     ParallelAnalysisInterface, \
     parallel_blocking_call
 
 
-@add_metaclass(ParallelDummy)
 class Halo(object):
     """
     A data source that returns particle information about the members of a
@@ -1534,7 +1532,6 @@ class HOPHaloFinder(GenericHaloFinder, HOPHaloList):
         HOPHaloList.__init__(self, self._data_source,
             threshold * total_mass / sub_mass, dm_only, ptype=self.ptype)
         self._parse_halolist(total_mass / sub_mass)
-        self._join_halolists()
 
 
 class FOFHaloFinder(GenericHaloFinder, FOFHaloList):
@@ -1643,7 +1640,6 @@ class FOFHaloFinder(GenericHaloFinder, FOFHaloList):
         FOFHaloList.__init__(self, self._data_source, linking_length, dm_only,
                              redshift=self.redshift, ptype=self.ptype)
         self._parse_halolist(1.)
-        self._join_halolists()
 
 HaloFinder = HOPHaloFinder
 


### PR DESCRIPTION
This speeds up yt fof/hop halo finding by bypassing the step where the halo lists are rejoined.  This step uses MPI broadcast calls for every quantity of every halo and so is a pretty large scaling bottleneck.  Since these halo finders are only called through the `HaloCatalog`, which then re-splits the halo list, we can skip the joining and re-splitting and simply let each processor operate on the halos it found.

This changes the answers only to the extent that the final halo catalog is no longer mass-sorted.

This is perhaps a bit hacky, but it could potentially be a huge speedup for large datasets, so it might be worth it.