### PR TITLE
Improve GIZMO fields

### DIFF
--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -1669,6 +1669,16 @@ loaded and aliased to ``("PartType0", "particle_magnetic_field")``. The
 corresponding component field like ``("PartType0", "particle_magnetic_field_x")``
 would be added automatically.
 
+Note that ``("PartType4", "StellarFormationTime")`` field has different
+meanings depending on whether it is a cosmological simulation. For cosmological
+runs this is the scale factor at the redshift when the star particle formed.
+For non-cosmological runs it is the time when the star particle formed. (See the
+`GIZMO User Guide <http://www.tapir.caltech.edu/~phopkins/Site/GIZMO_files/gizmo_documentation.html>`_)
+For this reason, ``("PartType4", "StellarFormationTime")`` is loaded as a
+dimensionless field. We defined two related fields
+``("PartType4", "creation_time")``, and ``("PartType4", "age")`` with physical
+units for your convenience.
+
 For Gizmo outputs written as raw binary outputs, you may have to specify
 a bounding box, field specification, and units as are done for standard
 Gadget outputs.  See :ref:`loading-gadget-data` for more information.

--- a/yt/frontends/gizmo/fields.py
+++ b/yt/frontends/gizmo/fields.py
@@ -32,25 +32,20 @@ metal_elements = ["He", "C", "N", "O", "Ne",
                   "Mg", "Si", "S", "Ca", "Fe"]
 
 class GizmoFieldInfo(GadgetFieldInfo):
+    # The known fields list is according to the GIZMO User Guide. See
+    # http://www.tapir.caltech.edu/~phopkins/Site/GIZMO_files/gizmo_documentation.html#snaps-reading
     known_particle_fields = (
-        ("Mass", ("code_mass", ["particle_mass"], None)),
-        ("Masses", ("code_mass", ["particle_mass"], None)),
         ("Coordinates", ("code_length", ["particle_position"], None)),
-        ("Velocity", ("code_velocity", ["particle_velocity"], None)),
         ("Velocities", ("code_velocity", ["particle_velocity"], None)),
-        ("MagneticField", ("code_magnetic", ["particle_magnetic_field"], None)),
         ("ParticleIDs", ("", ["particle_index"], None)),
+        ("Masses", ("code_mass", ["particle_mass"], None)),
         ("InternalEnergy", ("code_specific_energy", ["thermal_energy"], None)),
-        ("SmoothingLength", ("code_length", ["smoothing_length"], None)),
         ("Density", ("code_mass / code_length**3", ["density"], None)),
-        ("MaximumTemperature", ("K", [], None)),
-        ("Temperature", ("K", ["temperature"], None)),
-        ("Epsilon", ("code_length", [], None)),
-        ("Metals", ("code_metallicity", ["metallicity"], None)),
-        ("Metallicity", ("code_metallicity", ["metallicity"], None)),
-        ("Phi", ("code_length", [], None)),
+        ("SmoothingLength", ("code_length", ["smoothing_length"], None)),
+        ("ElectronAbundance", ("", [], None)),
+        ("NeutralHydrogenAbundance", ("", [], None)),
         ("StarFormationRate", ("Msun / yr", [], None)),
-        ("FormationTime", ("code_time", ["creation_time"], None)),
+        ("Metallicity", ("code_metallicity", ["metallicity"], None)),
         ("Metallicity_00", ("", ["metallicity"], None)),
         ("Metallicity_01", ("", ["He_metallicity"], None)),
         ("Metallicity_02", ("", ["C_metallicity"], None)),
@@ -62,6 +57,15 @@ class GizmoFieldInfo(GadgetFieldInfo):
         ("Metallicity_08", ("", ["S_metallicity"], None)),
         ("Metallicity_09", ("", ["Ca_metallicity"], None)),
         ("Metallicity_10", ("", ["Fe_metallicity"], None)),
+        ("ArtificialViscosity", ("", [], None)),
+        ("MagneticField",
+         ("code_magnetic", ["particle_magnetic_field"], None)),
+        ("DivergenceOfMagneticField",
+         ("code_magnetic / code_length", [], None)),
+        ("StellarFormationTime", ("code_time", ["creation_time"], None)),
+        ("BH_Mass", ("code_mass", [], None)),
+        ("BH_Mdot", ("code_mass / code_time", [], None)),
+        ("BH_Mass_AlphaDisk", ("code_mass", [], None)),
     )
 
     def __init__(self, *args, **kwargs):

--- a/yt/frontends/gizmo/tests/test_outputs.py
+++ b/yt/frontends/gizmo/tests/test_outputs.py
@@ -48,7 +48,7 @@ gmhd_bbox = [[-400, 400]] * 3
 
 @requires_ds(g64, big_data=True)
 def test_gizmo_64():
-    ds = data_dir_load(g64)
+    ds = yt.load(g64)
     assert isinstance(ds, GizmoDataset)
     for test in sph_answer(ds, 'snap_N64L16_135', 524288, fields):
         test_gizmo_64.__name__ = test.description

--- a/yt/frontends/gizmo/tests/test_outputs.py
+++ b/yt/frontends/gizmo/tests/test_outputs.py
@@ -25,7 +25,6 @@ from yt.utilities.answer_testing.framework import \
 from yt.frontends.gizmo.api import GizmoDataset
 from yt.frontends.gizmo.fields import metal_elements
 
