### PR TITLE
Added ability to override profile bins to allow custom step sizes +tests

### DIFF
--- a/doc/source/analyzing/generating_processed_data.rst
+++ b/doc/source/analyzing/generating_processed_data.rst
@@ -175,6 +175,19 @@ whether to use a log or linear scale, and whether or not to do accumulation to
 create a cumulative distribution function.  For more information, see the API
 documentation on the :func:`~yt.data_objects.profiles.create_profile` function.
 
+For custom bins the other keyword arguments can be overriden using the
+``override_bins`` keyword argument. This accepts a dictionary with an array
+for each bin field or ``None`` to use the default settings. 
+
+.. code-block:: python
+
+    custom_bins = np.array([1e-27, 1e-25, 2e-25, 5e-25, 1e-23])
+    profile2d = source.profile([("gas", "density"), ("gas", "temperature")],
+                                [("gas", "cell_mass")], 
+                                override_bins = {("gas", "density"):custom_bins,
+                                                 ("gas", "temperature"):None}) 
+
+
 .. _generating-line-queries:
 
 Line Queries and Planar Integrals

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -1085,7 +1085,11 @@ def create_profile(data_source, bin_fields, fields, n_bins=64,
             try:
                 field_ex = list(extrema[bin_field[-1]])
             except KeyError:
-                field_ex = list(extrema[bin_field])
+                try:
+                    field_ex = list(extrema[bin_field])
+                except KeyError:
+                    raise RuntimeError("Could not find field {0} or {1} in override_bins".format(bin_field[-1], bin_field))
+
             if isinstance(field_ex[0], tuple):
                 field_ex = [data_source.ds.quan(*f) for f in field_ex]
             if any([exi is None for exi in field_ex]):

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -431,10 +431,12 @@ class Profile1D(ProfileND):
         spaced in linear (False) or log (True) space.
     weight_field : string field name
         The field to weight the profiled fields by.
+    override_bins_x : array
+        Array to set as xbins and ignore other parameters if set
 
     """
     def __init__(self, data_source, x_field, x_n, x_min, x_max, x_log,
-                 weight_field = None):
+                 weight_field = None, override_bins_x=None):
         super(Profile1D, self).__init__(data_source, weight_field)
         self.x_field = data_source._determine_fields(x_field)[0]
         self.field_info[self.x_field] = \
@@ -445,6 +447,11 @@ class Profile1D(ProfileND):
         self.x_bins = array_like_field(data_source,
                                        self._get_bins(x_min, x_max, x_n, x_log),
                                        self.x_field)
+
+        if override_bins_x is not None:
+            self.x_bins = array_like_field(data_source, override_bins_x,
+                                           self.x_field)
+
         self.size = (self.x_bins.size - 1,)
         self.bin_fields = (self.x_field,)
         self.x = 0.5*(self.x_bins[1:]+self.x_bins[:-1])
@@ -529,12 +536,17 @@ class Profile2D(ProfileND):
         spaced in linear (False) or log (True) space.
     weight_field : string field name
         The field to weight the profiled fields by.
+    override_bins_x : array
+        Array to set as xbins and ignore other parameters if set
+    override_bins_y : array
+        Array to set as ybins and ignore other parameters if set
 
     """
     def __init__(self, data_source,
                  x_field, x_n, x_min, x_max, x_log,
                  y_field, y_n, y_min, y_max, y_log,
-                 weight_field = None):
+                 weight_field = None,
+                 override_bins_x = None, override_bins_y = None):
         super(Profile2D, self).__init__(data_source, weight_field)
         # X
         self.x_field = data_source._determine_fields(x_field)[0]
@@ -546,6 +558,11 @@ class Profile2D(ProfileND):
         self.x_bins = array_like_field(data_source,
                                        self._get_bins(x_min, x_max, x_n, x_log),
                                        self.x_field)
+        if override_bins_x is not None:
+            self.x_bins = array_like_field(data_source, override_bins_x,
+                                           self.x_field)
+
+
         # Y
         self.y_field = data_source._determine_fields(y_field)[0]
         self.y_log = y_log
@@ -556,6 +573,9 @@ class Profile2D(ProfileND):
         self.y_bins = array_like_field(data_source,
                                        self._get_bins(y_min, y_max, y_n, y_log),
                                        self.y_field)
+        if override_bins_y is not None:
+            self.y_bins = array_like_field(data_source, override_bins_y,
+                                           self.y_field)
 
         self.size = (self.x_bins.size - 1, self.y_bins.size - 1)
 
@@ -774,13 +794,20 @@ class Profile3D(ProfileND):
         spaced in linear (False) or log (True) space.
     weight_field : string field name
         The field to weight the profiled fields by.
