### PR TITLE
[bugfix] Make sure that units are respected properly for particle annotations

### DIFF
--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -48,7 +48,6 @@ from yt.geometry.unstructured_mesh_handler import UnstructuredIndex
 from yt.utilities.lib.mesh_triangulation import triangulate_indices
 from yt.utilities.exceptions import \
     YTDataTypeUnsupported
-
 callback_registry = {}
 
 def _verify_geometry(func):
@@ -1638,9 +1637,15 @@ class ParticleCallback(PlotCallback):
         if iterable(self.width):
             validate_width_tuple(self.width)
             self.width = plot.data.ds.quan(self.width[0], self.width[1])
+        elif isinstance(self.width, YTQuantity):
+            self.width = plot.data.ds.quan(self.width.value, self.width.units)
+        else:
+            self.width = plot.data.ds.quan(self.width, "code_length")
         # we construct a rectangular prism
-        x0, x1 = plot.xlim
-        y0, y1 = plot.ylim
+        x0 = plot.xlim[0].to("code_length")
+        x1 = plot.xlim[1].to("code_length")
+        y0 = plot.ylim[0].to("code_length")
+        y1 = plot.ylim[1].to("code_length")
         xx0, xx1 = plot._axes.get_xlim()
         yy0, yy1 = plot._axes.get_ylim()
         reg = self._get_region((x0,x1), (y0,y1), plot.data.axis, data)
@@ -1705,7 +1710,8 @@ class ParticleCallback(PlotCallback):
         LE[xax], RE[xax] = xlim
         LE[yax], RE[yax] = ylim
         LE[zax] = data.center[zax] - self.width*0.5
-        RE[zax] = data.center[zax] + self.width*0.5
+        LE[zax].convert_to_units("code_length")
+        RE[zax] = LE[zax] + self.width
         if self.region is not None \
             and np.all(self.region.left_edge <= LE) \
             and np.all(self.region.right_edge >= RE):

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -48,6 +48,7 @@ from yt.geometry.unstructured_mesh_handler import UnstructuredIndex
 from yt.utilities.lib.mesh_triangulation import triangulate_indices
 from yt.utilities.exceptions import \
     YTDataTypeUnsupported
+
 callback_registry = {}
 
 def _verify_geometry(func):


### PR DESCRIPTION
I had a `SlicePlot` where I set the `center` and `width` arguments by hand with a specific unit, and then tried to set the `width` parameter in `annotate_particles` using `code_length`:

```python
slc = yt.SlicePlot(ds, "x", ['density'], width=(1.5, "Mpc"),
                             center=ds.arr([0.0, 0.0, 0.2], "Mpc"), origin='native')
slc.annotate_particles(3.0856e24, col='k', stride=100)
```

Two things happened here which prevented me from seeing the particles:

1. `annotate_particles` now assumes that the thing you pass in has units, either as a `YTQuantity` or as a `(value, unit)` tuple, so this fixes it so if you pass in a float it assumes `code_length`. 
2. If one mixes different types of length units in the current code, you end up somewhere down the line with combining `YTQuantity` instances in a list and then wrapping that in `YTArray` (in the `ds.region` code), and that happily clobbers the differences between the units. The solution is to make sure everything is converted to `code_length` beforehand.