### PR TITLE
[WIP] xy-grid extrusion along z

### DIFF
--- a/yt/data_objects/point_grid_extruded_mesh.py
+++ b/yt/data_objects/point_grid_extruded_mesh.py
@@ -1,0 +1,127 @@
+"""
+Unstructured mesh base container.
+
+
+
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013, yt Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+import numpy as np
+
+from yt.funcs import mylog
+from yt.utilities.exceptions import \
+    YTParticleDepositionNotImplemented
+from yt.utilities.lib.mesh_utilities import \
+    fill_fcoords_extruded
+
+from yt.data_objects.data_containers import \
+    YTSelectionContainer
+import yt.geometry.particle_deposit as particle_deposit
+
+class PointGridExtrudedMesh(YTSelectionContainer):
+    # This particular format expects to have a grid of x, y points that define
+    # the vertices, coupled with a "distance" that defines the ranges to the
+    # different grid points.  We assume that we can connect along these grids.
+    # For instance, this might be the form of an elevation-azimuth-range
+    # dataset.
+    _connectivity_length = 8
+    _type_name = "point_grid_extruded_mesh"
+    _container_fields = ("dx", "dy", "dz")
+    _spatial = False
+    _skip_add = True
+    _index_offset = 0
+    _con_args = ('mesh_id', 'filename', '_grid_locations', '_grid_extrusion')
+    def __init__(self, mesh_id, filename, xy_grid, extruded_grid, index):
+        super(PointGridExtrudedMesh, self).__init__(index.dataset, None)
+        self.filename = filename
+        self.mesh_id = mesh_id
+        # This is where we set up the connectivity information
+        self._grid_locations = xy_grid.copy()
+        self._grid_extrusion = extruded_grid.copy()
+        self.ds = index.dataset
+        self._index = index
+        self._last_mask = None
+        self._last_count = -1
+        self._last_selector_id = None
+
+    def get_global_startindex(self):
+        """
+        Return the integer starting index for each dimension at the current
+        level.
+
+        """
+        raise NotImplementedError
+
+    def convert(self, datatype):
+        """
+        This will attempt to convert a given unit to cgs from code units. It
+        either returns the multiplicative factor or throws a KeyError.
+
+        """
+        return self.ds[datatype]
+
+    @property
+    def shape(self):
+        raise NotImplementedError
+
+    def __repr__(self):
+        return "PointGridExtrudedMesh_%04i" % (self.mesh_id)
+
+    def select_fcoords(self, dobj = None):
+        # This computes centroids!
+        mask = self._get_selector_mask(dobj.selector)
+        if mask is None: return np.empty((0,3), dtype='float64')
+        centers = fill_fcoords_extruded(self._grid_locations,
+                                        self._grid_extrusion)
+        return centers[mask, :]
+
+    def select_fwidth(self, dobj):
+        # This is a placeholder; it's not immediately obvious to me if we will
+        # be able to implement a meaningful fwidth, since the data points will
+        # be irregular in some dimensions.  A width is not necessarily
+        # "meaningful" when discussing the types of polyhedra.
+        raise NotImplementedError
+        mask = self._get_selector_mask(dobj.selector)
+        if mask is None: return np.empty((0,3), dtype='float64')
+        widths = fill_fwidths(self.connectivity_coords,
+                              self.connectivity_indices,
+                              self._index_offset)
+        return widths[mask, :]
+
+    def select_ires(self, dobj):
+        ind = np.zeros(self.connectivity_indices.shape[0])
+        mask = self._get_selector_mask(dobj.selector)
+        if mask is None: return np.empty(0, dtype='int32')
+        return ind[mask]
+
+    def select_tcoords(self, dobj):
+        mask = self._get_selector_mask(dobj.selector)
+        if mask is None: return np.empty(0, dtype='float64')
+        dt, t = dobj.selector.get_dt_mesh(self, mask.sum(), self._index_offset)
+        return dt, t
+
+    def _generate_container_field(self, field):
+        if self._current_chunk is None:
+            self.index._identify_base_chunk(self)
+        if field == "dx":
+            return self._current_chunk.fwidth[:,0]
+        elif field == "dy":
+            return self._current_chunk.fwidth[:,1]
+        elif field == "dz":
+            return self._current_chunk.fwidth[:,2]
+
+    def select(self, selector, source, dest, offset):
+        mask = self._get_selector_mask(selector)
+        count = self.count(selector)
+        if count == 0: return 0
+        # Note: this likely will not work with vector fields.
+        dest[offset:offset+count] = source.flat[mask]
+        return count
+

--- a/yt/data_objects/point_grid_extruded_mesh.py
+++ b/yt/data_objects/point_grid_extruded_mesh.py
@@ -40,6 +40,9 @@ class PointGridExtrudedMesh(YTSelectionContainer):
     _con_args = ('mesh_id', 'filename', '_grid_locations', '_grid_extrusion')
     def __init__(self, mesh_id, filename, xy_grid, extruded_grid, index):
         super(PointGridExtrudedMesh, self).__init__(index.dataset, None)
+        nx, ny = xy_grid.shape
+        nz = extruded_grid.shape[0]
+        self.ActiveDimensions = (nx - 1) * (ny - 1) * (nz - 1)
         self.filename = filename
         self.mesh_id = mesh_id
         # This is where we set up the connectivity information

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -196,8 +196,10 @@ class FieldInfoContainer(dict):
                 units = ""
             elif units == 1.0:
                 units = ""
+            if field[1] == 'reflectivity':
+                take_log = False
             self.add_output_field(field, sampling_type="cell", units = units,
-                                  display_name = display_name)
+                                  display_name = display_name, take_log=take_log)
             for alias in aliases:
                 self.alias((ftype, alias), field)
 

--- a/yt/frontends/_skeleton/data_structures.py
+++ b/yt/frontends/_skeleton/data_structures.py
@@ -30,8 +30,8 @@ class SkeletonGrid(AMRGridPatch):
     _id_offset = 0
 
     def __init__(self, id, index, level):
-        super(SkeletonGrid, self).__init__(self, id, filename=index.index_filename,
-                              index=index)
+        super(SkeletonGrid, self).__init__(
+            id, filename=index.index_filename, index=index)
         self.Parent = None
         self.Children = []
         self.Level = level
@@ -51,7 +51,7 @@ class SkeletonHierarchy(GridIndex):
         self.directory = os.path.dirname(self.index_filename)
         # float type for the simulation edges and must be float64 now
         self.float_type = np.float64
-        super(SkeletonHierarchy, self).__init__(self, ds, dataset_type)
+        super(SkeletonHierarchy, self).__init__(ds, dataset_type)
 
     def _detect_output_fields(self):
         # This needs to set a self.field_list that contains all the available,
@@ -97,7 +97,7 @@ class SkeletonDataset(Dataset):
                  storage_filename=None,
                  units_override=None):
         self.fluid_types += ('skeleton',)
-        super(SkeletonDataset, self).__init__(self, filename, dataset_type,
+        super(SkeletonDataset, self).__init__(filename, dataset_type,
                          units_override=units_override)
         self.storage_filename = storage_filename
         # refinement factor between a grid and its subgrid

--- a/yt/frontends/api.py
+++ b/yt/frontends/api.py
@@ -23,6 +23,7 @@ _frontends = [
     'athena',
     'athena_pp',
     'boxlib',
+    'cf_radial',
     'chombo',
     'eagle',
     'enzo',

--- a/yt/frontends/cf_radial/__init__.py
+++ b/yt/frontends/cf_radial/__init__.py
@@ -1,0 +1,14 @@
+"""
+API for yt.frontends.cf_radial
+
+
+
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) 2018, yt Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------

