### PR TITLE
Add custom definition

### DIFF
--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -2105,7 +2105,7 @@ There are three way to make yt detect all the particle fields. For example, if y
 
 1. ``yt.load`` method. Whenever loading a dataset, add the extra particle fields as a keyword argument to the ``yt.load`` call.
 
-  .. code-block:: python
+   .. code-block:: python
 
       import yt
       epf = [('particle_birth_time', 'd'), ('particle_metallicity', 'd')]
@@ -2118,36 +2118,36 @@ There are three way to make yt detect all the particle fields. For example, if y
 
    .. code-block:: none
 
-       [ramses-particles]
-       fields = particle_position_x, d
-                particle_position_y, d
-                particle_position_z, d
-                particle_velocity_x, d
-                particle_velocity_y, d
-                particle_velocity_z, d
-                particle_mass, d
-                particle_identifier, i
-                particle_refinement_level, I
-                particle_birth_time, d
-                particle_metallicity, d
+      [ramses-particles]
+      fields = particle_position_x, d
+               particle_position_y, d
+               particle_position_z, d
+               particle_velocity_x, d
+               particle_velocity_y, d
+               particle_velocity_z, d
+               particle_mass, d
+               particle_identifier, i
+               particle_refinement_level, I
+               particle_birth_time, d
+               particle_metallicity, d
 
 3. New RAMSES way. Recent versions of RAMSES automatically write in their output an ``hydro_file_descriptor.txt`` file that gives information about which field is where. If you wish, you can simply create such a file in the folder containing the ``info_xxxxx.txt`` file
 
-    .. code-block:: none
+   .. code-block:: none
 
-        # version:  1
-        # ivar, variable_name, variable_type
-         1, position_x, d
-         2, position_y, d
-         3, position_z, d
-         4, velocity_x, d
-         5, velocity_y, d
-         6, velocity_z, d
-         7, mass, d
-         8, identity, i
-         9, levelp, i
-        10, birth_time, d
-        11, metallicity, d
+      # version:  1
+      # ivar, variable_name, variable_type
+       1, position_x, d
+       2, position_y, d
+       3, position_z, d
+       4, velocity_x, d
+       5, velocity_y, d
+       6, velocity_z, d
+       7, mass, d
+       8, identity, i
+       9, levelp, i
+      10, birth_time, d
+      11, metallicity, d
 
    It is important to note that this file should not end with an empty line (but in this case with ``11, metallicity, d``).
 
@@ -2163,42 +2163,42 @@ There are three way to make yt detect all the particle fields. For example, if y
 
 1. ``yt.load`` method. Whenever loading a dataset, add the extra particle fields as a keyword argument to the ``yt.load`` call.
 
-    .. code-block:: python
+   .. code-block:: python
 
-        import yt
-        fields = ["Density",
-                  "x-velocity", "y-velocity", "z-velocity",
-                  "Pressure", "Metallicity", "Scalar_01"]
-	ds = yt.load('output_00123/info_00123.txt', fields=fields)
-	('ramses', 'Metallicity') in ds.field_list  # is True
-	('ramses', 'Scalar_01') in ds.field_list  # is True
+      import yt
+      fields = ["Density",
+                "x-velocity", "y-velocity", "z-velocity",
+                "Pressure", "Metallicity", "Scalar_01"]
+      ds = yt.load('output_00123/info_00123.txt', fields=fields)
+      ('ramses', 'Metallicity') in ds.field_list  # is True
+      ('ramses', 'Scalar_01') in ds.field_list  # is True
 
 2. yt config method. If you don't want to pass the arguments for each call of ``yt.load``, you can add in your configuration
 
    .. code-block:: none
 
