### PR TITLE
Updating tests to use fake dataset instead of real data

### DIFF
--- a/yt/data_objects/tests/test_covering_grid.py
+++ b/yt/data_objects/tests/test_covering_grid.py
@@ -1,13 +1,8 @@
 import numpy as np
 
-from yt import \
-    load
+from yt import load_octree
 from yt.frontends.stream.data_structures import load_particles
-from yt.testing import \
-    requires_file, \
-    fake_random_ds, \
-    assert_equal, \
-    assert_almost_equal
+from yt.testing import fake_random_ds, assert_equal, assert_almost_equal
 
 def setup():
     from yt.config import ytcfg
@@ -134,29 +129,39 @@ def test_arbitrary_grid():
                     2**ref_level * ds.domain_dimensions)
             assert_almost_equal(cg["density"], ag["density"])
 
-output_00080 = "output_00080/info_00080.txt"
-@requires_file(output_00080)
 def test_octree_cg():
-    ds = load(output_00080)
-    cgrid = ds.covering_grid(0, left_edge=ds.domain_left_edge, dims=ds.domain_dimensions)
+    oct_mask_list = [8, 0, 0, 0, 0, 8, 0, 0,
+                     0, 0, 0, 0, 0, 0, 0, 0,
+                     8, 0, 0, 0, 0, 0, 0, 0,
+                     0]
+    octree_mask = np.array(oct_mask_list, dtype=np.uint8)
+    quantities = {}
+    quantities[('gas', 'density')] = np.ones((22, 1), dtype=float)
+    bbox = np.array([[-10., 10.], [-10., 10.], [-10., 10.]])
+    ds = load_octree(octree_mask=octree_mask, data=quantities, bbox=bbox,
+                     over_refine_factor=0, partial_coverage=0)
+    cgrid = ds.covering_grid(0, left_edge=ds.domain_left_edge,
+                             dims=ds.domain_dimensions)
     density_field = cgrid["density"]
     assert_equal((density_field == 0.0).sum(), 0)
 
-ekh = 'EnzoKelvinHelmholtz/DD0011/DD0011'
-@requires_file(ekh)
 def test_smoothed_covering_grid_2d_dataset():
-    ds = load(ekh)
+    ds = fake_random_ds(64, nprocs=4)
     ds.periodicity = (True, True, True)
-    scg = ds.smoothed_covering_grid(1, [0, 0, 0], [128, 128, 1])
-    assert_equal(scg['density'].shape, [128, 128, 1])
+    scg = ds.smoothed_covering_grid(1, [0.0, 0.0, 0.0], ds.domain_dimensions)
+    assert_equal(scg['density'].shape, ds.domain_dimensions)
 
-isogal = "IsolatedGalaxy/galaxy0030/galaxy0030"
-@requires_file(isogal)
 def test_arbitrary_grid_derived_field():
+    def custom_metal_density(field, data):
+        # Calculating some random value
+        return data['gas', 'density']*np.random.random_sample()
+
+    ds = fake_random_ds(64, nprocs=8, particles=16**2)
+    ds.add_field(("gas", "Metal_Density"), units="g/cm**3",
+                 function=custom_metal_density, sampling_type='cell')
+
     def _tracerf(field, data):
         return data['Metal_Density']/data['gas', 'density']
-
-    ds = load(isogal)
 
     ds.add_field(("gas", "tracerf"), function=_tracerf, units="dimensionless",
                  take_log=False)

--- a/yt/data_objects/tests/test_covering_grid.py
+++ b/yt/data_objects/tests/test_covering_grid.py
@@ -1,8 +1,8 @@
 import numpy as np
 
-from yt import load_octree
 from yt.frontends.stream.data_structures import load_particles
-from yt.testing import fake_random_ds, assert_equal, assert_almost_equal
+from yt.testing import fake_random_ds, assert_equal, assert_almost_equal, \
+    fake_octree_ds
 
 def setup():
     from yt.config import ytcfg
@@ -130,16 +130,7 @@ def test_arbitrary_grid():
             assert_almost_equal(cg["density"], ag["density"])
 
 def test_octree_cg():
