### PR TITLE
array_like_field should only use output_units for particle fields

### DIFF
--- a/yt/fields/tests/test_fields.py
+++ b/yt/fields/tests/test_fields.py
@@ -304,6 +304,21 @@ def test_array_like_field():
     u2 = array_like_field(ad, 1., ("all", "particle_mass")).units
     assert u1 == u2
 
+ISOGAL = 'IsolatedGalaxy/galaxy0030/galaxy0030'
+
+@requires_file(ISOGAL)
+def test_array_like_field_output_units():
+    ds = load(ISOGAL)
+    ad = ds.all_data()
+    u1 = ad["particle_mass"].units
+    u2 = array_like_field(ad, 1., ("all", "particle_mass")).units
+    assert u1 == u2
+    assert str(u1) == ds.fields.all.particle_mass.output_units
+    u1 = ad['gas', 'x'].units
+    u2 = array_like_field(ad, 1., ("gas", "x")).units
+    assert u1 == u2
+    assert str(u1) == ds.fields.gas.x.units
+
 def test_add_field_string():
     ds = fake_random_ds(16)
     ad = ds.all_data()
@@ -358,8 +373,6 @@ def test_field_inference():
     # If this is not true this means the result of field inference depends
     # on the order we did field detection, which is random in Python3
     assert_equal(ds._last_freq, (None, None))
-
-ISOGAL = 'IsolatedGalaxy/galaxy0030/galaxy0030'
 
 @requires_file(ISOGAL)
 def test_deposit_amr():

--- a/yt/units/yt_array.py
+++ b/yt/units/yt_array.py
@@ -1678,9 +1678,13 @@ def ustack(arrs, axis=0):
 def array_like_field(data, x, field):
     field = data._determine_fields(field)[0]
     if isinstance(field, tuple):
-        units = data.ds._get_field_info(field[0],field[1]).output_units
+        finfo = data.ds._get_field_info(field[0],field[1])
     else:
-        units = data.ds._get_field_info(field).output_units
+        finfo = data.ds._get_field_info(field)
+    if finfo.sampling_type == 'particle':
+        units = finfo.output_units
+    else:
+        units = finfo.units
     if isinstance(x, YTArray):
         arr = copy.deepcopy(x)
         arr.convert_to_units(units)


### PR DESCRIPTION
This fixes one of the issues Nick Gnedin reported on the mailing list. One of these days we'll be able to get rid of the distinction between `units` and `output_units` once and for all. For now we isolate the awfulness in this case by only using it for particle fields in `array_like_fields`. Currently `output_units` are only systematically handled in yt for particle fields. Another solution would be to make all fields respect it, but I'm certain that would cause more breakage.