### PR TITLE
fix to_glue method, add test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
     NOSETIMER=nose-timer
     REQUESTS=requests
     GLUE=glueviz
+    PYQT=pyqt5
 
 before_install:
   - |
@@ -56,7 +57,7 @@ install:
     pip install --upgrade wheel
     pip install --upgrade setuptools
     # Install dependencies
-    pip install $MOCK $NUMPY $SCIPY $H5PY $CYTHON $MATPLOTLIB $SYMPY $FASTCACHE $IPYTHON $FLAKE8 $CODECOV $COVERAGE $PANDAS $NOSE $NOSETIMER $REQUESTS $GLUE
+    pip install $MOCK $NUMPY $SCIPY $H5PY $CYTHON $MATPLOTLIB $SYMPY $FASTCACHE $IPYTHON $FLAKE8 $CODECOV $COVERAGE $PANDAS $NOSE $NOSETIMER $REQUESTS $GLUE $PYQT
     # install yt
     if [[ $TRAVIS_BUILD_STAGE_NAME != "Lint" ]]; then
       pip install -e .
@@ -66,12 +67,12 @@ jobs:
   include:
     - stage: lint
       python: 3.6
-      env: MOCK= NOSETIMER= NOSE= CODECOV= COVERAGE= NUMPY= CYTHON= MATPLOTLIB= SYMPY= H5PY= SCIPY= FASTCACHE= IPYTHON= PANDAS= REQUESTS= GLUE=
+      env: MOCK= NOSETIMER= NOSE= CODECOV= COVERAGE= NUMPY= CYTHON= MATPLOTLIB= SYMPY= H5PY= SCIPY= FASTCACHE= IPYTHON= PANDAS= REQUESTS= GLUE= PYQT=
       script: flake8 yt/
 
     - stage: lint
       python: 2.7
-      env: MOCK= NOSETIMER= NOSE= CODECOV= COVERAGE= NUMPY= CYTHON= MATPLOTLIB= SYMPY= H5PY= SCIPY= FASTCACHE= IPYTHON= PANDAS= REQUESTS= GLUE=
+      env: MOCK= NOSETIMER= NOSE= CODECOV= COVERAGE= NUMPY= CYTHON= MATPLOTLIB= SYMPY= H5PY= SCIPY= FASTCACHE= IPYTHON= PANDAS= REQUESTS= GLUE= PYQT=
       script: flake8 yt/
 
     - stage: tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
     MOCK=mock
     NOSETIMER=nose-timer
     REQUESTS=requests
+    GLUE=glueviz
 
 before_install:
   - |
@@ -55,7 +56,7 @@ install:
     pip install --upgrade wheel
     pip install --upgrade setuptools
     # Install dependencies
-    pip install $MOCK $NUMPY $SCIPY $H5PY $CYTHON $MATPLOTLIB $SYMPY $FASTCACHE $IPYTHON $FLAKE8 $CODECOV $COVERAGE $PANDAS $NOSE $NOSETIMER $REQUESTS
+    pip install $MOCK $NUMPY $SCIPY $H5PY $CYTHON $MATPLOTLIB $SYMPY $FASTCACHE $IPYTHON $FLAKE8 $CODECOV $COVERAGE $PANDAS $NOSE $NOSETIMER $REQUESTS $GLUE
     # install yt
     if [[ $TRAVIS_BUILD_STAGE_NAME != "Lint" ]]; then
       pip install -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,13 +78,13 @@ jobs:
     - stage: tests
       name: "Python: 2.7 Unit Tests"
       python: 2.7
-      env: NUMPY=numpy==1.10.4 CYTHON=cython==0.24 MATPLOTLIB=matplotlib==1.5.3 SYMPY=sympy==1.0 H5PY= SCIPY= FASTCACHE= FLAKE8= IPYTHON=ipython==1.0 REQUESTS=
+      env: NUMPY=numpy==1.10.4 CYTHON=cython==0.24 MATPLOTLIB=matplotlib==1.5.3 SYMPY=sympy==1.0 H5PY= SCIPY= FASTCACHE= FLAKE8= IPYTHON=ipython==1.0 REQUESTS= GLUE= PYQT=
       script: coverage run $(which nosetests) -c nose_unit.cfg
 
     - stage: tests
       name: "Python: 2.7 Unit Tests"
       python: 2.7
-      env: FLAKE8= REQUESTS=
+      env: FLAKE8= REQUESTS= GLUE= PYQT=
       script: coverage run $(which nosetests) -c nose_unit.cfg
 
     - stage: tests
@@ -102,7 +102,7 @@ jobs:
     - stage: tests
       name: "Python: 2.7 Answer Tests"
       python: 2.7
