### PR TITLE
Return early from _reconstruct_parent_child in the boxlib frontend if max_level is 0.

### DIFF
--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -493,6 +493,8 @@ class BoxlibHierarchy(GridIndex):
         mylog.debug("Done creating grid objects")
 
     def _reconstruct_parent_child(self):
+        if (self.max_level == 0):
+            return
         mask = np.empty(len(self.grids), dtype='int32')
         mylog.debug("First pass; identifying child grids")
         for i, grid in enumerate(self.grids):


### PR DESCRIPTION
This is an optimization for large AMReX datasets with no mesh refinement. In those cases, a significant amount of time can be spent in `_reconstruct_parent_child`, even though none of that work is needed when `max_level == 0`. 