### PR TITLE
Fix Issue #1948

### DIFF
--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -1309,7 +1309,7 @@ class NyxDataset(BoxlibDataset):
 
         # alias
         self.current_redshift = self.parameters["CosmologyCurrentRedshift"]
-        if os.path.isdir(os.path.join(self.output_dir, "DM")):
+        if os.path.isfile(os.path.join(self.output_dir, "DM/Header")):
             # we have particles
             self.parameters["particles"] = 1 
             self.particle_types = ("DM",)


### PR DESCRIPTION
The Nyx frontend was using the presence of a `DM` subdirectory to determine whether particles exist or not. Apparently, this always gets created in Nyx, whether or not there are any particles present. However, the file `DM/Header` should only exist if particles are actually in the run. 