-       [ramses-hydro]
-       fields = Density
-                x-velocity
-		y-velocity
-		z-velocity
-		Pressure
-		Metallicity
-		Scalar_01
+      [ramses-hydro]
+      fields = Density
+               x-velocity
+               y-velocity
+               z-velocity
+               Pressure
+               Metallicity
+               Scalar_01
 
 3. New RAMSES way. Recent versions of RAMSES automatically write in their output an ``hydro_file_descriptor.txt`` file that gives information about which field is where. If you wish, you can simply create such a file in the folder containing the ``info_xxxxx.txt`` file
 
-    .. code-block:: none
+   .. code-block:: none
 
-        # version:  1
-        # ivar, variable_name, variable_type
-         1, density, d
-         2, velocity_x, d
-         3, velocity_y, d
-         4, velocity_z, d
-         5, pressure, d
-         6, metallicity, d
-	 7, scalar_01
+      # version:  1
+      # ivar, variable_name, variable_type
+       1, density, d
+       2, velocity_x, d
+       3, velocity_y, d
+       4, velocity_z, d
+       5, pressure, d
+       6, metallicity, d
+       7, scalar_01
 
    It is important to note that this file should not end with an empty line (but in this case with ``11, metallicity, d``).
 

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -2200,7 +2200,7 @@ There are three way to make yt detect all the particle fields. For example, if y
        6, metallicity, d
        7, scalar_01
 
-   It is important to note that this file should not end with an empty line (but in this case with `` 7, scalar_01, d``).
+   It is important to note that this file should not end with an empty line (but in this case with ``_7, scalar_01, d``. Note that the ``_`` stands for a space).
 
 Customizing the particle type association
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -2098,54 +2098,109 @@ It is possible to provide extra arguments to the load function when loading RAMS
 	 The ``bbox`` feature is only available for datasets using
 	 Hilbert ordering.
 
+Adding custom particle fields
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+There are three way to make yt detect all the particle fields. For example, if you wish to make yt detect the birth time and metallicity of your particles, use one of these methods
+
+1. ``yt.load`` method. Whenever loading a dataset, add the extra particle fields as a keyword argument to the ``yt.load`` call.
+
+  .. code-block:: python
+
+      import yt
+      epf = [('particle_birth_time', 'd'), ('particle_metallicity', 'd')]
+      ds = yt.load('dataset', extra_particle_fields=epf)
+
+      ('io', 'particle_birth_time') in ds.derived_field_list  # is True
+      ('io', 'particle_metallicity') in ds.derived_field_list  # is True
+
+2. yt config method. If you don't want to pass the arguments for each call of ``yt.load``, you can add in your configuration
+
+   .. code-block:: none
+
+       [ramses-particles]
+       fields = particle_position_x, d
+                particle_position_y, d
+                particle_position_z, d
+                particle_velocity_x, d
+                particle_velocity_y, d
+                particle_velocity_z, d
+                particle_mass, d
+                particle_identifier, i
+                particle_refinement_level, I
+                particle_birth_time, d
+                particle_metallicity, d
+
+3. New RAMSES way. Recent versions of RAMSES automatically write in their output an ``hydro_file_descriptor.txt`` file that gives information about which field is where. If you wish, you can simply create such a file in the folder containing the ``info_xxxxx.txt`` file
+
+    .. code-block:: none
+
+        # version:  1
+        # ivar, variable_name, variable_type
+         1, position_x, d
+         2, position_y, d
+         3, position_z, d
+         4, velocity_x, d
+         5, velocity_y, d
+         6, velocity_z, d
+         7, mass, d
+         8, identity, i
+         9, levelp, i
+        10, birth_time, d
+        11, metallicity, d
+
+   It is important to note that this file should not end with an empty line (but in this case with ``11, metallicity, d``).
+
+.. note::
+
+   The kind (``i``, ``d``, ``I``, ...) of the field follow the `python convention <https://docs.python.org/3.5/library/struct.html#format-characters>`_.
+
 
 Adding custom particle fields
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-It is possible to teach yt which particle fields are located in the
-files using yt configuration. For example to add support by default
-for ``birth_time`` and ``metallicity`` in your particle files, one
-would add
 
