### PR TITLE
Make it possible to create a ProfilePlot and PhasePlot from a dataset

### DIFF
--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -33,6 +33,10 @@ from .plot_container import \
     validate_plot, invalidate_plot
 from yt.data_objects.profiles import \
     create_profile
+from yt.data_objects.static_output import \
+    Dataset
+from yt.data_objects.data_containers import \
+    YTSelectionContainer
 from yt.frontends.ytdata.data_structures import \
     YTProfileDataset
 from yt.utilities.exceptions import \
@@ -118,6 +122,15 @@ def sanitize_label(label, nprofiles):
 
     return label
 
+def data_object_or_all_data(data_source):
+    if isinstance(data_source, Dataset):
+        data_source = data_source.all_data()
+
+    if not isinstance(data_source, YTSelectionContainer):
+        raise RuntimeError("data_source must be a yt selection data object")
+
+    return data_source
+
 class ProfilePlot(object):
     r"""
     Create a 1d profile plot from a data source or from a list 
@@ -135,7 +148,8 @@ class ProfilePlot(object):
     ----------
     data_source : YTSelectionContainer Object
         The data object to be profiled, such as all_data, region, or 
-        sphere.
+        sphere. If a dataset is passed in instead, an all_data data object
+        is generated internally from the dataset.
     x_field : str
         The binning field for the profile.
     y_fields : str or list
@@ -221,6 +235,8 @@ class ProfilePlot(object):
                  accumulation=False, fractional=False,
                  label=None, plot_spec=None,
                  x_log=None, y_log=None):
+
+        data_source = data_object_or_all_data(data_source)
 
         if x_log is None:
             logs = None
@@ -833,7 +849,8 @@ class PhasePlot(ImagePlotContainer):
     ----------
     data_source : YTSelectionContainer Object
         The data object to be profiled, such as all_data, region, or 
-        sphere.
+        sphere. If a dataset is passed in instead, an all_data data object
+        is generated internally from the dataset.
     x_field : str
         The x binning field for the profile.
     y_field : str
@@ -897,6 +914,8 @@ class PhasePlot(ImagePlotContainer):
                  weight_field="cell_mass", x_bins=128, y_bins=128,
                  accumulation=False, fractional=False,
                  fontsize=18, figure_size=8.0):
+
+        data_source = data_object_or_all_data(data_source)
 
         if isinstance(data_source.ds, YTProfileDataset):
             profile = data_source.ds.profile

--- a/yt/visualization/tests/test_profile_plots.py
+++ b/yt/visualization/tests/test_profile_plots.py
@@ -22,7 +22,8 @@ from yt.testing import \
     fake_random_ds, \
     assert_array_almost_equal, \
     requires_file, \
-    assert_fname
+    assert_fname, \
+    assert_allclose_units
 from yt.visualization.profile_plotter import \
     ProfilePlot, PhasePlot
 from yt.visualization.tests.test_plotwindow import \
@@ -178,6 +179,22 @@ def test_set_labels():
     # make sure we can set the labels without erroring out
     plot.set_ylabel("all", "test ylabel")
     plot.set_xlabel("test xlabel")
+
+def test_create_from_dataset():
+    ds = fake_random_ds(16)
+    plot1 = yt.ProfilePlot(ds, "radius", ["velocity_x", "density"],
+                           weight_field=None)
+    plot2 = yt.ProfilePlot(ds.all_data(), "radius", ["velocity_x", "density"],
+                           weight_field=None)
+    assert_allclose_units(
+        plot1.profiles[0]['density'], plot2.profiles[0]['density'])
+    assert_allclose_units(
+        plot1.profiles[0]['velocity_x'], plot2.profiles[0]['velocity_x'])
+
+    plot1 = yt.PhasePlot(ds, 'density', 'velocity_x', 'cell_mass')
+    plot2 = yt.PhasePlot(ds.all_data(), 'density', 'velocity_x', 'cell_mass')
+    assert_allclose_units(
+        plot1.profile['cell_mass'], plot2.profile['cell_mass'])
 
 class TestAnnotations(unittest.TestCase):
 


### PR DESCRIPTION
Right now if you do:

```
yt.ProfilePlot(ds, 'density', 'temperature')
```

you get an unfriendly `AttributeError` generated inside the `ProfilePlot` initializer. Ditto for `PhasePlot`. Given the `SlicePlot` API, where we explicitly expect people to pass in a dataset, I think erroring out here is needlessly inconsistent.

This PR makes it so that if you pass a `Dataset` instance into the `ProfilePlot` or `PhasePlot` initializer, yt internally generates an `all_data` data object from the dataset. It also adds a check for whether a user passed in another kind of object and raises a more informative error message if someone does pass in something besides a dataset or a data object.