-FIRE_m12i = 'FIRE_M12i_ref11/snapshot_600.hdf5'
 
 # This maps from field names to weight field names to use for projections
 fields = OrderedDict(

--- a/yt/frontends/gizmo/tests/test_outputs.py
+++ b/yt/frontends/gizmo/tests/test_outputs.py
@@ -17,6 +17,8 @@ Gizmo frontend tests
 from collections import OrderedDict
 
 import yt
+from yt.testing import \
+    requires_file
 from yt.utilities.answer_testing.framework import \
     requires_ds, \
     sph_answer
@@ -53,7 +55,7 @@ def test_gizmo_64():
         yield test
 
 
-@requires_ds(gmhd, big_data=True)
+@requires_file(gmhd)
 def test_gizmo_mhd():
     """
     Magnetic fields should be loaded correctly when they are present.
@@ -75,7 +77,7 @@ def test_gizmo_mhd():
         assert f.shape == (409013,)
 
 
-@requires_ds(gmhd, big_data=True)
+@requires_file(gmhd)
 def test_gas_particle_fields():
     """
     Test fields set up in GizmoFieldInfo.setup_gas_particle_fields.
@@ -108,7 +110,7 @@ def test_gas_particle_fields():
         assert (ptype, field) in ds.derived_field_list
 
 
-@requires_ds(gmhd, big_data=True)
+@requires_file(gmhd)
 def test_star_particle_fields():
     """
     Test fields set up in GizmoFieldInfo.setup_star_particle_fields.

--- a/yt/frontends/gizmo/tests/test_outputs.py
+++ b/yt/frontends/gizmo/tests/test_outputs.py
@@ -16,11 +16,12 @@ Gizmo frontend tests
 
 from collections import OrderedDict
 
+import yt
 from yt.utilities.answer_testing.framework import \
-    data_dir_load, \
     requires_ds, \
     sph_answer
 from yt.frontends.gizmo.api import GizmoDataset
+from yt.frontends.gizmo.fields import metal_elements
 
 FIRE_m12i = 'FIRE_M12i_ref11/snapshot_600.hdf5'
 
@@ -40,6 +41,7 @@ fields = OrderedDict(
 
 g64 = "gizmo_64/output/snap_N64L16_135.hdf5"
 gmhd = "gizmo_mhd_mwdisk/gizmo_mhd_mwdisk.hdf5"
+gmhd_bbox = [[-400, 400]] * 3
 
 
 @requires_ds(g64, big_data=True)
@@ -56,11 +58,7 @@ def test_gizmo_mhd():
     """
     Magnetic fields should be loaded correctly when they are present.
     """
-    kwargs = {
-        'bounding_box': [[-400, 400]] * 3,
-        'unit_system': 'code'
-    }
-    ds = data_dir_load(gmhd, kwargs=kwargs)
+    ds = yt.load(gmhd, bounding_box=gmhd_bbox, unit_system='code')
     ad = ds.all_data()
     ptype = 'PartType0'
 
@@ -75,3 +73,52 @@ def test_gizmo_mhd():
         f = ad[ptype, fmag + '_' + axis]
         assert str(f.units) == 'code_magnetic'
         assert f.shape == (409013,)
+
+
+@requires_ds(gmhd, big_data=True)
+def test_gas_particle_fields():
+    """
+    Test fields set up in GizmoFieldInfo.setup_gas_particle_fields.
+    """
+    ds = yt.load(gmhd, bounding_box=gmhd_bbox)
+
+    ptype = "PartType0"
+    derived_fields = []
+    # Add species fields
+    for species in ["H", "H_p0", "H_p1"]:
+        for suffix in ["density", "fraction", "mass", "number_density"]:
+            derived_fields += ["%s_%s" % (species, suffix)]
+    for species in metal_elements:
+        derived_fields += ["%s_nuclei_mass_density" % species]
+    # Add magnetic fields
+    derived_fields += ["particle_magnetic_field_%s" % axis for axis in "xyz"]
+    # Check
+    for field in derived_fields:
+        assert (ptype, field) in ds.derived_field_list
+    
+    ptype = "gas"
+    derived_fields = []
+    for species in ["H", "H_p0", "H_p1"]:
+        for suffix in ["density", "number_density"]:
+            derived_fields += ["%s_%s" % (species, suffix)]
+    for species in metal_elements:
+        for suffix in ["nuclei_mass_density", "metallicity"]:
+            derived_fields += ["%s_%s" % (species, suffix)]
+    for field in derived_fields:
+        assert (ptype, field) in ds.derived_field_list
+
+
+@requires_ds(gmhd, big_data=True)
+def test_star_particle_fields():
+    """
+    Test fields set up in GizmoFieldInfo.setup_star_particle_fields.
+    """
+    ds = yt.load(gmhd, bounding_box=gmhd_bbox)
+
+    ptype = "PartType4"
+    derived_fields =[
+        "creation_time",
+        "age"
+    ]
+    for field in derived_fields:
+        assert (ptype, field) in ds.derived_field_list


### PR DESCRIPTION
## PR Summary

This PR aims to improve GIZMO frontend's field system. The following are done:

- The field list is cleaned up according to the GIZMO User Manual.
- New derived fields are added:
  - Star creation time: `("PartType4", "creation_time")`
  - Star age: `("PartType4", "creation_time")`

While I'm at it, if you have any suggestions about GIZMO fields, I'm willing to add them to this PR.

## PR Checklist

- [x] Code passes flake8 checker
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.