-.. code-block:: none
+There are three way to make yt detect all the particle fields. For example, if you wish to make yt detect the metallicity and a passive field (e.g. for a zoom-in simulation), use one of these methods
 
-   [ramses-particles]
-   fields = particle_position_x, d
-	    particle_position_y, d
-	    particle_position_z, d
-	    particle_velocity_x, d
-	    particle_velocity_y, d
-	    particle_velocity_z, d
-	    particle_mass, d
-	    particle_identifier, i
-	    particle_refinement_level, I
-	    particle_birth_time, d
-	    particle_metallicity, d
+1. ``yt.load`` method. Whenever loading a dataset, add the extra particle fields as a keyword argument to the ``yt.load`` call.
 
-where the first element of each line is the name the field will have
-in the dataset and the second item is the kind (``d`` for double
-precision, ``i`` for integer following `python convention
-<https://docs.python.org/3.5/library/struct.html#format-characters>`_). See
-:ref:`configuration` for more information.
+    .. code-block:: python
 
+        import yt
+        fields = ["Density",
+                  "x-velocity", "y-velocity", "z-velocity",
+                  "Pressure", "Metallicity", "Scalar_01"]
+	ds = yt.load('output_00123/info_00123.txt', fields=fields)
+	('ramses', 'Metallicity') in ds.field_list  # is True
+	('ramses', 'Scalar_01') in ds.field_list  # is True
 
-Adding custom fluid fields
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-It is also possible to teach yt which fluid fields are located in the
-files using yt configuration (see :ref:`configuration`). For example
-to add support by default for ``metallicity`` and
-``refinement_scalar`` for your fluid files, one would add
+2. yt config method. If you don't want to pass the arguments for each call of ``yt.load``, you can add in your configuration
 
-.. code-block:: none
+   .. code-block:: none
 
-   [ramses-hydro]
-   fields = Density
-	    x-velocity
-	    y-velocity
-	    z-velocity
-	    Pressure
-	    Metallicity
-	    Refinement-scalar
+       [ramses-hydro]
+       fields = Density
+                x-velocity
+		y-velocity
+		z-velocity
+		Pressure
+		Metallicity
+		Scalar_01
 
+3. New RAMSES way. Recent versions of RAMSES automatically write in their output an ``hydro_file_descriptor.txt`` file that gives information about which field is where. If you wish, you can simply create such a file in the folder containing the ``info_xxxxx.txt`` file
+
+    .. code-block:: none
+
+        # version:  1
+        # ivar, variable_name, variable_type
+         1, density, d
+         2, velocity_x, d
+         3, velocity_y, d
+         4, velocity_z, d
+         5, pressure, d
+         6, metallicity, d
+	 7, scalar_01
+
+   It is important to note that this file should not end with an empty line (but in this case with ``11, metallicity, d``).
 
 Customizing the particle type association
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -2200,7 +2200,7 @@ There are three way to make yt detect all the particle fields. For example, if y
        6, metallicity, d
        7, scalar_01
 
-   It is important to note that this file should not end with an empty line (but in this case with ``11, metallicity, d``).
+   It is important to note that this file should not end with an empty line (but in this case with `` 7, scalar_01, d``).
 
 Customizing the particle type association
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -2101,15 +2101,68 @@ It is possible to provide extra arguments to the load function when loading RAMS
 
 Adding custom particle fields
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+It is possible to teach yt which particle fields are located in the
+files using yt configuration. For example to add support by default
+for ``birth_time`` and ``metallicity`` in your particle files, one
+would add
 