--- a/yt/frontends/cf_radial/api.py
+++ b/yt/frontends/cf_radial/api.py
@@ -1,0 +1,25 @@
+"""
+API for yt.frontends.cf_radial
+
+
+
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013, yt Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from .data_structures import \
+    CFRadialGrid, \
+    CFRadialHierarchy, \
+    CFRadialDataset
+
+from .fields import \
+    CFRadialFieldInfo
+
+from .io import \
+    CFRadialIOHandler

--- a/yt/frontends/cf_radial/data_structures.py
+++ b/yt/frontends/cf_radial/data_structures.py
@@ -31,7 +31,7 @@ class CFRadialGrid(AMRGridPatch):
 
     def __init__(self, id, index, level):
         super(CFRadialGrid, self).__init__(
-            self, id, filename=index.index_filename, index=index)
+            id, filename=index.index_filename, index=index)
         self.Parent = None
         self.Children = []
         self.Level = level
@@ -51,7 +51,8 @@ class CFRadialHierarchy(GridIndex):
         self.directory = os.path.dirname(self.index_filename)
         # float type for the simulation edges and must be float64 now
         self.float_type = np.float64
-        super(CFRadialHierarchy, self).__init__(self, ds, dataset_type)
+        super(CFRadialHierarchy, self).__init__(
+            ds, dataset_type)
 
     def _detect_output_fields(self):
         # This needs to set a self.field_list that contains all the available,
@@ -97,8 +98,9 @@ class CFRadialDataset(Dataset):
                  storage_filename=None,
                  units_override=None):
         self.fluid_types += ('cf_radial',)
-        super(CFRadialDataset, self).__init__(self, filename, dataset_type,
-                         units_override=units_override)
+        super(CFRadialDataset, self).__init__(
+            filename, dataset_type,
+            units_override=units_override)
         self.storage_filename = storage_filename
         # refinement factor between a grid and its subgrid
         # self.refine_by = 2

--- a/yt/frontends/cf_radial/data_structures.py
+++ b/yt/frontends/cf_radial/data_structures.py
@@ -1,0 +1,152 @@
+"""
+CF Radial data structures
+
+
+
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) 2018, yt Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+import os
+import numpy as np
+import weakref
+
+from yt.data_objects.grid_patch import \
+    AMRGridPatch
+from yt.geometry.grid_geometry_handler import \
+    GridIndex
+from yt.data_objects.static_output import \
+    Dataset
+from .fields import CFRadialFieldInfo
+
+
+class CFRadialGrid(AMRGridPatch):
+    _id_offset = 0
+
+    def __init__(self, id, index, level):
+        super(CFRadialGrid, self).__init__(
+            self, id, filename=index.index_filename, index=index)
+        self.Parent = None
+        self.Children = []
+        self.Level = level
+
+    def __repr__(self):
+        return "CFRadialGrid_%04i (%s)" % (self.id, self.ActiveDimensions)
+
+
+class CFRadialHierarchy(GridIndex):
+    grid = CFRadialGrid
+
+    def __init__(self, ds, dataset_type='cf_radial'):
+        self.dataset_type = dataset_type
+        self.dataset = weakref.proxy(ds)
+        # for now, the index file is the dataset!
+        self.index_filename = self.dataset.parameter_filename
+        self.directory = os.path.dirname(self.index_filename)
+        # float type for the simulation edges and must be float64 now
+        self.float_type = np.float64
+        super(CFRadialHierarchy, self).__init__(self, ds, dataset_type)
+
+    def _detect_output_fields(self):
+        # This needs to set a self.field_list that contains all the available,
+        # on-disk fields. No derived fields should be defined here.
+        # NOTE: Each should be a tuple, where the first element is the on-disk
+        # fluid type or particle type.  Convention suggests that the on-disk
+        # fluid type is usually the dataset_type and the on-disk particle type
+        # (for a single population of particles) is "io".
+        pass
+
+    def _count_grids(self):
+        # This needs to set self.num_grids
+        pass
+
+    def _parse_index(self):
+        # This needs to fill the following arrays, where N is self.num_grids:
+        #   self.grid_left_edge         (N, 3) <= float64
+        #   self.grid_right_edge        (N, 3) <= float64
+        #   self.grid_dimensions        (N, 3) <= int
+        #   self.grid_particle_count    (N, 1) <= int
+        #   self.grid_levels            (N, 1) <= int
+        #   self.grids                  (N, 1) <= grid objects
+        #   self.max_level = self.grid_levels.max()
+        pass
+
+    def _populate_grid_objects(self):
+        # For each grid, this must call:
+        #   grid._prepare_grid()
+        #   grid._setup_dx()
+        # This must also set:
+        #   grid.Children <= list of child grids
+        #   grid.Parent   <= parent grid
+        # This is handled by the frontend because often the children must be
+        # identified.
+        pass
+
+
+class CFRadialDataset(Dataset):
+    _index_class = CFRadialHierarchy
+    _field_info_class = CFRadialFieldInfo
+
+    def __init__(self, filename, dataset_type='cf_radial',
+                 storage_filename=None,
+                 units_override=None):
+        self.fluid_types += ('cf_radial',)
+        super(CFRadialDataset, self).__init__(self, filename, dataset_type,
+                         units_override=units_override)
+        self.storage_filename = storage_filename
+        # refinement factor between a grid and its subgrid
+        # self.refine_by = 2
+
+    def _set_code_unit_attributes(self):
+        # This is where quantities are created that represent the various
+        # on-disk units.  These are the currently available quantities which
+        # should be set, along with examples of how to set them to standard
+        # values.
+        #
+        # self.length_unit = self.quan(1.0, "cm")
+        # self.mass_unit = self.quan(1.0, "g")
+        # self.time_unit = self.quan(1.0, "s")
+        # self.time_unit = self.quan(1.0, "s")
+        #
+        # These can also be set:
+        # self.velocity_unit = self.quan(1.0, "cm/s")
+        # self.magnetic_unit = self.quan(1.0, "gauss")
+        pass
+
+    def _parse_parameter_file(self):
+        # This needs to set up the following items.  Note that these are all
+        # assumed to be in code units; domain_left_edge and domain_right_edge
+        # will be converted to YTArray automatically at a later time.
+        # This includes the cosmological parameters.
+        #
+        #   self.unique_identifier      <= unique identifier for the dataset
+        #                                  being read (e.g., UUID or ST_CTIME)
+        #   self.parameters             <= full of code-specific items of use
+        #   self.domain_left_edge       <= array of float64
+        #   self.domain_right_edge      <= array of float64
+        #   self.dimensionality         <= int
+        #   self.domain_dimensions      <= array of int64
+        #   self.periodicity            <= three-element tuple of booleans
+        #   self.current_time           <= simulation time in code units
+        #
+        # We also set up cosmological information.  Set these to zero if
+        # non-cosmological.
+        #
+        #   self.cosmological_simulation    <= int, 0 or 1
+        #   self.current_redshift           <= float
+        #   self.omega_lambda               <= float
+        #   self.omega_matter               <= float
+        #   self.hubble_constant            <= float
+        pass
+
+    @classmethod
+    def _is_valid(self, *args, **kwargs):
+        # This accepts a filename or a set of arguments and returns True or
+        # False depending on if the file is of the type requested.
+        return False

