### PR TITLE
Derived quantity particles

### DIFF
--- a/doc/source/analyzing/objects.rst
+++ b/doc/source/analyzing/objects.rst
@@ -482,13 +482,14 @@ all the cells contained in a sphere at the center of our dataset.
    sp = ds.sphere('c', (10, 'kpc'))
    print(sp.quantities.angular_momentum_vector())
 
-Some quantities can be calculated for a specific particle type only. For exmaple, to 
-get the center of mass of all stars within the sphere:
+Some quantities can be calculated for a specific particle type only. For example, to 
+get the center of mass of only the stars within the sphere:
 
 .. code-block:: python
    ds=load("my_data")
    sp=ds.sphere('c',(10,'kpc'))
    print(sp.quantities.center_of_mass(use_gas=False,use_particles=True,particle_type='star'))
+
 
 Quickly Processing Data
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/analyzing/objects.rst
+++ b/doc/source/analyzing/objects.rst
@@ -482,6 +482,14 @@ all the cells contained in a sphere at the center of our dataset.
    sp = ds.sphere('c', (10, 'kpc'))
    print(sp.quantities.angular_momentum_vector())
 
+Some quantities can be calculated for a specific particle type only. For exmaple, to 
+get the center of mass of all stars within the sphere:
+
+.. code-block:: python
+   ds=load("my_data")
+   sp=ds.sphere('c',(10,'kpc'))
+   print(sp.quantities.center_of_mass(use_gas=False,use_particles=True,particle_type='star'))
+
 Quickly Processing Data
 ^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -582,15 +590,19 @@ Available Derived Quantities
 
 **Bulk Velocity**
     | Class :class:`~yt.data_objects.derived_quantities.BulkVelocity`
-    | Usage: ``bulk_velocity(use_gas=True, use_particles=True)``
+    | Usage: ``bulk_velocity(use_gas=True, use_particles=True, particle_type='all')``
     | The mass-weighted average velocity of the particles, gas, or both.
+      The quantity can be calculated for all particles or a given 
+      particle_type only.
 
 **Center of Mass**
     | Class :class:`~yt.data_objects.derived_quantities.CenterOfMass`
-    | Usage: ``center_of_mass(use_cells=True, use_particles=False)``
+    | Usage: ``center_of_mass(use_cells=True, use_particles=False, particle_type='all')``
     | The location of the center of mass. By default, it computes of
       the *non-particle* data in the object, but it can be used on
-      particles, gas, or both.
+      particles, gas, or both. The quantity can be
+      calculated for all particles or a given particle_type only.
+
 
 **Extrema**
     | Class :class:`~yt.data_objects.derived_quantities.Extrema`
@@ -621,8 +633,9 @@ Available Derived Quantities
 
 **Spin Parameter**
     | Class :class:`~yt.data_objects.derived_quantities.SpinParameter`
