### PR TITLE
Change "clobber" to "overwrite", add deprecation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -250,6 +250,7 @@ intersphinx_mapping = {'http://docs.python.org/': None,
                        'http://ipython.org/ipython-doc/stable/': None,
                        'http://docs.scipy.org/doc/numpy/': None,
                        'http://matplotlib.org/': None,
+                       'http://docs.astropy.org/en/stable': None,
                        }
 
 if not on_rtd:

--- a/yt/analysis_modules/absorption_spectrum/absorption_spectrum.py
+++ b/yt/analysis_modules/absorption_spectrum/absorption_spectrum.py
@@ -626,7 +626,7 @@ class AbsorptionSpectrum(object):
         col3 = pyfits.Column(name='flux', format='E', array=self.flux_field)
         cols = pyfits.ColDefs([col1, col2, col3])
         tbhdu = pyfits.BinTableHDU.from_columns(cols)
-        tbhdu.writeto(filename, clobber=True)
+        tbhdu.writeto(filename, overwrite=True)
 
     @parallel_root_only
     def _write_spectrum_hdf5(self, filename):

--- a/yt/analysis_modules/ppv_cube/ppv_cube.py
+++ b/yt/analysis_modules/ppv_cube/ppv_cube.py
@@ -261,15 +261,15 @@ class PPVCube(object):
         self.dv = self.vbins[1]-self.vbins[0]
 
     @parallel_root_only
-    def write_fits(self, filename, clobber=False, length_unit=None,
-                   sky_scale=None, sky_center=None):
+    def write_fits(self, filename, overwrite=False, length_unit=None,
+                   sky_scale=None, sky_center=None, **kwargs):
         r""" Write the PPVCube to a FITS file.
 
         Parameters
         ----------
         filename : string
             The name of the file to write to. 
-        clobber : boolean, optional
+        overwrite : boolean, optional
             Whether to overwrite a file with the same name that already 
             exists. Default False.
         length_unit : string, optional
@@ -283,7 +283,7 @@ class PPVCube(object):
 
         Examples
         --------
-        >>> cube.write_fits("my_cube.fits", clobber=False, 
+        >>> cube.write_fits("my_cube.fits", overwrite=False, 
         ...                 sky_scale=(1.0,"arcsec/kpc"), sky_center=(30.,45.))
         """
         vunit = fits_info[self.axis_type][0]
@@ -312,7 +312,7 @@ class PPVCube(object):
         fib.update_all_headers("btype", self.field)
         if sky_scale is not None and sky_center is not None:
             fib.create_sky_wcs(sky_center, sky_scale)