--- a/yt/frontends/cf_radial/data_structures.py
+++ b/yt/frontends/cf_radial/data_structures.py
@@ -149,4 +149,22 @@ class CFRadialDataset(Dataset):
     def _is_valid(self, *args, **kwargs):
         # This accepts a filename or a set of arguments and returns True or
         # False depending on if the file is of the type requested.
+        try:
+            import xarray
+        except ImportError:
+            return False
+
+        try:
+            ds = xarray.open_dataset(args[0])
+        except FileNotFoundError:
+            return False
+
+        try:
+            conventions = ds.attrs['Conventions']
+        except KeyError:
+            return False
+
+        if 'CF/Radial' in conventions:
+            return True
+
         return False

--- a/yt/frontends/cf_radial/data_structures.py
+++ b/yt/frontends/cf_radial/data_structures.py
@@ -26,6 +26,11 @@ from yt.data_objects.static_output import \
     Dataset
 from .fields import CFRadialFieldInfo
 
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
+
 import xarray
 
 class CFRadialGrid(AMRGridPatch):
@@ -68,9 +73,6 @@ class CFRadialHierarchy(GridIndex):
         # fluid type or particle type.  Convention suggests that the on-disk
         # fluid type is usually the dataset_type and the on-disk particle type
         # (for a single population of particles) is "io".
