### PR TITLE
Coordinates for aitoff pixelizer

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -112,7 +112,7 @@ answer_tests:
     - yt/analysis_modules/absorption_spectrum/tests/test_absorption_spectrum.py:test_absorption_spectrum_cosmo_sph
     - yt/analysis_modules/absorption_spectrum/tests/test_absorption_spectrum.py:test_absorption_spectrum_with_continuum
 
-  local_axialpix_003:
+  local_axialpix_004:
     - yt/geometry/coordinates/tests/test_axial_pixelization.py:test_axial_pixelization
 
   local_particle_trajectory_000:

--- a/yt/geometry/coordinates/geographic_coordinates.py
+++ b/yt/geometry/coordinates/geographic_coordinates.py
@@ -175,14 +175,15 @@ class GeographicCoordinateHandler(CoordinateHandler):
 
     def _ortho_pixelize(self, data_source, field, bounds, size, antialias,
                         dim, periodic):
-        # For axis=2, x axis will be latitude, y axis will be longitude
-        px = (data_source["px"].d + 90) * np.pi/180
+        # For a radial axis, px will correspond to longitude and py will
+        # correspond to latitude.
+        px = (data_source["px"].d + 180) * np.pi/180
         pdx = data_source["pdx"].d * np.pi/180
-        py = (data_source["py"].d + 180) * np.pi/180
+        py = (data_source["py"].d + 90) * np.pi/180
         pdy = data_source["pdy"].d * np.pi/180
         # First one in needs to be the equivalent of "theta", which is
         # longitude
-        buff = pixelize_aitoff(py, pdy, px, pdx,
+        buff = pixelize_aitoff(px, pdx, py, pdy,
                                size, data_source[field], None,
                                None).transpose()
         return buff
@@ -274,11 +275,11 @@ class GeographicCoordinateHandler(CoordinateHandler):
 
     _x_pairs = (('latitude', 'longitude'),
                 ('longitude', 'latitude'),
-                ('altitude', 'latitude'))
+                ('altitude', 'longitude'))
 
     _y_pairs = (('latitude', 'altitude'),
                 ('longitude', 'altitude'),
-                ('altitude', 'longitude'))
+                ('altitude', 'latitude'))
 
     @property
     def period(self):
@@ -365,11 +366,11 @@ class InternalGeographicCoordinateHandler(GeographicCoordinateHandler):
 
     _x_pairs = (('latitude', 'longitude'),
                 ('longitude', 'latitude'),
-                ('depth', 'latitude'))
+                ('depth', 'longitude'))
 
     _y_pairs = (('latitude', 'depth'),
                 ('longitude', 'depth'),
-                ('depth', 'longitude'))
+                ('depth', 'latitude'))
 
     def sanitize_center(self, center, axis):
         center, display_center = super(
@@ -398,8 +399,8 @@ class InternalGeographicCoordinateHandler(GeographicCoordinateHandler):
               axis, width, depth)
         elif name == self.radial_axis:
             rax = self.radial_axis
-            width = [self.ds.domain_width[self.y_axis[rax]],
-                     self.ds.domain_width[self.x_axis[rax]]]
+            width = [self.ds.domain_width[self.x_axis[rax]],
+                     self.ds.domain_width[self.y_axis[rax]]]
         elif name == 'latitude':
             ri = self.axis_id[self.radial_axis]
             # Remember, in spherical coordinates when we cut in theta,

--- a/yt/geometry/coordinates/spherical_coordinates.py
+++ b/yt/geometry/coordinates/spherical_coordinates.py
@@ -114,8 +114,8 @@ class SphericalCoordinateHandler(CoordinateHandler):
 
     def _ortho_pixelize(self, data_source, field, bounds, size, antialias,
                         dim, periodic):
-        buff = pixelize_aitoff(data_source["py"], data_source["pdy"],
-                               data_source["px"], data_source["pdx"],
+        buff = pixelize_aitoff(data_source["px"], data_source["pdx"],
+                               data_source["py"], data_source["pdy"],
                                size, data_source[field], None,
                                None, theta_offset = 0,
                                phi_offset = 0).transpose()

--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -577,8 +577,8 @@ def pixelize_aitoff(np.float64_t[:] theta,
                     np.float64_t theta_offset = 0.0,
                     np.float64_t phi_offset = 0.0):
     # http://paulbourke.net/geometry/transformationprojection/
-    # longitude is -pi to pi
-    # latitude is -pi/2 to pi/2
+    # (theta) longitude is -pi to pi
+    # (phi) latitude is -pi/2 to pi/2
     # z^2 = 1 + cos(latitude) cos(longitude/2)
     # x = cos(latitude) sin(longitude/2) / z
     # y = sin(latitude) / z


### PR DESCRIPTION
The aitoff pixelizer does not get used very much.  It's used only when pixelizing along the radial axis in the spherical coordinate handler or in the geographic coordinate handler.

I have recently been poking at removing some of our machinery that operates in this space and replacing it with cartopy; the pixelizer would likely still be used in some form, but we would transition to using cartopy for all management of axes, etc.

In the process of poking at that, I began to work at examining some spherical and geographic datasets (specifically, from GEOS, which I have uploaded to http://use.yt/upload/ff63bba3 totaling 1.6 GB) and looking at slices.  The slices were manifestly incorrect:

![image 3](https://user-images.githubusercontent.com/89019/40283146-5214b70c-5c3f-11e8-924d-1567b70f2b41.png)

(The axes, which I'm sure will draw attention, are pretty bad in that they assume cartesian shapes to a non-cartesian geometry.  That's why we need cartopy.)  Looking at this, we can see that the x/y axes are labeled "correctly" but with the wrong bounds; the aspect ratio is wrong, too.

This PR consists of two main changes.  The first is to change which axis corresponds to x and y in the geographic coordinate handler and its subclass.  This fixes the bounds issues.  (Note that the name of the axes are controlled by a slightly different variable, which was correct, `image_axis_name`.)  The second change is, now that we have the correct x and y axes, we need to supply them correctly to the pixelizer itself.  I have applied this second change to the spherical handler, too.

I've verified that this gives correct results -- again, ignore the backwardsness of the axis bounds for latitude, please, that's why I'm working on this anyway -- and that I can get this to work with spherical datasets loaded in either `('r', 'theta', 'phi')` or `('r', 'phi', 'theta')`, which is as it should be.

![download 2](https://user-images.githubusercontent.com/89019/40283194-de5f10fe-5c3f-11e8-8891-4eef1a77f61f.png)
![download 1](https://user-images.githubusercontent.com/89019/40283195-de6fcb56-5c3f-11e8-96dd-aae4bd620582.png)
![download](https://user-images.githubusercontent.com/89019/40283196-de7df55a-5c3f-11e8-998f-abbe51a74be3.png)

I've attached a (zipped) notebook here, which includes code from @Xarthisius , that loads the dataset and makes the images.

[spherical data.zip](https://github.com/yt-project/yt/files/2020656/spherical.data.zip)

