### PR TITLE
allow PhasePlot.set_log to accept field tuples or objects as well as strings

### DIFF
--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -1381,14 +1381,15 @@ class PhasePlot(ImagePlotContainer):
                 self.z_log[field] = log
             self._profile_valid = False
         else:
-            if field == p.x_field[1]:
+            field, = self.profile.data_source._determine_fields([field])
+            if field == p.x_field:
                 self.x_log = log
                 self._profile_valid = False
-            elif field == p.y_field[1]:
+            elif field == p.y_field:
                 self.y_log = log
                 self._profile_valid = False
-            elif field in p.field_map:
-                self.z_log[p.field_map[field]] = log
+            elif field in p.field_data:
+                self.z_log[field] = log
             else:
                 raise KeyError("Field %s not in phase plot!" % (field))
         return self

--- a/yt/visualization/tests/test_particle_plot.py
+++ b/yt/visualization/tests/test_particle_plot.py
@@ -227,8 +227,8 @@ def test_particle_phase_plot_semantics():
                         ('Gas', 'density'),
                         ('Gas', 'temperature'),
                         ('Gas', 'particle_mass'))
-    plot.set_log('density', True)
-    plot.set_log('temperature', True)
+    plot.set_log(('Gas', 'density'), True)
+    plot.set_log(('Gas', 'temperature'), True)
     p = plot.profile
 
     # bin extrema are field extrema
@@ -246,8 +246,8 @@ def test_particle_phase_plot_semantics():
     dylogybins = logybins[1:] - logybins[:-1]
     assert_allclose(dylogybins, dylogybins[0])
 
-    plot.set_log('density', False)
-    plot.set_log('temperature', False)
+    plot.set_log(('Gas', 'density'), False)
+    plot.set_log(('Gas', 'temperature'), False)
     p = plot.profile
 
     # bin extrema are field extrema

--- a/yt/visualization/tests/test_profile_plots.py
+++ b/yt/visualization/tests/test_profile_plots.py
@@ -224,3 +224,27 @@ class TestAnnotations(unittest.TestCase):
 
         with self.assertRaises(YTFieldNotFound):
             self.plot.annotate_text(1e-1, 1e1, "Annotated text", "wrong_field_name")
+
+@requires_file(ETC46)
+def test_phaseplot_set_log():
+    ds = yt.load(ETC46)
+    sp = ds.sphere("max", (1.0, "Mpc"))
+    p1 = yt.ProfilePlot(sp, "radius", ("enzo", "Density"))
+    p2 = yt.PhasePlot(sp, ("enzo", "Density"), ("enzo", "Temperature"), "cell_mass")
+    # make sure we can set the log-scaling using the tuple without erroring out
+    p1.set_log(("enzo", "Density"), False)
+    p2.set_log(("enzo", "Temperature"), False)
+    assert p1.y_log["enzo", "Density"] is False
+    assert p2.y_log is False
+
+    # make sure we can set the log-scaling using a string without erroring out
+    p1.set_log("Density", True)
+    p2.set_log("Temperature", True)
+    assert p1.y_log["enzo", "Density"] is True
+    assert p2.y_log is True
+
+    # make sure we can set the log-scaling using a field object
+    p1.set_log(ds.fields.enzo.Density, False)
+    p2.set_log(ds.fields.enzo.Temperature, False)
+    assert p1.y_log["enzo", "Density"] is False
+    assert p2.y_log is False


### PR DESCRIPTION
Currently `PhasePlot.set_log` seems to expect string field names. This PR adds a call to _determine_fields to allow accepting tuples as well as field objects. I've added a test as well.