### PR TITLE
adding coverage report from appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,14 +29,17 @@ install:
     - "python --version"
 
     # Install specified version of numpy and dependencies
-    - "conda install --yes -c conda-forge numpy scipy nose setuptools ipython Cython sympy fastcache h5py matplotlib flake8 mock"
+    - "conda install --yes -c conda-forge numpy scipy nose setuptools ipython Cython sympy fastcache h5py matplotlib flake8 mock nose-timer coverage codecov"
     - "pip install -e ."
 
 # Not a .NET project
 build: false
 
 test_script:
-  - "nosetests --nologcapture -sv yt"
+  - "coverage run -m nose -c nose.cfg"
+
+on_success:
+  - "codecov"
 
 # Enable this to be able to login to the build worker. You can use the
 # `remmina` program in Ubuntu, use the login information that the line below


### PR DESCRIPTION

## PR Summary

With this, AppVeyor coverage reports will be sent to yt's Codecov dashboard. Though, these reports are just a subset of Travis CI (since these also run only the unit tests) and do not add any additional value to the reporting portal. But the aim is to have coverage from all (Travis/AppVeyor/Jenkins) at yt's Codecov portal.