-    | Usage: ``spin_parameter(use_gas=True, use_particles=True)``
-    | The spin parameter for the baryons using the particles, gas, or both.
+    | Usage: ``spin_parameter(use_gas=True, use_particles=True,' particle_type='all')``
+    | The spin parameter for the baryons using the particles, gas, or both. The 
+      quantity can be calculated for all particles or a given particle_type only.
 
 **Total Mass**
     | Class :class:`~yt.data_objects.derived_quantities.TotalMass`

--- a/doc/source/analyzing/objects.rst
+++ b/doc/source/analyzing/objects.rst
@@ -635,7 +635,7 @@ Available Derived Quantities
 
 **Spin Parameter**
     | Class :class:`~yt.data_objects.derived_quantities.SpinParameter`
-    | Usage: ``spin_parameter(use_gas=True, use_particles=True,' particle_type='all')``
+    | Usage: ``spin_parameter(use_gas=True, use_particles=True, particle_type='all')``
     | The spin parameter for the baryons using the particles, gas, or both. The 
       quantity can be calculated for all particles or a given particle_type only.
 

--- a/yt/data_objects/derived_quantities.py
+++ b/yt/data_objects/derived_quantities.py
@@ -244,7 +244,7 @@ class CenterOfMass(DerivedQuantity):
 
     """
     def count_values(self, use_gas = True, use_particles = False, particle_type="all"):
-        if not particle_type in self.data_source.ds.particle_types:
+        if particle_type not in self.data_source.ds.particle_types:
             raise YTParticleTypeNotFound(particle_type,self.data_source.ds)
         use_gas &= \
           (("gas", "cell_mass") in self.data_source.ds.field_info)
@@ -320,7 +320,7 @@ class BulkVelocity(DerivedQuantity):
 
     """
     def count_values(self, use_gas = True, use_particles = False, particle_type= "all"):
-        if not particle_type in self.data_source.ds.particle_types:
+        if particle_type not in self.data_source.ds.particle_types:
             raise YTParticleTypeNotFound(particle_type,self.data_source.ds)
         # This is a list now
         self.num_vals = 0
@@ -457,7 +457,7 @@ class AngularMomentumVector(DerivedQuantity):
 
     """
     def count_values(self, use_gas=True, use_particles=True, particle_type = "all"):
-        if not particle_type in self.data_source.ds.particle_types:
+        if particle_type not in self.data_source.ds.particle_types:
             raise YTParticleTypeNotFound(particle_type,self.data_source.ds)
         num_vals = 0
         # create the index if it doesn't exist yet
@@ -716,7 +716,7 @@ class SpinParameter(DerivedQuantity):
         self.num_vals = 3
 
     def process_chunk(self, data, use_gas=True, use_particles=True, particle_type= "all"):
-        if not particle_type in self.data_source.ds.particle_types:
+        if particle_type not in self.data_source.ds.particle_types:
             raise YTParticleTypeNotFound(particle_type,self.data_source.ds)
         use_gas &= \
           (("gas", "cell_mass") in self.data_source.ds.field_info)

--- a/yt/data_objects/derived_quantities.py
+++ b/yt/data_objects/derived_quantities.py
@@ -323,7 +323,7 @@ class BulkVelocity(DerivedQuantity):
         if use_particles:
             self.num_vals += 4
 
-    def process_chunk(self, data, use_gas = True, use_particles = False  p_type= "all"):
+    def process_chunk(self, data, use_gas = True, use_particles = False, p_type= "all"):
         vals = []
         if use_gas:
             vals += [(data["gas", "velocity_%s" % ax] *

--- a/yt/data_objects/derived_quantities.py
+++ b/yt/data_objects/derived_quantities.py
@@ -228,7 +228,7 @@ class CenterOfMass(DerivedQuantity):
         Flag to include particles in the calculation.  Particles are ignored
         if not present.
         Default: False
-    p_type : str
+    particle_type : str
         Particle type to be used for Center of mass calculation when use_particle
         = True.
         Default: all
@@ -241,22 +241,22 @@ class CenterOfMass(DerivedQuantity):
     >>> print ad.quantities.center_of_mass()
 
     """
-    def count_values(self, use_gas = True, use_particles = False, p_type="all"):
+    def count_values(self, use_gas = True, use_particles = False, particle_type="all"):
         use_gas &= \
           (("gas", "cell_mass") in self.data_source.ds.field_info)
         use_particles &= \
-          ((p_type, "particle_mass") in self.data_source.ds.field_info)
+          ((particle_type, "particle_mass") in self.data_source.ds.field_info)
         self.num_vals = 0
         if use_gas:
             self.num_vals += 4
         if use_particles:
             self.num_vals += 4
 
-    def process_chunk(self, data, use_gas = True, use_particles = False, p_type="all"):
+    def process_chunk(self, data, use_gas = True, use_particles = False, particle_type="all"):
         use_gas &= \
           (("gas", "cell_mass") in self.data_source.ds.field_info)
         use_particles &= \
-          ((p_type, "particle_mass") in self.data_source.ds.field_info)
+          ((particle_type, "particle_mass") in self.data_source.ds.field_info)
         vals = []
         if use_gas:
             vals += [(data["gas", ax] *
@@ -264,10 +264,10 @@ class CenterOfMass(DerivedQuantity):
                      for ax in 'xyz']
             vals.append(data["gas", "cell_mass"].sum(dtype=np.float64))
         if use_particles:
-            vals += [(data[p_type, "particle_position_%s" % ax] *
-                      data[p_type, "particle_mass"]).sum(dtype=np.float64)
+            vals += [(data[particle_type, "particle_position_%s" % ax] *
+                      data[particle_type, "particle_mass"]).sum(dtype=np.float64)
                      for ax in 'xyz']
-            vals.append(data[p_type, "particle_mass"].sum(dtype=np.float64))
+            vals.append(data[particle_type, "particle_mass"].sum(dtype=np.float64))
         return vals
 
     def reduce_intermediate(self, values):
@@ -302,7 +302,7 @@ class BulkVelocity(DerivedQuantity):
         Flag to include particles in the calculation.  Particles are ignored
         if not present.
         Default: True
-    p_type : str
+    particle_type : str
         Particle type to be used for Center of mass calculation when use_particle
         = True.
         Default: all
@@ -315,7 +315,7 @@ class BulkVelocity(DerivedQuantity):
     >>> print ad.quantities.bulk_velocity()
 
     """
-    def count_values(self, use_gas = True, use_particles = False, p_type= "all"):
+    def count_values(self, use_gas = True, use_particles = False, particle_type= "all"):
         # This is a list now
         self.num_vals = 0
         if use_gas:
@@ -323,7 +323,7 @@ class BulkVelocity(DerivedQuantity):
         if use_particles:
             self.num_vals += 4
 
-    def process_chunk(self, data, use_gas = True, use_particles = False, p_type= "all"):
+    def process_chunk(self, data, use_gas = True, use_particles = False, particle_type= "all"):
         vals = []
         if use_gas:
             vals += [(data["gas", "velocity_%s" % ax] *
@@ -331,10 +331,10 @@ class BulkVelocity(DerivedQuantity):
                      for ax in 'xyz']
             vals.append(data["gas", "cell_mass"].sum(dtype=np.float64))
         if use_particles:
-            vals += [(data[p_type, "particle_velocity_%s" % ax] *
-                      data[p_type, "particle_mass"]).sum(dtype=np.float64)
+            vals += [(data[particle_type, "particle_velocity_%s" % ax] *
+                      data[particle_type, "particle_mass"]).sum(dtype=np.float64)
                      for ax in 'xyz']
-            vals.append(data[p_type, "particle_mass"].sum(dtype=np.float64))
+            vals.append(data[particle_type, "particle_mass"].sum(dtype=np.float64))
         return vals
 
     def reduce_intermediate(self, values):
@@ -436,7 +436,7 @@ class AngularMomentumVector(DerivedQuantity):
         Flag to include particles in the calculation.  Particles are ignored
         if not present.
         Default: True
-    p_type : str
+    particle_type : str
         Particle type to be used for Center of mass calculation when use_particle
         = True.
         Default: all
@@ -450,21 +450,21 @@ class AngularMomentumVector(DerivedQuantity):
     >>> print ad.quantities.angular_momentum_vector()
 
     """
-    def count_values(self, use_gas=True, use_particles=True, p_type = "all"):
+    def count_values(self, use_gas=True, use_particles=True, particle_type = "all"):
         num_vals = 0
         # create the index if it doesn't exist yet
         self.data_source.ds.index
         self.use_gas = use_gas & \
             (("gas", "cell_mass") in self.data_source.ds.field_info)
         self.use_particles = use_particles & \
-            ((p_type, "particle_mass") in self.data_source.ds.field_info)
+            ((particle_type, "particle_mass") in self.data_source.ds.field_info)
         if self.use_gas:
             num_vals += 4
         if self.use_particles:
             num_vals += 4
         self.num_vals = num_vals
 
-    def process_chunk(self, data, use_gas = True, use_particles = False, p_type= "all"):
+    def process_chunk(self, data, use_gas = True, use_particles = False, particle_type= "all"):
         rvals = []
         if self.use_gas:
             rvals.extend([(data["gas", "specific_angular_momentum_%s" % axis] *
@@ -472,10 +472,10 @@ class AngularMomentumVector(DerivedQuantity):
                           for axis in "xyz"])
             rvals.append(data["gas", "cell_mass"].sum(dtype=np.float64))
         if self.use_particles:
-            rvals.extend([(data[p_type, "particle_specific_angular_momentum_%s" % axis] *
-                           data[p_type, "particle_mass"]).sum(dtype=np.float64) \
+            rvals.extend([(data[particle_type, "particle_specific_angular_momentum_%s" % axis] *
+                           data[particle_type, "particle_mass"]).sum(dtype=np.float64) \
                           for axis in "xyz"])
-            rvals.append(data[p_type, "particle_mass"].sum(dtype=np.float64))
+            rvals.append(data[particle_type, "particle_mass"].sum(dtype=np.float64))
         return rvals
 
     def reduce_intermediate(self, values):
@@ -691,7 +691,7 @@ class SpinParameter(DerivedQuantity):
         Flag to include particles in the calculation.  Particles are ignored
         if not present.
         Default: True
-    p_type : str
+    particle_type : str
         Particle type to be used for Center of mass calculation when use_particle
         = True.
         Default: all
@@ -707,11 +707,11 @@ class SpinParameter(DerivedQuantity):
     def count_values(self, **kwargs):
         self.num_vals = 3
 
-    def process_chunk(self, data, use_gas=True, use_particles=True, p_type= "all"):
+    def process_chunk(self, data, use_gas=True, use_particles=True, particle_type= "all"):
         use_gas &= \
           (("gas", "cell_mass") in self.data_source.ds.field_info)
         use_particles &= \
-          ((p_type, "particle_mass") in self.data_source.ds.field_info)
+          ((particle_type, "particle_mass") in self.data_source.ds.field_info)
         e = data.ds.quan(0., "erg")
         j = data.ds.quan(0., "g*cm**2/s")
         m = data.ds.quan(0., "g")
@@ -721,10 +721,10 @@ class SpinParameter(DerivedQuantity):
             j += data["gas", "angular_momentum_magnitude"].sum(dtype=np.float64)
             m += data["gas", "cell_mass"].sum(dtype=np.float64)
         if use_particles:
-            e += (data[p_type, "particle_velocity_magnitude"]**2 *
-                  data[p_type, "particle_mass"]).sum(dtype=np.float64)
-            j += data[p_type, "particle_angular_momentum_magnitude"].sum(dtype=np.float64)
-            m += data[p_type, "particle_mass"].sum(dtype=np.float64)
+            e += (data[particle_type, "particle_velocity_magnitude"]**2 *
+                  data[particle_type, "particle_mass"]).sum(dtype=np.float64)
+            j += data[particle_type, "particle_angular_momentum_magnitude"].sum(dtype=np.float64)
+            m += data[particle_type, "particle_mass"].sum(dtype=np.float64)
         return (e, j, m)
 
     def reduce_intermediate(self, values):

--- a/yt/data_objects/derived_quantities.py
+++ b/yt/data_objects/derived_quantities.py
@@ -27,6 +27,8 @@ from yt.utilities.physical_constants import \
     gravitational_constant_cgs
 from yt.utilities.physical_ratios import HUGE
 from yt.extern.six import add_metaclass
+from yt.utilities.exceptions import \
+    YTParticleTypeNotFound
 
 derived_quantity_registry = {}
 
@@ -242,6 +244,8 @@ class CenterOfMass(DerivedQuantity):
 
     """
     def count_values(self, use_gas = True, use_particles = False, particle_type="all"):
+        if not particle_type in self.data_source.ds.particle_types:
+            raise YTParticleTypeNotFound(particle_type,self.data_source.ds)
         use_gas &= \
           (("gas", "cell_mass") in self.data_source.ds.field_info)
         use_particles &= \
@@ -316,6 +320,8 @@ class BulkVelocity(DerivedQuantity):
 
     """
     def count_values(self, use_gas = True, use_particles = False, particle_type= "all"):
+        if not particle_type in self.data_source.ds.particle_types:
+            raise YTParticleTypeNotFound(particle_type,self.data_source.ds)
         # This is a list now
         self.num_vals = 0
         if use_gas:
@@ -451,6 +457,8 @@ class AngularMomentumVector(DerivedQuantity):
 
     """
     def count_values(self, use_gas=True, use_particles=True, particle_type = "all"):
+        if not particle_type in self.data_source.ds.particle_types:
+            raise YTParticleTypeNotFound(particle_type,self.data_source.ds)
         num_vals = 0
         # create the index if it doesn't exist yet
         self.data_source.ds.index
@@ -708,6 +716,8 @@ class SpinParameter(DerivedQuantity):
         self.num_vals = 3
 
     def process_chunk(self, data, use_gas=True, use_particles=True, particle_type= "all"):
+        if not particle_type in self.data_source.ds.particle_types:
+            raise YTParticleTypeNotFound(particle_type,self.data_source.ds)
         use_gas &= \
           (("gas", "cell_mass") in self.data_source.ds.field_info)
         use_particles &= \

--- a/yt/data_objects/derived_quantities.py
+++ b/yt/data_objects/derived_quantities.py
@@ -245,7 +245,7 @@ class CenterOfMass(DerivedQuantity):
 
     """
     def count_values(self, use_gas = True, use_particles = False, particle_type="all"):
-        if particle_type not in self.data_source.ds.particle_types:
+        if use_particles and particle_type not in self.data_source.ds.particle_types:
             raise YTParticleTypeNotFound(particle_type,self.data_source.ds)
         use_gas &= \
           (("gas", "cell_mass") in self.data_source.ds.field_info)
@@ -322,7 +322,7 @@ class BulkVelocity(DerivedQuantity):
 
     """
     def count_values(self, use_gas = True, use_particles = False, particle_type= "all"):
-        if particle_type not in self.data_source.ds.particle_types:
+        if use_particles and particle_type not in self.data_source.ds.particle_types:
             raise YTParticleTypeNotFound(particle_type,self.data_source.ds)
         # This is a list now
         self.num_vals = 0
@@ -466,7 +466,7 @@ class AngularMomentumVector(DerivedQuantity):
 
     """
     def count_values(self, use_gas=True, use_particles=True, particle_type = "all"):
-        if particle_type not in self.data_source.ds.particle_types:
+        if use_particles and particle_type not in self.data_source.ds.particle_types:
             raise YTParticleTypeNotFound(particle_type,self.data_source.ds)
         num_vals = 0
         # create the index if it doesn't exist yet
@@ -726,7 +726,7 @@ class SpinParameter(DerivedQuantity):
         self.num_vals = 3
 
     def process_chunk(self, data, use_gas=True, use_particles=True, particle_type= "all"):
-        if particle_type not in self.data_source.ds.particle_types:
+        if use_particles and particle_type not in self.data_source.ds.particle_types:
             raise YTParticleTypeNotFound(particle_type,self.data_source.ds)
         use_gas &= \
           (("gas", "cell_mass") in self.data_source.ds.field_info)

--- a/yt/data_objects/derived_quantities.py
+++ b/yt/data_objects/derived_quantities.py
@@ -464,7 +464,7 @@ class AngularMomentumVector(DerivedQuantity):
             num_vals += 4
         self.num_vals = num_vals
 
-    def process_chunk(self, data, **kwargs):
+    def process_chunk(self, data, use_gas = True, use_particles = False, p_type= "all"):
         rvals = []
         if self.use_gas:
             rvals.extend([(data["gas", "specific_angular_momentum_%s" % axis] *

--- a/yt/data_objects/tests/test_derived_quantities.py
+++ b/yt/data_objects/tests/test_derived_quantities.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from yt.testing import \
     fake_random_ds, \
+    fake_particle_ds, \
     assert_equal, \
     assert_rel_equal, \
     assert_almost_equal
@@ -124,30 +125,7 @@ def test_sample_at_max_field_values():
 
 def test_derived_quantities_with_particle_types():
 
-    #ds=fake_particle_data()
-    #ad=ds.all_data()
-
-    @particle_filter(requires=["particle_position_x"], filtered_type='all')
-    def low_x(pfilter,data):
-        return data['particle_position_x'].in_units('code_length')<0.5
-
-    #Create pre-defined particle dataset
-    nparts=100
-    ppx = pvx = np.array(np.linspace(0,1,nparts))
-    ppy = pvy = np.array(np.linspace(1,0,nparts))
-    ppz = pvz = ppx-ppy
-    pm = np.ones(nparts)
-
-    data={'particle_position_x':ppx,
-          'particle_position_y':ppy,
-          'particle_position_z':ppx,
-          'particle_velocity_x':pvx,
-          'particle_velocity_y':pvy,
-          'particle_velocity_z':pvz,
-          'particle_mass':pm}
-
-    bbox=np.array([[min(ppx), max(ppx)], [min(ppy), max(ppy)], [min(ppz), max(ppz)]])
-    ds = load_particles(data, n_ref=6, bbox=bbox, length_unit=parsec, mass_unit=Msun)
+    ds = fake_particle_ds()
 
     @particle_filter(requires=["particle_position_x"], filtered_type='all')
     def low_x(pfilter,data):
@@ -167,5 +145,5 @@ def test_derived_quantities_with_particle_types():
 
 
     #Check spin parameter values
-    assert_almost_equal(ad.quantities.spin_parameter(use_gas=False,use_particles=True),1.1973910384754621e+27)
-    assert_almost_equal(ad.quantities.spin_parameter(use_gas=False,use_particles=True,particle_type='low_x'),2.1171960652141979e+27)
+    assert_almost_equal(ad.quantities.spin_parameter(use_gas=False,use_particles=True),655.7311454765503)
+    assert_almost_equal(ad.quantities.spin_parameter(use_gas=False,use_particles=True,particle_type='low_x'),1309.164886405665)

--- a/yt/data_objects/tests/test_derived_quantities.py
+++ b/yt/data_objects/tests/test_derived_quantities.py
@@ -143,6 +143,9 @@ def test_derived_quantities_with_particle_types():
         com_x=(ad[(ptype,'particle_mass')]*ad[(ptype,'particle_position_x')]/ad[(ptype,'particle_mass')].sum()).sum()
         assert_almost_equal(ad.quantities.center_of_mass(use_gas=False,use_particles=True,particle_type=ptype)[0],com_x,5)
 
+        #Check angular momentum vector
+        l_x=(ad[(ptype,'particle_specific_angular_momentum_x')]*ad[(ptype,'particle_mass')]/ad[(ptype,'particle_mass')].sum()).sum()
+        assert_almost_equal(ad.quantities.angular_momentum_vector(use_gas=False,use_particles=True,particle_type=ptype)[0],l_x,5)
 
     #Check spin parameter values
     assert_almost_equal(ad.quantities.spin_parameter(use_gas=False,use_particles=True),655.7311454765503)

--- a/yt/data_objects/tests/test_derived_quantities.py
+++ b/yt/data_objects/tests/test_derived_quantities.py
@@ -8,8 +8,6 @@ from yt.testing import \
     assert_almost_equal
 
 from yt import particle_filter
-from yt import load_particles
-from yt.units import parsec, Msun
 
 def setup():
     from yt.config import ytcfg

--- a/yt/data_objects/tests/test_derived_quantities.py
+++ b/yt/data_objects/tests/test_derived_quantities.py
@@ -3,7 +3,12 @@ import numpy as np
 from yt.testing import \
     fake_random_ds, \
     assert_equal, \
-    assert_rel_equal
+    assert_rel_equal, \
+    assert_almost_equal
+
+from yt import particle_filter
+from yt import load_particles
+from yt.units import parsec, Msun
 
 def setup():
     from yt.config import ytcfg
@@ -31,7 +36,7 @@ def test_average():
     for nprocs in [1, 2, 4, 8]:
         ds = fake_random_ds(16, nprocs = nprocs, fields = ("density",))
         for ad in [ds.all_data(), ds.r[0.5, :, :]]:
-        
+
             my_mean = ad.quantities["WeightedAverageQuantity"]("density", "ones")
             assert_rel_equal(my_mean, ad["density"].mean(), 12)
 
@@ -43,15 +48,15 @@ def test_variance():
     for nprocs in [1, 2, 4, 8]:
         ds = fake_random_ds(16, nprocs = nprocs, fields = ("density", ))
         for ad in [ds.all_data(), ds.r[0.5, :, :]]:
-        
+
             my_std, my_mean = ad.quantities["WeightedVariance"]("density", "ones")
             assert_rel_equal(my_mean, ad["density"].mean(), 12)
             assert_rel_equal(my_std, ad["density"].std(), 12)
 
-            my_std, my_mean = ad.quantities["WeightedVariance"]("density", "cell_mass")        
+            my_std, my_mean = ad.quantities["WeightedVariance"]("density", "cell_mass")
             a_mean = (ad["density"] * ad["cell_mass"]).sum() / ad["cell_mass"].sum()
             assert_rel_equal(my_mean, a_mean, 12)
-            a_std = np.sqrt((ad["cell_mass"] * (ad["density"] - a_mean)**2).sum() / 
+            a_std = np.sqrt((ad["cell_mass"] * (ad["density"] - a_mean)**2).sum() /
                             ad["cell_mass"].sum())
             assert_rel_equal(my_std, a_std, 12)
 
@@ -116,3 +121,51 @@ def test_sample_at_max_field_values():
 
             assert_equal(ad["temperature"][mi], temp)
             assert_equal(ad["velocity_x"][mi], vm)
+
+def test_derived_quantities_with_particle_types():
+
+    #ds=fake_particle_data()
+    #ad=ds.all_data()
+
+    @particle_filter(requires=["particle_position_x"], filtered_type='all')
+    def low_x(pfilter,data):
+        return data['particle_position_x'].in_units('code_length')<0.5
+
+    #Create pre-defined particle dataset
+    nparts=100
+    ppx = pvx = np.array(np.linspace(0,1,nparts))
+    ppy = pvy = np.array(np.linspace(1,0,nparts))
+    ppz = pvz = ppx-ppy
+    pm = np.ones(nparts)
+
+    data={'particle_position_x':ppx,
+          'particle_position_y':ppy,
+          'particle_position_z':ppx,
+          'particle_velocity_x':pvx,
+          'particle_velocity_y':pvy,
+          'particle_velocity_z':pvz,
+          'particle_mass':pm}
+
+    bbox=np.array([[min(ppx), max(ppx)], [min(ppy), max(ppy)], [min(ppz), max(ppz)]])
+    ds = load_particles(data, n_ref=6, bbox=bbox, length_unit=parsec, mass_unit=Msun)
+
+    @particle_filter(requires=["particle_position_x"], filtered_type='all')
+    def low_x(pfilter,data):
+        return data['particle_position_x'].in_units('code_length')<0.5
+    ds.add_particle_filter('low_x')
+
+    ad=ds.all_data()
+
+    for ptype in ['all','low_x']:
+        #Check bulk velocity
+        bulk_vx=(ad[(ptype,'particle_mass')]*ad[(ptype,'particle_velocity_x')]/ad[(ptype,'particle_mass')].sum()).sum()
+        assert_almost_equal(ad.quantities.bulk_velocity(use_gas=False,use_particles=True,particle_type=ptype)[0],bulk_vx,5)
+
+        #Check center of mass
+        com_x=(ad[(ptype,'particle_mass')]*ad[(ptype,'particle_position_x')]/ad[(ptype,'particle_mass')].sum()).sum()
+        assert_almost_equal(ad.quantities.center_of_mass(use_gas=False,use_particles=True,particle_type=ptype)[0],com_x,5)
+
+
+    #Check spin parameter values
+    assert_almost_equal(ad.quantities.spin_parameter(use_gas=False,use_particles=True),1.1973910384754621e+27)
+    assert_almost_equal(ad.quantities.spin_parameter(use_gas=False,use_particles=True,particle_type='low_x'),2.1171960652141979e+27)

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -67,6 +67,14 @@ class YTFieldNotFound(YTException):
     def __str__(self):
         return "Could not find field '%s' in %s." % (self.fname, self.ds)
 
+class YTParticleTypeNotFound(YTException):
+    def __init__(self, fname, ds):
+        self.fname = fname
+        self.ds = ds
+
+    def __str__(self):
+        return ("Could not find particle_type '%s' in %s." % (self.fname, self.ds))
+
 class YTSceneFieldNotFound(YTException):
     pass
 


### PR DESCRIPTION
## PR Summary

This pull request adds an option argument called "p_type" to a variety of derived quantities, such as center_of_mass and similar, which allows that derived quantity to be calculated for a given particle type only. 

This is a new feature that will aid in data analysis, allowing for example the spin paramter of stars or the centre of mass of DM to be calculated easily and quickly.

The default behaviour of all derived quantities has not been changed, as p_type defaults to "all". 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes flake8 checker
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->

PS: Sorry, I also removed a bunch of trailing whitespaces which makes the pull request look messier than it actually is. 