### PR TITLE
Default periodicity for cylindrical set to False

### DIFF
--- a/yt/geometry/coordinates/cylindrical_coordinates.py
+++ b/yt/geometry/coordinates/cylindrical_coordinates.py
@@ -96,7 +96,11 @@ class CylindricalCoordinateHandler(CoordinateHandler):
                  units = "code_length")
 
     def pixelize(self, dimension, data_source, field, bounds, size,
-                 antialias = True, periodic = True):
+                 antialias = True, periodic = False):
+        # Note that above, we set periodic by default to be *false*.  This is
+        # because our pixelizers, at present, do not handle periodicity
+        # correctly, and if you change the "width" of a cylindrical plot, it
+        # double-counts in the edge buffers.  See, for instance, issue 1669.
         ax_name = self.axis_name[dimension]
         if ax_name in ('r', 'theta'):
             return self._ortho_pixelize(data_source, field, bounds, size,


### PR DESCRIPTION
The periodicity argument for cylindrical pixelization behaves
incorrectly; in particular, because the period is set to zero, this ends
up causing double-counting (and sometimes quad-counting) at the edges of
an FRB as the (orthogonal) pixelization routine iterates over the false
periods.  It does not make sense, in practice, to have periodicity in
the dimensions represented by an orthogonal pixelization in cylindrical
coordinates in almost any case, and so we disable it.

Closes #1669.