### PR TITLE
fix py3 issues in Enzo FOF merger tree

### DIFF
--- a/yt/analysis_modules/halo_analysis/enzofof_merger_tree.py
+++ b/yt/analysis_modules/halo_analysis/enzofof_merger_tree.py
@@ -226,9 +226,9 @@ class EnzoFOFMergerBranch(object):
         self.progenitor = -1
         max_relationship = 0.0
         halo_count = 0
-        sorted_keys = sorted(tree.relationships[output_num][halo_id].keys())
-        for k in sorted_keys:
-            if not str(k).isdigit(): continue
+        keys = list(tree.relationships[output_num][halo_id].keys())
+        keys.remove('NumberOfParticles')
+        for k in sorted(keys):
             v = tree.relationships[output_num][halo_id][k]
             if v[1] > min_relation and halo_count < max_children:
                 halo_count += 1
@@ -490,7 +490,7 @@ class EnzoFOFMergerTree(object):
         It stores info from the FOF_groups file: location, mass, id, etc.
         """
         f = h5py.File("%s/%s" % (self.FOF_directory, filename), 'a')
-        cycle_fin = self.redshifts.keys()[-1]
+        cycle_fin = sorted(list(self.redshifts.keys()))[-1]
         halo_id = self.levels[cycle_fin][0].halo_id
         halo = "halo%05d" % halo_id
         if halo in f:


### PR DESCRIPTION
This fixes some python3 compatibility issues reported by Xiaoli Lian on the mailing list:

https://mail.python.org/mm3/archives/list/yt-users@python.org/thread/L2GC5YUPXHZCXYQ7RRPPJMIPVAKCTZ2W/

It turns out that this code has poor test coverage and I don't think was ever updated for python3. Thankfully the fixes were relatively straightforward, although there might be other issues that Xiaoli's test script didn't trigger.

I haven't carefully checked to make sure the outputs are still correct, but with this chnge Xiaoli's test script runs to completion without error.