### PR TITLE
Fix implementation of AnswerTestingTest.prefix

### DIFF
--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -138,11 +138,11 @@ class AnswerTesting(Plugin):
                 print('Please supply an output directory with the --local-dir option')
                 sys.exit(1)
             storage_class = AnswerTestLocalStorage
+            output_dir = os.path.realpath(options.output_dir)
             # Fix up filename for local storage
             if self.compare_name is not None:
-                self.compare_name = "%s/%s/%s" % \
-                    (os.path.realpath(options.output_dir), self.compare_name,
-                     self.compare_name)
+                self.compare_name = os.path.join(output_dir, self.compare_name,
+                                                 self.compare_name)
 
             # Create a local directory only when `options.answer_name` is
             # provided. If it is not provided then creating local directory
@@ -150,13 +150,10 @@ class AnswerTesting(Plugin):
             # test, this case is handled in AnswerTestingTest.
             if self.store_name is not None and options.store_results \
                     and options.answer_name is not None:
-                name_dir_path = "%s/%s" % \
-                    (os.path.realpath(options.output_dir),
-                    self.store_name)
+                name_dir_path = os.path.join(output_dir, self.store_name)
                 if not os.path.isdir(name_dir_path):
                     os.makedirs(name_dir_path)
-                self.store_name= "%s/%s" % \
-                        (name_dir_path, self.store_name)
+                self.store_name= os.path.join(name_dir_path, self.store_name)
         else:
             storage_class = AnswerTestCloudStorage
 
@@ -220,7 +217,8 @@ class AnswerTestCloudStorage(AnswerTestStorage):
         # This is where we dump our result storage up to Amazon, if we are able
         # to.
         import pyrax
-        pyrax.set_credential_file(os.path.expanduser("~/.yt/rackspace"))
+        credentials = os.path.expanduser(os.path.join('~', '.yt', 'rackspace'))
+        pyrax.set_credential_file(credentials)
         cf = pyrax.cloudfiles
         c = cf.get_container("yt-answer-tests")
         pb = get_pbar("Storing results ", len(result_storage))
@@ -361,7 +359,7 @@ class AnswerTestingTest(object):
             self.prefix = "{}_{}".format(pyver, self.prefix)
 
             answer_store_dir = os.path.realpath(self.options.output_dir)
-            ref_name = "%s/%s/%s" % (answer_store_dir, self.prefix, self.prefix)
+            ref_name = os.path.join(answer_store_dir, self.prefix, self.prefix)
             self.reference_storage.reference_name = ref_name
             self.reference_storage.answer_name = self.prefix
 
@@ -369,7 +367,7 @@ class AnswerTestingTest(object):
             # - create the answer directory for this test
             # - self.reference_storage.answer_name will be path to answer files
             if self.options.store_results:
-                answer_test_dir = "%s/%s" % (answer_store_dir, self.prefix)
+                answer_test_dir = os.path.join(answer_store_dir, self.prefix)
                 if not os.path.isdir(answer_test_dir):
                     os.makedirs(answer_test_dir)
                 self.reference_storage.reference_name = None

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -143,7 +143,13 @@ class AnswerTesting(Plugin):
                 self.compare_name = "%s/%s/%s" % \
                     (os.path.realpath(options.output_dir), self.compare_name,
                      self.compare_name)
-            if self.store_name is not None and options.store_results:
+
+            # Create a local directory only when `options.answer_name` is
+            # provided. If it is not provided then creating local directory
+            # will depend on the answer_name from the `prefix` value of the
+            # test, this case is handled in AnswerTestingTest.
+            if self.store_name is not None and options.store_results \
+                    and options.answer_name is not None:
                 name_dir_path = "%s/%s" % \
                     (os.path.realpath(options.output_dir),
                     self.store_name)
@@ -157,6 +163,7 @@ class AnswerTesting(Plugin):
         # Initialize answer/reference storage
         AnswerTestingTest.reference_storage = self.storage = \
                 storage_class(self.compare_name, self.store_name)
+        AnswerTestingTest.options = options
 
         self.local_results = options.local_results
         global run_big_data
@@ -331,6 +338,7 @@ class AnswerTestingTest(object):
     reference_storage = None
     result_storage = None
     prefix = ""
+    options = None
     def __init__(self, ds_fn):
         if ds_fn is None:
             self.ds = None
@@ -343,7 +351,32 @@ class AnswerTestingTest(object):
         if AnswerTestingTest.result_storage is None:
             return
         nv = self.run()
+
+        # This is for running answer test when `--answer-name` is not set in
+        # nosetests command line arguments. In this case, set the answer_name
+        # from the `prefix` keyword in the test case
+        if self.options.answer_name is None and self.prefix:
+            pyver = "py{}{}".format(sys.version_info.major,
+                                    sys.version_info.minor)
+            self.prefix = "{}_{}".format(pyver, self.prefix)
+
+            answer_store_dir = os.path.realpath(self.options.output_dir)
+            ref_name = "%s/%s/%s" % (answer_store_dir, self.prefix, self.prefix)
+            self.reference_storage.reference_name = ref_name
+            self.reference_storage.answer_name = self.prefix
+
+            # If we are generating golden answers (passed --answer-store arg):
+            # - create the answer directory for this test
+            # - self.reference_storage.answer_name will be path to answer files
+            if self.options.store_results:
+                answer_test_dir = "%s/%s" % (answer_store_dir, self.prefix)
+                if not os.path.isdir(answer_test_dir):
+                    os.makedirs(answer_test_dir)
+                self.reference_storage.reference_name = None
+                self.reference_storage.answer_name = ref_name
+
         if self.reference_storage.reference_name is not None:
+            # Compare test generated values against the golden answer
             dd = self.reference_storage.get(self.storage_name)
             if dd is None or self.description not in dd:
                 raise YTNoOldAnswer(
@@ -351,6 +384,7 @@ class AnswerTestingTest(object):
             ov = dd[self.description]
             self.compare(nv, ov)
         else:
+            # Store results, hence do nothing (in case of --answer-store arg)
             ov = None
         self.result_storage[self.storage_name][self.description] = nv
 


### PR DESCRIPTION
## PR Summary

For an answer testing test, if we specify `prefix` then it should be compared against the data file in `prefix` directory of  `answer-store`.  However, it is not the case currently.

With this fix, all the answer tests could be executed with just one `nosetests` command.

For example, with the following command all the tests having the decorator `@attr("answer_test")` could be executed (all these tests are of type answer test).
```
nosetests --attr "answer_test" --with-answer-testing --nologcapture -d -v --local --local-dir=answer-store yt
```

 Without this fix, we have to pass one more parameter 
`--answer-name="name_of_the_answer_file_in_answer_store"` and execute each of the answer tests one by one.


## PR Checklist

- [X] Code passes flake8 checker
- [ ] **TODO:** Update the doc [Answer Testing](http://yt-project.org/doc/developing/testing.html#answer-testing) with `prefix` usage 

## Adding Reviewers
@ngoldbaum @Xarthisius @colinmarc