### PR TITLE
Fixing appveyor python2.7 run of nosetests with coverage

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,14 +29,18 @@ install:
     - "python --version"
 
     # Install specified version of numpy and dependencies
-    - "conda install --yes -c conda-forge numpy scipy nose setuptools ipython Cython sympy fastcache h5py matplotlib flake8 mock"
+    - "conda install --yes -c conda-forge numpy scipy nose setuptools ipython Cython sympy fastcache h5py matplotlib mock codecov coverage"
     - "pip install -e ."
 
 # Not a .NET project
 build: false
 
 test_script:
-  - "nosetests --nologcapture -sv yt"
+  -  "nosetests --with-coverage --nologcapture --cover-erase --cover-inclusive --cover-branches -svd yt"
+
+on_success:
+  - "coverage report"
+  - "codecov -X gcov"
 
 # Enable this to be able to login to the build worker. You can use the
 # `remmina` program in Ubuntu, use the login information that the line below


### PR DESCRIPTION
## PR Summary

#1845 does not run tests for python 2.7 when nosetests are run inside coverage.
Hopefully, this will fix this issue.