### PR TITLE
[Bugfix] Dont loop twice over generator object

### DIFF
--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -412,3 +412,17 @@ def test_cooling_fields():
     check_unit(ds.r[('gas','number_density')],'cm**(-3)')
     check_unit(ds.r[('gas','mu')],'dimensionless')
     check_unit(ds.r[('gas','Electron_number_density')],'cm**(-3)')
+
+
+ramses_rt = "ramses_rt_00088/output_00088/info_00088.txt"
+@requires_file(ramses_rt)
+def test_ramses_mixed_files():
+    # Test that one can use derived fields that depend on different
+    # files (here hydro and rt files)
+    ds = yt.load(ramses_rt)
+    def _mixed_field(field, data):
+        return data['rt', 'photon_density_1'] / data['gas', 'H_nuclei_density']
+    ds.add_field(('gas', 'mixed_files'), function=_mixed_field, sampling_type='cell')
+
+    # Access the field
+    ds.r[('gas', 'mixed_files')]


### PR DESCRIPTION
This fixes #1847.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

Before the PR, we were looping on chunks one time per field type. However, since chunks is a generator, the second time, it would yield 0 chunk, resulting in an error.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes flake8 checker
- [x] Adds a test for any bugs fixed.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
