### PR TITLE
add functions defined in plugins file to yt namespace

### DIFF
--- a/yt/fields/tests/test_fields_plugins.py
+++ b/yt/fields/tests/test_fields_plugins.py
@@ -1,4 +1,3 @@
-# -*- coding: UTF-8 -*-
 #-----------------------------------------------------------------------------
 # Copyright (c) 2016, yt Development Team.
 #
@@ -12,12 +11,19 @@ import sys
 import unittest
 import yt
 from yt.config import ytcfg, CONFIG_DIR
-from yt.testing import fake_random_ds
+from yt.testing import \
+    assert_raises, \
+    fake_random_ds
 
-TEST_PLUGIN_FILE = '''def _myfunc(field, data):
+TEST_PLUGIN_FILE = '''
+def _myfunc(field, data):
     return np.random.random(data['density'].shape)
 add_field('random', dimensions='dimensionless',
-          function=_myfunc, units='auto')'''
+          function=_myfunc, units='auto', sampling_type='cell')
+def myfunc():
+    return 4
+foobar = 12
+'''
 
 
 def setUpModule():
@@ -47,6 +53,7 @@ def tearDownModule():
         if os.path.isfile(potential_plugin_file + '.bak_test'):
             os.rename(potential_plugin_file + '.bak_test',
                       potential_plugin_file)
+    del yt.myfunc
 
 
 class TestPluginFile(unittest.TestCase):
@@ -67,3 +74,5 @@ class TestPluginFile(unittest.TestCase):
         dd = ds.all_data()
         self.assertEqual(str(dd['random'].units), 'dimensionless')
         self.assertEqual(dd['random'].shape, dd['density'].shape)
+        assert yt.myfunc() == 4
+        assert_raises(AttributeError, getattr, yt, 'foobar')

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -994,11 +994,18 @@ def enable_plugins():
                 os.path.join(old_config_dir, my_plugin_name),
                 os.path.join(CONFIG_DIR, my_plugin_name))
         mylog.info("Loading plugins from %s", _fn)
-        execdict = yt.__dict__.copy()
+        ytdict = yt.__dict__
+        execdict = ytdict.copy()
         execdict['add_field'] = my_plugins_fields.add_field
+        localdict = {}
         with open(_fn) as f:
             code = compile(f.read(), _fn, 'exec')
-            exec(code, execdict)
+            exec(code, execdict, localdict)
+        ytnamespace = list(ytdict.keys())
+        for k in localdict.keys():
+            if k not in ytnamespace:
+                if callable(localdict[k]):
+                    setattr(yt, k, localdict[k])
 
 def fix_unitary(u):
     if u == '1':


### PR DESCRIPTION
According to http://yt-project.org/doc/reference/configuration.html#the-plugin-file if you define a function in `my_plugins.py` then that function should be available in the yt namespace. However, that does not actually work right now.

Since this is a documented behavior and we had a user report that this behavior is broken, rather than modifying the docs to no longer say that this is possible, let's just add the functionality. 

This PR adds variables defined in `my_plugins.py` to the yt namespace if the variable is a function (e.g. `callable(var)` is `True`) and if its name doesn't shadow a name that's already in the yt namespace.

I've added tests for this behavior.