### PR TITLE
Annotation tweaks

### DIFF
--- a/doc/source/visualizing/callbacks.rst
+++ b/doc/source/visualizing/callbacks.rst
@@ -622,8 +622,8 @@ Add the Current Time and/or Redshift
 
 .. function:: annotate_timestamp(x_pos=None, y_pos=None, corner='lower_left',\
                                  time=True, redshift=False, \
-                                 time_format='t = {time:.0f} {units}', \
-                                 time_unit=None, \
+                                 time_format='t = {time:.1f} {units}', \
+                                 time_unit=None, time_offset=None, \
                                  redshift_format='z = {redshift:.2f}', \
                                  draw_inset_box=False, coord_system='axis', \
                                  text_args=None, inset_box_args=None)
@@ -635,8 +635,9 @@ Add the Current Time and/or Redshift
     location in the image (either in a present corner, or by specifying (x,y)
     image coordinates with the x_pos, y_pos arguments.  If no time_units are
     specified, it will automatically choose appropriate units.  It allows for
-    custom formatting of the time and redshift information, as well as the
-    specification of an inset box around the text.
+    custom formatting of the time and redshift information, the specification
+    of an inset box around the text, and changing the value of the timestamp
+    via a constant offset.
 
 .. python-script::
 
@@ -650,11 +651,14 @@ Add the Current Time and/or Redshift
 
 Add a Physical Scale Bar
 ~~~~~~~~~~~~~~~~~~~~~~~~
+
 .. function:: annotate_scale(corner='lower_right', coeff=None, \
-                             unit=None, pos=None, max_frac=0.16, \
-                             min_frac=0.015, coord_system='axis', \
-                             text_args=None, size_bar_args=None, \
-                             draw_inset_box=False, inset_box_args=None)
+                             unit=None, pos=None, 
+                             scale_text_format="{scale} {units}", \
+                             max_frac=0.16, min_frac=0.015, \
+                             coord_system='axis', text_args=None, \
+                             size_bar_args=None, draw_inset_box=False, \
+                             inset_box_args=None)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.ScaleCallback`.)
@@ -670,7 +674,8 @@ Add a Physical Scale Bar
     dictionary accepts matplotlib's font_properties arguments to override
     the default font_properties for the current plot.  The size_bar_args
     dictionary accepts keyword arguments for the AnchoredSizeBar class in
-    matplotlib's axes_grid toolkit.
+    matplotlib's axes_grid toolkit. Finally, the format of the scale bar text
+    can be adjusted using the scale_text_format keyword argument.
 
 .. python-script::
 

--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -600,6 +600,7 @@ two element tuples.
 
 Flipping the plot view axes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 By default, all :class:`~yt.visualization.plot_window.PlotWindow` objects plot
 with the assumption that the eastern direction on the plot forms a right handed
 coordinate system with the ``normal`` and ``north_vector`` for the system, whether

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -1852,7 +1852,9 @@ class TimestampCallback(PlotCallback):
 
     time_offset : float, (value, unit) tuple, or YTQuantity, optional
         Apply an offset to the time shown in the annotation from the
-        value of the current time. Default: None, meaning no offset.
+        value of the current time. If a scalar value with no units is
+        passed in, the value of the *time_unit* kwarg is used for the
+        units. Default: None, meaning no offset.
 
     text_args : dictionary, optional
         A dictionary of any arbitrary parameters to be passed to the Matplotlib
@@ -2019,11 +2021,12 @@ class ScaleCallback(PlotCallback):
         The image location of the scale bar in the plot coordinate system.
         Setting pos overrides the corner parameter.
 
-    format : string, optional
+    scalebar_text_format : string, optional
         This specifies the format of the scalebar value assuming "scale" is the
         numerical value and "unit" is units of the scale (e.g. 'cm', 'kpc', etc.)
         The scale can be specified to arbitrary precision according to printf
-        formatting codes. Example: "Length = {scale:.2f} {units}".
+        formatting codes. The format string must only specify "scale" and "units".
+        Example: "Length = {scale:.2f} {units}". Default: "{scale} {units}"
 
     min_frac, max_frac: float, optional
         The minimum/maximum fraction of the axis width for the scale bar to
@@ -2075,9 +2078,9 @@ class ScaleCallback(PlotCallback):
     _type_name = "scale"
     _supported_geometries = ("cartesian", "spectral_cube", "force")
     def __init__(self, corner='lower_right', coeff=None, unit=None, pos=None,
-                 format="{scale} {units}", max_frac=0.16, min_frac=0.015, 
-                 coord_system='axis', text_args=None, size_bar_args=None, 
-                 draw_inset_box=False, inset_box_args=None):
+                 scale_text_format="{scale} {units}", max_frac=0.16, 
+                 min_frac=0.015, coord_system='axis', text_args=None, 
+                 size_bar_args=None, draw_inset_box=False, inset_box_args=None):
 
         def_size_bar_args = {
             'pad': 0.05,
@@ -2102,7 +2105,7 @@ class ScaleCallback(PlotCallback):
         self.max_frac = max_frac
         self.min_frac = min_frac
         self.coord_system = coord_system
-        self.format = format
+        self.scale_text_format = scale_text_format
         if size_bar_args is None:
             self.size_bar_args = def_size_bar_args
         else:
@@ -2157,7 +2160,8 @@ class ScaleCallback(PlotCallback):
             self.coeff = max_scale.v
             self.unit = max_scale.units
         self.scale = YTQuantity(self.coeff, self.unit)
-        text = self.format.format(scale=int(self.coeff), units=self.unit)
+        text = self.scale_text_format.format(scale=int(self.coeff), 
+                                             units=self.unit)
         image_scale = (plot.frb.convert_distance_x(self.scale) /
                        plot.frb.convert_distance_x(xsize)).v
         size_vertical = self.size_bar_args.pop(

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -1880,10 +1880,13 @@ class TimestampCallback(PlotCallback):
                  draw_inset_box=False, coord_system='axis', time_offset=None,
                  text_args=None, inset_box_args=None):
 
-        def_text_args = {'color':'white', 'horizontalalignment':'center',
-                         'verticalalignment':'top'}
-        def_inset_box_args = {'boxstyle':'square,pad=0.3', 'facecolor':'black',
-                              'linewidth':3, 'edgecolor':'white', 'alpha':0.5}
+        def_text_args = {'color': 'white',
+                         'horizontalalignment': 'center',
+                         'verticalalignment': 'top'}
+        def_inset_box_args = {'boxstyle': 'square,pad=0.3',
+                              'facecolor': 'black',
+                              'linewidth': 3,
+                              'edgecolor': 'white', 'alpha': 0.5}
 
         # Set position based on corner argument.
         self.pos = (x_pos, y_pos)

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -1850,6 +1850,10 @@ class TimestampCallback(PlotCallback):
 
             "figure" -- the MPL figure coordinates: (0,0) is lower left, (1,1) is upper right
 
+    time_offset : float, (value, unit) tuple, or YTQuantity, optional
+        Apply an offset to the time shown in the annotation from the
+        value of the current time. Default: None, meaning no offset.
+
     text_args : dictionary, optional
         A dictionary of any arbitrary parameters to be passed to the Matplotlib
         text object.  Defaults: ``{'color':'white',
@@ -2011,6 +2015,12 @@ class ScaleCallback(PlotCallback):
     pos : 2- or 3-element tuples, lists, or arrays, optional
         The image location of the scale bar in the plot coordinate system.
         Setting pos overrides the corner parameter.
+
+    format : string, optional
+        This specifies the format of the scalebar value assuming "scale" is the
+        numerical value and "unit" is units of the scale (e.g. 'cm', 'kpc', etc.)
+        The scale can be specified to arbitrary precision according to printf
+        formatting codes. Example: "Length = {scale:.2f} {units}".
 
     min_frac, max_frac: float, optional
         The minimum/maximum fraction of the axis width for the scale bar to

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -1943,6 +1943,9 @@ class TimestampCallback(PlotCallback):
                     toffset = plot.ds.quan(self.time_offset[0], self.time_offset[1])
                 elif isinstance(self.time_offset, Number):
                     toffset = plot.ds.quan(self.time_offset, self.time_unit)
+                elif not isinstance(self.time_offset, YTQuantity):
+                    raise RuntimeError("'time_offset' must be a float, tuple, or"
+                                       "YTQuantity!")
                 t -= toffset.in_units(self.time_unit)
             self.text += self.time_format.format(time=float(t),
                                                  units=self.time_unit)

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -2021,13 +2021,6 @@ class ScaleCallback(PlotCallback):
         The image location of the scale bar in the plot coordinate system.
         Setting pos overrides the corner parameter.
 
-    scalebar_text_format : string, optional
-        This specifies the format of the scalebar value assuming "scale" is the
-        numerical value and "unit" is units of the scale (e.g. 'cm', 'kpc', etc.)
-        The scale can be specified to arbitrary precision according to printf
-        formatting codes. The format string must only specify "scale" and "units".
-        Example: "Length = {scale:.2f} {units}". Default: "{scale} {units}"
-
     min_frac, max_frac: float, optional
         The minimum/maximum fraction of the axis width for the scale bar to
         extend. A value of 1 would allow the scale bar to extend across the
@@ -2066,6 +2059,12 @@ class ScaleCallback(PlotCallback):
         object that represents the inset box.
         Defaults: ``{'facecolor': 'black', 'linewidth': 3, 'edgecolor': 'white', 'alpha': 0.5, 'boxstyle': 'square'}``
 
+    scale_text_format : string, optional
+        This specifies the format of the scalebar value assuming "scale" is the
+        numerical value and "unit" is units of the scale (e.g. 'cm', 'kpc', etc.)
+        The scale can be specified to arbitrary precision according to printf
+        formatting codes. The format string must only specify "scale" and "units".
+        Example: "Length = {scale:.2f} {units}". Default: "{scale} {units}"
 
     Example
     -------
@@ -2078,9 +2077,9 @@ class ScaleCallback(PlotCallback):
     _type_name = "scale"
     _supported_geometries = ("cartesian", "spectral_cube", "force")
     def __init__(self, corner='lower_right', coeff=None, unit=None, pos=None,
-                 scale_text_format="{scale} {units}", max_frac=0.16, 
-                 min_frac=0.015, coord_system='axis', text_args=None, 
-                 size_bar_args=None, draw_inset_box=False, inset_box_args=None):
+                 max_frac=0.16, min_frac=0.015, coord_system='axis', 
+                 text_args=None, size_bar_args=None, draw_inset_box=False, 
+                 inset_box_args=None, scale_text_format="{scale} {units}"):
 
         def_size_bar_args = {
             'pad': 0.05,


### PR DESCRIPTION
This PR adds two tweaks to plot annotations.

* An offset for timestamps, e.g. if you want to make the timestamp shown on the plot to be (say) `ds.current_time` - 5 Gyr so that the zero is at a different time.

* A `format` argument for the `ScaleCallback` similar to the `time_format` argument for the `TimestampCallback`. 

Not sure what would be a good test here, still need to add notes to the narrative documentation. Suggestions welcome.