### PR TITLE
[yt-4.0] use an explicit field type to get the smoothing length unit

### DIFF
--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -204,7 +204,7 @@ def off_axis_projection(data_source, center, normal_vector,
 
             # Assure that the path length unit is in the default length units
             # for the dataset by scaling the units of the smoothing length
-            path_length_unit = data_source.ds._get_field_info('smoothing_length').units
+            path_length_unit = data_source.ds._get_field_info((ptype, 'smoothing_length')).units
             path_length_unit = Unit(path_length_unit, registry=data_source.ds.unit_registry)
             default_path_length_unit = data_source.ds.unit_system['length']
             buf *= data_source.ds.quan(1, path_length_unit).in_units(default_path_length_unit)


### PR DESCRIPTION
Fixes #1986.

This ensures we are referring to the same `smoothing_length` field we used to generate the projection above.