### PR TITLE
In boxlib/data_structures split using os.sep

### DIFF
--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -1350,7 +1350,7 @@ def _guess_pcast(vals):
 
 def _read_raw_field_names(raw_file):
     header_files = glob.glob(raw_file + "*_H")
-    return [hf.split("/")[-1][:-2] for hf in header_files]
+    return [hf.split(os.sep)[-1][:-2] for hf in header_files]
 
 
 def _string_to_numpy_array(s):
@@ -1559,7 +1559,7 @@ class WarpXDataset(BoxlibDataset):
         self.periodicity = ensure_tuple(periodicity)
 
         particle_types = glob.glob(self.output_dir + "/*/Header")
-        particle_types = [cpt.split("/")[-2] for cpt in particle_types]
+        particle_types = [cpt.split(os.sep)[-2] for cpt in particle_types]
         if len(particle_types) > 0:
             self.parameters["particles"] = 1
             self.particle_types = tuple(particle_types)
@@ -1606,7 +1606,7 @@ class AMReXDataset(BoxlibDataset):
     def _parse_parameter_file(self):
         super(AMReXDataset, self)._parse_parameter_file()
         particle_types = glob.glob(self.output_dir + "/*/Header")
-        particle_types = [cpt.split("/")[-2] for cpt in particle_types]
+        particle_types = [cpt.split(os.sep)[-2] for cpt in particle_types]
         if len(particle_types) > 0:
             self.parameters["particles"] = 1
             self.particle_types = tuple(particle_types)


### PR DESCRIPTION

## PR Summary

Fixes `IndexError: list index out of range` while executing following script in windows:

```python
import yt
from yt.utilities.answer_testing.framework import data_dir_load
raw_fields = "Laser/plt00015"
ds = data_dir_load(raw_fields)
```

[Full error log](http://paste.yt-project.org/show/43/)

## PR Checklist
- [X] Code passes flake8 checker