-        #self.field_list = [
-         #   ('cf_radial', 'reflectivity')
-       # ]
         self.field_list = []
         for key in self.ds._handle.variables.keys():
             if all(x in self.ds._handle[key].dims for x

--- a/yt/frontends/cf_radial/data_structures.py
+++ b/yt/frontends/cf_radial/data_structures.py
@@ -13,8 +13,9 @@ CF Radial data structures
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-import os
 import numpy as np
+import os
+import stat
 import weakref
 
 from yt.data_objects.grid_patch import \
@@ -25,16 +26,18 @@ from yt.data_objects.static_output import \
     Dataset
 from .fields import CFRadialFieldInfo
 
+import xarray
 
 class CFRadialGrid(AMRGridPatch):
     _id_offset = 0
 
-    def __init__(self, id, index, level):
+    def __init__(self, id, index, level, dimensions):
         super(CFRadialGrid, self).__init__(
             id, filename=index.index_filename, index=index)
         self.Parent = None
         self.Children = []
         self.Level = level
+        self.ActiveDimensions = dimensions
 
     def __repr__(self):
         return "CFRadialGrid_%04i (%s)" % (self.id, self.ActiveDimensions)
@@ -54,6 +57,10 @@ class CFRadialHierarchy(GridIndex):
         super(CFRadialHierarchy, self).__init__(
             ds, dataset_type)
 
+    def _initialize_state_variables(self):
+        super(CFRadialHierarchy, self)._initialize_state_variables()
+        self.num_grids = 1
+
     def _detect_output_fields(self):
         # This needs to set a self.field_list that contains all the available,
         # on-disk fields. No derived fields should be defined here.
@@ -61,7 +68,9 @@ class CFRadialHierarchy(GridIndex):
         # fluid type or particle type.  Convention suggests that the on-disk
         # fluid type is usually the dataset_type and the on-disk particle type
         # (for a single population of particles) is "io".
-        pass
+        self.field_list = [
+            ('cf_radial', 'reflectivity')
+        ]
 
     def _count_grids(self):
         # This needs to set self.num_grids
@@ -76,6 +85,17 @@ class CFRadialHierarchy(GridIndex):
         #   self.grid_levels            (N, 1) <= int
         #   self.grids                  (N, 1) <= grid objects
         #   self.max_level = self.grid_levels.max()
+        self.grid_left_edge[0][:] = self.ds.domain_left_edge[:]
+        self.grid_right_edge[0][:] = self.ds.domain_right_edge[:]
+        self.grid_dimensions[0][:] = self.ds.domain_dimensions[:]
+        self.grids = np.empty(self.num_grids, dtype='object')
+        for i in range(self.num_grids):
+            g = self.grid(i, self, self.grid_levels.flat[i],
+                          self.grid_dimensions[i])
+            g._prepare_grid()
+            g._setup_dx()
+            self.grids[i] = g
+        self.max_level = 1
         pass
 
     def _populate_grid_objects(self):
@@ -98,6 +118,7 @@ class CFRadialDataset(Dataset):
                  storage_filename=None,
                  units_override=None):
         self.fluid_types += ('cf_radial',)
