### PR TITLE
Adding a ds_hold operation to swap datasets

### DIFF
--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1441,6 +1441,21 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface):
         self._locked = False
 
     @contextmanager
+    def _ds_hold(self, new_ds):
+        old_ds = self.ds
+        old_index = self._index
+        self.ds = new_ds
+        self._index = new_ds.index
+        old_chunk_info = self._chunk_info
+        self._chunk_info = None
+        self._index._identify_base_chunk(self)
+        with self._chunked_read(None):
+            yield
+        self._index = old_index
+        self.ds = old_ds
+        self._chunk_info = old_chunk_info
+
+    @contextmanager
     def _chunked_read(self, chunk):
         # There are several items that need to be swapped out
         # field_data, size, shape

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1442,18 +1442,30 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface):
 
     @contextmanager
     def _ds_hold(self, new_ds):
+        """
+        This contextmanager is used to take a data object and preserve its
+        attributes but allow the dataset that underlies it to be swapped out.
+        This is typically only used internally, and differences in unit systems
+        may present interesting possibilities.
+        """
         old_ds = self.ds
         old_index = self._index
         self.ds = new_ds
         self._index = new_ds.index
         old_chunk_info = self._chunk_info
+        old_chunk = self._current_chunk
+        old_size = self.size
         self._chunk_info = None
+        self._current_chunk = None
+        self.size = None
         self._index._identify_base_chunk(self)
         with self._chunked_read(None):
             yield
         self._index = old_index
         self.ds = old_ds
         self._chunk_info = old_chunk_info
+        self._current_chunk = old_chunk
+        self.size = old_size
 
     @contextmanager
     def _chunked_read(self, chunk):

--- a/yt/data_objects/tests/test_chunking.py
+++ b/yt/data_objects/tests/test_chunking.py
@@ -4,7 +4,6 @@ from yt.testing import \
     assert_true
 from yt.units.yt_array import \
     uconcatenate
