### PR TITLE
[feature] Faster cut region query

### DIFF
--- a/yt/data_objects/selection_data_containers.py
+++ b/yt/data_objects/selection_data_containers.py
@@ -24,8 +24,6 @@ from yt.extern.six import string_types
 from yt.funcs import ensure_list, iterable, validate_width_tuple, \
     fix_length, fix_axis, validate_3d_array, validate_float, \
     validate_iterable, validate_object, validate_axis, validate_center
-from yt.geometry.selection_routines import \
-    points_in_cells
 from yt.units.yt_array import \
     YTArray, \
     YTQuantity

--- a/yt/data_objects/selection_data_containers.py
+++ b/yt/data_objects/selection_data_containers.py
@@ -935,10 +935,15 @@ class YTCutRegion(YTSelectionContainer3D):
         parent = getattr(self, "parent", self.base_object)
         units = "code_length"
 
-        pos = np.stack([self[("index", k)].to(units) for k in 'xyz'], axis=1).value
-        dx = np.stack([self[("index", "d%s" % k)].to(units) for k in 'xyz'], axis=1).value
-        ppos = np.stack([parent[(ptype, "particle_position_%s" % k)]
-                         for k in 'xyz'], axis=1).value
+        pos = np.stack([self[("index", 'x')].to(units),
+                        self[("index", 'y')].to(units),
+                        self[("index", 'z')].to(units)], axis=1).value
+        dx = np.stack([self[("index", "dx")].to(units),
+                       self[("index", "dy")].to(units),
+                       self[("index", "dz")].to(units)], axis=1).value
+        ppos = np.stack([parent[(ptype, "particle_position_x")],
+                         parent[(ptype, "particle_position_y")],
+                         parent[(ptype, "particle_position_z")]], axis=1).value
         levels = self[("index", "grid_level")].astype('int32').value
         levelmin = levels.min()
         levelmax = levels.max()

--- a/yt/data_objects/selection_data_containers.py
+++ b/yt/data_objects/selection_data_containers.py
@@ -36,7 +36,7 @@ from yt.utilities.minimal_representation import \
 from yt.utilities.math_utils import get_rotation_matrix
 from yt.utilities.orientation import Orientation
 from yt.geometry.selection_routines import points_in_cells
-from yt.utilities.on_demand_imports import _scipy, NotAModule
+from yt.utilities.on_demand_imports import _scipy
 
 
 class YTPoint(YTSelectionContainer0D):

--- a/yt/data_objects/selection_data_containers.py
+++ b/yt/data_objects/selection_data_containers.py
@@ -948,7 +948,6 @@ class YTCutRegion(YTSelectionContainer3D):
         for lvl in range(levelmax, levelmin-1, -1):
             # Filter out cells not in the current level
             lvl_mask = (levels == lvl)
-            print(lvl, lvl_mask.sum(), mask.sum(), mask.shape[0])
             dx_loc = dx[lvl_mask]
             pos_loc = pos[lvl_mask]
 

--- a/yt/data_objects/selection_data_containers.py
+++ b/yt/data_objects/selection_data_containers.py
@@ -954,7 +954,6 @@ class YTCutRegion(YTSelectionContainer3D):
         mask = np.zeros(dist.shape[0], dtype=bool)
         # Loop over all eigh nearest neighbors
         for n in range(N):
-            print(n, mask.sum())
             # Keep particles with a neighbor
             local_mask = np.isfinite(dist[:, n]) & np.logical_not(mask)
 

--- a/yt/data_objects/selection_data_containers.py
+++ b/yt/data_objects/selection_data_containers.py
@@ -976,19 +976,6 @@ class YTCutRegion(YTSelectionContainer3D):
         if self._particle_mask.get(ptype) is None:
             mask = self._part_ind_KDTree(ptype)
             self._particle_mask[ptype] = mask
-
-            #     mask = points_in_cells(
-            #         self[("index", "x")].to(units),
-            #         self[("index", "y")].to(units),
-            #         self[("index", "z")].to(units),
-            #         self[("index", "dx")].to(units),
-            #         self[("index", "dy")].to(units),
-            #         self[("index", "dz")].to(units),
-            #         parent[(ptype, "particle_position_x")].to(units),
-            #         parent[(ptype, "particle_position_y")].to(units),
-            #         parent[(ptype, "particle_position_z")].to(units))
-            # finally:
-            #     self._particle_mask[ptype] = mask
         return self._particle_mask[ptype]
 
     @property

--- a/yt/data_objects/selection_data_containers.py
+++ b/yt/data_objects/selection_data_containers.py
@@ -991,10 +991,12 @@ class YTCutRegion(YTSelectionContainer3D):
             # If scipy is installed, use the fast KD tree
             # implementation. Else, fall back onto the direct
             # brute-force algorithm.
