### PR TITLE
use sudo infra on travis to get more RAM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
-sudo: false
+sudo: required
+dist: precise
 cache:
   pip: true
   directories:


### PR DESCRIPTION
I don't see any memory issues when I run the tests locally on a linux box. Since I'm still not sure what the problem is let's try papering it over by using the `sudo: required` hosts on travis which have more RAM.