-      env: NUMPY=numpy==1.10.4 CYTHON=cython==0.24 MATPLOTLIB=matplotlib==1.5.3 SYMPY=sympy==1.0 H5PY= SCIPY= FASTCACHE= FLAKE8= IPYTHON=ipython==1.0
+      env: NUMPY=numpy==1.10.4 CYTHON=cython==0.24 MATPLOTLIB=matplotlib==1.5.3 SYMPY=sympy==1.0 H5PY= SCIPY= FASTCACHE= FLAKE8= IPYTHON=ipython==1.0 GLUE= PYQT=
       script: coverage run $(which nosetests) -c nose_answer.cfg
       after_failure: python tests/report_failed_answers.py -f -m --xunit-file "answer_nosetests.xml"
 
@@ -118,6 +118,7 @@ jobs:
       os: osx
       osx_image: xcode7.3
       language: generic  # https://github.com/travis-ci/travis-ci/issues/2312
+      env: FLAKE8= REQUESTS= GLUE= PYQT=
       cache:
         pip: false
         directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ env:
     NOSETIMER=nose-timer
     REQUESTS=requests
     GLUE=glueviz
+    PYQT=pyqt
 
 before_install:
   - |
@@ -56,7 +57,7 @@ install:
     pip install --upgrade wheel
     pip install --upgrade setuptools
     # Install dependencies
-    pip install $MOCK $NUMPY $SCIPY $H5PY $CYTHON $MATPLOTLIB $SYMPY $FASTCACHE $IPYTHON $FLAKE8 $CODECOV $COVERAGE $PANDAS $NOSE $NOSETIMER $REQUESTS $GLUE
+    pip install $MOCK $NUMPY $SCIPY $H5PY $CYTHON $MATPLOTLIB $SYMPY $FASTCACHE $IPYTHON $FLAKE8 $CODECOV $COVERAGE $PANDAS $NOSE $NOSETIMER $REQUESTS $GLUE $PYQT
     # install yt
     if [[ $TRAVIS_BUILD_STAGE_NAME != "Lint" ]]; then
       pip install -e .
@@ -66,12 +67,12 @@ jobs:
   include:
     - stage: lint
       python: 3.6
-      env: MOCK= NOSETIMER= NOSE= CODECOV= COVERAGE= NUMPY= CYTHON= MATPLOTLIB= SYMPY= H5PY= SCIPY= FASTCACHE= IPYTHON= PANDAS= REQUESTS=
+      env: MOCK= NOSETIMER= NOSE= CODECOV= COVERAGE= NUMPY= CYTHON= MATPLOTLIB= SYMPY= H5PY= SCIPY= FASTCACHE= IPYTHON= PANDAS= REQUESTS= GLUE= PYQT=
       script: flake8 yt/
 
     - stage: lint
       python: 2.7
-      env: MOCK= NOSETIMER= NOSE= CODECOV= COVERAGE= NUMPY= CYTHON= MATPLOTLIB= SYMPY= H5PY= SCIPY= FASTCACHE= IPYTHON= PANDAS= REQUESTS=
+      env: MOCK= NOSETIMER= NOSE= CODECOV= COVERAGE= NUMPY= CYTHON= MATPLOTLIB= SYMPY= H5PY= SCIPY= FASTCACHE= IPYTHON= PANDAS= REQUESTS= GLUE= PYQT=
       script: flake8 yt/
 
     - stage: tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ env:
     NOSETIMER=nose-timer
     REQUESTS=requests
     GLUE=glueviz
-    PYQT=pyqt
 
 before_install:
   - |
@@ -57,7 +56,7 @@ install:
     pip install --upgrade wheel
     pip install --upgrade setuptools
     # Install dependencies
-    pip install $MOCK $NUMPY $SCIPY $H5PY $CYTHON $MATPLOTLIB $SYMPY $FASTCACHE $IPYTHON $FLAKE8 $CODECOV $COVERAGE $PANDAS $NOSE $NOSETIMER $REQUESTS $GLUE $PYQT
+    pip install $MOCK $NUMPY $SCIPY $H5PY $CYTHON $MATPLOTLIB $SYMPY $FASTCACHE $IPYTHON $FLAKE8 $CODECOV $COVERAGE $PANDAS $NOSE $NOSETIMER $REQUESTS $GLUE
     # install yt
     if [[ $TRAVIS_BUILD_STAGE_NAME != "Lint" ]]; then
       pip install -e .
@@ -67,12 +66,12 @@ jobs:
   include:
     - stage: lint
       python: 3.6
-      env: MOCK= NOSETIMER= NOSE= CODECOV= COVERAGE= NUMPY= CYTHON= MATPLOTLIB= SYMPY= H5PY= SCIPY= FASTCACHE= IPYTHON= PANDAS= REQUESTS= GLUE= PYQT=
+      env: MOCK= NOSETIMER= NOSE= CODECOV= COVERAGE= NUMPY= CYTHON= MATPLOTLIB= SYMPY= H5PY= SCIPY= FASTCACHE= IPYTHON= PANDAS= REQUESTS= GLUE=
       script: flake8 yt/
 
     - stage: lint
       python: 2.7
