### PR TITLE
don't specify dist in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 sudo: required
-dist: precise
 cache:
   pip: true
   directories:


### PR DESCRIPTION
As pointed out by @colinmarc we probably don't want to specify dist at all and definitely don't want 12.04.