+    override_bins_x : array
+        Array to set as xbins and ignore other parameters if set
+    override_bins_y : array
+        Array to set as xbins and ignore other parameters if set
+    override_bins_z : array
+        Array to set as xbins and ignore other parameters if set
 
     """
     def __init__(self, data_source,
                  x_field, x_n, x_min, x_max, x_log,
                  y_field, y_n, y_min, y_max, y_log,
                  z_field, z_n, z_min, z_max, z_log,
-                 weight_field = None):
+                 weight_field = None, override_bins_x=None,
+                 override_bins_y=None,override_bins_z=None):
         super(Profile3D, self).__init__(data_source, weight_field)
         # X
         self.x_field = data_source._determine_fields(x_field)[0]
@@ -792,6 +819,9 @@ class Profile3D(ProfileND):
         self.x_bins = array_like_field(data_source,
                                        self._get_bins(x_min, x_max, x_n, x_log),
                                        self.x_field)
+        if override_bins_x is not None:
+            self.x_bins = array_like_field(data_source, override_bins_x,
+                                           self.x_field)
         # Y
         self.y_field = data_source._determine_fields(y_field)[0]
         self.y_log = y_log
@@ -802,6 +832,9 @@ class Profile3D(ProfileND):
         self.y_bins = array_like_field(data_source,
                                        self._get_bins(y_min, y_max, y_n, y_log),
                                        self.y_field)
+        if override_bins_y is not None:
+            self.y_bins = array_like_field(data_source, override_bins_y,
+                                           self.y_field)
         # Z
         self.z_field = data_source._determine_fields(z_field)[0]
         self.z_log = z_log
@@ -812,6 +845,9 @@ class Profile3D(ProfileND):
         self.z_bins = array_like_field(data_source,
                                        self._get_bins(z_min, z_max, z_n, z_log),
                                        self.z_field)
+        if override_bins_z is not None:
+            self.z_bins = array_like_field(data_source, override_bins_z,
+                                           self.z_field)
 
         self.size = (self.x_bins.size - 1,
                      self.y_bins.size - 1,
@@ -899,7 +935,7 @@ def create_profile(data_source, bin_fields, fields, n_bins=64,
                    extrema=None, logs=None, units=None,
                    weight_field="cell_mass",
                    accumulation=False, fractional=False,
-                   deposition='ngp'):
+                   deposition='ngp', override_bins=None):
     r"""
     Create a 1, 2, or 3D profile object.
 
