### PR TITLE
Support periodic BC in ParticleProjectionPlot

### DIFF
--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -588,13 +588,13 @@ class ParticleImageBuffer(FixedResolutionBuffer):
         data = self.data_source.dd[item]
 
         # Handle periodicity
-        dx = x_data - self.bounds[0]
-        dy = y_data - self.bounds[2]
+        dx = x_data.in_units("code_length").d - bounds[0]
+        dy = y_data.in_units("code_length").d - bounds[2]
         if self.periodic:
-            dx %= self._period[0]
-            dy %= self._period[1]
-        px = dx / (self.bounds[1] - self.bounds[0])
-        py = dy / (self.bounds[3] - self.bounds[2])
+            dx %= float(self._period[0].in_units("code_length"))
+            dy %= float(self._period[1].in_units("code_length"))
+        px = dx / (bounds[1] - bounds[0])
+        py = dy / (bounds[3] - bounds[2])
 
         # select only the particles that will actually show up in the image
         mask = np.logical_and(np.logical_and(px >= 0.0, px <= 1.0),

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -587,12 +587,14 @@ class ParticleImageBuffer(FixedResolutionBuffer):
         y_data = self.data_source.dd[ftype, self.y_field]
         data = self.data_source.dd[item]
 
-        # Handle periodicity
+        # handle periodicity
         dx = x_data.in_units("code_length").d - bounds[0]
         dy = y_data.in_units("code_length").d - bounds[2]
         if self.periodic:
             dx %= float(self._period[0].in_units("code_length"))
             dy %= float(self._period[1].in_units("code_length"))
+
+        # convert to pixels
         px = dx / (bounds[1] - bounds[0])
         py = dy / (bounds[3] - bounds[2])
 

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -587,9 +587,14 @@ class ParticleImageBuffer(FixedResolutionBuffer):
         y_data = self.data_source.dd[ftype, self.y_field]
         data = self.data_source.dd[item]
 
-        # convert to pixels
-        px = (x_data - self.bounds[0]) / (self.bounds[1] - self.bounds[0])
-        py = (y_data - self.bounds[2]) / (self.bounds[3] - self.bounds[2])
+        # Handle periodicity
+        dx = x_data - self.bounds[0]
+        dy = y_data - self.bounds[2]
+        if self.periodic:
+            dx %= self._period[0]
+            dy %= self._period[1]
+        px = dx / (self.bounds[1] - self.bounds[0])
+        py = dy / (self.bounds[3] - self.bounds[2])
 
         # select only the particles that will actually show up in the image
         mask = np.logical_and(np.logical_and(px >= 0.0, px <= 1.0),


### PR DESCRIPTION
Resolves #1971.

With the same code, now we get the following image:
![snap_n64l16_093_particle_z_particle_mass](https://user-images.githubusercontent.com/5176695/44822864-1afb3800-abb2-11e8-9afe-34e0a0686d81.png)
instead of the previous:
![snap_n64l16_093_particle_z_particle_mass](https://user-images.githubusercontent.com/5176695/44060243-e6b093e8-9f08-11e8-8a47-58d56b55b221.png)
