### PR TITLE
yt-4.0 normalization fix

### DIFF
--- a/doc/source/yt4differences.rst
+++ b/doc/source/yt4differences.rst
@@ -68,30 +68,27 @@ lifting in these functions is undertaken by cython functions.
 
 It is now possible to generate slice plots, projection plots and arbitrary grids
 of smoothed quanitities using these operations. The following code demonstrates
-how this could be achieved.
+how this could be achieved:
 
-```python
+.. code-block:: python
 
-import yt
+    import yt
 
-ds = yt.load('snapshot_033/snap_033.0.hdf5')
+    ds = yt.load('snapshot_033/snap_033.0.hdf5')
 
-plot = yt.SlicePlot(ds, 2, ('gas', 'density'))
+    plot = yt.SlicePlot(ds, 2, ('gas', 'density'))
+    plot.save()
 
-plot.set_zlim(('gas', 'density'), 1e-32, 1e-27)
+    plot = yt.ProjectionPlot(ds, 2, ('gas', 'density'))
+    plot.save()
 
-plot.save()
+    arbitrary_grid = ds.arbitrary_grid([0.0, 0.0, 0.0], [5, 5, 5],
+                                       dims=[10, 10, 10])
+    density = arbitrary_grid[('gas', 'density')]
 
-plot = yt.ProjectionPlot(ds, 2, ('gas', 'density'))
-
-plot.set_zlim(('gas', 'density'), 8e-6, 8e-3)
-
-plot.save()
-
-arbitrary_grid = ds.arbitrary_grid([0.0, 0.0, 0.0], [5, 5, 5],dims=[10, 10, 10])
-density = arbitrary_grid[('gas', 'density')]
-print(density)
-```
+The default behaviour for sPH interpolation is that the values are normalized
+inline with Eq. 9 in `SPLASH, Price (2009) <https://arxiv.org/pdf/0709.0832.pdf>`_.
+This can be disabled with `ds.use_sph_normalization = False`.
 
 Off-Axis Projection for SPH Data
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -926,7 +926,8 @@ class YTArbitraryGrid(YTCoveringGrid):
         for field in fields:
             dest = np.zeros(self.ActiveDimensions, dtype="float64")
 
-            if self.ds.use_sph_normalization:
+            normalize = getattr(self.ds, 'use_sph_normalization', True)
+            if normalize:
                 dest_den = np.zeros(self.ActiveDimensions, dtype="float64")
 
             bounds = np.empty(6, dtype=float)
@@ -950,12 +951,12 @@ class YTArbitraryGrid(YTCoveringGrid):
                 pixelize_sph_kernel_arbitrary_grid(dest, px, py, pz, hsml,
                                                    mass, dens, field_quantity,
                                                    bounds, pbar)
-                if self.ds.use_sph_normalization:
+                if normalize:
                     pixelize_sph_kernel_arbitrary_grid(dest_den, px, py, pz,
                                     hsml, mass, dens, np.ones(hsml.shape[0]),
                                     bounds)
 
-            if self.ds.use_sph_normalization:
+            if normalize:
                 normalization_3d_utility(dest, dest_den)
 
             self[field] = self.ds.arr(dest, field_quantity.units)

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -66,7 +66,7 @@ from yt.frontends.sph.data_structures import ParticleDataset
 from yt.units.yt_array import YTArray
 import yt.extern.six as six
 from yt.utilities.lib.pixelization_routines import \
-    pixelize_sph_kernel_arbitrary_grid
+    pixelize_sph_kernel_arbitrary_grid, normalization_3d_utility
 from yt.extern.tqdm import tqdm
 
 class YTStreamline(YTSelectionContainer1D):
@@ -925,6 +925,7 @@ class YTArbitraryGrid(YTCoveringGrid):
         ptype = self.ds._sph_ptype
         for field in fields:
             dest = np.zeros(self.ActiveDimensions, dtype="float64")
+            dest_den = np.zeros(self.ActiveDimensions, dtype="float64")
 
             bounds = np.empty(6, dtype=float)
             bounds[0] = self.left_edge[0].in_base("code")
@@ -946,7 +947,14 @@ class YTArbitraryGrid(YTCoveringGrid):
 
                 pixelize_sph_kernel_arbitrary_grid(dest,px,py,pz,hsml,mass,
                                                    dens,field_quantity,bounds,
-                                                   pbar)
+                                                   pbar,
+                                                   use_normalization=False)
+                pixelize_sph_kernel_arbitrary_grid(dest_den,px,py,pz,hsml,mass,
+                                                   dens,np.ones(hsml.shape[0]),
+                                                   bounds,
+                                                   use_normalization=False)
+
+            normalization_3d_utility(dest, dest_den)
 
             self[field] = self.ds.arr(dest, field_quantity.units)
             pbar.close()

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -925,7 +925,9 @@ class YTArbitraryGrid(YTCoveringGrid):
         ptype = self.ds._sph_ptype
         for field in fields:
             dest = np.zeros(self.ActiveDimensions, dtype="float64")
