### PR TITLE
[bugfix] Fixes OAP unit mismatch issue in OAPs. Fixes #1906

### DIFF
--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -202,11 +202,15 @@ def off_axis_projection(data_source, center, normal_vector,
                     normal_vector,
                     north)
 
+            # Assure that the path length unit is in the default length units
+            # for the dataset by scaling the units of the smoothing length
             path_length_unit = data_source.ds._get_field_info('smoothing_length').units
             path_length_unit = Unit(path_length_unit, registry=data_source.ds.unit_registry)
+            default_path_length_unit = data_source.ds.unit_system['length']
+            buf *= data_source.ds.quan(1, path_length_unit).in_units(default_path_length_unit)
             item_unit = data_source.ds._get_field_info(item).units
             item_unit = Unit(item_unit, registry=data_source.ds.unit_registry)
-            funits = item_unit * path_length_unit
+            funits = item_unit * default_path_length_unit
 
         else:
             # if there is a weight field, take two projections:


### PR DESCRIPTION
## PR Summary

Issue #1906 demonstrates how OffAxisProjections in demeshening project with weird units.  This PR fixes that issue by assuring that the path length unit is in the default length units for that dataset.  

This script demonstrates this solution (note how the zlims and units are the same for each on-axis/off-axis pair now):

```
import yt
ds = yt.load('FIRE_M12i_ref11/snapshot_600.hdf5')
yt.ProjectionPlot(ds, 'z', ('gas', 'density')).save('on.png')
yt.ProjectionPlot(ds, 'z', ('gas', 'temperature'), weight_field=('gas', 'density')).save('on_temp.png')
yt.OffAxisProjectionPlot(ds, [0,0,1], ('gas', 'density'), north_vector=[0,1,0]).save('off.png')
yt.OffAxisProjectionPlot(ds, [0,0,1], ('gas', 'temperature'), weight_field=('gas', 'density'), north_vector=[0,1,0]).save('off_temp.png')
```

On Axis Projection in density:
![on](https://user-images.githubusercontent.com/8250999/43928425-b586fca6-9be5-11e8-8eb3-679d64debd94.png)

Off Axis Projection in density (identical):
![off](https://user-images.githubusercontent.com/8250999/43928430-bb961a6e-9be5-11e8-91b5-57f0f911d214.png)

On Axis Projection in density-weighted temperature:
![on_temp](https://user-images.githubusercontent.com/8250999/43928437-c078566e-9be5-11e8-95ef-085bc4888635.png)

Off Axis Projection in density-weighted temperature:
![off_temp](https://user-images.githubusercontent.com/8250999/43928442-c531bdd0-9be5-11e8-8197-ccf6070935bc.png)