### PR TITLE
[bugfix, enhancement] Fix width in annotate_halos callback

### DIFF
--- a/doc/source/visualizing/callbacks.rst
+++ b/doc/source/visualizing/callbacks.rst
@@ -329,7 +329,9 @@ Overplot Halo Annotations
 
    Accepts a :class:`~yt.analysis_modules.halo_analysis.halo_catalog.HaloCatalog`
    and plots a circle at the location of each halo with the radius of the
-   circle corresponding to the virial radius of the halo.  If ``width`` is set
+   circle corresponding to the virial radius of the halo. Also accepts a
+   :ref:`loaded halo catalog dataset <halo-catalog-data>` or a data
+   container from a halo catalog dataset. If ``width`` is set
    to None (default) all halos are plotted, otherwise it accepts a tuple in
    the form (1.0, ‘Mpc’) to only display halos that fall within a slab with
    width ``width`` centered on the center of the plot data.  The appearance of
@@ -358,16 +360,12 @@ Overplot Halo Annotations
 .. python-script::
 
    import yt
-   from yt.analysis_modules.halo_analysis.halo_catalog import HaloCatalog
 
    data_ds = yt.load('Enzo_64/RD0006/RedshiftOutput0006')
    halos_ds = yt.load('rockstar_halos/halos_0.0.bin')
 
-   hc = HaloCatalog(halos_ds=halos_ds)
-   hc.create()
-
    prj = yt.ProjectionPlot(data_ds, 'z', 'density')
-   prj.annotate_halos(hc, annotate_field='particle_identifier')
+   prj.annotate_halos(halos_ds, annotate_field='particle_identifier')
    prj.save()
 
 .. _annotate-image-line:

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -27,8 +27,14 @@ from numbers import Number
 
 from yt.analysis_modules.level_sets.clump_handling import \
     Clump
+from yt.analysis_modules.halo_analysis.halo_catalog import \
+    HaloCatalog
 from yt.frontends.ytdata.data_structures import \
     YTClumpContainer
+from yt.data_objects.data_containers import \
+    YTDataContainer
+from yt.data_objects.static_output import \
+    Dataset
 from yt.funcs import \
     iterable, \
     mylog, \
@@ -1468,30 +1474,78 @@ class HaloCatalogCallback(PlotCallback):
     in a halo catalog with radii corresponding to the
     virial radius of each halo.
 
-    circle_args: Contains the arguments controlling the
+    Parameters
+    ----------
+    halo_catalog : Dataset, DataContainer, or HaloCatalog
+        The object containing halos to be overplotted. This can
+        be a HaloCatalog object, a loaded halo catalog dataset,
+        or a data container from a halo catalog dataset.
+    circle_args : list
+        Contains the arguments controlling the
         appearance of the circles, supplied to the
         Matplotlib patch Circle.
-    width: the width over which to select halos to plot,
+    width : tuple
+        The width over which to select halos to plot,
         useful when overplotting to a slice plot. Accepts
         a tuple in the form (1.0, 'Mpc').
-    annotate_field: Accepts a field contained in the
+    annotate_field : str
+        A field contained in the
         halo catalog to add text to the plot near the halo.
         Example: annotate_field = 'particle_mass' will
         write the halo mass next to each halo.
-    radius_field: Accepts a field contained in the halo
+    radius_field : str
+        A field contained in the halo
         catalog to set the radius of the circle which will
-        surround each halo.
-    center_field_prefix: Accepts a field prefix which will
+        surround each halo. Default: 'virial_radius'.
+    center_field_prefix : str
+        Accepts a field prefix which will
         be used to find the fields containing the coordinates
         of the center of each halo. Ex: 'particle_position'
         will result in the fields 'particle_position_x' for x
         'particle_position_y' for y, and 'particle_position_z' 
-        for z.
-    text_args: Contains the arguments controlling the text
+        for z. Default: 'particle_position'.
+    text_args : dict
+        Contains the arguments controlling the text
         appearance of the annotated field.
-    factor: A number the virial radius is multiplied by for
+    factor : float
+        A number the virial radius is multiplied by for
         plotting the circles. Ex: factor = 2.0 will plot
         circles with twice the radius of each halo virial radius.
