### PR TITLE
Make the (length, unit) tuple parsing a bit more careful. Closes #1748 

### DIFF
--- a/yt/units/tests/test_ytarray.py
+++ b/yt/units/tests/test_ytarray.py
@@ -677,6 +677,8 @@ def test_fix_length():
     new_length = fix_length(length, ds=ds)
     assert_equal(YTQuantity(10, 'cm'), new_length)
 
+    assert_raises(RuntimeError, fix_length, (length, 'code_length'), ds)
+
 def test_code_unit_combinations():
     """
     Test comparing code units coming from different datasets


### PR DESCRIPTION
This makes it so yt raises an error if you pass it a (length, unit) tuple where the length is a quantity with units attached.

I guess this is a backward incompatible change? I could make it issue a warning and ignore the units on the array. I'd prefer to keep the error though so people don't accidentally request yt do something with ambiguous units.
