### PR TITLE
fix test fixture

### DIFF
--- a/yt/fields/tests/test_fields_plugins.py
+++ b/yt/fields/tests/test_fields_plugins.py
@@ -25,38 +25,37 @@ def myfunc():
 foobar = 12
 '''
 
-
-def setUpModule():
-    my_plugin_name = ytcfg.get('yt', 'pluginfilename')
-    # In the following order if pluginfilename is: an absolute path, located in
-    # the CONFIG_DIR, located in an obsolete config dir.
-    old_config_dir = os.path.join(os.path.expanduser('~'), '.yt')
-    for base_prefix in ('', CONFIG_DIR, old_config_dir):
-        potential_plugin_file = os.path.join(base_prefix, my_plugin_name)
-        if os.path.isfile(potential_plugin_file):
-            os.rename(potential_plugin_file,
-                      potential_plugin_file + '.bak_test')
-
-    plugin_file = os.path.join(CONFIG_DIR, my_plugin_name)
-    with open(plugin_file, 'w') as fh:
-        fh.write(TEST_PLUGIN_FILE)
-
-
-def tearDownModule():
-    my_plugin_name = ytcfg.get('yt', 'pluginfilename')
-    plugin_file = os.path.join(CONFIG_DIR, my_plugin_name)
-    os.remove(plugin_file)
-
-    old_config_dir = os.path.join(os.path.expanduser('~'), '.yt')
-    for base_prefix in ('', CONFIG_DIR, old_config_dir):
-        potential_plugin_file = os.path.join(base_prefix, my_plugin_name)
-        if os.path.isfile(potential_plugin_file + '.bak_test'):
-            os.rename(potential_plugin_file + '.bak_test',
-                      potential_plugin_file)
-    del yt.myfunc
-
-
 class TestPluginFile(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        my_plugin_name = ytcfg.get('yt', 'pluginfilename')
+        # In the following order if pluginfilename is: an absolute path, located in
+        # the CONFIG_DIR, located in an obsolete config dir.
+        old_config_dir = os.path.join(os.path.expanduser('~'), '.yt')
+        for base_prefix in ('', CONFIG_DIR, old_config_dir):
+            potential_plugin_file = os.path.join(base_prefix, my_plugin_name)
+            if os.path.isfile(potential_plugin_file):
+                os.rename(potential_plugin_file,
+                          potential_plugin_file + '.bak_test')
+
+        plugin_file = os.path.join(CONFIG_DIR, my_plugin_name)
+        with open(plugin_file, 'w') as fh:
+            fh.write(TEST_PLUGIN_FILE)
+
+    @classmethod
+    def tearDownClass(cls):
+        my_plugin_name = ytcfg.get('yt', 'pluginfilename')
+        plugin_file = os.path.join(CONFIG_DIR, my_plugin_name)
+        os.remove(plugin_file)
+
+        old_config_dir = os.path.join(os.path.expanduser('~'), '.yt')
+        for base_prefix in ('', CONFIG_DIR, old_config_dir):
+            potential_plugin_file = os.path.join(base_prefix, my_plugin_name)
+            if os.path.isfile(potential_plugin_file + '.bak_test'):
+                os.rename(potential_plugin_file + '.bak_test',
+                          potential_plugin_file)
+        del yt.myfunc
 
     def testCustomField(self):
         plugin_file = os.path.join(


### PR DESCRIPTION
## PR Summary

Running `nosetests` with `--attr` for `test_fields_plugins.py` results in error, that is `nosetests --attr answer_test -svd yt\fields\tests\test_fields_plugins.py`

```shell
======================================================================
ERROR: test suite for <module 'yt.fields.tests.test_fields_plugins' from 'e:\\devworkspace\\yt-git\\yt\\fields\\tests\\test_fields_plugins.py'>
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Abhishek\Softwares\Anaconda3\lib\site-packages\nose\suite.py", line 228, in run
    self.tearDown()
  File "C:\Abhishek\Softwares\Anaconda3\lib\site-packages\nose\suite.py", line 351, in tearDown
    self.teardownContext(ancestor)
  File "C:\Abhishek\Softwares\Anaconda3\lib\site-packages\nose\suite.py", line 367, in teardownContext
    try_run(context, names)
  File "C:\Abhishek\Softwares\Anaconda3\lib\site-packages\nose\util.py", line 471, in try_run
    return func()
  File "e:\devworkspace\yt-git\yt\fields\tests\test_fields_plugins.py", line 56, in tearDownModule
    del yt.myfunc
AttributeError: myfunc

----------------------------------------------------------------------
XML: E:\DevWorkspace\yt-git\nosetests.xml
----------------------------------------------------------------------
Ran 0 tests in 0.140s

FAILED (errors=1)
```

After fixing the setup and teardown  methods correctly, it works fine.

## PR Checklist
- [X] Code passes flake8 checker
