### PR TITLE
Adding list_same_dimensions to UnitRegistry

### DIFF
--- a/yt/units/tests/test_units.py
+++ b/yt/units/tests/test_units.py
@@ -27,6 +27,7 @@ from yt.testing import \
     assert_almost_equal
 from yt.units.unit_registry import UnitRegistry
 from yt.units import electrostatic_unit, elementary_charge
+from yt.units.unit_object import default_unit_registry
 
 # dimensions
 from yt.units.dimensions import \
@@ -523,3 +524,14 @@ def test_creation_from_ytarray():
     assert_equal((u1/u2).base_value, electrostatic_unit/elementary_charge)
 
     assert_raises(UnitParseError, Unit, [1, 2, 3]*elementary_charge)
+
+def test_list_same_dimensions():
+    reg = default_unit_registry
+    for name1, u1 in reg.unit_objs.items():
+        for name2 in reg.list_same_dimensions(u1):
+            if name2 == name1: continue
+            if name2 in reg.unit_objs:
+                dim2 = reg.unit_objs[name2].dimensions
+            else:
+                _, dim2, _, _ = reg.lut[name2]
+            assert_true(u1.dimensions is dim2)

--- a/yt/units/unit_registry.py
+++ b/yt/units/unit_registry.py
@@ -174,3 +174,15 @@ class UnitRegistry:
             lut[k] = tuple(unsan_v)
 
         return cls(lut=lut, add_default_symbols=False)
+
+    def list_same_dimensions(self, unit_object):
+        """
+        Return a list of base unit names that this registry knows about that
+        are of equivalent dimensions to *unit_object*.
+        """
+        equiv = [k for k, v in self.lut.items()
+                 if v[1] is unit_object.dimensions]
+        equiv += [n for n, u in self.unit_objs.items()
+                 if u.dimensions is unit_object.dimensions]
+        equiv = list(sorted(set(equiv)))
+        return equiv


### PR DESCRIPTION
## PR Summary

This adds a `list_same_dimensions` function to a `UnitRegistry` that returns the names of all base units in the lookup table for that registry, along with anything that exists in `unit_objs`, when supplied a `unit_object`.  For instance,

```python
arr = ds.domain_width
equiv = unit_registry.list_same_dimensions(arr.units)
```

would return `unitary`, `cm`, etc, for most datasets.

## PR Checklist

- [ ] Code passes flake8 checker
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.