### PR TITLE
[bugfix] Pass field parameters in contour finder

### DIFF
--- a/yt/analysis_modules/level_sets/contour_finder.py
+++ b/yt/analysis_modules/level_sets/contour_finder.py
@@ -34,6 +34,7 @@ def identify_contours(data_source, field, min_val, max_val,
     DLE = data_source.ds.domain_left_edge
     masks = dict((g.id, m) for g, m in data_source.blocks)
     for (g, node, (sl, dims, gi)) in data_source.tiles.slice_traverse():
+        g.field_parameters.update(data_source.field_parameters)
         node.node_ind = len(node_ids)
         nid = node.node_id
         node_ids.append(nid)

--- a/yt/analysis_modules/level_sets/tests/test_clump_finding.py
+++ b/yt/analysis_modules/level_sets/tests/test_clump_finding.py
@@ -26,6 +26,8 @@ from yt.analysis_modules.level_sets.api import \
     get_lowest_clumps
 from yt.convenience import \
     load
+from yt.fields.derived_field import \
+    ValidateParameter
 from yt.frontends.stream.api import \
     load_uniform_grid
 from yt.testing import \
@@ -135,3 +137,43 @@ def test_clump_tree_save():
 
     os.chdir(curdir)
     shutil.rmtree(tmpdir)
+
+i30 = "IsolatedGalaxy/galaxy0030/galaxy0030"
+@requires_file(i30)
+def test_clump_field_parameters():
+    """
+    Make sure clump finding on fields with field parameters works.
+    """
+
+    def _also_density(field, data):
+        factor = data.get_field_parameter("factor")
+        return factor * data["density"]
+
+    ds = data_dir_load(i30)
+    ds.add_field("also_density", function=_also_density,
+                 units=ds.fields.gas.density.units,
+                 sampling_type="cell",
+                 validators=[ValidateParameter("factor")])
+    data_source = ds.disk([0.5, 0.5, 0.5], [0., 0., 1.],
+                          (8, 'kpc'), (1, 'kpc'))
+    data_source.set_field_parameter("factor", 1)
+
+    step = 2.0
+    field = ("gas", "density")
+    c_min = 10**np.floor(np.log10(data_source[field]).min()  )
+    c_max = 10**np.floor(np.log10(data_source[field]).max()+1)
+
+    master_clump_1 = Clump(data_source, ("gas", "density"))
+    master_clump_1.add_validator("min_cells", 20)
+    master_clump_2 = Clump(data_source, ("gas", "also_density"))
+    master_clump_2.add_validator("min_cells", 20)
+
+
+    find_clumps(master_clump_1, c_min, c_max, step)
+    find_clumps(master_clump_2, c_min, c_max, step)
+    leaf_clumps_1 = get_lowest_clumps(master_clump_1)
+    leaf_clumps_2 = get_lowest_clumps(master_clump_2)
+
+    for c1, c2 in zip(leaf_clumps_1, leaf_clumps_2):
+        assert_array_equal(c1["gas", "density"],
+                           c2["gas", "density"])


### PR DESCRIPTION
This fixes the issue reported on the yt-users list by Dan Le.  Field parameters were not getting passed to the grid objects in the contour finder, so contouring/clump finding could not be done using fields that had them.