### PR TITLE
[bugfix] min/max location must use different signs for "huge" values

### DIFF
--- a/yt/data_objects/derived_quantities.py
+++ b/yt/data_objects/derived_quantities.py
@@ -531,6 +531,7 @@ class Extrema(DerivedQuantity):
                 for mis, mas in zip(values[::2], values[1::2])]
 
 class SampleAtMaxFieldValues(DerivedQuantity):
+    _sign = -1
     r"""
     Calculates the maximum value and returns whichever fields are asked to be
     sampled.
@@ -562,7 +563,7 @@ class SampleAtMaxFieldValues(DerivedQuantity):
 
     def process_chunk(self, data, field, sample_fields):
         field = data._determine_fields(field)[0]
-        ma = array_like_field(data, -HUGE, field)
+        ma = array_like_field(data, self._sign*HUGE, field)
         vals = [array_like_field(data, -1, sf) for sf in sample_fields]
         maxi = -1
         if data[field].size > 0:
@@ -579,6 +580,7 @@ class SampleAtMaxFieldValues(DerivedQuantity):
         return np.argmax(arr)
 
 class MaxLocation(SampleAtMaxFieldValues):
+    _sign = 1
     r"""
     Calculates the maximum value plus the x, y, and z position of the maximum.
 

--- a/yt/data_objects/derived_quantities.py
+++ b/yt/data_objects/derived_quantities.py
@@ -580,7 +580,6 @@ class SampleAtMaxFieldValues(DerivedQuantity):
         return np.argmax(arr)
 
 class MaxLocation(SampleAtMaxFieldValues):
-    _sign = 1
     r"""
     Calculates the maximum value plus the x, y, and z position of the maximum.
 
@@ -607,6 +606,7 @@ class MaxLocation(SampleAtMaxFieldValues):
         return rv
 
 class SampleAtMinFieldValues(SampleAtMaxFieldValues):
+    _sign = 1
     r"""
     Calculates the minimum value and returns whichever fields are asked to be
     sampled.


### PR DESCRIPTION
To find the location of the max of a field in the `SampleAtMaxFieldValues` class, we fill an array with `-HUGE` values and then fill this array with real data from chunks. If a chunk happens to have no values of the particular field, then the `-HUGE` values stay, which is fine because we are trying to find the maximum.

The problem is that `SampleAtMinFieldValues` inherits from this class but only changes the function from `argmax` to `argmin` without recognizing that the sign of the value that serves as the limit also needs to change for the operation to work correctly in case a chunk has no data.

In yt-4.0 this was manifesting itself in a weird way--trying to find the minimum potential of star particles from a Gadget simulation was giving the wrong answer because some chunks didn't have star particles, and therefore the min value was `-HUGE`. We don't really have chunking for particle data in 3.x, so it would be hard for this bug to manifest there. However, the origin of the bug is still in the 3.x series, and so it should be fixed here. 