### PR TITLE
add masked I/O to unstructured mesh frontends

### DIFF
--- a/yt/frontends/exodus_ii/io.py
+++ b/yt/frontends/exodus_ii/io.py
@@ -86,6 +86,7 @@ class IOHandlerExodusII(BaseIOHandler):
                                                        (field_ind + 1, mesh_id)][:]
                         data = fdata[self.ds.step, :]
                         ind += g.select(selector, data, rv[field], ind)  # caches
+                rv[field] = rv[field][:ind]
             return rv
 
     def _read_chunk_data(self, chunk, fields):

--- a/yt/frontends/stream/io.py
+++ b/yt/frontends/stream/io.py
@@ -294,5 +294,6 @@ class IOHandlerStreamUnstructured(BaseIOHandler):
                     f = ('connect%d' % (g.mesh_id + 1), fname)
                     ds = self.fields[g.mesh_id][f]
                 ind += g.select(selector, ds, rv[field], ind) # caches
+            rv[field] = rv[field][:ind]
         return rv
 

--- a/yt/visualization/tests/test_mesh_slices.py
+++ b/yt/visualization/tests/test_mesh_slices.py
@@ -52,20 +52,36 @@ def test_mesh_slices_amr():
 @attr(ANSWER_TEST_TAG)
 def test_mesh_slices_tetrahedral():
     ds = fake_tetrahedral_ds()
+
+    mesh = ds.index.meshes[0]
+    ad = ds.all_data()
+
     for field in ds.field_list:
         for idir in [0, 1, 2]:
             prefix = "%s_%s_%s" % (field[0], field[1], idir)
             yield compare(ds, field, idir, test_prefix=prefix,
                           test_name="mesh_slices_tetrahedral", annotate=True)
 
+            sl_obj = ds.slice(idir, ds.domain_center[idir])
+            assert sl_obj[field].shape[0] == mesh.count(sl_obj.selector)
+            assert sl_obj[field].shape[0] < ad[field].shape[0]
+
 @attr(ANSWER_TEST_TAG)
 def test_mesh_slices_hexahedral():
+    # hexahedral ds
     ds = fake_hexahedral_ds()
+    ad = ds.all_data()
+    mesh = ds.index.meshes[0]
+
     for field in ds.field_list:
         for idir in [0, 1, 2]:
             prefix = "%s_%s_%s" % (field[0], field[1], idir)
             yield compare(ds, field, idir, test_prefix=prefix,
                           test_name="mesh_slices_hexahedral", annotate=True)
+
+            sl_obj = ds.slice(idir, ds.domain_center[idir])
+            assert sl_obj[field].shape[0] == mesh.count(sl_obj.selector)
+            assert sl_obj[field].shape[0] < ad[field].shape[0]
 
 def test_perfect_element_intersection():
     # This test tests mesh line annotation where a z=0 slice


### PR DESCRIPTION
closes #1916 

This makes it so that data object accesses on unstructured mesh data return data with the correct shape (i.e. not equal to the shape of the total number of mesh elements in the dataset).

As far as I can tell, this was not a problem until now because the unstructured mesh pixelizer uses `ds.all_data()` to generate the data it needs to feed to the pixelizer. I think with this change in principle we could use a slice data object there.

Do I need to touch other places? I'm not sure. Maybe the PYNE/MOAB frontend? @munkm this might impact your Denuvo frontend.