### PR TITLE
Ramses lazy reading

### DIFF
--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -462,8 +462,10 @@ class RAMSESDataset(Dataset):
         Dataset.__init__(self, filename, dataset_type, units_override=units_override,
                          unit_system=unit_system)
         for FH in get_field_handlers():
+            FH.purge_detected_fields(self)
             if FH.any_exist(self):
                 self.fluid_types += (FH.ftype, )
+
         self.storage_filename = storage_filename
 
 

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -68,7 +68,6 @@ class RAMSESDomainFile(object):
             setattr(self, "%s_fn" % t, basename % t)
         self._part_file_descriptor = part_file_descriptor
         self._read_amr_header()
-        # self._read_hydro_header()
 
         # Autodetect field files
         field_handlers = [FH(self)
@@ -461,6 +460,17 @@ class RAMSESDataset(Dataset):
         self._bbox = bbox
         Dataset.__init__(self, filename, dataset_type, units_override=units_override,
                          unit_system=unit_system)
+
+        # Add the particle types
+        ptypes = []
+        for PH in get_particle_handlers():
+            if PH.any_exist(self):
+                ptypes.append(PH.ptype)
+
+        ptypes = tuple(ptypes)
+        self.particle_types = self.particle_types_raw = ptypes
+
+        # Add the fluid types
         for FH in get_field_handlers():
             FH.purge_detected_fields(self)
             if FH.any_exist(self):
@@ -616,15 +626,6 @@ class RAMSESDataset(Dataset):
                              self.t_frw[iage-1]*(age-self.tau_frw[iage  ])/(self.tau_frw[iage-1]-self.tau_frw[iage])
 
             self.current_time = (self.time_tot + self.time_simu)/(self.hubble_constant*1e7/3.08e24)/self.parameters['unit_t']
-
-        # Add the particle types
-        ptypes = []
-        for PH in get_particle_handlers():
-            if PH.any_exist(self):
-                ptypes.append(PH.ptype)
-
-        ptypes = tuple(ptypes)
-        self.particle_types = self.particle_types_raw = ptypes
 
 
 

--- a/yt/frontends/ramses/field_handlers.py
+++ b/yt/frontends/ramses/field_handlers.py
@@ -234,7 +234,7 @@ class HydroFieldFileHandler(FieldFileHandler):
         # This is to force the redetection of the fields when changing
         # dataset.
         if cls.detected_fields and cls.ds == ds:
-            return cls.detected_fields
+            return cls.detected_fields.copy()
         cls.ds = ds
 
         num = os.path.basename(ds.parameter_filename).split("."
@@ -365,8 +365,9 @@ class RTFieldFileHandler(FieldFileHandler):
         # object.
         # This is to force the redetection of the fields when changing
         # dataset.
+        print(cls.detected_fields)
         if cls.detected_fields and cls.ds == ds:
-            return cls.detected_fields
+            return cls.detected_fields.copy()
         cls.ds = ds
 
         fname = ds.parameter_filename.replace('info_', 'info_rt_')

--- a/yt/frontends/ramses/field_handlers.py
+++ b/yt/frontends/ramses/field_handlers.py
@@ -365,7 +365,6 @@ class RTFieldFileHandler(FieldFileHandler):
         # object.
         # This is to force the redetection of the fields when changing
         # dataset.
-        print(cls.detected_fields)
         if cls.detected_fields and cls.ds == ds:
             return cls.detected_fields.copy()
         cls.ds = ds

--- a/yt/frontends/ramses/field_handlers.py
+++ b/yt/frontends/ramses/field_handlers.py
@@ -52,7 +52,7 @@ class FieldFileHandler(object):
     # These properties are computed dynamically
     field_offsets = None     # Mapping from field to offset in file
     field_types = None       # Mapping from field to the type of the data (float, integer, ...)
-
+    detected_fields = None   # Detected fields in file
     def __init__(self, domain):
         '''
         Initalize an instance of the class. This automatically sets
@@ -228,6 +228,8 @@ class HydroFieldFileHandler(FieldFileHandler):
 
     @classmethod
     def detect_fields(cls, ds):
+        if cls.detected_fields:
+            return cls.detected_fields
         num = os.path.basename(ds.parameter_filename).split("."
                 )[0].split("_")[1]
         testdomain = 1 # Just pick the first domain file to read
@@ -278,10 +280,12 @@ class HydroFieldFileHandler(FieldFileHandler):
             if rt_flag: # rt run
                 if nvar < 10:
                     mylog.info('Detected RAMSES-RT file WITHOUT IR trapping.')
+
                     fields = ["Density", "x-velocity", "y-velocity", "z-velocity", "Pressure",
                               "Metallicity", "HII", "HeII", "HeIII"]
                 else:
                     mylog.info('Detected RAMSES-RT file WITH IR trapping.')
+
                     fields = ["Density", "x-velocity", "y-velocity", "z-velocity", "Pres_IR",
                               "Pressure", "Metallicity", "HII", "HeII", "HeIII"]
             else:
@@ -321,6 +325,7 @@ class HydroFieldFileHandler(FieldFileHandler):
         if count_extra > 0:
             mylog.debug('Detected %s extra fluid fields.' % count_extra)
         cls.field_list = [(cls.ftype, e) for e in fields]
+        cls.detected_fields = fields
 
         return fields
 
@@ -349,6 +354,8 @@ class RTFieldFileHandler(FieldFileHandler):
 
     @classmethod
     def detect_fields(cls, ds):
+        if cls.detected_fields:
+            return cls.detected_fields
         fname = ds.parameter_filename.replace('info_', 'info_rt_')
 
         rheader = {}
@@ -385,6 +392,7 @@ class RTFieldFileHandler(FieldFileHandler):
             fields.extend([t % (ng + 1) for t in tmp])
 
         cls.field_list = [(cls.ftype, e) for e in fields]
+        cls.detected_fields = fields
         return fields
 
     @classmethod

--- a/yt/frontends/ramses/field_handlers.py
+++ b/yt/frontends/ramses/field_handlers.py
@@ -167,6 +167,11 @@ class FieldFileHandler(object):
 
     @classmethod
     def purge_detected_fields(cls, ds):
+        '''Purge the list of fields.
+
+        This should be called on dataset creation to force the field
+        detection to be called.
+        '''
         if ds.unique_identifier in DETECTED_FIELDS:
             DETECTED_FIELDS.pop(ds.unique_identifier)
 

--- a/yt/frontends/ramses/field_handlers.py
+++ b/yt/frontends/ramses/field_handlers.py
@@ -53,6 +53,7 @@ class FieldFileHandler(object):
     field_offsets = None     # Mapping from field to offset in file
     field_types = None       # Mapping from field to the type of the data (float, integer, ...)
     detected_fields = None   # Detected fields in file
+    ds = None                # Weak reference to the dataset
     def __init__(self, domain):
         '''
         Initalize an instance of the class. This automatically sets
@@ -228,8 +229,14 @@ class HydroFieldFileHandler(FieldFileHandler):
 
     @classmethod
     def detect_fields(cls, ds):
-        if cls.detected_fields:
+        # Important: here we also detect that the dataset is the same
+        # object.
+        # This is to force the redetection of the fields when changing
+        # dataset.
+        if cls.detected_fields and cls.ds == ds:
             return cls.detected_fields
+        cls.ds = ds
+
         num = os.path.basename(ds.parameter_filename).split("."
                 )[0].split("_")[1]
         testdomain = 1 # Just pick the first domain file to read
@@ -354,8 +361,14 @@ class RTFieldFileHandler(FieldFileHandler):
 
     @classmethod
     def detect_fields(cls, ds):
-        if cls.detected_fields:
+        # Important: here we also detect that the dataset is the same
+        # object.
+        # This is to force the redetection of the fields when changing
+        # dataset.
+        if cls.detected_fields and cls.ds == ds:
             return cls.detected_fields
+        cls.ds = ds
+
         fname = ds.parameter_filename.replace('info_', 'info_rt_')
 
         rheader = {}

--- a/yt/frontends/ramses/field_handlers.py
+++ b/yt/frontends/ramses/field_handlers.py
@@ -165,6 +165,10 @@ class FieldFileHandler(object):
             cls.ftype: fields
         })
 