-    oct_mask_list = [8, 0, 0, 0, 0, 8, 0, 0,
-                     0, 0, 0, 0, 0, 0, 0, 0,
-                     8, 0, 0, 0, 0, 0, 0, 0,
-                     0]
-    octree_mask = np.array(oct_mask_list, dtype=np.uint8)
-    quantities = {}
-    quantities[('gas', 'density')] = np.ones((22, 1), dtype=float)
-    bbox = np.array([[-10., 10.], [-10., 10.], [-10., 10.]])
-    ds = load_octree(octree_mask=octree_mask, data=quantities, bbox=bbox,
-                     over_refine_factor=0, partial_coverage=0)
+    ds = fake_octree_ds(over_refine_factor=0, partial_coverage=0)
     cgrid = ds.covering_grid(0, left_edge=ds.domain_left_edge,
                              dims=ds.domain_dimensions)
     density_field = cgrid["density"]

--- a/yt/data_objects/tests/test_fluxes.py
+++ b/yt/data_objects/tests/test_fluxes.py
@@ -6,21 +6,16 @@ import numpy as np
 
 from unittest import TestCase
 
-from yt.testing import \
-    fake_random_ds, \
-    assert_almost_equal, \
-    assert_equal, \
+from yt.testing import fake_random_ds, assert_almost_equal, assert_equal, \
     requires_file
-
-from yt.convenience import \
-    load
+from yt.convenience import load
 
 def setup():
     from yt.config import ytcfg
     ytcfg["yt","__withintesting"] = "True"
 
 def test_flux_calculation():
-    ds = fake_random_ds(64, nprocs = 4)
+    ds = fake_random_ds(64, nprocs=4)
     dd = ds.all_data()
     surf = ds.surface(dd, "x", 0.51)
     assert_equal(surf["x"], 0.51)
@@ -29,7 +24,7 @@ def test_flux_calculation():
     assert_equal(str(flux.units), 'cm**2')
 
 def test_sampling():
-    ds = fake_random_ds(64, nprocs = 4)
+    ds = fake_random_ds(64, nprocs=4)
     dd = ds.all_data()
     for i, ax in enumerate('xyz'):
         surf = ds.surface(dd, ax, 0.51)
@@ -55,7 +50,7 @@ class ExporterTests(TestCase):
         shutil.rmtree(self.tmpdir)
 
     def test_export_ply(self):
-        ds = fake_random_ds(64, nprocs = 4)
+        ds = fake_random_ds(64, nprocs=4)
         dd = ds.all_data()
         surf = ds.surface(dd, 'x', 0.51)
         surf.export_ply('my_ply.ply', bounds=[(0, 1), (0, 1), (0, 1)])
@@ -64,27 +59,26 @@ class ExporterTests(TestCase):
                         sample_type='vertex', color_field='density')
         assert os.path.exists('my_ply2.ply')
 
-    @requires_file(ISOGAL)
     def test_export_obj(self):
-        ds = load(ISOGAL)
-        sp = ds.sphere("max", (10, "kpc"))
-        trans = 1.0
-        distf = 3.1e18*1e3 # distances into kpc
-        surf = ds.surface(sp, "density", 5e-27)
-        surf.export_obj("my_galaxy", transparency=trans, dist_fac = distf)
+        ds = fake_random_ds(16, nprocs=4, particles=16**3,
+                            fields=("density", "temperature"),
+                            units=('g/cm**3', 'K'))
+        sp = ds.sphere("max", (1.0, "cm"))
+        surf = ds.surface(sp, "density", 0.5)
+        surf.export_obj("my_galaxy", transparency=1.0, dist_fac=1.0)
         assert os.path.exists('my_galaxy.obj')
         assert os.path.exists('my_galaxy.mtl')
 
         mi, ma = sp.quantities.extrema('temperature')
-        rhos = [1e-24, 1e-25]
+        rhos = [0.5, 0.25]
         trans = [0.5, 1.0]
         for i, r in enumerate(rhos):
             surf = ds.surface(sp,'density',r)
             surf.export_obj("my_galaxy_color".format(i),
                             transparency=trans[i],
-                            color_field='temperature', dist_fac = distf,
-                            plot_index = i, color_field_max = ma,
-                            color_field_min = mi)
+                            color_field='temperature', dist_fac=1.0,
+                            plot_index=i, color_field_max=ma,
+                            color_field_min=mi)
 
         assert os.path.exists('my_galaxy_color.obj')
         assert os.path.exists('my_galaxy_color.mtl')
@@ -100,7 +94,7 @@ class ExporterTests(TestCase):
                             transparency=trans[i],
                             color_field='temperature',
                             emit_field='emissivity',
-                            dist_fac = distf, plot_index = i)
+                            dist_fac=1.0, plot_index=i)
 
         assert os.path.exists('my_galaxy_emis.obj')
         assert os.path.exists('my_galaxy_emis.mtl')