+        self._handle = xarray.open_dataset(filename)
         super(CFRadialDataset, self).__init__(
             filename, dataset_type,
             units_override=units_override)
@@ -112,30 +133,48 @@ class CFRadialDataset(Dataset):
         # values.
         #
         # self.length_unit = self.quan(1.0, "cm")
-        # self.mass_unit = self.quan(1.0, "g")
-        # self.time_unit = self.quan(1.0, "s")
-        # self.time_unit = self.quan(1.0, "s")
         #
         # These can also be set:
         # self.velocity_unit = self.quan(1.0, "cm/s")
         # self.magnetic_unit = self.quan(1.0, "gauss")
-        pass
+        length_unit = self._handle.variables['x'].attrs['units']
+        self.length_unit = self.quan(1.0, length_unit)
+        self.mass_unit = self.quan(1.0, "kg")
+        self.time_unit = self.quan(1.0, "s")
+
 
     def _parse_parameter_file(self):
         # This needs to set up the following items.  Note that these are all
         # assumed to be in code units; domain_left_edge and domain_right_edge
         # will be converted to YTArray automatically at a later time.
         # This includes the cosmological parameters.
+
         #
         #   self.unique_identifier      <= unique identifier for the dataset
         #                                  being read (e.g., UUID or ST_CTIME)
