### PR TITLE
Improve derive fields

### DIFF
--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1311,7 +1311,6 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface):
             # We need to create the field on the raw particle types
             # for particles types (when the field is not directly
             # defined for the derived particle type only)
-               # field not in self.ds.field_list and \
             if field not in self.ds.derived_field_list and \
                field[0] in self.ds.filtered_particle_types:
                 f = self.ds.known_filters[field[0]]

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1311,8 +1311,10 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface):
             # We need to create the field on the raw particle types
             # for particles types (when the field is not directly
             # defined for the derived particle type only)
-            if field not in self.ds.derived_field_list and \
-               field[0] in self.ds.filtered_particle_types:
+            finfo = self.ds.field_info[field]
+
+            if field[0] in self.ds.filtered_particle_types and \
+               finfo._function.__name__ == '_TranslationFunc':
                 f = self.ds.known_filters[field[0]]
                 apply_fields[field[0]].append(
                     (f.filtered_type, field[1]))

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1308,7 +1308,12 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface):
         nfields = []
         apply_fields = defaultdict(list)
         for field in self._determine_fields(fields):
-            if field[0] in self.ds.filtered_particle_types:
+            # We need to create the field on the raw particle types
+            # for particles types (when the field is not directly
+            # defined for the derived particle type only)
+               # field not in self.ds.field_list and \
+            if field not in self.ds.derived_field_list and \
+               field[0] in self.ds.filtered_particle_types:
                 f = self.ds.known_filters[field[0]]
                 apply_fields[field[0]].append(
                     (f.filtered_type, field[1]))

--- a/yt/data_objects/tests/test_data_containers.py
+++ b/yt/data_objects/tests/test_data_containers.py
@@ -141,7 +141,6 @@ class TestDataContainers(unittest.TestCase):
         ds = fake_particle_ds()
         dd = ds.all_data()
 
-
         @particle_filter(requires=['particle_mass'], filtered_type='io')
         def massive(pfilter, data):
             return data[(pfilter.filtered_type, 'particle_mass')].to('code_mass') > 0.5

--- a/yt/data_objects/tests/test_data_containers.py
+++ b/yt/data_objects/tests/test_data_containers.py
@@ -9,6 +9,7 @@ from nose.tools import assert_raises
 from numpy.testing import assert_array_equal
 
 from yt.data_objects.data_containers import YTDataContainer
+from yt.data_objects.particle_filters import particle_filter
 from yt.testing import assert_equal, fake_random_ds, fake_amr_ds,\
     fake_particle_ds, requires_module
 from yt.utilities.exceptions import YTFieldNotFound, YTException
@@ -133,3 +134,26 @@ class TestDataContainers(unittest.TestCase):
         rho = q("particle_velocity_x", weight="particle_mass")
         with assert_raises(NotImplementedError):
             dd.extract_isocontours("density", rho, sample_values='x')
+
+    def test_derived_field(self):
+        # Test that derived field on filtered particles do not require
+        # their parent field to be created
+        ds = fake_particle_ds()
+        dd = ds.all_data()
+
+
+        @particle_filter(requires=['particle_mass'], filtered_type='io')
+        def massive(pfilter, data):
+            return data[(pfilter.filtered_type, 'particle_mass')].to('code_mass') > 0.5
+
+        ds.add_particle_filter('massive')
+
+        def fun(field, data):
+            return data[field.name[0], 'particle_mass']
+
+        # Add the field to the massive particles
+        ds.add_field(('massive', 'test'), function=fun,
+                     sampling_type='particle', units='code_mass')
+
+        # Access the field
+        dd['massive', 'test']


### PR DESCRIPTION
## PR Summary

This PR add the possibility to create a new fields defined for a filtered particle type without the need to define it for its parent particle type. For example if you have a particle type `io` and a derived particle type that selects only the massive particles called `massive`, you can define for the latter only.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes flake8 checker
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

## Example code
```python
import yt

ds = yt.load('ramses_new_format/output_00002/info_00002.txt')
def fun(field, data):
    print(field)
    return data[field.name[0], 'particle_mass']

ds.add_field(('star', 'mass'), function=fun, sampling_type='particle', units='g')
# ds.add_field(('io', 'mass'), function=fun, sampling_type='particle', units='g')

print('Accessing fields')
print(ds.r['star', 'mass'].shape)
print(ds.r['star', 'particle_mass'].shape)
```
This now prints
```
Accessing fields
Derived Field (star, mass): (units: g, particle field)
Derived Field (star, mass): (units: g, particle field)
```
Before it would fail with `yt.utilities.exceptions.YTFieldNotFound: Could not find field '('io', 'mass')' in info_00002.`.