### PR TITLE
Added missing known fields with nontrivial units 

### DIFF
--- a/yt/frontends/artio/fields.py
+++ b/yt/frontends/artio/fields.py
@@ -47,6 +47,11 @@ class ARTIOFieldInfo(FieldInfoContainer):
         ("HVAR_METAL_DENSITY_II", (rho_units, ["metal_ii_density"], None)),
         ("VAR_POTENTIAL", ("", ["potential"], None)),
         ("VAR_POTENTIAL_HYDRO", ("", ["gas_potential"], None)),
+        ("RT_HVAR_HI", (rho_units, ["HI density"], None)),
+        ("RT_HVAR_HII", (rho_units, ["HII density"], None)),
+        ("RT_HVAR_HeI", (rho_units, ["HeI density"], None)),
+        ("RT_HVAR_HeII", (rho_units, ["HeII density"], None)),
+        ("RT_HVAR_HeIII", (rho_units, ["HeIII density"], None)),
     )
 
     known_particle_fields = (


### PR DESCRIPTION
ARTIO frontend is missing densities of atomic species in the list of known fields. By default, these fields are treated as dimensionless, while they are not (have units of mass density).
