### PR TITLE
[Gadget frontend] Calculate header size from header spec to allow for non-standard headers

### DIFF
--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -58,7 +58,7 @@ def _compute_header_size(header_spec):
     return sum(field[1] * np.dtype(field[2]).itemsize for field in header_spec)
 
 
-def _get_gadget_format(filename, header_size=256):
+def _get_gadget_format(filename, header_size):
     # check and return gadget binary format with file endianness
     ff = open(filename, 'rb')
     (rhead,) = struct.unpack('<I', ff.read(4))

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -125,6 +125,10 @@ class GadgetDataset(SPHDataset):
         self._header_spec = self._setup_binary_spec(
             header_spec, gadget_header_specs)
         self._header_size = _compute_header_size(self._header_spec)
+        if self._header_size != 256:
+            only_on_root(
+                mylog.warn, "Non-standard header size! (%s instead of 256)",
+                self._header_size)
         self._field_spec = self._setup_binary_spec(
             field_spec, gadget_field_specs)
         self._ptype_spec = self._setup_binary_spec(

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -127,8 +127,16 @@ class GadgetDataset(SPHDataset):
         self._header_size = _compute_header_size(self._header_spec)
         if self._header_size != 256:
             only_on_root(
-                mylog.warn, "Non-standard header size! (%s instead of 256)",
-                self._header_size)
+                mylog.warn,
+                "Non-standard header size is detected! "
+                "Gadget-2 standard header is 256 bytes, but yours is %s. "
+                "Make sure a non-standard header is actually expected. "
+                "Otherwise something is wrong, "
+                "and you might want to check how the dataset is loaded. "
+                "Futher information about header specification can be found in "
+                "https://yt-project.org/docs/dev/examining/loading_data.html#header-specification.",
+                self._header_size
+            )
         self._field_spec = self._setup_binary_spec(
             field_spec, gadget_field_specs)
         self._ptype_spec = self._setup_binary_spec(

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -50,16 +50,20 @@ def _fix_unit_ordering(unit):
     return unit
 
 
+def _byte_swap_32(x):
+    return struct.unpack('>I', struct.pack('<I', x))[0]
+
+
 def _get_gadget_format(filename):
     # check and return gadget binary format with file endianness
     ff = open(filename, 'rb')
     (rhead,) = struct.unpack('<I', ff.read(4))
     ff.close()
-    if (rhead == 134217728):
+    if (rhead == _byte_swap_32(8)):
         return 2, '>'
     elif (rhead == 8):
         return 2, '<'
-    elif (rhead == 65536):
+    elif (rhead == _byte_swap_32(256)):
         return 1, '>'
     elif (rhead == 256):
         return 1, '<'
@@ -367,7 +371,7 @@ class GadgetDataset(SPHDataset):
 
         # First int32 is 256 for a Gadget2 binary file with SnapFormat=1,
         # 8 for a Gadget2 binary file with SnapFormat=2 file,
-        # or the byte swapped equivalents (65536 and 134217728).
+        # or the byte swapped equivalents.
         # The int32 following the header (first 4+256 bytes) must equal this
         # number.
         try:
@@ -378,9 +382,9 @@ class GadgetDataset(SPHDataset):
         # Use value to check endianness
         if rhead == 256:
             endianswap = '<'
-        elif rhead == 65536:
+        elif rhead == _byte_swap_32(256):
             endianswap = '>'
-        elif rhead in (8, 134217728):
+        elif rhead in (8, _byte_swap_32(8)):
             # This is only true for snapshot format 2
             # we do not currently support double precision
             # snap format 2 data

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -376,6 +376,8 @@ class GadgetDataset(SPHDataset):
         # or the byte swapped equivalents.
         # The int32 following the header (first 4+256 bytes) must equal this
         # number.
+        # Note that 256 is the Gadget2 standard value, but other value could be
+        # set using the header_size argument.
         try:
             (rhead,) = struct.unpack('<I', f.read(4))
         except struct.error:

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -170,7 +170,8 @@ class GadgetDataset(SPHDataset):
             self.length_unit.convert_to_units('kpc')
             self.mass_unit.convert_to_units('Msun')
 
-    def _setup_binary_spec(self, spec, spec_dict):
+    @classmethod
+    def _setup_binary_spec(cls, spec, spec_dict):
         if isinstance(spec, str):
             _hs = ()
             for hs in spec.split("+"):
@@ -420,12 +421,12 @@ class GadgetDataset(SPHDataset):
             return False, 1
 
     @classmethod
-    def _is_valid(self, *args, **kwargs):
+    def _is_valid(cls, *args, **kwargs):
         if 'header_spec' in kwargs:
             # Compute header size if header is customized
-            header_spec = self._setup_binary_spec(
-                header_spec, gadget_header_specs)
-            header_size = self._compute_header_size(header_spec)
+            header_spec = cls._setup_binary_spec(
+                kwargs['header_spec'], gadget_header_specs)
+            header_size = _compute_header_size(header_spec)
         else:
             header_size = 256
         # First 4 bytes used to check load

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -344,7 +344,8 @@ class IOHandlerGadgetBinary(BaseIOHandler):
     def _initialize_index(self, data_file, regions):
         DLE = data_file.ds.domain_left_edge
         DRE = data_file.ds.domain_right_edge
-        self._float_type = data_file.ds._validate_header(data_file.filename)[1]
+        self._float_type = data_file.ds._validate_header(
+            data_file.filename, data_file.ds._header_size)[1]
         if self.index_ptype == "all":
             count = sum(data_file.total_particles.values())
             return self._get_morton_from_position(

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -242,7 +242,7 @@ class IOHandlerGadgetBinary(BaseIOHandler):
         self._fields = ds._field_spec
         self._ptypes = ds._ptype_spec
         self.data_files = set([])
-        gformat = _get_gadget_format(ds.parameter_filename)
+        gformat = _get_gadget_format(ds.parameter_filename, ds._header_size)
         # gadget format 1 original, 2 with block name
         self._format = gformat[0]
         self._endian = gformat[1]

--- a/yt/frontends/gadget/testing.py
+++ b/yt/frontends/gadget/testing.py
@@ -45,7 +45,7 @@ def write_block(fp, data, endian, fmt, block_id):
 
 
 def fake_gadget_binary(
-        filename,
+        filename='fake_gadget_binary',
         npart=(100, 100, 100, 0, 100, 0),
         header_spec='default',
         field_spec='default',
@@ -99,8 +99,8 @@ def fake_gadget_binary(
             # Generate and write field block
             data = []
             for pt in ptype:
-                data += [np.random.rand(npart[pt], dim).astype(dtype)]
-            data = np.concatenate(data)
+                data += [np.random.rand(npart[pt], dim)]
+            data = np.concatenate(data).astype(dtype)
             if field in block_ids:
                 block_id = block_ids[field]
             else:

--- a/yt/frontends/gadget/testing.py
+++ b/yt/frontends/gadget/testing.py
@@ -1,0 +1,109 @@
+import numpy as np
+
+from .definitions import (
+    gadget_field_specs,
+    gadget_header_specs,
+    gadget_ptype_specs,
+)
+from .data_structures import GadgetDataset
+from .io import IOHandlerGadgetBinary
+
+
+vector_fields = dict(IOHandlerGadgetBinary._vector_fields)
+
+block_ids = {
+    'Coordinates': 'POS',
+    'Velocities': 'VEL',
+    'ParticleIDs': 'ID',
+    'Mass': 'MASS',
+    'InternalEnergy': 'U',
+    'Density': 'RHO',
+    'SmoothingLength': 'HSML',
+}
+
+
+def write_record(fp, data, endian):
+    dtype = endian + 'i4'
+    size = np.array(data.nbytes, dtype=dtype)
+    fp.write(size.tobytes())
+    fp.write(data.tobytes())
+    fp.write(size.tobytes())
+
+
+def write_block(fp, data, endian, fmt, block_id):
+    assert fmt in [1, 2]
+    block_id = '%-4s' % block_id
+    if fmt ==2:
+        block_id_dtype = np.dtype(
+            [('id', 'S', 4), ('offset', endian + 'i4', 1)]
+        )
+        block_id_data = np.array(1, dtype=block_id_dtype)
+        block_id_data['id'] = block_id
+        block_id_data['offset'] = data.nbytes + 8
+        write_record(fp, block_id_data, endian)
+    write_record(fp, data, endian)
+
+
+def fake_gadget_binary(
+        filename,
+        npart=(100, 100, 100, 0, 100, 0),
+        header_spec='default',
+        field_spec='default',
+        ptype_spec='default',
+        endian='', fmt=2
+    ):
+    """Generate a fake Gadget binary snapshot."""
+    header_spec = GadgetDataset._setup_binary_spec(
+        header_spec, gadget_header_specs
+    )
+    field_spec = GadgetDataset._setup_binary_spec(
+        field_spec, gadget_field_specs
+    )
+    ptype_spec = GadgetDataset._setup_binary_spec(
+        ptype_spec, gadget_ptype_specs
+    )
+    with open(filename, 'wb') as fp:
+        # Generate and write header block
+        header_dtype = np.dtype(
+            [(name, endian + dtype, dim) for name, dim, dtype in header_spec]
+        )
+        header = np.zeros(1, dtype=header_dtype)
+        header['Npart'] = npart
+        header['Nall'] = npart
+        header['NumFiles'] = 1
+        header['BoxSize'] = 1
+        header['HubbleParam'] = 1
+        write_block(fp, header, endian, fmt, 'HEAD')
+
+        npart = dict(zip(ptype_spec, npart))
+        for fs in field_spec:
+            # Parse field name and particle type
+            if isinstance(fs, str):
+                field = fs
+                ptype = ptype_spec
+            else:
+                field, ptype = fs
+                if isinstance(ptype, str):
+                    ptype = (ptype,)
+            # Determine field dimension
+            if field in vector_fields:
+                dim = vector_fields[field]
+            else:
+                dim = 1
+            # Determine dtype (in numpy convention)
+            if field == 'ParticleIDs':
+                dtype = 'u4'
+            else:
+                dtype = 'f4'
+            dtype = endian + dtype
+            # Generate and write field block
+            data = []
+            for pt in ptype:
+                data += [np.random.rand(npart[pt], dim).astype(dtype)]
+            data = np.concatenate(data)
+            if field in block_ids:
+                block_id = block_ids[field]
+            else:
+                block_id = ''
+            write_block(fp, data, endian, fmt, block_id)
+    return filename

--- a/yt/frontends/gadget/testing.py
+++ b/yt/frontends/gadget/testing.py
@@ -37,7 +37,7 @@ def write_block(fp, data, endian, fmt, block_id):
         block_id_dtype = np.dtype(
             [('id', 'S', 4), ('offset', endian + 'i4', 1)]
         )
-        block_id_data = np.array(1, dtype=block_id_dtype)
+        block_id_data = np.zeros(1, dtype=block_id_dtype)
         block_id_data['id'] = block_id
         block_id_data['offset'] = data.nbytes + 8
         write_record(fp, block_id_data, endian)


### PR DESCRIPTION
## PR Summary

Currently, Gadget frontend assumes a fixed header size of 256, which is the standard value. But since header spec is already configurable, it would be more self-consistent to calculate header size from header spec instead, thus allowing for non-standard headers.

Resolves #1846.

## PR Checklist

- [x] Code passes flake8 checker
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.
