### PR TITLE
Fix an edge case in ensure_dir_exists

### DIFF
--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -860,7 +860,11 @@ def get_output_filename(name, keyword, suffix):
 def ensure_dir_exists(path):
     r"""Create all directories in path recursively in a parallel safe manner"""
     my_dir = os.path.dirname(path)
-    ensure_dir(my_dir)
+    # If path is a file in the current directory, like "test.txt", then my_dir
+    # would be an empty string, resulting in FileNotFoundError when passed to
+    # ensure_dir. Let's avoid that.
+    if my_dir:
+        ensure_dir(my_dir)
 
 def ensure_dir(path):
     r"""Parallel safe directory maker."""


### PR DESCRIPTION
## PR Summary

The current implementation would result in `FileNotFoundError` when a file in current directory (`'test.txt'` for example) is passed to `ensure_dir_exists`.

An alternative solution is to write `my_dir = os.path.dirname(os.path.abspath(path))` instead. Let me know if this one is prefered.

## PR Checklist

- [ ] Code passes flake8 checker
- [ ] Adds a test for any bugs fixed