### PR TITLE
Adding ImportError checks for pyembree

### DIFF
--- a/yt/visualization/volume_rendering/render_source.py
+++ b/yt/visualization/volume_rendering/render_source.py
@@ -35,11 +35,13 @@ from yt.utilities.lib.misc_utilities import \
 from yt.utilities.on_demand_imports import NotAModule
 try:
     from yt.utilities.lib import mesh_traversal
+# Catch ValueError in case size of objects in Cython change
 except (ImportError, ValueError):
     mesh_traversal = NotAModule("pyembree")
     ytcfg["yt", "ray_tracing_engine"] = "yt"
 try:
     from yt.utilities.lib import mesh_construction
+# Catch ValueError in case size of objects in Cython change
 except (ImportError, ValueError):
     mesh_construction = NotAModule("pyembree")
     ytcfg["yt", "ray_tracing_engine"] = "yt"

--- a/yt/visualization/volume_rendering/render_source.py
+++ b/yt/visualization/volume_rendering/render_source.py
@@ -35,12 +35,12 @@ from yt.utilities.lib.misc_utilities import \
 from yt.utilities.on_demand_imports import NotAModule
 try:
     from yt.utilities.lib import mesh_traversal
-except ImportError:
+except (ImportError, ValueError):
     mesh_traversal = NotAModule("pyembree")
     ytcfg["yt", "ray_tracing_engine"] = "yt"
 try:
     from yt.utilities.lib import mesh_construction
-except ImportError:
+except (ImportError, ValueError):
     mesh_construction = NotAModule("pyembree")
     ytcfg["yt", "ray_tracing_engine"] = "yt"
 

--- a/yt/visualization/volume_rendering/utils.py
+++ b/yt/visualization/volume_rendering/utils.py
@@ -9,7 +9,7 @@ from yt.utilities.lib.image_samplers import \
 from yt.utilities.on_demand_imports import NotAModule
 try:
     from yt.utilities.lib import mesh_traversal
-except ImportError:
+except (ImportError, ValueError):
     mesh_traversal = NotAModule("pyembree")
 
 def data_source_or_all(data_source):

--- a/yt/visualization/volume_rendering/utils.py
+++ b/yt/visualization/volume_rendering/utils.py
@@ -9,7 +9,8 @@ from yt.utilities.lib.image_samplers import \
 from yt.utilities.on_demand_imports import NotAModule
 try:
     from yt.utilities.lib import mesh_traversal
-except (ImportError, ValueError):
+# Catch ValueError in case size of objects in Cython change
+except (ImportError, ValueError): 
     mesh_traversal = NotAModule("pyembree")
 
 def data_source_or_all(data_source):


### PR DESCRIPTION
I recently ran into an issue which I *believe* is due to a recent rebuild of pyembree on conda.  The size of the object changed in Cython, which caused importing to fail -- but *not* by throwing an `ImportError`.  Because the object size changed, it threw a `ValueError` instead.  This caused the entire `yt` import to fail.

I'm not *certain* but it's possible that there's a way that current conda installs might make this happen.  It was on my jupyterhub for class, so it's way less likely that I did something strange with the installation, as I don't have any development there.

Regardless, this fixes the issue.

(ping @scopatz as well)