### PR TITLE
[Feature] Wiring frb buffers with plot_window

### DIFF
--- a/doc/source/visualizing/callbacks.rst
+++ b/doc/source/visualizing/callbacks.rst
@@ -890,7 +890,7 @@ Overplot the Path of a Ray
 
 
 Applying filters on the final image
------------------------------
+-----------------------------------
 
 It is also possible to operate on the plotted image directly by using
 one of the fixed resolution buffer filter as described in

--- a/doc/source/visualizing/callbacks.rst
+++ b/doc/source/visualizing/callbacks.rst
@@ -887,3 +887,21 @@ Overplot the Path of a Ray
    p.annotate_ray(oray)
    p.annotate_ray(ray)
    p.save()
+
+
+Operating on the final image
+-----------------------------
+
+It is also possible to operate on the plotted image directly by using
+one of the fixed resolution buffer filter as described in
+:ref:`frb-filters`. 
+
+.. python-script::
+
+   import yt
+
+   ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
+   p = yt.SlicePlot(ds, 'z', 'density')
+   p.frb.apply_gauss_beam(sigma=30)
+   p.save()
+

--- a/doc/source/visualizing/callbacks.rst
+++ b/doc/source/visualizing/callbacks.rst
@@ -889,7 +889,7 @@ Overplot the Path of a Ray
    p.save()
 
 
-Operating on the final image
+Applying filters on the final image
 -----------------------------
 
 It is also possible to operate on the plotted image directly by using

--- a/doc/source/visualizing/callbacks.rst
+++ b/doc/source/visualizing/callbacks.rst
@@ -894,7 +894,7 @@ Applying filters on the final image
 
 It is also possible to operate on the plotted image directly by using
 one of the fixed resolution buffer filter as described in
-:ref:`frb-filters`. 
+:ref:`frb-filters`.
 
 .. python-script::
 
@@ -904,4 +904,3 @@ one of the fixed resolution buffer filter as described in
    p = yt.SlicePlot(ds, 'z', 'density')
    p.frb.apply_gauss_beam(sigma=30)
    p.save()
-

--- a/doc/source/visualizing/manual_plotting.rst
+++ b/doc/source/visualizing/manual_plotting.rst
@@ -101,13 +101,12 @@ Currently available filters:
 Gaussian Smoothing
 ~~~~~~~~~~~~~~~~~~
 
-.. function:: apply_gauss_beam(self, nbeam=30, sigma=2.0)
+.. function:: apply_gauss_beam(self, sigma=2.0)
 
    (This is a proxy for
    :class:`~yt.visualization.fixed_resolution_filters.FixedResolutionBufferGaussBeamFilter`.)
 
-    This filter convolves the FRB with 2d Gaussian that is "nbeam" pixel wide
-    and has standard deviation "sigma".
+    This filter convolves the FRB with 2d Gaussian that has standard deviation "sigma".
 
 White Noise
 ~~~~~~~~~~~

--- a/doc/source/visualizing/manual_plotting.rst
+++ b/doc/source/visualizing/manual_plotting.rst
@@ -91,7 +91,7 @@ using them matters.
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
    slc = ds.slice("z", 0.5)
    frb = slc.to_frb((20, "kpc"), 512)
-   frb.apply_gauss_beam(nbeam=30, sigma=2.0)
+   frb.apply_gauss_beam(sigma=2.0)
    frb.apply_white_noise(5e-23)
    plt.imshow(frb["gas", "density"].d)
    plt.savefig("frb_filters.png")

--- a/yt/utilities/on_demand_imports.py
+++ b/yt/utilities/on_demand_imports.py
@@ -349,7 +349,6 @@ class scipy_imports:
             self._ndimage = ndimage
         return self._ndimage
 
-
 _scipy = scipy_imports()
 
 

--- a/yt/utilities/on_demand_imports.py
+++ b/yt/utilities/on_demand_imports.py
@@ -349,6 +349,7 @@ class scipy_imports:
             self._ndimage = ndimage
         return self._ndimage
 
+
 _scipy = scipy_imports()
 
 

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -540,7 +540,7 @@ class CylindricalFixedResolutionBuffer(FixedResolutionBuffer):
     that supports non-aligned input data objects, primarily cutting planes.
     """
 
-    def __init__(self, data_source, radius, buff_size, antialias=True):
+    def __init__(self, data_source, radius, buff_size, antialias=True, plot_window=None):
 
         self.data_source = data_source
         self.ds = data_source.ds
@@ -548,6 +548,7 @@ class CylindricalFixedResolutionBuffer(FixedResolutionBuffer):
         self.buff_size = buff_size
         self.antialias = antialias
         self.data = {}
+        self.plot_window = plot_window
 
         ds = getattr(data_source, "ds", None)
         if ds is not None:
@@ -576,12 +577,6 @@ class OffAxisProjectionFixedResolutionBuffer(FixedResolutionBuffer):
     :class:`yt.visualization.fixed_resolution.FixedResolutionBuffer`
     that supports off axis projections.  This calls the volume renderer.
     """
-
-    def __init__(self, data_source, bounds, buff_size, antialias=True, periodic=False):
-        self.data = {}
-        FixedResolutionBuffer.__init__(
-            self, data_source, bounds, buff_size, antialias, periodic
-        )
 
     def __getitem__(self, item):
         if item in self.data:
@@ -629,10 +624,9 @@ class ParticleImageBuffer(FixedResolutionBuffer):
 
     """
 
-    def __init__(self, data_source, bounds, buff_size, antialias=True, periodic=False):
-        self.data = {}
+    def __init__(self, data_source, bounds, buff_size, antialias=True, plot_window=None, periodic=False):
         FixedResolutionBuffer.__init__(
-            self, data_source, bounds, buff_size, antialias, periodic
+            self, data_source, bounds, buff_size, antialias, plot_window, periodic
         )
 
         # set up the axis field names

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -542,15 +542,14 @@ class CylindricalFixedResolutionBuffer(FixedResolutionBuffer):
     that supports non-aligned input data objects, primarily cutting planes.
     """
 
