### PR TITLE
[bugfix] Fix error message in cosmology splice calculation.

### DIFF
--- a/yt/analysis_modules/cosmological_observation/cosmology_splice.py
+++ b/yt/analysis_modules/cosmological_observation/cosmology_splice.py
@@ -168,14 +168,17 @@ class CosmologySplice(object):
                         break
 
                 if current_slice["redshift"] < z_target:
+                    need_fraction = self.cosmology.comoving_radial_distance(
+                        current_slice["redshift"],
+                        cosmology_splice[-1]["redshift"]) / \
+                        self.simulation.box_size
                     raise RuntimeError(
                         ("Cannot create cosmology splice: " +
                          "Getting from z = %f to %f requires " +
                          "max_box_fraction = %f, but max_box_fraction "
                          "is set to %f") %
-                         (z, z_target, (z - current_slice["redshift"]) /
-                          cosmology_splice[-1]["dz_max"],
-                          max_box_fraction))
+                         (z, current_slice["redshift"],
+                          need_fraction, max_box_fraction))
 
                 cosmology_splice.append(current_slice)
                 z = current_slice["redshift"]

--- a/yt/analysis_modules/cosmological_observation/cosmology_splice.py
+++ b/yt/analysis_modules/cosmological_observation/cosmology_splice.py
@@ -169,8 +169,7 @@ class CosmologySplice(object):
 
                 if current_slice["redshift"] < z_target:
                     need_fraction = self.cosmology.comoving_radial_distance(
-                        current_slice["redshift"],
-                        cosmology_splice[-1]["redshift"]) / \
+                        current_slice["redshift"], z) / \
                         self.simulation.box_size
                     raise RuntimeError(
                         ("Cannot create cosmology splice: " +


### PR DESCRIPTION
This fixes the error message printed when the cosmology splice can't connect two datasets.  We were not correctly printing the values of the starting and ending redshifts that we were attempting to connect.