### PR TITLE
Fixes bug in Off Axis Projections in yt-4.0 [bugfix]

### DIFF
--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -162,6 +162,7 @@ def off_axis_projection(data_source, center, normal_vector,
         else:
             north = np.array(north_vector)
             north = north / np.linalg.norm(north)
+            east_vector = np.cross(north, normal).ravel()
         
         #if weight is None:
         


### PR DESCRIPTION
## PR Summary

Currently, when one attempts to specify a `north_vector` in an `off_axis_projection`, the code fails since it tries to access the `east_vector`, which hasn't yet been defined.  This addresses that and specifies the correct `east_vector`.