-It is possible to add support for particle fields. For this, one
-should tweak
-:func:`~yt.frontends.ramses.io._read_part_file_descriptor` to include
-the field as well as its data type to the assoc list, following the
-convention from
-`python struct module <https://docs.python.org/3.5/library/struct.html#format-characters>`_.
-For example, to add support for a longint field named
-``my_custom_field``, one would add ``('my_custom_field', 'l')`` to ``assoc``.
+.. code-block:: none
+
+   [ramses-particles]
+   fields = particle_position_x, d
+	    particle_position_y, d
+	    particle_position_z, d
+	    particle_velocity_x, d
+	    particle_velocity_y, d
+	    particle_velocity_z, d
+	    particle_mass, d
+	    particle_identifier, i
+	    particle_refinement_level, I
+	    particle_birth_time, d
+	    particle_metallicity, d
+
+where the first element of each line is the name the field will have
+in the dataset and the second item is the kind (``d`` for double
+precision, ``i`` for integer following `python convention
+<https://docs.python.org/3.5/library/struct.html#format-characters>`_). See
+:ref:`configuration` for more information.
+
+
+Adding custom fluid fields
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+It is also possible to teach yt which fluid fields are located in the
+files using yt configuration (see :ref:`configuration`). For example
+to add support by default for ``metallicity`` and
+``refinement_scalar`` for your fluid files, one would add
+
+.. code-block:: none
+
+   [ramses-hydro]
+   fields = Density
+	    x-velocity
+	    y-velocity
+	    z-velocity
+	    Pressure
+	    Metallicity
+	    Refinement-scalar
+
+
+Customizing the particle type association
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+In verions of RAMSES more recent than December 2017, particles carry
+along a ``family`` array. The value of this array gives the kind of
+the particle, e.g. 1 for dark matter. It is possible to customize the
+association between particle type and family by customizing the yt
+config (see :ref:`configuration`), adding
+
+.. code-block:: none
+
+   [ramses-families]
+   gas_tracer = 100
+   star_tracer = 101
+   dm = 0
+   star = 1
+
 
 
 .. _loading-sph-data:

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -700,9 +700,9 @@ upon being loaded into yt it is automatically decomposed into grids:
 
    level  # grids         # cells     # cells^3
    ----------------------------------------------
-     0	     512	  981940800       994
+     0       512          981940800       994
    ----------------------------------------------
-             512	  981940800
+             512          981940800
 
 yt will generate its own domain decomposition, but the number of grids can be
 set manually by passing the ``nprocs`` parameter to the ``load`` call:
@@ -786,9 +786,9 @@ upon being loaded into yt it is automatically decomposed into grids:
 
    level  # grids         # cells     # cells^3
    ----------------------------------------------
-     0	     512	  981940800       994
+     0       512          981940800       994
    ----------------------------------------------
-             512	  981940800
+             512          981940800
 
 For 3D spectral-cube data, the decomposition into grids will be done along the
 spectral axis since this will speed up many common operations for this
@@ -1403,8 +1403,8 @@ three-dimensional grid fields:
 
    data = dict(Density = dens,
                particle_position_x = posx_arr,
-	           particle_position_y = posy_arr,
-	           particle_position_z = posz_arr)
+                   particle_position_y = posy_arr,
+                   particle_position_z = posz_arr)
    bbox = np.array([[-1.5, 1.5], [-1.5, 1.5], [1.5, 1.5]])
    ds = yt.load_uniform_grid(data, arr.shape, 3.08e24, bbox=bbox, nprocs=12)
 
@@ -1457,8 +1457,8 @@ the hexahedral cells, and thus should have the shape,
 .. code-block:: python
 
    bbox = numpy.array([[numpy.min(xgrid),numpy.max(xgrid)],
-	               [numpy.min(ygrid),numpy.max(ygrid)],
-	               [numpy.min(zgrid),numpy.max(zgrid)]])
+                       [numpy.min(ygrid),numpy.max(ygrid)],
+                       [numpy.min(zgrid),numpy.max(zgrid)]])
    data = {"density" : arr}
    ds = yt.load_hexahedral_mesh(data,conn,coords,1.0,bbox=bbox)
 
