### PR TITLE
sort the list of fields to read and generate

### DIFF
--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1262,7 +1262,7 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface):
             requested = self._determine_fields(list(set(fd.requested)))
             deps = [d for d in requested if d not in fields_to_get]
             fields_to_get += deps
-        return fields_to_get
+        return sorted(fields_to_get)
 
     def get_data(self, fields=None):
         if self._current_chunk is None:


### PR DESCRIPTION
Fixes #1821

It turns out that the order of the list returned by `_identify_depdendencies`
is not stable across processors. I'm not sure exactly why, but sorting the list
of fields to get does seem to fix the issue.

I'm not sure how to test this without running the test in parallel, which isn't something we're really set up for.