@@ -115,10 +109,18 @@ def test_correct_output_unit():
     sur = ds.surface(sp1,"HI_Density", .5*Nmax)
     sur['x'][0]
 
-@requires_file(ISOGAL)
+def test_correct_output_unit_fake_ds():
+    # implementing test_correct_output_unit() with fake dataset
+    ds = fake_random_ds(64, nprocs=4, particles=16**3)
+    x = y = z = .5
+    sp1 = ds.sphere((x, y, z), (300, 'kpc'))
+    Nmax = sp1.max('density')
+    sur = ds.surface(sp1, "density", .5*Nmax)
+    sur['x'][0]
+
 def test_radius_surface():
     # see #1407
-    ds = load(ISOGAL)
+    ds = fake_random_ds(64, nprocs=4, particles=16**3)
     reg = ds.all_data()
     sp = ds.sphere(ds.domain_center, (0.5, 'code_length'))
     for obj in [reg, sp]:

--- a/yt/data_objects/tests/test_fluxes.py
+++ b/yt/data_objects/tests/test_fluxes.py
@@ -6,9 +6,7 @@ import numpy as np
 
 from unittest import TestCase
 
-from yt.testing import fake_random_ds, assert_almost_equal, assert_equal, \
-    requires_file
-from yt.convenience import load
+from yt.testing import fake_random_ds, assert_almost_equal, assert_equal
 
 def setup():
     from yt.config import ytcfg
@@ -35,8 +33,6 @@ def test_sampling():
         vert_shape = surf.vertices.shape
         assert_equal(dens.shape[0], vert_shape[1]//vert_shape[0])
         assert_equal(str(dens.units), 'g/cm**3')
-
-ISOGAL = 'IsolatedGalaxy/galaxy0030/galaxy0030'
 
 class ExporterTests(TestCase):
 
@@ -99,18 +95,8 @@ class ExporterTests(TestCase):
         assert os.path.exists('my_galaxy_emis.obj')
         assert os.path.exists('my_galaxy_emis.mtl')
 
-@requires_file(ISOGAL)
-def test_correct_output_unit():
-    # see issue #1368
-    ds = load(ISOGAL)
-    x = y = z = .5
-    sp1 = ds.sphere((x,y,z), (300, 'kpc'))
-    Nmax = sp1.max('HI_Density')
-    sur = ds.surface(sp1,"HI_Density", .5*Nmax)
-    sur['x'][0]
-
 def test_correct_output_unit_fake_ds():
-    # implementing test_correct_output_unit() with fake dataset
+    # see issue #1368
     ds = fake_random_ds(64, nprocs=4, particles=16**3)
     x = y = z = .5
     sp1 = ds.sphere((x, y, z), (300, 'kpc'))

--- a/yt/data_objects/tests/test_fluxes.py
+++ b/yt/data_objects/tests/test_fluxes.py
@@ -106,7 +106,7 @@ def test_correct_output_unit_fake_ds():
 
 def test_radius_surface():
     # see #1407
-    ds = fake_random_ds(64, nprocs=4, particles=16**3)
+    ds = fake_random_ds(64, nprocs=4, particles=16**3, length_unit=10.0)
     reg = ds.all_data()
     sp = ds.sphere(ds.domain_center, (0.5, 'code_length'))
     for obj in [reg, sp]:
@@ -116,7 +116,5 @@ def test_radius_surface():
                 surface.surface_area.v, 4*np.pi*rad**2, decimal=2)
             verts = surface.vertices
             for i in range(3):
-                assert_almost_equal(
-                    verts[i, :].min().v, 0.5-rad, decimal=2)
-                assert_almost_equal(
-                    verts[i, :].max().v, 0.5+rad, decimal=2)
+                assert_almost_equal(verts[i, :].min().v, 0.5-rad, decimal=2)
+                assert_almost_equal(verts[i, :].max().v, 0.5+rad, decimal=2)

--- a/yt/data_objects/tests/test_points.py
+++ b/yt/data_objects/tests/test_points.py
@@ -51,7 +51,7 @@ def test_domain_point():
     assert_equal(ppos_den_vel[1], ppos_vel)
 
 def test_fast_find_field_values_at_points():
-    ds = fake_random_ds(64, nprocs=8, particles=16**2)
+    ds = fake_random_ds(64, nprocs=8, particles=16**3)
     ad = ds.all_data()
     # right now this is slow for large numbers of particles, so randomly
     # sample 100 particles

