### PR TITLE
use pypi's new support for markdown readmes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,12 +39,8 @@ VERSION = "3.5.dev0"
 if os.path.exists('MANIFEST'):
     os.remove('MANIFEST')
 
-try:
-    import pypandoc
-    long_description = pypandoc.convert_file('README.md', 'rst')
-except (ImportError, IOError):
-    with open('README.md') as file:
-        long_description = file.read()
+with open('README.md') as file:
+    long_description = file.read()
 
 if check_for_openmp() is True:
     omp_args = ['-fopenmp']
@@ -361,6 +357,7 @@ setup(
     version=VERSION,
     description="An analysis and visualization toolkit for volumetric data",
     long_description = long_description,
+    long_description_content_type='text/markdown',
     classifiers=["Development Status :: 5 - Production/Stable",
                  "Environment :: Console",
                  "Intended Audience :: Science/Research",


### PR DESCRIPTION
See https://stackoverflow.com/a/26737258/1382869 for more details about this. This is a new feature of the new pypi implementation (pypi.org).

This pypandoc hack never worked for some reason anyway.

Once this is merged and we do a release, the page for yt on pypi.org will look much nicer than it does right now:

http://pypi.org/project/yt

It won't look nice on the old pypi, but that's getting shut down on Monday anyway.