### PR TITLE
fix logic error in ComposeSelector.select_grids

### DIFF
--- a/yt/data_objects/tests/test_slice.py
+++ b/yt/data_objects/tests/test_slice.py
@@ -15,7 +15,9 @@ import os
 import numpy as np
 import tempfile
 from yt.testing import \
-    fake_random_ds, assert_equal
+    assert_equal, \
+    fake_amr_ds, \
+    fake_random_ds
 from yt.units.unit_object import Unit
 
 
@@ -101,3 +103,13 @@ def test_slice_over_outer_boundary():
     slc = ds.slice(2, 1.0)
     slc["density"]
     assert_equal(slc["density"].size, 0)
+
+def test_slice_region_data_source():
+    ds = fake_amr_ds()
+    ad = ds.all_data()
+    slc = ds.slice(2, 0.5, data_source=ad)
+    assert slc['grid_level'].max() == 4
+    ad = ds.all_data()
+    ad.max_level = 2
+    slc = ds.slice(2, 0.5, data_source=ad)
+    assert slc['grid_level'].max() == 2

--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -1999,7 +1999,7 @@ cdef class ComposeSelector(SelectorObject):
                      np.ndarray[np.float64_t, ndim=2] left_edges,
                      np.ndarray[np.float64_t, ndim=2] right_edges,
                      np.ndarray[np.int32_t, ndim=2] levels):
-        return np.logical_or(
+        return np.logical_and(
                     self.selector1.select_grids(left_edges, right_edges, levels),
                     self.selector2.select_grids(left_edges, right_edges, levels))
 


### PR DESCRIPTION
The `ComposeSelector` corresponds to the *intersection* of two data objects but in the case of grids was returning the *intersection* of the grids belonging to two data objects.

I've added a test that creates a `YTSlice` that uses a tweaked `YTRegion` for data selection. The `YTSlice` internally creates a `ComposeSelector` that with this change now correctly excludes grids with AMR level greater than 2 for the second part of the test.