### PR TITLE
fix name of text size keyword in contour callback test

### DIFF
--- a/yt/visualization/tests/test_callbacks.py
+++ b/yt/visualization/tests/test_callbacks.py
@@ -472,7 +472,7 @@ def test_contour_callback():
         p.annotate_contour("temperature", ncont=10, factor=8,
             take_log=False, clim=(0.4, 0.6),
             plot_args={'linewidths':2.0}, label=True,
-            text_args={'text-size':'x-large'})
+            text_args={'fontsize':'x-large'})
         p.save(prefix)
 
         p = SlicePlot(ds, "x", "density")
@@ -480,7 +480,7 @@ def test_contour_callback():
         p.annotate_contour("temperature", ncont=10, factor=8,
             take_log=False, clim=(0.4, 0.6),
             plot_args={'linewidths':2.0}, label=True,
-            text_args={'text-size':'x-large'},
+            text_args={'fontsize':'x-large'},
             data_source=s2)
         p.save(prefix)
 
@@ -504,7 +504,7 @@ def test_contour_callback():
         p.annotate_contour("temperature", ncont=10, factor=8,
             take_log=False, clim=(0.4, 0.6),
             plot_args={'linewidths':2.0}, label=True,
-            text_args={'text-size':'x-large'})
+            text_args={'fontsize':'x-large'})
         assert_raises(YTDataTypeUnsupported, p.save, prefix)
 
 


### PR DESCRIPTION
This fixes the test for the contour callback when running the yt test suite with matplotlib 3.0.0 rc1. This was not noticed until now because before https://github.com/matplotlib/matplotlib/pull/10545 matplotlib did not complain about unprocessed keyword arguments. Not it does complain so we need to be more careful. As a bonus this test is now testing what it said it was testing.