### PR TITLE
Spherical aitoff fix

### DIFF
--- a/yt/geometry/coordinates/spherical_coordinates.py
+++ b/yt/geometry/coordinates/spherical_coordinates.py
@@ -114,8 +114,8 @@ class SphericalCoordinateHandler(CoordinateHandler):
 
     def _ortho_pixelize(self, data_source, field, bounds, size, antialias,
                         dim, periodic):
-        buff = pixelize_aitoff(data_source["px"], data_source["pdx"],
-                               data_source["py"], data_source["pdy"],
+        buff = pixelize_aitoff(data_source["py"], data_source["pdy"],
+                               data_source["px"], data_source["pdx"],
                                size, data_source[field], None,
                                None, theta_offset = 0,
                                phi_offset = 0).transpose()

--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -558,11 +558,12 @@ def pixelize_cylinder(np.float64_t[:,:] buff,
                 r_i += 0.5*dx
             theta_i += dthetamin
 
-cdef void aitoff_thetaphi_to_xy(np.float64_t theta, np.float64_t phi,
-                                np.float64_t *x, np.float64_t *y):
+cdef int aitoff_thetaphi_to_xy(np.float64_t theta, np.float64_t phi,
+                               np.float64_t *x, np.float64_t *y) except -1:
     cdef np.float64_t z = math.sqrt(1 + math.cos(phi) * math.cos(theta / 2.0))
     x[0] = math.cos(phi) * math.sin(theta / 2.0) / z
     y[0] = math.sin(phi) / z
+    return 0
 
 @cython.cdivision(True)
 @cython.boundscheck(False)


### PR DESCRIPTION
This fixes the error messages that are currently being printed by some of the unit tests. I've also made it so the function that is printing these messages raises errors instead of silently failing only with a warning message. See #1796 for a more long-term fix.
