### PR TITLE
avoid possible IndexError in test_fast_find_field_values_at_points

### DIFF
--- a/yt/data_objects/tests/test_points.py
+++ b/yt/data_objects/tests/test_points.py
@@ -57,7 +57,7 @@ def test_fast_find_field_values_at_points():
     # sample 100 particles
     nparticles = 100
     ppos = ad['all', 'particle_position']
-    ppos = ppos[np.random.random_integers(0, len(ppos), size=nparticles)]
+    ppos = ppos[np.random.random_integers(0, len(ppos)-1, size=nparticles)]
 
     ppos_den = ds.find_field_values_at_points('density', ppos)
     ppos_vel = ds.find_field_values_at_points('velocity_x', ppos)


### PR DESCRIPTION
fixes #1823 

This should happen 2% of the time, so I guess I was just lucky to see this twice in a couple of days.