### PR TITLE
directly calculate constants in enzo's cosmology units

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -11,10 +11,10 @@ answer_tests:
   local_chombo_002:
     - yt/frontends/chombo/tests/test_outputs.py
 
-  local_enzo_003:
+  local_enzo_004:
     - yt/frontends/enzo
 
-  local_enzo_p_004:
+  local_enzo_p_005:
     - yt/frontends/enzo_p/tests/test_outputs.py
 
   local_fits_002:
@@ -35,7 +35,7 @@ answer_tests:
   local_gizmo_002:
     - yt/frontends/gizmo/tests/test_outputs.py
 
-  local_halos_007:
+  local_halos_008:
     - yt/analysis_modules/halo_analysis/tests/test_halo_finders.py
     - yt/analysis_modules/halo_analysis/tests/test_halo_catalog.py
     - yt/analysis_modules/halo_finding/tests/test_rockstar.py
@@ -47,7 +47,7 @@ answer_tests:
   local_owls_002:
     - yt/frontends/owls/tests/test_outputs.py
 
-  local_pw_023:
+  local_pw_024:
     - yt/visualization/tests/test_plotwindow.py:test_attributes
     - yt/visualization/tests/test_plotwindow.py:test_attributes_wt
     - yt/visualization/tests/test_profile_plots.py:test_phase_plot_attributes
@@ -101,10 +101,10 @@ answer_tests:
   local_ramses_001:
     - yt/frontends/ramses/tests/test_outputs.py
 
-  local_ytdata_003:
+  local_ytdata_004:
     - yt/frontends/ytdata
 
-  local_absorption_spectrum_006:
+  local_absorption_spectrum_007:
     - yt/analysis_modules/absorption_spectrum/tests/test_absorption_spectrum.py:test_absorption_spectrum_non_cosmo
     - yt/analysis_modules/absorption_spectrum/tests/test_absorption_spectrum.py:test_absorption_spectrum_non_cosmo_novpec
     - yt/analysis_modules/absorption_spectrum/tests/test_absorption_spectrum.py:test_absorption_spectrum_cosmo
@@ -115,10 +115,10 @@ answer_tests:
   local_axialpix_005:
     - yt/geometry/coordinates/tests/test_axial_pixelization.py:test_axial_pixelization
 
-  local_particle_trajectory_000:
+  local_particle_trajectory_001:
     - yt/data_objects/tests/test_particle_trajectories.py
 
-  local_light_cone_001:
+  local_light_cone_002:
     - yt/analysis_modules/cosmological_observation/light_cone/tests/test_light_cone.py
 
 other_tests:

--- a/yt/frontends/enzo/misc.py
+++ b/yt/frontends/enzo/misc.py
@@ -16,7 +16,11 @@ Miscellaneous functions that are Enzo-specific
 import numpy as np
 
 from yt.utilities.physical_ratios import \
-    rho_crit_g_cm3_h2, cm_per_mpc
+    boltzmann_constant_erg_per_K, \
+    cm_per_mpc, \
+    mass_hydrogen_grams, \
+    newton_cgs, \
+    rho_crit_g_cm3_h2
 
 def cosmology_get_units(hubble_constant, omega_matter, box_size,
                         initial_redshift, current_redshift):
