### PR TITLE
[bugfix] Particle filters

### DIFF
--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1313,8 +1313,7 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface):
             # defined for the derived particle type only)
             finfo = self.ds.field_info[field]
 
-            if field[0] in self.ds.filtered_particle_types and \
-               finfo._function.__name__ == '_TranslationFunc':
+            if field[0] in self.ds.filtered_particle_types and finfo._inherited:
                 f = self.ds.known_filters[field[0]]
                 apply_fields[field[0]].append(
                     (f.filtered_type, field[1]))

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1313,7 +1313,7 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface):
             # defined for the derived particle type only)
             finfo = self.ds.field_info[field]
 
-            if field[0] in self.ds.filtered_particle_types and finfo._inherited:
+            if field[0] in self.ds.filtered_particle_types and finfo._inherited_particle_filter:
                 f = self.ds.known_filters[field[0]]
                 apply_fields[field[0]].append(
                     (f.filtered_type, field[1]))

--- a/yt/data_objects/particle_filters.py
+++ b/yt/data_objects/particle_filters.py
@@ -70,6 +70,8 @@ class ParticleFilter(object):
         new_fi.name = (self.name, field_name[1])
         if old_fi._function == NullFunc:
             new_fi._function = TranslationFunc(old_fi.name)
+        # Marking the field as inherited
+        new_fi._inherited = True
         return new_fi
 
 

--- a/yt/data_objects/particle_filters.py
+++ b/yt/data_objects/particle_filters.py
@@ -71,7 +71,7 @@ class ParticleFilter(object):
         if old_fi._function == NullFunc:
             new_fi._function = TranslationFunc(old_fi.name)
         # Marking the field as inherited
-        new_fi._inherited = True
+        new_fi._inherited_particle_filter = True
         return new_fi
 
 

--- a/yt/data_objects/tests/test_data_containers.py
+++ b/yt/data_objects/tests/test_data_containers.py
@@ -14,7 +14,7 @@ from yt.testing import assert_equal, fake_random_ds, fake_amr_ds,\
     fake_particle_ds, requires_module
 from yt.utilities.exceptions import YTFieldNotFound, YTException
 
