### PR TITLE
optimize octree off-axis projections

### DIFF
--- a/yt/data_objects/octree_subset.py
+++ b/yt/data_objects/octree_subset.py
@@ -457,15 +457,17 @@ class OctreeSubsetBlockSlicePosition(object):
 
     @property
     def LeftEdge(self):
-        LE = (self.block_slice._fcoords[0,0,0,self.ind,:]
-            - self.block_slice._fwidth[0,0,0,self.ind,:]*0.5)
-        return LE
+        LE = (self.block_slice._fcoords[0,0,0,self.ind,:].d
+            - self.block_slice._fwidth[0,0,0,self.ind,:].d*0.5)
+        return self.block_slice.octree_subset.ds.arr(
+            LE, self.block_slice._fcoords.units)
 
     @property
     def RightEdge(self):
-        RE = (self.block_slice._fcoords[-1,-1,-1,self.ind,:]
-            + self.block_slice._fwidth[-1,-1,-1,self.ind,:]*0.5)
-        return RE
+        RE = (self.block_slice._fcoords[-1,-1,-1,self.ind,:].d
+            + self.block_slice._fwidth[-1,-1,-1,self.ind,:].d*0.5)
+        return self.block_slice.octree_subset.ds.arr(
+            RE, self.block_slice._fcoords.units)
 
     @property
     def dds(self):

--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -187,7 +187,13 @@ def off_axis_projection(data_source, center, normal_vector,
     mylog.debug("Casting rays")
 
     for i, (grid, mask) in enumerate(data_source.blocks):
-        data = [(grid[f] * mask).astype("float64") for f in fields]
+        data = []
+        for f in fields:
+            # strip units before multiplying by mask for speed
+            grid_data = grid[f]
+            units = grid_data.units
+            data.append(data_source.ds.arr(
+                grid_data.d*mask, units, dtype='float64'))
         pg = PartitionedGrid(
             grid.id, data,
             mask.astype('uint8'),


### PR DESCRIPTION
Ping @earnric who motivated this work.

This pull request reduces the time to run the following script:

```python
import yt
ds = yt.load('output_00080/info_00080.txt')
m, c = ds.find_max(('gas', 'density'))
plot = yt.OffAxisProjectionPlot(ds, [1, 1, 1], 'density', center=c, width=(1, 'Mpc'))
plot.save()
```

from 127.795 s to 56.528 s, more than a 2x speedup!

I haven't yet done a line profile of the actual off-axis projection operation, but there are probably some other places to optimize this operation in the `off_axis_projection` function.