+        self.unique_identifier = int(os.stat(
+            self.parameter_filename)[stat.ST_CTIME])
         #   self.parameters             <= full of code-specific items of use
+        self.parameters = {}
+
+        coords = self._handle.coords
+        x, y, z = [coords[d] for d in 'xyz']
+
         #   self.domain_left_edge       <= array of float64
+        dle = [x.min(), y.min(), z.min()]
+        self.domain_left_edge = np.array(dle)
         #   self.domain_right_edge      <= array of float64
+        dre = [x.max(), y.max(), z.max()]
+        self.domain_right_edge = np.array(dre)
         #   self.dimensionality         <= int
+        self.dimensionality = 3
         #   self.domain_dimensions      <= array of int64
+        dims = [self._handle.dims[d] for d in 'xyz']
+        self.domain_dimensions = np.array(dims, dtype='int64')
         #   self.periodicity            <= three-element tuple of booleans
+        self.periodicity = (False, False, False)
         #   self.current_time           <= simulation time in code units
+        self.current_time = float(self._handle.time.values)
         #
         # We also set up cosmological information.  Set these to zero if
         # non-cosmological.
@@ -145,7 +184,11 @@ class CFRadialDataset(Dataset):
         #   self.omega_lambda               <= float
         #   self.omega_matter               <= float
         #   self.hubble_constant            <= float
-        pass
+        self.cosmological_simulation = 0.0
+        self.current_redshift = 0.0
+        self.omega_lambda = 0.0
+        self.omega_matter = 0.0
+        self.hubble_constant = 0.0
 
     @classmethod
     def _is_valid(self, *args, **kwargs):
@@ -158,7 +201,7 @@ class CFRadialDataset(Dataset):
 
         try:
             ds = xarray.open_dataset(args[0])
-        except FileNotFoundError:
+        except (FileNotFoundError, OSError):
             return False
 
         try:

--- a/yt/frontends/cf_radial/definitions.py
+++ b/yt/frontends/cf_radial/definitions.py
@@ -1,0 +1,1 @@
+# This file is often empty.  It can hold definitions related to a frontend.

