### PR TITLE
[bugfix] add read-only tag to h5py file load to prevent false modifying time

### DIFF
--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -80,7 +80,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
 
     def _yield_coordinates(self, data_file, needed_ptype=None):
         si, ei = data_file.start, data_file.end
-        f = h5py.File(data_file.filename)
+        f = h5py.File(data_file.filename, "r")
         pcount = f["/Header"].attrs["NumPart_ThisFile"][:].astype("int")
         np.clip(pcount - si, 0, ei - si, out=pcount)
         pcount = pcount.sum()
@@ -102,7 +102,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
         ptype = self.ds._sph_ptype
         ind = int(ptype[-1])
         si, ei = data_file.start, data_file.end
-        with h5py.File(data_file.filename) as f:
+        with h5py.File(data_file.filename, "r") as f:
             pcount = f["/Header"].attrs["NumPart_ThisFile"][ind].astype("int")
             pcount = np.clip(pcount - si, 0, ei - si)
             ds = f[ptype]["SmoothingLength"][si:ei,...]


### PR DESCRIPTION
## PR Summary

There is an upstream bug with [h5py](https://github.com/h5py/h5py/issues/28) which means that when a file is opened with read/write (the default mode) the last modified time gets changed for the file, even if no modification is made.

This modification changes our file hash, so we regenerate kdtrees and octrees needlessly. This PR adds the `"r"` mode tag to force h5py to open in read-only.

### Example
```python
In [1]: import h5py

In [2]: import os

In [3]: os.path.getmtime('test.hdf5')
Out[3]: 1534969719.6641185

In [4]: f = h5py.File("test.hdf5")

In [5]: f.close()

In [6]: os.path.getmtime("test.hdf5")
Out[6]: 1534969745.043913
```

## PR Checklist

- [x] Code passes flake8 checker
- [ ] **NA** New features are documented, with docstrings and narrative docs
- [ ] **NA** Adds a test for any bugs fixed. Adds tests for new features.