### PR TITLE
 use inverse matrix to do rotations for SPH off-axis projections 

### DIFF
--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -1480,8 +1480,8 @@ def off_axis_projection_SPH(np.float64_t[:] px,
     cdef np.float64_t[:] coordinate_matrix = np.empty(3, dtype='float_')
     cdef np.float64_t[:] rotated_coordinates
     cdef np.float64_t[:] rotated_center
-    rotated_center = rotation_matmul(rotation_matrix,
-                                     np.array([center[0], center[1], center[2]]))
+    rotated_center = rotation_matmul(
+        rotation_matrix, np.array([center[0], center[1], center[2]]))
 
     # set up the rotated bounds
     cdef np.float64_t rot_bounds_x0 = rotated_center[0] - width[0] / 2
@@ -1493,7 +1493,8 @@ def off_axis_projection_SPH(np.float64_t[:] px,
         coordinate_matrix[0] = px[i]
         coordinate_matrix[1] = py[i]
         coordinate_matrix[2] = pz[i]
-        rotated_coordinates = rotation_matmul(rotation_matrix, coordinate_matrix)
+        rotated_coordinates = rotation_matmul(
+            rotation_matrix, coordinate_matrix)
         px_rotated[i] = rotated_coordinates[0]
         py_rotated[i] = rotated_coordinates[1]
 
@@ -1514,12 +1515,9 @@ def off_axis_projection_SPH(np.float64_t[:] px,
 cdef np.float64_t[:] rotation_matmul(np.float64_t[:, :] rotation_matrix, 
                                      np.float64_t[:] coordinate_matrix):
     cdef np.float64_t[:] out = np.zeros(3)
-    cdef np.float64_t s = 0
     for i in range(3):
         for j in range(3):
-            s += rotation_matrix[i, j] * coordinate_matrix[j]
-        out[i] = s
-        s = 0
+            out[i] += rotation_matrix[i, j] * coordinate_matrix[j]
     return out
 
 
@@ -1527,8 +1525,9 @@ cdef np.float64_t[:] rotation_matmul(np.float64_t[:, :] rotation_matrix,
 @cython.wraparound(False)
 cpdef np.float64_t[:, :] get_rotation_matrix(normal_vector):
     """ Returns a numpy rotation matrix corresponding to the
-    rotation of the z-axis ([0, 0, 1]) to a given normal vector
-    https://math.stackexchange.com/a/476311
+    rotation of the given normal vector to the z-axis ([0, 0, 1]).
+    See https://math.stackexchange.com/a/476311 although note we return the
+    inverse of what's specified there.
     """
     cdef np.float64_t[:] normal_vector_np = np.array([normal_vector[0], normal_vector[1], normal_vector[2]], 
                                                      dtype='float_')
@@ -1549,9 +1548,9 @@ cpdef np.float64_t[:, :] get_rotation_matrix(normal_vector):
                                                       [v[2], 0, -1 * v[0]],
                                                       [-1 * v[1], v[0], 0]], 
                                                       dtype='float_')
-    return np.identity(3, dtype='float_') + cross_product_matrix \
-        + np.matmul(cross_product_matrix, cross_product_matrix) \
-        * 1/(1+c)
+    return np.linalg.inv(np.identity(3, dtype='float_') + cross_product_matrix 
+                         + np.matmul(cross_product_matrix, cross_product_matrix)
+                         * 1/(1+c))
 
 
 @cython.initializedcheck(False)

--- a/yt/visualization/volume_rendering/tests/test_off_axis_SPH.py
+++ b/yt/visualization/volume_rendering/tests/test_off_axis_SPH.py
@@ -56,12 +56,12 @@ def test_no_rotation():
 
 @requires_module('scipy')
 def test_basic_rotation_1():
-    """ Rotation of z-axis onto y-axis. All fake particles on Z-axis should now be on the Y-Axis
+    """ All particles on Z-axis should now be on the negative Y-Axis
         fake_sph_orientation has three z-axis particles, so there should be three y-axis particles 
         after rotation 
-        (0, 0, 1) -> (0, 1)
-        (0, 0, 2) -> (0, 2)
-        (0, 0, 3) -> (0, 3)
+        (0, 0, 1) -> (0, -1)
+        (0, 0, 2) -> (0, -2)
+        (0, 0, 3) -> (0, -3)
         In addition, we should find a local maxima at (0, 0) due to:
         (0, 0, 0) -> (0, 0)
         (0, 1, 0) -> (0, 0)
@@ -69,7 +69,7 @@ def test_basic_rotation_1():
         and the one particle on the x-axis should not change its position:
         (1, 0, 0) -> (1, 0)
     """
-    expected_maxima = ([0., 0., 0., 0., 1.], [0., 1., 2., 3., 0.])
+    expected_maxima = ([0., 0., 0., 0., 1.], [0., -1., -2., -3., 0.])
     normal_vector = [0., 1., 0.]
     resolution = (64, 64)
     ds = fake_sph_orientation_ds()
@@ -89,12 +89,12 @@ def test_basic_rotation_1():
 
 @requires_module('scipy')
 def test_basic_rotation_2():
-    """ Rotation of z-axis onto x-axis. All fake particles on z-axis should now be on the x-Axis
+    """ Rotation of x-axis onto z-axis. All particles on z-axis should now be on the negative x-Axis
     fake_sph_orientation has three z-axis particles, so there should be three x-axis particles 
     after rotation 
-    (0, 0, 1) -> (1, 0)
-    (0, 0, 2) -> (2, 0)
-    (0, 0, 3) -> (3, 0)
+    (0, 0, 1) -> (-1, 0)
+    (0, 0, 2) -> (-2, 0)
+    (0, 0, 3) -> (-3, 0)
     In addition, we should find a local maxima at (0, 0) due to:
     (0, 0, 0) -> (0, 0)
     (1, 0, 0) -> (0, 0)
@@ -102,7 +102,7 @@ def test_basic_rotation_2():
     (0, 1, 0) -> (0, 1)
     (0, 2, 0) -> (0, 2)
     """ 
-    expected_maxima = ([1., 2., 3., 0., 0., 0.], 
+    expected_maxima = ([-1., -2., -3., 0., 0., 0.], 
                        [0., 0., 0., 0., 1., 2.])
     normal_vector = [1., 0., 0.]
     resolution = (64, 64)


### PR DESCRIPTION
This fixes the issues @chummels described in #1902. The angular momentum vector was correct, but the rotation performed by the off-axis projection machinery was calculating the rotation matrix necessary to rotate the z-axis to the specified normal vector. However, what we wanted was the rotation matrix that does the inverse operation: rotating the the specified normal vector to the z-axis. The fix was just to add a call to `np.lingalg.inv` on the return statement for `get_rotation_matrix`. There are a couple other minor formatting changes, I also updated the tests which had encoded the incorrect answer before.