--- a/yt/frontends/cf_radial/fields.py
+++ b/yt/frontends/cf_radial/fields.py
@@ -1,0 +1,47 @@
+"""
+CF-radial-specific fields
+
+
+
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) 2018, yt Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from yt.fields.field_info_container import \
+    FieldInfoContainer
+
+# We need to specify which fields we might have in our dataset.  The field info
+# container subclass here will define which fields it knows about.  There are
+# optionally methods on it that get called which can be subclassed.
+
+
+class CFRadialFieldInfo(FieldInfoContainer):
+    known_other_fields = (
+        # Each entry here is of the form
+        # ( "name", ("units", ["fields", "to", "alias"], # "display_name")),
+    )
+
+    known_particle_fields = (
+        # Identical form to above
+        # ( "name", ("units", ["fields", "to", "alias"], # "display_name")),
+    )
+
+    def __init__(self, ds, field_list):
+        super(CFRadialFieldInfo, self).__init__(ds, field_list)
+        # If you want, you can check self.field_list
+
+    def setup_fluid_fields(self):
+        # Here we do anything that might need info about the dataset.
+        # You can use self.alias, self.add_output_field (for on-disk fields)
+        # and self.add_field (for derived fields).
+        pass
+
+    def setup_particle_fields(self, ptype):
+        super(CFRadialFieldInfo, self).setup_particle_fields(ptype)
+        # This will get called for every particle type.

--- a/yt/frontends/cf_radial/fields.py
+++ b/yt/frontends/cf_radial/fields.py
@@ -25,6 +25,7 @@ class CFRadialFieldInfo(FieldInfoContainer):
     known_other_fields = (
         # Each entry here is of the form
         # ( "name", ("units", ["fields", "to", "alias"], # "display_name")),
+        ("reflectivity", ("", [], None)),
     )
 
     known_particle_fields = (

--- a/yt/frontends/cf_radial/io.py
+++ b/yt/frontends/cf_radial/io.py
@@ -1,0 +1,59 @@
+"""
+CF-Radial-specific IO functions
+
+
+
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013, yt Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from yt.utilities.io_handler import \
+    BaseIOHandler
+
+
+class CFRadialIOHandler(BaseIOHandler):
+    _particle_reader = False
+    _dataset_type = 'cf-radial'
+
+    def _read_particle_coords(self, chunks, ptf):
+        # This needs to *yield* a series of tuples of (ptype, (x, y, z)).
+        # chunks is a list of chunks, and ptf is a dict where the keys are
+        # ptypes and the values are lists of fields.
+        pass
+
+    def _read_particle_fields(self, chunks, ptf, selector):
+        # This gets called after the arrays have been allocated.  It needs to
+        # yield ((ptype, field), data) where data is the masked results of
+        # reading ptype, field and applying the selector to the data read in.
+        # Selector objects have a .select_points(x,y,z) that returns a mask, so
+        # you need to do your masking here.
+        pass
+
+    def _read_fluid_selection(self, chunks, selector, fields, size):
+        # This needs to allocate a set of arrays inside a dictionary, where the
+        # keys are the (ftype, fname) tuples and the values are arrays that
+        # have been masked using whatever selector method is appropriate.  The
+        # dict gets returned at the end and it should be flat, with selected
+        # data.  Note that if you're reading grid data, you might need to
+        # special-case a grid selector object.
+        # Also note that "chunks" is a generator for multiple chunks, each of
+        # which contains a list of grids. The returned numpy arrays should be
+        # in 64-bit float and contiguous along the z direction. Therefore, for
+        # a C-like input array with the dimension [x][y][z] or a
+        # Fortran-like input array with the dimension (z,y,x), a matrix
+        # transpose is required (e.g., using np_array.transpose() or
+        # np_array.swapaxes(0,2)).
+        pass
+
+    def _read_chunk_data(self, chunk, fields):
+        # This reads the data from a single chunk without doing any selection,
+        # and is only used for caching data that might be used by multiple
+        # different selectors later. For instance, this can speed up ghost zone
+        # computation.
+        pass

--- a/yt/frontends/cf_radial/io.py
+++ b/yt/frontends/cf_radial/io.py
@@ -65,7 +65,6 @@ class CFRadialIOHandler(BaseIOHandler):
                     ds = self.ds._handle
                     variable = ds.variables[field[1]]
                     data = variable.values[0, ...].T
-                    data[np.isnan(data)] = 0
                     offset += grid.select(
                         selector, data, rv[field], offset)
         return rv

