### PR TITLE
use a different approach for calculating enzo magnetic units

### DIFF
--- a/yt/frontends/enzo/data_structures.py
+++ b/yt/frontends/enzo/data_structures.py
@@ -924,8 +924,8 @@ class EnzoDataset(Dataset):
             setdefaultattr(
                 self, 'velocity_unit', self.length_unit / self.time_unit)
 
-        magnetic_unit = np.sqrt(4*np.pi * self.mass_unit /
-                                (self.time_unit**2 * self.length_unit))
+        density_unit = self.mass_unit / self.length_unit**3
+        magnetic_unit = np.sqrt(4*np.pi * density_unit) * self.velocity_unit
         magnetic_unit = np.float64(magnetic_unit.in_cgs())
         setdefaultattr(self, 'magnetic_unit', self.quan(magnetic_unit, "gauss"))
 


### PR DESCRIPTION
This was originally reported to me by Paola Dominguez and Stefan Hackstein - I don't know their github handles so I'll e-mail them a link to this PR.

Take a look at this script:

```python
import yt
from matplotlib import pyplot as plt

ts = yt.load('gas_plus_dm_pancake/DD????/data????')

Bs, a_s = [], []

for ds in ts:
    B1 = ds.index.grids[0]['magnetic_field_strength']
    a = ds.scale_factor
    Bs.append(B1.mean()*a**2)
    a_s.append(a)

plt.loglog(a_s, Bs)
plt.ylim(1e-7, 1e-5)
plt.savefig('test.png')
```

That script uses this dataset: http://use.yt/upload/7844e216

Currently this script produces this image: https://i.imgur.com/flO8YZb.png (not a horizontal line)

With this PR it produces this image: https://i.imgur.com/D1EMcan.png (a horizontal line)

The script is sampling a grid that does not get affected by any of the dynamics in the simulation, so the magnetic field should just be modified by cosmic expansion in a manner that goes as a^2. Our current way of calculating the `magnetic_unit` does not capture this, because in cosmology simulations `ds.velocity_unit` is *not* the same thing as `ds.length_unit/ds.time_unit`.

ping @dcollins4096 who knows a lot more about MHD than I do.