+
+    Examples
+    --------
+
+    >>> import yt
+    >>> dds = yt.load("Enzo_64/DD0043/data0043")
+    >>> hds = yt.load("rockstar_halos/halos_0.0.bin")
+    >>> p = yt.ProjectionPlot(dds, "x", "density", weight_field="density")
+    >>> p.annotate_halos(hds)
+    >>> p.save()
+
+    >>> # plot a subset of all halos
+    >>> import yt
+    >>> dds = yt.load("Enzo_64/DD0043/data0043")
+    >>> hds = yt.load("rockstar_halos/halos_0.0.bin")
+    >>> # make a region half the width of the box
+    >>> dregion = dds.box(dds.domain_center - 0.25*dds.domain_width,
+    ...                   dds.domain_center + 0.25*dds.domain_width)
+    >>> hregion = hds.box(hds.domain_center - 0.25*hds.domain_width,
+    ...                   hds.domain_center + 0.25*hds.domain_width)
+    >>> p = yt.ProjectionPlot(dds, "x", "density", weight_field="density",
+    ...                       data_source=dregion, width=0.5)
+    >>> p.annotate_halos(hregion)
+    >>> p.save()
+
+    >>> # plot halos from a HaloCatalog
+    >>> import yt
+    >>> from yt.analysis_modules.halo_analysis.api import HaloCatalog
+    >>> dds = yt.load("Enzo_64/DD0043/data0043")
+    >>> hds = yt.load("rockstar_halos/halos_0.0.bin")
+    >>> hc = HaloCatalog(data_ds=dds, halos_ds=hds)
+    >>> p = yt.ProjectionPlot(dds, "x", "density", weight_field="density")
+    >>> p.annotate_halos(hc)
+    >>> p.save()
+
     """
 
     _type_name = 'halos'
@@ -1507,7 +1561,21 @@ class HaloCatalogCallback(PlotCallback):
         PlotCallback.__init__(self)
         def_circle_args = {'edgecolor':'white', 'facecolor':'None'}
         def_text_args = {'color':'white'}
-        self.halo_catalog = halo_catalog
+
+        if isinstance(halo_catalog, YTDataContainer):
+            self.halo_data = halo_catalog
+        elif isinstance(halo_catalog, Dataset):
+            self.halo_data = halo_catalog.all_data()
+        elif isinstance(halo_catalog, HaloCatalog):
+            if halo_catalog.data_source.ds == halo_catalog.halos_ds:
+                self.halo_data = halo_catalog.data_source
+            else:
+                self.halo_data = halo_catalog.halos_ds.all_data()
+        else:
+            raise RuntimeError(
+                "halo_catalog argument must be a HaloCatalog object, " +
+                "a dataset, or a data container.")
+
         self.width = width
         self.radius_field = radius_field
         self.center_field_prefix = center_field_prefix
@@ -1534,7 +1602,7 @@ class HaloCatalogCallback(PlotCallback):
         xx0, xx1 = plot._axes.get_xlim()
         yy0, yy1 = plot._axes.get_ylim()
 
-        halo_data= self.halo_catalog.halos_ds.all_data()
+        halo_data = self.halo_data
         axis_names = plot.data.ds.coordinates.axis_name
         xax = plot.data.ds.coordinates.x_axis[data.axis]
         yax = plot.data.ds.coordinates.y_axis[data.axis]

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -1583,7 +1583,7 @@ class HaloCatalogCallback(PlotCallback):
             # but I dont really want to reimplement get_sanitized_width...
             width = data.ds.arr(self.width[0], self.width[1]).in_units('code_length')
 
-            indices = np.where((pz > c-width) & (pz < c+width))
+            indices = np.where((pz > c-0.5*width) & (pz < c+0.5*width))
 
             px = px[indices]
             py = py[indices]


### PR DESCRIPTION
## PR Summary

The width was off by a factor of two for the `annotate_halos` callback. For example, [this script](http://paste.yt-project.org/show/52/)
```
import yt
from yt.analysis_modules.halo_analysis.api import HaloCatalog

dds = yt.load("Enzo_64/DD0043/data0043")
hds = yt.load("rockstar_halos/halos_0.0.bin")
region = dds.box(dds.domain_center - 0.25*dds.domain_width,
                 dds.domain_center + 0.25*dds.domain_width)
hc = HaloCatalog(data_ds=dds, halos_ds=hds)
p = yt.ProjectionPlot(dds, "x", "density", weight_field="density",
                      data_source=dregion, width=0.5)
width = hds.quan(0.5*dds.domain_width[0])
p.annotate_halos(hc, width=(0.5, "code_length"))
p.save()
```
will give the following image:
https://i.imgur.com/t59d2Mw.png

After this fix, it gives:
https://i.imgur.com/Zzpylwj.png

In addition, I've made it so the user can just provide a loaded halo catalog dataset or data container from said dataset, instead of having to create the `HaloCatalog` object.

## PR Checklist

- [ ] Code passes flake8 checker
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.