@@ -2035,8 +2035,8 @@ It is possible to provide extra arguments to the load function when loading RAMS
           fields = ["Density",
                     "x-velocity", "y-velocity", "z-velocity",
                     "Pressure", "my-awesome-field"]
-	  ds = yt.load('output_00123/info_00123.txt', fields=fields)
-	  'my-awesome-field' in ds.field_list  # is True
+          ds = yt.load('output_00123/info_00123.txt', fields=fields)
+          'my-awesome-field' in ds.field_list  # is True
 
 
 ``extra_particle_fields``
@@ -2073,20 +2073,20 @@ It is possible to provide extra arguments to the load function when loading RAMS
       .. code-block:: python
 
           import yt
-	  # Only load a small cube of size (0.1)**3
-	  bbox = [[0., 0., 0.], [0.1, 0.1, 0.1]]
-	  ds = yt.load('output_00001/info_00001.txt', bbox=bbox)
+          # Only load a small cube of size (0.1)**3
+          bbox = [[0., 0., 0.], [0.1, 0.1, 0.1]]
+          ds = yt.load('output_00001/info_00001.txt', bbox=bbox)
 
-	  # See the note below for the following examples
-	  ds.right_edge == [1, 1, 1]             # is True
+          # See the note below for the following examples
+          ds.right_edge == [1, 1, 1]             # is True
 
-	  ad = ds.all_data()
-	  ad['particle_position_x'].max() > 0.1  # _may_ be True
+          ad = ds.all_data()
+          ad['particle_position_x'].max() > 0.1  # _may_ be True
 
-	  bb = ds.box(left_edge=bbox[0], right_edge=bbox[1])
-	  bb['particle_position_x'].max() < 0.1  # is True
+          bb = ds.box(left_edge=bbox[0], right_edge=bbox[1])
+          bb['particle_position_x'].max() < 0.1  # is True
       .. note::
-	 When using the bbox argument, yt will read all the CPUs
+         When using the bbox argument, yt will read all the CPUs
          intersecting with the subbox. However it may also read some
          data *outside* the selected region. This is due to the fact
          that domains have a complicated shape when using Hilbert
@@ -2095,8 +2095,8 @@ It is possible to provide extra arguments to the load function when loading RAMS
          the selected region, you may want to use ``ds.box(…)``.
 
       .. note::
-	 The ``bbox`` feature is only available for datasets using
-	 Hilbert ordering.
+         The ``bbox`` feature is only available for datasets using
+         Hilbert ordering.
 
 Adding custom particle fields
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/yt/frontends/ramses/definitions.py
+++ b/yt/frontends/ramses/definitions.py
@@ -15,6 +15,8 @@ Definitions for RAMSES files
 #-----------------------------------------------------------------------------
 
 # These functions are RAMSES-specific
+from yt.config import ytcfg
+from yt.funcs import mylog
 
 def ramses_header(hvals):
     header = ( ('ncpu', 1, 'i'),
@@ -67,3 +69,10 @@ particle_families = {
     'dust_tracer': -4,
     'gas_tracer': 0
 }
+
+if ytcfg.has_section('ramses-families'):
+    for key in particle_families.keys():
+        val = ytcfg.getint('ramses-families', key, fallback=None)
+        if val is not None:
+            mylog.info('Changing family %s from %s to %s' % (key, particle_families[key], val))
+            particle_families[key] = val

--- a/yt/frontends/ramses/fields.py
+++ b/yt/frontends/ramses/fields.py
@@ -89,7 +89,7 @@ class RAMSESFieldInfo(FieldInfoContainer):
         ("particle_velocity_y", (vel_units, [], None)),
         ("particle_velocity_z", (vel_units, [], None)),
         ("particle_mass", ("code_mass", [], None)),
-        ("particle_identifier", ("", ["particle_index"], None)),
+        ("particle_identity", ("", ["particle_index"], None)),
         ("particle_refinement_level", ("", [], None)),
         ("particle_age", ("code_time", ['age'], None)),
         ("particle_birth_time", ("code_time", ['age'], None)),

--- a/yt/frontends/ramses/particle_handlers.py
+++ b/yt/frontends/ramses/particle_handlers.py
@@ -82,6 +82,7 @@ class ParticleFileHandler(object):
                 basename,
                 self.file_descriptor)
 
