### PR TITLE
Don't override the units for fluid index aliases

### DIFF
--- a/yt/analysis_modules/cosmological_observation/light_cone/light_cone_projection.py
+++ b/yt/analysis_modules/cosmological_observation/light_cone/light_cone_projection.py
@@ -57,29 +57,32 @@ def _light_cone_projection(my_slice, field, pixels, weight_field=None,
           my_slice["projection_center"][my_slice["projection_axis"]] \
             + 0.5 * my_slice["box_depth_fraction"]
         if (depthLeft < 0):
-            cut_mask = ("((obj[\"%s\"] + 0.5*obj[\"d%s\"] >= 0) & " + \
-              "(obj[\"%s\"] - 0.5*obj[\"d%s\"] <= %f)) | " + \
-              "((obj[\"%s\"] + 0.5*obj[\"d%s\"] >= %f) & " + \
-              "(obj[\"%s\"] - 0.5*obj[\"d%s\"] <= 1))") % \
+            cut_mask = (
+                "((obj['index', '%s'] + 0.5*obj['index', 'd%s'] >= 0) & "
+                " (obj['index', '%s'] - 0.5*obj['index', 'd%s'] <= %f)) | "
+                "((obj['index', '%s'] + 0.5*obj['index', 'd%s'] >= %f) & "
+                " (obj['index', '%s'] - 0.5*obj['index', 'd%s'] <= 1))") % \
                 (axis, axis, axis, axis, depthRight, 
                  axis, axis, (depthLeft+1), axis, axis)
         elif (depthRight > 1):
-            cut_mask = ("((obj[\"%s\"] + 0.5*obj[\"d%s\"] >= 0) & " + \
-              "(obj[\"%s\"] - 0.5*obj[\"d%s\"] <= %f)) | " + \
-              "((obj[\"%s\"] + 0.5*obj[\"d%s\"] >= %f) & " + \
-              "(obj[\"%s\"] - 0.5*obj[\"d%s\"] <= 1))") % \
+            cut_mask = (
+                "((obj['index', '%s'] + 0.5*obj['index', 'd%s'] >= 0) & "
+                "(obj['index', '%s'] - 0.5*obj['index', 'd%s'] <= %f)) | "
+                "((obj['index', '%s'] + 0.5*obj['index', 'd%s'] >= %f) & "
+                "(obj['index', '%s'] - 0.5*obj['index', 'd%s'] <= 1))") % \
                 (axis, axis, axis, axis, (depthRight-1),
                  axis, axis, depthLeft, axis, axis)
         else:
-            cut_mask = ("(obj[\"%s\"] + 0.5*obj[\"d%s\"] >= %f) & " + \
-              "(obj[\"%s\"] - 0.5*obj[\"%s\"] <= %f)") % \
-              (axis, axis, depthLeft, axis, axis, depthRight)
+            cut_mask = (
+                "(obj['index', '%s'] + 0.5*obj['index', 'd%s'] >= %f) & "
+                "(obj['index', '%s'] - 0.5*obj['index', '%s'] <= %f)") % \
+                (axis, axis, depthLeft, axis, axis, depthRight)
 
         these_field_cuts.append(cut_mask)
 
     data_source = my_slice["object"].all_data()
     cut_region = data_source.cut_region(these_field_cuts)
-        
+
     # Make projection.
     proj = my_slice["object"].proj(field, my_slice["projection_axis"], 
         weight_field, center=region_center,

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -571,7 +571,7 @@ class YTDataContainer(object):
         else:
             data.update(self.field_data)
         # get the extra fields needed to reconstruct the container
-        tds_fields = tuple(self._determine_fields(list(self._tds_fields)))
+        tds_fields = tuple([('index', t) for t in self._tds_fields])
         for f in [f for f in self._container_fields + tds_fields \
                   if f not in data]:
             data[f] = self[f]

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -281,12 +281,14 @@ been deprecated, use profile.standard_deviation instead."""
         if field in self.field_data:
             fname = field
         else:
+            # deal with string vs tuple field names and attempt to guess which field
+            # we are supposed to be talking about
             fname = self.field_map.get(field, None)
             if isinstance(field, tuple):
-                if field in self.field_data:
-                    fname = field
-                else:
-                    fname = self.field_map.get(field[1], None)
+                fname = self.field_map.get(field[1], None)
+                if fname != field:
+                    raise KeyError("Asked for field '{}' but only have data for "
+                                   "field '{}'".format(field, fname))
             elif isinstance(field, DerivedField):
                 fname = self.field_map.get(field.name[1], None)
             if fname is None:

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -278,19 +278,23 @@ been deprecated, use profile.standard_deviation instead."""
         return arr, weight_data, bin_fields
 
     def __getitem__(self, field):
-        fname = self.field_map.get(field, None)
-        if fname is None:
+        if field in self.field_data:
+            fname = field
+        else:
+            fname = self.field_map.get(field, None)
             if isinstance(field, tuple):
-                fname = self.field_map.get(field[1], None)
+                if field in self.field_data:
+                    fname = field
+                else:
+                    fname = self.field_map.get(field[1], None)
             elif isinstance(field, DerivedField):
                 fname = self.field_map.get(field.name[1], None)
-        if fname is None:
-            raise KeyError(field)
+            if fname is None:
+                raise KeyError(field)
+        if getattr(self, 'fractional', False):
+            return self.field_data[fname]
         else:
-            if getattr(self, 'fractional', False):
-                return self.field_data[fname]
-            else:
-                return self.field_data[fname].in_units(self.field_units[fname])
+            return self.field_data[fname].in_units(self.field_units[fname])
 
     def items(self):
         return [(k,self[k]) for k in self.field_data.keys()]

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -824,7 +824,8 @@ class Dataset(object):
             source.quantities.max_location(field)
         mylog.info("Max Value is %0.5e at %0.16f %0.16f %0.16f",
               max_val, mx, my, mz)
-        return max_val, self.arr([mx, my, mz], 'code_length', dtype="float64")
+        center = self.arr([mx, my, mz], dtype="float64").to('code_length')
+        return max_val, center
 
     def find_min(self, field):
         """
@@ -836,7 +837,8 @@ class Dataset(object):
             source.quantities.min_location(field)
         mylog.info("Min Value is %0.5e at %0.16f %0.16f %0.16f",
               min_val, mx, my, mz)
-        return min_val, self.arr([mx, my, mz], 'code_length', dtype="float64")
+        center = self.arr([mx, my, mz], dtype="float64").to('code_length')
+        return min_val, center
 
     def find_field_values_at_point(self, fields, coords):
         """

--- a/yt/data_objects/tests/test_profiles.py
+++ b/yt/data_objects/tests/test_profiles.py
@@ -382,3 +382,17 @@ class TestBadProfiles(unittest.TestCase):
         assert_raises(
             YTProfileDataShape,
             yt.PhasePlot, ds.data, 'temperature', 'density', 'cell_mass')
+
+def test_index_field_units():
+    # see #1849
+    ds = fake_random_ds(16, length_unit=2)
+    ad = ds.all_data()
+    icv_units = ad['index', 'cell_volume'].units
+    assert str(icv_units) == 'code_length**3'
+    gcv_units = ad['gas', 'cell_volume'].units
+    assert str(gcv_units) == 'cm**3'
+    prof = ad.profile(['density', 'velocity_x'],
+                      [('gas', 'cell_volume'), ('index', 'cell_volume')],
+                      weight_field=None)
+    assert str(prof['index', 'cell_volume'].units) == 'code_length**3'
+    assert str(prof['gas', 'cell_volume'].units) == 'cm**3'

--- a/yt/data_objects/tests/test_projection.py
+++ b/yt/data_objects/tests/test_projection.py
@@ -108,8 +108,8 @@ def test_projection():
             # wf == None
             assert_equal(wf, None)
             v1 = proj["density"].sum()
-            v2 = (LENGTH_UNIT * dd["density"] * dd["d%s" % an]).sum()
-            assert_rel_equal(v1, v2, 10)
+            v2 = (dd["density"] * dd["d%s" % an]).sum()
+            assert_rel_equal(v1, v2.in_units(v1.units), 10)
     teardown_func(fns)
 
 

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -81,10 +81,6 @@ class FieldInfoContainer(dict):
             for f in index_fields:
                 if (ftype, f) in self: continue
                 self.alias((ftype, f), ("index", f))
-                # Different field types have different default units.
-                # We want to make sure the aliased field will have
-                # the same units as the "index" field.
-                self[(ftype, f)].units = self["index", f].units
 
     def setup_particle_fields(self, ptype, ftype='gas', num_neighbors=64 ):
         skip_output_units = ("code_length")

--- a/yt/geometry/coordinates/cartesian_coordinates.py
+++ b/yt/geometry/coordinates/cartesian_coordinates.py
@@ -244,8 +244,8 @@ class CartesianCoordinateHandler(CoordinateHandler):
         indices = np.argsort(data_source['pdx'])[::-1].astype(np.int_)
         buff = np.zeros((size[1], size[0]), dtype="f8")
         pixelize_off_axis_cartesian(buff,
-                              data_source['x'], data_source['y'],
-                              data_source['z'], data_source['px'],
+                              data_source['index', 'x'], data_source['index', 'y'],
+                              data_source['index', 'z'], data_source['px'],
                               data_source['py'], data_source['pdx'],
                               data_source['pdy'], data_source['pdz'],
                               data_source.center, data_source._inv_mat, indices,

--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -973,7 +973,7 @@ cdef class CutRegionSelector(SelectorObject):
     cdef tuple _conditionals
 
     def __init__(self, dobj):
-        positions = np.array([dobj['x'], dobj['y'], dobj['z']]).T
+        positions = np.array([dobj['index', 'x'], dobj['index', 'y'], dobj['index', 'z']]).T
         self._conditionals = tuple(dobj.conditionals)
         self._positions = set(tuple(position) for position in positions)
 

--- a/yt/geometry/tests/test_particle_octree.py
+++ b/yt/geometry/tests/test_particle_octree.py
@@ -25,6 +25,7 @@ from yt.geometry.particle_oct_container import \
 from yt.geometry.oct_container import _ORDER_MAX
 from yt.geometry.selection_routines import RegionSelector, AlwaysSelector
 from yt.testing import \
+    assert_almost_equal, \
     assert_equal, \
     requires_file
 from yt.units.unit_registry import UnitRegistry
@@ -152,11 +153,12 @@ def test_particle_index_ptype():
     dd = ds.all_data()
     dd_all = ds_all.all_data()
     dd_pt0 = ds_pt0.all_data()
-    cv = dd["cell_volume"]
-    cv_all = dd_all["cell_volume"]
-    cv_pt0 = dd_pt0["cell_volume"]
+    cv = dd['index', "cell_volume"]
+    cv_all = dd_all['index', "cell_volume"]
+    cv_pt0 = dd_pt0['index', "cell_volume"]
     assert_equal(cv.shape, cv_all.shape)
-    assert_equal(cv.sum(dtype="float64"), cv_pt0.sum(dtype="float64"))
+    assert_almost_equal(
+        cv.sum(dtype="float64"), cv_pt0.sum(dtype="float64"))
 
 class FakeDS:
     domain_left_edge = None


### PR DESCRIPTION
Closes #1849.

Merging #1799 caused the breakage Matt ran into in #1849. It turns out that `('gas', 'cell_volume')` has `units='code_length**3'` but `output_units='cm**3'`, so it turns out I wasn't correct that only particle fields use `output_units`.

The fix (I think) is to make `units` and `output_units` the same for the fluid index aliases created in the function this PR modifies.

I'm not sure if this will pass the tests so I am opening this PR to get the full test suite run against this change.