### PR TITLE
don't generate the kdtree for particle projections

### DIFF
--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -357,23 +357,17 @@ class YTProj(YTSelectionContainer2D):
             else:
                 self._projected_units[field] = field_unit
 
-class YTKDTreeProj(YTProj):
+class YTParticleProj(YTProj):
     """
-    TODO add docstring
+    A projection operation optimized for SPH particle data.
     """
     _type_name = "particle_proj"
     def __init__(self, field, axis, weight_field=None, center=None, ds=None,
                  data_source=None, style=None, method="integrate",
                  field_parameters=None, max_level=None):
-        super(YTKDTreeProj, self).__init__(
+        super(YTParticleProj, self).__init__(
             field, axis, weight_field, center, ds, data_source, style, method,
             field_parameters, max_level)
-
-        # ensure the dataset has a kdtree built
-        ds.index.kdtree
-
-    def _get_tree(self, nvals):
-        return self.ds.index.kdtree
 
     def _handle_chunk(self, chunk, fields, tree):
         raise NotImplementedError("Particle projections have not yet been "

--- a/yt/geometry/coordinates/cartesian_coordinates.py
+++ b/yt/geometry/coordinates/cartesian_coordinates.py
@@ -240,7 +240,7 @@ class CartesianCoordinateHandler(CoordinateHandler):
         from yt.data_objects.selection_data_containers import \
             YTSlice
         from yt.data_objects.construction_data_containers import \
-            YTKDTreeProj
+            YTParticleProj
         # We should be using fcoords
         field = data_source._determine_fields(field)[0]
         period = self.period[:2].copy() # dummy here
@@ -269,7 +269,7 @@ class CartesianCoordinateHandler(CoordinateHandler):
             ounits = data_source.ds.field_info[field].output_units
             px_name = 'particle_position_%s' % self.axis_name[self.x_axis[dim]]
             py_name = 'particle_position_%s' % self.axis_name[self.y_axis[dim]]
-            if isinstance(data_source, YTKDTreeProj):
+            if isinstance(data_source, YTParticleProj):
                 weight = data_source.weight_field
                 le = data_source.data_source.left_edge.in_units('code_length')
                 re = data_source.data_source.right_edge.in_units('code_length')


### PR DESCRIPTION
In the spring I was experimenting with doing particle projections using the kdtree. This didn't get much further than some experiments but I did make it so that the kdtree gets unconditionally generated. This is unnecessary and causes scaling issues for large datasets, so let's not do that.

Fixes #1973.