### PR TITLE
Use set() instead of list, since same ans test could have iterations

### DIFF
--- a/tests/report_failed_answers.py
+++ b/tests/report_failed_answers.py
@@ -314,25 +314,25 @@ def parse_nose_xml(nose_xml):
         eg. ['yt.visualization.tests.test_line_plots:test_multi_line_plot']
 
     """
-    missing_answers = []
-    failed_answers = []
+    missing_answers = set()
+    failed_answers = set()
     missing_errors = ["No such file or directory",
                       "There is no old answer available"]
     tree = ET.parse(nose_xml)
     testsuite = tree.getroot()
 
     for testcase in testsuite:
-        for error in testcase:
+        for error in testcase.iter('error'):
             test_name = testcase.attrib["classname"] + ":" \
                         + testcase.attrib["name"]
             if missing_errors[0] in error.attrib["message"] or \
                     missing_errors[1] in error.attrib["message"]:
-                    missing_answers.append(test_name)
+                    missing_answers.add(test_name)
 
             elif "Items are not equal" in error.attrib["message"]:
                 img_path = extract_image_locations(error.attrib["message"])
                 if img_path:
-                    failed_answers.append((test_name, img_path))
+                    failed_answers.add((test_name, img_path))
     return failed_answers, missing_answers
 
 if __name__ == "__main__":


### PR DESCRIPTION
## PR Summary

Use set() instead of list for `missing_answers` and `failed_answers`, since same anwer test could have iterations.
eg:
```python
    for lens_type in ['plane-parallel', 'perspective']:
        frame = 0

        cam = sc.add_camera(ds, lens_type=lens_type)
        cam.resolution = (1000, 1000)
        cam.position = ds.arr(np.array([-4., 0., 0.]), 'code_length')
        cam.switch_orientation(normal_vector=[1., 0., 0.],
                               north_vector=[0., 0., 1.])
        cam.set_width(ds.domain_width*2.)
        test1_prefix = '%s_%04d' % (lens_type, frame)
        test1 = VRImageComparisonTest(sc, ds, test1_prefix, decimals)
        test1.prefix = test1_prefix
        test1.answer_name = test_name
        yield test1
```

In this if no answer is present in the answer store, we will get 2 error messages but we only want it once.
## PR Checklist

- [X] Code passes flake8 checker

## Adding Reviewers
@ngoldbaum @Xarthisius @colinmarc