### PR TITLE
[bugfix] Make extra check before writing bitmasks to avoid crash

### DIFF
--- a/yt/geometry/particle_geometry_handler.py
+++ b/yt/geometry/particle_geometry_handler.py
@@ -150,9 +150,9 @@ class ParticleIndex(Index):
             self._initialize_coarse_index()
             self._initialize_refined_index()
             wdir = os.path.dirname(fname)
-            # Sometimes os mis-reports whether a directory is writable,
-            # So pass if writing the bitmask file fails.
             if not dont_cache and os.access(wdir, os.W_OK):
+                # Sometimes os mis-reports whether a directory is writable,
+                # So pass if writing the bitmask file fails.
                 try:
                     self.regions.save_bitmasks(fname)
                 except OSError:

--- a/yt/geometry/particle_geometry_handler.py
+++ b/yt/geometry/particle_geometry_handler.py
@@ -150,8 +150,13 @@ class ParticleIndex(Index):
             self._initialize_coarse_index()
             self._initialize_refined_index()
             wdir = os.path.dirname(fname)
+            # Sometimes os mis-reports whether a directory is writable,
+            # So pass if writing the bitmask file fails.
             if not dont_cache and os.access(wdir, os.W_OK):
-                self.regions.save_bitmasks(fname)
+                try:
+                    self.regions.save_bitmasks(fname)
+                except OSError:
+                    pass
             rflag = self.regions.check_bitmasks()
             
     def _initialize_coarse_index(self):


### PR DESCRIPTION
I've been having problems on Caltech's cluster where yt fails when trying to access some particle-based datasets, because it tries to write the bitmask (.ewah) file when it thinks permissions are writable but they are not.  I don't know why os.access mis-reports this information, but it does.  This just avoids the failure if it cannot actually write the .ewah file.
