### PR TITLE
Use patch groups in GAMER

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -26,7 +26,7 @@ answer_tests:
   local_gadget_001:
     - yt/frontends/gadget/tests/test_outputs.py
 
-  local_gamer_002:
+  local_gamer_003:
     - yt/frontends/gamer/tests/test_outputs.py
 
   local_gdf_001:

--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -64,6 +64,8 @@ class GAMERHierarchy(GridIndex):
         self._group_particle  = ds._group_particle
         self.float_type       = 'float64' # fixed even when FLOAT8 is off
         self._particle_handle = ds._particle_handle
+        self.refine_by        = ds.refine_by
+        self.pgroup           = self.refine_by**3 # number of patches in a patch group
         GridIndex.__init__(self, ds, dataset_type)
 
     def _detect_output_fields(self):
@@ -77,21 +79,21 @@ class GAMERHierarchy(GridIndex):
 
     def _count_grids(self):
         # count the total number of patches at all levels
-        self.num_grids = self.dataset.parameters['NPatch'].sum()
+        self.num_grids = self.dataset.parameters['NPatch'].sum()/self.pgroup
 
     def _parse_index(self):
         parameters       = self.dataset.parameters
         gid0             = 0
-        grid_corner      = self._handle['Tree/Corner'].value
+        grid_corner      = self._handle['Tree/Corner'].value[::self.pgroup]
         convert2physical = self._handle['Tree/Corner'].attrs['Cvt2Phy']
 
-        self.grid_dimensions[:] = parameters['PatchSize']
+        self.grid_dimensions[:] = parameters['PatchSize']*2
 
         for lv in range(0, parameters['NLevel']):
-            num_grids_level = parameters['NPatch'][lv]
+            num_grids_level = parameters['NPatch'][lv]/self.pgroup
             if num_grids_level == 0: break
 
-            patch_scale = parameters['PatchSize']*parameters['CellScale'][lv]
+            patch_scale = parameters['PatchSize']*parameters['CellScale'][lv]*2
 
             # set the level and edge of each grid
             # (left/right_edge are YT arrays in code units)
@@ -102,7 +104,7 @@ class GAMERHierarchy(GridIndex):
                 = (grid_corner[ gid0:gid0 + num_grids_level ] + patch_scale)*convert2physical
 
             gid0 += num_grids_level
-        self.grid_left_edge += self.dataset.domain_left_edge
+        self.grid_left_edge  += self.dataset.domain_left_edge
         self.grid_right_edge += self.dataset.domain_left_edge
 
         # allocate all grid objects
@@ -115,7 +117,8 @@ class GAMERHierarchy(GridIndex):
 
         # number of particles in each grid
         try:
-            self.grid_particle_count[:] = self._handle['Tree/NPar'].value[:,None]
+            self.grid_particle_count[:] = \
+                np.sum( self._handle['Tree/NPar'].value.reshape(-1,self.pgroup), axis=1 )[:,None]
         except KeyError:
             self.grid_particle_count[:] = 0.0
 
@@ -130,11 +133,10 @@ class GAMERHierarchy(GridIndex):
 
         for gid in range(self.num_grids):
             grid     = self.grids[gid]
-            son_gid0 = son_list[gid]
+            son_gid0 = son_list[gid*self.pgroup:(gid+1)*self.pgroup]/self.pgroup
 
             # set up the parent-children relationship
-            if son_gid0 >= 0:
-                grid.Children = [ self.grids[son_gid0+s] for s in range(8) ]
+            grid.Children = [ self.grids[t] for t in son_gid0[son_gid0>=0] ]
 
             for son_grid in grid.Children: son_grid.Parent = grid
 
@@ -155,8 +157,8 @@ class GAMERHierarchy(GridIndex):
         for grid in self.grids:
             # parent->children == itself
             if grid.Parent is not None:
-                assert grid.Parent.Children[0+grid.id%8] is grid, \
-                       'Grid %d, Parent %d, Parent->Children %d' % \
+                assert grid in grid.Parent.Children, \
+                       'Grid %d, Parent %d, Parent->Children[0] %d' % \
                        (grid.id, grid.Parent.id, grid.Parent.Children[0].id)
 
             # children->parent == itself
@@ -174,15 +176,20 @@ class GAMERHierarchy(GridIndex):
 
             # parent index is consistent with the loaded dataset
             if grid.Level > 0:
-                father_gid = father_list[grid.id]
+                father_gid = father_list[grid.id*self.pgroup]/self.pgroup
                 assert father_gid == grid.Parent.id, \
-                       'Grid %d, Level %d, Parent_Found %d, Parent_Expect %d'%\
+                       'Grid %d, Level %d, Parent_Found %d, Parent_Expect %d' % \
                        (grid.id, grid.Level, grid.Parent.id, father_gid)
 
             # edges between children and parent
-            if len(grid.Children) > 0:
-                assert_equal(grid.LeftEdge,  grid.Children[0].LeftEdge )
-                assert_equal(grid.RightEdge, grid.Children[7].RightEdge)
+            for c in grid.Children:
+                for d in range(0,3):
+                    assert grid.LeftEdge[d] <= c.LeftEdge[d], \
+                           'Grid %d, Children %d, Grid->EdgeL %14.7e, Children->EdgeL %14.7e' % \
+                           (grid.id, c.id, grid.LeftEdge[d], c.LeftEdge[d])
+                    assert grid.RightEdge[d] >= c.RightEdge[d], \
+                           'Grid %d, Children %d, Grid->EdgeR %14.7e, Children->EdgeR %14.7e' % \
+                           (grid.id, c.id, grid.RightEdge[d], c.RightEdge[d])
         mylog.info('Check passed')
 
 

--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -86,13 +86,13 @@ class GAMERHierarchy(GridIndex):
         grid_corner      = self._handle['Tree/Corner'].value[::self.pgroup]
         convert2physical = self._handle['Tree/Corner'].attrs['Cvt2Phy']
 
-        self.grid_dimensions[:] = parameters['PatchSize']*2
+        self.grid_dimensions[:] = parameters['PatchSize']*self.refine_by
 
         for lv in range(0, parameters['NLevel']):
             num_grids_level = parameters['NPatch'][lv]/self.pgroup
             if num_grids_level == 0: break
 
-            patch_scale = parameters['PatchSize']*parameters['CellScale'][lv]*2
+            patch_scale = parameters['PatchSize']*parameters['CellScale'][lv]*self.refine_by
 
             # set the level and edge of each grid
             # (left/right_edge are YT arrays in code units)

--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -31,7 +31,6 @@ from yt.utilities.file_handler import \
     HDF5FileHandler
 from .fields import GAMERFieldInfo
 from .definitions import geometry_parameters
-from yt.testing import assert_equal
 
 
 

--- a/yt/frontends/gamer/io.py
+++ b/yt/frontends/gamer/io.py
@@ -50,6 +50,8 @@ class IOHandlerGAMER(BaseIOHandler):
         self._group_particle  = ds._group_particle
         self._field_dtype     = "float64" # fixed even when FLOAT8 is off
         self._particle_handle = ds._particle_handle
+        self.patch_size       = ds.parameters['PatchSize']*2
+        self.pgroup           = ds.refine_by**3 # number of patches in a patch group
 
     def _read_particle_coords(self, chunks, ptf):
         chunks = list(chunks)   # generator --> list
@@ -115,14 +117,34 @@ class IOHandlerGAMER(BaseIOHandler):
         mylog.debug( "Reading %s cells of %s fields in %s grids",
                      size, [f2 for f1, f2 in fields], ng )
 
+        # shortcuts
+        ps2 = self.patch_size
+        ps1 = ps2/2
+
         for field in fields:
             ds     = self._group_grid[ field[1] ]
             offset = 0
             for chunk in chunks:
                 for gs in grid_sequences(chunk.objs):
