### PR TITLE
Forced integer division in save_annotated to prevent errors in newer numpy versions

### DIFF
--- a/yt/visualization/volume_rendering/tests/test_scene.py
+++ b/yt/visualization/volume_rendering/tests/test_scene.py
@@ -106,4 +106,5 @@ def test_annotations():
     im = sc._last_render
     for c in ([1, 0, 0, 1], [0, 1, 0, 1], [0, 0, 1, 1], [1, 1, 1, 1]):
         assert np.where((im == c).all(axis=-1))[0].shape[0] > 0
+    sc[0].tfh.tf.add_layers(10, colormap='cubehelix')
     sc.save_annotated('test_scene_annotated.png', text_annotate=[[(.1, 1.05), "test_string"]])

--- a/yt/visualization/volume_rendering/tests/test_scene.py
+++ b/yt/visualization/volume_rendering/tests/test_scene.py
@@ -106,3 +106,4 @@ def test_annotations():
     im = sc._last_render
     for c in ([1, 0, 0, 1], [0, 1, 0, 1], [0, 0, 1, 1], [1, 1, 1, 1]):
         assert np.where((im == c).all(axis=-1))[0].shape[0] > 0
+    sc.save_annotated('test_scene_annotated.png', text_annotate=[[(.1, 1.05), "test_string"]])

--- a/yt/visualization/volume_rendering/transfer_functions.py
+++ b/yt/visualization/volume_rendering/transfer_functions.py
@@ -540,7 +540,7 @@ class ColorTransferFunction(MultiVariateTransferFunction):
         xticks = np.arange(np.ceil(self.alpha.x[0]), np.floor(self.alpha.x[-1]) + 1, 1) - self.alpha.x[0]
         xticks *= (self.alpha.x.size-1) / (self.alpha.x[-1] - self.alpha.x[0])
         if len(xticks) > 5:
-            xticks = xticks[::len(xticks)/5]
+            xticks = xticks[::len(xticks)//5]
         ax.xaxis.set_ticks(xticks)
         def x_format(x, pos):
             return "%.1f" % (x * (self.alpha.x[-1] - self.alpha.x[0]) / (self.alpha.x.size-1) + self.alpha.x[0])
@@ -594,7 +594,7 @@ class ColorTransferFunction(MultiVariateTransferFunction):
         xticks = np.arange(np.ceil(self.alpha.x[0]), np.floor(self.alpha.x[-1]) + 1, 1) - self.alpha.x[0]
         xticks *= (self.alpha.x.size-1) / (self.alpha.x[-1] - self.alpha.x[0])
         if len(xticks) > 5:
-            xticks = xticks[::len(xticks)/5]
+            xticks = xticks[::len(xticks)//5]
 
         # Add colorbar limits to the ticks (May not give ideal results)
         xticks = np.append(visible[0], xticks)


### PR DESCRIPTION
Starting with numpy 1.12, indexing an array with floats [raises an IndexError](https://docs.scipy.org/doc/numpy-1.12.0/release.html). This happens in the save_annotated function of the volume_rendering module. 

E.g. with numpy 1.13.3, matplotlib 2.2.2 and yt 3.4.1 (all installed via anaconda) I get:
> egaraldi@science05:/vol/3Drendering$ python customTF.py 
> step  5 ...
> yt : [INFO     ] 2018-05-22 11:52:09,551 Parameters: current_time              = 0.0
> yt : [INFO     ] 2018-05-22 11:52:09,551 Parameters: domain_dimensions         = [128 128 128]
> yt : [INFO     ] 2018-05-22 11:52:09,551 Parameters: domain_left_edge          = [-50. -50. -50.]
> yt : [INFO     ] 2018-05-22 11:52:09,552 Parameters: domain_right_edge         = [ 50.  50.  50.]
> yt : [INFO     ] 2018-05-22 11:52:09,552 Parameters: cosmological_simulation   = 0.0
> yt : [INFO     ] 2018-05-22 11:52:11,995 Rendering scene (Can take a while).
> yt : [INFO     ] 2018-05-22 11:52:12,014 Creating volume
> Traceback (most recent call last):
>   File "customTF.py", line 143, in <module>
>     sc.save_annotated('mytf%i.png'%istep,sigma_clip=3)#,text_annotate=[[(.1, 1.05), "test"]])
>   File "/vol/aibn230/data1/egaraldi/anaconda3/lib/python3.6/site-packages/yt/visualization/volume_rendering/scene.py", line 431, in save_annotated
>     self._annotate(ax.axes, tf, rs, label=label, label_fmt=label_fmt)
>   File "/vol/aibn230/data1/egaraldi/anaconda3/lib/python3.6/site-packages/yt/visualization/volume_rendering/scene.py", line 485, in _annotate
>     log_scale=source.log_field)
>   File "/vol/aibn230/data1/egaraldi/anaconda3/lib/python3.6/site-packages/yt/visualization/volume_rendering/transfer_functions.py", line 597, in vert_cbar
>     xticks = xticks[::len(xticks)/5]
> TypeError: slice indices must be integers or None or have an \_\_index\_\_ method

This PR addresses the issue by forcing integer indices.