### PR TITLE
fix formatting of example for load_uniform_grid

### DIFF
--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -645,25 +645,13 @@ def load_uniform_grid(data, domain_dimensions, length_unit=None, bbox=None,
 
     >>> bbox = np.array([[0., 1.0], [-1.5, 1.5], [1.0, 2.5]])
     >>> arr = np.random.random((128, 128, 128))
-
     >>> data = dict(density=arr)
     >>> ds = load_uniform_grid(data, arr.shape, length_unit='cm',
     ...                        bbox=bbox, nprocs=12)
     >>> dd = ds.all_data()
     >>> dd['density']
-
     YTArray([ 0.87568064,  0.33686453,  0.70467189, ...,  0.70439916,
             0.97506269,  0.03047113]) g/cm**3
-
-    >>> data = dict(density=(arr, 'kg/m**3'))
-    >>> ds = load_uniform_grid(data, arr.shape, length_unit=3.03e24,
-    ...                        bbox=bbox, nprocs=12)
-    >>> dd = ds.all_data()
-    >>> dd['density']
-
-    YTArray([  8.75680644e-04,   3.36864527e-04,   7.04671886e-04, ...,
-             7.04399160e-04,   9.75062693e-04,   3.04711295e-05]) g/cm**3
-
     """
 
     domain_dimensions = np.array(domain_dimensions)


### PR DESCRIPTION
This makes the example render more nicely on sphinx. Here's what it looks like right now:

http://yt-project.org/doc/reference/api/yt.frontends.stream.data_structures.html?highlight=load_uniform_grid#yt.frontends.stream.data_structures.load_uniform_grid

I also deleted the last bit of the example because it wasn't really doing anything that meaningfully improved understanding of how to use the function (at least in my opinion).