### PR TITLE
give ValidateParameter the ability to inject needed parameters into field detection

### DIFF
--- a/doc/source/developing/creating_derived_fields.rst
+++ b/doc/source/developing/creating_derived_fields.rst
@@ -194,20 +194,20 @@ transparent and simple example).
                 function=_my_radial_velocity,
                 units="cm/s",
                 take_log=False,
-                validators=[ValidateParameter('center'),
-                            ValidateParameter('bulk_velocity')])
+                validators=[ValidateParameter(['center', 'bulk_velocity'])])
 
-Note that we have added a few parameters below the main function; we specify
-that we do not wish to display this field as logged, that we require both
-``bulk_velocity`` and ``center`` to be present in a given data object we wish
-to calculate this for, and we say that it should not be displayed in a
-drop-down box of fields to display. This is done through the parameter
-*validators*, which accepts a list of :class:`~yt.fields.derived_field.FieldValidator`
-objects. These objects define the way in which the field is generated, and
-when it is able to be created. In this case, we mandate that parameters
-``center`` and ``bulk_velocity`` are set before creating the field. These are
-set via :meth:`~yt.data_objects.data_containers.set_field_parameter`, which can
-be called on any object that has fields:
+Note that we have added a few optional arguments to ``yt.add_field``; we specify
+that we do not wish to display this field as logged, that we require both the
+``bulk_velocity`` and ``center`` field parameters to be present in a given data
+object we wish to calculate this for, and we say that it should not be displayed
+in a drop-down box of fields to display. This is done through the parameter
+*validators*, which accepts a list of
+:class:`~yt.fields.derived_field.FieldValidator` objects. These objects define
+the way in which the field is generated, and when it is able to be created. In
+this case, we mandate that parameters ``center`` and ``bulk_velocity`` are set
+before creating the field. These are set via
+:meth:`~yt.data_objects.data_containers.set_field_parameter`, which can be
+called on any object that has fields:
 
 .. code-block:: python
 
@@ -222,9 +222,15 @@ not set it. Also, note that ``center`` and ``bulk_velocity`` need to be
 If you are writing a derived field that uses a field parameter that changes the
 behavior of the field depending on the value of the field parameter, you can
 make yt test to make sure the field handles all possible values for the field
-parameter using the ``ValidateParameter`` field validator.
+parameter using a special form of the ``ValidateParameter`` field validator. In
+particular, ``ValidateParameter`` supports an optional second argument, which
+takes a dictionary mapping from parameter names to parameter values that
+you would like yt to test. This is useful when a field will select different
+fields to access based on the value of a field parameter. This option allows you
+to force yt to select *all* needed dependent fields for your derived field
+definition at field detection time. This can avoid errors related to missing fields.
 
-For example, let's write a field that depends on a field parameter named ``'axis'``::
+For example, let's write a field that depends on a field parameter named ``'axis'``:
 
 .. code-block:: python
 
@@ -241,6 +247,14 @@ For example, let's write a field that depends on a field parameter named ``'axis
 
    ds.add_field('my_axis_field', function=my_axis_field, units='cm/s',
                 validators=[ValidateParameter("axis", {"axis": [0, 1, 2]})])
+
+In this example, we've told yt's field system that the data object we are
+querying ``my_axis_field`` must have the ``axis`` field parameter set. In
+addition, it forces yt to recognize that this field might depend on any one of
+``x-velocity``, ``y-velocity``, or ``z-velocity``. By specifying that ``axis``
+might be 0, 1, or 2 in the ``ValidataParameter`` call, this ensures that this
+field will only be valid and available for datasets that have all three fields
+available.
 
 Other examples for creating derived fields can be found in the cookbook recipe
 :ref:`cookbook-simple-derived-fields`.

--- a/doc/source/developing/creating_derived_fields.rst
+++ b/doc/source/developing/creating_derived_fields.rst
@@ -219,6 +219,29 @@ In this case, we already know what the ``center`` of the sphere is, so we do
 not set it. Also, note that ``center`` and ``bulk_velocity`` need to be
 :class:`~yt.units.yt_array.YTArray` objects with units.
 
