### PR TITLE
Fix issues plotting data containing NaN

### DIFF
--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -210,9 +210,10 @@ class ImagePlotMPL(PlotMPL):
             norm = matplotlib.colors.Normalize()
         elif (cbnorm == 'symlog'):
             if cblinthresh is None:
-                cblinthresh = (data.max()-data.min())/10.
+                cblinthresh = float((np.nanmax(data)-np.nanmin(data))/10.)
             norm = matplotlib.colors.SymLogNorm(
-                cblinthresh, vmin=float(data.min()), vmax=float(data.max()))
+                cblinthresh, vmin=float(np.nanmin(data)),
+                vmax=float(np.nanmax(data)))
         extent = [float(e) for e in extent]
         # tuple colormaps are from palettable (or brewer2mpl)
         if isinstance(cmap, tuple):
@@ -232,23 +233,23 @@ class ImagePlotMPL(PlotMPL):
                 **formatter_kwargs)
             self.cb = self.figure.colorbar(
                 self.image, self.cax, format=formatter)
-            if data.min() >= 0.0:
-                yticks = [data.min().v] + list(
+            if np.nanmin(data) >= 0.0:
+                yticks = [np.nanmin(data).v] + list(
                     10**np.arange(np.rint(np.log10(cblinthresh)),
-                                  np.ceil(np.log10(data.max())) + 1))
-            elif data.max() <= 0.0:
+                                  np.ceil(np.log10(np.nanmax(data))) + 1))
+            elif np.nanmax(data) <= 0.0:
                 yticks = list(
                     -10**np.arange(
-                        np.floor(np.log10(-data.min())),
+                        np.floor(np.log10(-np.nanmin(data))),
                         np.rint(np.log10(cblinthresh)) - 1, -1)) + \
-                    [data.max().v]
+                    [np.nanmax(data).v]
             else:
                 yticks = list(
-                    -10**np.arange(np.floor(np.log10(-data.min())),
+                    -10**np.arange(np.floor(np.log10(-np.nanmin(data))),
                                    np.rint(np.log10(cblinthresh))-1, -1)) + \
                     [0] + \
                     list(10**np.arange(np.rint(np.log10(cblinthresh)),
-                                       np.ceil(np.log10(data.max()))+1))
+                                       np.ceil(np.log10(np.nanmax(data)))+1))
             self.cb.set_ticks(yticks)
         else:
             self.cb = self.figure.colorbar(self.image, self.cax)

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -550,3 +550,16 @@ def test_symlog_colorbar():
         plot.set_log(field, True, linthresh=0.1)
         with tempfile.NamedTemporaryFile(suffix='png') as f:
             plot.save(f.name)
+
+def test_nan_data():
+    data = np.random.random((16, 16, 16)) - 0.5
+    data[:9, :9, :9] = np.nan
+
+    data = {'density': data}
+
+    ds = load_uniform_grid(data, [16, 16, 16])
+
+    plot = SlicePlot(ds, 'z', 'density')
+
+    with tempfile.NamedTemporaryFile(suffix='png') as f:
+        plot.save(f.name)


### PR DESCRIPTION
If you load a dataset that contains NaNs and make a plot through a field that contains NaNs and has values less than zero, you will get an error generated by matplotlib. The cause is us passing NaNs to matplotlib in our plotting code. The fix is to use `np.nanmin` and `np.nanmax` instead of `array.min` and `array.max` when setting up colorbars inside yt.

I've added a test that fails on the current master branch but passes with this PR.