### PR TITLE
[bugfix] Making north vector work with SPH off axis projections; fixes #1907

### DIFF
--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -1530,7 +1530,7 @@ cdef np.float64_t[:] rotation_matmul(np.float64_t[:, :] rotation_matrix,
 @cython.wraparound(False)
 cpdef np.float64_t[:, :] get_rotation_matrix(normal_vector, final_vector):
     """ Returns a numpy rotation matrix corresponding to the
-    rotation of the given normal vector to the z-axis ([0, 0, 1]).
+    rotation of the given normal vector to the specified final_vector.
     See https://math.stackexchange.com/a/476311 although note we return the
     inverse of what's specified there.
     """
@@ -1539,16 +1539,17 @@ cpdef np.float64_t[:, :] get_rotation_matrix(normal_vector, final_vector):
     cdef np.float64_t[:] final_vector_np = np.array([final_vector[0], final_vector[1], final_vector[2]], 
                                                      dtype='float_')
     cdef np.float64_t[:] normal_unit_vector = normal_vector_np / np.linalg.norm(normal_vector_np)
-    cdef np.float64_t[:] v = np.cross(final_vector, normal_unit_vector)
+    cdef np.float64_t[:] final_unit_vector = final_vector_np / np.linalg.norm(final_vector_np)
+    cdef np.float64_t[:] v = np.cross(final_unit_vector, normal_unit_vector)
     cdef np.float64_t s = np.linalg.norm(v)
-    cdef np.float64_t c = np.dot(final_vector, normal_unit_vector)
-    # if the normal vector is identical to the z-axis, just return the
+    cdef np.float64_t c = np.dot(final_unit_vector, normal_unit_vector)
+    # if the normal vector is identical to the final vector, just return the
     # identity matrix
     if np.isclose(c, 1, rtol=1e-09):
         return np.identity(3, dtype='float_')
     # if the normal vector is the negative z-axis, return:
-    if np.isclose(s, 0, rtol=1e-09):
-        return np.array([[0, -1, 0],[-1, 0, 0],[0, 0, -1]], dtype='float_')
+    #if np.isclose(s, 0, rtol=1e-09):
+    #    return np.array([[0, -1, 0],[-1, 0, 0],[0, 0, -1]], dtype='float_')
 
     cdef np.float64_t[:, :] cross_product_matrix = np.array([[0, -1 * v[2], v[1]],
                                                       [v[2], 0, -1 * v[0]],

--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -1467,6 +1467,7 @@ def off_axis_projection_SPH(np.float64_t[:] px,
                             np.float64_t[:] quantity_to_smooth,
                             np.float64_t[:, :] projection_array,
                             normal_vector,
+                            north_vector,
                             weight_field=None):
     # Do nothing in event of a 0 normal vector
     if np.allclose(normal_vector, np.array([0., 0., 0.]), rtol=1e-09):

--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -1537,18 +1537,15 @@ cdef np.float64_t[:] rotation_matmul(np.float64_t[:, :] rotation_matrix,
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cpdef np.float64_t[:, :] get_rotation_matrix(normal_vector, final_vector):
+cpdef np.float64_t[:, :] get_rotation_matrix(np.float64_t[:] normal_vector,
+                                             np.float64_t[:] final_vector):
     """ Returns a numpy rotation matrix corresponding to the
     rotation of the given normal vector to the specified final_vector.
     See https://math.stackexchange.com/a/476311 although note we return the
     inverse of what's specified there.
     """
-    cdef np.float64_t[:] normal_vector_np = np.array([normal_vector[0], normal_vector[1], normal_vector[2]], 
-                                                     dtype='float_')
-    cdef np.float64_t[:] final_vector_np = np.array([final_vector[0], final_vector[1], final_vector[2]], 
-                                                     dtype='float_')
-    cdef np.float64_t[:] normal_unit_vector = normal_vector_np / np.linalg.norm(normal_vector_np)
-    cdef np.float64_t[:] final_unit_vector = final_vector_np / np.linalg.norm(final_vector_np)
+    cdef np.float64_t[:] normal_unit_vector = normal_vector / np.linalg.norm(normal_vector)
+    cdef np.float64_t[:] final_unit_vector = final_vector / np.linalg.norm(final_vector)
     cdef np.float64_t[:] v = np.cross(final_unit_vector, normal_unit_vector)
     cdef np.float64_t s = np.linalg.norm(v)
     cdef np.float64_t c = np.dot(final_unit_vector, normal_unit_vector)

--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -190,7 +190,8 @@ def off_axis_projection(data_source, center, normal_vector,
                     width.to('code_length').d,
                     chunk[item].in_units(ounits),
                     buf,
-                    normal_vector)
+                    normal_vector,
+                    north_vector)
 
             path_length_unit = data_source.ds._get_field_info('smoothing_length').units
             path_length_unit = Unit(path_length_unit, registry=data_source.ds.unit_registry)
@@ -218,6 +219,7 @@ def off_axis_projection(data_source, center, normal_vector,
                     chunk[item].in_units(ounits),
                     buf,
                     normal_vector,
+                    north_vector,
                     weight_field=chunk[weight].in_units(wounits))
 
             for chunk in data_source.chunks([], 'io'):
@@ -233,7 +235,8 @@ def off_axis_projection(data_source, center, normal_vector,
                     width.to('code_length').d,
                     chunk[weight].to(wounits),
                     weight_buff,
-                    normal_vector)
+                    normal_vector,
+                    north_vector)
 
             buf /= weight_buff
             item_unit = data_source.ds._get_field_info(item).units

--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -22,7 +22,8 @@ from yt.utilities.lib.partitioned_grid import \
 from yt.units.unit_object import Unit
 from yt.data_objects.api import ImageArray
 from yt.utilities.lib.pixelization_routines import \
-    off_axis_projection_SPH
+    off_axis_projection_SPH, \
+    normalization_2d_utility
 import numpy as np
 
 
@@ -238,7 +239,7 @@ def off_axis_projection(data_source, center, normal_vector,
                     normal_vector,
                     north)
 
-            buf /= weight_buff
+            normalization_2d_utility(buf, weight_buff)
             item_unit = data_source.ds._get_field_info(item).units
             item_unit = Unit(item_unit, registry=data_source.ds.unit_registry)
             funits = item_unit

--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -118,6 +118,11 @@ def off_axis_projection(data_source, center, normal_vector,
 
     item = data_source._determine_fields([item])[0]
 
+    # Assure vectors are numpy arrays as expected by cython code
+    normal_vector = np.array(normal_vector, dtype='float64')
+    if north_vector is not None:
+        north_vector = np.array(north_vector, dtype='float64')
+
     # Sanitize units
     if not hasattr(center, "units"):
         center = data_source.ds.arr(center, 'code_length')

--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -191,7 +191,7 @@ def off_axis_projection(data_source, center, normal_vector,
                     chunk[item].in_units(ounits),
                     buf,
                     normal_vector,
-                    north_vector)
+                    north)
 
             path_length_unit = data_source.ds._get_field_info('smoothing_length').units
             path_length_unit = Unit(path_length_unit, registry=data_source.ds.unit_registry)
@@ -219,7 +219,7 @@ def off_axis_projection(data_source, center, normal_vector,
                     chunk[item].in_units(ounits),
                     buf,
                     normal_vector,
-                    north_vector,
+                    north,
                     weight_field=chunk[weight].in_units(wounits))
 
             for chunk in data_source.chunks([], 'io'):
@@ -236,7 +236,7 @@ def off_axis_projection(data_source, center, normal_vector,
                     chunk[weight].to(wounits),
                     weight_buff,
                     normal_vector,
-                    north_vector)
+                    north)
 
             buf /= weight_buff
             item_unit = data_source.ds._get_field_info(item).units

--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -133,11 +133,13 @@ def off_axis_projection(data_source, center, normal_vector,
 
         raise_error = False
 
+        # Assure that the field we're trying to off-axis project is a
+        # particle field or a 'gas' field.
         if fi.alias_field:
             if fi.alias_name[0] != ptype:
                 raise_error = True
         else:
-            if fi.name[0] != ptype:
+            if fi.name[0] != ptype and fi.name[0] != 'gas':
                 raise_error = True
 
         if raise_error:

--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -138,8 +138,9 @@ def off_axis_projection(data_source, center, normal_vector,
 
         raise_error = False
 
-        # Assure that the field we're trying to off-axis project is a
-        # particle field or a 'gas' field.
+        # Assure that the field we're trying to off-axis project 
+        # has a field type as the SPH particle type or if the field is an 
+        # alias to an SPH field or is a 'gas' field
         if fi.alias_field:
             if fi.alias_name[0] != ptype:
                 raise_error = True

--- a/yt/visualization/volume_rendering/tests/test_off_axis_SPH.py
+++ b/yt/visualization/volume_rendering/tests/test_off_axis_SPH.py
@@ -18,7 +18,7 @@ def test_no_rotation():
     image buffer if processed directly through 
     pixelize_sph_kernel_projection
     """
-    normal_vector = [0., 0., 1.]
+    normal_vector = np.array([0., 0., 1.])
     resolution = (64, 64)
     ds = fake_sph_orientation_ds()
     ad = ds.all_data()
@@ -70,7 +70,7 @@ def test_basic_rotation_1():
         (1, 0, 0) -> (1, 0)
     """
     expected_maxima = ([0., 0., 0., 0., 1.], [0., -1., -2., -3., 0.])
-    normal_vector = [0., 1., 0.]
+    normal_vector = np.array([0., 1., 0.])
     resolution = (64, 64)
     ds = fake_sph_orientation_ds()
     left_edge = ds.domain_left_edge
@@ -104,7 +104,7 @@ def test_basic_rotation_2():
     """ 
     expected_maxima = ([-1., -2., -3., 0., 0., 0.], 
                        [0., 0., 0., 0., 1., 2.])
-    normal_vector = [1., 0., 0.]
+    normal_vector = np.array([1., 0., 0.])
     resolution = (64, 64)
     ds = fake_sph_orientation_ds()
     left_edge = ds.domain_left_edge
@@ -138,7 +138,7 @@ def test_basic_rotation_3():
     (0, 2, 0) -> (-2, 0)
     """ 
     expected_maxima = ([0., 0., -1., -2.], [0., -1., 0., 0.])
-    normal_vector = [0., 0., -1.]
+    normal_vector = np.array([0., 0., -1.])
     resolution = (64, 64)
     ds = fake_sph_orientation_ds()
     left_edge = ds.domain_left_edge
@@ -169,7 +169,7 @@ def test_center_1():
     (1, 0, 0) -> (1, -3)
     """
     expected_maxima = ([0., 0., 0., 1.], [-2., -1., -3., -3.])
-    normal_vector = [0., 0., 1.]
+    normal_vector = np.array([0., 0., 1.])
     resolution = (64, 64)
     ds = fake_sph_orientation_ds()
     left_edge = ds.domain_left_edge
@@ -203,7 +203,7 @@ def test_center_2():
     (1, 0, 0) -> (1, 1)
     """
     expected_maxima = ([0., 0., 0., 1.], [2., 3., 1., 1.])
-    normal_vector = [0., 0., 1.]
+    normal_vector = np.array([0., 0., 1.])
     resolution = (64, 64)
     ds = fake_sph_orientation_ds()
     left_edge = ds.domain_left_edge
@@ -227,7 +227,7 @@ def test_center_3():
     With this, we should not be able to see anything !
     """
     expected_maxima = ([], [])
-    normal_vector = [0., 0., 1.]
+    normal_vector = np.array([0., 0., 1.])
     resolution = (64, 64)
     ds = fake_sph_orientation_ds()
     left_edge = ds.domain_left_edge

--- a/yt/visualization/volume_rendering/tests/test_off_axis_SPH.py
+++ b/yt/visualization/volume_rendering/tests/test_off_axis_SPH.py
@@ -156,6 +156,44 @@ def test_basic_rotation_3():
 
 
 @requires_module('scipy')
+def test_basic_rotation_4():
+    """ Rotation of x-axis to z-axis and original z-axis to y-axis with the use
+    of the north_vector. All fake particles on z-axis should now be on the
+    y-Axis.  All fake particles on the x-axis should now be on the z-axis, and
+    all fake particles on the y-axis should now be on the x-axis.
+
+    (0, 0, 1) -> (0, 1)
+    (0, 0, 2) -> (0, 2)
+    (0, 0, 3) -> (0, 3)
+    In addition, (0, 0, 0) should contribute to the local maxima at (0, 0):
+    (0, 0, 0) -> (0, 0)
+    x-axis particles should be rotated and contribute to the local maxima at (0, 0):
+    (1, 0, 0) -> (0, 0)
+    and the y-axis particles shift into the positive x direction:
+    (0, 1, 0) -> (1, 0)
+    (0, 2, 0) -> (2, 0)
+    """
+    expected_maxima = ([0., 0., 0., 0., 1., 2.], [1., 2., 3., 0., 0., 0.])
+    normal_vector = np.array([1., 0., 0.])
+    north_vector = np.array([0., 0., 1.])
+    resolution = (64, 64)
+    ds = fake_sph_orientation_ds()
+    left_edge = ds.domain_left_edge
+    right_edge = ds.domain_right_edge
+    center = (left_edge + right_edge)/2
+    width = (right_edge - left_edge)
+    buf1 = OffAP.off_axis_projection(ds,
+                                     center,
+                                     normal_vector,
+                                     width,
+                                     resolution,
+                                     ('gas', 'density'),
+                                     north_vector=north_vector
+                                     )
+    find_compare_maxima(expected_maxima, buf1, resolution, width)
+
+
+@requires_module('scipy')
 def test_center_1():
     """ Change the center to [0, 3, 0] 
     Every point will be shifted by 3 in the y-domain

--- a/yt/visualization/volume_rendering/tests/test_off_axis_SPH.py
+++ b/yt/visualization/volume_rendering/tests/test_off_axis_SPH.py
@@ -18,7 +18,7 @@ def test_no_rotation():
     image buffer if processed directly through 
     pixelize_sph_kernel_projection
     """
-    normal_vector = np.array([0., 0., 1.])
+    normal_vector = [0., 0., 1.]
     resolution = (64, 64)
     ds = fake_sph_orientation_ds()
     ad = ds.all_data()
@@ -70,8 +70,8 @@ def test_basic_rotation_1():
         (1, 0, 0) -> (1, 0)
     """
     expected_maxima = ([0., 0., 0., 0., 1.], [0., -1., -2., -3., 0.])
-    normal_vector = np.array([0., 1., 0.])
-    north_vector = np.array([0., 0., -1.])
+    normal_vector = [0., 1., 0.]
+    north_vector = [0., 0., -1.]
     resolution = (64, 64)
     ds = fake_sph_orientation_ds()
     left_edge = ds.domain_left_edge
@@ -106,8 +106,8 @@ def test_basic_rotation_2():
     """ 
     expected_maxima = ([-1., -2., -3., 0., 0., 0.], 
                        [0., 0., 0., 0., 1., 2.])
-    normal_vector = np.array([1., 0., 0.])
-    north_vector = np.array([0., 1., 0.])
+    normal_vector = [1., 0., 0.]
+    north_vector = [0., 1., 0.]
     resolution = (64, 64)
     ds = fake_sph_orientation_ds()
     left_edge = ds.domain_left_edge
@@ -142,7 +142,7 @@ def test_basic_rotation_3():
     (0, 2, 0) -> (-2, 0)
     """ 
     expected_maxima = ([0., 0., -1., -2.], [0., -1., 0., 0.])
-    normal_vector = np.array([0., 0., -1.])
+    normal_vector = [0., 0., -1.]
     resolution = (64, 64)
     ds = fake_sph_orientation_ds()
     left_edge = ds.domain_left_edge
@@ -178,8 +178,8 @@ def test_basic_rotation_4():
     (0, 2, 0) -> (2, 0)
     """
     expected_maxima = ([0., 0., 0., 0., 1., 2.], [1., 2., 3., 0., 0., 0.])
-    normal_vector = np.array([1., 0., 0.])
-    north_vector = np.array([0., 0., 1.])
+    normal_vector = [1., 0., 0.]
+    north_vector = [0., 0., 1.]
     resolution = (64, 64)
     ds = fake_sph_orientation_ds()
     left_edge = ds.domain_left_edge
@@ -211,7 +211,7 @@ def test_center_1():
     (1, 0, 0) -> (1, -3)
     """
     expected_maxima = ([0., 0., 0., 1.], [-2., -1., -3., -3.])
-    normal_vector = np.array([0., 0., 1.])
+    normal_vector = [0., 0., 1.]
     resolution = (64, 64)
     ds = fake_sph_orientation_ds()
     left_edge = ds.domain_left_edge
@@ -219,7 +219,7 @@ def test_center_1():
     # center = [(left_edge[0] + right_edge[0])/2,
     #            left_edge[1],
     #           (left_edge[2] + right_edge[2])/2]
-    center = np.array([0., 3., 0.])
+    center = [0., 3., 0.]
     width = (right_edge - left_edge)
     buf1 = OffAP.off_axis_projection(ds,
                                      center,
@@ -245,12 +245,12 @@ def test_center_2():
     (1, 0, 0) -> (1, 1)
     """
     expected_maxima = ([0., 0., 0., 1.], [2., 3., 1., 1.])
-    normal_vector = np.array([0., 0., 1.])
+    normal_vector = [0., 0., 1.]
     resolution = (64, 64)
     ds = fake_sph_orientation_ds()
     left_edge = ds.domain_left_edge
     right_edge = ds.domain_right_edge
-    center = np.array([0., -1., 0.])
+    center = [0., -1., 0.]
     width = (right_edge - left_edge)      
     buf1 = OffAP.off_axis_projection(ds,
                                      center,
@@ -269,12 +269,12 @@ def test_center_3():
     With this, we should not be able to see anything !
     """
     expected_maxima = ([], [])
-    normal_vector = np.array([0., 0., 1.])
+    normal_vector = [0., 0., 1.]
     resolution = (64, 64)
     ds = fake_sph_orientation_ds()
     left_edge = ds.domain_left_edge
     right_edge = ds.domain_right_edge
-    center = np.array([0., -1., 0.])
+    center = [0., -1., 0.]
     width = [(right_edge[0] - left_edge[0]),
              left_edge[1],
              (right_edge[2] - left_edge[2])]    

--- a/yt/visualization/volume_rendering/tests/test_off_axis_SPH.py
+++ b/yt/visualization/volume_rendering/tests/test_off_axis_SPH.py
@@ -71,6 +71,7 @@ def test_basic_rotation_1():
     """
     expected_maxima = ([0., 0., 0., 0., 1.], [0., -1., -2., -3., 0.])
     normal_vector = np.array([0., 1., 0.])
+    north_vector = np.array([0., 0., -1.])
     resolution = (64, 64)
     ds = fake_sph_orientation_ds()
     left_edge = ds.domain_left_edge
@@ -82,7 +83,8 @@ def test_basic_rotation_1():
                                      normal_vector,
                                      width,
                                      resolution,
-                                     ('gas', 'density')  
+                                     ('gas', 'density'),
+                                     north_vector=north_vector
                                      )
     find_compare_maxima(expected_maxima, buf1, resolution, width)
 
@@ -105,6 +107,7 @@ def test_basic_rotation_2():
     expected_maxima = ([-1., -2., -3., 0., 0., 0.], 
                        [0., 0., 0., 0., 1., 2.])
     normal_vector = np.array([1., 0., 0.])
+    north_vector = np.array([0., 1., 0.])
     resolution = (64, 64)
     ds = fake_sph_orientation_ds()
     left_edge = ds.domain_left_edge
@@ -116,7 +119,8 @@ def test_basic_rotation_2():
                                      normal_vector,
                                      width,
                                      resolution,
-                                     ('gas', 'density')  
+                                     ('gas', 'density'),
+                                     north_vector=north_vector
                                      )
     find_compare_maxima(expected_maxima, buf1, resolution, width)
 


### PR DESCRIPTION
## PR Summary

This implements the `north_vector` keyword for `off_axis_projection` and `OffAxisProjectionPlot` within the demeshening.  Had to apply a second rotation to the data to rotate the north-vector to the +y direction but now it works.  This closes issue #1907 .

As a demonstration, this script gives the following results showing that on-axis and off-axis projections are identical when using the appropriate axes:

```
import yt
import numpy as np
fn = 'GadgetDiskGalaxy/snapshot_200.hdf5'
ds = yt.load(fn)
_, c = ds.find_max('density')

x = ds.arr([1,0,0], 'unitary')
y = ds.arr([0,1,0], 'unitary')
z = ds.arr([0,0,1], 'unitary')

yt.ProjectionPlot(ds, 'x', ('gas', 'density'), center=c, width=(200, 'kpc')).save('OnAxis_x.png')
yt.ProjectionPlot(ds, 'y', ('gas', 'density'), center=c, width=(200, 'kpc')).save('OnAxis_y.png')
yt.ProjectionPlot(ds, 'z', ('gas', 'density'), center=c, width=(200, 'kpc')).save('OnAxis_z.png')
yt.OffAxisProjectionPlot(ds, x, ('gas', 'density'), north_vector=z, center=c, width=(200, 'kpc'))save('OffAxis_x.png')
yt.OffAxisProjectionPlot(ds, y, ('gas', 'density'), north_vector=x, center=c, width=(200, 'kpc'))save('OffAxis_y.png')
yt.OffAxisProjectionPlot(ds, z, ('gas', 'density'), north_vector=y, center=c, width=(200, 'kpc'))save('OffAxis_z.png')
```

OnAxis_x.png:
![onaxis_x](https://user-images.githubusercontent.com/8250999/43746219-c2429e6e-9997-11e8-9db1-585f311d8112.png)

OffAxis_x.png:
![offaxis_x](https://user-images.githubusercontent.com/8250999/43746227-cecbed02-9997-11e8-864b-73dec99a7709.png)

OnAxis_y.png:
![onaxis_y](https://user-images.githubusercontent.com/8250999/43746233-d509ce28-9997-11e8-91e2-dfec6be8b6b9.png)

OffAxis_y.png:
![offaxis_y](https://user-images.githubusercontent.com/8250999/43746237-da8a30a4-9997-11e8-9e61-1c328d4bba9b.png)

OnAxis_z.png:
![onaxis_z](https://user-images.githubusercontent.com/8250999/43746242-e022b7d4-9997-11e8-8e29-c83949e635c8.png)

OffAxis_z.png:
![offaxis_z](https://user-images.githubusercontent.com/8250999/43746246-e47200ec-9997-11e8-9be0-eae96acb52af.png)

The units are still wrong, but that's issue #1906, and will be addressed in another PR.