### PR TITLE
set default inset box arguments to None instead of {}

### DIFF
--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -1357,7 +1357,6 @@ class TextLabelCallback(PlotCallback):
                           "the keyword coord_system='data' instead.")
         if text_args is None: text_args = def_text_args
         self.text_args = text_args
-        if inset_box_args is None: inset_box_args = {}
         self.inset_box_args = inset_box_args
         self.coord_system = coord_system
         self.transform = None
@@ -1895,7 +1894,7 @@ class TimestampCallback(PlotCallback):
         self.inset_box_args = inset_box_args
 
         # if inset box is not desired, set inset_box_args to {}
-        if not draw_inset_box: self.inset_box_args = {}
+        if not draw_inset_box: self.inset_box_args = None
 
     def __call__(self, plot):
         # Setting pos overrides corner argument


### PR DESCRIPTION
As reported on IRC by Josh Wall, currently when you do, e.g. something like this:

```
plot = yt.SlicePlot(ds, 2, 'density')
plot.annotate_text((0, 0), 'text!', coord_system='plot')
plot.save()
```

You end up with a plot that has an inset box, even though the default `inset_box_args` is None. The problem is that `None` gets replaced by `{}` in the `TextLabelCallback`, which gets interpreted by matplotlib as "please draw an inset box with the default arguments".

The fix is not to replace the default `None` value with an empty dict.