### PR TITLE
Fix syntax errors in docs

### DIFF
--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -2223,35 +2223,35 @@ at the big bang, and all particles should have positive values for the
 To help clarify the above discussion, the following table describes the meaning
 of the various particle formation time and age fields:
 
-+------------------+-------------------------+-------------------------------+
-| Simulation type  | Field name              | Description                   |
-|==================|=========================+===============================+
-| cosmological     | `conformal_birth_time`  | Formation time in conformal   |
-|                  |                         | units (dimensionless)         |
-+------------------+-------------------------+--------------------------------+
-| any              | `particle_birth_time`   | The time relative to the       |
-|                  |                         | beginning of the simulation    |
-|                  |                         | when the particle was formed.  |
-|                  |                         | For non-cosmological           |
-|                  |                         | simulations, this field will   |
-|                  |                         | have positive values for       |
-|                  |                         | particles formed during the    |
-|                  |                         | simulation and negative for    |
-|                  |                         | particles of finite age in the |
-|                  |                         | initial conditions. For        |
-|                  |                         | cosmological simulations this  |
-|                  |                         | is the time the particle       |
-|                  |                         | formed relative to the big     |
-|                  |                         | bang, therefore the value of   |
-|                  |                         | this field should be between   |
-|                  |                         | 0 and 13.7 Gyr.                |
-+------------------+-------------------------+--------------------------------+
-| any              | `star_age`              | Age of the particle.           |
-|                  |                         | Only physically meaningful for |
-|                  |                         | stars and particles that       |
-|                  |                         | formed dynamically during the  |
-|                  |                         | simulation.                    |
-+------------------+-------------------------+--------------------------------+
++------------------+--------------------------+--------------------------------+
+| Simulation type  | Field name               | Description                    |
+|==================|==========================+================================+
+| cosmological     | ``conformal_birth_time`` | Formation time in conformal    |
+|                  |                          | units (dimensionless)          |
++------------------+--------------------------+--------------------------------+
+| any              | ``particle_birth_time``  | The time relative to the       |
+|                  |                          | beginning of the simulation    |
+|                  |                          | when the particle was formed.  |
+|                  |                          | For non-cosmological           |
+|                  |                          | simulations, this field will   |
+|                  |                          | have positive values for       |
+|                  |                          | particles formed during the    |
+|                  |                          | simulation and negative for    |
+|                  |                          | particles of finite age in the |
+|                  |                          | initial conditions. For        |
+|                  |                          | cosmological simulations this  |
+|                  |                          | is the time the particle       |
+|                  |                          | formed relative to the big     |
+|                  |                          | bang, therefore the value of   |
+|                  |                          | this field should be between   |
+|                  |                          | 0 and 13.7 Gyr.                |
++------------------+--------------------------+--------------------------------+
+| any              | ``star_age``             | Age of the particle.           |
+|                  |                          | Only physically meaningful for |
+|                  |                          | stars and particles that       |
+|                  |                          | formed dynamically during the  |
+|                  |                          | simulation.                    |
++------------------+--------------------------+--------------------------------+
 
 RAMSES datasets produced by a version of the code newer than November 2017
 contain the metadata necessary for yt to automatically distinguish between star

--- a/doc/source/visualizing/callbacks.rst
+++ b/doc/source/visualizing/callbacks.rst
@@ -230,7 +230,7 @@ Axis-Aligned Data Sources
    p = yt.ProjectionPlot(ds, 'z', 'density', center=[0.5, 0.5, 0.5],
                          weight_field='density', width=(20, 'kpc'))
    p.annotate_quiver('velocity_x', 'velocity_y', factor=16, 
-                     plot_args={"color":"purple})
+                     plot_args={"color": "purple"})
    p.save()
 
 Off-Axis Data Sources

--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -1097,7 +1097,7 @@ function of radius. The xlabel is set to "Radius", for all plots, and the ylabel
    plot = yt.ProfilePlot(ad, "density", ["temperature", "velocity_x"],
                     weight_field=None)
    plot.set_xlabel("Radius")
-   plot.set_ylabel("x-velocity", "velocity in x direction")
+   plot.set_ylabel("velocity_x", "velocity in x direction")
    plot.save()
 
 Adding plot title

--- a/yt/analysis_modules/ppv_cube/ppv_cube.py
+++ b/yt/analysis_modules/ppv_cube/ppv_cube.py
@@ -281,6 +281,8 @@ class PPVCube(object):
             The (RA, Dec) coordinate in degrees of the central pixel. Must
             be specified with *sky_scale*.
 
+        Notes
+        -----
         Additional keyword arguments are passed to
         :meth:`~astropy.io.fits.HDUList.writeto`.
 

--- a/yt/fields/magnetic_field.py
+++ b/yt/fields/magnetic_field.py
@@ -176,6 +176,7 @@ def setup_magnetic_field_aliases(registry, ds_ftype, ds_fields, ftype="gas"):
     from the `setup_fluid_fields` method (for grid dataset) or the
     `setup_gas_particle_fields` method (for particle dataset) of a frontend's
     :class:`FieldInfoContainer` instance.
+
     Parameters
     ----------
     registry : :class:`FieldInfoContainer`
@@ -190,6 +191,7 @@ def setup_magnetic_field_aliases(registry, ds_ftype, ds_fields, ftype="gas"):
         vector magnetic field.
     ftype : string, optional
         The resulting field type of the fields. Default "gas".
+
     Examples
     --------
     >>> from yt.fields.magnetic_field import setup_magnetic_field_aliases


### PR DESCRIPTION
Minor issues I spotted while porting docs' build to py3.6.