### PR TITLE
set verbosity to 2 in nose config

### DIFF
--- a/nose.cfg
+++ b/nose.cfg
@@ -6,6 +6,6 @@ cover-package=yt
 detailed-errors=1
 exclude=answer_testing
 nocapture=1
-verbosity=1
+verbosity=2
 where=yt
 with-timer=1


### PR DESCRIPTION
This lets us more easily see what tests are running on travis. We've recently been seeing random test failures (probably due to using too much memory somewhere or a new memory leak) and I want to know what test it's dying on.