### PR TITLE
fix AttributeError in _export_ply

### DIFF
--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -1761,8 +1761,8 @@ class YTSurface(YTSelectionContainer3D):
             if sample_type == "face" and \
                 color_field not in self.field_data:
                 self[color_field]
-            elif sample_type == "vertex" and \
-                color_field not in self.vertex_data:
+            elif (sample_type == "vertex" and
+                  color_field not in self.vertex_samples):
                 self.get_data(color_field, sample_type, no_ghost=no_ghost)
         self._export_ply(filename, bounds, color_field, color_map, color_log,
                          sample_type)

--- a/yt/data_objects/tests/test_fluxes.py
+++ b/yt/data_objects/tests/test_fluxes.py
@@ -60,6 +60,9 @@ class ExporterTests(TestCase):
         surf = ds.surface(dd, 'x', 0.51)
         surf.export_ply('my_ply.ply', bounds=[(0, 1), (0, 1), (0, 1)])
         assert os.path.exists('my_ply.ply')
+        surf.export_ply('my_ply2.ply', bounds=[(0, 1), (0, 1), (0, 1)],
+                        sample_type='vertex', color_field='density')
+        assert os.path.exists('my_ply2.ply')
 
     @requires_file(ISOGAL)
     def test_export_obj(self):


### PR DESCRIPTION
The `vertex_data` attribute is named `vertex_samples` now. I'm not sure when this change was made but it looks like it was at least five years ago.

I've added a test to make sure the code path that I've changed in `_export_ply` gets triggered by the tests.