-            dest_den = np.zeros(self.ActiveDimensions, dtype="float64")
+
+            if self.ds.use_sph_normalization:
+                dest_den = np.zeros(self.ActiveDimensions, dtype="float64")
 
             bounds = np.empty(6, dtype=float)
             bounds[0] = self.left_edge[0].in_base("code")
@@ -945,16 +947,16 @@ class YTArbitraryGrid(YTCoveringGrid):
                 dens = chunk[(ptype,'density')].in_base("code")
                 field_quantity = chunk[field]
 
-                pixelize_sph_kernel_arbitrary_grid(dest,px,py,pz,hsml,mass,
-                                                   dens,field_quantity,bounds,
-                                                   pbar,
-                                                   use_normalization=False)
-                pixelize_sph_kernel_arbitrary_grid(dest_den,px,py,pz,hsml,mass,
-                                                   dens,np.ones(hsml.shape[0]),
-                                                   bounds,
-                                                   use_normalization=False)
+                pixelize_sph_kernel_arbitrary_grid(dest, px, py, pz, hsml,
+                                                   mass, dens, field_quantity,
+                                                   bounds, pbar)
+                if self.ds.use_sph_normalization:
+                    pixelize_sph_kernel_arbitrary_grid(dest_den, px, py, pz,
+                                    hsml, mass, dens, np.ones(hsml.shape[0]),
+                                    bounds)
 
-            normalization_3d_utility(dest, dest_den)
+            if self.ds.use_sph_normalization:
+                normalization_3d_utility(dest, dest_den)
 
             self[field] = self.ds.arr(dest, field_quantity.units)
             pbar.close()

--- a/yt/frontends/sph/data_structures.py
+++ b/yt/frontends/sph/data_structures.py
@@ -27,6 +27,7 @@ from yt.geometry.particle_geometry_handler import \
 class SPHDataset(ParticleDataset):
     default_kernel_name = "cubic"
     _num_neighbors = 32
+    _use_sph_normalization = True
 
     def __init__(self, filename, dataset_type=None, file_style=None,
                  units_override=None, unit_system="cgs",
@@ -41,6 +42,16 @@ class SPHDataset(ParticleDataset):
             filename, dataset_type=dataset_type, file_style=file_style,
             units_override=units_override, unit_system=unit_system,
             index_order=index_order, index_filename=index_filename)
+
+    @property
+    def use_sph_normalization(self):
+        return self._use_sph_normalization
+
+    @use_sph_normalization.setter
+    def use_sph_normalization(self, value):
+        if value is not True and value is not False:
+            raise ValueError("SPH normalization needs to be True or False!")
+        self._use_sph_normalization = value
 
     def add_smoothed_particle_field(self, smooth_field,
                                     method="volume_weighted", nneighbors=64,

--- a/yt/geometry/coordinates/cartesian_coordinates.py
+++ b/yt/geometry/coordinates/cartesian_coordinates.py
@@ -329,7 +329,8 @@ class CartesianCoordinateHandler(CoordinateHandler):
                     buff /= weight_buff
             elif isinstance(data_source, YTSlice):
                 buff = np.zeros(size, dtype='float64')
-                if self.ds.use_sph_normalization:
+                normalize = getattr(self.ds, 'use_sph_normalization', True)
+                if normalize:
                     buff_den = np.zeros(size, dtype='float64')
 
                 for chunk in data_source.chunks([], 'io'):
@@ -342,7 +343,7 @@ class CartesianCoordinateHandler(CoordinateHandler):
                         chunk[ptype, 'density'],
                         chunk[field].in_units(ounits),
                         bounds)
-                    if self.ds.use_sph_normalization:
+                    if normalize:
                         pixelize_sph_kernel_slice(
                             buff_den,
                             chunk[ptype, px_name],
@@ -353,7 +354,7 @@ class CartesianCoordinateHandler(CoordinateHandler):
                             np.ones(chunk[ptype, 'density'].shape[0]),
                             bounds)
 
