### PR TITLE
Improvements for data object max_level and min_level

### DIFF
--- a/doc/source/cookbook/calculating_information.rst
+++ b/doc/source/cookbook/calculating_information.rst
@@ -115,10 +115,18 @@ See :ref:`filtering-particles` for more information.
 Making a Turbulent Kinetic Energy Power Spectrum
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This recipe shows how to use `yt` to read data and put it on a uniform
+This recipe shows how to use ``yt`` to read data and put it on a uniform
 grid to interface with the NumPy FFT routines and create a turbulent
 kinetic energy power spectrum.  (Note: the dataset used here is of low
 resolution, so the turbulence is not very well-developed.  The spike
 at high wavenumbers is due to non-periodicity in the z-direction).
 
 .. yt_cookbook:: power_spectrum_example.py
+
+Downsampling an AMR Dataset
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This recipe shows how to use the ``max_level`` attribute of a yt data
+object to only select data up to a maximum AMR level.
+
+.. yt_cookbook:: downsampling_amr.py

--- a/doc/source/cookbook/downsampling_amr.py
+++ b/doc/source/cookbook/downsampling_amr.py
@@ -1,0 +1,28 @@
+import yt
+
+ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
+
+# The maximum refinement level of this dataset is 8
+print(ds.max_level)
+
+# If we ask for *all* of the AMR data, we get back field
+# values sampled at about 3.6 million AMR zones
+ad = ds.all_data()
+print(ad['gas', 'density'].shape)
+
+# Let's only sample data up to AMR level 2
+ad.max_level = 2
+
+# Now we only sample from about 200,000 zones
+print(ad['gas', 'density'].shape)
+
+# Note that this includes data at level 2 that would
+# normally be masked out. There aren't any "holes" in
+# the downsampled AMR mesh, the volume still sums to
+# the volume of the domain:
+print(ad['index', 'cell_volume'].sum())
+print(ds.domain_width.prod())
+
+# Now let's make a downsampled plot
+plot = yt.SlicePlot(ds, 'z', ('gas', 'density'), data_source=ad)
+plot.save('downsampled.png')

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1186,6 +1186,8 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface):
     _current_chunk = None
     _data_source = None
     _dimensionality = None
+    _max_level = None
+    _min_level = None
 
     def __init__(self, ds, field_parameters, data_source=None):
         ParallelAnalysisInterface.__init__(self)
@@ -1204,7 +1206,8 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface):
 
     @property
     def selector(self):
-        if self._selector is not None: return self._selector
+        if self._selector is not None:
+            return self._selector
         s_module = getattr(self, '_selector_module',
                            yt.geometry.selection_routines)
         sclass = getattr(s_module,
@@ -1497,6 +1500,40 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface):
         if self._current_chunk is None:
             self.index._identify_base_chunk(self)
         return self._current_chunk.fcoords_vertex
+
+    @property
+    def max_level(self):
+        if self._max_level is None:
+            return self.ds.max_level
+        return self._max_level
+
+    @max_level.setter
+    def max_level(self, value):
+        if value < self.min_level:
+            raise RuntimeError(
+                "Cannot set data object max_level to be less than min_level")
+        if self._selector is not None:
+            del self._selector
+            self._selector = None
+        self.field_data.clear()
+        self._max_level = value
+
+    @property
+    def min_level(self):
+        if self._min_level is not None:
+            return self._min_level
+        return self.ds.min_level
+
+    @min_level.setter
+    def min_level(self, value):
+        if value > self.max_level:
+            raise RuntimeError(
+                "Cannot set data object min_level to be greater than max_level")
+        if self._selector is not None:
+            del self._selector
+            self._selector = None
+        self.field_data.clear()
+        self._min_level = value
 
 class YTSelectionContainer0D(YTSelectionContainer):
     _spatial = False

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1528,7 +1528,7 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface):
     def min_level(self):
         if self._min_level is None:
             try:
-                return self.ds.min_level
+                return 0
             except AttributeError:
                 return None
         return self._min_level

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1518,6 +1518,9 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface):
         if self._selector is not None:
             del self._selector
             self._selector = None
+        self._current_chunk = None
+        self.size = None
+        self.shape = None
         self.field_data.clear()
         self._max_level = value
 
@@ -1525,7 +1528,7 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface):
     def min_level(self):
         if self._min_level is None:
             try:
-                return self.ds.max_level
+                return self.ds.min_level
             except AttributeError:
                 return None
         return self._min_level
@@ -1539,6 +1542,9 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface):
             del self._selector
             self._selector = None
         self.field_data.clear()
+        self.size = None
+        self.shape = None
+        self._current_chunk = None
         self._min_level = value
 
 class YTSelectionContainer0D(YTSelectionContainer):

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1512,9 +1512,6 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface):
 
     @max_level.setter
     def max_level(self, value):
-        if value < self.min_level:
-            raise RuntimeError(
-                "Cannot set data object max_level to be less than min_level")
         if self._selector is not None:
             del self._selector
             self._selector = None
@@ -1535,9 +1532,6 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface):
 
     @min_level.setter
     def min_level(self, value):
-        if value > self.max_level:
-            raise RuntimeError(
-                "Cannot set data object min_level to be greater than max_level")
         if self._selector is not None:
             del self._selector
             self._selector = None

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1504,7 +1504,10 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface):
     @property
     def max_level(self):
         if self._max_level is None:
