### PR TITLE
remove usage of pyplot for annotated volume rendering

### DIFF
--- a/doc/source/cookbook/vol-annotated.py
+++ b/doc/source/cookbook/vol-annotated.py
@@ -26,4 +26,4 @@ text_string = "T = {} Gyr".format(float(ds.current_time.to('Gyr')))
 # save an annotated version of the volume rendering including a representation
 # of the transfer function and a nice label showing the simulation time.
 sc.save_annotated("vol_annotated.png", sigma_clip=6,
-                  text_annotate=[[(.1, 1.05), text_string]])
+                  text_annotate=[[(.1, 0.95), text_string]])

--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -461,16 +461,16 @@ class Scene(object):
             canvas = self.canvas
 
         self._render_figure.canvas = canvas
-
-        self._render_figure.savefig(fname, facecolor='black',
-                                    bbox_inches='tight', pad_inches=0)
+        self._render_figure.tight_layout()
+        self._render_figure.savefig(fname, facecolor='black', pad_inches=0)
 
     def _show_mpl(self, im, sigma_clip=None, dpi=100):
         from matplotlib.figure import Figure
         s = im.shape
         self._render_figure = Figure(figsize=(s[1]/float(dpi), s[0]/float(dpi)))
         self._render_figure.clf()
-        ax = self._render_figure.add_axes([0, 0, 1, 1])
+        ax = self._render_figure.add_subplot(111)
+        ax.set_position([0, 0, 1, 1])
 
         if sigma_clip is not None:
             nz = im[im > 0.0]

--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -396,8 +396,8 @@ class Scene(object):
         ...                                        horizontalalignment="center")]])
 
         """
-        import matplotlib.pyplot as plt
-
+        from yt.visualization._mpl_imports import \
+            FigureCanvasAgg, FigureCanvasPdf, FigureCanvasPS
         sources = list(itervalues(self.sources))
         rensources = [s for s in sources if isinstance(s, RenderSource)]
 
@@ -429,11 +429,10 @@ class Scene(object):
         ax = self._show_mpl(self._last_render.swapaxes(0, 1),
                             sigma_clip=sigma_clip, dpi=dpi)
         self._annotate(ax.axes, tf, rs, label=label, label_fmt=label_fmt)
-        plt.tight_layout()
 
         # any text?
         if text_annotate is not None:
-            f = plt.gcf()
+            f = self._render_figure
             for t in text_annotate:
                 xy = t[0]
                 string = t[1]
@@ -446,18 +445,32 @@ class Scene(object):
                 if "color" not in opt:
                     opt["color"] = "w"
 
-                plt.text(xy[0], xy[1], string,
-                         transform=f.transFigure, **opt)
+                ax.axes.text(xy[0], xy[1], string,
+                             transform=f.transFigure, **opt)
 
-        plt.savefig(fname, facecolor='black', pad_inches=0)
+        suffix = get_image_suffix(fname)
+
+        if suffix == ".png":
+            canvas = FigureCanvasAgg(self._render_figure)
+        elif suffix == ".pdf":
+            canvas = FigureCanvasPdf(self._render_figure)
+        elif suffix in (".eps", ".ps"):
+            canvas = FigureCanvasPS(self._render_figure)
+        else:
+            mylog.warning("Unknown suffix %s, defaulting to Agg", suffix)
+            canvas = self.canvas
+
+        self._render_figure.canvas = canvas
+
+        self._render_figure.savefig(fname, facecolor='black',
+                                    bbox_inches='tight', pad_inches=0)
 
     def _show_mpl(self, im, sigma_clip=None, dpi=100):
-        import matplotlib.pyplot as plt
+        from matplotlib.figure import Figure
         s = im.shape
-        self._render_figure = plt.figure(1, figsize=(s[1]/float(dpi), s[0]/float(dpi)))
+        self._render_figure = Figure(figsize=(s[1]/float(dpi), s[0]/float(dpi)))
         self._render_figure.clf()
-        ax = plt.gca()
-        ax.set_position([0, 0, 1, 1])
+        ax = self._render_figure.add_axes([0, 0, 1, 1])
 
         if sigma_clip is not None:
             nz = im[im > 0.0]
@@ -467,19 +480,18 @@ class Scene(object):
             del nz
         else:
             nim = im
-        axim = plt.imshow(nim[:,:,:3]/nim[:,:,:3].max(),
-                          interpolation="bilinear")
+        axim = ax.imshow(nim[:,:,:3]/nim[:,:,:3].max(),
+                         interpolation="bilinear")
 
         return axim
 
     def _annotate(self, ax, tf, source, label="", label_fmt=None):
-        import matplotlib.pyplot as plt
         ax.get_xaxis().set_visible(False)
         ax.get_xaxis().set_ticks([])
         ax.get_yaxis().set_visible(False)
         ax.get_yaxis().set_ticks([])
-        cb = plt.colorbar(ax.images[0], pad=0.0, fraction=0.05,
-                          drawedges=True, shrink=0.75)
+        cb = self._render_figure.colorbar(ax.images[0], pad=0.0, fraction=0.05,
+                                          drawedges=True)
         tf.vert_cbar(ax=cb.ax, label=label, label_fmt=label_fmt,
                      resolution=self.camera.resolution[0],
                      log_scale=source.log_field)

--- a/yt/visualization/volume_rendering/tests/test_scene.py
+++ b/yt/visualization/volume_rendering/tests/test_scene.py
@@ -96,6 +96,7 @@ class RotationTest(TestCase):
             sc.save('test_rot_%04i.png' % i, sigma_clip=6.0)
 
 def test_annotations():
+    from matplotlib.image import imread
     ds = fake_vr_orientation_test_ds(N=16)
     sc = create_scene(ds)
     sc.annotate_axes()
@@ -108,3 +109,6 @@ def test_annotations():
         assert np.where((im == c).all(axis=-1))[0].shape[0] > 0
     sc[0].tfh.tf.add_layers(10, colormap='cubehelix')
     sc.save_annotated('test_scene_annotated.png', text_annotate=[[(.1, 1.05), "test_string"]])
+    image = imread('test_scene_annotated.png')
+    assert image.shape == sc.camera.resolution + (4,)
+    os.remove('test_scene_annotated.png')

--- a/yt/visualization/volume_rendering/transfer_functions.py
+++ b/yt/visualization/volume_rendering/transfer_functions.py
@@ -554,7 +554,7 @@ class ColorTransferFunction(MultiVariateTransferFunction):
         ax.set_ylabel("Opacity")
         ax.set_xlabel("Value")
 
-    def vert_cbar(self, resolution, log_scale, ax=None, label=None, 
+    def vert_cbar(self, resolution, log_scale, ax, label=None, 
                   label_fmt=None):
         r"""Display an image of the transfer function
 
