### PR TITLE
allow the particle callback to work with ParticleProjectionPlot

### DIFF
--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -962,7 +962,7 @@ class PWViewerMPL(PlotWindow):
                             'StreamlineCallback']
             if self._plot_type == 'Particle':
                 ignored += ['HopCirclesCallback','HopParticleCallback',
-                            'ParticleCallback','ClumpContourCallback',
+                            'ClumpContourCallback',
                             'GridBoundaryCallback', 'VelocityCallback',
                             'MagFieldCallback', 'QuiverCallback',
                             'CuttingQuiverCallback', 'StreamlineCallback',


### PR DESCRIPTION
This seems like a useful thing to enable, especially given the context of e.g. Stephanie Ho's message to the mailing list today:

https://mail.python.org/mm3/archives/list/yt-users@python.org/thread/4IFJKQOB4SBJC7DMR6RF4FVUIK37PXKC/

Here's an example notebook where I make use of this:

https://gist.github.com/ngoldbaum/123e5e93a638dcb0144372fc9920ba9d

@atmyers do you happen to remember why you blacklisted the particle callback in the first place?