### PR TITLE
Optimize yt.funcs:camelcase_to_underscore

### DIFF
--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -39,6 +39,7 @@ from numbers import Number as numeric_type
 
 from yt.extern.six.moves import urllib
 from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.lru_cache import lru_cache
 from yt.utilities.exceptions import \
     YTInvalidWidthError, \
     YTEquivalentDimsError
@@ -892,9 +893,13 @@ def validate_width_tuple(width):
         msg += "Valid widths look like this: (12, 'au')"
         raise YTInvalidWidthError(msg)
 
+_first_cap_re = re.compile('(.)([A-Z][a-z]+)')
+_all_cap_re = re.compile('([a-z0-9])([A-Z])')
+
+@lru_cache(maxsize=128, typed=False)
 def camelcase_to_underscore(name):
-    s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
-    return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
+    s1 = _first_cap_re.sub(r'\1_\2', name)
+    return _all_cap_re.sub(r'\1_\2', s1).lower()
 
 def set_intersection(some_list):
     if len(some_list) == 0: return set([])


### PR DESCRIPTION
While working on #1747 I noticed it takes a lot of time to merely generate `index`:

```
86.197 <module>  ala.py:1
├─ 72.665 index  yt/data_objects/static_output.py:500
│  ├─ 71.706 __init__  yt/frontends/flash/data_structures.py:56
│  │  └─ 71.706 __init__  yt/geometry/geometry_handler.py:39
│  │     └─ 71.706 _setup_geometry  yt/geometry/grid_geometry_handler.py:43
│  │        ├─ 48.438 _parse_index  yt/frontends/flash/data_structures.py:90
│  │        │  └─ 48.071 __init__  yt/frontends/flash/data_structures.py:41
│  │        │     └─ 47.860 __init__  yt/data_objects/grid_patch.py:58
│  │        │        └─ 47.216 __init__  yt/data_objects/data_containers.py:1190
│  │        │           ├─ 34.421 __new__  yt/data_objects/derived_quantities.py:87
│  │        │           │  ├─ 29.787 camelcase_to_underscore  yt/funcs.py:887
│  │        │           │  │  └─ 28.221 sub  re.py:184
│  │        │           │  │     ├─ 10.642 filter  re.py:330
│  │        │           │  │     │  └─ 6.239 expand_template  sre_parse.py:964
│  │        │           │  │     ├─ 10.275 _subx  re.py:324
│  │        │           │  │     └─ 2.120 _compile  re.py:286
```
This PR helps a bit:

```
55.367 <module>  ala.py:1
├─ 41.992 index  yt/data_objects/static_output.py:500
│  ├─ 41.013 __init__  yt/frontends/flash/data_structures.py:56
│  │  └─ 41.013 __init__  yt/geometry/geometry_handler.py:39
│  │     └─ 41.013 _setup_geometry  yt/geometry/grid_geometry_handler.py:43
│  │        ├─ 22.888 _populate_grid_objects  yt/frontends/flash/data_structures.py:156
│  │        │  ├─ 11.024 __array_ufunc__  yt/units/yt_array.py:1342
│  │        │  │  ├─ 3.281 get_inp_u_binary  yt/units/yt_array.py:138
│  │        │  │  │  └─ 2.133 __new__  yt/units/unit_object.py:167
│  │        │  │  │     └─ 0.979 _get_unit_data_from_expr  yt/units/unit_object.py:559
│  │        │  │  │        └─ 0.771 __float__  sympy/core/numbers.py:597
│  │        │  │  ├─ 2.056 __new__  yt/units/yt_array.py:458
│  │        │  │  │  └─ 0.629 __array_finalize__  yt/units/yt_array.py:1403
│  │        │  │  ├─ 1.133 asarray  numpy/core/numeric.py:424
│  │        │  │  └─ 0.790 __hash__  yt/units/unit_object.py:313
│  │        │  ├─ 3.957 _prepare_grid  yt/data_objects/grid_patch.py:173
│  │        │  │  ├─ 1.155 iterable  yt/funcs.py:50
│  │        │  │  └─ 0.970 __getitem__  yt/units/yt_array.py:1035
│  │        │  ├─ 3.808 <listcomp>  yt/frontends/flash/data_structures.py:163
│  │        │  └─ 2.599 _setup_dx  yt/data_objects/grid_patch.py:137
│  │        └─ 18.082 _parse_index  yt/frontends/flash/data_structures.py:90
│  │           └─ 17.813 __init__  yt/frontends/flash/data_structures.py:41
│  │              └─ 17.647 __init__  yt/data_objects/grid_patch.py:58
│  │                 └─ 17.220 __init__  yt/data_objects/data_containers.py:1190
│  │                    ├─ 11.074 __init__  yt/data_objects/data_containers.py:132
│  │                    │  ├─ 6.355 __new__  yt/units/yt_array.py:458
│  │                    │  │  ├─ 1.517 __new__  yt/units/unit_object.py:167
│  │                    │  │  ├─ 1.321 __array_finalize__  yt/units/yt_array.py:1403
│  │                    │  │  └─ 1.286 asarray  numpy/core/numeric.py:424
│  │                    │  ├─ 1.179 _set_default_field_parameters  yt/data_objects/data_containers.py:184
│  │                    │  └─ 0.603 debug  logging/__init__.py:1284
│  │                    └─ 5.565 __new__  yt/data_objects/derived_quantities.py:87
│  │                       └─ 3.684 __getitem__  yt/data_objects/derived_quantities.py:94
│  │                          └─ 2.755 __init__  yt/data_objects/derived_quantities.py:53
```