### PR TITLE
[bugfix] Fixing velocity unit in gadget_fof frontend.

### DIFF
--- a/yt/frontends/gadget_fof/data_structures.py
+++ b/yt/frontends/gadget_fof/data_structures.py
@@ -270,7 +270,8 @@ class GadgetFOFDataset(Dataset):
         elif "UnitTime_in_s" in unit_base:
             time_unit = (unit_base["UnitTime_in_s"], "s")
         else:
-            time_unit = (1., "s")        
+            tu = (self.length_unit / self.velocity_unit).to("yr/h")
+            time_unit = (tu.d, tu.units)
         setdefaultattr(self, 'time_unit', self.quan(time_unit[0], time_unit[1]))
 
     def __repr__(self):

--- a/yt/frontends/gadget_fof/data_structures.py
+++ b/yt/frontends/gadget_fof/data_structures.py
@@ -245,7 +245,7 @@ class GadgetFOFDataset(Dataset):
             if self.cosmological_simulation == 0:
                 velocity_unit = (1e5, "cm/s")
             else:
-                velocity_unit = (1e5, "cmcm/s")
+                velocity_unit = (1e5, "cm/s * sqrt(a)")
         velocity_unit = _fix_unit_ordering(velocity_unit)
         setdefaultattr(self, 'velocity_unit',
                        self.quan(velocity_unit[0], velocity_unit[1]))

--- a/yt/frontends/owls_subfind/data_structures.py
+++ b/yt/frontends/owls_subfind/data_structures.py
@@ -186,7 +186,7 @@ class OWLSSubfindDataset(Dataset):
         elif "UnitVelocity_in_cm_per_s" in unit_base:
             velocity_unit = (unit_base["UnitVelocity_in_cm_per_s"], "cm/s")
         else:
-            velocity_unit = (1e5, "cm/s")
+            velocity_unit = (1e5, "cm/s  * sqrt(a)")
         velocity_unit = _fix_unit_ordering(velocity_unit)
         setdefaultattr(self, 'velocity_unit',
                        self.quan(velocity_unit[0], velocity_unit[1]))
@@ -211,7 +211,8 @@ class OWLSSubfindDataset(Dataset):
         elif "UnitTime_in_s" in unit_base:
             time_unit = (unit_base["UnitTime_in_s"], "s")
         else:
-            time_unit = (1., "s")        
+            tu = (self.length_unit / self.velocity_unit).to("yr/h")
+            time_unit = (tu.d, tu.units)
         setdefaultattr(self, 'time_unit', self.quan(time_unit[0], time_unit[1]))
 
     @classmethod


### PR DESCRIPTION
This fixes the velocity unit similarly to the [bugfix for the Eagle frontend](https://github.com/yt-project/yt/pull/1675).

After reading through the subfind manual, I found a proper definition for `time_unit`, so I fixed that, too.  I also corrected similar errors in the OWLS_Subfind frontend.