### PR TITLE
Add ppc64le to install_script list of known Miniconda Linux architectures

### DIFF
--- a/doc/install_script.sh
+++ b/doc/install_script.sh
@@ -431,10 +431,13 @@ then
     elif [ $MYARCH = "x86_64"  ]
     then
         MINICONDA_ARCH="x86_64"
+    elif [ $MYARCH = "ppc64le"  ]
+    then
+        MINICONDA_ARCH="ppc64le"
     else
         echo "Not sure which architecture you are running."
         echo "Going with x86_64 architecture."
-        MINICONDA_OS="Linux-x86_64"
+        MINICONDA_ARCH="x86_64"
     fi
 else
     echo "The yt install script is not supported on the ${MYOS}"


### PR DESCRIPTION
ppc64le (little endian 64-bit POWER) is a known Miniconda architecture on Linux; this fix allows the install script to work on this architecture (e.g. Summit at Oak Ridge).

Also fixes a bug when the Linux arch is unknown.