-class TestDataContainers(object):
+class TestDataContainers(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.tmpdir = tempfile.mkdtemp()
@@ -161,8 +161,7 @@ class TestDataContainers(object):
 
         def test_this(fname):
             data = dd[fname]
-
             assert_equal(data.shape[0], expected_size)
 
         for fname in fields_to_test:
-            yield test_this, fname
+            test_this(fname)

--- a/yt/data_objects/tests/test_data_containers.py
+++ b/yt/data_objects/tests/test_data_containers.py
@@ -14,7 +14,7 @@ from yt.testing import assert_equal, fake_random_ds, fake_amr_ds,\
     fake_particle_ds, requires_module
 from yt.utilities.exceptions import YTFieldNotFound, YTException
 
-class TestDataContainers(unittest.TestCase):
+class TestDataContainers(object):
     @classmethod
     def setUpClass(cls):
         cls.tmpdir = tempfile.mkdtemp()
@@ -154,5 +154,15 @@ class TestDataContainers(unittest.TestCase):
         ds.add_field(('massive', 'test'), function=fun,
                      sampling_type='particle', units='code_mass')
 
-        # Access the field
-        dd['massive', 'test']
+        expected_size = (dd['io', 'particle_mass'].to('code_mass') > 0.5).sum()
+
+        fields_to_test = (f for f in ds.derived_field_list
+                          if f[0] == 'massive')
+
+        def test_this(fname):
+            data = dd[fname]
+
+            assert_equal(data.shape[0], expected_size)
+
+        for fname in fields_to_test:
+            yield test_this, fname

--- a/yt/fields/derived_field.py
+++ b/yt/fields/derived_field.py
@@ -100,7 +100,7 @@ class DerivedField(object):
        that the field defined at the centers of the 4 edges that are normal to the
        x axis, while nodal_flag = [1, 1, 1] would be defined at the 8 cell corners.
     """
-    _inherited_particle_filter = False  # True for fields that were inherited
+    _inherited_particle_filter = False
     def __init__(self, name, sampling_type, function, units=None,
                  take_log=True, validators=None,
                  particle_type=None, vector_field=False, display_field=True,

--- a/yt/fields/derived_field.py
+++ b/yt/fields/derived_field.py
@@ -100,6 +100,7 @@ class DerivedField(object):
        that the field defined at the centers of the 4 edges that are normal to the
        x axis, while nodal_flag = [1, 1, 1] would be defined at the 8 cell corners.
     """
+    _inherited = False  # True for fields that were inherited
     def __init__(self, name, sampling_type, function, units=None,
                  take_log=True, validators=None,
                  particle_type=None, vector_field=False, display_field=True,

--- a/yt/fields/derived_field.py
+++ b/yt/fields/derived_field.py
@@ -100,7 +100,7 @@ class DerivedField(object):
        that the field defined at the centers of the 4 edges that are normal to the
        x axis, while nodal_flag = [1, 1, 1] would be defined at the 8 cell corners.
     """
-    _inherited = False  # True for fields that were inherited
+    _inherited_particle_filter = False  # True for fields that were inherited
     def __init__(self, name, sampling_type, function, units=None,
                  take_log=True, validators=None,
                  particle_type=None, vector_field=False, display_field=True,


### PR DESCRIPTION
## PR Summary

c497c942976465bcb88c99f29cca4f2485622992 in #1993 introduced a new bug (and solved another one!).

The bug appears for filtered particles, when a field inherited from the parent particle type is itself a derived field. Let `N` and `M` be the number of parent particles and filtered respectively.

Before #1993, yt would receive an array of length `N`. It would then try to apply a mask (that selects the filtered particles) of size `N` with `M` true values, so that the output is of shape `M`. In some cases it would not crash but would return an array with the wrong shape.

#1993 shortcircuits the field generation machinery so that yt would directly receive an array of size `M`, would still try to mask it with an array of size `M` and would crash.

This PR fixes this by adding a new `inherited` flag to fields that are inherited from the parent particle type. If and only if the field is inherited, the code uses the parent field and then masks it. If it is not inherited (e.g. it has been defined by the user). In all other cases, the function defining the field is directly called (or the field is an on-disk field, in which case the code reads it from disk).

## Example of failing code

```python
from yt.testing import fake_particle_ds
ds = fake_particle_ds()
dd = ds.all_data()

@particle_filter(requires=['particle_mass'], filtered_type='io')
def massive(pfilter, data):
    return data[(pfilter.filtered_type, 'particle_mass')].to('code_mass') > 0.5

ds.add_particle_filter('massive')

def fun(field, data):
    return data[field.name[0], 'particle_mass']

# Add the field to the massive particles
ds.add_field(('massive', 'test'), function=fun,
             sampling_type='particle', units='code_mass')

expected_size = (dd['io', 'particle_mass'].to('code_mass') > 0.5).sum()

def test_this(fname):
    data = dd[fname]

    if data.shape[0] != expected_size:
        print('\tERROR: %s: Got %s, expected %s' % (fname, data.shape[0], expected_size))
    else:
        print('\tOK:    %s' % (fname, ))

fields_to_test = [('massive', 'particle_position'), ('massive', 'test')]
for fname in fields_to_test:
    print('testing', fname)
    test_this(fname)
```
On master (b0fb0f3f7f8899046463e46bc51d55ba20204c13), this returns
```
testing ('massive', 'particle_position')
	ERROR: ('massive', 'particle_position'): Got 4096, expected 2051
testing ('massive', 'test')
	OK:    ('massive', 'test')
```
Now it returns
```
testing ('massive', 'particle_position')
	OK:    ('massive', 'particle_position')
testing ('massive', 'test')
	OK:    ('massive', 'test')
```

## PR Checklist

- [x] Code passes flake8 checker
- [x] Adds a test for any bugs fixed. Adds tests for new features.