-      env: MOCK= NOSETIMER= NOSE= CODECOV= COVERAGE= NUMPY= CYTHON= MATPLOTLIB= SYMPY= H5PY= SCIPY= FASTCACHE= IPYTHON= PANDAS= REQUESTS= GLUE= PYQT=
+      env: MOCK= NOSETIMER= NOSE= CODECOV= COVERAGE= NUMPY= CYTHON= MATPLOTLIB= SYMPY= H5PY= SCIPY= FASTCACHE= IPYTHON= PANDAS= REQUESTS= GLUE=
       script: flake8 yt/
 
     - stage: tests

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -637,12 +637,16 @@ class YTDataContainer(object):
         the Glue environment, you can pass a *data_collection* object,
         otherwise Glue will be started.
         """
+        from yt.config import ytcfg
         from glue.core import DataCollection, Data
-        try:
-            from glue.app.qt.application import GlueApplication
-        except ImportError:
-            from glue.qt.glue_application import GlueApplication
-
+        if ytcfg.getboolean("yt", "__withintesting"):
+            from glue.core.application_base import \
+                Application as GlueApplication
+        else:
+            try:
+                from glue.app.qt.application import GlueApplication
+            except ImportError:
+                from glue.qt.glue_application import GlueApplication
         gdata = Data(label=label)
         for component_name in fields:
             gdata.add_component(self[component_name], component_name)
@@ -650,7 +654,12 @@ class YTDataContainer(object):
         if data_collection is None:
             dc = DataCollection([gdata])
             app = GlueApplication(dc)
-            app.start()
+            try:
+                app.start()
+            except AttributeError:
+                # In testing we're using a dummy glue application object
+                # that doesn't have a start method
+                pass
         else:
             data_collection.append(gdata)
 

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -638,7 +638,10 @@ class YTDataContainer(object):
         otherwise Glue will be started.
         """
         from glue.core import DataCollection, Data
-        from glue.qt.glue_application import GlueApplication
+        try:
+            from glue.app.qt.application import GlueApplication
+        except ImportError:
+            from glue.qt.glue_application import GlueApplication
 
         gdata = Data(label=label)
         for component_name in fields:

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -1088,7 +1088,7 @@ def create_profile(data_source, bin_fields, fields, n_bins=64,
                 try:
                     field_ex = list(extrema[bin_field])
                 except KeyError:
-                    raise RuntimeError("Could not find field {0} or {1} in override_bins".format(bin_field[-1], bin_field))
+                    raise RuntimeError("Could not find field {0} or {1} in extrema".format(bin_field[-1], bin_field))
 
             if isinstance(field_ex[0], tuple):
                 field_ex = [data_source.ds.quan(*f) for f in field_ex]

--- a/yt/data_objects/tests/test_glue.py
+++ b/yt/data_objects/tests/test_glue.py
@@ -1,0 +1,13 @@
+import nose
+
+from yt.config import ytcfg
+from yt.testing import fake_random_ds
+
+def setup_func():
+    ytcfg["yt", "__withintesting"] = "True"
+
+@nose.with_setup(setup_func)
+def test_glue_data_object():
+    ds = fake_random_ds(16)
+    ad = ds.all_data()
+    ad.to_glue([('gas', 'density')])

--- a/yt/data_objects/tests/test_glue.py
+++ b/yt/data_objects/tests/test_glue.py
@@ -6,7 +6,7 @@ from yt.testing import fake_random_ds, requires_module
 def setup_func():
     ytcfg["yt", "__withintesting"] = "True"
 
-@requires_module('glue')
+@requires_module('glue.core')
 @nose.with_setup(setup_func)
 def test_glue_data_object():
     ds = fake_random_ds(16)

--- a/yt/data_objects/tests/test_glue.py
+++ b/yt/data_objects/tests/test_glue.py
@@ -1,11 +1,12 @@
 import nose
 
 from yt.config import ytcfg
-from yt.testing import fake_random_ds
+from yt.testing import fake_random_ds, requires_module
 
 def setup_func():
     ytcfg["yt", "__withintesting"] = "True"
 
+@requires_module('glue')
 @nose.with_setup(setup_func)
 def test_glue_data_object():
     ds = fake_random_ds(16)

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -358,12 +358,15 @@ class FITSImageData(object):
         """
         from glue.core import DataCollection, Data
         from glue.core.coordinates import coordinates_from_header
-        from glue.qt.glue_application import GlueApplication
+        try:
+            from glue.app.qt.application import GlueApplication
+        except ImportError:
+            from glue.qt.glue_application import GlueApplication
 
         image = Data(label=label)
         image.coords = coordinates_from_header(self.wcs.to_header())
-        for k,f in self.hdulist.items():
-            image.add_component(f.data, k)
+        for k in self.fields:
+            image.add_component(self[k].data, k)
         if data_collection is None:
             dc = DataCollection([image])
             app = GlueApplication(dc)


### PR DESCRIPTION
The glue internal API changed, this adds a fix that avoids the `ImportError` that currently gets generated with the latest version of glue.

Since glue is a QT gui app, it's not straightforward to directly test this. Instead we're using the dummy base glue application class within testing to mock the full GUI app. This isn't perfect and we may want to rethink this if/when integration gets more extensive but this should allow us to detect breakage like changed internal imports in glue.