### PR TITLE
Use weak refs for ExodusII is_valid function

### DIFF
--- a/yt/frontends/exodus_ii/data_structures.py
+++ b/yt/frontends/exodus_ii/data_structures.py
@@ -392,7 +392,9 @@ class ExodusIIDataset(Dataset):
         try:
             from netCDF4 import Dataset
             filename = args[0]
-            with Dataset(filename) as f:
+            # We use keepweakref here to avoid holding onto the file handle
+            # which can interfere with other is_valid calls.
+            with Dataset(filename, keepweakref=True) as f:
                 f.variables['connect1']
             return True
         except:


### PR DESCRIPTION
It is possible for ExodusII to hold onto strong references in its
`is_valid` function, which interferes with things like FLASH being able
to call `is_valid` in some cases.  This shows up in `h5py` as an error
that the "file close degree doesn't match."

This should have no side effects, so if it does, that's trouble!