### PR TITLE
[Bugfix] WarpX datasets with no particles

### DIFF
--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -1564,7 +1564,10 @@ class WarpXDataset(BoxlibDataset):
             self.parameters["particles"] = 1
             self.particle_types = tuple(particle_types)
             self.particle_types_raw = self.particle_types
-
+        else:
+            self.particle_types = ()
+            self.particle_types_raw = ()
+            
     def _set_code_unit_attributes(self):
         setdefaultattr(self, 'length_unit', self.quan(1.0, "m"))
         setdefaultattr(self, 'mass_unit', self.quan(1.0, "kg"))


### PR DESCRIPTION
This change is needed to properly read WarpX datasets that don't have particles.