### PR TITLE
define __format__ on YTArray

### DIFF
--- a/yt/units/yt_array.py
+++ b/yt/units/yt_array.py
@@ -531,6 +531,10 @@ class YTArray(np.ndarray):
         """
         return str(self.view(np.ndarray)) + ' ' + str(self.units)
 
+    def __format__(self, format_spec):
+        ret = super(YTArray, self).__format__(format_spec)
+        return ret + ' {}'.format(self.units)
+
     #
     # Start unit conversion methods
     #


### PR DESCRIPTION
This backports an implementation of `__format__` from `unyt_array`. This makes it possible to do this:

```
>>> '{:.3f}'.format((km/3))
'0.333 km'
```

Without this PR you'd get:

```
>>> '{:.3f}'.format((km/3))
'0.333'
```