### PR TITLE
Adding URLs to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -391,7 +391,13 @@ setup(
     cmdclass={'sdist': sdist, 'build_ext': build_ext},
     author="The yt project",
     author_email="yt-dev@python.org",
-    url="http://yt-project.org/",
+    url="https://github.com/yt-project/yt",
+    project_urls={
+        'Homepage': 'https://yt-project.org/',
+        'Documentation': 'https://yt-project.org/doc/',
+        'Source': 'https://github.com/yt-project/yt/',
+        'Tracker': 'https://github.com/yt-project/yt/issues'
+    },
     license="BSD 3-Clause",
     zip_safe=False,
     scripts=["scripts/iyt"],


### PR DESCRIPTION
This change should get github statistics on our [project page](https://pypi.org/project/yt/) on pypi and still keep the other URLs.