### PR TITLE
Ensure artio particle age fields have the correct units during field detection

### DIFF
--- a/yt/fields/field_detector.py
+++ b/yt/fields/field_detector.py
@@ -139,12 +139,16 @@ class FieldDetector(defaultdict):
                 self[item] = \
                   YTArray(np.ones((self.NumberOfParticles, 4)),
                           finfo.units, registry=self.ds.unit_registry)
-
             else:
                 # Not a vector
                 self[item] = \
                   YTArray(np.ones(self.NumberOfParticles),
                           finfo.units, registry=self.ds.unit_registry)
+            if item == ('STAR', 'BIRTH_TIME'):
+                # hack for the artio frontend so we pass valid times to
+                # the artio functions for calculating physical times
+                # from internal times
+                self[item] *= -0.1
             self.requested.append(item)
             return self[item]
         self.requested.append(item)

--- a/yt/frontends/artio/fields.py
+++ b/yt/frontends/artio/fields.py
@@ -16,8 +16,6 @@ ARTIO-specific fields
 
 from yt.fields.field_info_container import \
     FieldInfoContainer
-from yt.fields.field_detector import \
-    FieldDetector
 from yt.units.yt_array import \
     YTArray
 from yt.utilities.physical_constants import \
@@ -125,16 +123,9 @@ class ARTIOFieldInfo(FieldInfoContainer):
     def setup_particle_fields(self, ptype):
         if ptype == "STAR":
             def _creation_time(field,data):
-                # this test is necessary to avoid passing invalid tcode values
-                # to the function tphys_from_tcode during field detection
-                # (1.0 is not a valid tcode value)
-                if isinstance(data, FieldDetector):
-                    return data["STAR","BIRTH_TIME"]
                 return YTArray(data.ds._handle.tphys_from_tcode_array(data["STAR","BIRTH_TIME"]),"yr")
 
             def _age(field, data):
-                if isinstance(data, FieldDetector):
-                    return data["STAR","creation_time"]
                 return data.ds.current_time - data["STAR","creation_time"]
 
             self.add_field((ptype, "creation_time"), sampling_type="particle",  function=_creation_time, units="yr")
@@ -142,11 +133,6 @@ class ARTIOFieldInfo(FieldInfoContainer):
 
             if self.ds.cosmological_simulation:
                 def _creation_redshift(field,data):
-                    # this test is necessary to avoid passing invalid tcode values
-                    # to the function auni_from_tcode during field detection
-                    # (1.0 is not a valid tcode value)
-                    if isinstance(data, FieldDetector):
-                        return data["STAR","BIRTH_TIME"]
                     return 1.0/data.ds._handle.auni_from_tcode_array(data["STAR","BIRTH_TIME"]) - 1.0
 
                 self.add_field((ptype, "creation_redshift"), sampling_type="particle",  function=_creation_redshift)

--- a/yt/frontends/artio/tests/test_outputs.py
+++ b/yt/frontends/artio/tests/test_outputs.py
@@ -14,8 +14,10 @@ ARTIO frontend tests
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
+from yt.convenience import load
 from yt.testing import \
     assert_equal, \
+    assert_allclose_units, \
     requires_file, \
     units_override_check
 from yt.utilities.answer_testing.framework import \
@@ -58,3 +60,20 @@ def test_ARTIODataset():
 @requires_file(sizmbhloz)
 def test_units_override():
     units_override_check(sizmbhloz)
+
+@requires_file(sizmbhloz)
+def test_particle_derived_field():
+    def star_age_alias(field, data):
+        # test to make sure we get back data in the correct units
+        # during field detection
+        return data['STAR', 'age'].in_units('Myr')
+
+    ds = load(sizmbhloz)
+
+    ds.add_field(("STAR", "new_field"), function=star_age_alias,
+                 units='Myr', sampling_type="particle")
+
+    ad = ds.all_data()
+
+    assert_allclose_units(ad['STAR', 'age'].in_units("Myr"),
+                          ad["STAR", "new_field"])


### PR DESCRIPTION
Currently there are already hacks in the artio frontend to avoid issues with field detection. These hacks make it so the artio particle age fields don't have the correct units during field detection, requiring users who make use of these fields in a derived field to also add similar hacks.

The fix is to make it so we don't pass invalid data during field detection to the artio frontend's helpers for converting from internal time units to physical time units.

This does mean adding an ARTIO-specific hack to the field detection machinery. Optimally we would have a way of telling the field detection machinery to draw from a range of possible values during field detection, but we don't have something like that yet.