### PR TITLE
update plot answers for new matplotlib version

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -47,7 +47,7 @@ answer_tests:
   local_owls_002:
     - yt/frontends/owls/tests/test_outputs.py
 
-  local_pw_022:
+  local_pw_023:
     - yt/visualization/tests/test_plotwindow.py:test_attributes
     - yt/visualization/tests/test_plotwindow.py:test_attributes_wt
     - yt/visualization/tests/test_profile_plots.py:test_phase_plot_attributes

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -47,7 +47,7 @@ answer_tests:
   local_owls_002:
     - yt/frontends/owls/tests/test_outputs.py
 
-  local_pw_021:
+  local_pw_022:
     - yt/visualization/tests/test_plotwindow.py:test_attributes
     - yt/visualization/tests/test_plotwindow.py:test_attributes_wt
     - yt/visualization/tests/test_profile_plots.py:test_phase_plot_attributes
@@ -69,7 +69,7 @@ answer_tests:
     - yt/analysis_modules/photon_simulator/tests/test_spectra.py
     - yt/analysis_modules/photon_simulator/tests/test_sloshing.py
 
-  local_unstructured_009:
+  local_unstructured_010:
     - yt/visualization/volume_rendering/tests/test_mesh_render.py
     - yt/visualization/tests/test_mesh_slices.py:test_tri2
     - yt/visualization/tests/test_mesh_slices.py:test_quad2


### PR DESCRIPTION
Kacper updated matplotlib on the test box which broke a bunch of the answer tests. This updates the plot answers to unbreak those tests.