### PR TITLE
reverting #1845 merge

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,17 +29,14 @@ install:
     - "python --version"
 
     # Install specified version of numpy and dependencies
-    - "conda install --yes -c conda-forge numpy scipy nose setuptools ipython Cython sympy fastcache h5py matplotlib flake8 mock nose-timer coverage codecov"
+    - "conda install --yes -c conda-forge numpy scipy nose setuptools ipython Cython sympy fastcache h5py matplotlib mock"
     - "pip install -e ."
 
 # Not a .NET project
 build: false
 
 test_script:
-  - "coverage run -m nose -c nose.cfg"
-
-on_success:
-  - "codecov"
+  - "nosetests --nologcapture -sv yt"
 
 # Enable this to be able to login to the build worker. You can use the
 # `remmina` program in Ubuntu, use the login information that the line below


### PR DESCRIPTION

## PR Summary

Reverting #1845 merge, since running nosetests with coverage is causing issues in python 2.7 in Appveyor.
