### PR TITLE
make assert_fname assert a boolean expression

### DIFF
--- a/yt/testing.py
+++ b/yt/testing.py
@@ -1101,5 +1101,5 @@ def assert_fname(fname):
     elif data.startswith(b'%PDF'):
         image_type = '.pdf'
 
-    return image_type == os.path.splitext(fname)[1]
+    assert image_type == os.path.splitext(fname)[1]
 

--- a/yt/visualization/tests/test_particle_plot.py
+++ b/yt/visualization/tests/test_particle_plot.py
@@ -214,7 +214,7 @@ class TestParticlePhasePlotSave(unittest.TestCase):
         particle_phases[0]._repr_html_()
         for p in particle_phases:
             for fname in TEST_FLNMS:
-                assert assert_fname(p.save(fname)[0])
+                assert_fname(p.save(fname)[0])
 
 tgal = 'TipsyGalaxy/galaxy.00300'
 @requires_file(tgal)
@@ -307,7 +307,7 @@ class TestParticleProjectionPlotSave(unittest.TestCase):
         for dim in range(3):
             pplot = ParticleProjectionPlot(test_ds, dim, "particle_mass")
             for fname in TEST_FLNMS:
-                assert assert_fname(pplot.save(fname)[0])
+                assert_fname(pplot.save(fname)[0])
 
     def test_particle_plot_ds(self):
         test_ds = fake_particle_ds()

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -297,7 +297,7 @@ class TestPlotWindowSave(unittest.TestCase):
         for dim in range(3):
             slc = SlicePlot(test_ds, dim, 'density')
             for fname in TEST_FLNMS:
-                assert assert_fname(slc.save(fname)[0])
+                assert_fname(slc.save(fname)[0])
 
     def test_repr_html(self):
         test_ds = fake_random_ds(16)
@@ -309,7 +309,7 @@ class TestPlotWindowSave(unittest.TestCase):
         for dim in range(3):
             proj = ProjectionPlot(test_ds, dim, 'density')
             for fname in TEST_FLNMS:
-                assert assert_fname(proj.save(fname)[0])
+                assert_fname(proj.save(fname)[0])
 
     def test_projection_plot_ds(self):
         test_ds = fake_random_ds(16)
@@ -340,13 +340,13 @@ class TestPlotWindowSave(unittest.TestCase):
         test_ds = fake_random_ds(16)
         slc = OffAxisSlicePlot(test_ds, [1, 1, 1], "density")
         for fname in TEST_FLNMS:
-            assert assert_fname(slc.save(fname)[0])
+            assert_fname(slc.save(fname)[0])
 
     def test_offaxis_projection_plot(self):
         test_ds = fake_random_ds(16)
         prj = OffAxisProjectionPlot(test_ds, [1, 1, 1], "density")
         for fname in TEST_FLNMS:
-            assert assert_fname(prj.save(fname)[0])
+            assert_fname(prj.save(fname)[0])
 
     def test_creation_with_width(self):
         test_ds = fake_random_ds(16)


### PR DESCRIPTION
I noticed this while reviewing one of @git-abhishek pull requests where he made use of this decorator. It looks like most places in yt just call this function without asserting anything, so let's just adapt to that usage and make `assert_fname` do an assert.

There's a small chance this will break some tests where we weren't actually asserting anything before. I will fix those if there are any.