+        # Attempt to read the list of fields from the config file
         if self.config_field and ytcfg.has_section(self.config_field):
             cfg = ytcfg.get(self.config_field, 'fields')
             known_fields = []

--- a/yt/frontends/ramses/particle_handlers.py
+++ b/yt/frontends/ramses/particle_handlers.py
@@ -3,6 +3,7 @@ import yt.utilities.fortran_utils as fpu
 import glob
 from yt.extern.six import add_metaclass
 from yt.funcs import mylog
+from yt.config import ytcfg
 
 from .io import _read_part_file_descriptor
 
@@ -45,11 +46,13 @@ class ParticleFileHandler(object):
 
     attrs = None  # The attributes of the header
     known_fields = None  # A list of tuple containing the field name and its type
+    config_field = None  # Name of the config section (if any)
 
     # These properties are computed dynamically
     field_offsets = None     # Mapping from field to offset in file
     field_types = None       # Mapping from field to the type of the data (float, integer, ...)
     local_particle_count = None  # The number of particle in the domain
+
 
     def __init__(self, ds, domain_id):
         '''
@@ -78,6 +81,14 @@ class ParticleFileHandler(object):
             self.file_descriptor = os.path.join(
                 basename,
                 self.file_descriptor)
+
+        if self.config_field and ytcfg.has_section(self.config_field):
+            cfg = ytcfg.get(self.config_field, 'fields')
+            known_fields = []
+            for c in (_.strip() for _ in cfg.split('\n') if _.strip() != ''):
+                field, field_type = (_.strip() for _ in c.split(','))
+                known_fields.append((field, field_type))
+            self.known_fields = known_fields
 
     @property
     def exists(self):
@@ -146,6 +157,7 @@ class DefaultParticleFileHandler(ParticleFileHandler):
     ptype = 'io'
     fname = 'part_{iout:05d}.out{icpu:05d}'
     file_descriptor = 'part_file_descriptor.txt'
+    config_field = 'ramses-particles'
 
     attrs = ( ('ncpu', 1, 'I'),
               ('ndim', 1, 'I'),
@@ -164,9 +176,8 @@ class DefaultParticleFileHandler(ParticleFileHandler):
         ("particle_velocity_y", "d"),
         ("particle_velocity_z", "d"),
         ("particle_mass", "d"),
-        ("particle_identifier", "i"),
+        ("particle_identity", "i"),
         ("particle_refinement_level", "I")]
-
 
     @classmethod
     def any_exist(cls, ds):
@@ -240,6 +251,7 @@ class SinkParticleFileHandler(ParticleFileHandler):
     ptype = 'sink'
     fname = 'sink_{iout:05d}.out{icpu:05d}'
     file_descriptor = 'sink_file_descriptor.txt'
+    config_field = 'ramses-sink-particles'
 
     attrs = (('nsink', 1, 'I'),
              ('nindsink', 1, 'I'))

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -248,15 +248,15 @@ def test_custom_particle_def():
     ytcfg.add_section('ramses-particles')
     ytcfg['ramses-particles', 'fields'] = '''particle_position_x, d
          particle_position_y, d