-        fib.writeto(filename, clobber=clobber)
+        fib.writeto(filename, overwrite=overwrite, **kwargs)
 
     def __repr__(self):
         return "PPVCube [%d %d %d] (%s < %s < %s)" % (self.nx, self.ny, self.nv,

--- a/yt/analysis_modules/ppv_cube/ppv_cube.py
+++ b/yt/analysis_modules/ppv_cube/ppv_cube.py
@@ -281,6 +281,9 @@ class PPVCube(object):
             The (RA, Dec) coordinate in degrees of the central pixel. Must
             be specified with *sky_scale*.
 
+        Additional keyword arguments are passed to
+        :meth:`~astropy.io.fits.HDUList.writeto`.
+
         Examples
         --------
         >>> cube.write_fits("my_cube.fits", overwrite=False, 

--- a/yt/analysis_modules/sunrise_export/sunrise_exporter.py
+++ b/yt/analysis_modules/sunrise_export/sunrise_exporter.py
@@ -418,7 +418,7 @@ def create_fits_file(ds,fn, refined,output,particle_data,fle,fre):
     hls = [phdu, st_table, mg_table,md_table]
     hls.append(particle_data)
     hdus = pyfits.HDUList(hls)
-    hdus.writeto(fn, clobber=True)
+    hdus.writeto(fn, overwrite=True)
 
 def nearest_power(x):
     #round to the nearest power of 2

--- a/yt/analysis_modules/sunrise_export/sunrise_exporter.py
+++ b/yt/analysis_modules/sunrise_export/sunrise_exporter.py
@@ -14,16 +14,12 @@ from __future__ import print_function
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-try:
-    import pyfits
-except ImportError:
-    pass
-
 import os
 import time
 import numpy as np
 
 import yt.utilities.lib.api as amr_utils
+from yt.utilities.on_demand_imports import _astropy as astropy
 
 from yt import add_field
 from yt.funcs import get_pbar, mylog
@@ -349,6 +345,7 @@ def RecurseOctreeDepthFirstHilbert(cell_index, #integer (rep as a float) on the 
 
 def create_fits_file(ds,fn, refined,output,particle_data,fle,fre):
     #first create the grid structure
+    pyfits = astropy.pyfits
     structure = pyfits.Column("structure", format="B", array=refined.astype("bool"))
     cols = pyfits.ColDefs([structure])
     st_table = pyfits.new_table(cols)
@@ -490,6 +487,7 @@ def prepare_star_particles(ds,star_type,pos=None,vel=None, age=None,
                           radius = None,
                           fle=[0.,0.,0.],fre=[1.,1.,1.],
                           dd=None):
+    pyfits = astropy.pyfits
     if dd is None:
         dd = ds.all_data()
     idxst = dd["particle_type"] == star_type

--- a/yt/analysis_modules/sunyaev_zeldovich/projection.py
+++ b/yt/analysis_modules/sunyaev_zeldovich/projection.py
@@ -367,6 +367,9 @@ class SZProjection(object):
         overwrite : boolean, optional
             If the file already exists, do we overwrite?
 
+        Additional keyword arguments are passed to
+        :meth:`~astropy.io.fits.HDUList.writeto`.
+
         Examples
         --------
         >>> # This example just writes out a FITS file with kpc coords

--- a/yt/analysis_modules/sunyaev_zeldovich/projection.py
+++ b/yt/analysis_modules/sunyaev_zeldovich/projection.py
@@ -347,7 +347,8 @@ class SZProjection(object):
         self.data["TeSZ"] = self.ds.arr(Te, "keV")
 
     @parallel_root_only
-    def write_fits(self, filename, sky_scale=None, sky_center=None, clobber=True):
+    def write_fits(self, filename, sky_scale=None, sky_center=None, overwrite=True,
+                   **kwargs):
         r""" Export images to a FITS file. Writes the SZ distortion in all
         specified frequencies as well as the mass-weighted temperature and the
         optical depth. Distance units are in kpc, unless *sky_center*
@@ -363,13 +364,13 @@ class SZProjection(object):
         sky_center : tuple, optional
             The (RA, Dec) coordinate in degrees of the central pixel. Must
             be specified with *sky_scale*.
-        clobber : boolean, optional
+        overwrite : boolean, optional
             If the file already exists, do we overwrite?
 
         Examples
         --------
         >>> # This example just writes out a FITS file with kpc coords
-        >>> szprj.write_fits("SZbullet.fits", clobber=False)
+        >>> szprj.write_fits("SZbullet.fits", overwrite=False)
         >>> # This example uses sky coords
         >>> sky_scale = (1., "arcsec/kpc") # One arcsec per kpc
         >>> sky_center = (30., 45., "deg")
@@ -390,7 +391,7 @@ class SZProjection(object):
         fib = FITSImageData(self.data, fields=self.data.keys(), wcs=w)
         if sky_scale is not None and sky_center is not None:
             fib.create_sky_wcs(sky_center, sky_scale)
-        fib.writeto(filename, clobber=clobber)
+        fib.writeto(filename, overwrite=overwrite, **kwargs)
 
     @parallel_root_only
     def write_png(self, filename_prefix, cmap_name=None,

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -782,7 +782,7 @@ class YTCoveringGrid(YTSelectionContainer3D):
         Examples
         --------
         >>> cube.write_to_gdf("clumps.h5", ["density","temperature"], nprocs=16,
-        ...                   clobber=True)
+        ...                   overwrite=True)
         """
         data = {}
         for field in fields:

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -516,7 +516,7 @@ class YTGDFAlreadyExists(Exception):
         self.filename = filename
 
     def __str__(self):
-        return "A file already exists at %s and clobber=False." % self.filename
+        return "A file already exists at %s and overwrite=False." % self.filename
 
 class YTGDFUnknownGeometry(Exception):
     def __init__(self, geometry):

--- a/yt/utilities/particle_generator.py
+++ b/yt/utilities/particle_generator.py
@@ -167,17 +167,18 @@ class ParticleGenerator(object):
                                 grid.dds[0])
         pbar.finish()
 
-    def apply_to_stream(self, overwrite=False, clobber=None):
+    def apply_to_stream(self, overwrite=False, **kwargs):
         """
         Apply the particles to a grid-based stream dataset. If particles 
         already exist, and overwrite=False, do not overwrite them, but add 
         the new ones to them.
         """
-        if clobber is not None:
-            issue_deprecation_warning("The \"clobber\" keyword argument has been "
-                                      "replaced by the \"overwrite\" argument and "
-                                      "will be removed in a future release.")
-            overwrite = clobber
+        if "clobber" in kwargs:
+            issue_deprecation_warning("The \"clobber\" keyword argument "
+                                      "is deprecated. Use the \"overwrite\" "
+                                      "argument, which has the same effect, "
+                                      "instead.")
+            overwrite = kwargs.pop("clobber")
         grid_data = []
         for i, g in enumerate(self.ds.index.grids):
             data = {}

--- a/yt/utilities/particle_generator.py
+++ b/yt/utilities/particle_generator.py
@@ -1,7 +1,7 @@
 import numpy as np
 from yt.utilities.lib.particle_mesh_operations import \
     CICSample_3
-from yt.funcs import get_pbar
+from yt.funcs import get_pbar, issue_deprecation_warning
 from yt.units.yt_array import uconcatenate
 from yt.extern.six import string_types
 
@@ -167,22 +167,27 @@ class ParticleGenerator(object):
                                 grid.dds[0])
         pbar.finish()
 
-    def apply_to_stream(self, clobber=False):
+    def apply_to_stream(self, overwrite=False, clobber=None):
         """
         Apply the particles to a grid-based stream dataset. If particles 
-        already exist, and clobber=False, do not overwrite them, but add 
+        already exist, and overwrite=False, do not overwrite them, but add 
         the new ones to them.
         """
+        if clobber is not None:
+            issue_deprecation_warning("The \"clobber\" keyword argument has been "
+                                      "replaced by the \"overwrite\" argument and "
+                                      "will be removed in a future release.")
+            overwrite = clobber
         grid_data = []
         for i, g in enumerate(self.ds.index.grids):
             data = {}
             number_of_particles = self.NumberOfParticles[i]
-            if not clobber:
+            if not overwrite:
                 number_of_particles += g.NumberOfParticles
             grid_particles = self.get_for_grid(g)
             for field in self.field_list:
                 if number_of_particles > 0:
-                    if g.NumberOfParticles > 0 and not clobber and \
+                    if g.NumberOfParticles > 0 and not overwrite and \
                         field in self.ds.field_list:
                         # We have particles in this grid, we're not
                         # overwriting them, and the field is in the field

--- a/yt/utilities/tests/test_particle_generator.py
+++ b/yt/utilities/tests/test_particle_generator.py
@@ -100,10 +100,10 @@ def test_particle_generator():
     for field in field_list:
         pdata[field] = dd[field]
 
-    # Test the "from-list" generator and particle field clobber
+    # Test the "from-list" generator and particle field overwrite
     num_particles3 = num_particles+np.product(pdims)
     particles3 = FromListParticleGenerator(ds, num_particles3, pdata)
-    particles3.apply_to_stream(clobber=True)
+    particles3.apply_to_stream(overwrite=True)
 
     # Test the number of particles again
     particles_per_grid3 = [grid.NumberOfParticles for grid in ds.index.grids]

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -331,8 +331,9 @@ class FITSImageData(object):
         clobber : overwrite, optional
             Whether or not to overwrite a previously existing file.
             Default: False
-        All other keyword arguments are passed to the `writeto`
-        method of `astropy.io.fits.HDUList`.
+
+        Additional keyword arguments are passed to
+        :meth:`~astropy.io.fits.HDUList.writeto`.
         """
         if "clobber" in kwargs:
             issue_deprecation_warning("The \"clobber\" keyword argument "

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -11,9 +11,9 @@ FITSImageData Class
 #-----------------------------------------------------------------------------
 from yt.extern.six import string_types
 import numpy as np
-from distutils.version import LooseVersion
 from yt.fields.derived_field import DerivedField
-from yt.funcs import mylog, iterable, fix_axis, ensure_list
+from yt.funcs import mylog, iterable, fix_axis, ensure_list, \
+    issue_deprecation_warning
 from yt.visualization.fixed_resolution import FixedResolutionBuffer
 from yt.data_objects.construction_data_containers import YTCoveringGrid
 from yt.utilities.on_demand_imports import _astropy
@@ -317,7 +317,7 @@ class FITSImageData(object):
             return results[2:]
 
     @parallel_root_only
-    def writeto(self, fileobj, fields=None, clobber=False, **kwargs):
+    def writeto(self, fileobj, fields=None, overwrite=False, **kwargs):
         r"""
         Write all of the fields or a subset of them to a FITS file. 
 
@@ -328,22 +328,25 @@ class FITSImageData(object):
         fields : list of strings, optional
             The fields to write to the file. If not specified
             all of the fields in the buffer will be written.
-        clobber : boolean, optional
+        clobber : overwrite, optional
             Whether or not to overwrite a previously existing file.
             Default: False
         All other keyword arguments are passed to the `writeto`
         method of `astropy.io.fits.HDUList`.
         """
+        if "clobber" in kwargs:
+            issue_deprecation_warning("The \"clobber\" keyword argument "
+                                      "is deprecated. Use the \"overwrite\" "
+                                      "argument, which has the same effect, "
+                                      "instead.")
+            overwrite = kwargs.pop("clobber")
         if fields is None:
             hdus = self.hdulist
         else:
             hdus = _astropy.pyfits.HDUList()
             for field in fields:
                 hdus.append(self.hdulist[field])
-        if LooseVersion(_astropy.__version__) < LooseVersion('2.0.0'):
-            hdus.writeto(fileobj, clobber=clobber, **kwargs)
-        else:
-            hdus.writeto(fileobj, overwrite=clobber, **kwargs)
+        hdus.writeto(fileobj, overwrite=overwrite, **kwargs)
 
     def to_glue(self, label="yt", data_collection=None):
         """

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -296,8 +296,8 @@ class FixedResolutionBuffer(object):
             output.create_dataset(field,data=self[field])
         output.close()
 
-    def export_fits(self, filename, fields=None, clobber=False,
-                    other_keys=None, units="cm"):
+    def export_fits(self, filename, fields=None, overwrite=False,
+                    other_keys=None, units="cm", **kwargs):
         r"""Export a set of pixelized fields to a FITS file.
 
         This will export a set of FITS images of either the fields specified
@@ -310,7 +310,7 @@ class FixedResolutionBuffer(object):
         fields : list of strings
             These fields will be pixelized and output. If "None", the keys of the
             FRB will be used.
-        clobber : boolean
+        overwrite : boolean
             If the file exists, this governs whether we will overwrite.
         other_keys : dictionary, optional
             A set of header keys and values to write into the FITS header.
@@ -336,7 +336,7 @@ class FixedResolutionBuffer(object):
         if other_keys is not None:
             for k,v in other_keys.items():
                 fib.update_all_headers(k,v)
-        fib.writeto(filename, clobber=clobber)
+        fib.writeto(filename, overwrite=overwrite, **kwargs)
 
     def export_dataset(self, fields=None, nprocs=1):
         r"""Export a set of pixelized fields to an in-memory dataset that can be

--- a/yt/visualization/tests/test_fits_image.py
+++ b/yt/visualization/tests/test_fits_image.py
@@ -50,7 +50,7 @@ def test_fits_image():
     assert_equal(fid1["density"].data, fits_prj["density"].data)
     assert_equal(fid1["temperature"].data, fits_prj["temperature"].data)
 
-    fid1.writeto("fid1.fits", clobber=True)
+    fid1.writeto("fid1.fits", overwrite=True)
     new_fid1 = FITSImageData.from_file("fid1.fits")
 
     assert_equal(fid1["density"].data, new_fid1["density"].data)
@@ -96,7 +96,7 @@ def test_fits_image():
     assert_equal(fid3["temperature"].data, fits_cut["temperature"].data)
 
     fid3.create_sky_wcs([30.,45.], (1.0,"arcsec/kpc"))
-    fid3.writeto("fid3.fits", clobber=True)
+    fid3.writeto("fid3.fits", overwrite=True)
     new_fid3 = FITSImageData.from_file("fid3.fits")
     assert_same_wcs(fid3.wcs, new_fid3.wcs)
     assert new_fid3.wcs.wcs.cunit[0] == "deg"

--- a/yt/visualization/volume_rendering/image_handling.py
+++ b/yt/visualization/volume_rendering/image_handling.py
@@ -40,7 +40,7 @@ def export_rgba(image, fn, h5=True, fits=False, ):
         data["b"] = image[:,:,2]
         data["a"] = image[:,:,3]
         fib = FITSImageData(data)
-        fib.writeto('%s.fits'%fn,clobber=True)
+        fib.writeto('%s.fits'%fn,overwrite=True)
 
 def import_rgba(name, h5=True):
     """


### PR DESCRIPTION
Eventually AstroPy is going to get rid of the `clobber` keyword when writing FITS files completely (it appears they tried recently but balked because of the volume of legacy code, see discussion at astropy/astropy#6381). Currently `overwrite` is recommended for overwriting files. 

This PR goes through the code wherever we use the `clobber` keyword argument and replaces it with `overwrite`, allowing `clobber` to be caught in `**kwargs` and issuing a deprecation warning if it is found.  