### PR TITLE
remove pypandoc import check from sdist run

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -336,17 +336,6 @@ class sdist(_sdist):
     # is converted from markdown to restructured text.  See
     # http://stackoverflow.com/a/18418524/1382869
     def run(self):
-        # Make sure the compiled Cython files in the distribution are
-        # up-to-date
-
-        try:
-            import pypandoc
-        except ImportError:
-            raise RuntimeError(
-                'Trying to create a source distribution without pypandoc. '
-                'The readme will not render correctly on pypi without '
-                'pypandoc so we are exiting.'
-            )
         # Make sure the compiled Cython files in the distribution are up-to-date
         from Cython.Build import cythonize
         cythonize(cython_extensions)


### PR DESCRIPTION
This is no longer necessary now that `pypi` supports markdown readmes. I missed this in #1752.