+    @classmethod
+    def purge_detected_fields(cls, ds):
+        if ds.unique_identifier in DETECTED_FIELDS:
+            DETECTED_FIELDS.pop(ds.unique_identifier)
 
     @property
     def level_count(self):

--- a/yt/frontends/ramses/field_handlers.py
+++ b/yt/frontends/ramses/field_handlers.py
@@ -143,7 +143,7 @@ class FieldFileHandler(object):
     @classmethod
     def get_detected_fields(cls, ds):
         '''
-        Get the detected fields from the register.
+        Get the detected fields from the registry.
         '''
         if ds.unique_identifier in DETECTED_FIELDS:
             d = DETECTED_FIELDS[ds.unique_identifier]
@@ -156,7 +156,7 @@ class FieldFileHandler(object):
     @classmethod
     def set_detected_fields(cls, ds, fields):
         '''
-        Store the detected fields into the register.
+        Store the detected fields into the registry.
         '''
         if ds.unique_identifier not in DETECTED_FIELDS:
             DETECTED_FIELDS[ds.unique_identifier] = {}
@@ -167,7 +167,8 @@ class FieldFileHandler(object):
 
     @classmethod
     def purge_detected_fields(cls, ds):
-        '''Purge the list of fields.
+        '''
+        Purge the registry.
 
         This should be called on dataset creation to force the field
         detection to be called.
