### PR TITLE
fix issues with fake_octree_ds having hidden state

### DIFF
--- a/yt/testing.py
+++ b/yt/testing.py
@@ -449,9 +449,13 @@ def fake_vr_orientation_test_ds(N = 96, scale=1):
     return ds
 
 
-def construct_octree_mask(prng=RandomState(0x1d3d3d3), refined=[True]):
+def construct_octree_mask(prng=RandomState(0x1d3d3d3), refined=None):
     # Implementation taken from url:
     # http://docs.hyperion-rt.org/en/stable/advanced/indepth_oct.html
+
+
+    if refined is None:
+        refined = [True]
 
     # Loop over subcells
     for subcell in range(8):
@@ -467,14 +471,13 @@ def construct_octree_mask(prng=RandomState(0x1d3d3d3), refined=[True]):
             construct_octree_mask(prng, refined)
     return refined
 
-def fake_octree_ds(prng=RandomState(0x1d3d3d3), refined=[True], quantities=None,
+def fake_octree_ds(prng=RandomState(0x1d3d3d3), quantities=None,
                    bbox=None, sim_time=0.0, length_unit=None, mass_unit=None,
                    time_unit=None, velocity_unit=None, magnetic_unit=None,
                    periodicity=(True, True, True), over_refine_factor=1,
                    partial_coverage=1, unit_system="cgs"):
     from yt.frontends.stream.api import load_octree
-    octree_mask = np.asarray(construct_octree_mask(prng=prng, refined=refined),
-                             dtype=np.uint8)
+    octree_mask = np.asarray(construct_octree_mask(prng=prng), dtype=np.uint8)
     particles = np.sum(np.invert(octree_mask))
 
     if quantities is None:

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -454,8 +454,11 @@ def construct_octree_mask(prng=RandomState(0x1d3d3d3), refined=None):
     # http://docs.hyperion-rt.org/en/stable/advanced/indepth_oct.html
 
 
-    if refined is None:
+    if refined in (None, True):
         refined = [True]
+    if refined is False:
+        refined = [False]
+        return refined
 
     # Loop over subcells
     for subcell in range(8):
@@ -471,13 +474,14 @@ def construct_octree_mask(prng=RandomState(0x1d3d3d3), refined=None):
             construct_octree_mask(prng, refined)
     return refined
 
-def fake_octree_ds(prng=RandomState(0x1d3d3d3), quantities=None,
+def fake_octree_ds(prng=RandomState(0x1d3d3d3), refined=None, quantities=None,
                    bbox=None, sim_time=0.0, length_unit=None, mass_unit=None,
                    time_unit=None, velocity_unit=None, magnetic_unit=None,
                    periodicity=(True, True, True), over_refine_factor=1,
                    partial_coverage=1, unit_system="cgs"):
     from yt.frontends.stream.api import load_octree
-    octree_mask = np.asarray(construct_octree_mask(prng=prng), dtype=np.uint8)
+    octree_mask = np.asarray(construct_octree_mask(prng=prng, refined=refined),
+                             dtype=np.uint8)
     particles = np.sum(np.invert(octree_mask))
 
     if quantities is None:


### PR DESCRIPTION
This will fix the issues @MatthewTurk ran into in #1858 

@git-abhishek sorry for missing this in the initial code review. In general it's an antipattern in python to make the default value of a keyword argument an mutable type like a list or a dict. This is the #1 gotcha in this listing of python gotchas: http://docs.python-guide.org/en/latest/writing/gotchas/#mutable-default-arguments