@@ -570,11 +570,7 @@ class ColorTransferFunction(MultiVariateTransferFunction):
         >>> tf.add_gaussian(-9.0, 0.01, 1.0)
         >>> tf.show()
         """
-        from matplotlib import pyplot
         from matplotlib.ticker import FuncFormatter
-        #pyplot.clf()
-        if ax is None:
-            ax = pyplot.axes()
         if label is None:
             label = ''
         alpha = self.alpha.y 
@@ -583,6 +579,7 @@ class ColorTransferFunction(MultiVariateTransferFunction):
         i_data[:,:,0] = np.outer(self.funcs[0].y, np.ones(self.alpha.x.size))
         i_data[:,:,1] = np.outer(self.funcs[1].y, np.ones(self.alpha.x.size))
         i_data[:,:,2] = np.outer(self.funcs[2].y, np.ones(self.alpha.x.size))
+
         ax.imshow(i_data, origin='lower', aspect='auto')
         ax.plot(alpha, np.arange(self.alpha.y.size), 'w')
 


### PR DESCRIPTION
Since #1793 the travis tests are intermittently failing in the call to save_annotated because of missing `DISPLAY` environment variable.

We don't really need pyplot at all and in principle real users would hit this error on e.g. a cluster or any other headless SSH session.

I've gone ahead and removed the usages of pyplot in `save_annotated` and functions called by `save_annotated`. This does make the resulting image change appearance slightly. Here's the output of `vol_annotated.py` in the documentation

old:
![](https://i.imgur.com/YO9qPJP.png)

new:
![](https://i.imgur.com/RESfRZU.png)

Note how in the old version the text annotation doesn't actually appear because it's "off the page". I think the new format looks a bit cleaner. If people disagree I can certainly try to make the images match a bit more.