### PR TITLE
Input validation for disk object fixes #1768

### DIFF
--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -922,7 +922,8 @@ class YTSmoothedCoveringGrid(YTCoveringGrid):
         self._final_start_index = self.global_startindex
 
     def _setup_data_source(self, level_state = None):
-        if level_state is None: return
+        if level_state is None:
+            return super(YTSmoothedCoveringGrid, self)._setup_data_source()
         # We need a buffer region to allow for zones that contribute to the
         # interpolation but are not directly inside our bounds
         level_state.data_source = self.ds.region(

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -419,7 +419,7 @@ class YTDataContainer(object):
     def write_out(self, filename, fields=None, format="%0.16e"):
         if fields is None: fields=sorted(self.field_data.keys())
         if self._key_fields is None: raise ValueError
-        field_order = self._key_fields[:]
+        field_order = sorted(self._determine_fields(self._key_fields))
         for field in field_order: self[field]
         field_order += [field for field in fields if field not in field_order]
         fid = open(filename,"w")

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -80,19 +80,6 @@ def force_array(item, shape):
         else:
             return np.zeros(shape, dtype='bool')
 
-def restore_field_information_state(func):
-    """
-    A decorator that takes a function with the API of (self, grid, field)
-    and ensures that after the function is called, the field_parameters will
-    be returned to normal.
-    """
-    def save_state(self, grid, field=None, *args, **kwargs):
-        old_params = grid.field_parameters
-        grid.field_parameters = self.field_parameters
-        tr = func(self, grid, field, *args, **kwargs)
-        grid.field_parameters = old_params
-        return tr
-    return save_state
 
 def sanitize_weight_field(ds, field, weight):
     field_object = ds._get_field_info(field)
@@ -215,6 +202,10 @@ class YTDataContainer(object):
                 self.center = self.ds.find_max(("gas", "density"))[1]
             elif center.startswith("max_"):
                 self.center = self.ds.find_max(center[4:])[1]
+            elif center.lower() == "min":
+                self.center = self.ds.find_min(("gas", "density"))[1]
+            elif center.startswith("min_"):
+                self.center = self.ds.find_min(center[4:])[1]
         else:
             self.center = self.ds.arr(center, 'code_length', dtype='float64')
         self.set_field_parameter('center', self.center)
@@ -1990,20 +1981,7 @@ class YTSelectionContainer3D(YTSelectionContainer):
                     {'contour_slices_%s' % contour_key: cids})
         return cons, contours
 
-    def paint_grids(self, field, value, default_value=None):
-        """
-        This function paints every cell in our dataset with a given *value*.
-        If default_value is given, the other values for the given in every grid
-        are discarded and replaced with *default_value*.  Otherwise, the field is
-        mandated to 'know how to exist' in the grid.
 
-        Note that this only paints the cells *in the dataset*, so cells in grids
-        with child cells are left untouched.
-        """
-        for grid in self._grids:
-            if default_value is not None:
-                grid[field] = np.ones(grid.ActiveDimensions)*default_value
-            grid[field][self._get_point_indices(grid)] = value
 
     def volume(self):
         """

--- a/yt/data_objects/selection_data_containers.py
+++ b/yt/data_objects/selection_data_containers.py
@@ -34,6 +34,7 @@ from yt.utilities.exceptions import \
     YTSphereTooSmall, \
     YTIllDefinedCutRegion, \
     YTEllipsoidOrdering
+from yt.utilities.input_validator import input_validator
 from yt.utilities.minimal_representation import \
     MinimalSliceData
 from yt.utilities.math_utils import get_rotation_matrix
@@ -585,6 +586,8 @@ class YTDisk(YTSelectionContainer3D):
     """
     _type_name = "disk"
     _con_args = ('center', '_norm_vec', 'radius', 'height')