--- a/yt/data_objects/tests/test_points.py
+++ b/yt/data_objects/tests/test_points.py
@@ -1,10 +1,7 @@
 import numpy as np
 import yt
 
-from yt.testing import \
-    fake_random_ds, \
-    assert_equal, \
-    requires_file
+from yt.testing import fake_random_ds, assert_equal
 
 def setup():
     from yt.config import ytcfg
@@ -53,11 +50,8 @@ def test_domain_point():
     assert_equal(ppos_den_vel[0], ppos_den)
     assert_equal(ppos_den_vel[1], ppos_vel)
 
-g30 = "IsolatedGalaxy/galaxy0030/galaxy0030"
-
-@requires_file(g30)
 def test_fast_find_field_values_at_points():
-    ds = yt.load(g30)
+    ds = fake_random_ds(64, nprocs=8, particles=16**2)
     ad = ds.all_data()
     # right now this is slow for large numbers of particles, so randomly
     # sample 100 particles

--- a/yt/data_objects/tests/test_profiles.py
+++ b/yt/data_objects/tests/test_profiles.py
@@ -4,8 +4,8 @@ import numpy as np
 from yt.data_objects.particle_filters import add_particle_filter
 from yt.data_objects.profiles import Profile1D, Profile2D, Profile3D,\
     create_profile
-from yt.testing import fake_random_ds, fake_particle_ds, assert_equal,\
-    assert_raises, assert_rel_equal
+from yt.testing import fake_random_ds, assert_equal, assert_raises,\
+    assert_rel_equal
 from yt.utilities.exceptions import YTIllDefinedProfile
 from yt.visualization.profile_plotter import ProfilePlot, PhasePlot
 
@@ -273,19 +273,15 @@ def test_profile_zero_weight():
 
     add_particle_filter("DM", function=DMparticles,
                         filtered_type='io', requires=["particle_type"])
+
     _fields = ("particle_position_x", "particle_position_y",
                "particle_position_z", "particle_mass", "particle_velocity_x",
-               "particle_velocity_y", "particle_velocity_z", "particle_type",
-               "density", "temperature")
-    _units = ('cm', 'cm', 'cm', 'g', 'cm/s', 'cm/s', 'cm/s', 'dimensionless',
-              'g/cm**3','K')
-    _negative = (False, False, False, False, True, True, True, False, False,
-                 False)
-    ds = fake_particle_ds(fields=_fields, units=_units, negative=_negative,
-                          npart=16 ** 2, length_unit=1.0)
+               "particle_velocity_y", "particle_velocity_z", "particle_type")
+    _units = ('cm', 'cm', 'cm', 'g', 'cm/s', 'cm/s', 'cm/s', 'dimensionless')
+    ds = fake_random_ds(32, particle_fields=_fields,
+                        particle_field_units=_units, particles=16)
 
     ds.add_particle_filter('DM')
-
     ds.add_field(("gas", "DM_cell_mass"), units="g", function=DM_in_cell_mass,
                  sampling_type='cell')
 
@@ -293,7 +289,7 @@ def test_profile_zero_weight():
 
     profile = yt.create_profile(sp,
                                 [("gas", "density")],
-                                [("gas", "temperature")],
+                                [("gas", "radial_velocity")],
                                 weight_field=("gas", "DM_cell_mass"))
 
-    assert not np.any(np.isnan(profile['gas', 'temperature']))
+    assert not np.any(np.isnan(profile['gas', 'radial_velocity']))

--- a/yt/data_objects/tests/test_profiles.py
+++ b/yt/data_objects/tests/test_profiles.py
@@ -1,24 +1,13 @@
 import yt
 import numpy as np
 
-from yt.data_objects.particle_filters import \
-    add_particle_filter
-from yt.data_objects.profiles import \
-    Profile1D, \
-    Profile2D, \
-    Profile3D, \
+from yt.data_objects.particle_filters import add_particle_filter
+from yt.data_objects.profiles import Profile1D, Profile2D, Profile3D,\
     create_profile
-from yt.testing import \
-    fake_random_ds, \
-    assert_equal, \
-    assert_raises, \
-    assert_rel_equal, \
-    requires_file
-from yt.utilities.exceptions import \
-    YTIllDefinedProfile
-from yt.visualization.profile_plotter import \
-    ProfilePlot, \
-    PhasePlot
+from yt.testing import fake_random_ds, fake_particle_ds, assert_equal,\
+    assert_raises, assert_rel_equal
+from yt.utilities.exceptions import YTIllDefinedProfile
+from yt.visualization.profile_plotter import ProfilePlot, PhasePlot
 
 _fields = ("density", "temperature", "dinosaurs", "tribbles")
 _units = ("g/cm**3", "K", "dyne", "erg")