-                if self.ds.use_sph_normalization:
+                if normalize:
                     normalization_2d_utility(buff, buff_den)
             else:
                 raise NotImplementedError(

--- a/yt/geometry/coordinates/cartesian_coordinates.py
+++ b/yt/geometry/coordinates/cartesian_coordinates.py
@@ -29,7 +29,8 @@ from yt.utilities.lib.pixelization_routines import \
     pixelize_cartesian_nodal, \
     pixelize_sph_kernel_slice, \
     pixelize_sph_kernel_projection, \
-    pixelize_element_mesh_line
+    pixelize_element_mesh_line, \
+    normalization_2d_utility
 from yt.data_objects.unstructured_mesh import SemiStructuredMesh
 from yt.utilities.nodal_data_utils import get_nodal_data
 
@@ -328,6 +329,7 @@ class CartesianCoordinateHandler(CoordinateHandler):
                     buff /= weight_buff
             elif isinstance(data_source, YTSlice):
                 buff = np.zeros(size, dtype='float64')
+                buff_den = np.zeros(size, dtype='float64')
                 for chunk in data_source.chunks([], 'io'):
                     pixelize_sph_kernel_slice(
                         buff,
@@ -337,7 +339,18 @@ class CartesianCoordinateHandler(CoordinateHandler):
                         chunk[ptype, 'particle_mass'],
                         chunk[ptype, 'density'],
                         chunk[field].in_units(ounits),
-                        bounds)
+                        bounds, use_normalization=False)
+                    pixelize_sph_kernel_slice(
+                        buff_den,
+                        chunk[ptype, px_name],
+                        chunk[ptype, py_name],
+                        chunk[ptype, 'smoothing_length'],
+                        chunk[ptype, 'particle_mass'],
+                        chunk[ptype, 'density'],
+                        np.ones(chunk[ptype, 'density'].shape[0]),
+                        bounds, use_normalization=False)
+
+                normalization_2d_utility(buff, buff_den)
             else:
                 raise NotImplementedError(
                     "A pixelization routine has not been implemented for %s "

--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -1498,3 +1498,30 @@ cpdef np.float64_t[:, :] get_rotation_matrix(normal_vector):
     return np.identity(3, dtype='float_') + cross_product_matrix \
         + np.matmul(cross_product_matrix, cross_product_matrix) \
         * 1/(1+c)
+
+
+@cython.initializedcheck(False)
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.cdivision(True)
+def normalization_2d_utility(np.float64_t[:, :] num,
+                             np.float64_t[:, :] den):
+    cdef int i, j
+    for i in range(num.shape[0]):
+        for j in range(num.shape[1]):
+            if den[i, j] != 0.0:
+                num[i, j] = num[i, j] / den[i, j]
+
+@cython.initializedcheck(False)
+@cython.boundscheck(False)
+@cython.wraparound(False)
+@cython.cdivision(True)
+def normalization_3d_utility(np.float64_t[:, :, :] num,
+                             np.float64_t[:, :, :] den):
+    cdef int i, j, k
+    for i in range(num.shape[0]):
+        for j in range(num.shape[1]):
+            for k in range(num.shape[2]):
+                if den[i, j, k] != 0.0:
+                    num[i, j, k] = num[i, j, k] / den[i, j, k]
+

--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -1060,8 +1060,7 @@ def pixelize_sph_kernel_slice(
         np.float64_t[:] hsml, np.float64_t[:] pmass,
         np.float64_t[:] pdens,
         np.float64_t[:] quantity_to_smooth,
-        bounds, kernel_name="cubic",
-        use_normalization=True):
+        bounds, kernel_name="cubic"):
 
     # similar method to pixelize_sph_kernel_projection
     cdef np.intp_t xsize, ysize