-    def __init__(self, data_source, radius, buff_size, antialias=True, plot_window=None):
-
+    def __init__(self, data_source, radius, buff_size, antialias=True, filters=None) :
         self.data_source = data_source
         self.ds = data_source.ds
         self.radius = radius
         self.buff_size = buff_size
         self.antialias = antialias
         self.data = {}
-        self.plot_window = plot_window
+        self._filters = filters if filters else []
 
         ds = getattr(data_source, "ds", None)
         if ds is not None:
@@ -625,8 +624,8 @@ class ParticleImageBuffer(FixedResolutionBuffer):
     buffer.
 
     """
-    def __init__(self, data_source, bounds, buff_size, antialias=True, periodic=False):
-        super(ParticleImageBuffer, self).__init__(data_source, bounds, buff_size, antialias, periodic)
+    def __init__(self, data_source, radius, buff_size, antialias=True, periodic=False, filters=None):
+        super(ParticleImageBuffer, self).__init__(data_source, radius, buff_size, antialias, periodic, filters)
 
         # set up the axis field names
         axis = self.axis

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -642,9 +642,7 @@ class ParticleImageBuffer(FixedResolutionBuffer):
         periodic=False,
         filters=None,
     ):
-        super(ParticleImageBuffer, self).__init__(
-            data_source, radius, buff_size, antialias, periodic, filters
-        )
+        super().__init__(data_source, radius, buff_size, antialias, periodic, filters)
 
         # set up the axis field names
         axis = self.axis

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -87,7 +87,7 @@ class FixedResolutionBuffer:
         ("index", "dtheta"),
     )
 
-    def __init__(self, data_source, bounds, buff_size, antialias=True, periodic=False):
+    def __init__(self, data_source, bounds, buff_size, antialias=True, plot_window=None, periodic=False):
         self.data_source = data_source
         self.ds = data_source.ds
         self.bounds = bounds
@@ -97,6 +97,7 @@ class FixedResolutionBuffer:
         self._filters = []
         self.axis = data_source.axis
         self.periodic = periodic
+        self.plot_window = plot_window
 
         ds = getattr(data_source, "ds", None)
         if ds is not None:

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -87,7 +87,15 @@ class FixedResolutionBuffer:
         ("index", "dtheta"),
     )
 
-    def __init__(self, data_source, bounds, buff_size, antialias=True, periodic=False, filters=None):
+    def __init__(
+        self,
+        data_source,
+        bounds,
+        buff_size,
+        antialias=True,
+        periodic=False,
+        filters=None,
+    ):
         self.data_source = data_source
         self.ds = data_source.ds
         self.bounds = bounds
@@ -542,7 +550,7 @@ class CylindricalFixedResolutionBuffer(FixedResolutionBuffer):
     that supports non-aligned input data objects, primarily cutting planes.
     """
 
-    def __init__(self, data_source, radius, buff_size, antialias=True, filters=None) :
+    def __init__(self, data_source, radius, buff_size, antialias=True, filters=None):
         self.data_source = data_source
         self.ds = data_source.ds
         self.radius = radius
@@ -624,8 +632,19 @@ class ParticleImageBuffer(FixedResolutionBuffer):
     buffer.
 
     """
-    def __init__(self, data_source, radius, buff_size, antialias=True, periodic=False, filters=None):
-        super(ParticleImageBuffer, self).__init__(data_source, radius, buff_size, antialias, periodic, filters)
+
+    def __init__(
+        self,
+        data_source,
+        radius,
+        buff_size,
+        antialias=True,
+        periodic=False,
+        filters=None,
+    ):
+        super(ParticleImageBuffer, self).__init__(
+            data_source, radius, buff_size, antialias, periodic, filters
+        )
 
         # set up the axis field names
         axis = self.axis

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -87,7 +87,7 @@ class FixedResolutionBuffer:
         ("index", "dtheta"),
     )
 
-    def __init__(self, data_source, bounds, buff_size, antialias=True, plot_window=None, periodic=False):
+    def __init__(self, data_source, bounds, buff_size, antialias=True, periodic=False, filters=None):
         self.data_source = data_source
         self.ds = data_source.ds
         self.bounds = bounds
@@ -97,7 +97,8 @@ class FixedResolutionBuffer:
         self._filters = []
         self.axis = data_source.axis
         self.periodic = periodic
-        self.plot_window = plot_window
+        self._data_valid = False
+        self._filters = filters if filters else []
 
         ds = getattr(data_source, "ds", None)
         if ds is not None:
@@ -123,7 +124,7 @@ class FixedResolutionBuffer:
         del self.data[item]
 
     def __getitem__(self, item):
-        if item in self.data:
+        if item in self.data and self._data_valid:
             return self.data[item]
         mylog.info(
             "Making a fixed resolution buffer of (%s) %d by %d",
@@ -163,6 +164,7 @@ class FixedResolutionBuffer:
 
         ia = ImageArray(buff, units=units, info=self._get_info(item))
         self.data[item] = ia
+        self._data_valid = True
         return self.data[item]
 
     def __setitem__(self, item, val):
@@ -623,11 +625,8 @@ class ParticleImageBuffer(FixedResolutionBuffer):
     buffer.
 
     """
-
-    def __init__(self, data_source, bounds, buff_size, antialias=True, plot_window=None, periodic=False):
-        FixedResolutionBuffer.__init__(
-            self, data_source, bounds, buff_size, antialias, plot_window, periodic
-        )
+    def __init__(self, data_source, bounds, buff_size, antialias=True, periodic=False):
+        super(ParticleImageBuffer, self).__init__(data_source, bounds, buff_size, antialias, periodic)
 
         # set up the axis field names
         axis = self.axis

--- a/yt/visualization/fixed_resolution_filters.py
+++ b/yt/visualization/fixed_resolution_filters.py
@@ -2,6 +2,8 @@ from functools import wraps
 
 import numpy as np
 