-	 particle_position_z, d
-	 particle_velocity_x, d
-	 particle_velocity_y, d
-	 particle_velocity_z, d
-	 particle_mass, d
-	 particle_identifier, i
-	 particle_refinement_level, I
-	 particle_birth_time, d
-	 particle_foobar, d
+         particle_position_z, d
+         particle_velocity_x, d
+         particle_velocity_y, d
+         particle_velocity_z, d
+         particle_mass, d
+         particle_identifier, i
+         particle_refinement_level, I
+         particle_birth_time, d
+         particle_foobar, d
     '''
     ds = yt.load(ramsesCosmo)
 

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -25,6 +25,7 @@ from yt.utilities.answer_testing.framework import \
     FieldValuesTest, \
     create_obj
 from yt.frontends.ramses.api import RAMSESDataset
+from yt.config import ytcfg
 import os
 import yt
 
@@ -241,3 +242,26 @@ def test_ramses_part_count():
 
     assert_equal(pcount['io'], 17132, err_msg='Got wrong number of io particle')
     assert_equal(pcount['sink'], 8, err_msg='Got wrong number of sink particle')
+
+@requires_file(ramsesCosmo)
+def test_custom_def():
+    ytcfg.add_section('ramses-particles')
+    ytcfg['ramses-particles', 'fields'] = '''particle_position_x, d
+         particle_position_y, d
+	 particle_position_z, d
+	 particle_velocity_x, d
+	 particle_velocity_y, d
+	 particle_velocity_z, d
+	 particle_mass, d
+	 particle_identifier, i
+	 particle_refinement_level, I
+	 particle_birth_time, d
+	 particle_foobar, d
+    '''
+    ds = yt.load(ramsesCosmo)
+
+    try:
+        assert ('io', 'particle_birth_time') in ds.derived_field_list
+        assert ('io', 'particle_foobar') in ds.derived_field_list
+    finally:
+        ytcfg.remove_section('ramses-particles')

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -244,7 +244,7 @@ def test_ramses_part_count():
     assert_equal(pcount['sink'], 8, err_msg='Got wrong number of sink particle')
 
 @requires_file(ramsesCosmo)
-def test_custom_def():
+def test_custom_particle_def():
     ytcfg.add_section('ramses-particles')
     ytcfg['ramses-particles', 'fields'] = '''particle_position_x, d
          particle_position_y, d
@@ -260,8 +260,14 @@ def test_custom_def():
     '''
     ds = yt.load(ramsesCosmo)
 
+    def check_unit(array, unit):
+        assert str(array.in_cgs().units) == unit
+
     try:
         assert ('io', 'particle_birth_time') in ds.derived_field_list
         assert ('io', 'particle_foobar') in ds.derived_field_list
+
+        check_unit(ds.r['io', 'particle_birth_time'], 's')
+        check_unit(ds.r['io', 'particle_foobar'], 'dimensionless')
     finally:
         ytcfg.remove_section('ramses-particles')

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -271,3 +271,28 @@ def test_custom_particle_def():
         check_unit(ds.r['io', 'particle_foobar'], 'dimensionless')
     finally:
         ytcfg.remove_section('ramses-particles')
+
+@requires_file(ramsesCosmo)
+def test_custom_hydro_def():
+    ytcfg.add_section('ramses-hydro')
+    ytcfg['ramses-hydro', 'fields'] = '''
+    Density
+    x-velocity
+    y-velocity
+    z-velocity
+    Foo
+    Bar
+    '''
+    ds = yt.load(ramsesCosmo)
+
+    def check_unit(array, unit):
+        assert str(array.in_cgs().units) == unit
+
+    try:
+        assert ('ramses', 'Foo') in ds.derived_field_list
+        assert ('ramses', 'Bar') in ds.derived_field_list
+
+        check_unit(ds.r['ramses', 'Foo'], 'dimensionless')
+        check_unit(ds.r['ramses', 'Bar'], 'dimensionless')
+    finally:
+        ytcfg.remove_section('ramses-hydro')


### PR DESCRIPTION
Recent changes in yt have broken support for the automatic detection of e.g. the `birth_time` of particles in RAMSES. This PR adds back some support for this using yt configuration.

## PR Summary

- Now possible to configure system-wide or per folder the fields in the files using yt configuration
- Now possible to customize which `family` is associated to which particle type in yt.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes flake8 checker
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