--- a/yt/geometry/unstructured_mesh_handler.py
+++ b/yt/geometry/unstructured_mesh_handler.py
@@ -92,3 +92,7 @@ class UnstructuredIndex(Index):
         for subset in oobjs:
             s = self._count_selection(dobj, oobjs)
             yield YTDataChunk(dobj, "io", [subset], s, cache = cache)
+
+class ExtrudedGridIndex(UnstructuredIndex):
+    def get_smallest_dx(self):
+        raise NotImplementedError

--- a/yt/units/unit_lookup_table.py
+++ b/yt/units/unit_lookup_table.py
@@ -127,6 +127,8 @@ default_unit_symbol_lut = {
     "mol": (1.0/amu_grams, dimensions.dimensionless, 0.0, r"\rm{mol}"),
     'Sv': (cm_per_m**2, dimensions.specific_energy, 0.0, r"\rm{Sv}"),
     "rayleigh": (0.25e6/np.pi, dimensions.count_intensity, 0.0, r"\rm{R}"),
+    "dBZ": (1.0, dimensions.dimensionless, 0.0, r"\rm{dBZ}"),
+    "dB": (1.0, dimensions.dimensionless, 0.0, r"\rm{dB}"),
 
     # for AstroPy compatibility
     "solMass": (mass_sun_grams, dimensions.mass, 0.0, r"M_\odot"),

--- a/yt/utilities/lib/mesh_utilities.pyx
+++ b/yt/utilities/lib/mesh_utilities.pyx
@@ -75,6 +75,33 @@ def fill_fwidths(np.ndarray[np.float64_t, ndim=2] coords,
             fwidths[i, j] = RE[j] - LE[j]
     return fwidths
 
+def fill_fcoords_extruded(np.ndarray[np.float64_t, ndim=3] grid_xy,
+                          np.ndarray[np.float64_t, ndim=1] grid_z):
+    cdef np.ndarray[np.float64_t, ndim=2] fcoords
+    # This is for barycenters
+    nv = 8
+    cdef int nx, ny, nz, ind
+    cdef np.float64_t pos[3]
+    nx = grid_xy.shape[0]
+    ny = grid_xy.shape[1]
+    nz = grid_z.shape[0]
+    nc = (nx - 1) * (ny - 1) * (nz - 1)
+    fcoords = np.empty((nc, 3), dtype="float64")
+    ind = 0
+    for i in range(nx - 1):
+        for j in range(ny - 1):
+            pos[0] = (grid_xy[i,j,0] + grid_xy[i+1,j,0] +
+                      grid_xy[i+1,j,0] + grid_xy[i+1,j+1,0])/4.0
+            pos[1] = (grid_xy[i,j,1] + grid_xy[i+1,j,1] +
+                      grid_xy[i+1,j,1] + grid_xy[i+1,j+1,1])/4.0
+            for k in range(nz - 1):
+                pos[2] = (grid_z[k] + grid_z[k+1])/2.0
+                fcoords[ind, 0] = pos[0]
+                fcoords[ind, 1] = pos[1]
+                fcoords[ind, 2] = pos[2]
+                ind += 1
+    return fcoords
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)


### PR DESCRIPTION
This implements the first steps toward a data index that is defined by an xy grid of points with constant z.  For instance, the particular use case is ARM data that is taken at multiple sweeps along the azimuth, at roughly onstant elevation, and *always* constant "range" (distance).  This could be defined as a hexahedral mesh, but because we have a reduced dimensionality in xy, it can reduce memory considerably to define it with `xy_grid` and `z_grid`.

Also!  I may have messed up my git branching!  So there's the likely possibility that I'm including irrelevant changesets!  But, when Nathan's PR goes in and I rebase, maybe that will go away?

There are numerous todo's, including:

- [ ] finish implementation of extrusion base data object
- [ ] finish fwidth
- [ ] integrate into pixelizers the new extruded mesh pixelizer
- [ ] implement `cf_sweep` frontend
- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