+from yt.funcs import issue_deprecation_warning
+
 filter_registry = {}
 
 
@@ -46,7 +48,12 @@ class FixedResolutionBufferGaussBeamFilter(FixedResolutionBufferFilter):
 
     _filter_name = "gauss_beam"
 
-    def __init__(self, sigma=2.0, **kwa):
+    def __init__(self, sigma=2.0, nbeam=None, **kwa):
+        if nbeam is not None:
+            issue_deprecation_warning(
+                "The `nbeam` argument has been deprecated and should be replaced by "
+                "the `truncate` argument where `truncate=nbeam/sigma`.")
+            kwa['truncate'] = nbeam / sigma
         self.sigma = sigma
         self.extra_args = kwa
 

--- a/yt/visualization/fixed_resolution_filters.py
+++ b/yt/visualization/fixed_resolution_filters.py
@@ -52,18 +52,16 @@ class FixedResolutionBufferGaussBeamFilter(FixedResolutionBufferFilter):
         if nbeam is not None:
             issue_deprecation_warning(
                 "The `nbeam` argument has been deprecated and should be replaced by "
-                "the `truncate` argument where `truncate=nbeam/sigma`.")
-            kwa['truncate'] = nbeam / sigma
+                "the `truncate` argument where `truncate=nbeam/sigma`."
+            )
+            kwa["truncate"] = nbeam / sigma
         self.sigma = sigma
         self.extra_args = kwa
 
     def apply(self, buff):
         from yt.utilities.on_demand_imports import _scipy
-        spl = _scipy.ndimage.gaussian_filter(
-            buff,
-            self.sigma,
-            **self.extra_args
-        )
+
+        spl = _scipy.ndimage.gaussian_filter(buff, self.sigma, **self.extra_args)
         return spl
 
 

--- a/yt/visualization/fixed_resolution_filters.py
+++ b/yt/visualization/fixed_resolution_filters.py
@@ -54,8 +54,7 @@ class FixedResolutionBufferGaussBeamFilter(FixedResolutionBufferFilter):
                 "The `nbeam` argument has been deprecated and should be replaced by "
                 "the `truncate` argument where `truncate=nbeam/sigma`."
             )
-            if truncate is None:
-                truncate = kwargs["nbeam"] / sigma
+            truncate = kwargs["nbeam"] / sigma
 
         self.sigma = sigma
         self.truncate = truncate

--- a/yt/visualization/fixed_resolution_filters.py
+++ b/yt/visualization/fixed_resolution_filters.py
@@ -42,33 +42,24 @@ class FixedResolutionBufferGaussBeamFilter(FixedResolutionBufferFilter):
     """
     This filter convolves
     :class:`yt.visualization.fixed_resolution.FixedResolutionBuffer` with
-    2d gaussian that is 'nbeam' pixels wide and has standard deviation
-    'sigma'.
+    2d gaussian that has standard deviation 'sigma'. Extra arguments
+    are directly passed to `scipy.ndimage.gaussian_filter`.
     """
 
     _filter_name = "gauss_beam"
 
-    def __init__(self, nbeam=30, sigma=2.0):
-        self.nbeam = nbeam
+    def __init__(self, sigma=2.0, **kwa):
         self.sigma = sigma
+        self.extra_args = kwa
 
     def apply(self, buff):
         from yt.utilities.on_demand_imports import _scipy
