### PR TITLE
Fix unit issues in PlotCallback.convert_to_plot and ParticleCallback

### DIFF
--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -145,17 +145,20 @@ class PlotCallback(object):
         # Convert the data and plot limits to tiled numpy arrays so that
         # convert_to_plot is automatically vectorized.
 
-        x0 = np.array(np.tile(plot.xlim[0],ncoord))
-        x1 = np.array(np.tile(plot.xlim[1],ncoord))
+        x0 = np.array(np.tile(plot.xlim[0].to('code_length'),ncoord))
+        x1 = np.array(np.tile(plot.xlim[1].to('code_length'),ncoord))
         xx0 = np.tile(plot._axes.get_xlim()[0],ncoord)
         xx1 = np.tile(plot._axes.get_xlim()[1],ncoord)
 
-        y0 = np.array(np.tile(plot.ylim[0],ncoord))
-        y1 = np.array(np.tile(plot.ylim[1],ncoord))
+        y0 = np.array(np.tile(plot.ylim[0].to('code_length'),ncoord))
+        y1 = np.array(np.tile(plot.ylim[1].to('code_length'),ncoord))
         yy0 = np.tile(plot._axes.get_ylim()[0],ncoord)
         yy1 = np.tile(plot._axes.get_ylim()[1],ncoord)
 
-        ccoord = np.array(coord)
+        try:
+            ccoord = np.array(coord.to('code_length'))
+        except AttributeError:
+            ccoord = np.array(coord)
 
         # We need a special case for when we are only given one coordinate.
         if ccoord.shape == (2,):


### PR DESCRIPTION
This fixes an issue reported by Stephanie Ho on the mailing list:

https://mail.python.org/mm3/archives/list/yt-users@python.org/message/VGZIRE7HO6APK4MKUSCIPI3TXC4PNMRL/

With this PR her script produces the following image:

![test_annotateparticle](https://user-images.githubusercontent.com/3126246/39262453-0d43f264-4885-11e8-8281-84d2ab696077.png)

The fix ended up being to avoid stripping units until we get to `convert_to_plot` and then inside `convert_to_plot` to ensure that all data are in code units before stripping units.

I haven't looked carefully at the other callbacks that call `convert_to_plot` although I think the changes I've made there are generally going to be safe and backward compatible.