### PR TITLE
create individual particle fields using SNIa and SNII metallicities 

### DIFF
--- a/yt/frontends/art/fields.py
+++ b/yt/frontends/art/fields.py
@@ -159,7 +159,7 @@ SNIa_abundance = {
     'Mn' : 7.04E+19, 'Fe' : 5.85E+21, 'Co' : 7.69E+18, 
     'Ni' : 9.34E+20, 'Cu' : 2.06E+16, 'Zn' : 1.88E+17}
 
-# number of atoms per gram of SNIa metal
+# number of atoms per gram of SNII metal
 SNII_abundance = {
     'H'  : 0.00E+00, 'He' : 0.00E+00, 'C'  : 1.55E+21, 
     'N'  : 2.62E+19, 'O'  : 2.66E+22, 'F'  : 1.44E+13, 

--- a/yt/frontends/art/fields.py
+++ b/yt/frontends/art/fields.py
@@ -15,6 +15,7 @@ ART-specific fields
 
 from yt.fields.field_info_container import \
     FieldInfoContainer
+from yt.utilities.physical_constants import mh
 
 b_units = "code_magnetic"
 ra_units = "code_length / code_time**2"
@@ -128,3 +129,57 @@ class ARTFieldInfo(FieldInfoContainer):
         self.add_field(('gas', 'metallicity'), sampling_type="cell", 
                        function=_metallicity,
                        units='')
+
+        atoms = ['C', 'N', 'O', 'F', 'Ne', 'Na', 'Mg', \
+        'Al', 'Si', 'P', 'S', 'Cl', 'Ar', 'K', 'Ca', 'Sc', \
+        'Ti', 'V', 'Cr', 'Mn', 'Fe', 'Co', 'Ni', 'Cu', 'Zn']
+        for atom in atoms:
+            def _specific_metal_density(field, data):
+                nucleus_densityIa = data[('gas','metal_ia_density')].in_units("g / cm**3")*\
+                                    data.ds.quan(SNIa_abundance[atom],"1 / g")*atomic_mass[atom]*mh
+                nucleus_densityII = data[('gas','metal_ii_density')].in_units("g / cm**3")*\
+                                    data.ds.quan(SNIa_abundance[atom],"1 / g")*atomic_mass[atom]*mh
+                return nucleus_densityIa + nucleus_densityII
+            self.add_field(('gas','%s_nuclei_mass_density'%atom),sampling_type="cell",
+                            function=_specific_metal_density,
+                            units=unit_system["density"])
+
+
+
+# based on Iwamoto et al 1999
+# number of atoms per gram of SNIa metal
+SNIa_abundance = {
+    'H'  : 0.00E+00, 'He' : 0.00E+00, 'C'  : 1.75E+21, 
+    'N'  : 3.61E+16, 'O'  : 3.90E+21, 'F'  : 1.30E+13, 
+    'Ne' : 9.76E+19, 'Na' : 1.20E+18, 'Mg' : 1.54E+20, 
+    'Al' : 1.59E+19, 'Si' : 2.43E+21, 'P'  : 5.02E+18, 
+    'S'  : 1.18E+21, 'Cl' : 2.14E+18, 'Ar' : 1.71E+20, 
+    'K'  : 8.74E+17, 'Ca' : 1.30E+20, 'Sc' : 2.14E+15, 
+    'Ti' : 3.12E+18, 'V'  : 6.41E+17, 'Cr' : 7.11E+19, 
+    'Mn' : 7.04E+19, 'Fe' : 5.85E+21, 'Co' : 7.69E+18, 
+    'Ni' : 9.34E+20, 'Cu' : 2.06E+16, 'Zn' : 1.88E+17}
+
+# number of atoms per gram of SNIa metal
+SNII_abundance = {
+    'H'  : 0.00E+00, 'He' : 0.00E+00, 'C'  : 1.55E+21, 
+    'N'  : 2.62E+19, 'O'  : 2.66E+22, 'F'  : 1.44E+13, 
+    'Ne' : 2.70E+21, 'Na' : 6.67E+19, 'Mg' : 1.19E+21, 
+    'Al' : 1.29E+20, 'Si' : 1.02E+21, 'P'  : 9.20E+18, 
+    'S'  : 3.02E+20, 'Cl' : 7.95E+17, 'Ar' : 4.71E+19, 
+    'K'  : 4.06E+17, 'Ca' : 3.45E+19, 'Sc' : 1.20E+15, 
+    'Ti' : 6.47E+17, 'V'  : 4.62E+16, 'Cr' : 5.96E+18, 
+    'Mn' : 1.65E+18, 'Fe' : 3.82E+20, 'Co' : 2.90E+17, 
+    'Ni' : 2.40E+19, 'Cu' : 4.61E+15, 'Zn' : 6.81E+16}
+
+# taken from TRIDENT
+atomic_mass = {
+    'H' : 1.00794,   'He': 4.002602,  'Li': 6.941,
+    'Be': 9.012182,  'B' : 10.811,    'C' : 12.0107,
+    'N' : 14.0067,   'O' : 15.9994,   'F' : 18.9984032,
+    'Ne': 20.1797,   'Na': 22.989770, 'Mg': 24.3050,
+    'Al': 26.981538, 'Si': 28.0855,   'P' : 30.973761,
+    'S' : 32.065,    'Cl': 35.453,    'Ar': 39.948,
+    'K' : 39.0983,   'Ca': 40.078,    'Sc': 44.955910,
+    'Ti': 47.867,    'V' : 50.9415,   'Cr': 51.9961,
+    'Mn': 54.938049, 'Fe': 55.845,    'Co': 58.933200,
+    'Ni': 58.6934,   'Cu': 63.546,    'Zn': 65.409}


### PR DESCRIPTION
TRIDENT requires fields named `O_nuclei_mass_density, C_nuclei_mass_density, Fe_nuclei_mass_density`, etc in order to use specific atoms in it's density calculations. If they are missing, then it uses an overall "metallicity" field and assumes solar abundance. 

Since ART tracks type Ia and type II SNe separately, and they have very different abundances, it would be more accurate to insert atom fields at this stage using that information, so that TRIDENT doesn't have to assume this.

This PR adds those fields to the setup_fluid_fields method.
