### PR TITLE
fix usage of behavior deprecated in numpy 1.15

### DIFF
--- a/yt/fields/fluid_fields.py
+++ b/yt/fields/fluid_fields.py
@@ -201,19 +201,17 @@ def setup_gradient_fields(registry, grad_field, field_units, slice_info = None):
         div_fac = 2.0
     else:
         sl_left, sl_right, div_fac = slice_info
-    slice_3d = [slice(1, -1), slice(1, -1), slice(1, -1)]
+    slice_3d = (slice(1, -1), slice(1, -1), slice(1, -1))
 
     def grad_func(axi, ax):
-        slice_3dl = slice_3d[:]
-        slice_3dr = slice_3d[:]
-        slice_3dl[axi] = sl_left
-        slice_3dr[axi] = sl_right
+        slice_3dl = slice_3d[:axi] + (sl_left,) + slice_3d[axi+1:]
+        slice_3dr = slice_3d[:axi] + (sl_right,) + slice_3d[axi+1:]
         def func(field, data):
             ds = div_fac * data[ftype, "d%s" % ax]
             f  = data[grad_field][slice_3dr]/ds[slice_3d]
             f -= data[grad_field][slice_3dl]/ds[slice_3d]
-            new_field = data.ds.arr(np.zeros_like(data[grad_field], dtype=np.float64),
-                                    f.units)
+            new_field = np.zeros_like(data[grad_field], dtype=np.float64)
+            new_field = data.ds.arr(new_field, f.units)
             new_field[slice_3d] = f
             return new_field
         return func

--- a/yt/fields/vector_operations.py
+++ b/yt/fields/vector_operations.py
@@ -421,7 +421,7 @@ def create_averaged_field(registry, basename, field_units, ftype="gas",
         i_i, j_i, k_i = np.mgrid[0:3, 0:3, 0:3]
 
         for i, j, k in zip(i_i.ravel(), j_i.ravel(), k_i.ravel()):
-            sl = [slice(i, nx-(2-i)), slice(j, ny-(2-j)), slice(k, nz-(2-k))]
+            sl = (slice(i, nx-(2-i)), slice(j, ny-(2-j)), slice(k, nz-(2-k)))
             new_field += data[(ftype, basename)][sl] * data[(ftype, weight)][sl]
             weight_field += data[(ftype, weight)][sl]
 

--- a/yt/frontends/athena/io.py
+++ b/yt/frontends/athena/io.py
@@ -87,7 +87,7 @@ class IOHandlerAthena(BaseIOHandler):
         sl[axis] = slice(coord, coord + 1)
         if grid.ds.field_ordering == 1:
             sl.reverse()
-        return self._read_data_set(grid, field)[sl]
+        return self._read_data_set(grid, field)[tuple(sl)]
 
     def _read_fluid_selection(self, chunks, selector, fields, size):
         chunks = list(chunks)

--- a/yt/frontends/chombo/io.py
+++ b/yt/frontends/chombo/io.py
@@ -110,7 +110,8 @@ class IOHandlerChomboHDF5(BaseIOHandler):
         stop = start + boxsize
         data = lev[self._data_string][start:stop]
         data_no_ghost = data.reshape(shape, order='F')
-        ghost_slice = [slice(g, d-g, None) for g, d in zip(self.ghost, dims)]
+        ghost_slice = tuple(
+            [slice(g, d-g, None) for g, d in zip(self.ghost, dims)])
         ghost_slice = ghost_slice[0:self.dim]
         return data_no_ghost[ghost_slice]
 

--- a/yt/frontends/enzo/data_structures.py
+++ b/yt/frontends/enzo/data_structures.py
@@ -147,17 +147,19 @@ class EnzoGridGZ(EnzoGrid):
             end_zone = None
         else:
             end_zone = -(NGZ - n_zones)
-        sl = [slice(start_zone, end_zone) for i in range(3)]
+        sl = tuple([slice(start_zone, end_zone) for i in range(3)])
         if fields is None: return cube
         for field in ensure_list(fields):
             if field in self.field_list:
                 conv_factor = 1.0
                 if field in self.ds.field_info:
-                    conv_factor = self.ds.field_info[field]._convert_function(self)
+                    conv_factor = self.ds.field_info[field]._convert_function(
+                        self)
                 if self.ds.field_info[field].particle_type: continue
                 temp = self.index.io._read_raw_data_set(self, field)
                 temp = temp.swapaxes(0, 2)
-                cube.field_data[field] = np.multiply(temp, conv_factor, temp)[sl]
+                cube.field_data[field] = np.multiply(
+                    temp, conv_factor, temp)[sl]
         return cube
 
 class EnzoHierarchy(GridIndex):

--- a/yt/geometry/coordinates/coordinate_handler.py
+++ b/yt/geometry/coordinates/coordinate_handler.py
@@ -197,12 +197,12 @@ class CoordinateHandler(object):
             if not iterable(axis):
                 xax = self.x_axis[axis]
                 yax = self.y_axis[axis]
-                w = self.ds.domain_width[[xax, yax]]
+                w = self.ds.domain_width[np.array([xax, yax])]
             else:
                 # axis is actually the normal vector
                 # for an off-axis data object.
                 mi = np.argmin(self.ds.domain_width)
-                w = self.ds.domain_width[[mi,mi]]
+                w = self.ds.domain_width[np.array((mi, mi))]
             width = (w[0], w[1])
         elif iterable(width):
             width = validate_iterable_width(width, self.ds)

--- a/yt/geometry/grid_geometry_handler.py
+++ b/yt/geometry/grid_geometry_handler.py
@@ -128,7 +128,7 @@ class GridIndex(Index):
         #   1 = number of cells
         #   2 = blank
         desc = {'names': ['numgrids','numcells','level'],
-                'formats':['Int64']*3}
+                'formats':['int64']*3}
         self.level_stats = blankRecordArray(desc, MAXLEVEL)
         self.level_stats['level'] = [i for i in range(MAXLEVEL)]
         self.level_stats['numgrids'] = [0 for i in range(MAXLEVEL)]