@@ -30,14 +34,20 @@ def cosmology_get_units(hubble_constant, omega_matter, box_size,
     k = {}
     # For better agreement with values calculated by Enzo,
     # adopt the exact constants that are used there.
-    k["utim"] = 2.52e17 / np.sqrt(omega_matter) / \
+
+    time_scaling = np.sqrt((1 / (4*np.pi*newton_cgs*rho_crit_g_cm3_h2)))
+    vel_scaling = cm_per_mpc / time_scaling
+    temp_scaling = (mass_hydrogen_grams / boltzmann_constant_erg_per_K *
+                    vel_scaling**2)
+
+    k["utim"] = time_scaling / np.sqrt(omega_matter) / \
       hubble_constant / zip1**1.5
     k["urho"] = rho_crit_g_cm3_h2 * omega_matter * \
       hubble_constant**2 * zp1**3
     k["uxyz"] = cm_per_mpc * box_size / hubble_constant / zp1
     k["uaye"] = 1.0 / zip1
-    k["uvel"] = 1.225e7 * box_size * np.sqrt(omega_matter) \
+    k["uvel"] = vel_scaling * box_size * np.sqrt(omega_matter) \
       * np.sqrt(zip1)
-    k["utem"] = 1.88e6 * (box_size**2) * omega_matter * zip1
+    k["utem"] = temp_scaling * (box_size**2) * omega_matter * zip1
     k["aye"]  = zip1 / zp1
     return k

--- a/yt/frontends/enzo/misc.py
+++ b/yt/frontends/enzo/misc.py
@@ -35,19 +35,17 @@ def cosmology_get_units(hubble_constant, omega_matter, box_size,
     # For better agreement with values calculated by Enzo,
     # adopt the exact constants that are used there.
 
-    time_scaling = np.sqrt((1 / (4*np.pi*newton_cgs*rho_crit_g_cm3_h2)))
+    time_scaling = np.sqrt(1 / (4*np.pi*newton_cgs*rho_crit_g_cm3_h2))
     vel_scaling = cm_per_mpc / time_scaling
     temp_scaling = (mass_hydrogen_grams / boltzmann_constant_erg_per_K *
                     vel_scaling**2)
 
-    k["utim"] = time_scaling / np.sqrt(omega_matter) / \
-      hubble_constant / zip1**1.5
-    k["urho"] = rho_crit_g_cm3_h2 * omega_matter * \
-      hubble_constant**2 * zp1**3
+    k["utim"] = (time_scaling / np.sqrt(omega_matter) /hubble_constant /
+                 zip1**1.5)
+    k["urho"] = rho_crit_g_cm3_h2 * omega_matter * hubble_constant**2 * zp1**3
     k["uxyz"] = cm_per_mpc * box_size / hubble_constant / zp1
     k["uaye"] = 1.0 / zip1
-    k["uvel"] = vel_scaling * box_size * np.sqrt(omega_matter) \
-      * np.sqrt(zip1)
+    k["uvel"] = vel_scaling * box_size * np.sqrt(omega_matter) * np.sqrt(zip1)
     k["utem"] = temp_scaling * (box_size**2) * omega_matter * zip1
     k["aye"]  = zip1 / zp1
     return k

--- a/yt/frontends/enzo/tests/test_outputs.py
+++ b/yt/frontends/enzo/tests/test_outputs.py
@@ -212,7 +212,7 @@ def test_deeply_nested_zoom():
 
     v, c = ds.find_max('density')
 
-    assert_allclose_units(v, ds.quan(0.005879315652144976, 'g/cm**3'))
+    assert_allclose_units(v, ds.quan(0.005878286377124154, 'g/cm**3'))
 
     c_actual = [0.49150732540021, 0.505260532936791, 0.49058055816398]
     c_actual = ds.arr(c_actual, 'code_length')

--- a/yt/utilities/physical_ratios.py
+++ b/yt/utilities/physical_ratios.py
@@ -119,7 +119,7 @@ jansky_cgs = 1.0e-23
 # Cosmological constants
 # Calculated with H = 100 km/s/Mpc, value given in units of h^2 g cm^-3
 # Multiply by h^2 to get the critical density in units of g cm^-3
-rho_crit_g_cm3_h2 = 1.8788e-29
+rho_crit_g_cm3_h2 = 1.8784710838431654e-29
 primordial_H_mass_fraction = 0.76
 
 # Misc. Approximations


### PR DESCRIPTION
Currently there are a number of hard-coded constants in the function that calculates the units for enzo cosmological data. I've gone ahead and replaced these hardcoded constants with calculations, which I've verified agree with what's there and what's in the Enzo source code.

This may cause some of the answer tests to fail since I'm changing the units for cosmology data slightly.

The goal here is to make our conversion from cosmology units to physical units as close as possible to what Enzo actually uses internally while at the same time making yt's source code easier to read.