### PR TITLE
Keep only png format while doing plot.save() in visualization module

### DIFF
--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -43,8 +43,7 @@ def setup():
     ytcfg["yt", "__withintesting"] = "True"
 
 
-TEST_FLNMS = [None, 'test', 'test.png', 'test.eps',
-              'test.ps', 'test.pdf']
+TEST_FLNMS = ['test.png']
 M7 = "DD0010/moving7_0010"
 WT = "WindTunnel/windtunnel_4lev_hdf5_plt_cnt_0030"
 


### PR DESCRIPTION
## PR Summary

It is sufficient to test the plots for only `.png` format and not all the formats like `.eps`, `.pdf`, `.ps`.
Saving plot for other file formats increases disk I/O and leads to more runtime at Travis.

## PR Checklist

- [X] Code passes flake8 checker

## Adding Reviewers
@ngoldbaum @Xarthisius @colinmarc