-            if issubclass(_scipy.spatial, NotAModule):
-                mask = self._part_ind_brute_force(ptype)
-            else:
+            try:
+                _scipy.spatial.KDTree
                 mask = self._part_ind_KDTree(ptype)
+            except ImportError:
+                mask = self._part_ind_brute_force(ptype)
+
             self._particle_mask[ptype] = mask
         return self._particle_mask[ptype]
 

--- a/yt/data_objects/selection_data_containers.py
+++ b/yt/data_objects/selection_data_containers.py
@@ -951,7 +951,7 @@ class YTCutRegion(YTSelectionContainer3D):
             dx_loc = dx[lvl_mask]
             pos_loc = pos[lvl_mask]
 
-            grid_tree = _scipy.KDTree(pos_loc, boxsize=1)
+            grid_tree = _scipy.spatial.cKDTree(pos_loc, boxsize=1)
 
             # Compute closest cell for all remaining particles
             dist, icell = grid_tree.query(ppos[~mask], distance_upper_bound=dx_loc.max(),
@@ -991,7 +991,7 @@ class YTCutRegion(YTSelectionContainer3D):
             # If scipy is installed, use the fast KD tree
             # implementation. Else, fall back onto the direct
             # brute-force algorithm.
-            if issubclass(_scipy.KDTree, NotAModule):
+            if issubclass(_scipy.spatial, NotAModule):
                 mask = self._part_ind_brute_force(ptype)
             else:
                 mask = self._part_ind_KDTree(ptype)

--- a/yt/data_objects/tests/test_extract_regions.py
+++ b/yt/data_objects/tests/test_extract_regions.py
@@ -4,8 +4,8 @@ from yt.testing import \
     fake_random_ds, \
     fake_amr_ds, \
     assert_equal, \
-    assert_almost_equal
-
+    assert_almost_equal, \
+    requires_module
 
 
 def setup():
@@ -49,7 +49,7 @@ def test_cut_region():
         p2 = ds.proj("density", 2, data_source=cr, weight_field = "density")
         assert_equal(p2["density"].max() > 0.25, True)
 
-
+@requires_module('scipy')
 def test_region_and_particles():
     ds = fake_amr_ds(particles=10000)
 

--- a/yt/data_objects/tests/test_extract_regions.py
+++ b/yt/data_objects/tests/test_extract_regions.py
@@ -20,7 +20,7 @@ def test_cut_region():
         r = dd.cut_region( [ "obj['temperature'] > 0.5",
                              "obj['density'] < 0.75",
                              "obj['velocity_x'] > 0.25" ])
-        t = ( (dd["temperature"] > 0.5 ) 
+        t = ( (dd["temperature"] > 0.5 )
             & (dd["density"] < 0.75 )
             & (dd["velocity_x"] > 0.25 ) )
         assert_equal(np.all(r["temperature"] > 0.5), True)
@@ -46,3 +46,21 @@ def test_cut_region():
         assert_equal(p2["density"].max() > 0.25, True)
         p2 = ds.proj("density", 2, data_source=cr, weight_field = "density")
         assert_equal(p2["density"].max() > 0.25, True)
+
+
+def test_region_and_particles():
+    ds = fake_random_ds(
+        64, nprocs=8,
+        particle_fields=('particle_position_x', 'particle_position_y', 'particle_position_z',
+                         'particle_identity'),
+        particle_field_units=('cm', 'cm', 'cm', '1'),
+        particles=100)
+
+    ad = ds.all_data()
+    reg = ad.cut_region('obj["x"] < .5')
+
+    mask = ad['particle_position_x'] < 0.5
+    expected = np.sort(ad['particle_position_x'][mask].value)
+    result = np.sort(reg['particle_position_x'])
+
+    assert_equal(expected.shape, result.shape)

--- a/yt/data_objects/tests/test_extract_regions.py
+++ b/yt/data_objects/tests/test_extract_regions.py
@@ -2,8 +2,10 @@ import numpy as np
 
 from yt.testing import \
     fake_random_ds, \
+    fake_amr_ds, \
     assert_equal, \
     assert_almost_equal
+
 
 
 def setup():
@@ -49,12 +51,7 @@ def test_cut_region():
 
 
 def test_region_and_particles():
-    ds = fake_random_ds(
-        64, nprocs=8,
-        particle_fields=('particle_position_x', 'particle_position_y', 'particle_position_z',
-                         'particle_identity'),
-        particle_field_units=('cm', 'cm', 'cm', '1'),
-        particles=100)
+    ds = fake_amr_ds(particles=10000)
 
     ad = ds.all_data()
     reg = ad.cut_region('obj["x"] < .5')

--- a/yt/data_objects/tests/test_extract_regions.py
+++ b/yt/data_objects/tests/test_extract_regions.py
@@ -4,9 +4,7 @@ from yt.testing import \
     fake_random_ds, \
     fake_amr_ds, \
     assert_equal, \
-    assert_almost_equal, \
-    requires_module
-
+    assert_almost_equal
 
 def setup():
     from yt.config import ytcfg

--- a/yt/data_objects/tests/test_extract_regions.py
+++ b/yt/data_objects/tests/test_extract_regions.py
@@ -49,7 +49,6 @@ def test_cut_region():
         p2 = ds.proj("density", 2, data_source=cr, weight_field = "density")
         assert_equal(p2["density"].max() > 0.25, True)
 
-@requires_module('scipy')
 def test_region_and_particles():
     ds = fake_amr_ds(particles=10000)
 

--- a/yt/data_objects/tests/test_extract_regions.py
+++ b/yt/data_objects/tests/test_extract_regions.py
@@ -58,3 +58,4 @@ def test_region_and_particles():
     result = np.sort(reg['particle_position_x'])
 
     assert_equal(expected.shape, result.shape)
+    assert_equal(expected, result)

--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -2092,20 +2092,15 @@ def points_in_cells(
 
     n_p = px.size
     n_c = cx.size
-    mask = np.ones(n_p, dtype="bool")
+    mask = np.zeros(n_p, dtype="bool")
 
     for p in range(n_p):
         for c in range(n_c):
-            if fabs(px[p] - cx[c]) > 0.5 * dx[c]:
-                mask[p] = False
-                continue
-            if fabs(py[p] - cy[c]) > 0.5 * dy[c]:
-                mask[p] = False
-                continue
-            if fabs(pz[p] - cz[c]) > 0.5 * dz[c]:
-                mask[p] = False
-                continue
-            if mask[p]: break
+            if (fabs(px[p] - cx[c]) <= 0.5 * dx[c] and
+                fabs(py[p] - cy[c]) <= 0.5 * dy[c] and
+                fabs(pz[p] - cz[c]) <= 0.5 * dz[c]):
+                mask[p] = True
+                break
 
     return mask
 

--- a/yt/utilities/on_demand_imports.py
+++ b/yt/utilities/on_demand_imports.py
@@ -227,17 +227,6 @@ class scipy_imports(object):
             self._spatial = spatial
         return self._spatial
 
-    _KDTree = None
-    @property
-    def KDTree(self):
-        if self._KDTree is None:
-            try:
-                from scipy.spatial import cKDTree as KDTree
-            except ImportError:
-                KDTree = NotAModule(self._name)
-            self._KDTree = KDTree
-        return self._KDTree
-
 _scipy = scipy_imports()
 
 class h5py_imports(object):

--- a/yt/utilities/on_demand_imports.py
+++ b/yt/utilities/on_demand_imports.py
@@ -234,7 +234,7 @@ class scipy_imports(object):
             try:
                 from scipy.spatial import cKDTree as KDTree
             except ImportError:
-                from yt.extern.pykdtree import KDTree
+                KDTree = NotAModule(self._name)
             self._KDTree = KDTree
         return self._KDTree
 

--- a/yt/utilities/on_demand_imports.py
+++ b/yt/utilities/on_demand_imports.py
@@ -234,7 +234,7 @@ class scipy_imports(object):
             try:
                 from scipy.spatial import cKDTree as KDTree
             except ImportError:
-                from yt.extern import KDTree
+                from yt.extern.pykdtree import KDTree
             self._KDTree = KDTree
         return self._KDTree
 

--- a/yt/utilities/on_demand_imports.py
+++ b/yt/utilities/on_demand_imports.py
@@ -227,6 +227,17 @@ class scipy_imports(object):
             self._spatial = spatial
         return self._spatial
 
+    _KDTree = None
+    @property
+    def KDTree(self):
+        if self._KDTree is None:
+            try:
+                from scipy.spatial import cKDTree as KDTree
+            except ImportError:
+                from yt.extern import KDTree
+            self._KDTree = KDTree
+        return self._KDTree
+
 _scipy = scipy_imports()
 
 class h5py_imports(object):


### PR DESCRIPTION
## PR Summary

The selection method used to find particles in a "cut region" was using a brute force algorithm that was scaling as `npart * ncell`. For larger simulations, this would become the bottleneck. This PR improves the previous version using a tree-based algorithm.

The positions of the cells are stored in a KD-tree. Then for all the particles in the parent container, we look at the closest cell in the tree. There is then a selection step where we loop on all the neighbouring cells to check whether each particle is within the candidate cell.

Note: we should also think about how many neighbors we should query in general so that we are sure to find the cell containing the particle. This may require building a more complex distance function in units of the local dx, but I don't know how to do that yet.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes flake8 checker
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