-                    start = gs[ 0].id
-                    end   = gs[-1].id + 1
-                    data  = ds[start:end,:,:,:].transpose()
+                    start = (gs[ 0].id  )*self.pgroup
+                    end   = (gs[-1].id+1)*self.pgroup
+                    buf   = ds[start:end,:,:,:]
+                    ngrid = len( gs )
+                    data  = np.empty( (ngrid,ps2,ps2,ps2), dtype=self._field_dtype )
+
+                    for g in range(ngrid):
+                        pid0 = g*self.pgroup
+                        data[g,   0:ps1,   0:ps1,   0:ps1] = buf[pid0+0,:,:,:]
+                        data[g,   0:ps1,   0:ps1, ps1:ps2] = buf[pid0+1,:,:,:]
+                        data[g,   0:ps1, ps1:ps2,   0:ps1] = buf[pid0+2,:,:,:]
+                        data[g, ps1:ps2,   0:ps1,   0:ps1] = buf[pid0+3,:,:,:]
+                        data[g,   0:ps1, ps1:ps2, ps1:ps2] = buf[pid0+4,:,:,:]
+                        data[g, ps1:ps2, ps1:ps2,   0:ps1] = buf[pid0+5,:,:,:]
+                        data[g, ps1:ps2,   0:ps1, ps1:ps2] = buf[pid0+6,:,:,:]
+                        data[g, ps1:ps2, ps1:ps2, ps1:ps2] = buf[pid0+7,:,:,:]
+
+                    data = data.transpose()
+
                     for i, g in enumerate(gs):
                         offset += g.select( selector, data[...,i], rv[field], offset )
         return rv
@@ -150,13 +172,32 @@ class IOHandlerGAMER(BaseIOHandler):
         # fluid
         if len(fluid_fields) == 0: return rv
 
+        ps2 = self.patch_size
+        ps1 = ps2/2
+
         for field in fluid_fields:
             ds = self._group_grid[ field[1] ]
 
             for gs in grid_sequences(chunk.objs):
-                start = gs[ 0].id
-                end   = gs[-1].id + 1
-                data  = ds[start:end,:,:,:].transpose()
+                start = (gs[ 0].id  )*self.pgroup
+                end   = (gs[-1].id+1)*self.pgroup
+                buf   = ds[start:end,:,:,:]
+                ngrid = len( gs )
+                data  = np.empty( (ngrid,ps2,ps2,ps2), dtype=self._field_dtype )
+
+                for g in range(ngrid):
+                    pid0 = g*self.pgroup
+                    data[g,   0:ps1,   0:ps1,   0:ps1] = buf[pid0+0,:,:,:]
+                    data[g,   0:ps1,   0:ps1, ps1:ps2] = buf[pid0+1,:,:,:]
+                    data[g,   0:ps1, ps1:ps2,   0:ps1] = buf[pid0+2,:,:,:]
+                    data[g, ps1:ps2,   0:ps1,   0:ps1] = buf[pid0+3,:,:,:]
+                    data[g,   0:ps1, ps1:ps2, ps1:ps2] = buf[pid0+4,:,:,:]
+                    data[g, ps1:ps2, ps1:ps2,   0:ps1] = buf[pid0+5,:,:,:]
+                    data[g, ps1:ps2,   0:ps1, ps1:ps2] = buf[pid0+6,:,:,:]
+                    data[g, ps1:ps2, ps1:ps2, ps1:ps2] = buf[pid0+7,:,:,:]
+
+                data = data.transpose()
+
                 for i, g in enumerate(gs):
-                    rv[g.id][field] = np.asarray( data[...,i], dtype=self._field_dtype )
+                    rv[g.id][field] = data[...,i]
         return rv

--- a/yt/frontends/gamer/io.py
+++ b/yt/frontends/gamer/io.py
@@ -50,7 +50,7 @@ class IOHandlerGAMER(BaseIOHandler):
         self._group_particle  = ds._group_particle
         self._field_dtype     = "float64" # fixed even when FLOAT8 is off
         self._particle_handle = ds._particle_handle
-        self.patch_size       = ds.parameters['PatchSize']*2
+        self.patch_size       = ds.parameters['PatchSize']*ds.refine_by
         self.pgroup           = ds.refine_by**3 # number of patches in a patch group
 
     def _read_particle_coords(self, chunks, ptf):


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

This PR uses patch groups (i.e. 8 nearby patches that share the same parent patch) instead of individual patches to map to the yt grid objects in the GAMER frontend. It significantly reduces the memory overhead by reducing the total number of grid objects by a factor of 8. This improvement can be crucial since each grid object consumes ~10 kB of memory and some GAMER snapshots have as many as ~2e7 patches. So with this PR the memory overhead associated with grid objects reduces from ~200 GB to ~25 GB. The revision is also measured to be faster.

This PR slightly changes the results of analysis using the `io_cic` field, probably because the grid *boundaries* are different. So the answer tests version number is also updated. 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [v] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