@@ -1070,12 +1069,8 @@ def pixelize_sph_kernel_slice(
     cdef np.float64_t q, posx_diff, posy_diff, ih_j
     cdef np.float64_t x, y, dx, dy, idx, idy, h_j2, h_j
     cdef int index, i, j
-    cdef np.float64_t[:, :] buff_num
-    cdef np.float64_t[:, :] buff_denom
 
     xsize, ysize = buff.shape[0], buff.shape[1]
-    buff_num = np.zeros((xsize, ysize), dtype='f8')
-    buff_denom = np.zeros((xsize, ysize), dtype='f8')
 
     x_min = bounds[0]
     x_max = bounds[1]
@@ -1088,10 +1083,6 @@ def pixelize_sph_kernel_slice(
     idy = 1.0/dy
 
     kernel_func = get_kernel_func(kernel_name)
-
-    # define this to avoid using the use_normalization python object
-    # in the tight loop
-    cdef np.intp_t use_norm = int(use_normalization)
 
     with nogil:
         for j in range(0, posx.shape[0]):
@@ -1140,19 +1131,7 @@ def pixelize_sph_kernel_slice(
                         continue
 
                     # see equations 6, 9, and 11 of the SPLASH paper
-                    if use_norm:
-                        buff_num[xi, yi] += coeff * kernel_func(q)
-                        buff_denom[xi, yi] += w_j * kernel_func(q)
-                    else:
-                        buff[xi, yi] += coeff * kernel_func(q)
-    if use_norm:
-        # now we can calculate the normalized image buffer we want to
-        # return, being careful to avoid producing NaNs in the result
-        for xi in range(xsize):
-            for yi in range(ysize):
-                if buff_denom[xi, yi] == 0:
-                    continue
-                buff[xi, yi] += buff_num[xi, yi] / buff_denom[xi, yi]
+                    buff[xi, yi] += coeff * kernel_func(q)
 
 @cython.initializedcheck(False)
 @cython.boundscheck(False)
@@ -1163,8 +1142,7 @@ def pixelize_sph_kernel_arbitrary_grid(np.float64_t[:, :, :] buff,
         np.float64_t[:] hsml, np.float64_t[:] pmass,
         np.float64_t[:] pdens,
         np.float64_t[:] quantity_to_smooth,
-        bounds, pbar=None, kernel_name="cubic",
-        use_normalization=True):
+        bounds, pbar=None, kernel_name="cubic"):
 
     cdef np.intp_t xsize, ysize, zsize
     cdef np.float64_t x_min, x_max, y_min, y_max, z_min, z_max, w_j, coeff
@@ -1172,12 +1150,8 @@ def pixelize_sph_kernel_arbitrary_grid(np.float64_t[:, :, :] buff,
     cdef np.float64_t q, posx_diff, posy_diff, posz_diff
     cdef np.float64_t x, y, z, dx, dy, dz, idx, idy, idz, h_j3, h_j2, h_j, ih_j
     cdef int index, i, j, k
-    cdef np.float64_t[:, :, :] buff_num
-    cdef np.float64_t[:, :, :] buff_denom
 
     xsize, ysize, zsize = buff.shape[0], buff.shape[1], buff.shape[2]
-    buff_num = np.zeros((xsize, ysize, zsize), dtype='f8')
-    buff_denom = np.zeros((xsize, ysize, zsize), dtype='f8')
 
     x_min = bounds[0]
     x_max = bounds[1]
@@ -1194,10 +1168,6 @@ def pixelize_sph_kernel_arbitrary_grid(np.float64_t[:, :, :] buff,
     idz = 1.0/dz
 
     kernel_func = get_kernel_func(kernel_name)
-
-    # define this to avoid using the use_normalization python object
-    # in the tight loop
-    cdef np.intp_t use_norm = int(use_normalization)
 
     with nogil:
         for j in range(0, posx.shape[0]):
@@ -1261,22 +1231,7 @@ def pixelize_sph_kernel_arbitrary_grid(np.float64_t[:, :, :] buff,
                         if q >= 1:
                             continue
 
-                        # see equations 6, 9, and 11 of the SPLASH paper
-                        if use_norm:
-                            buff_num[xi, yi, zi] += coeff * kernel_func(q)
-                            buff_denom[xi, yi, zi] += w_j * kernel_func(q)
-                        else:
-                            buff[xi, yi, zi] += coeff * kernel_func(q)
-
-    if use_norm:
-        # now we can calculate the normalized buffer we want to return, being
-        # careful to avoid producing NaNs in the result
-        for xi in range(xsize):
-            for yi in range(ysize):
-                for zi in range(zsize):
-                    if buff_denom[xi, yi, zi] == 0:
-                        continue
-                    buff[xi, yi, zi] += buff_num[xi, yi, zi] / buff_denom[xi, yi, zi]
+                        buff[xi, yi, zi] += coeff * kernel_func(q)
 
 def pixelize_element_mesh_line(np.ndarray[np.float64_t, ndim=2] coords,
                                np.ndarray[np.int64_t, ndim=2] conn,


### PR DESCRIPTION
## PR Summary

Fixed normalization of some pixelization routines with the addition of two utility functions to normalize

The plots with the fix:
![with_fix](https://user-images.githubusercontent.com/30047498/42780504-4b5a7d88-893b-11e8-8cea-6618174de3a5.png)

The plots without the fix:
![without_fix](https://user-images.githubusercontent.com/30047498/42780505-4b7788a6-893b-11e8-9069-b4f1180571b1.png)

NOTE: These fixes may break the tests, I'm not 100% sure.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes flake8 checker
- **NA** New features are documented, with docstrings and narrative docs
- **NA** Adds a test for any bugs fixed. Adds tests for new features.