### PR TITLE
 avoid float precision issues leading to overflow in bitmap index 

### DIFF
--- a/yt/geometry/particle_oct_container.pyx
+++ b/yt/geometry/particle_oct_container.pyx
@@ -1830,6 +1830,15 @@ cdef class ParticleBitmapSelector:
                             ncur_ind[0], ncur_ind[1], ncur_ind[2])
                         if sbbox == 2: # an edge cell
                             if self.is_refined(mi1) == 1:
+                                # note we pass zeros here in the last argument
+                                # this is because we now need to generate
+                                # *refined* indices above order1 so we need to
+                                # start a new running count of refined indices.
+                                #
+                                # note that recursive_morton_mask does not
+                                # mutate the last argument (a new index is
+                                # calculated in each stack frame) so this is
+                                # safe
                                 self.recursive_morton_mask(
                                     nlevel, npos, ndds, mi1, zeros)
                         self.add_coarse(mi1, sbbox)

--- a/yt/geometry/particle_oct_container.pyx
+++ b/yt/geometry/particle_oct_container.pyx
@@ -18,7 +18,7 @@ from oct_container cimport OctreeContainer, Oct, OctInfo, ORDER_MAX, \
     SparseOctreeContainer, OctKey, OctAllocationContainer
 cimport oct_visitors
 from oct_visitors cimport cind, OctVisitor
-from libc.stdlib cimport malloc, realloc, free, qsort
+from libc.stdlib cimport malloc, free, qsort
 from libc.math cimport floor, ceil, fmod
 from yt.utilities.lib.fp_utils cimport *
 from yt.utilities.lib.geometry_utils cimport bounded_morton, \

--- a/yt/utilities/lib/geometry_utils.pxd
+++ b/yt/utilities/lib/geometry_utils.pxd
@@ -281,9 +281,9 @@ cdef inline np.uint64_t bounded_morton_relative(np.float64_t x, np.float64_t y, 
     for i in range(3):
         dds1[i] = (DRE[i] - DLE[i]) / (1 << order1)
         dds2[i] = dds1[i] / (1 << order2)
-    DLE2[0] = <np.float64_t> (<np.int64_t> ((x - DLE[0])/dds1[0])) * dds1[0]
-    DLE2[1] = <np.float64_t> (<np.int64_t> ((y - DLE[1])/dds1[1])) * dds1[1]
-    DLE2[2] = <np.float64_t> (<np.int64_t> ((z - DLE[2])/dds1[2])) * dds1[2]
+    DLE2[0] = <np.float64_t> (<np.uint64_t> ((x - DLE[0])/dds1[0])) * dds1[0]
+    DLE2[1] = <np.float64_t> (<np.uint64_t> ((y - DLE[1])/dds1[1])) * dds1[1]
+    DLE2[2] = <np.float64_t> (<np.uint64_t> ((z - DLE[2])/dds1[2])) * dds1[2]
     x_ind = <np.uint64_t> ((x - DLE2[0])/dds2[0])
     y_ind = <np.uint64_t> ((y - DLE2[1])/dds2[1])
     z_ind = <np.uint64_t> ((z - DLE2[2])/dds2[2])
@@ -309,9 +309,9 @@ cdef inline np.uint64_t bounded_morton_relative_dds(np.float64_t x, np.float64_t
     cdef np.float64_t DLE2[3]
     cdef np.uint64_t x_ind, y_ind, z_ind
     cdef np.uint64_t mi2
-    DLE2[0] = <np.float64_t> (<np.int64_t> ((x - DLE[0])/dds1[0])) * dds1[0]
-    DLE2[1] = <np.float64_t> (<np.int64_t> ((y - DLE[1])/dds1[1])) * dds1[1]
-    DLE2[2] = <np.float64_t> (<np.int64_t> ((z - DLE[2])/dds1[2])) * dds1[2]
+    DLE2[0] = <np.float64_t> (<np.uint64_t> ((x - DLE[0])/dds1[0])) * dds1[0]
+    DLE2[1] = <np.float64_t> (<np.uint64_t> ((y - DLE[1])/dds1[1])) * dds1[1]
+    DLE2[2] = <np.float64_t> (<np.uint64_t> ((z - DLE[2])/dds1[2])) * dds1[2]
     x_ind = <np.uint64_t> ((x - DLE2[0])/dds2[0])
     y_ind = <np.uint64_t> ((y - DLE2[1])/dds2[1])
     z_ind = <np.uint64_t> ((z - DLE2[2])/dds2[2])
@@ -336,9 +336,9 @@ cdef inline np.uint64_t bounded_morton_split_relative_dds(np.float64_t x, np.flo
                                np.uint64_t *p2):
     cdef np.float64_t DLE2[3]
     cdef np.uint64_t mi2
-    DLE2[0] = DLE[0] + <np.float64_t> (<np.int64_t> ((x - DLE[0])/dds1[0])) * dds1[0]
-    DLE2[1] = DLE[1] + <np.float64_t> (<np.int64_t> ((y - DLE[1])/dds1[1])) * dds1[1]
-    DLE2[2] = DLE[2] + <np.float64_t> (<np.int64_t> ((z - DLE[2])/dds1[2])) * dds1[2]
+    DLE2[0] = DLE[0] + <np.float64_t> (<np.uint64_t> ((x - DLE[0])/dds1[0])) * dds1[0]
+    DLE2[1] = DLE[1] + <np.float64_t> (<np.uint64_t> ((y - DLE[1])/dds1[1])) * dds1[1]
+    DLE2[2] = DLE[2] + <np.float64_t> (<np.uint64_t> ((z - DLE[2])/dds1[2])) * dds1[2]
     p2[0] = <np.uint64_t> ((x - DLE2[0])/dds2[0])
     p2[1] = <np.uint64_t> ((y - DLE2[1])/dds2[1])
     p2[2] = <np.uint64_t> ((z - DLE2[2])/dds2[2])


### PR DESCRIPTION
This fixes the issues @AshKelly ran into with the test SWIFT dataset in #1962.

Ultimately the issue was due to going between float coordinates and int coordinates. The fix is just to avoid those conversions and calculate the int coordinates as we recurse.

In addition we converted some pointer arrays to memoryviews, that makes it easier to debug this code when it breaks.