-
-        hnbeam = self.nbeam // 2
-        sigma = self.sigma
-
-        l = np.linspace(-hnbeam, hnbeam, num=self.nbeam + 1)
-        x, y = np.meshgrid(l, l)
-        g2d = (1.0 / (sigma * np.sqrt(2.0 * np.pi))) * np.exp(
-            -((x / sigma) ** 2 + (y / sigma) ** 2) / (2 * sigma ** 2)
+        spl = _scipy.ndimage.gaussian_filter(
+            buff,
+            self.sigma,
+            **self.extra_args
         )
-        g2d /= g2d.max()
-
-        npm, nqm = np.shape(buff)
-        spl = _scipy.signal.convolve(buff, g2d)
-
-        return spl[hnbeam : npm + hnbeam, hnbeam : nqm + hnbeam]
+        return spl
 
 
 class FixedResolutionBufferWhiteNoiseFilter(FixedResolutionBufferFilter):

--- a/yt/visualization/fixed_resolution_filters.py
+++ b/yt/visualization/fixed_resolution_filters.py
@@ -2,7 +2,7 @@ from functools import wraps
 
 import numpy as np
 
-from yt.funcs import issue_deprecation_warning
+from yt._maintenance.deprecation import issue_deprecation_warning
 
 filter_registry = {}
 

--- a/yt/visualization/fixed_resolution_filters.py
+++ b/yt/visualization/fixed_resolution_filters.py
@@ -64,7 +64,10 @@ class FixedResolutionBufferGaussBeamFilter(FixedResolutionBufferFilter):
         from yt.utilities.on_demand_imports import _scipy
 
         spl = _scipy.ndimage.gaussian_filter(
-            buff, self.sigma, truncate=self.truncate, **self.extra_args,
+            buff,
+            self.sigma,
+            truncate=self.truncate,
+            **self.extra_args,
         )
         return spl
 

--- a/yt/visualization/fixed_resolution_filters.py
+++ b/yt/visualization/fixed_resolution_filters.py
@@ -10,10 +10,8 @@ def apply_filter(f):
     def newfunc(*args, **kwargs):
         frb = args[0]
         frb._filters.append((f.__name__, (args, kwargs)))
-        # We need to invalidate the data to force the plot window to
-        # take the filter into account.
-        if frb.plot_window:
-            frb.plot_window._data_valid = False
+        # Invalidate the data of the frb to force its regeneration
+        frb._data_valid = False
         return args[0]
 
     return newfunc

--- a/yt/visualization/fixed_resolution_filters.py
+++ b/yt/visualization/fixed_resolution_filters.py
@@ -8,7 +8,12 @@ filter_registry = {}
 def apply_filter(f):
     @wraps(f)
     def newfunc(*args, **kwargs):
-        args[0]._filters.append((f.__name__, (args, kwargs)))
+        frb = args[0]
+        frb._filters.append((f.__name__, (args, kwargs)))
+        # We need to invalidate the data to force the plot window to
+        # take the filter into account.
+        if frb.plot_window:
+            frb.plot_window._data_valid = False
         return args[0]
 
     return newfunc

--- a/yt/visualization/fixed_resolution_filters.py
+++ b/yt/visualization/fixed_resolution_filters.py
@@ -48,20 +48,25 @@ class FixedResolutionBufferGaussBeamFilter(FixedResolutionBufferFilter):
 
     _filter_name = "gauss_beam"
 
-    def __init__(self, sigma=2.0, nbeam=None, **kwa):
-        if nbeam is not None:
+    def __init__(self, sigma=2.0, truncate=4.0, **kwargs):
+        if "nbeam" in kwargs:
             issue_deprecation_warning(
                 "The `nbeam` argument has been deprecated and should be replaced by "
                 "the `truncate` argument where `truncate=nbeam/sigma`."
             )
-            kwa["truncate"] = nbeam / sigma
+            if truncate is None:
+                truncate = kwargs["nbeam"] / sigma
+
         self.sigma = sigma
-        self.extra_args = kwa
+        self.truncate = truncate
+        self.extra_args = kwargs
 
     def apply(self, buff):
         from yt.utilities.on_demand_imports import _scipy
 
-        spl = _scipy.ndimage.gaussian_filter(buff, self.sigma, **self.extra_args)
+        spl = _scipy.ndimage.gaussian_filter(
+            buff, self.sigma, truncate=self.truncate, **self.extra_args,
+        )
         return spl
 
 

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -95,8 +95,7 @@ def validate_plot(f):
     @wraps(f)
     def newfunc(*args, **kwargs):
         if hasattr(args[0], '_data_valid'):
-            if (not args[0]._data_valid or
-                not args[0]._frb._data_valid):
+            if not args[0].data_is_valid():
                 args[0]._recreate_frb()
         if hasattr(args[0], "_profile_valid"):
             if not args[0]._profile_valid:

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -94,8 +94,9 @@ def invalidate_plot(f):
 def validate_plot(f):
     @wraps(f)
     def newfunc(*args, **kwargs):
-        if hasattr(args[0], "_data_valid"):
-            if not args[0]._data_valid:
+        if hasattr(args[0], '_data_valid'):
+            if (not args[0]._data_valid or
+                not args[0]._frb._data_valid):
                 args[0]._recreate_frb()
         if hasattr(args[0], "_profile_valid"):
             if not args[0]._profile_valid:

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -431,7 +431,8 @@ class PlotContainer:
 
         self.data_source = new_object
         
-        self._frb = None
+        if self._frb is not None:
+            self._frb._data_valid = False
         self._plot_valid = False
 
         for d in "xyz":

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -95,7 +95,7 @@ def validate_plot(f):
     @wraps(f)
     def newfunc(*args, **kwargs):
         if hasattr(args[0], '_data_valid'):
-            if not args[0].data_is_valid():
+            if not args[0].data_is_valid:
                 args[0]._recreate_frb()
         if hasattr(args[0], "_profile_valid"):
             if not args[0]._profile_valid:

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -430,7 +430,7 @@ class PlotContainer:
             new_object = getattr(new_ds, name)(**kwargs)
 
         self.data_source = new_object
-        
+
         if self._frb is not None:
             self._frb._data_valid = False
         self._plot_valid = False

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -61,8 +61,8 @@ def invalidate_data(f):
     def newfunc(*args, **kwargs):
         rv = f(*args, **kwargs)
         plot = args[0]
-        if plot._frb is not None:
-            plot._frb._data_valid = False
+        # if plot._frb is not None:
+        #   plot._frb._data_valid = False
         plot._plot_valid = False
         return rv
 

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -97,7 +97,7 @@ def validate_plot(f):
     @wraps(f)
     def newfunc(*args, **kwargs):
         plot = args[0]
-        if not plot.data_is_valid:
+        if hasattr(plot, "data_is_valid") and not plot.data_is_valid:
             plot._recreate_frb()
         if hasattr(plot, "_profile_valid") and not plot._profile_valid:
             plot._recreate_profile()

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -99,9 +99,8 @@ def validate_plot(f):
         plot = args[0]
         if not plot.data_is_valid:
             plot._recreate_frb()
-        if hasattr(plot, "_profile_valid"):
-            if not plot._profile_valid:
-                plot._recreate_profile()
+        if hasattr(plot, "_profile_valid") and not plot._profile_valid:
+            plot._recreate_profile()
         if not plot._plot_valid:
             # it is the responsibility of _setup_plots to
             # call plot.run_callbacks()

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -303,7 +303,7 @@ class VelocityCallback(PlotCallback):
     with substantial variation in field strength.
     """
 
-    _type_name = "velocity"
+    _type_name = "annotate_velocity"
     _supported_geometries = ("cartesian", "spectral_cube", "polar", "cylindrical")
 
     def __init__(
@@ -393,7 +393,7 @@ class MagFieldCallback(PlotCallback):
     clearly seen for fields with substantial variation in field strength.
     """
 
-    _type_name = "magnetic_field"
+    _type_name = "annotate_magnetic_field"
     _supported_geometries = ("cartesian", "spectral_cube", "polar", "cylindrical")
 
     def __init__(
@@ -470,7 +470,7 @@ class QuiverCallback(PlotCallback):
     substantial variation in field strength.
     """
 
-    _type_name = "quiver"
+    _type_name = "annotate_quiver"
     _supported_geometries = ("cartesian", "spectral_cube", "polar", "cylindrical")
 
     def __init__(
@@ -580,7 +580,7 @@ class ContourCallback(PlotCallback):
     queried.
     """
 
-    _type_name = "contour"
+    _type_name = "annotate_contour"
     _supported_geometries = ("cartesian", "spectral_cube", "cylindrical")
 
     def __init__(
@@ -724,8 +724,7 @@ class GridBoundaryCallback(PlotCallback):
     One can set min and maximum level of grids to display, and
     can change the linewidth of the displayed grids.
     """
-
-    _type_name = "grids"
+    _type_name = "annotate_grids"
     _supported_geometries = ("cartesian", "spectral_cube", "cylindrical")
 
     def __init__(
@@ -900,7 +899,7 @@ class StreamlineCallback(PlotCallback):
     their line width set to 0.
     """
 
-    _type_name = "streamlines"
+    _type_name = "annotate_streamlines"
     _supported_geometries = ("cartesian", "spectral_cube", "polar", "cylindrical")
 
     def __init__(
@@ -1041,7 +1040,7 @@ class LinePlotCallback(PlotCallback):
 
     """
 
-    _type_name = "line"
+    _type_name = "annotate_line"
     _supported_geometries = ("cartesian", "spectral_cube", "polar", "cylindrical")
 
     def __init__(self, p1, p2, data_coords=False, coord_system="data", plot_args=None):
@@ -1081,7 +1080,7 @@ class ImageLineCallback(LinePlotCallback):
 
     """
 
-    _type_name = "image_line"
+    _type_name = "annotate_image_line"
     _supported_geometries = ("cartesian", "spectral_cube", "cylindrical")
 
     def __init__(self, p1, p2, data_coords=False, coord_system="axis", plot_args=None):
@@ -1108,7 +1107,7 @@ class CuttingQuiverCallback(PlotCallback):
     substantial variation in field strength.
     """
 
-    _type_name = "cquiver"
+    _type_name = "annotate_cquiver"
     _supported_geometries = ("cartesian", "spectral_cube")
 
     def __init__(
@@ -1201,7 +1200,7 @@ class ClumpContourCallback(PlotCallback):
     Take a list of *clumps* and plot them as a set of contours.
     """
 
-    _type_name = "clumps"
+    _type_name = "annotate_clumps"
     _supported_geometries = ("cartesian", "spectral_cube", "cylindrical")
 
     def __init__(self, clumps, plot_args=None):
@@ -1342,7 +1341,7 @@ class ArrowCallback(PlotCallback):
 
     """
 
-    _type_name = "arrow"
+    _type_name = "annotate_arrow"
     _supported_geometries = ("cartesian", "spectral_cube", "cylindrical")
 
     def __init__(
@@ -1496,7 +1495,7 @@ class MarkerAnnotateCallback(PlotCallback):
 
     """
 
-    _type_name = "marker"
+    _type_name = "annotate_marker"
     _supported_geometries = ("cartesian", "spectral_cube", "polar", "cylindrical")
 
     def __init__(self, pos, marker="x", coord_system="data", plot_args=None):
@@ -1570,7 +1569,7 @@ class SphereCallback(PlotCallback):
 
     """
 
-    _type_name = "sphere"
+    _type_name = "annotate_sphere"
     _supported_geometries = ("cartesian", "spectral_cube", "polar", "cylindrical")
 
     def __init__(
@@ -1706,7 +1705,7 @@ class TextLabelCallback(PlotCallback):
     >>> s.save()
     """
 
-    _type_name = "text"
+    _type_name = "annotate_text"
     _supported_geometries = ("cartesian", "spectral_cube", "polar", "cylindrical")
 
     def __init__(
@@ -1759,7 +1758,7 @@ class PointAnnotateCallback(TextLabelCallback):
 
     """
 
-    _type_name = "point"
+    _type_name = "annotate_point"
     _supported_geometries = ("cartesian", "spectral_cube", "cylindrical")
 
     def __init__(
@@ -1883,7 +1882,7 @@ class HaloCatalogCallback(PlotCallback):
 
     """
 
-    _type_name = "halos"
+    _type_name = "annotate_halos"
     region = None
     _descriptor = None
     _supported_geometries = ("cartesian", "spectral_cube")
@@ -2041,7 +2040,7 @@ class ParticleCallback(PlotCallback):
     default the plot's data source will be queried.
     """
 
-    _type_name = "particles"
+    _type_name = "annotate_particles"
     region = None
     _descriptor = None
     _supported_geometries = ("cartesian", "spectral_cube", "cylindrical")
@@ -2190,7 +2189,7 @@ class TitleCallback(PlotCallback):
     Accepts a *title* and adds it to the plot
     """
 
-    _type_name = "title"
+    _type_name = "annotate_title"
 
     def __init__(self, title):
         PlotCallback.__init__(self)
@@ -2226,7 +2225,7 @@ class MeshLinesCallback(PlotCallback):
 
     """
 
-    _type_name = "mesh_lines"
+    _type_name = "annotate_mesh_lines"
     _supported_geometries = ("cartesian", "spectral_cube")
 
     def __init__(self, plot_args=None):
@@ -2293,7 +2292,7 @@ class TriangleFacetsCallback(PlotCallback):
     of the geometry represented by the triangles.
     """
 
-    _type_name = "triangle_facets"
+    _type_name = "annotate_triangle_facets"
     _supported_geometries = ("cartesian", "spectral_cube")
 
     def __init__(self, triangle_vertices, plot_args=None):
@@ -2415,7 +2414,7 @@ class TimestampCallback(PlotCallback):
     >>> s.annotate_timestamp()
     """
 
-    _type_name = "timestamp"
+    _type_name = "annotate_timestamp"
     _supported_geometries = ("cartesian", "spectral_cube", "cylindrical")
 
     def __init__(
@@ -2656,7 +2655,7 @@ class ScaleCallback(PlotCallback):
     >>> s.annotate_scale()
     """
 
-    _type_name = "scale"
+    _type_name = "annotate_scale"
     _supported_geometries = ("cartesian", "spectral_cube", "force")
 
     def __init__(
@@ -2855,7 +2854,7 @@ class RayCallback(PlotCallback):
 
     """
 
-    _type_name = "ray"
+    _type_name = "annotate_ray"
     _supported_geometries = ("cartesian", "spectral_cube", "force")
 
     def __init__(self, ray, arrow=False, plot_args=None):
@@ -3007,7 +3006,7 @@ class LineIntegralConvolutionCallback(PlotCallback):
     ... )
     """
 
-    _type_name = "line_integral_convolution"
+    _type_name = "annotate_line_integral_convolution"
     _supported_geometries = ("cartesian", "spectral_cube", "polar", "cylindrical")
 
     def __init__(
@@ -3122,7 +3121,7 @@ class CellEdgesCallback(PlotCallback):
     >>> s.save()
     """
 
-    _type_name = "cell_edges"
+    _type_name = "annotate_cell_edges"
     _supported_geometries = ("cartesian", "spectral_cube", "cylindrical")
 
     def __init__(self, line_width=0.002, alpha=1.0, color="black"):

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -3185,32 +3185,3 @@ class CellEdgesCallback(PlotCallback):
         )
         plot._axes.set_xlim(xx0, xx1)
         plot._axes.set_ylim(yy0, yy1)
-
-class SmoothCallback(PlotCallback):
-    """
-    Smooth the plotting window.
-
-    [WIP]
-    """
-    _type_name = "smooth"
-    _supported_geometries = ("cartesian", "spectral_cube")
-
-
-    def __init__(self, kernel_name, kernel_params={}):
-        if callable(kernel_name):
-            self.kernel = kernel_name
-            self.kernel_params = kernel_params
-        else:
-            self.kernel = getattr(self, kernel_name, None)
-            if self.kernel is None:
-                raise Exception('Kernel not found')
-            self.kernel_params = kernel_params
-
-    def __call__(self, plot):
-        data = plot.image._A.copy()
-
-        plot.image._A = self.kernel(data, **self.kernel_params)
-
-    def gaussian(self, data, sigma=5):
-        from scipy.ndimage import gaussian_filter
-        return np.ma.masked_array(gaussian_filter(data, sigma))

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -724,6 +724,7 @@ class GridBoundaryCallback(PlotCallback):
     One can set min and maximum level of grids to display, and
     can change the linewidth of the displayed grids.
     """
+
     _type_name = "annotate_grids"
     _supported_geometries = ("cartesian", "spectral_cube", "cylindrical")
 

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -3185,3 +3185,32 @@ class CellEdgesCallback(PlotCallback):
         )
         plot._axes.set_xlim(xx0, xx1)
         plot._axes.set_ylim(yy0, yy1)
+
+class SmoothCallback(PlotCallback):
+    """
+    Smooth the plotting window.
+
+    [WIP]
+    """
+    _type_name = "smooth"
+    _supported_geometries = ("cartesian", "spectral_cube")
+
+
+    def __init__(self, kernel_name, kernel_params={}):
+        if callable(kernel_name):
+            self.kernel = kernel_name
+            self.kernel_params = kernel_params
+        else:
+            self.kernel = getattr(self, kernel_name, None)
+            if self.kernel is None:
+                raise Exception('Kernel not found')
+            self.kernel_params = kernel_params
+
+    def __call__(self, plot):
+        data = plot.image._A.copy()
+
+        plot.image._A = self.kernel(data, **self.kernel_params)
+
+    def gaussian(self, data, sigma=5):
+        from scipy.ndimage import gaussian_filter
+        return np.ma.masked_array(gaussian_filter(data, sigma))

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -276,7 +276,7 @@ class PlotWindow(ImagePlotContainer):
             # * if there's none
             # * if the data has been invalidated
             # * if the frb has been inalidated
-            if not self.data_is_valid():
+            if not self.data_is_valid:
                 self._recreate_frb()
             return self._frb
 
@@ -879,6 +879,7 @@ class PWViewerMPL(PlotWindow):
         self._splat_color = kwargs.pop("splat_color", None)
         PlotWindow.__init__(self, *args, **kwargs)
 
+    @property
     def data_is_valid(self):
         return self._data_valid and self._frb and self._frb._data_valid
 
@@ -971,7 +972,7 @@ class PWViewerMPL(PlotWindow):
 
         if self._plot_valid:
             return
-        if not self.data_is_valid():
+        if not self.data_is_valid:
             self._recreate_frb()
             self._data_valid = True
         self._colorbar_valid = True

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -314,7 +314,7 @@ class PlotWindow(ImagePlotContainer):
             self.buff_size,
             self.antialias,
             periodic=self._periodic,
-            filters=old_filders
+            filters=old_filters,
         )
 
         # At this point the frb has the valid bounds, size, aliasing, etc.

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -282,13 +282,11 @@ class PlotWindow(ImagePlotContainer):
 
         def fset(self, value):
             self._frb = value
-            self._data_valid = True
             self._plot_valid = False
 
         def fdel(self):
             del self._frb
             self._frb = None
-            self._data_valid = False
 
         return locals()
 
@@ -869,7 +867,6 @@ class PWViewerMPL(PlotWindow):
     _current_field = None
     _frb_generator = None
     _plot_type = None
-    _data_valid = False
 
     def __init__(self, *args, **kwargs):
         if self._frb_generator is None:
@@ -881,7 +878,7 @@ class PWViewerMPL(PlotWindow):
 
     @property
     def data_is_valid(self):
-        return self._data_valid and self._frb and self._frb._data_valid
+        return self._frb and self._frb._data_valid
 
     def _setup_origin(self):
         origin = self.origin
@@ -974,7 +971,6 @@ class PWViewerMPL(PlotWindow):
             return
         if not self.data_is_valid:
             self._recreate_frb()
-            self._data_valid = True
         self._colorbar_valid = True
         for f in list(set(self.data_source._determine_fields(self.fields))):
             axis_index = self.data_source.axis

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -282,7 +282,7 @@ class PlotWindow(ImagePlotContainer):
 
         def fset(self, value):
             self._frb = value
-            self._plot_valid = False
+            self._frb._data_valid = True
 
         def fdel(self):
             del self._frb

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1292,6 +1292,15 @@ class PWViewerMPL(PlotWindow):
 
             self.__dict__["annotate_" + cbname] = closure()
 
+            # the following 4 lines were commented out to resolve a merging conflict
+            # during a rebase for PR #1877
+            # They are possibly still relevant but look redudant with the code they
+            # were conflicting against.
+            #CallbackMaker = callback_registry[key]
+            #callback = invalidate_plot(apply_callback(CallbackMaker))
+            #callback.__doc__ = CallbackMaker.__doc__
+            #self.__dict__[cbname] = types.MethodType(callback, self)
+
     def annotate_clear(self, index=None):
         """
         Clear callbacks from the plot.  If index is not set, clear all

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -279,6 +279,7 @@ class PlotWindow(ImagePlotContainer):
         def fset(self, value):
             self._frb = value
             self._data_valid = True
+            self._plot_valid = False
 
         def fdel(self):
             del self._frb
@@ -291,10 +292,12 @@ class PlotWindow(ImagePlotContainer):
 
     def _recreate_frb(self):
         old_fields = None
+        old_filters = []
         # If we are regenerating an frb, we want to know what fields we had before
         if self._frb is not None:
             old_fields = list(self._frb.keys())
             old_units = [str(self._frb[of].units) for of in old_fields]
+            old_filters = self._frb._filters
 
         # Set the bounds
         if hasattr(self, "zlim"):
@@ -308,8 +311,11 @@ class PlotWindow(ImagePlotContainer):
             bounds,
             self.buff_size,
             self.antialias,
+            plot_window=self,
             periodic=self._periodic,
         )
+        # Restoring old_filters
+        self._frb._filters = old_filters
 
         # At this point the frb has the valid bounds, size, aliasing, etc.
         if old_fields is None:

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -272,7 +272,14 @@ class PlotWindow(ImagePlotContainer):
         doc = "The frb property."
 
         def fget(self):
-            if self._frb is None or not self._data_valid:
+            # Force the regeneration of the fixed resolution buffer
+            # * if there's none
+            # * if the data has been invalidated
+            # * if the frb has been inalidated
+            if (self._frb is None or
+                not self._data_valid or
+                not self._frb._data_valid
+            ):
                 self._recreate_frb()
             return self._frb
 
@@ -311,11 +318,9 @@ class PlotWindow(ImagePlotContainer):
             bounds,
             self.buff_size,
             self.antialias,
-            plot_window=self,
             periodic=self._periodic,
+            filters=old_filders
         )
-        # Restoring old_filters
-        self._frb._filters = old_filters
 
         # At this point the frb has the valid bounds, size, aliasing, etc.
         if old_fields is None:
@@ -966,7 +971,9 @@ class PWViewerMPL(PlotWindow):
 
         if self._plot_valid:
             return
-        if not self._data_valid:
+        if ( not self._data_valid or
+             self._frb is None or
+             not self._frb._data_valid):
             self._recreate_frb()
             self._data_valid = True
         self._colorbar_valid = True

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -276,10 +276,7 @@ class PlotWindow(ImagePlotContainer):
             # * if there's none
             # * if the data has been invalidated
             # * if the frb has been inalidated
-            if (self._frb is None or
-                not self._data_valid or
-                not self._frb._data_valid
-            ):
+            if not self.data_is_valid():
                 self._recreate_frb()
             return self._frb
 
@@ -882,6 +879,9 @@ class PWViewerMPL(PlotWindow):
         self._splat_color = kwargs.pop("splat_color", None)
         PlotWindow.__init__(self, *args, **kwargs)
 
+    def data_is_valid(self):
+        return self._data_valid and self._frb and self._frb._data_valid
+
     def _setup_origin(self):
         origin = self.origin
         axis_index = self.data_source.axis
@@ -971,9 +971,7 @@ class PWViewerMPL(PlotWindow):
 
         if self._plot_valid:
             return
-        if ( not self._data_valid or
-             self._frb is None or
-             not self._frb._data_valid):
+        if not self.data_is_valid():
             self._recreate_frb()
             self._data_valid = True
         self._colorbar_valid = True

--- a/yt/visualization/tests/test_filters.py
+++ b/yt/visualization/tests/test_filters.py
@@ -31,11 +31,29 @@ def test_filter_wiring():
     from scipy.ndimage import gaussian_filter
     ds = fake_amr_ds(fields=("density", ))
     p = yt.SlicePlot(ds, 'x', 'density')
-    data_before = p.frb['density'].value
+
+    frb1 = p.frb
+    data_orig = frb1['density'].value
+
     sigma = 2
     p.frb.apply_gauss_beam(sigma)
-    data_after = p.frb['density'].value
+    frb2 = p.frb
+    data_gauss = frb2['density'].value
 
-    # Check that the frb yields the same result
-    assert np.allclose(gaussian_filter(data_before, sigma),
-                       data_after)
+    p.frb.apply_white_noise()
+    frb3 = p.frb
+    data_white = frb3['density'].value
+
+    # We check the frb have changed
+    assert frb1 != frb2
+    assert frb1 != frb3
+    assert frb2 != frb3
+
+    # We check the resulting image are different each time
+    assert np.allclose(data_orig, data_gauss) is False
+    assert np.allclose(data_orig, data_white) is False
+    assert np.allclose(data_gauss, data_white) is False
+
+    # Check the gaussian filtering should is ok
+    assert np.allclose(gaussian_filter(data_orig, sigma),
+                       data_gauss)

--- a/yt/visualization/tests/test_filters.py
+++ b/yt/visualization/tests/test_filters.py
@@ -3,9 +3,11 @@ Tests for frb filters
 
 """
 
-from yt.testing import fake_amr_ds, requires_module
-import yt
 import numpy as np
+
+import yt
+from yt.testing import fake_amr_ds, requires_module
+
 
 @requires_module("scipy")
 def test_white_noise_filter():
@@ -29,20 +31,21 @@ def test_gauss_beam_filter():
 @requires_module("scipy")
 def test_filter_wiring():
     from scipy.ndimage import gaussian_filter
-    ds = fake_amr_ds(fields=("density", ))
-    p = yt.SlicePlot(ds, 'x', 'density')
+
+    ds = fake_amr_ds(fields=("density",))
+    p = yt.SlicePlot(ds, "x", "density")
 
     frb1 = p.frb
-    data_orig = frb1['density'].value
+    data_orig = frb1["density"].value
 
     sigma = 2
     p.frb.apply_gauss_beam(sigma)
     frb2 = p.frb
-    data_gauss = frb2['density'].value
+    data_gauss = frb2["density"].value
 
     p.frb.apply_white_noise()
     frb3 = p.frb
-    data_white = frb3['density'].value
+    data_white = frb3["density"].value
 
     # We check the frb have changed
     assert frb1 != frb2
@@ -55,5 +58,4 @@ def test_filter_wiring():
     assert np.allclose(data_gauss, data_white) is False
 
     # Check the gaussian filtering should is ok
-    assert np.allclose(gaussian_filter(data_orig, sigma),
-                       data_gauss)
+    assert np.allclose(gaussian_filter(data_orig, sigma), data_gauss)

--- a/yt/visualization/tests/test_filters.py
+++ b/yt/visualization/tests/test_filters.py
@@ -4,7 +4,8 @@ Tests for frb filters
 """
 
 from yt.testing import fake_amr_ds, requires_module
-
+import yt
+import numpy as np
 
 @requires_module("scipy")
 def test_white_noise_filter():
@@ -21,5 +22,20 @@ def test_gauss_beam_filter():
     ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
     p = ds.proj(("gas", "density"), "z")
     frb = p.to_frb((1, "unitary"), 64)
-    frb.apply_gauss_beam(nbeam=15, sigma=1.0)
+    frb.apply_gauss_beam(sigma=1.0)
     frb[("gas", "density")]
+
+
+@requires_module("scipy")
+def test_filter_wiring():
+    from scipy.ndimage import gaussian_filter
+    ds = fake_amr_ds(fields=("density", ))
+    p = yt.SlicePlot(ds, 'x', 'density')
+    data_before = p.frb['density'].value
+    sigma = 2
+    p.frb.apply_gauss_beam(sigma)
+    data_after = p.frb['density'].value
+
+    # Check that the frb yields the same result
+    assert np.allclose(gaussian_filter(data_before, sigma),
+                       data_after)

--- a/yt/visualization/tests/test_filters.py
+++ b/yt/visualization/tests/test_filters.py
@@ -35,6 +35,7 @@ def test_filter_wiring():
     ds = fake_amr_ds(fields=("density",))
     p = yt.SlicePlot(ds, "x", "density")
 
+    # Note: frb is a FixedResolutionBuffer object
     frb1 = p.frb
     data_orig = frb1["density"].value
 
@@ -47,15 +48,15 @@ def test_filter_wiring():
     frb3 = p.frb
     data_white = frb3["density"].value
 
-    # We check the frb have changed
-    assert frb1 != frb2
-    assert frb1 != frb3
-    assert frb2 != frb3
+    # We check the frb objects are different
+    assert frb1 is not frb2
+    assert frb1 is not frb3
+    assert frb2 is not frb3
 
     # We check the resulting image are different each time
-    assert np.allclose(data_orig, data_gauss) is False
-    assert np.allclose(data_orig, data_white) is False
-    assert np.allclose(data_gauss, data_white) is False
+    assert not np.allclose(data_orig, data_gauss)
+    assert not np.allclose(data_orig, data_white)
+    assert not np.allclose(data_gauss, data_white)
 
-    # Check the gaussian filtering should is ok
+    # Check the gaussian filtering is ok
     assert np.allclose(gaussian_filter(data_orig, sigma), data_gauss)


### PR DESCRIPTION
## PR Summary

This wires the FixedResolutionBuffer objects to their parent `plot_window` (if any) so that the addition of a filter results in the invalidation of the plot window.

The PR also modified the `apply_gauss_beam` filter to use https://docs.scipy.org/doc/scipy-0.16.1/reference/generated/scipy.ndimage.filters.gaussian_filter.html.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes flake8 checker
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

## Example script

```python
import yt
from yt.testing import fake_amr_ds

ds = fake_amr_ds(fields=["density", "temperature"])

fields = ['density', 'temperature']
p = yt.SlicePlot(ds, 'x', fields)
p.save('/tmp/', suffix='unsmoothed')

p.frb.apply_gauss_beam(sigma=10) # pixels
p.save('/tmp/', suffix='smoothed')

p.frb.apply_white_noise()
p.save('/tmp/', suffix='smoothed+whitenoise')
```
![amrgriddata_slice_x_temperature unsmoothed](https://user-images.githubusercontent.com/5411875/42246503-252f7762-7f1d-11e8-9e3e-df0651aa34d9.png)
![amrgriddata_slice_x_temperature smoothed](https://user-images.githubusercontent.com/5411875/42246504-25621604-7f1d-11e8-99c0-9d904c1e0145.png)
![amrgriddata_slice_x_temperature smoothed whitenoise](https://user-images.githubusercontent.com/5411875/42246564-6084dd84-7f1d-11e8-94de-ea9f4c55da68.png)

![amrgriddata_slice_x_density unsmoothed](https://user-images.githubusercontent.com/5411875/42246505-25cfc4b0-7f1d-11e8-9c55-c810cf429f7d.png)
![amrgriddata_slice_x_density smoothed](https://user-images.githubusercontent.com/5411875/42246506-2615183a-7f1d-11e8-9989-2e40530eaa7c.png)
![amrgriddata_slice_x_density smoothed whitenoise](https://user-images.githubusercontent.com/5411875/42246565-60a9d576-7f1d-11e8-882f-7822d07ab0e7.png)