+If you are writing a derived field that uses a field parameter that changes the
+behavior of the field depending on the value of the field parameter, you can
+make yt test to make sure the field handles all possible values for the field
+parameter using the ``ValidateParameter`` field validator.
+
+For example, let's write a field that depends on a field parameter named ``'axis'``::
+
+.. code-block:: python
+
+   def my_axis_field(field, data):
+       axis = data.get_field_parameter('axis')
+       if axis == 0:
+           return data['x-velocity']
+       elif axis == 1:
+           return data['y-velocity']
+       elif axis == 2:
+           return data['z-velocity']
+       else:
+           raise ValueError
+
+   ds.add_field('my_axis_field', function=my_axis_field, units='cm/s',
+                validators=[ValidateParameter("axis", {"axis": [0, 1, 2]})])
+
 Other examples for creating derived fields can be found in the cookbook recipe
 :ref:`cookbook-simple-derived-fields`.
 

--- a/yt/fields/derived_field.py
+++ b/yt/fields/derived_field.py
@@ -211,6 +211,19 @@ class DerivedField(object):
             e[self.name]
         return e
 
+    def _get_needed_parameters(self, fd):
+        params = []
+        values = []
+        for val in self.validators:
+            if isinstance(val, ValidateParameter):
+                params.extend(val.parameters)
+                if val.parameter_values is not None:
+                    values.extend(val.parameter_values)
+                else:
+                    values.extend(
+                        [fd.get_field_parameter(fp) for fp in val.parameters])
+        return dict(zip(params, values))
+
     _unit_registry = None
     @contextlib.contextmanager
     def unit_registry(self, data):

--- a/yt/fields/derived_field.py
+++ b/yt/fields/derived_field.py
@@ -25,7 +25,6 @@ from .field_exceptions import \
     NeedsDataField, \
     NeedsProperty, \
     NeedsParameter, \
-    NeedsParameterValue, \
     FieldUnitsError
 from .field_detector import \
     FieldDetector
@@ -214,15 +213,16 @@ class DerivedField(object):
     def _get_needed_parameters(self, fd):
         params = []
         values = []
-        for val in self.validators:
-            if isinstance(val, ValidateParameter):
+        permute_params = {}
+        vals = [v for v in self.validators if isinstance(v, ValidateParameter)]
+        for val in vals:
+            if val.parameter_values is not None:
+                permute_params.update(val.parameter_values)
+            else:
                 params.extend(val.parameters)
-                if val.parameter_values is not None:
-                    values.extend(val.parameter_values)
-                else:
-                    values.extend(
-                        [fd.get_field_parameter(fp) for fp in val.parameters])
-        return dict(zip(params, values))
+                values.extend(
+                    [fd.get_field_parameter(fp) for fp in val.parameters])
+        return dict(zip(params, values)), permute_params
 
     _unit_registry = None
     @contextlib.contextmanager
@@ -369,9 +369,6 @@ class ValidateParameter(FieldValidator):
         self.parameter_values = parameter_values
     def __call__(self, data):
         doesnt_have = []
-        if self.parameter_values is not None:
-            if isinstance(data, FieldDetector):
-                raise NeedsParameterValue(self.parameter_values)
         for p in self.parameters:
             if not data.has_field_parameter(p):
                 doesnt_have.append(p)

--- a/yt/fields/field_exceptions.py
+++ b/yt/fields/field_exceptions.py
@@ -46,10 +46,6 @@ class NeedsParameter(ValidationException):
     def __str__(self):
         return "(%s)" % (self.missing_parameters)
 
-class NeedsParameterValue(ValidationException):
-    def __init__(self, parameter_values):
-        self.parameter_values = parameter_values
-
 class NeedsConfiguration(ValidationException):
     def __init__(self, parameter, value):
         self.parameter = parameter


### PR DESCRIPTION
Recently, in #1693  I changed the implementation of `FieldDetector.has_field_parameter` to return True only for known field parameters. This had the unintended consequence of breaking support for unknown field parameters, which subsequently caused the unit tests to start failing when #1732 from @brittonsmith was merged.

The fix is to make the field detection system check if a field has `ValidateParameter` validators registered before detecting whether that field has errors and add the needed field parameters.

I've also substantially simplified the parameter validation logic, completely removing `NeedsParameterValue`. I also added some documentation for `ValidateParameter.parameter_values`. I didn't add a test since the existing field tests are sufficient.