### PR TITLE
Fix answer testing plugin

### DIFF
--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -288,6 +288,19 @@ class YTNoOldAnswer(YTException):
         return "There is no old answer available.\n" + \
                str(self.path)
 
+class YTNoAnswerNameSpecified(YTException):
+    def __init__(self, message=None):
+        if message is None or message == "":
+            message = ("Answer name not provided for the answer testing test."
+                       "\n  Please specify --answer-name=<answer_name> in"
+                       " command line mode or in AnswerTestingTest.answer_name"
+                       " variable."
+                       )
+        self.message = message
+
+    def __str__(self):
+        return str(self.message)
+
 class YTCloudError(YTException):
     def __init__(self, path):
         self.path = path


### PR DESCRIPTION
## PR Background

Please check #1905 

## PR Summary

The earlier merged PR yt-project/yt#1905 had a bug identified while writing a new answer test to be run on Travis. This PR corrects that implementation.

With this fix, answer name could be specified in the answer test case
itself. As a  result, all the answer tests could be executed by just one
nosetests command. Earlier, this was not possible and one nose command
had to be run per answer test as --answer-name had to be specified for
each answer test.

In addition, prepend py-version before AnswerTestingTest.answer_name,
to avoid conflict in answer-store images


## PR Checklist

- [X] Code passes flake8 checker

## Adding Reviewers

@ngoldbaum @Xarthisius @colinmarc
@brittonsmith @jwise77 @bwoshea 