### PR TITLE
Set up magnetic field in GIZMO frontend

### DIFF
--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -1645,6 +1645,11 @@ may load Gizmo datasets as Gadget depending on the circumstances, but this
 should not pose a problem in most situations.  FIRE outputs will be loaded
 accordingly due to the number of metallicity fields found (11 or 17).
 
+If ``("PartType0", "MagneticField")`` is present in the output, it would be
+loaded and aliased to ``("PartType0", "particle_magnetic_field")``. The
+corresponding component field like ``("PartType0", "particle_magnetic_field_x")``
+would be added automatically.
+
 For Gizmo outputs written as raw binary outputs, you may have to specify
 a bounding box, field specification, and units as are done for standard
 Gadget outputs.  See :ref:`loading-gadget-data` for more information.

--- a/yt/fields/field_detector.py
+++ b/yt/fields/field_detector.py
@@ -130,7 +130,7 @@ class FieldDetector(defaultdict):
                "Velocity" in (item, item[1]) or \
                "Velocities" in (item, item[1]) or \
                "Coordinates" in (item, item[1]) or \
-               "MagneticField" in ((item, item[1])):
+               "MagneticField" in (item, item[1]):
                 # A vector
                 self[item] = \
                   YTArray(np.ones((self.NumberOfParticles, 3)),

--- a/yt/fields/field_detector.py
+++ b/yt/fields/field_detector.py
@@ -126,9 +126,11 @@ class FieldDetector(defaultdict):
         elif finfo is not None and finfo.particle_type:
             if "particle_position" in (item, item[1]) or \
                "particle_velocity" in (item, item[1]) or \
+               "particle_magnetic_field" in (item, item[1]) or \
                "Velocity" in (item, item[1]) or \
                "Velocities" in (item, item[1]) or \
-               "Coordinates" in (item, item[1]):
+               "Coordinates" in (item, item[1]) or \
+               "MagneticField" in ((item, item[1])):
                 # A vector
                 self[item] = \
                   YTArray(np.ones((self.NumberOfParticles, 3)),

--- a/yt/fields/magnetic_field.py
+++ b/yt/fields/magnetic_field.py
@@ -213,8 +213,7 @@ def setup_magnetic_field_aliases(registry, ds_ftype, ds_fields, ftype="gas"):
     else:
         # Otherwise, we assume a particle dataset
         sampling_type = "particle"
-        ds_field = ds_fields
-        ds_field = (ds_ftype, ds_field)
+        ds_field = (ds_ftype, ds_fields)
     if ds_field not in registry:
         return
 

--- a/yt/fields/magnetic_field.py
+++ b/yt/fields/magnetic_field.py
@@ -195,6 +195,8 @@ def setup_magnetic_field_aliases(registry, ds_ftype, ds_fields, ftype="gas"):
     ...         setup_magnetic_field_aliases(self, "chombo", ["bx%s" % ax for ax in [1,2,3]])
     """
     ds_fields = [(ds_ftype, fd) for fd in ds_fields]
+    if ds_fields[0] not in registry:
+        return
     convert, units = _setup_magnet_unit_conversion(registry, ds_fields[0])
     def mag_field(fd):
         def _mag_field(field, data):
@@ -232,6 +234,8 @@ def setup_particle_magnetic_field_aliases(registry, ds_ptype, ds_field):
     ...                                               "MagneticField")
     """
     ds_field = (ds_ptype, ds_field)
+    if ds_field not in registry:
+        return
     convert, units = _setup_magnet_unit_conversion(registry, ds_field)
     def mag_field(ax):
         def _mag_field(field, data):
@@ -246,8 +250,6 @@ def setup_particle_magnetic_field_aliases(registry, ds_ptype, ds_field):
 def _setup_magnet_unit_conversion(registry, ds_field):
     """Figure out the unit conversion to use for the magnetic field."""
     unit_system = registry.ds.unit_system
-    if ds_field not in registry:
-        return
     from_units = Unit(registry[ds_field].units,
                       registry=registry.ds.unit_registry)
     if dimensions.current_mks in unit_system.base_units:

--- a/yt/fields/tests/test_magnetic_fields.py
+++ b/yt/fields/tests/test_magnetic_fields.py
@@ -19,7 +19,7 @@ def test_magnetic_fields():
 
     ds1 = load_uniform_grid(data1, ddims, unit_system="cgs")
     ds2 = load_uniform_grid(data2, ddims, unit_system="mks")
-    # By default, code units are cgs units
+    # For this test dataset, code units are cgs units
     ds3 = load_uniform_grid(data2, ddims, unit_system="code")
 
     ds1.index

--- a/yt/fields/tests/test_magnetic_fields.py
+++ b/yt/fields/tests/test_magnetic_fields.py
@@ -19,12 +19,16 @@ def test_magnetic_fields():
 
     ds1 = load_uniform_grid(data1, ddims, unit_system="cgs")
     ds2 = load_uniform_grid(data2, ddims, unit_system="mks")
+    # By default, code units are cgs units
+    ds3 = load_uniform_grid(data2, ddims, unit_system="code")
 
     ds1.index
     ds2.index
+    ds3.index
 
     dd1 = ds1.all_data()
     dd2 = ds2.all_data()
+    dd3 = ds3.all_data()
 
     assert ds1.fields.gas.magnetic_field_strength.units == "gauss"
     assert ds1.fields.gas.magnetic_field_poloidal.units == "gauss"
@@ -32,6 +36,9 @@ def test_magnetic_fields():
     assert ds2.fields.gas.magnetic_field_strength.units == "T"
     assert ds2.fields.gas.magnetic_field_poloidal.units == "T"
     assert ds2.fields.gas.magnetic_field_toroidal.units == "T"
+    assert ds3.fields.gas.magnetic_field_strength.units == "code_magnetic"
+    assert ds3.fields.gas.magnetic_field_poloidal.units == "code_magnetic"
+    assert ds3.fields.gas.magnetic_field_toroidal.units == "code_magnetic"
 
     emag1 = (dd1["magnetic_field_x"]**2 +
              dd1["magnetic_field_y"]**2 +
@@ -43,10 +50,18 @@ def test_magnetic_fields():
              dd2["magnetic_field_z"]**2)/(2.0*mu_0)
     emag2.convert_to_units("Pa")
 
+    emag3 = (dd3["magnetic_field_x"]**2 +
+             dd3["magnetic_field_y"]**2 +
+             dd3["magnetic_field_z"]**2)/(8.0*np.pi)
+    emag3.convert_to_units("code_pressure")
+
     assert_almost_equal(emag1, dd1["magnetic_energy"])
     assert_almost_equal(emag2, dd2["magnetic_energy"])
+    assert_almost_equal(emag3, dd3["magnetic_energy"])
 
     assert str(emag1.units) == str(dd1["magnetic_energy"].units)
     assert str(emag2.units) == str(dd2["magnetic_energy"].units)
+    assert str(emag3.units) == str(dd3["magnetic_energy"].units)
 
     assert_almost_equal(emag1.in_cgs(), emag2.in_cgs())
+    assert_almost_equal(emag1.in_cgs(), emag3.in_cgs())

--- a/yt/fields/tests/test_magnetic_fields.py
+++ b/yt/fields/tests/test_magnetic_fields.py
@@ -1,4 +1,5 @@
 import numpy as np
+import yt
 from yt.utilities.physical_constants import mu_0
 from yt.testing import assert_almost_equal
 from yt.frontends.stream.api import load_uniform_grid
@@ -7,6 +8,9 @@ def setup():
     from yt.config import ytcfg
     ytcfg["yt","__withintesting"] = "True"
 
+gizmo_mhd = "gizmo_mhd_mwdisk/gizmo_mhd_mwdisk.hdf5"
+
+@requires_ds(gizmo_mhd, big_data=True)
 def test_magnetic_fields():
 
     ddims = (16,16,16)
@@ -19,12 +23,15 @@ def test_magnetic_fields():
 
     ds1 = load_uniform_grid(data1, ddims, unit_system="cgs")
     ds2 = load_uniform_grid(data2, ddims, unit_system="mks")
+    ds3 = yt.load(gizmo_mhd, bounding_box=[[-400, 400]]*3, unit_system="code")
 
     ds1.index
     ds2.index
+    ds3.index
 
     dd1 = ds1.all_data()
     dd2 = ds2.all_data()
+    dd3 = ds3.all_data()
 
     assert ds1.fields.gas.magnetic_field_strength.units == "gauss"
     assert ds1.fields.gas.magnetic_field_poloidal.units == "gauss"
@@ -32,6 +39,7 @@ def test_magnetic_fields():
     assert ds2.fields.gas.magnetic_field_strength.units == "T"
     assert ds2.fields.gas.magnetic_field_poloidal.units == "T"
     assert ds2.fields.gas.magnetic_field_toroidal.units == "T"
+    assert ds3.fields.PartType0.particle_magnetic_field.units == "code_magnetic"
 
     emag1 = (dd1["magnetic_field_x"]**2 +
              dd1["magnetic_field_y"]**2 +

--- a/yt/fields/tests/test_magnetic_fields.py
+++ b/yt/fields/tests/test_magnetic_fields.py
@@ -1,5 +1,4 @@
 import numpy as np
-import yt
 from yt.utilities.physical_constants import mu_0
 from yt.testing import assert_almost_equal
 from yt.frontends.stream.api import load_uniform_grid
@@ -8,9 +7,6 @@ def setup():
     from yt.config import ytcfg
     ytcfg["yt","__withintesting"] = "True"
 
-gizmo_mhd = "gizmo_mhd_mwdisk/gizmo_mhd_mwdisk.hdf5"
-
-@requires_ds(gizmo_mhd, big_data=True)
 def test_magnetic_fields():
 
     ddims = (16,16,16)
@@ -23,15 +19,12 @@ def test_magnetic_fields():
 
     ds1 = load_uniform_grid(data1, ddims, unit_system="cgs")
     ds2 = load_uniform_grid(data2, ddims, unit_system="mks")
-    ds3 = yt.load(gizmo_mhd, bounding_box=[[-400, 400]]*3, unit_system="code")
 
     ds1.index
     ds2.index
-    ds3.index
 
     dd1 = ds1.all_data()
     dd2 = ds2.all_data()
-    dd3 = ds3.all_data()
 
     assert ds1.fields.gas.magnetic_field_strength.units == "gauss"
     assert ds1.fields.gas.magnetic_field_poloidal.units == "gauss"
@@ -39,7 +32,6 @@ def test_magnetic_fields():
     assert ds2.fields.gas.magnetic_field_strength.units == "T"
     assert ds2.fields.gas.magnetic_field_poloidal.units == "T"
     assert ds2.fields.gas.magnetic_field_toroidal.units == "T"
-    assert ds3.fields.PartType0.particle_magnetic_field.units == "code_magnetic"
 
     emag1 = (dd1["magnetic_field_x"]**2 +
              dd1["magnetic_field_y"]**2 +

--- a/yt/frontends/gizmo/fields.py
+++ b/yt/frontends/gizmo/fields.py
@@ -15,7 +15,7 @@ Gizmo-specific fields
 #-----------------------------------------------------------------------------
 
 from yt.fields.magnetic_field import \
-    setup_particle_magnetic_field_aliases
+    setup_magnetic_field_aliases
 from yt.fields.field_info_container import \
     FieldInfoContainer
 from yt.fields.particle_fields import \
@@ -140,4 +140,6 @@ class GizmoFieldInfo(GadgetFieldInfo):
 
         magnetic_field = "MagneticField"
         if (ptype, magnetic_field) in self.field_list:
-            setup_particle_magnetic_field_aliases(self, ptype, magnetic_field)
+            setup_magnetic_field_aliases(
+                self, ptype, magnetic_field, ftype=ptype
+            )

--- a/yt/frontends/gizmo/fields.py
+++ b/yt/frontends/gizmo/fields.py
@@ -14,10 +14,10 @@ Gizmo-specific fields
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-from yt.fields.magnetic_field import \
-    setup_magnetic_field_aliases
 from yt.fields.field_info_container import \
     FieldInfoContainer
+from yt.fields.magnetic_field import \
+    setup_magnetic_field_aliases
 from yt.fields.particle_fields import \
     add_volume_weighted_smoothed_field
 from yt.fields.species_fields import \

--- a/yt/frontends/gizmo/fields.py
+++ b/yt/frontends/gizmo/fields.py
@@ -14,6 +14,8 @@ Gizmo-specific fields
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
+from yt.fields.magnetic_field import \
+    setup_particle_magnetic_field_aliases
 from yt.fields.field_info_container import \
     FieldInfoContainer
 from yt.fields.particle_fields import \
@@ -36,6 +38,7 @@ class GizmoFieldInfo(GadgetFieldInfo):
         ("Coordinates", ("code_length", ["particle_position"], None)),
         ("Velocity", ("code_velocity", ["particle_velocity"], None)),
         ("Velocities", ("code_velocity", ["particle_velocity"], None)),
+        ("MagneticField", ("code_magnetic", ["particle_magnetic_field"], None)),
         ("ParticleIDs", ("", ["particle_index"], None)),
         ("InternalEnergy", ("code_specific_energy", ["thermal_energy"], None)),
         ("SmoothingLength", ("code_length", ["smoothing_length"], None)),
@@ -134,3 +137,7 @@ class GizmoFieldInfo(GadgetFieldInfo):
                     self, num_neighbors)
 
                 self.alias(("gas", field), fn[0])
+
+        magnetic_field = "MagneticField"
+        if (ptype, magnetic_field) in self.field_list:
+            setup_particle_magnetic_field_aliases(self, ptype, magnetic_field)

--- a/yt/frontends/gizmo/tests/test_outputs.py
+++ b/yt/frontends/gizmo/tests/test_outputs.py
@@ -74,4 +74,4 @@ def test_gizmo_mhd():
     for axis in 'xyz':
         f = ad[ptype, fmag + '_' + axis]
         assert str(f.units) == 'code_magnetic'
-        assert f.shape == (409013, 1)
+        assert f.shape == (409013,)

--- a/yt/frontends/gizmo/tests/test_outputs.py
+++ b/yt/frontends/gizmo/tests/test_outputs.py
@@ -56,7 +56,11 @@ def test_gizmo_mhd():
     """
     Magnetic fields should be loaded correctly when they are present.
     """
-    ds = data_dir_load(gmhd, kwargs={'bounding_box': [[-400, 400]] * 3})
+    kwargs = {
+        'bounding_box': [[-400, 400]] * 3,
+        'unit_system': 'code'
+    }
+    ds = data_dir_load(gmhd, kwargs=kwargs)
     ad = ds.all_data()
     ptype = 'PartType0'
 

--- a/yt/frontends/gizmo/tests/test_outputs.py
+++ b/yt/frontends/gizmo/tests/test_outputs.py
@@ -39,6 +39,8 @@ fields = OrderedDict(
 )
 
 g64 = "gizmo_64/output/snap_N64L16_135.hdf5"
+gmhd = "gizmo_mhd_mwdisk/gizmo_mhd_mwdisk.hdf5"
+
 
 @requires_ds(g64, big_data=True)
 def test_gizmo_64():
@@ -47,3 +49,25 @@ def test_gizmo_64():
     for test in sph_answer(ds, 'snap_N64L16_135', 524288, fields):
         test_gizmo_64.__name__ = test.description
         yield test
+
+
+@requires_ds(gmhd, big_data=True)
+def test_gizmo_mhd():
+    """
+    Magnetic fields should be loaded correctly when they are present.
+    """
+    ds = data_dir_load(gmhd, kwargs={'bounding_box': [[-400, 400]] * 3})
+    ad = ds.all_data()
+    ptype = 'PartType0'
+
+    # Test vector magnetic field
+    fmag = 'particle_magnetic_field'
+    f = ad[ptype, fmag]
+    assert str(f.units) == 'code_magnetic'
+    assert f.shape == (409013, 3)
+
+    # Test component magnetic fields
+    for axis in 'xyz':
+        f = ad[ptype, fmag + '_' + axis]
+        assert str(f.units) == 'code_magnetic'
+        assert f.shape == (409013, 1)


### PR DESCRIPTION
## PR Summary

A function to set up magnetic field aliases for particle dataset is implemented. And it is used to set up the magnetic field in GIZMO frontend.

## PR Checklist

- [x] Code passes flake8 checker
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds tests for new features
