### PR TITLE
Make ramses less noisy

### DIFF
--- a/yt/frontends/ramses/io.py
+++ b/yt/frontends/ramses/io.py
@@ -224,7 +224,7 @@ def _read_part_file_descriptor(fname):
     with open(fname, 'r') as f:
         line = f.readline()
         tmp = VERSION_RE.match(line)
-        mylog.info('Reading part file descriptor.')
+        mylog.debug('Reading part file descriptor %s.' % fname)
         if not tmp:
             raise YTParticleOutputFormatNotImplemented()
 
@@ -276,7 +276,7 @@ def _read_fluid_file_descriptor(fname):
     with open(fname, 'r') as f:
         line = f.readline()
         tmp = VERSION_RE.match(line)
-        mylog.info('Reading fluid file descriptor.')
+        mylog.debug('Reading fluid file descriptor %s.' % fname)
         if not tmp:
             return []
 


### PR DESCRIPTION
I've had multiple person asking me how to decrease the level of verbosity of the RAMSES frontend. This is due to the fact that each particle file and fluid file will send an info saying `Reading ... file descriptor`. While this is OK for debugging it gets annoying when you have thousands of CPU.

## PR Summary

This PR replaces the noisy `mylog.info` by `mylog.debug`.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes flake8 checker

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
