### PR TITLE
Adding an ill-defined profile error for 0-logs

### DIFF
--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -1157,7 +1157,7 @@ def create_profile(data_source, bin_fields, fields, n_bins=64,
 
     args = [data_source]
     for f, n, (mi, ma), l in zip(bin_fields, n_bins, ex, logs):
-        if mi == 0 and l:
+        if mi <= 0 and l:
             raise YTIllDefinedBounds(mi, ma)
         args += [f, n, mi, ma, l]
     kwargs = dict(weight_field=weight_field)

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -30,7 +30,7 @@ from yt.units.yt_array import \
 from yt.units.unit_object import Unit
 from yt.data_objects.field_data import YTFieldData
 from yt.utilities.exceptions import \
-    YTIllDefinedProfile
+    YTIllDefinedProfile, YTIllDefinedBounds
 from yt.utilities.lib.misc_utilities import \
     new_bin_profile1d, \
     new_bin_profile2d, \
@@ -1157,6 +1157,8 @@ def create_profile(data_source, bin_fields, fields, n_bins=64,
 
     args = [data_source]
     for f, n, (mi, ma), l in zip(bin_fields, n_bins, ex, logs):
+        if mi == 0 and l:
+            raise YTIllDefinedBounds(mi, ma)
         args += [f, n, mi, ma, l]
     kwargs = dict(weight_field=weight_field)
     if cls is ParticleProfile:


### PR DESCRIPTION
This fixes #1614.  Rather than intermittently failing, throw an error.