@@ -274,7 +263,6 @@ def test_particle_profile_negative_field():
             weight_field=None, deposition='cic',
             accumulation=True, fractional=True)
 
-@requires_file("IsolatedGalaxy/galaxy0030/galaxy0030")
 def test_profile_zero_weight():
     def DMparticles(pfilter, data):
         filter = data[(pfilter.filtered_type, "particle_type")] == 1
@@ -285,8 +273,16 @@ def test_profile_zero_weight():
 
     add_particle_filter("DM", function=DMparticles,
                         filtered_type='io', requires=["particle_type"])
-
-    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
+    _fields = ("particle_position_x", "particle_position_y",
+               "particle_position_z", "particle_mass", "particle_velocity_x",
+               "particle_velocity_y", "particle_velocity_z", "particle_type",
+               "density", "temperature")
+    _units = ('cm', 'cm', 'cm', 'g', 'cm/s', 'cm/s', 'cm/s', 'dimensionless',
+              'g/cm**3','K')
+    _negative = (False, False, False, False, True, True, True, False, False,
+                 False)
+    ds = fake_particle_ds(fields=_fields, units=_units, negative=_negative,
+                          npart=16 ** 2, length_unit=1.0)
 
     ds.add_particle_filter('DM')
 

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -444,6 +444,51 @@ def fake_vr_orientation_test_ds(N = 96, scale=1):
     ds = load_uniform_grid(data, arr.shape, bbox=bbox)
     return ds
 
+
+def construct_octree_mask(prng=RandomState(0x1d3d3d3), refined=[True]):
+    # Implementation taken from url:
+    # http://docs.hyperion-rt.org/en/stable/advanced/indepth_oct.html
+
+    # Loop over subcells
+    for subcell in range(8):
+        # Insert criterion for whether cell should be sub-divided. Here we
+        # just use a random number to demonstrate.
+        divide = prng.random_sample() < 0.12
+
+        # Append boolean to overall list
+        refined.append(divide)
+
+        # If the cell is sub-divided, recursively divide it further
+        if divide:
+            construct_octree_mask(prng, refined)
+    return refined
+
+def fake_octree_ds(prng=RandomState(0x1d3d3d3), refined=[True], quantities=None,
+                   bbox=None, sim_time=0.0, length_unit=None, mass_unit=None,
+                   time_unit=None, velocity_unit=None, magnetic_unit=None,
+                   periodicity=(True, True, True), over_refine_factor=1,
+                   partial_coverage=1, unit_system="cgs"):
+    from yt.frontends.stream.api import load_octree
+    octree_mask = np.asarray(construct_octree_mask(prng=prng, refined=refined),
+                             dtype=np.uint8)
+    particles = np.sum(np.invert(octree_mask))
+
+    if quantities is None:
+        quantities = {}
+        quantities[('gas', 'density')] = prng.random_sample((particles, 1))
+        quantities[('gas', 'velocity_x')] = prng.random_sample((particles, 1))
+        quantities[('gas', 'velocity_y')] = prng.random_sample((particles, 1))
+        quantities[('gas', 'velocity_z')] = prng.random_sample((particles, 1))
+
+    ds = load_octree(octree_mask=octree_mask, data=quantities, bbox=bbox,
+                     sim_time=sim_time, length_unit=length_unit,
+                     mass_unit=mass_unit, time_unit=time_unit,
+                     velocity_unit=velocity_unit, magnetic_unit=magnetic_unit,
+                     periodicity=periodicity, partial_coverage=partial_coverage,
+                     over_refine_factor=over_refine_factor,
+                     unit_system=unit_system)
+    return ds
+
 def expand_keywords(keywords, full=False):
     """
     expand_keywords is a means for testing all possible keyword


### PR DESCRIPTION
Removed real data usage from test cases

## PR Summary

Updated test cases to use `fake_particle_ds` or `fake_random_ds` instead of real dataset and other such changes.
This should increase coverage and reduce runtime (both by small amount).

## PR Checklist
- [X] Code passes flake8 checker
- [X] New features are documented, with docstrings and narrative docs
- [X] Adds a test for any bugs fixed. Adds tests for new features.