@@ -195,7 +196,7 @@ class FieldFileHandler(object):
         and computes the offset at each level.
 
         It should be generic enough for most of the cases, but if the
-        *structure* of your fluid file is non-canonial, change this.
+        *structure* of your fluid file is non-canonical, change this.
         '''
 
         if getattr(self, '_offset', None) is not None:

--- a/yt/frontends/ramses/field_handlers.py
+++ b/yt/frontends/ramses/field_handlers.py
@@ -145,10 +145,10 @@ class FieldFileHandler(object):
         '''
         Get the detected fields from the register.
         '''
-        if cls.ftype in DETECTED_FIELDS:
-            d = DETECTED_FIELDS[cls.ftype]
-            if ds.unique_identifier in d:
-                return d[ds.unique_identifier]
+        if ds.unique_identifier in DETECTED_FIELDS:
+            d = DETECTED_FIELDS[ds.unique_identifier]
+            if cls.ftype in d:
+                return d[cls.ftype]
 
         return None
 
@@ -158,11 +158,11 @@ class FieldFileHandler(object):
         '''
         Store the detected fields into the register.
         '''
-        if cls.ftype not in DETECTED_FIELDS:
-            DETECTED_FIELDS[cls.ftype] = {}
+        if ds.unique_identifier not in DETECTED_FIELDS:
+            DETECTED_FIELDS[ds.unique_identifier] = {}
 
-        DETECTED_FIELDS[cls.ftype].update({
-            ds.unique_identifier: fields
+        DETECTED_FIELDS[ds.unique_identifier].update({
+            cls.ftype: fields
         })
 
 

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -26,7 +26,6 @@ from yt.utilities.answer_testing.framework import \
     create_obj
 from yt.frontends.ramses.api import RAMSESDataset
 from yt.config import ytcfg
-from yt.frontends.ramses.field_handlers import HydroFieldFileHandler
 from yt.frontends.ramses.field_handlers import DETECTED_FIELDS, HydroFieldFileHandler
 import os
 import yt
@@ -303,8 +302,7 @@ def test_custom_hydro_def():
 @requires_file(output_00080)
 def test_ramses_field_detection():
     # Empty the detected fields cache
-    for k in DETECTED_FIELDS.keys():
-        DETECTED_FIELDS.drop(k)
+    DETECTED_FIELDS.clear()
 
     ds1 = yt.load(ramses_rt)
 

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -301,9 +301,6 @@ def test_custom_hydro_def():
 @requires_file(ramses_sink)
 @requires_file(output_00080)
 def test_ramses_field_detection():
-    # Empty the detected fields cache
-    DETECTED_FIELDS.clear()
-
     ds1 = yt.load(ramses_rt)
 
     assert 'ramses' not in DETECTED_FIELDS
@@ -318,7 +315,7 @@ def test_ramses_field_detection():
     assert P1['nvar'] == 10
     assert len(fields_1) == P1['nvar']
 
-    # Now low another dataset
+    # Now load another dataset
     ds2 = yt.load(output_00080)
     ds2.index
     P2 = HydroFieldFileHandler.parameters

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -27,6 +27,7 @@ from yt.utilities.answer_testing.framework import \
 from yt.frontends.ramses.api import RAMSESDataset
 from yt.config import ytcfg
 from yt.frontends.ramses.field_handlers import HydroFieldFileHandler
+from yt.frontends.ramses.field_handlers import DETECTED_FIELDS, HydroFieldFileHandler
 import os
 import yt
 
@@ -301,16 +302,19 @@ def test_custom_hydro_def():
 @requires_file(ramses_sink)
 @requires_file(output_00080)
 def test_ramses_field_detection():
+    # Empty the detected fields cache
+    for k in DETECTED_FIELDS.keys():
+        DETECTED_FIELDS.drop(k)
+
     ds1 = yt.load(ramses_rt)
 
-    # Check that the fields are detected in a lazy way
-    assert HydroFieldFileHandler.detected_fields is None
+    assert 'ramses' not in DETECTED_FIELDS
 
     # Now they are detected !
     ds1.index
     P1 = HydroFieldFileHandler.parameters
-    assert HydroFieldFileHandler.detected_fields is not None
-    fields_1 = set(HydroFieldFileHandler.detected_fields.copy())
+    assert DETECTED_FIELDS[ds1.unique_identifier]['ramses'] is not None
+    fields_1 = set(DETECTED_FIELDS[ds1.unique_identifier]['ramses'])
 
     # Check the right number of variables has been loaded
     assert P1['nvar'] == 10
@@ -320,7 +324,7 @@ def test_ramses_field_detection():
     ds2 = yt.load(output_00080)
     ds2.index
     P2 = HydroFieldFileHandler.parameters
-    fields_2 = set(HydroFieldFileHandler.detected_fields.copy())
+    fields_2 = set(DETECTED_FIELDS[ds2.unique_identifier]['ramses'])
 
     # Check the right number of variables has been loaded
     assert P2['nvar'] == 6

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -26,6 +26,7 @@ from yt.utilities.answer_testing.framework import \
     create_obj
 from yt.frontends.ramses.api import RAMSESDataset
 from yt.config import ytcfg
+from yt.frontends.ramses.field_handlers import HydroFieldFileHandler
 import os
 import yt
 
@@ -296,3 +297,31 @@ def test_custom_hydro_def():
         check_unit(ds.r['ramses', 'Bar'], 'dimensionless')
     finally:
         ytcfg.remove_section('ramses-hydro')
+
+@requires_file(ramses_sink)
+@requires_file(output_00080)
+def test_ramses_field_detection():
+    ds1 = yt.load(ramses_rt)
+
+    # Check that the fields are detected in a lazy way
+    assert HydroFieldFileHandler.detected_fields is None
+
+    # Now they are detected !
+    ds1.index
+    P1 = HydroFieldFileHandler.parameters
+    assert HydroFieldFileHandler.detected_fields is not None
+    fields_1 = set(HydroFieldFileHandler.detected_fields.copy())
+
+    # Check the right number of variables has been loaded
+    assert P1['nvar'] == 10
+    assert len(fields_1) == P1['nvar']
+
+    # Now low another dataset
+    ds2 = yt.load(output_00080)
+    ds2.index
+    P2 = HydroFieldFileHandler.parameters
+    fields_2 = set(HydroFieldFileHandler.detected_fields.copy())
+
+    # Check the right number of variables has been loaded
+    assert P2['nvar'] == 6
+    assert len(fields_2) == P2['nvar']


### PR DESCRIPTION
Currently the RAMSES frontends reads the particle/rt field descriptors multiple times (ncpu times to be precise). This is useless as the fields detected are the same in all the files.

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

This PR adds some logic to store in the class the detected fields, as well as reset the detected field upon dataset change.

As a side effect, there is less information printed to the console as the detection only happens once per dataset.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes flake8 checker
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
