### PR TITLE
Round to integer

### DIFF
--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1814,7 +1814,7 @@ class YTSelectionContainer3D(YTSelectionContainer):
             else: f = open(filename, "w")
             for v1 in verts:
                 f.write("v %0.16e %0.16e %0.16e\n" % (v1[0], v1[1], v1[2]))
-            for i in range(len(verts)/3):
+            for i in range(len(verts)//3):
                 f.write("f %s %s %s\n" % (i*3+1, i*3+2, i*3+3))
             if not hasattr(filename, "write"): f.close()
         if sample_values is not None:


### PR DESCRIPTION
We can't supply floats to ranges, so we need to use `//`.