+
+    @input_validator(_type_name)
     def __init__(self, center, normal, radius, height, fields=None,
                  ds=None, field_parameters=None, data_source=None):
         YTSelectionContainer3D.__init__(self, center, ds,

--- a/yt/data_objects/tests/test_clone.py
+++ b/yt/data_objects/tests/test_clone.py
@@ -22,3 +22,10 @@ def test_clone_sphere():
     sp1["density"]
 
     assert_array_equal(sp0["density"], sp1["density"])
+
+def test_clone_cut_region():
+    ds = fake_random_ds(64, nprocs=4, fields=("density", "temperature"))
+    dd = ds.all_data()
+    reg1 = dd.cut_region(["obj['temperature'] > 0.5", "obj['density'] < 0.75"])
+    reg2 = reg1.clone()
+    assert_array_equal(reg1['density'], reg2['density'])

--- a/yt/data_objects/tests/test_connected_sets.py
+++ b/yt/data_objects/tests/test_connected_sets.py
@@ -1,14 +1,11 @@
-from yt.utilities.answer_testing.level_sets_tests import \
-    ExtractConnectedSetsTest
-from yt.utilities.answer_testing.framework import \
-    requires_ds, \
-    data_dir_load
+from yt.testing import fake_random_ds
+from yt.utilities.answer_testing.level_sets_tests import ExtractConnectedSetsTest
 
-g30 = "IsolatedGalaxy/galaxy0030/galaxy0030"
-@requires_ds(g30, big_data=True)
 def test_connected_sets():
-    ds = data_dir_load(g30)
-    data_source = ds.disk([0.5, 0.5, 0.5], [0., 0., 1.],
-                          (8, 'kpc'), (1, 'kpc'))
-    yield ExtractConnectedSetsTest(g30, data_source, ("gas", "density"),
-                                   5, 1e-24, 8e-24)
+    ds = fake_random_ds(16, nprocs=8, particles=16**3)
+    data_source = ds.disk([0.5, 0.5, 0.5], [0., 0., 1.], (8, 'kpc'), (1, 'kpc'))
+    field = ("gas", "density")
+    min_val, max_val = data_source[field].min()/2, data_source[field].max()/2
+    data_source.extract_connected_sets(field, 5, min_val, max_val,
+                                       log_space=True, cumulative=True)
+    yield ExtractConnectedSetsTest(ds, data_source, field, 5, min_val, max_val)

--- a/yt/data_objects/tests/test_data_containers.py
+++ b/yt/data_objects/tests/test_data_containers.py
@@ -1,0 +1,114 @@
+import shelve
+
+import numpy as np
+from nose.tools import assert_raises
+from numpy.testing import assert_array_equal
+
+from yt.data_objects.data_containers import YTDataContainer
+from yt.testing import assert_equal, fake_random_ds, fake_amr_ds, fake_particle_ds
+from yt.utilities.exceptions import YTFieldNotFound
+
+
+def test_yt_data_container():
+    # Test if ds could be None
+    with assert_raises(RuntimeError) as err:
+        YTDataContainer(None, None)
+    desired = 'Error: ds must be set either through class type or parameter' \
+              ' to the constructor'
+    assert_equal(str(err.exception), desired)
+
+    # Test if field_data key exists
+    ds = fake_random_ds(5)
+    proj = ds.proj("density", 0, data_source=ds.all_data())
+    assert_equal(proj.has_key('px'), True)
+    assert_equal(proj.has_key('pz'), False)
+
+    # Delete the key and check if exits
+    proj.__delitem__('px')
+    assert_equal(proj.has_key('px'), False)
+    proj.__delitem__('density')
+    assert_equal(proj.has_key('density'), False)
+
+    # Delete a non-existent field
+    with assert_raises(YTFieldNotFound) as ex:
+        proj.__delitem__('p_mass')
+    desired = "Could not find field '('stream', 'p_mass')' in UniformGridData."
+    assert_equal(str(ex.exception), desired)
+
+    # Test the convert method
+    assert_equal(proj.convert('HydroMethod'), -1)
+
+def test_write_out():
+    filename = "sphere.txt"
+    ds = fake_particle_ds()
+    sp = ds.sphere(ds.domain_center, 0.25)
+    sp.write_out(filename)
+
+    with open(filename, "r") as file:
+        file_row_1 = file.readline()
+        file_row_2 = file.readline()
+        file_row_2 = np.array(file_row_2.split('\t'), dtype=np.float64)
+    _keys = [str(k) for k in sp.field_data.keys()]
+    _keys = "\t".join(["#"] + _keys + ["\n"])
+    _data = [sp.field_data[k][0] for k in sp.field_data.keys()]
+
+    assert_equal(_keys, file_row_1)
+    assert_array_equal(_data, file_row_2)
+
+def test_save_object():
+    ds = fake_particle_ds()
+    sp = ds.sphere(ds.domain_center, 0.25)
+    sp.save_object("my_sphere_1", filename="test_save_obj")
+    with shelve.open("test_save_obj", protocol=-1) as obj:
+        loaded_sphere = obj["my_sphere_1"][1]
+    assert_array_equal(loaded_sphere.center, sp.center)
+    assert_equal(loaded_sphere.radius, sp.radius)
+
+    sp.save_object("my_sphere_2")
+
+def test_to_dataframe():
+    fields = ["density", "velocity_z"]
+    ds = fake_random_ds(6)
+    dd = ds.all_data()
+    df1 = dd.to_dataframe(fields)
+    assert_array_equal(dd[fields[0]], df1[fields[0]])
+    assert_array_equal(dd[fields[1]], df1[fields[1]])
+
+def test_std():
+    ds = fake_random_ds(3)
+    ds.all_data().std('density', weight="velocity_z")
+
+def test_to_frb():
+    ds = fake_amr_ds(fields=["density", "cell_mass"], geometry="cylindrical",
+                     particles=16**3)
+    proj = ds.proj("density", weight_field="cell_mass", axis=1,
+                   data_source=ds.all_data())
+    proj.to_frb((1.0, 'unitary'), 64)
+
+def test_extract_isocontours():
+    # Test isocontour properties for AMRGridData
+    ds = fake_amr_ds(fields=["density", "cell_mass"], particles=16**3)
+    dd = ds.all_data()
+    rho = dd.quantities["WeightedAverageQuantity"]("density",
+                                                   weight="cell_mass")
+    dd.extract_isocontours("density", rho, "triangles.obj", True)
+    dd.calculate_isocontour_flux("density", rho, "x", "y", "z",
+                                 "dx")
+
+    # Test error in case of ParticleData
+    ds = fake_particle_ds()
+    dd = ds.all_data()
+    rho = dd.quantities["WeightedAverageQuantity"]("particle_velocity_x",
+                                                   weight="particle_mass")
+    with assert_raises(NotImplementedError):
+        dd.extract_isocontours("density", rho, sample_values='x')
+
+def test_extract_connected_sets():
+
+    ds = fake_random_ds(16, nprocs=8, particles=16 ** 3)
+    data_source = ds.disk([0.5, 0.5, 0.5], [0., 0., 1.], (8, 'kpc'), (1, 'kpc'))
+    field = ("gas", "density")
+    min_val, max_val = data_source[field].min() / 2, data_source[field].max() / 2
+
+    data_source.extract_connected_sets(field, 3, min_val, max_val,
+                                              log_space=True, cumulative=True)

--- a/yt/data_objects/tests/test_data_containers.py
+++ b/yt/data_objects/tests/test_data_containers.py
@@ -20,14 +20,14 @@ def test_yt_data_container():
     # Test if field_data key exists
     ds = fake_random_ds(5)
     proj = ds.proj("density", 0, data_source=ds.all_data())
-    assert_equal(proj.has_key('px'), True)
-    assert_equal(proj.has_key('pz'), False)
+    assert_equal('px' in proj.keys(), True)
+    assert_equal('pz' in proj.keys(), False)
 
     # Delete the key and check if exits
     proj.__delitem__('px')
-    assert_equal(proj.has_key('px'), False)
+    assert_equal('px' in proj.keys(), False)
     proj.__delitem__('density')
-    assert_equal(proj.has_key('density'), False)
+    assert_equal('density' in proj.keys(), False)
 
     # Delete a non-existent field
     with assert_raises(YTFieldNotFound) as ex:

--- a/yt/data_objects/tests/test_data_containers.py
+++ b/yt/data_objects/tests/test_data_containers.py
@@ -48,9 +48,10 @@ def test_write_out():
         file_row_1 = file.readline()
         file_row_2 = file.readline()
         file_row_2 = np.array(file_row_2.split('\t'), dtype=np.float64)
-    _keys = [str(k) for k in sp.field_data.keys()]
+    sorted_keys = sorted(sp.field_data.keys())
+    _keys = [str(k) for k in sorted_keys]
     _keys = "\t".join(["#"] + _keys + ["\n"])
-    _data = [sp.field_data[k][0] for k in sp.field_data.keys()]
+    _data = [sp.field_data[k][0] for k in sorted_keys]
 
     assert_equal(_keys, file_row_1)
     assert_array_equal(_data, file_row_2)
@@ -67,12 +68,16 @@ def test_save_object():
     sp.save_object("my_sphere_2")
 
 def test_to_dataframe():
-    fields = ["density", "velocity_z"]
-    ds = fake_random_ds(6)
-    dd = ds.all_data()
-    df1 = dd.to_dataframe(fields)
-    assert_array_equal(dd[fields[0]], df1[fields[0]])
-    assert_array_equal(dd[fields[1]], df1[fields[1]])
+    try:
+        import pandas as pd
+        fields = ["density", "velocity_z"]
+        ds = fake_random_ds(6)
+        dd = ds.all_data()
+        df1 = dd.to_dataframe(fields)
+        assert_array_equal(dd[fields[0]], df1[fields[0]])
+        assert_array_equal(dd[fields[1]], df1[fields[1]])
+    except ImportError:
+        pass
 
 def test_std():
     ds = fake_random_ds(3)

--- a/yt/data_objects/tests/test_data_containers.py
+++ b/yt/data_objects/tests/test_data_containers.py
@@ -69,13 +69,15 @@ def test_save_object():
 
 def test_to_dataframe():
     try:
-        import pandas as pd
-        fields = ["density", "velocity_z"]
-        ds = fake_random_ds(6)
-        dd = ds.all_data()
-        df1 = dd.to_dataframe(fields)
-        assert_array_equal(dd[fields[0]], df1[fields[0]])
-        assert_array_equal(dd[fields[1]], df1[fields[1]])
+        import importlib
+        pandas_loader = importlib.util.find_spec("pandas")
+        if pandas_loader is not None:
+            fields = ["density", "velocity_z"]
+            ds = fake_random_ds(6)
+            dd = ds.all_data()
+            df1 = dd.to_dataframe(fields)
+            assert_array_equal(dd[fields[0]], df1[fields[0]])
+            assert_array_equal(dd[fields[1]], df1[fields[1]])
     except ImportError:
         pass
 

--- a/yt/data_objects/tests/test_spheres.py
+++ b/yt/data_objects/tests/test_spheres.py
@@ -1,10 +1,9 @@
 import numpy as np
+from numpy.testing import assert_array_equal
 
 from yt.data_objects.profiles import create_profile
-from yt.testing import \
-    fake_random_ds, \
-    assert_equal, \
-    periodicity_cases
+from yt.testing import fake_random_ds, assert_equal, periodicity_cases
+
 
 def setup():
     from yt.config import ytcfg
@@ -65,3 +64,16 @@ def test_domain_sphere():
         for f in _fields_to_compare:
             sp[f].sort()
             assert_equal(sp[f], ref_sp[f])
+
+def test_sphere_center():
+    ds = fake_random_ds(16, nprocs=8,
+                        fields=("density", "temperature", "velocity_x"))
+
+    # Test if we obtain same center in different ways
+    sp1 = ds.sphere("max", (0.25, 'unitary'))
+    sp2 = ds.sphere("max_density", (0.25, 'unitary'))
+    assert_array_equal(sp1.center, sp2.center)
+
+    sp1 = ds.sphere("min", (0.25, 'unitary'))
+    sp2 = ds.sphere("min_density", (0.25, 'unitary'))
+    assert_array_equal(sp1.center, sp2.center)

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -742,3 +742,17 @@ class YTCommandRequiresModule(YTException):
         msg += "or:\n"
         msg += "  pip install %s\n" % self.module
         return msg
+
+class YTInvalidArgumentType(YTException):
+    def __init__(self, obj_type):
+        self.obj_type = obj_type
+
+    def __str__(self):
+        msg = "One of the arguments to %s (selector) does not match its" \
+              " signature type.\n" % self.obj_type
+        msg += "Please check the type of arguments passed to this function.\n"
+        msg += "For docstrings http://yt-project.org/doc/" \
+               "analyzing/objects.html#available-objects\n"
+        msg += "For full reference check http://yt-project.org/doc/" \
+               "reference/api/api.html#api-reference\n"
+        return msg

--- a/yt/utilities/input_validator.py
+++ b/yt/utilities/input_validator.py
@@ -1,0 +1,46 @@
+import numpy as np
+
+from yt import YTQuantity, YTArray
+from yt.data_objects.static_output import Dataset
+from yt.utilities.exceptions import YTInvalidArgumentType
+
+def input_validator(_type_name):
+    def validator(func):
+        def wrapper(*args, **kwargs):
+            bad_input = False
+            data_category_1 = (list, np.ndarray, YTArray, YTQuantity)
+            data_category_2 = (int, float, tuple, YTQuantity)
+
+            if _type_name == 'disk':
+                kwargs_list = ['fields', 'ds', 'field_parameters', 'data_source']
+
+                if not isinstance(args[1], data_category_1) \
+                        or not isinstance(args[2], data_category_1) \
+                        or not isinstance(args[3], data_category_2) \
+                        or not isinstance(args[4], data_category_2):
+                    bad_input = True
+
+                if len(args[1]) != 3 or len(args[2]) != 3 \
+                    or (isinstance(args[3], YTQuantity) and len(args[3]) != 1) \
+                    or (isinstance(args[4], YTQuantity) and len(args[4]) != 1):
+                    bad_input = True
+
+                from yt.data_objects.selection_data_containers import YTRegion
+                for k in kwargs :
+                    if (k == kwargs_list[0] and
+                        not isinstance(kwargs[k], (list, np.ndarray))) \
+                        or (k == kwargs_list[1] and not isinstance(kwargs[k], Dataset)) \
+                        or (k == kwargs_list[2] and
+                            not isinstance(kwargs[k], dict)) \
+                        or (k == kwargs_list[3]
+                            and not isinstance(kwargs[k], YTRegion)):
+                        bad_input = True
+                    if bad_input:
+                        break
+
+            if not bad_input:
+                func(*args, **kwargs)
+            else:
+                raise YTInvalidArgumentType(_type_name)
+        return wrapper
+    return validator

--- a/yt/utilities/tests/test_input_validator.py
+++ b/yt/utilities/tests/test_input_validator.py
@@ -1,0 +1,15 @@
+from nose.tools import assert_raises, assert_equal
+
+from yt.testing import fake_random_ds
+from yt.utilities.exceptions import YTInvalidArgumentType
+
+
+def test_bad_disk_input():
+    # Fixes 1768
+    ds = fake_random_ds(16)
+    with assert_raises(YTInvalidArgumentType) as ex:
+        disk = ds.disk(ds.domain_center, [0, 0, 1], ds.domain_center, (20, 'kpc'))
+        disk['density']
+    desired = "One of the arguments to disk (selector) does not match" \
+              " its signature type."
+    assert_equal(str(ex.exception)[:50], desired[:50])


### PR DESCRIPTION
## PR Summary

Added a decorator to validate input while creating disk object. This approach is scalable and checks for other geometric objects could be added very easily. 

## PR Checklist

- [X] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs **NA**
- [X] Adds a test for any bugs fixed. Adds tests for new features.