-import weakref
 
 def _get_dobjs(c):
     dobjs = [("sphere", ("center", (1.0, "unitary"))),
@@ -45,13 +44,13 @@ def test_ds_hold():
     ds1 = fake_random_ds(64)
     ds2 = fake_random_ds(128)
     dd = ds1.all_data()
-    assert_true(dd.ds == ds1) # dd.ds is a weakref, so can't use "is"
+    assert_true(hash(dd.ds) == hash(ds1)) # dd.ds is a weakref, so can't use "is"
     assert_true(dd.index is ds1.index)
     assert_equal(dd["ones"].size, 64**3)
     with dd._ds_hold(ds2):
-        assert_true(dd.ds == ds2)
+        assert_true(hash(dd.ds) == hash(ds2))
         assert_true(dd.index is ds2.index)
         assert_equal(dd["ones"].size, 128**3)
-    assert_true(dd.ds == ds1) 
+    assert_true(hash(dd.ds) == hash(ds1)) 
     assert_true(dd.index is ds1.index)
     assert_equal(dd["ones"].size, 64**3)

--- a/yt/data_objects/tests/test_chunking.py
+++ b/yt/data_objects/tests/test_chunking.py
@@ -1,8 +1,10 @@
 from yt.testing import \
     fake_random_ds, \
-    assert_equal
+    assert_equal, \
+    assert_true
 from yt.units.yt_array import \
     uconcatenate
+import weakref
 
 def _get_dobjs(c):
     dobjs = [("sphere", ("center", (1.0, "unitary"))),
@@ -38,3 +40,18 @@ def test_chunking():
             assert_equal(coords['f']['io'], coords['f']['spatial'])
             assert_equal(coords['i']['io'], coords['i']['all'])
             assert_equal(coords['i']['io'], coords['i']['spatial'])
+
+def test_ds_hold():
+    ds1 = fake_random_ds(64)
+    ds2 = fake_random_ds(128)
+    dd = ds1.all_data()
+    assert_true(dd.ds == ds1) # dd.ds is a weakref, so can't use "is"
+    assert_true(dd.index is ds1.index)
+    assert_equal(dd["ones"].size, 64**3)
+    with dd._ds_hold(ds2):
+        assert_true(dd.ds == ds2)
+        assert_true(dd.index is ds2.index)
+        assert_equal(dd["ones"].size, 128**3)
+    assert_true(dd.ds == ds1) 
+    assert_true(dd.index is ds1.index)
+    assert_equal(dd["ones"].size, 64**3)

--- a/yt/data_objects/tests/test_chunking.py
+++ b/yt/data_objects/tests/test_chunking.py
@@ -44,16 +44,14 @@ def test_chunking():
 def test_ds_hold():
     ds1 = fake_random_ds(64)
     ds2 = fake_random_ds(128)
-    ds1wr = weakref.proxy(ds1)
-    ds2wr = weakref.proxy(ds2)
     dd = ds1.all_data()
-    assert_true(dd.ds == ds1wr) # dd.ds is a weakref, so can't use "is"
+    assert_true(dd.ds.__hash__() == ds1.__hash__()) # dd.ds is a weakref, so can't use "is"
     assert_true(dd.index is ds1.index)
     assert_equal(dd["ones"].size, 64**3)
     with dd._ds_hold(ds2):
-        assert_true(dd.ds == ds2wr)
+        assert_true(dd.ds.__hash__() == ds2.__hash__())
         assert_true(dd.index is ds2.index)
         assert_equal(dd["ones"].size, 128**3)
-    assert_true(dd.ds == ds1wr) 
+    assert_true(dd.ds.__hash__() == ds1.__hash__())
     assert_true(dd.index is ds1.index)
     assert_equal(dd["ones"].size, 64**3)

--- a/yt/data_objects/tests/test_chunking.py
+++ b/yt/data_objects/tests/test_chunking.py
@@ -4,7 +4,6 @@ from yt.testing import \
     assert_true
 from yt.units.yt_array import \
     uconcatenate
-import weakref
 
 def _get_dobjs(c):
     dobjs = [("sphere", ("center", (1.0, "unitary"))),

--- a/yt/data_objects/tests/test_chunking.py
+++ b/yt/data_objects/tests/test_chunking.py
@@ -4,6 +4,7 @@ from yt.testing import \
     assert_true
 from yt.units.yt_array import \
     uconcatenate
+import weakref
 
 def _get_dobjs(c):
     dobjs = [("sphere", ("center", (1.0, "unitary"))),
@@ -43,14 +44,16 @@ def test_chunking():
 def test_ds_hold():
     ds1 = fake_random_ds(64)
     ds2 = fake_random_ds(128)
+    ds1wr = weakref.proxy(ds1)
+    ds2wr = weakref.proxy(ds2)
     dd = ds1.all_data()
-    assert_true(hash(dd.ds) == hash(ds1)) # dd.ds is a weakref, so can't use "is"
+    assert_true(dd.ds == ds1wr) # dd.ds is a weakref, so can't use "is"
     assert_true(dd.index is ds1.index)
     assert_equal(dd["ones"].size, 64**3)
     with dd._ds_hold(ds2):
-        assert_true(hash(dd.ds) == hash(ds2))
+        assert_true(dd.ds == ds2wr)
         assert_true(dd.index is ds2.index)
         assert_equal(dd["ones"].size, 128**3)
-    assert_true(hash(dd.ds) == hash(ds1)) 
+    assert_true(dd.ds == ds1wr) 
     assert_true(dd.index is ds1.index)
     assert_equal(dd["ones"].size, 64**3)


### PR DESCRIPTION
I have been poking at a `MultiIndex` that combines multiple datasets or index objects.  I've found that I've been able to implement nearly all of it outside of core changes to yt except for this.

This -- in the vein of the other context managers in the data container class -- sets up a holding system so that when you are in the context manager, you are free to use the data object in such a way that the index is not assumed to be the one it was built with.

One example usage would be something like this, which I'm using in the multi index object:

```
def _chunk_io(self, dobj, cache = True, local_only = False):
        indices = getattr(dobj._current_chunk, "objs", dobj._chunk_info)
        print(indices)
        for ind in indices:
            with dobj._ds_hold(ind.ds):
                for c in ind._chunk_io(dobj, cache, local_only):
                    yield c
```

I'm issuing this PR because I intend to develop the multi index object externally for a while, as I suspect it's rather experimental and potentially volatile, and I don't have a timeline.