### PR TITLE
ensure FRB buff_size is a two-element tuple of ints

### DIFF
--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -90,7 +90,7 @@ class FixedResolutionBuffer(object):
         self.data_source = data_source
         self.ds = data_source.ds
         self.bounds = bounds
-        self.buff_size = buff_size
+        self.buff_size = (int(buff_size[0]), int(buff_size[1]))
         self.antialias = antialias
         self.data = {}
         self._filters = []

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -452,6 +452,9 @@ def test_frb_regen():
     slc = SlicePlot(ds, 2, 'density')
     slc.set_buff_size(1200)
     assert_equal(slc.frb['density'].shape, (1200, 1200))
+    slc.set_buff_size((400., 200.7))
+    assert_equal(slc.frb['density'].shape, (200, 400))
+
 
 def test_set_background_color():
     ds = fake_random_ds(32)


### PR DESCRIPTION
This avoids an ugly error if you happen to pass in floats to `set_buff_size` or when manually creating an FRB:

```python traceback
In [2]: plot.set_buff_size([400., 400.])
Out[2]: <yt.visualization.plot_window.AxisAlignedSlicePlot at 0x110a34780>

In [3]: plot.save()
yt : [INFO     ] 2018-05-23 11:01:39,357 Making a fixed resolution buffer of (('gas', 'density')) 400 by 400
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
~/Documents/yt-git-fixes/yt/mods.py in <module>()
----> 1 plot.save()

~/Documents/yt-git-fixes/yt/visualization/plot_container.py in newfunc(*args, **kwargs)
     86         if hasattr(args[0], '_data_valid'):
     87             if not args[0]._data_valid:
---> 88                 args[0]._recreate_frb()
     89         if hasattr(args[0], '_profile_valid'):
     90             if not args[0]._profile_valid:

~/Documents/yt-git-fixes/yt/visualization/plot_window.py in _recreate_frb(self)
    274             # Restore the old fields
    275             for key, unit in zip(old_fields, old_units):
--> 276                 self._frb[key]
    277                 equiv = self._equivalencies[key]
    278                 if equiv[0] is None:

~/Documents/yt-git-fixes/yt/visualization/fixed_resolution.py in __getitem__(self, item)
    132         buff = self.ds.coordinates.pixelize(self.data_source.axis,
    133             self.data_source, item, bounds, self.buff_size,
--> 134             int(self.antialias))
    135
    136         for name, (args, kwargs) in self._filters:

~/Documents/yt-git-fixes/yt/geometry/coordinates/cartesian_coordinates.py in pixelize(self, dimension, data_source, field, bounds, size, antialias, periodic)
    156         elif self.axis_id.get(dimension, dimension) < 3:
    157             return self._ortho_pixelize(data_source, field, bounds, size,
--> 158                                         antialias, dimension, periodic)
    159         else:
    160             return self._oblique_pixelize(data_source, field, bounds, size,

~/Documents/yt-git-fixes/yt/geometry/coordinates/cartesian_coordinates.py in _ortho_pixelize(self, data_source, field, bounds, size, antialias, dim, periodic)
    221             period = period.in_units("code_length").d
    222
--> 223         buff = np.zeros((size[1], size[0]), dtype="f8")
    224
    225         finfo = self.ds._get_field_info(field)

TypeError: 'float' object cannot be interpreted as an integer
```

With this PR we ensure we're alwayts going to pass integer numbers of pixels to numpy and avoid this error.