### PR TITLE
[Experiment] coverage report from jenkins

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,3 +8,6 @@ coverage:
     patch:
       default:
         threshold: 100%
+
+codecov:
+  token: 4c73bd46-5ea2-4c6f-8dd1-8422f5490455

--- a/tests/nose_runner.py
+++ b/tests/nose_runner.py
@@ -1,4 +1,3 @@
-import subprocess
 import sys
 import os
 import yaml
@@ -130,10 +129,3 @@ if __name__ == "__main__":
         cov.stop()
         cov.combine()
         cov.xml_report(outfile="coverage.xml", ignore_errors=True)
-        try:
-            res = subprocess.check_output('codecov', stderr=subprocess.STDOUT,
-                                          universal_newlines=True, shell=True)
-            print(res)
-        except subprocess.CalledProcessError as e:
-            print("Error while uploading coverage data.")
-            print(e.output)

--- a/tests/nose_runner.py
+++ b/tests/nose_runner.py
@@ -1,8 +1,15 @@
+import subprocess
 import sys
 import os
 import yaml
 import multiprocessing
 import nose
+
+from coverage import Coverage
+cov = Coverage(config_file=".coveragerc", branch=True, auto_data=True,
+               concurrency="multiprocessing")
+cov.start()
+
 from yt.extern.six import StringIO
 from yt.config import ytcfg
 from yt.utilities.answer_testing.framework import AnswerTesting
@@ -94,27 +101,39 @@ def generate_tasks_input():
     return args
 
 if __name__ == "__main__":
-    # multiprocessing.log_to_stderr(logging.DEBUG)
-    tasks = multiprocessing.JoinableQueue()
-    results = multiprocessing.Queue()
+    try:
+        # multiprocessing.log_to_stderr(logging.DEBUG)
+        tasks = multiprocessing.JoinableQueue()
+        results = multiprocessing.Queue()
 
-    num_consumers = int(os.environ.get('NUM_WORKERS', 6))
-    consumers = [NoseWorker(tasks, results) for i in range(num_consumers)]
-    for w in consumers:
-        w.start()
+        num_consumers = int(os.environ.get('NUM_WORKERS', 6))
+        consumers = [NoseWorker(tasks, results) for i in range(num_consumers)]
+        for w in consumers:
+            w.start()
 
-    num_jobs = 0
-    for job in generate_tasks_input():
-        if job[1]:
-            num_consumers -= 1  # take into account exclusive jobs
-        tasks.put(NoseTask(job))
-        num_jobs += 1
+        num_jobs = 0
+        for job in generate_tasks_input():
+            if job[1]:
+                num_consumers -= 1  # take into account exclusive jobs
+            tasks.put(NoseTask(job))
+            num_jobs += 1
 
-    for i in range(num_consumers):
-        tasks.put(None)
+        for i in range(num_consumers):
+            tasks.put(None)
 
-    tasks.join()
+        tasks.join()
 
-    while num_jobs:
-        result = results.get()
-        num_jobs -= 1
+        while num_jobs:
+            result = results.get()
+            num_jobs -= 1
+    finally:
+        cov.stop()
+        cov.combine()
+        cov.xml_report(outfile="coverage.xml", ignore_errors=True)
+        try:
+            res = subprocess.check_output('codecov', stderr=subprocess.STDOUT,
+                                          universal_newlines=True, shell=True)
+            print(res)
+        except subprocess.CalledProcessError as e:
+            print("Error while uploading coverage data.")
+            print(e.output)


### PR DESCRIPTION
## PR Summary

Generating coverage report at Jenkins and uploading it to yt's [codecov](https://codecov.io/gh/yt-project/yt).

- Due to `Coverage`, the runtime at Jenkins has increased which can be seen in [`py3` Jenkins run](https://tests.yt-project.org/job/yt_py3_git/375/console) where we exit due to reaching the timeout mark (90 mins). Either we have to increase the execution limit or disable `Coverage` at Jenkins (reject this PR).  

- The `subprocess` call with `codecov` command in the PR is just to check if uploading to yt's codecov works or not. If this PR is accepted, I need to update the PR by removing this call and adding this step in the Jenkins configuration file.

## PR Checklist

- [X] Code passes flake8 checker

## Adding Reviewers
@ngoldbaum @Xarthisius @colinmarc