### PR TITLE
[bugfix] Alternate fix for PR #1912

### DIFF
--- a/yt/geometry/grid_geometry_handler.py
+++ b/yt/geometry/grid_geometry_handler.py
@@ -282,10 +282,6 @@ class GridIndex(Index):
 
     def _identify_base_chunk(self, dobj):
         fast_index = None
-        def _gsort(g):
-            if g.filename is None:
-                return str(g.id)
-            return g.filename
         if dobj._type_name == "grid":
             dobj._chunk_info = np.empty(1, dtype='object')
             dobj._chunk_info[0] = weakref.proxy(dobj)
@@ -293,6 +289,10 @@ class GridIndex(Index):
             gi = dobj.selector.select_grids(self.grid_left_edge,
                                             self.grid_right_edge,
                                             self.grid_levels)
+            if any([g.filename is not None for g in self.grids[gi]]):
+                _gsort = _grid_sort_mixed
+            else:
+                _gsort = _grid_sort_id
             grids = list(sorted(self.grids[gi], key = _gsort))
             dobj._chunk_info = np.empty(len(grids), dtype='object')
             for i, g in enumerate(grids):
@@ -387,3 +387,12 @@ class GridIndex(Index):
                 with self.io.preload(dc, preload_fields, 
                             4.0 * size):
                     yield dc
+
+
+def _grid_sort_id(g):
+    return g.id
+
+def _grid_sort_mixed(g):
+    if g.filename is None:
+        return str(g.id)
+    return g.filename

--- a/yt/geometry/grid_geometry_handler.py
+++ b/yt/geometry/grid_geometry_handler.py
@@ -284,7 +284,7 @@ class GridIndex(Index):
         fast_index = None
         def _gsort(g):
             if g.filename is None:
-                return g.id
+                return str(g.id)
             return g.filename
         if dobj._type_name == "grid":
             dobj._chunk_info = np.empty(1, dtype='object')
@@ -356,7 +356,8 @@ class GridIndex(Index):
         gobjs = getattr(dobj._current_chunk, "objs", dobj._chunk_info)
         fast_index = dobj._current_chunk._fast_index
         for g in gobjs:
-            gfiles[g.filename].append(g)
+            # Force to be a string because sometimes g.filename is None.
+            gfiles[str(g.filename)].append(g)
         # We can apply a heuristic here to make sure we aren't loading too
         # many grids all at once.
         if chunk_sizing == "auto":


### PR DESCRIPTION
This is an alternative implementation of the bugfix PR #1912.

After @MatthewTurk's comment, I've implemented a fix that does not remove grids where the `filename` is None and instead allows them to be sorted and potentially operated on. This may be safer than what I did in PR #1912. Only one of these two should be accepted.