### PR TITLE
[bugfix] python3 fix for selection in dm-only Enzo data

### DIFF
--- a/yt/geometry/grid_geometry_handler.py
+++ b/yt/geometry/grid_geometry_handler.py
@@ -283,8 +283,6 @@ class GridIndex(Index):
     def _identify_base_chunk(self, dobj):
         fast_index = None
         def _gsort(g):
-            if g.filename is None:
-                return g.id
             return g.filename
         if dobj._type_name == "grid":
             dobj._chunk_info = np.empty(1, dtype='object')
@@ -293,7 +291,8 @@ class GridIndex(Index):
             gi = dobj.selector.select_grids(self.grid_left_edge,
                                             self.grid_right_edge,
                                             self.grid_levels)
-            grids = list(sorted(self.grids[gi], key = _gsort))
+            grids = sorted([g for g in self.grids[gi]
+                            if g.filename is not None], key=_gsort)
             dobj._chunk_info = np.empty(len(grids), dtype='object')
             for i, g in enumerate(grids):
                 dobj._chunk_info[i] = g


### PR DESCRIPTION
This fixes a corner case for data selection in dark matter only Enzo datasets in Python 3.

In an Enzo dm-only dataset, grids with no particles do not have an associated filename.  In Python 2, sorting will happily and meaninglessly sort objects of different type, but Python 3 doesn't like that.  This fix removes grids with no filename from the selection list entirely. This is ok because we don't want them anyway.

I would add a test, but the dataset in which I can reproduce this is 2 GB and it may be difficult to reproduce. I don't know how often you end up with dark matter only datasets with grids that have no particles.

Who thought there were any py2->py3 bugs left?