@@ -948,6 +984,10 @@ def create_profile(data_source, bin_fields, fields, n_bins=64,
         Controls the type of deposition used for ParticlePhasePlots.
         Valid choices are 'ngp' and 'cic'. Default is 'ngp'. This parameter is
         ignored the if the input fields are not of particle type.
+    override_bins : dict of bins to profile plot with
+        If set, ignores n_bins and extrema settings and uses the
+        supplied bins to profile the field. If a units dict is provided,
+        bins are understood to be in the units specified in the dictionary.
 
 
     Examples
@@ -983,6 +1023,7 @@ def create_profile(data_source, bin_fields, fields, n_bins=64,
     units = sanitize_field_tuple_keys(units, data_source)
     extrema = sanitize_field_tuple_keys(extrema, data_source)
     logs = sanitize_field_tuple_keys(logs, data_source)
+    override_bins = sanitize_field_tuple_keys(override_bins, data_source)
 
     if any(is_pfield) and not all(is_pfield):
         raise YTIllDefinedProfile(
@@ -1082,12 +1123,43 @@ def create_profile(data_source, bin_fields, fields, n_bins=64,
                 field_ex[1] = data_source.ds.quan(field_ex[1][0], field_ex[1][1])
                 field_ex[1] = field_ex[1].in_units(bf_units)
             ex.append(field_ex)
+
+    if override_bins is not None:
+        o_bins = []
+        for bin_field in bin_fields:
+            bf_units = data_source.ds.field_info[bin_field].output_units
+            try:
+                field_obin = override_bins[bin_field[-1]]
+            except KeyError:
+                field_obin = override_bins[bin_field]
+
+            if field_obin is None:
+                o_bins.append(None)
+                continue
+
+            if isinstance(field_obin, tuple):
+                field_obin = data_source.ds.arr(*field_obin)
+
+            if units is not None and bin_field in units:
+                fe = data_source.ds.arr(field_obin, units[bin_field])
+            else:
+                if hasattr(field_obin, 'units'):
+                    fe = field_obin.to(bf_units)
+                else:
+                    fe = data_source.ds.arr(field_obin, bf_units)
+            fe.convert_to_units(bf_units)
+            field_obin = fe.d
+            o_bins.append(field_obin)
+
     args = [data_source]
     for f, n, (mi, ma), l in zip(bin_fields, n_bins, ex, logs):
         args += [f, n, mi, ma, l]
     kwargs = dict(weight_field=weight_field)
     if cls is ParticleProfile:
         kwargs['deposition'] = deposition
+    if override_bins is not None:
+        for o_bin, ax in zip(o_bins, ['x','y','z']):
+            kwargs["override_bins_{0}".format(ax)] = o_bin
     obj = cls(*args, **kwargs)
     setattr(obj, "accumulation", accumulation)
     setattr(obj, "fractional", fractional)

--- a/yt/data_objects/tests/test_profiles.py
+++ b/yt/data_objects/tests/test_profiles.py
@@ -303,3 +303,19 @@ def test_profile_override_limits():
                                 [ "density"],["temperature"],
                                 override_bins={"density":(obins, "g/cm**3")})
     assert_equal(ds.arr(obins, "g/cm**3"), profile.x_bins)
+
+    profile = yt.create_profile(sp,
+                                [ "density", "dinosaurs"],["temperature"],
+                                override_bins={"density":(obins, "g/cm**3"),
+                                               "dinosaurs":obins})
+    assert_equal(ds.arr(obins, "g/cm**3"), profile.x_bins)
+    assert_equal(ds.arr(obins, "dyne"), profile.y_bins)
+
+    profile = yt.create_profile(sp,
+                                [ "density", "dinosaurs", "tribbles"],["temperature"],
+                                override_bins={"density":(obins, "g/cm**3"),
+                                               "dinosaurs":obins,
+                                               "tribbles":(obins, "erg")})
+    assert_equal(ds.arr(obins, "g/cm**3"), profile.x_bins)
+    assert_equal(ds.arr(obins, "dyne"), profile.y_bins)
+    assert_equal(ds.arr(obins, "erg"), profile.z_bins)

--- a/yt/data_objects/tests/test_profiles.py
+++ b/yt/data_objects/tests/test_profiles.py
@@ -5,7 +5,7 @@ from yt.data_objects.particle_filters import add_particle_filter
 from yt.data_objects.profiles import Profile1D, Profile2D, Profile3D,\
     create_profile
 from yt.testing import fake_random_ds, assert_equal, assert_raises,\
-    assert_rel_equal
+    assert_rel_equal, assert_almost_equal
 from yt.utilities.exceptions import YTIllDefinedProfile
 from yt.visualization.profile_plotter import ProfilePlot, PhasePlot
 
@@ -293,3 +293,16 @@ def test_profile_zero_weight():
                                 weight_field=("gas", "DM_cell_mass"))
 
     assert not np.any(np.isnan(profile['gas', 'radial_velocity']))
+
+def test_profile_override_limits():
+
+    ds = fake_random_ds(32, particle_fields=_fields,
+                        particle_field_units=_units, particles=16)
+
+    sp = ds.sphere(ds.domain_center, (10, 'kpc'))
+    obins = np.linspace(-5,5,10)
+    profile = yt.create_profile(sp,
+                                [("gas", "density")],
+                                [("gas", "radial_velocity")],
+                                override_bins={("gas", "density"):(np.linspace(-5,5,10), "g/cm**3")})
+    assert_equal(ds.arr(obins, "g/cm**3"), profile.x_bins)

--- a/yt/data_objects/tests/test_profiles.py
+++ b/yt/data_objects/tests/test_profiles.py
@@ -5,7 +5,7 @@ from yt.data_objects.particle_filters import add_particle_filter
 from yt.data_objects.profiles import Profile1D, Profile2D, Profile3D,\
     create_profile
 from yt.testing import fake_random_ds, assert_equal, assert_raises,\
-    assert_rel_equal, assert_almost_equal
+    assert_rel_equal
 from yt.utilities.exceptions import YTIllDefinedProfile
 from yt.visualization.profile_plotter import ProfilePlot, PhasePlot
 
@@ -295,14 +295,11 @@ def test_profile_zero_weight():
     assert not np.any(np.isnan(profile['gas', 'radial_velocity']))
 
 def test_profile_override_limits():
-
-    ds = fake_random_ds(32, particle_fields=_fields,
-                        particle_field_units=_units, particles=16)
+    ds = fake_random_ds(64, nprocs = 8, fields = _fields, units = _units)
 
     sp = ds.sphere(ds.domain_center, (10, 'kpc'))
     obins = np.linspace(-5,5,10)
     profile = yt.create_profile(sp,
-                                [("gas", "density")],
-                                [("gas", "radial_velocity")],
-                                override_bins={("gas", "density"):(np.linspace(-5,5,10), "g/cm**3")})
+                                [ "density"],["temperature"],
+                                override_bins={"density":(obins, "g/cm**3")})
     assert_equal(ds.arr(obins, "g/cm**3"), profile.x_bins)


### PR DESCRIPTION
I wanted to be able to use custom bins but still get the yt profile infrastructure. I just added a kwarg to override all of the other bin settings when given an argument, otherwise it's ignored. I have a notebook showing that it works/why I wanted this functionality with my dataset, but I'm not sure how's best to share it?

(also hi everyone, get ready for a bunch of planetary astro PRs :) )