### PR TITLE
Fixing removed files from manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,5 @@
 include README* CREDITS COPYING.txt CITATION  setupext.py CONTRIBUTING.rst
 include yt/visualization/mapserver/html/map_index.html
-include yt/visualization/mapserver/html/leaflet/*.css
-include yt/visualization/mapserver/html/leaflet/*.js
-include yt/visualization/mapserver/html/leaflet/images/*.png
 include yt/utilities/mesh_types.yaml
 exclude scripts/pr_backport.py
 recursive-include yt *.py *.pyx *.pxd *.h README* *.txt LICENSE* *.cu


### PR DESCRIPTION
## PR Summary

Commit a271399f12da6a887d61aa9e5780209f0005f28d removed the static files required for the mapserver (to use online ones). This PR removes leftover paths listed in MANIFEST.in that point to non-existing file in the trunk.