### PR TITLE
Adds display_threshold option to StreamlineCallback

### DIFF
--- a/doc/source/visualizing/callbacks.rst
+++ b/doc/source/visualizing/callbacks.rst
@@ -498,7 +498,8 @@ Overplot Streamlines
 ~~~~~~~~~~~~~~~~~~~~
 
 .. function:: annotate_streamlines(self, field_x, field_y, factor=16, \
-                                   density = 1, plot_args=None)
+                                   density=1, display_threshold=None, \
+                                   plot_args=None)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.StreamlineCallback`.)

--- a/yt/visualization/tests/test_callbacks.py
+++ b/yt/visualization/tests/test_callbacks.py
@@ -46,7 +46,7 @@ import contextlib
 #  X quiver
 #  X contour
 #  X grids
-#    streamlines
+#  X streamlines
 #    units
 #  X line
 #    cquiver
@@ -591,6 +591,62 @@ def test_mesh_lines_callback():
             sl.annotate_mesh_lines(plot_args={'color':'black'})
             assert_fname(sl.save(prefix)[0])
                 
+@requires_file(cyl_2d)
+def test_streamline_callback():
+
+    with _cleanup_fname() as prefix:
+
+        ds = fake_amr_ds(fields=("density", "velocity_x", "velocity_y", "magvel"))
+
+        for ax in 'xyz':
+
+            # Projection plot tests
+            p = ProjectionPlot(ds, ax, "density")
+            p.annotate_streamlines("velocity_x", "velocity_y")
+            assert_fname(p.save(prefix)[0])
+
+            p = ProjectionPlot(ds, ax, "density", weight_field="density")
+            p.annotate_streamlines("velocity_x", "velocity_y")
+            assert_fname(p.save(prefix)[0])
+
+            # Slice plot test
+            p = SlicePlot(ds, ax, "density")
+            p.annotate_streamlines("velocity_x", "velocity_y")
+            assert_fname(p.save(prefix)[0])
+
+            # Additional features
+            p = SlicePlot(ds, ax, "density")
+            p.annotate_streamlines("velocity_x", "velocity_y", factor=32, density=4)
+            assert_fname(p.save(prefix)[0])
+
+            p = SlicePlot(ds, ax, "density")
+            p.annotate_streamlines("velocity_x", "velocity_y", field_color="magvel")
+            assert_fname(p.save(prefix)[0])
+
+            p = SlicePlot(ds, ax, "density")
+            p.annotate_streamlines("velocity_x", "velocity_y", field_color="magvel",
+                                   display_threshold=0.5,
+                                   plot_args={'cmap': ytcfg.get("yt", "default_colormap"),
+                                              'arrowstyle': '->'})
+            assert_fname(p.save(prefix)[0])
+
+    # Axisymmetric dataset
+    with _cleanup_fname() as prefix:
+
+        ds = load(cyl_2d)
+        slc = SlicePlot(ds, "theta", "density")
+        slc.annotate_streamlines("magnetic_field_r", "magnetic_field_z")
+        assert_fname(slc.save(prefix)[0])
+
+    # Spherical dataset
+    with _cleanup_fname() as prefix:
+
+        ds = fake_amr_ds(fields=("density", "velocity_r",
+                                 "velocity_theta", "velocity_phi"),
+                                 geometry="spherical")
+        p = SlicePlot(ds, "r", "density")
+        p.annotate_streamlines("velocity_theta", "velocity_phi")
+        assert_raises(YTDataTypeUnsupported, p.save, prefix)
 
 @requires_file(cyl_2d)
 def test_line_integral_convolution_callback():


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

Adds a feature to the StreamlineCallback that suppresses streamline segments where the color field fails to meet a given threshold. Also added a test for the callback.

**Note:** It is doubtful that the test ran properly - I may be having issues with my nose installation. If someone could make certain that the test executes and passes that would be appreciated.

<!--If it fixes an open issue, please link to the issue here.-->

The feature was discussed in issue #1921.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
