### PR TITLE
[WIP] Adding a new frontend for the Denovo neutral particle radiation transport code

### DIFF
--- a/yt/frontends/api.py
+++ b/yt/frontends/api.py
@@ -24,6 +24,7 @@ _frontends = [
     'athena_pp',
     'boxlib',
     'chombo',
+    'denovo',
     'eagle',
     'enzo',
     'enzo_p',

--- a/yt/frontends/denovo/__init__.py
+++ b/yt/frontends/denovo/__init__.py
@@ -1,0 +1,14 @@
+"""
+API for yt.frontends._skeleton
+
+
+
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013, yt Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------

--- a/yt/frontends/denovo/__init__.py
+++ b/yt/frontends/denovo/__init__.py
@@ -1,5 +1,5 @@
 """
-API for yt.frontends._skeleton
+API for yt.frontends.denovo
 
 
 

--- a/yt/frontends/denovo/api.py
+++ b/yt/frontends/denovo/api.py
@@ -1,0 +1,25 @@
+"""
+API for yt.frontends._skeleton
+
+
+
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013, yt Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from .data_structures import \
+      SkeletonGrid, \
+      SkeletonHierarchy, \
+      SkeletonDataset
+
+from .fields import \
+      SkeletonFieldInfo
+
+from .io import \
+      SkeletonIOHandler

--- a/yt/frontends/denovo/api.py
+++ b/yt/frontends/denovo/api.py
@@ -1,5 +1,5 @@
 """
-API for yt.frontends._skeleton
+API for Denovo frontend
 
 
 
@@ -14,12 +14,14 @@ API for yt.frontends._skeleton
 #-----------------------------------------------------------------------------
 
 from .data_structures import \
-      SkeletonGrid, \
-      SkeletonHierarchy, \
-      SkeletonDataset
+      DenovoGrid, \
+      DenovoHierarchy, \
+      DenovoDataset
 
 from .fields import \
-      SkeletonFieldInfo
+      DenovoFieldInfo
 
 from .io import \
-      SkeletonIOHandler
+      IOHandlerDenovoHDF5
+
+from . import tests

--- a/yt/frontends/denovo/api.py
+++ b/yt/frontends/denovo/api.py
@@ -14,7 +14,7 @@ API for Denovo frontend
 #-----------------------------------------------------------------------------
 
 from .data_structures import \
-      DenovoGrid, \
+      DenovoMesh, \
       DenovoHierarchy, \
       DenovoDataset
 

--- a/yt/frontends/denovo/api.py
+++ b/yt/frontends/denovo/api.py
@@ -15,7 +15,7 @@ API for Denovo frontend
 
 from .data_structures import \
       DenovoMesh, \
-      DenovoHierarchy, \
+      DenovoIndex, \
       DenovoDataset
 
 from .fields import \

--- a/yt/frontends/denovo/data_structures.py
+++ b/yt/frontends/denovo/data_structures.py
@@ -1,0 +1,152 @@
+"""
+Skeleton data structures
+
+
+
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013, yt Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+import os
+import numpy as np
+import weakref
+
+from yt.data_objects.grid_patch import \
+    AMRGridPatch
+from yt.geometry.grid_geometry_handler import \
+    GridIndex
+from yt.data_objects.static_output import \
+    Dataset
+from .fields import SkeletonFieldInfo
+
+
+class SkeletonGrid(AMRGridPatch):
+    _id_offset = 0
+
+    def __init__(self, id, index, level):
+        AMRGridPatch.__init__(self, id, filename=index.index_filename,
+                              index=index)
+        self.Parent = None
+        self.Children = []
+        self.Level = level
+
+    def __repr__(self):
+        return "SkeletonGrid_%04i (%s)" % (self.id, self.ActiveDimensions)
+
+
+class SkeletonHierarchy(GridIndex):
+    grid = SkeletonGrid
+
+    def __init__(self, ds, dataset_type='skeleton'):
+        self.dataset_type = dataset_type
+        self.dataset = weakref.proxy(ds)
+        # for now, the index file is the dataset!
+        self.index_filename = self.dataset.parameter_filename
+        self.directory = os.path.dirname(self.index_filename)
+        # float type for the simulation edges and must be float64 now
+        self.float_type = np.float64
+        GridIndex.__init__(self, ds, dataset_type)
+
+    def _detect_output_fields(self):
+        # This needs to set a self.field_list that contains all the available,
+        # on-disk fields. No derived fields should be defined here.
+        # NOTE: Each should be a tuple, where the first element is the on-disk
+        # fluid type or particle type.  Convention suggests that the on-disk
+        # fluid type is usually the dataset_type and the on-disk particle type
+        # (for a single population of particles) is "io".
+        pass
+
+    def _count_grids(self):
+        # This needs to set self.num_grids
+        pass
+
+    def _parse_index(self):
+        # This needs to fill the following arrays, where N is self.num_grids:
+        #   self.grid_left_edge         (N, 3) <= float64
+        #   self.grid_right_edge        (N, 3) <= float64
+        #   self.grid_dimensions        (N, 3) <= int
+        #   self.grid_particle_count    (N, 1) <= int
+        #   self.grid_levels            (N, 1) <= int
+        #   self.grids                  (N, 1) <= grid objects
+        #   self.max_level = self.grid_levels.max()
+        pass
+
+    def _populate_grid_objects(self):
+        # For each grid, this must call:
+        #   grid._prepare_grid()
+        #   grid._setup_dx()
+        # This must also set:
+        #   grid.Children <= list of child grids
+        #   grid.Parent   <= parent grid
+        # This is handled by the frontend because often the children must be
+        # identified.
+        pass
+
+
+class SkeletonDataset(Dataset):
+    _index_class = SkeletonHierarchy
+    _field_info_class = SkeletonFieldInfo
+
+    def __init__(self, filename, dataset_type='skeleton',
+                 storage_filename=None,
+                 units_override=None):
+        self.fluid_types += ('skeleton',)
+        Dataset.__init__(self, filename, dataset_type,
+                         units_override=units_override)
+        self.storage_filename = storage_filename
+        # refinement factor between a grid and its subgrid
+        # self.refine_by = 2
+
+    def _set_code_unit_attributes(self):
+        # This is where quantities are created that represent the various
+        # on-disk units.  These are the currently available quantities which
+        # should be set, along with examples of how to set them to standard
+        # values.
+        #
+        # self.length_unit = self.quan(1.0, "cm")
+        # self.mass_unit = self.quan(1.0, "g")
+        # self.time_unit = self.quan(1.0, "s")
+        # self.time_unit = self.quan(1.0, "s")
+        #
+        # These can also be set:
+        # self.velocity_unit = self.quan(1.0, "cm/s")
+        # self.magnetic_unit = self.quan(1.0, "gauss")
+        pass
+
+    def _parse_parameter_file(self):
+        # This needs to set up the following items.  Note that these are all
+        # assumed to be in code units; domain_left_edge and domain_right_edge
+        # will be converted to YTArray automatically at a later time.
+        # This includes the cosmological parameters.
+        #
+        #   self.unique_identifier      <= unique identifier for the dataset
+        #                                  being read (e.g., UUID or ST_CTIME)
+        #   self.parameters             <= full of code-specific items of use
+        #   self.domain_left_edge       <= array of float64
+        #   self.domain_right_edge      <= array of float64
+        #   self.dimensionality         <= int
+        #   self.domain_dimensions      <= array of int64
+        #   self.periodicity            <= three-element tuple of booleans
+        #   self.current_time           <= simulation time in code units
+        #
+        # We also set up cosmological information.  Set these to zero if
+        # non-cosmological.
+        #
+        #   self.cosmological_simulation    <= int, 0 or 1
+        #   self.current_redshift           <= float
+        #   self.omega_lambda               <= float
+        #   self.omega_matter               <= float
+        #   self.hubble_constant            <= float
+        pass
+
+    @classmethod
+    def _is_valid(self, *args, **kwargs):
+        # This accepts a filename or a set of arguments and returns True or
+        # False depending on if the file is of the type requested.
+        return False

--- a/yt/frontends/denovo/data_structures.py
+++ b/yt/frontends/denovo/data_structures.py
@@ -161,10 +161,19 @@ class DenovoDataset(Dataset):
         """
 
         loads in all of the parameters located in the 'denovo' group that are
-        not groups themselves and do not start with mesh.
+        not groups themselves and are not flux or source fields.
 
         """
 
+        for key,val in self._handle["/denovo"].items():
+            if isinstance(val, h5py.Dataset):
+                # skip the fields that will be stored elsewhere
+                if any([key == 'flux', key == 'source']):
+                    pass
+                else:
+                    self.parameters[key]=val.value
+
+        return self.parameters
 
 
     def _load_domain_edge():
@@ -175,14 +184,23 @@ class DenovoDataset(Dataset):
 
         """
 
-        mylog.info("Loading domain boundaries")
+        mylog.info("calculating domain boundaries")
 
-        if "mesh_x" not in self.parameters:
-            try:
+        if 'mesh_x' in self.parameters:
+            left_edge = [self.parameters['mesh_x'].min(),
+            self.parameters['mesh_y'].min(),
+            self.parameters['mesh_z'].min()]
 
+            right_edge = [self.parameters['mesh_x'].max(),
+            self.parameters['mesh_y'].max(),
+            self.parameters['mesh_z'].max()]
 
-        with self._handle.open_ds() as ds:
-            t
+        else:
+            left_edge = []
+            right_edge = []
+
+        return left_edge, right_edge
+
 
     @classmethod
     def _is_valid(self, *args, **kwargs):

--- a/yt/frontends/denovo/data_structures.py
+++ b/yt/frontends/denovo/data_structures.py
@@ -50,7 +50,7 @@ from .fields import DenovoFieldInfo
 
 class DenovoMesh(SemiStructuredMesh):
     _connectivity_length = 8
-    _index_offset = 1
+    _index_offset = 0
 
 class DenovoHierarchy(UnstructuredIndex):
 

--- a/yt/frontends/denovo/data_structures.py
+++ b/yt/frontends/denovo/data_structures.py
@@ -155,6 +155,7 @@ class DenovoDataset(Dataset):
         self.domain_left_edge, self.domain_right_edge = self._load_domain_edge()
         self.domain_dimensions = self.domain_right_edge - self.domain_left_edge
         self.dimensionality = len(self.domain_dimensions)
+        self._load_energy_fluid_types()
 
         # We know that Denovo datasets are never periodic, so periodicity will
         # be set to false.
@@ -192,6 +193,19 @@ class DenovoDataset(Dataset):
 
         return self.parameters
 
+    def _load_energy_fluid_types(self):
+        """
+
+        checks to see if mesh data is binned by energy, creates fluid types
+        that correspond with energy bins if they do.
+
+        """
+
+        if len(self.parameters['mesh_g']) > 0:
+            for group_number in self.parameters['mesh_g']:
+                self.fluid_types += ('egroup_%03i' %group_number,)
+        else:
+            return
 
     def _load_domain_edge(self):
         """

--- a/yt/frontends/denovo/data_structures.py
+++ b/yt/frontends/denovo/data_structures.py
@@ -1,5 +1,5 @@
 """
-Skeleton data structures
+Denovo data structures
 
 
 
@@ -16,6 +16,8 @@ Skeleton data structures
 import os
 import numpy as np
 import weakref
+from yt.utilities.on_demand_imports import _h5py as h5py
+from yt.utilities.logger import ytLogger as mylog
 
 from yt.data_objects.grid_patch import \
     AMRGridPatch
@@ -23,10 +25,11 @@ from yt.geometry.grid_geometry_handler import \
     GridIndex
 from yt.data_objects.static_output import \
     Dataset
-from .fields import SkeletonFieldInfo
+
+from .fields import DenovoFieldInfo
 
 
-class SkeletonGrid(AMRGridPatch):
+class DenovoGrid(AMRGridPatch):
     _id_offset = 0
 
     def __init__(self, id, index, level):
@@ -37,13 +40,13 @@ class SkeletonGrid(AMRGridPatch):
         self.Level = level
 
     def __repr__(self):
-        return "SkeletonGrid_%04i (%s)" % (self.id, self.ActiveDimensions)
+        return "DenovoGrid_%04i (%s)" % (self.id, self.ActiveDimensions)
 
 
-class SkeletonHierarchy(GridIndex):
-    grid = SkeletonGrid
+class DenovoHierarchy(GridIndex):
+    grid = DenovoGrid
 
-    def __init__(self, ds, dataset_type='skeleton'):
+    def __init__(self, ds, dataset_type='denovo'):
         self.dataset_type = dataset_type
         self.dataset = weakref.proxy(ds)
         # for now, the index file is the dataset!
@@ -89,14 +92,17 @@ class SkeletonHierarchy(GridIndex):
         pass
 
 
-class SkeletonDataset(Dataset):
-    _index_class = SkeletonHierarchy
-    _field_info_class = SkeletonFieldInfo
+class DenovoDataset(Dataset):
+    _index_class = DenovoHierarchy
+    _field_info_class = DenovoFieldInfo
+    _suffix = ".out.h5"
 
-    def __init__(self, filename, dataset_type='skeleton',
+    def __init__(self, filename,
+                 dataset_type='denovo',
                  storage_filename=None,
                  units_override=None):
-        self.fluid_types += ('skeleton',)
+
+        self.fluid_types += ('denovo',)
         Dataset.__init__(self, filename, dataset_type,
                          units_override=units_override)
         self.storage_filename = storage_filename
@@ -109,9 +115,9 @@ class SkeletonDataset(Dataset):
         # should be set, along with examples of how to set them to standard
         # values.
         #
-        # self.length_unit = self.quan(1.0, "cm")
-        # self.mass_unit = self.quan(1.0, "g")
-        # self.time_unit = self.quan(1.0, "s")
+        self.length_unit = self.quan(1.0, "cm")
+        self.mass_unit = self.quan(1.0, "g")
+        self.time_unit = self.quan(1.0, "s")
         # self.time_unit = self.quan(1.0, "s")
         #
         # These can also be set:
@@ -123,7 +129,6 @@ class SkeletonDataset(Dataset):
         # This needs to set up the following items.  Note that these are all
         # assumed to be in code units; domain_left_edge and domain_right_edge
         # will be converted to YTArray automatically at a later time.
-        # This includes the cosmological parameters.
         #
         #   self.unique_identifier      <= unique identifier for the dataset
         #                                  being read (e.g., UUID or ST_CTIME)

--- a/yt/frontends/denovo/data_structures.py
+++ b/yt/frontends/denovo/data_structures.py
@@ -34,7 +34,7 @@ class DenovoMesh(SemiStructuredMesh):
     _connectivity_length = 8
     _index_offset = 0
 
-class DenovoHierarchy(UnstructuredIndex):
+class DenovoIndex(UnstructuredIndex):
 
     def __init__(self, ds, dataset_type='denovo'):
         self.dataset_type = dataset_type
@@ -47,7 +47,7 @@ class DenovoHierarchy(UnstructuredIndex):
 
         # float type for the simulation edges and must be float64 now
         self.float_type = np.float64
-        super(DenovoHierarchy, self).__init__(ds, dataset_type)
+        super(DenovoIndex, self).__init__(ds, dataset_type)
 
     def _initialize_mesh(self):
         from yt.frontends.stream.data_structures import hexahedral_connectivity
@@ -106,7 +106,7 @@ class DenovoHierarchy(UnstructuredIndex):
 
 
 class DenovoDataset(Dataset):
-    _index_class = DenovoHierarchy
+    _index_class = DenovoIndex
     _field_info_class = DenovoFieldInfo
     _suffix = ".out.h5"
 
@@ -122,7 +122,7 @@ class DenovoDataset(Dataset):
         self.geometry = 'cartesian'
 
         super(DenovoDataset, self).__init__(filename, dataset_type,
-                         units_override=units_override)
+                units_override=units_override)
         self.storage_filename = storage_filename
         self.filename=filename
 
@@ -241,7 +241,7 @@ class DenovoDataset(Dataset):
             # for now check that denovo is in the solution file. This will need
             # to be updated for fwd/adjoint runs in the future with multiple
             # arguments for a valid dataset.
-            valid = "denovo" in fileh["/"]
+            valid = "denovo" in fileh["/"] or "denovo-forward" in fileh["/"]
             fileh.close()
             return valid
         except:

--- a/yt/frontends/denovo/data_structures.py
+++ b/yt/frontends/denovo/data_structures.py
@@ -153,7 +153,7 @@ class DenovoDataset(Dataset):
         self._handle = h5py.File(self.parameter_filename, "r")
         self.parameters = self._load_parameters()
         self.domain_left_edge, self.domain_right_edge = self._load_domain_edge()
-        self.domain_dimensions = self.domain_right_edge - self.domain_left_edge
+        self.domain_dimensions = np.array([2,2,2])
         self.dimensionality = len(self.domain_dimensions)
         self._load_energy_fluid_types()
 
@@ -186,7 +186,8 @@ class DenovoDataset(Dataset):
         for key,val in self._handle["/denovo"].items():
             if isinstance(val, h5py.Dataset):
                 # skip the fields that will be stored elsewhere
-                if any([key == 'flux', key == 'source']):
+                if any([key == 'flux', key == 'source', key == 'angular_flux',
+                    key == 'block']):
                     pass
                 else:
                     self.parameters[key]=val.value
@@ -249,4 +250,5 @@ class DenovoDataset(Dataset):
             return valid
         except:
             pass
+
         return False

--- a/yt/frontends/denovo/data_structures.py
+++ b/yt/frontends/denovo/data_structures.py
@@ -21,6 +21,10 @@ from yt.utilities.logger import ytLogger as mylog
 
 from yt.data_objects.grid_patch import \
     AMRGridPatch
+from yt.data_objects.unstructured_mesh import \
+    SemiStructuredMesh
+from yt.geometry.unstructured_mesh_handler import \
+    UnstructuredIndex
 from yt.geometry.grid_geometry_handler import \
     GridIndex
 from yt.data_objects.static_output import \

--- a/yt/frontends/denovo/data_structures.py
+++ b/yt/frontends/denovo/data_structures.py
@@ -33,7 +33,7 @@ class DenovoGrid(AMRGridPatch):
     _id_offset = 0
 
     def __init__(self, id, index, level):
-        AMRGridPatch.__init__(self, id, filename=index.index_filename,
+        super(DenovoGrid, self).__init__(id, filename=index.index_filename,
                               index=index)
         self.Parent = None
         self.Children = []
@@ -54,7 +54,7 @@ class DenovoHierarchy(GridIndex):
         self.directory = os.path.dirname(self.index_filename)
         # float type for the simulation edges and must be float64 now
         self.float_type = np.float64
-        GridIndex.__init__(self, ds, dataset_type)
+        super(DenovoHierarchy, self).__init__(ds, dataset_type)
 
     def _detect_output_fields(self):
         # This needs to set a self.field_list that contains all the available,
@@ -108,7 +108,7 @@ class DenovoDataset(Dataset):
 
         self.geometry = 'cartesian'
 
-        super(DenovoDataset, self).__init__(self, filename, dataset_type,
+        super(DenovoDataset, self).__init__(filename, dataset_type,
                          units_override=units_override)
         self.storage_filename = storage_filename
         self.cosmological_simulation = False

--- a/yt/frontends/denovo/data_structures.py
+++ b/yt/frontends/denovo/data_structures.py
@@ -39,6 +39,7 @@ class DenovoIndex(UnstructuredIndex):
     def __init__(self, ds, dataset_type='denovo'):
         self.dataset_type = dataset_type
         self.dataset = weakref.proxy(ds)
+        self._load_energy_fluid_types()
 
         # for now, the index file is the dataset!
         self.index_filename = self.dataset.parameter_filename
@@ -92,6 +93,20 @@ class DenovoIndex(UnstructuredIndex):
                 self.field_list.remove(('denovo','angular_mesh'))
             self.field_list.remove(('denovo','block'))
 
+
+    def _load_energy_fluid_types(self):
+        """
+
+        checks to see if mesh data is binned by energy, creates fluid types
+        that correspond with energy bins if they do.
+
+        """
+
+        if len(self.dataset.parameters['mesh_g']) > 0:
+            for group_number in self.dataset.parameters['mesh_g']:
+                self.dataset.fluid_types += ('egroup_%03i' %group_number,)
+        else:
+            return
 
     def _create_group_fields(self, group_number):
         field_type = 'egroup_%03i' %group_number
@@ -151,7 +166,6 @@ class DenovoDataset(Dataset):
         self.domain_left_edge, self.domain_right_edge = self._load_domain_edge()
         self.domain_dimensions = np.array([2,2,2])
         self.dimensionality = len(self.domain_dimensions)
-        self._load_energy_fluid_types()
 
         # We know that Denovo datasets are never periodic, so periodicity will
         # be set to false.
@@ -189,20 +203,6 @@ class DenovoDataset(Dataset):
                     self.parameters[key]=val.value
 
         return self.parameters
-
-    def _load_energy_fluid_types(self):
-        """
-
-        checks to see if mesh data is binned by energy, creates fluid types
-        that correspond with energy bins if they do.
-
-        """
-
-        if len(self.parameters['mesh_g']) > 0:
-            for group_number in self.parameters['mesh_g']:
-                self.fluid_types += ('egroup_%03i' %group_number,)
-        else:
-            return
 
     def _load_domain_edge(self):
         """

--- a/yt/frontends/denovo/data_structures.py
+++ b/yt/frontends/denovo/data_structures.py
@@ -111,12 +111,11 @@ class DenovoDataset(Dataset):
         super(DenovoDataset, self).__init__(filename, dataset_type,
                          units_override=units_override)
         self.storage_filename = storage_filename
-        self.cosmological_simulation = False
+        self.filename=filename
 
-        self.parameters["HydroMethod"] = 'denovo'
-        self.parameters
-        # refinement factor between a grid and its subgrid
-        # self.refine_by = 2
+        # Note for later: if this is set in _parse_parameter_file, does it need
+        # to be set here?
+        self.cosmological_simulation = False
 
     def _set_code_unit_attributes(self):
         #
@@ -128,20 +127,17 @@ class DenovoDataset(Dataset):
         setdefaultattr(self, 'mass_unit', self.quan(length_unit, "g"))
         setdefaultattr(self, 'time_unit', self.quan(length_unit, "s"))
         #
-        # These can also be set:
-        # self.velocity_unit = self.quan(1.0, "cm/s")
-        # self.magnetic_unit = self.quan(1.0, "gauss")
         pass
 
     def _parse_parameter_file(self):
         #
         self.unique_identifier = \
             int(os.stat(self.parameter_filename)[stat.ST_CTIME])
-        self.parameters             <= full of code-specific items of use
-        self.domain_left_edge       <= array of float64
-        self.domain_right_edge      <= array of float64
-        self.dimensionality         <= int
-        self.domain_dimensions      <= array of int64
+        self._handle = h5py.File(self.parameter_filename, "r")
+        self.parameters = self._load_parameters()
+        self.domain_left_edge, self.domain_right_edge = self._load_domain_edge()
+        self.domain_dimensions = self.domain_right_edge - self.domain_left_edge
+        self.dimensionality = len(self.domain_dimensions)
 
         # We know that Denovo datasets are never periodic, so periodicity will
         # be set to false.
@@ -160,6 +156,33 @@ class DenovoDataset(Dataset):
         self.omega_matter = 0
         self.hubble_constant = 0
         pass
+
+    def _load_parameters():
+        """
+
+        loads in all of the parameters located in the 'denovo' group that are
+        not groups themselves and do not start with mesh.
+
+        """
+
+
+
+    def _load_domain_edge():
+        """
+
+        Loads the boundaries for the domain edge using the min and max values
+        obtained from the x, y, and z meshes.
+
+        """
+
+        mylog.info("Loading domain boundaries")
+
+        if "mesh_x" not in self.parameters:
+            try:
+
+
+        with self._handle.open_ds() as ds:
+            t
 
     @classmethod
     def _is_valid(self, *args, **kwargs):

--- a/yt/frontends/denovo/data_structures.py
+++ b/yt/frontends/denovo/data_structures.py
@@ -82,38 +82,15 @@ class DenovoHierarchy(UnstructuredIndex):
                 self._fhandle['/denovo/db/hdf5_db'].items() if val.value]
 
         # right now we don't want to read in a few of these fields, so we'll
-        # manually delete them here until later.
-        #
+        # manually delete them here until support can be added for them
+        # later.
+
         if ('denovo','angular_mesh') in self.field_list:
             self.field_list.remove(('denovo','angular_mesh'))
         self.field_list.remove(('denovo','block'))
 
     def _count_grids(self):
         self.num_grids=1
-
-    # not sure if this is needed since it's not in the hexahedral OR Moab
-    # Hierarchy classes.
-    # def _parse_index(self):
-    #     # This needs to fill the following arrays, where N is self.num_grids:
-    #     #   self.grid_left_edge         (N, 3) <= float64
-    #     #   self.grid_right_edge        (N, 3) <= float64
-    #     #   self.grid_dimensions        (N, 3) <= int
-    #     #   self.grid_particle_count    (N, 1) <= int
-    #     #   self.grid_levels            (N, 1) <= int
-    #     #   self.grids                  (N, 1) <= grid objects
-    #     #   self.max_level = self.grid_levels.max()
-    #     pass
-
-    # def _populate_grid_objects(self):
-    #     # For each grid, this must call:
-    #     #   grid._prepare_grid()
-    #     #   grid._setup_dx()
-    #     # This must also set:
-    #     #   grid.Children <= list of child grids
-    #     #   grid.Parent   <= parent grid
-    #     # This is handled by the frontend because often the children must be
-    #     # identified.
-    #     pass
 
 
 class DenovoDataset(Dataset):
@@ -142,11 +119,12 @@ class DenovoDataset(Dataset):
         self.cosmological_simulation = False
 
     def _set_code_unit_attributes(self):
-        #
+
         # For now set the length mass and time units to what we expect.
-        # Denovo does not currently output what units the flux is in.
-        #
-        #
+        # Denovo does not currently output what units the flux is in
+        # explicitly, but these units are implied.
+
+
         setdefaultattr(self, 'length_unit', self.quan(1.0, "cm"))
         setdefaultattr(self, 'mass_unit', self.quan(1.0, "g"))
         setdefaultattr(self, 'time_unit', self.quan(1.0, "s"))
@@ -156,7 +134,6 @@ class DenovoDataset(Dataset):
     def _parse_parameter_file(self):
         #
         self.unique_identifier = self.parameter_filename
-        # int(os.stat(self.parameter_filename)[stat.ST_CTIME])
         self._handle = h5py.File(self.parameter_filename, "r")
         self.parameters = self._load_parameters()
         self.domain_left_edge, self.domain_right_edge = self._load_domain_edge()
@@ -170,10 +147,10 @@ class DenovoDataset(Dataset):
         # There is no time-dependence in the denovo solutions at this time, so
         # this will be set to 0.0
         self.current_time = 0.0
-        #
+
         # The next few parameters are set to 0 because Denovo is a
         # non-cosmological simulation tool.
-        #
+
         self.cosmological_simulation = 0
         self.current_redshift = 0
         self.omega_lambda = 0

--- a/yt/frontends/denovo/data_structures.py
+++ b/yt/frontends/denovo/data_structures.py
@@ -21,14 +21,10 @@ from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.file_handler import HDF5FileHandler
 from yt.funcs import setdefaultattr
 
-from yt.data_objects.grid_patch import \
-    AMRGridPatch
 from yt.data_objects.unstructured_mesh import \
     SemiStructuredMesh
 from yt.geometry.unstructured_mesh_handler import \
     UnstructuredIndex
-from yt.geometry.grid_geometry_handler import \
-    GridIndex
 from yt.data_objects.static_output import \
     Dataset
 

--- a/yt/frontends/denovo/definitions.py
+++ b/yt/frontends/denovo/definitions.py
@@ -1,0 +1,1 @@
+# This file is often empty.  It can hold definitions related to a frontend.

--- a/yt/frontends/denovo/definitions.py
+++ b/yt/frontends/denovo/definitions.py
@@ -1,1 +1,15 @@
-# This file is often empty.  It can hold definitions related to a frontend.
+"""
+Definitions specific to Denovo.
+
+
+None exist at this time.
+
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013, yt Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------

--- a/yt/frontends/denovo/fields.py
+++ b/yt/frontends/denovo/fields.py
@@ -1,0 +1,47 @@
+"""
+Skeleton-specific fields
+
+
+
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013, yt Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from yt.fields.field_info_container import \
+    FieldInfoContainer
+
+# We need to specify which fields we might have in our dataset.  The field info
+# container subclass here will define which fields it knows about.  There are
+# optionally methods on it that get called which can be subclassed.
+
+
+class SkeletonFieldInfo(FieldInfoContainer):
+    known_other_fields = (
+        # Each entry here is of the form
+        # ( "name", ("units", ["fields", "to", "alias"], # "display_name")),
+    )
+
+    known_particle_fields = (
+        # Identical form to above
+        # ( "name", ("units", ["fields", "to", "alias"], # "display_name")),
+    )
+
+    def __init__(self, ds, field_list):
+        super(SkeletonFieldInfo, self).__init__(ds, field_list)
+        # If you want, you can check self.field_list
+
+    def setup_fluid_fields(self):
+        # Here we do anything that might need info about the dataset.
+        # You can use self.alias, self.add_output_field (for on-disk fields)
+        # and self.add_field (for derived fields).
+        pass
+
+    def setup_particle_fields(self, ptype):
+        super(SkeletonFieldInfo, self).setup_particle_fields(ptype)
+        # This will get called for every particle type.

--- a/yt/frontends/denovo/fields.py
+++ b/yt/frontends/denovo/fields.py
@@ -24,11 +24,11 @@ source_units = "1"
 
 class DenovoFieldInfo(FieldInfoContainer):
     known_other_fields = (
-        ("source", (source_units, ["source_strength"], None)),
-        ("flux", (flux_units, ["scalar_flux"], r"\phi")),
-        ("uncflux", (flux_units, ["uncollided_flux"], r"\phi_{uncollided}")),
+        ("source", (source_units, [], None)),
+        ("flux", (flux_units, [], r"\phi")),
+        ("uncflux", (flux_units, [], r"\phi_{uncollided}")),
         ("angular_flux", (angular_flux_units, [], r"\Psi")),
-        ("ww_lower", ("", ["ww_lower_bound"], None)),
+        ("ww_lower", ("", [], None)),
     )
 
     known_particle_fields = (

--- a/yt/frontends/denovo/fields.py
+++ b/yt/frontends/denovo/fields.py
@@ -20,10 +20,10 @@ from yt.fields.field_info_container import \
 # container subclass here will define which fields it knows about.  There are
 # optionally methods on it that get called which can be subclassed.
 #
-flux_units = "neutrons / code_length**2"
-angular_flux_units = "neutrons / code_length**2 / steradian "
+flux_units = " 1 / code_length**2"
+angular_flux_units = " 1 / code_length**2 / steradian "
 density_units = "code_mass / code_length**3"
-source_units = "neutrons"
+source_units = "1"
 
 
 class DenovoFieldInfo(FieldInfoContainer):

--- a/yt/frontends/denovo/fields.py
+++ b/yt/frontends/denovo/fields.py
@@ -19,17 +19,25 @@ from yt.fields.field_info_container import \
 # We need to specify which fields we might have in our dataset.  The field info
 # container subclass here will define which fields it knows about.  There are
 # optionally methods on it that get called which can be subclassed.
+#
+flux_units = "neutrons / code_length**2"
+angular_flux_units = "neutrons / code_length**2 / steradian "
+density_units = "code_mass / code_length**3"
+source_units = "neutrons"
 
 
 class DenovoFieldInfo(FieldInfoContainer):
     known_other_fields = (
-        # Each entry here is of the form
-        # ( "name", ("units", ["fields", "to", "alias"], # "display_name")),
+        ("source", (source_units, ["source_strength"], None)),
+        ("flux", (flux_units, ["scalar_flux"], r"\phi")),
+        ("uncflux", (flux_units, ["uncollided_flux"], r"\phi_{uncollided}")),
+        ("angular_flux", (angular_flux_units, [], r"\Psi")),
+        ("ww_lower", ("", ["ww_lower_bound"], None)),
     )
 
     known_particle_fields = (
-        # Identical form to above
-        # ( "name", ("units", ["fields", "to", "alias"], # "display_name")),
+        # At this time Denovo does not output particle fields, so there are no
+        # particle fields defined in this file.
     )
 
     def __init__(self, ds, field_list):
@@ -40,8 +48,15 @@ class DenovoFieldInfo(FieldInfoContainer):
         # Here we do anything that might need info about the dataset.
         # You can use self.alias, self.add_output_field (for on-disk fields)
         # and self.add_field (for derived fields).
+        params = self.ds.parameters
+        self.setup_energy_field()
+        setup_magnetic_field_al
         pass
 
+    def setup_flux_fields(self):
+        unit_system = self.ds.unit_system
+
     def setup_particle_fields(self, ptype):
+        # Becuase there are no particle types in Denovo, this is empty for now.
         super(DenovoFieldInfo, self).setup_particle_fields(ptype)
-        # This will get called for every particle type.
+

--- a/yt/frontends/denovo/fields.py
+++ b/yt/frontends/denovo/fields.py
@@ -16,10 +16,6 @@ Denovo-specific fields
 from yt.fields.field_info_container import \
     FieldInfoContainer
 
-# We need to specify which fields we might have in our dataset.  The field info
-# container subclass here will define which fields it knows about.  There are
-# optionally methods on it that get called which can be subclassed.
-#
 flux_units = " 1 / code_length**2"
 angular_flux_units = " 1 / code_length**2 / steradian "
 density_units = "code_mass / code_length**3"
@@ -63,6 +59,5 @@ class DenovoFieldInfo(FieldInfoContainer):
 
     def setup_particle_fields(self, ptype):
         # Becuase there are no particle types in Denovo, this is empty for now.
-        # super(DenovoFieldInfo, self).setup_particle_fields(ptype)
         pass
 

--- a/yt/frontends/denovo/fields.py
+++ b/yt/frontends/denovo/fields.py
@@ -1,5 +1,5 @@
 """
-Skeleton-specific fields
+Denovo-specific fields
 
 
 
@@ -21,7 +21,7 @@ from yt.fields.field_info_container import \
 # optionally methods on it that get called which can be subclassed.
 
 
-class SkeletonFieldInfo(FieldInfoContainer):
+class DenovoFieldInfo(FieldInfoContainer):
     known_other_fields = (
         # Each entry here is of the form
         # ( "name", ("units", ["fields", "to", "alias"], # "display_name")),
@@ -33,7 +33,7 @@ class SkeletonFieldInfo(FieldInfoContainer):
     )
 
     def __init__(self, ds, field_list):
-        super(SkeletonFieldInfo, self).__init__(ds, field_list)
+        super(DenovoFieldInfo, self).__init__(ds, field_list)
         # If you want, you can check self.field_list
 
     def setup_fluid_fields(self):
@@ -43,5 +43,5 @@ class SkeletonFieldInfo(FieldInfoContainer):
         pass
 
     def setup_particle_fields(self, ptype):
-        super(SkeletonFieldInfo, self).setup_particle_fields(ptype)
+        super(DenovoFieldInfo, self).setup_particle_fields(ptype)
         # This will get called for every particle type.

--- a/yt/frontends/denovo/fields.py
+++ b/yt/frontends/denovo/fields.py
@@ -40,21 +40,6 @@ class DenovoFieldInfo(FieldInfoContainer):
         # Here we do anything that might need info about the dataset.
         # You can use self.alias, self.add_output_field (for on-disk fields)
         # and self.add_field (for derived fields).
-        # unit_system = self.ds.unit_system
-        # params = self.ds.parameters
-        # self.setup_flux_field()
-        # This might be where we set up the energy group-specific fields.
-        pass
-
-    def setup_flux_field(self):
-        # Right now I feel that it would be more intuitive to a new user to
-        # have flux fields loaded in a descriptive field, however, I might
-        # change this if we load in materials information, or ww information,
-        # which probably shouldn't be added to this function.
-        # unit_system = self.ds.unit_system
-        # params = self.ds.parameters
-
-        # super(DenovoFieldInfo, self).setup_flux_fields(fluxtype)
         pass
 
     def setup_particle_fields(self, ptype):

--- a/yt/frontends/denovo/fields.py
+++ b/yt/frontends/denovo/fields.py
@@ -48,8 +48,10 @@ class DenovoFieldInfo(FieldInfoContainer):
         # Here we do anything that might need info about the dataset.
         # You can use self.alias, self.add_output_field (for on-disk fields)
         # and self.add_field (for derived fields).
-        params = self.ds.parameters
-        self.setup_flux_field()
+        # unit_system = self.ds.unit_system
+        # params = self.ds.parameters
+        # self.setup_flux_field()
+        # This might be where we set up the energy group-specific fields.
         pass
 
     def setup_flux_field(self):
@@ -57,12 +59,14 @@ class DenovoFieldInfo(FieldInfoContainer):
         # have flux fields loaded in a descriptive field, however, I might
         # change this if we load in materials information, or ww information,
         # which probably shouldn't be added to this function.
-        unit_system = self.ds.unit_system
-        params = self.ds.parameters
+        # unit_system = self.ds.unit_system
+        # params = self.ds.parameters
 
-        super(DenovoFieldInfo, self).setup_flux_fields(fluxtype)
+        # super(DenovoFieldInfo, self).setup_flux_fields(fluxtype)
+        pass
 
     def setup_particle_fields(self, ptype):
         # Becuase there are no particle types in Denovo, this is empty for now.
-        super(DenovoFieldInfo, self).setup_particle_fields(ptype)
+        # super(DenovoFieldInfo, self).setup_particle_fields(ptype)
+        pass
 

--- a/yt/frontends/denovo/fields.py
+++ b/yt/frontends/denovo/fields.py
@@ -49,12 +49,18 @@ class DenovoFieldInfo(FieldInfoContainer):
         # You can use self.alias, self.add_output_field (for on-disk fields)
         # and self.add_field (for derived fields).
         params = self.ds.parameters
-        self.setup_energy_field()
-        setup_magnetic_field_al
+        self.setup_flux_field()
         pass
 
-    def setup_flux_fields(self):
+    def setup_flux_field(self):
+        # Right now I feel that it would be more intuitive to a new user to
+        # have flux fields loaded in a descriptive field, however, I might
+        # change this if we load in materials information, or ww information,
+        # which probably shouldn't be added to this function.
         unit_system = self.ds.unit_system
+        params = self.ds.parameters
+
+        super(DenovoFieldInfo, self).setup_flux_fields(fluxtype)
 
     def setup_particle_fields(self, ptype):
         # Becuase there are no particle types in Denovo, this is empty for now.

--- a/yt/frontends/denovo/fields.py
+++ b/yt/frontends/denovo/fields.py
@@ -40,10 +40,6 @@ class DenovoFieldInfo(FieldInfoContainer):
         # particle fields defined in this file.
     )
 
-    def __init__(self, ds, field_list):
-        super(DenovoFieldInfo, self).__init__(ds, field_list)
-        # If you want, you can check self.field_list
-
     def setup_fluid_fields(self):
         # Here we do anything that might need info about the dataset.
         # You can use self.alias, self.add_output_field (for on-disk fields)

--- a/yt/frontends/denovo/io.py
+++ b/yt/frontends/denovo/io.py
@@ -1,0 +1,59 @@
+"""
+Skeleton-specific IO functions
+
+
+
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013, yt Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from yt.utilities.io_handler import \
+    BaseIOHandler
+
+
+class SkeletonIOHandler(BaseIOHandler):
+    _particle_reader = False
+    _dataset_type = 'skeleton'
+
+    def _read_particle_coords(self, chunks, ptf):
+        # This needs to *yield* a series of tuples of (ptype, (x, y, z)).
+        # chunks is a list of chunks, and ptf is a dict where the keys are
+        # ptypes and the values are lists of fields.
+        pass
+
+    def _read_particle_fields(self, chunks, ptf, selector):
+        # This gets called after the arrays have been allocated.  It needs to
+        # yield ((ptype, field), data) where data is the masked results of
+        # reading ptype, field and applying the selector to the data read in.
+        # Selector objects have a .select_points(x,y,z) that returns a mask, so
+        # you need to do your masking here.
+        pass
+
+    def _read_fluid_selection(self, chunks, selector, fields, size):
+        # This needs to allocate a set of arrays inside a dictionary, where the
+        # keys are the (ftype, fname) tuples and the values are arrays that
+        # have been masked using whatever selector method is appropriate.  The
+        # dict gets returned at the end and it should be flat, with selected
+        # data.  Note that if you're reading grid data, you might need to
+        # special-case a grid selector object.
+        # Also note that "chunks" is a generator for multiple chunks, each of
+        # which contains a list of grids. The returned numpy arrays should be
+        # in 64-bit float and contiguous along the z direction. Therefore, for
+        # a C-like input array with the dimension [x][y][z] or a
+        # Fortran-like input array with the dimension (z,y,x), a matrix
+        # transpose is required (e.g., using np_array.transpose() or
+        # np_array.swapaxes(0,2)).
+        pass
+
+    def _read_chunk_data(self, chunk, fields):
+        # This reads the data from a single chunk without doing any selection,
+        # and is only used for caching data that might be used by multiple
+        # different selectors later. For instance, this can speed up ghost zone
+        # computation.
+        pass

--- a/yt/frontends/denovo/io.py
+++ b/yt/frontends/denovo/io.py
@@ -30,7 +30,7 @@ class IOHandlerDenovoHDF5(BaseIOHandler):
         super(IOHandlerDenovoHDF5, self).__init__(ds)
         self._handle = ds._handle
         try:
-            self.groups = ds.paramaters['mesh_g']
+            self.groups = ds.parameters['mesh_g']
         except KeyError:
             self.groups = False
 

--- a/yt/frontends/denovo/io.py
+++ b/yt/frontends/denovo/io.py
@@ -81,8 +81,8 @@ class IOHandlerDenovoHDF5(BaseIOHandler):
             ftype, fname = field
             # right now only pull in 0th group of the flux to see if things
             # work.
-            ds = np.array(fhandle[field_dname(fname)][0,:],
-                    dtype="float64").transpose()
+            ds = np.array(fhandle[field_dname(fname)][0,...],
+                    dtype="float64").transpose().copy()
             ind = 0
             for chunk in chunks:
                 for g in chunk.objs:

--- a/yt/frontends/denovo/io.py
+++ b/yt/frontends/denovo/io.py
@@ -39,8 +39,6 @@ class IOHandlerDenovoHDF5(BaseIOHandler):
         # file relevant to what we can plot here.
         pass
 
-
-
     def _read_particle_coords(self, chunks, ptf):
         # At this time Denovo has no particles, so this function will not
         # return particle coords.
@@ -48,24 +46,11 @@ class IOHandlerDenovoHDF5(BaseIOHandler):
 
     def _read_particle_fields(self, chunks, ptf, selector):
         # At this time Denovo has no particle fields, so this function
-        # will not return any particle fields.
+        # will not return any particle fields. This may be updated later if
+        # support for output data from shift is added.
         pass
 
     def _read_fluid_selection(self, chunks, selector, fields, size):
-        # This needs to allocate a set of arrays inside a dictionary, where the
-        # keys are the (ftype, fname) tuples and the values are arrays that
-        # have been masked using whatever selector method is appropriate.  The
-        # dict gets returned at the end and it should be flat, with selected
-        # data.  Note that if you're reading grid data, you might need to
-        # special-case a grid selector object.
-        # Also note that "chunks" is a generator for multiple chunks, each of
-        # which contains a list of grids. The returned numpy arrays should be
-        # in 64-bit float and contiguous along the z direction. Therefore, for
-        # a C-like input array with the dimension [x][y][z] or a
-        # Fortran-like input array with the dimension (z,y,x), a matrix
-        # transpose is required (e.g., using np_array.transpose() or
-        # np_array.swapaxes(0,2)).
-
         chunks = list(chunks)
         assert(len(chunks) == 1)
 
@@ -90,8 +75,4 @@ class IOHandlerDenovoHDF5(BaseIOHandler):
         return rv
 
     def _read_chunk_data(self, chunk, fields):
-        # This reads the data from a single chunk without doing any selection,
-        # and is only used for caching data that might be used by multiple
-        # different selectors later. For instance, this can speed up ghost zone
-        # computation.
         pass

--- a/yt/frontends/denovo/io.py
+++ b/yt/frontends/denovo/io.py
@@ -76,7 +76,7 @@ class IOHandlerDenovoHDF5(BaseIOHandler):
                     for g in chunk.objs:
                         ind += g.select(selector, ds, rv[field], ind) # caches
             else:
-                ds = np.array(fhandle[field_dname(fname)][...],
+                ds = np.array(fhandle[field_dname(fname)][0,...],
                         dtype="float64").transpose().copy()
                 ind = 0
                 for chunk in chunks:

--- a/yt/frontends/denovo/io.py
+++ b/yt/frontends/denovo/io.py
@@ -15,7 +15,6 @@ Denovo-specific IO functions
 
 from yt.utilities.io_handler import \
     BaseIOHandler
-from yt.utilities.on_demand_imports import _h5py as h5py
 import numpy as np
 from yt.utilities.logger import ytLogger as mylog
 

--- a/yt/frontends/denovo/io.py
+++ b/yt/frontends/denovo/io.py
@@ -24,18 +24,25 @@ class IOHandlerDenovHDF5(BaseIOHandler):
     _particle_reader = False
     _dataset_type = 'denovo'
 
+    def _read_field_names(self, grid):
+        # This function is used to pull in all of the fields from the Denovo
+        # file relevant to what we can plot here.
+
+        if grid.filename is None:
+            return []
+        f = h5py.File(grid.filename, "r")
+        try:
+
+
+
     def _read_particle_coords(self, chunks, ptf):
-        # This needs to *yield* a series of tuples of (ptype, (x, y, z)).
-        # chunks is a list of chunks, and ptf is a dict where the keys are
-        # ptypes and the values are lists of fields.
+        # At this time Denovo has no particles, so this function will not
+        # return particle coords.
         pass
 
     def _read_particle_fields(self, chunks, ptf, selector):
-        # This gets called after the arrays have been allocated.  It needs to
-        # yield ((ptype, field), data) where data is the masked results of
-        # reading ptype, field and applying the selector to the data read in.
-        # Selector objects have a .select_points(x,y,z) that returns a mask, so
-        # you need to do your masking here.
+        # At this time Denovo has no particle fields, so this function
+        # will not return any particle fields.
         pass
 
     def _read_fluid_selection(self, chunks, selector, fields, size):

--- a/yt/frontends/denovo/io.py
+++ b/yt/frontends/denovo/io.py
@@ -22,7 +22,7 @@ from yt.utilities.logger import ytLogger as mylog
 def field_dname(field_name):
     return "/denovo/{0}".format(field_name)
 
-class IOHandlerDenovHDF5(BaseIOHandler):
+class IOHandlerDenovoHDF5(BaseIOHandler):
     _particle_reader = False
     _dataset_type = 'denovo'
 

--- a/yt/frontends/denovo/io.py
+++ b/yt/frontends/denovo/io.py
@@ -74,7 +74,7 @@ class IOHandlerDenovoHDF5(BaseIOHandler):
         for field in fields:
             ftype, fname = field
             rv[field] = np.empty(size, dtype=fhandle[field_dname(fname)].dtype)
-            ngrids = sum(len(chunk.onjs) for chunk in chunks)
+            ngrids = sum(len(chunk.objs) for chunk in chunks)
             mylog.debug("Reading %s cells of %s fields in %s blocks",
                     size, [fname for ft, fn in fields], ngrids)
         for field in fields:

--- a/yt/frontends/denovo/io.py
+++ b/yt/frontends/denovo/io.py
@@ -1,5 +1,5 @@
 """
-Skeleton-specific IO functions
+Denovo-specific IO functions
 
 
 
@@ -15,11 +15,14 @@ Skeleton-specific IO functions
 
 from yt.utilities.io_handler import \
     BaseIOHandler
+from yt.utilities.on_demand_imports import _h5py as h5py
+import numpy as np
+from yt.utilities.logger import ytLogger as mylog
 
 
-class SkeletonIOHandler(BaseIOHandler):
+class IOHandlerDenovHDF5(BaseIOHandler):
     _particle_reader = False
-    _dataset_type = 'skeleton'
+    _dataset_type = 'denovo'
 
     def _read_particle_coords(self, chunks, ptf):
         # This needs to *yield* a series of tuples of (ptype, (x, y, z)).

--- a/yt/frontends/denovo/io.py
+++ b/yt/frontends/denovo/io.py
@@ -64,14 +64,25 @@ class IOHandlerDenovoHDF5(BaseIOHandler):
                     size, [fname for ft, fn in fields], ngrids)
         for field in fields:
             ftype, fname = field
-            # right now only pull in 0th group of the flux to see if things
-            # work.
-            ds = np.array(fhandle[field_dname(fname)][0,...],
-                    dtype="float64").transpose().copy()
-            ind = 0
-            for chunk in chunks:
-                for g in chunk.objs:
-                    ind += g.select(selector, ds, rv[field], ind) # caches
+            if 'egroup' in ftype:
+                # trying to get the energy group number from the egroup string
+                # isn't that pretty, but it works for now.
+                group_no = int(ftype.split('_')[-1])
+                mylog.info("trying to read in energy group {}".format(group_no))
+                ds = np.array(fhandle[field_dname(fname)][group_no,...],
+                        dtype="float64").transpose().copy()
+                ind = 0
+                for chunk in chunks:
+                    for g in chunk.objs:
+                        ind += g.select(selector, ds, rv[field], ind) # caches
+            else:
+                ds = np.array(fhandle[field_dname(fname)][...],
+                        dtype="float64").transpose().copy()
+                ind = 0
+                for chunk in chunks:
+                    for g in chunk.objs:
+                        ind += g.select(selector, ds, rv[field], ind) # caches
+
         return rv
 
     def _read_chunk_data(self, chunk, fields):

--- a/yt/frontends/denovo/io.py
+++ b/yt/frontends/denovo/io.py
@@ -68,7 +68,8 @@ class IOHandlerDenovoHDF5(BaseIOHandler):
                 # trying to get the energy group number from the egroup string
                 # isn't that pretty, but it works for now.
                 group_no = int(ftype.split('_')[-1])
-                mylog.info("trying to read in energy group {}".format(group_no))
+                mylog.debug("reading in {} data for energy group {}".format(fname,
+                        group_no))
                 ds = np.array(fhandle[field_dname(fname)][group_no,...],
                         dtype="float64").transpose().copy()
                 ind = 0

--- a/yt/frontends/denovo/misc.py
+++ b/yt/frontends/denovo/misc.py
@@ -1,0 +1,16 @@
+"""
+Miscellaneous functions that are Denovo-specific
+
+
+None exist at this time.
+
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013, yt Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

This PR creates a frontend for a radiation transport code, Denovo (https://www.ornl.gov/content/denovo-new-three-dimensional-parallel-discrete-ordinates-code-scale). This code is used to simulate steady-state nuclear systems for a number of applications. 

I still have a few things to do (including updating the docs and writing tests), but I wanted to bring up some questions.

1) In `fields.py`, the `known_other_fields` tuple contains fields that can be aliased in a list associated with each field. e.g. `( "name", ("units", ["fields", "to", "alias"], # "display_name"))`. It seems that the aliases are domain-specific. I wasn't sure exactly how to incorporate more domain-specific fields, so I have some generic names in my `frontends/denovo/fields.py` (e.g. 'scalar flux') , but I haven't implemented anything yet. Should I do that or is there a long-term domain-specific way of addressing that? 
2) Should string formatting (such as for the logger) be python 2 or python 3 specific? Or does it matter? I used python 3 formatting when I added new log messages, but I used older formatting in `io.py` that matched stream, moab, gdf, and athena_pp for a debug message in line 62 of `denovo/io.py`.
3) The data in these files are associated with an energy mesh. I create new fluid types that correspond to each energy group and load in flux and source data to each energy group. If there's a better/more sophisticated solution to this, or if any of you have any other suggestions on handling energy-chunked data (that I may want to access by energy group), I'd really appreciate it! Related to that: 
* I create the energy group fluid types based on the energy mesh, so an arbitrary number may be created, depending on the file. This is done in the `DenovoDataset` class, but I wasn't positive that it should go there because I add the 'source' and 'flux' fields that go with these fluid types in the `DenovoHierarchy` class. Do those classes have the correct functionality? 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
