### PR TITLE
[RAMSES] Warn only once when detecting extra fields

### DIFF
--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -19,6 +19,7 @@ import os
 import numpy as np
 import stat
 import weakref
+from collections import defaultdict
 
 from yt.extern.six import string_types
 from yt.funcs import \
@@ -460,8 +461,9 @@ class RAMSESDataset(Dataset):
                       its value.
         '''
         self._fields_in_file = fields
+        # By default, extra fields have not triggered a warning
+        self._warned_extra_fields = defaultdict(lambda: False)
         self._extra_particle_fields = extra_particle_fields
-        self._warn_extra_fields = False
         self.force_cosmological = cosmological
         self._bbox = bbox
         Dataset.__init__(self, filename, dataset_type, units_override=units_override,

--- a/yt/frontends/ramses/field_handlers.py
+++ b/yt/frontends/ramses/field_handlers.py
@@ -410,9 +410,10 @@ class GravFieldFileHandler(FieldFileHandler):
             fields = ['%s-acceleration' % k for k in 'xyz'[:ndim]]
             ndetected = ndim
 
-        if ndetected != nvar:
+        if ndetected != nvar and not ds._warned_extra_fields['gravity']:
             mylog.warning('Detected %s extra gravity fields.',
                           nvar-ndetected)
+            ds._warned_extra_fields['gravity'] = True
 
             for i in range(nvar-ndetected):
                 fields.append('var%s' % i)

--- a/yt/frontends/ramses/particle_handlers.py
+++ b/yt/frontends/ramses/particle_handlers.py
@@ -241,12 +241,12 @@ class DefaultParticleFileHandler(ParticleFileHandler):
             _pfields[ptype, field] = vtype
             fpu.skip(f, 1)
 
-        if iextra > 0 and not self.ds._warn_extra_fields:
-            self.ds._warn_extra_fields = True
+        if iextra > 0 and not self.ds._warned_extra_fields['io']:
             w = ("Detected %s extra particle fields assuming kind "
                  "`double`. Consider using the `extra_particle_fields` "
                  "keyword argument if you have unexpected behavior.")
             mylog.warning(w % iextra)
+            self.ds._warned_extra_fields['io'] = True
 
         self.field_offsets = field_offsets
         self.field_types = _pfields


### PR DESCRIPTION
This is a very minor refactoring to prevent multiple warning when detecting extra fields (e.g. in the particle files or gravity files)

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->


## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] New features are documented, with docstrings and narrative docs

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
