### PR TITLE
[bugfix] Don't try to read data if particle count is zero.

### DIFF
--- a/yt/frontends/gadget_fof/io.py
+++ b/yt/frontends/gadget_fof/io.py
@@ -47,6 +47,8 @@ class IOHandlerGadgetFOFHDF5(BaseIOHandler):
             with h5py.File(data_file.filename, "r") as f:
                 for ptype, field_list in sorted(ptf.items()):
                     pcount = data_file.total_particles[ptype]
+                    if pcount == 0:
+                        continue
                     coords = f[ptype]["%sPos" % ptype].value.astype("float64")
                     coords = np.resize(coords, (pcount, 3))
                     x = coords[:, 0]


### PR DESCRIPTION
When there are fewer halos/subhalos than files, some files are empty of certain fields and we get an error trying to read.