--- a/yt/utilities/io_handler.py
+++ b/yt/utilities/io_handler.py
@@ -151,7 +151,7 @@ class BaseIOHandler(object):
     def _read_data_slice(self, grid, field, axis, coord):
         sl = [slice(None), slice(None), slice(None)]
         sl[axis] = slice(coord, coord + 1)
-        tr = self._read_data_set(grid, field)[sl]
+        tr = self._read_data_set(grid, field)[tuple(sl)]
         if tr.dtype == "float32": tr = tr.astype("float64")
         return tr
 

--- a/yt/utilities/math_utils.py
+++ b/yt/utilities/math_utils.py
@@ -769,7 +769,7 @@ def quartiles(a, axis=None, out=None, overwrite_input=False):
             indexer[axis] = slice(index, index+1)
         # Use mean in odd and even case to coerce data type
         # and check, use out array.
-        result.append(np.mean(sorted[indexer], axis=axis, out=out))
+        result.append(np.mean(sorted[tuple(indexer)], axis=axis, out=out))
     return np.array(result)
 
 def get_perspective_matrix(fovy, aspect, z_near, z_far):

--- a/yt/utilities/nodal_data_utils.py
+++ b/yt/utilities/nodal_data_utils.py
@@ -38,4 +38,4 @@ def get_nodal_slices(shape, nodal_flag):
             for k, sl_k in enumerate(dir_slices[2]):
                 slices.append([sl_i, sl_j, sl_k])
                 
-    return slices
+    return tuple(slices)

--- a/yt/utilities/parallel_tools/io_runner.py
+++ b/yt/utilities/parallel_tools/io_runner.py
@@ -142,7 +142,7 @@ class IOHandlerRemote(BaseIOHandler):
         sl = [slice(None), slice(None), slice(None)]
         sl[axis] = slice(coord, coord + 1)
         #sl = tuple(reversed(sl))
-        return self._read_data_set(grid,field)[sl]
+        return self._read_data_set(grid,field)[tuple(sl)]
 
     def terminate(self):
         msg = dict(op='end')


### PR DESCRIPTION
This makes the unit tests run without any new warnings under numpy 1.15rc1 (which you can install from pip right now with `pip install -U --pre numpy`.

The main issue is the deprecation of non-tuple sequences as array indices. See https://github.com/numpy/numpy/pull/9686 for details. There was also one place where we used `Int64` instead of `int64` and NumPy has now grown slightly more picky about that.