### PR TITLE
fix compatibility with sphinx 1.7

### DIFF
--- a/doc/extensions/config_help.py
+++ b/doc/extensions/config_help.py
@@ -1,7 +1,7 @@
 import re
 import subprocess
 from docutils import statemachine
-from sphinx.util.compat import Directive
+from docutils.parsers.rst import Directive
 
 def setup(app):
     app.add_directive('config_help', GetConfigHelp)

--- a/doc/extensions/pythonscript_sphinxext.py
+++ b/doc/extensions/pythonscript_sphinxext.py
@@ -6,7 +6,7 @@ import shutil
 import subprocess
 import uuid
 import errno
-from sphinx.util.compat import Directive
+from docutils.parsers.rst import Directive
 from docutils import nodes
 
 

--- a/doc/extensions/yt_colormaps.py
+++ b/doc/extensions/yt_colormaps.py
@@ -3,7 +3,7 @@
 #  2. This script is added to the document in a literalinclude
 #  3. Any _static images found will be added
 
-from sphinx.util.compat import Directive
+from docutils.parsers.rst import Directive
 from docutils.parsers.rst import directives
 import os, glob, shutil
 

--- a/doc/extensions/yt_cookbook.py
+++ b/doc/extensions/yt_cookbook.py
@@ -3,7 +3,7 @@
 #  2. This script is added to the document in a literalinclude
 #  3. Any _static images found will be added
 
-from sphinx.util.compat import Directive
+from docutils.parsers.rst import Directive
 from docutils.parsers.rst import directives
 import os, glob, shutil
 

--- a/doc/extensions/yt_showfields.py
+++ b/doc/extensions/yt_showfields.py
@@ -1,6 +1,6 @@
 import subprocess
 import sys
-from sphinx.util.compat import Directive
+from docutils.parsers.rst import Directive
 
 def setup(app):
     app.add_directive('yt_showfields', ShowFields)


### PR DESCRIPTION
sphinx.util.compat was deprecated in sphinx 1.6 and removed in 1.7.

Thankfully Directive was just getting reimported from docutils so we can just import it from there.