-            return self.ds.max_level
+            try:
+                return self.ds.max_level
+            except AttributeError:
+                return None
         return self._max_level
 
     @max_level.setter
@@ -1520,9 +1523,12 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface):
 
     @property
     def min_level(self):
-        if self._min_level is not None:
-            return self._min_level
-        return self.ds.min_level
+        if self._min_level is None:
+            try:
+                return self.ds.max_level
+            except AttributeError:
+                return None
+        return self._min_level
 
     @min_level.setter
     def min_level(self, value):

--- a/yt/data_objects/tests/test_compose.py
+++ b/yt/data_objects/tests/test_compose.py
@@ -1,8 +1,9 @@
 import numpy as np
 
 from yt.testing import \
-    fake_random_ds, \
-    assert_array_equal
+    assert_array_equal, \
+    fake_amr_ds, \
+    fake_random_ds
 from yt.units.yt_array import \
     YTArray, \
     uintersect1d
@@ -147,3 +148,13 @@ def test_compose_overlap():
             id3 = data3['index', 'ID']
             id3.sort()
             assert_array_equal(uintersect1d(id1, id2), id3)
+
+def test_compose_max_level_min_level():
+    ds = fake_amr_ds()
+    ad = ds.all_data()
+    ad.max_level = 2
+    slc = ds.slice('x', 0.5, data_source=ad)
+    assert slc['grid_level'].max() == 2
+    frb = slc.to_frb(1.0, 128)
+    assert np.all(frb['Density'] > 0)
+    assert frb['grid_level'].max() == 2

--- a/yt/data_objects/tests/test_regions.py
+++ b/yt/data_objects/tests/test_regions.py
@@ -1,5 +1,6 @@
 from yt.testing import \
     assert_array_equal, \
+    fake_amr_ds, \
     fake_random_ds
 from yt.units import cm
 
@@ -15,3 +16,16 @@ def test_box_creation():
     dens_no_units = reg['density']
 
     assert_array_equal(dens_units, dens_no_units)
+
+def test_max_level_min_level_semantics():
+    ds = fake_amr_ds()
+    ad = ds.all_data()
+    assert ad['grid_level'].max() == 4
+    ad.max_level = 2
+    assert ad['grid_level'].max() == 2
+    ad.max_level = 8
+    assert ad['grid_level'].max() == 4
+    ad.min_level = 2
+    assert ad['grid_level'].min() == 2
+    ad.min_level = 0
+    assert ad['grid_level'].min() == 0

--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -116,8 +116,14 @@ cdef class SelectorObject:
         self._hash_initialized = 0
         cdef np.float64_t [:] DLE
         cdef np.float64_t [:] DRE
-        self.min_level = getattr(dobj, "min_level")
-        self.max_level = getattr(dobj, "max_level")
+        min_level = getattr(dobj, "min_level", None)
+        max_level = getattr(dobj, "max_level", None)
+        if min_level is None:
+            min_level = 0
+        if max_level is None:
+            max_level = 99
+        self.min_level = min_level
+        self.max_level = max_level
         self.overlap_cells = 0
 
         ds = getattr(dobj, 'ds', None)

--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -116,8 +116,8 @@ cdef class SelectorObject:
         self._hash_initialized = 0
         cdef np.float64_t [:] DLE
         cdef np.float64_t [:] DRE
-        self.min_level = getattr(dobj, "min_level", 0)
-        self.max_level = getattr(dobj, "max_level", 99)
+        self.min_level = getattr(dobj, "min_level")
+        self.max_level = getattr(dobj, "max_level")
         self.overlap_cells = 0
 
         ds = getattr(dobj, 'ds', None)
@@ -1994,6 +1994,8 @@ cdef class ComposeSelector(SelectorObject):
     def __init__(self, dobj, selector1, selector2):
         self.selector1 = selector1
         self.selector2 = selector2
+        self.min_level = max(selector1.min_level, selector2.min_level)
+        self.max_level = min(selector1.max_level, selector2.max_level)
 
     def select_grids(self,
                      np.ndarray[np.float64_t, ndim=2] left_edges,


### PR DESCRIPTION
This pull request adds new properties named `max_level` and `min_level` to the `YTSelectionContainer` class. This allows us to add some logic that fires when `max_level` or `min_level` are set or changed by a user.

This also makes the `ComposeSelector` (which is created when one does some like `dobj = ds.some_data_object(..., data_source=other_dobj)`) inherit `max_level` and `min_level` from the value of `max_level` or `min_level` on the underlying data objects it is created from.

The reason why this PR is necessary is most easily seen from what happens when you currently run either of the two new tests I'm adding:

```python
import yt
from yt.testing import fake_amr_ds

ds = fake_amr_ds()
ad = ds.all_data()
ad.max_level = 2

# The resulting plot will look the same as the plot you'd 
# get if you didn't have a `data_source` at all.
plot = yt.SlicePlot(ds, 2, 'density', data_source=ad)
plot.save()
```

Or:

```python
import yt
from yt.testing import fake_amr_ds

ds = fake_amr_ds()

ad = ds.all_data()
print(ad['grid_level'].max())

ad.max_level = 2
# still prints 4
print(ad['grid_level'].max())

# still prints 4
ad.field_data.clear()
print(ad['grid_level'].max())

# finally prints 2
del ad._selector
ad.field_data.clear()
print(ad['grid_level'].max())
```