### PR TITLE
Use Cython C++ idioms for EWAH

### DIFF
--- a/yt/utilities/lib/ewah_bool_wrap.pyx
+++ b/yt/utilities/lib/ewah_bool_wrap.pyx
@@ -183,29 +183,25 @@ cdef class FileBitmasks:
         coll_coll = <map[np.uint64_t, ewah_bool_array]*> coll.ewah_coll
         for ifile in range(self.nfiles):
             map_bitmask = (<map[np.uint64_t, ewah_bool_array]**> self.ewah_coll)[ifile]
-            it_mi1 = map_bitmask[0].begin()
-            while it_mi1 != map_bitmask[0].end():
-                mi1 = dereference(it_mi1).first
-                iarr = dereference(it_mi1).second
+            for it_mi1 in map_bitmask[0]:
+                mi1 = it_mi1.first
+                iarr = it_mi1.second
                 map_keys[mi1].logicaland(iarr, arr_two)
                 map_keys[mi1].logicalor(iarr, arr_swap)
                 map_keys[mi1].swap(arr_swap)
                 map_refn[mi1].logicalor(arr_two, arr_swap)
                 map_refn[mi1].swap(arr_swap)
-                preincrement(it_mi1)
         coll_coll[0] = map_refn
         # Count
         cdef int nc, nm
         nc = 0
         nm = 0
-        it_mi1 = map_refn.begin()
-        while it_mi1 != map_refn.end():
-            mi1 = dereference(it_mi1).first
-            iarr = dereference(it_mi1).second
+        for it_mi1 in map_refn:
+            mi1 = it_mi1.first
+            iarr = it_mi1.second
             nc += iarr.numberOfOnes()
             iarr = map_keys[mi1]
             nm += iarr.numberOfOnes()
-            preincrement(it_mi1)
         cdef tuple nout = (nc, nm)
         # Print
         if verbose == 1:

--- a/yt/utilities/lib/ewah_bool_wrap.pyx
+++ b/yt/utilities/lib/ewah_bool_wrap.pyx
@@ -41,6 +41,8 @@ DEF UncompressedFormat = 'Pointer'
 #ctypedef np.uint8_t bitarrtype
 ctypedef bint bitarrtype
 
+ctypedef pair[np.uint64_t, np.uint64_t] ind_pair
+
 # cdef class EwahIterator:
 
 #     def __cinit__(self void* citer):
@@ -1800,13 +1802,13 @@ cdef class SparseUnorderedBitmaskSet:
 # vector version
 cdef class SparseUnorderedRefinedBitmaskVector:
     def __cinit__(self):
-        cdef vector[pair[np.uint64_t,np.uint64_t]] *entries = new vector[pair[np.uint64_t,np.uint64_t]]()
+        cdef vector[ind_pair] *entries = new vector[ind_pair]()
         self.entries = <void *> entries
         self.total = 0
 
     cdef void _set(self, np.uint64_t ind1, np.uint64_t ind2):
-        cdef pair[np.uint64_t,np.uint64_t] ind
-        cdef vector[pair[np.uint64_t,np.uint64_t]] *entries = <vector[pair[np.uint64_t,np.uint64_t]]*> self.entries
+        cdef ind_pair ind
+        cdef vector[ind_pair] *entries = <vector[ind_pair]*> self.entries
         ind.first = ind1
         ind.second = ind2
         entries[0].push_back(ind)
@@ -1818,8 +1820,8 @@ cdef class SparseUnorderedRefinedBitmaskVector:
 
     cdef void _fill(self, np.uint8_t[:] mask1, np.uint8_t[:] mask2):
         cdef np.uint64_t i, ind
-        cdef vector[pair[np.uint64_t,np.uint64_t]] *entries = <vector[pair[np.uint64_t,np.uint64_t]]*> self.entries
-        cdef vector[pair[np.uint64_t,np.uint64_t]].iterator it
+        cdef vector[ind_pair] *entries = <vector[ind_pair]*> self.entries
+        cdef vector[ind_pair].iterator it
         it = entries[0].begin()
         while it != entries[0].end():
             ind = dereference(it).first
@@ -1831,8 +1833,8 @@ cdef class SparseUnorderedRefinedBitmaskVector:
     cdef void _fill_ewah(self, BoolArrayCollection mm):
         self._remove_duplicates()
         cdef np.uint64_t mi1, mi2
-        cdef vector[pair[np.uint64_t,np.uint64_t]] *entries = <vector[pair[np.uint64_t,np.uint64_t]]*> self.entries
-        cdef vector[pair[np.uint64_t,np.uint64_t]].iterator it
+        cdef vector[ind_pair] *entries = <vector[ind_pair]*> self.entries
+        cdef vector[ind_pair].iterator it
         it = entries[0].begin()
         while it != entries[0].end():
             mi1 = dereference(it).first
@@ -1843,8 +1845,8 @@ cdef class SparseUnorderedRefinedBitmaskVector:
     cdef void _fill_bool(self, BoolArrayCollectionUncompressed mm):
         self._remove_duplicates()
         cdef np.uint64_t mi1, mi2
-        cdef vector[pair[np.uint64_t,np.uint64_t]] *entries = <vector[pair[np.uint64_t,np.uint64_t]]*> self.entries
-        cdef vector[pair[np.uint64_t,np.uint64_t]].iterator it
+        cdef vector[ind_pair] *entries = <vector[ind_pair]*> self.entries
+        cdef vector[ind_pair].iterator it
         it = entries[0].begin()
         while it != entries[0].end():
             mi1 = dereference(it).first
@@ -1853,7 +1855,7 @@ cdef class SparseUnorderedRefinedBitmaskVector:
             preincrement(it)
 
     cdef void _reset(self):
-        cdef vector[pair[np.uint64_t,np.uint64_t]] *entries = <vector[pair[np.uint64_t,np.uint64_t]]*> self.entries
+        cdef vector[ind_pair] *entries = <vector[ind_pair]*> self.entries
         entries[0].erase(entries[0].begin(), entries[0].end())
         self.total = 0
 
@@ -1861,8 +1863,8 @@ cdef class SparseUnorderedRefinedBitmaskVector:
         cdef int i
         cdef np.ndarray[np.uint64_t, ndim=2] rv
         self._remove_duplicates()
-        cdef vector[pair[np.uint64_t,np.uint64_t]] *entries = <vector[pair[np.uint64_t,np.uint64_t]]*> self.entries
-        cdef vector[pair[np.uint64_t,np.uint64_t]].iterator it
+        cdef vector[ind_pair] *entries = <vector[ind_pair]*> self.entries
+        cdef vector[ind_pair].iterator it
         rv = np.empty((entries[0].size(),2),dtype='uint64')
         it = entries[0].begin()
         i = 0
@@ -1874,8 +1876,8 @@ cdef class SparseUnorderedRefinedBitmaskVector:
         return rv
 
     cdef void _remove_duplicates(self):
-        cdef vector[pair[np.uint64_t,np.uint64_t]] *entries = <vector[pair[np.uint64_t,np.uint64_t]]*> self.entries
-        cdef vector[pair[np.uint64_t,np.uint64_t]].iterator last
+        cdef vector[ind_pair] *entries = <vector[ind_pair]*> self.entries
+        cdef vector[ind_pair].iterator last
         sort(entries[0].begin(), entries[0].end())
         last = unique(entries[0].begin(), entries[0].end())
         entries[0].erase(last, entries[0].end())
@@ -1907,18 +1909,18 @@ cdef class SparseUnorderedRefinedBitmaskVector:
             self.total = 0
 
     def __dealloc__(self):
-        cdef vector[pair[np.uint64_t,np.uint64_t]] *entries = <vector[pair[np.uint64_t,np.uint64_t]]*> self.entries
+        cdef vector[ind_pair] *entries = <vector[ind_pair]*> self.entries
         del entries
 
 # Set version
 cdef class SparseUnorderedRefinedBitmaskSet:
     def __cinit__(self):
-        cdef cset[pair[np.uint64_t,np.uint64_t]] *entries = new cset[pair[np.uint64_t,np.uint64_t]]()
+        cdef cset[ind_pair] *entries = new cset[ind_pair]()
         self.entries = <void *> entries
 
     cdef void _set(self, np.uint64_t ind1, np.uint64_t ind2):
-        cdef pair[np.uint64_t,np.uint64_t] ind
-        cdef cset[pair[np.uint64_t,np.uint64_t]] *entries = <cset[pair[np.uint64_t,np.uint64_t]]*> self.entries
+        cdef ind_pair ind
+        cdef cset[ind_pair] *entries = <cset[ind_pair]*> self.entries
         ind.first = ind1
         ind.second = ind2
         entries[0].insert(ind)
@@ -1940,8 +1942,8 @@ cdef class SparseUnorderedRefinedBitmaskSet:
 
     cdef void _fill_ewah(self, BoolArrayCollection mm):
         cdef np.uint64_t mi1, mi2
-        cdef cset[pair[np.uint64_t,np.uint64_t]] *entries = <cset[pair[np.uint64_t,np.uint64_t]]*> self.entries
-        cdef cset[pair[np.uint64_t,np.uint64_t]].iterator it
+        cdef cset[ind_pair] *entries = <cset[ind_pair]*> self.entries
+        cdef cset[ind_pair].iterator it
         it = entries[0].begin()
         while it != entries[0].end():
             mi1 = dereference(it).first
@@ -1951,8 +1953,8 @@ cdef class SparseUnorderedRefinedBitmaskSet:
 
     cdef void _fill_bool(self, BoolArrayCollectionUncompressed mm):
         cdef np.uint64_t mi1, mi2
-        cdef cset[pair[np.uint64_t,np.uint64_t]] *entries = <cset[pair[np.uint64_t,np.uint64_t]]*> self.entries
-        cdef cset[pair[np.uint64_t,np.uint64_t]].iterator it
+        cdef cset[ind_pair] *entries = <cset[ind_pair]*> self.entries
+        cdef cset[ind_pair].iterator it
         it = entries[0].begin()
         while it != entries[0].end():
             mi1 = dereference(it).first
@@ -1961,7 +1963,7 @@ cdef class SparseUnorderedRefinedBitmaskSet:
             preincrement(it)
 
     cdef void _reset(self):
-        cdef cset[pair[np.uint64_t,np.uint64_t]] *entries = <cset[pair[np.uint64_t,np.uint64_t]]*> self.entries
+        cdef cset[ind_pair] *entries = <cset[ind_pair]*> self.entries
         entries[0].clear()
 
     cdef to_array(self):
@@ -1980,6 +1982,6 @@ cdef class SparseUnorderedRefinedBitmaskSet:
         return rv
 
     def __dealloc__(self):
-        cdef cset[pair[np.uint64_t,np.uint64_t]] *entries = <cset[pair[np.uint64_t,np.uint64_t]]*> self.entries
+        cdef cset[ind_pair] *entries = <cset[ind_pair]*> self.entries
         del entries
 

--- a/yt/utilities/lib/ewah_bool_wrap.pyx
+++ b/yt/utilities/lib/ewah_bool_wrap.pyx
@@ -44,11 +44,7 @@ ctypedef bint bitarrtype
 ctypedef pair[np.uint64_t, np.uint64_t] ind_pair
 ctypedef cmap[np.uint64_t, ewah_bool_array] ewahmap
 ctypedef cmap[np.uint64_t, ewah_bool_array].iterator ewahmap_it
-
-# cdef class EwahIterator:
-
-#     def __cinit__(self void* citer):
-        
+ctypedef pair[np.uint64_t, ewah_bool_array] ewahmap_p
 
 cdef class FileBitmasks:
 
@@ -82,6 +78,7 @@ cdef class FileBitmasks:
         cdef ewah_bool_array* arr2
         cdef ewahmap *map1
         cdef ewahmap *map2
+        cdef ewahmap_p pair1, pair2
         cdef ewahmap_it it_map1, it_map2
         if self.nfiles != solf.nfiles:
             return 0
@@ -99,22 +96,18 @@ cdef class FileBitmasks:
             # Map
             map1 = (<ewahmap **> self.ewah_coll)[ifile]
             map2 = (<ewahmap **> solf.ewah_coll)[ifile]
-            it_map1 = map1[0].begin()
-            while (it_map1 != map1[0].end()):
-                it_map2 = map2[0].find(dereference(it_map1).first)
+            for pair1 in map1[0]:
+                it_map2 = map2[0].find(pair1.first)
                 if it_map2 == map2[0].end():
                     return 0
-                if dereference(it_map1).second != dereference(it_map2).second:
+                if pair1.second != dereference(it_map2).second:
                     return 0
-                preincrement(it_map1)
-            it_map2 = map2[0].begin()
-            while (it_map2 != map2[0].end()):
-                it_map1 = map1[0].find(dereference(it_map2).first)
+            for pair2 in map2[0]:
+                it_map1 = map1[0].find(pair2.first)
                 if it_map1 == map1[0].end():
                     return 0
-                if dereference(it_map2).second != dereference(it_map1).second:
+                if pair2.second != dereference(it_map1).second:
                     return 0
-                preincrement(it_map2)
             # Match
             return 1
         

--- a/yt/utilities/lib/ewah_bool_wrap.pyx
+++ b/yt/utilities/lib/ewah_bool_wrap.pyx
@@ -42,6 +42,8 @@ DEF UncompressedFormat = 'Pointer'
 ctypedef bint bitarrtype
 
 ctypedef pair[np.uint64_t, np.uint64_t] ind_pair
+ctypedef cmap[np.uint64_t, ewah_bool_array] ewahmap
+ctypedef cmap[np.uint64_t, ewah_bool_array].iterator ewahmap_it
 
 # cdef class EwahIterator:
 
@@ -78,9 +80,9 @@ cdef class FileBitmasks:
         cdef np.int32_t ifile
         cdef ewah_bool_array* arr1
         cdef ewah_bool_array* arr2
-        cdef cmap[np.uint64_t, ewah_bool_array] *map1
-        cdef cmap[np.uint64_t, ewah_bool_array] *map2
-        cdef cmap[np.uint64_t, ewah_bool_array].iterator it_map1, it_map2
+        cdef ewahmap *map1
+        cdef ewahmap *map2
+        cdef ewahmap_it it_map1, it_map2
         if self.nfiles != solf.nfiles:
             return 0
         for ifile in range(self.nfiles): 
@@ -95,8 +97,8 @@ cdef class FileBitmasks:
             if arr1[0] != arr2[0]:
                 return 0
             # Map
-            map1 = (<cmap[np.uint64_t, ewah_bool_array] **> self.ewah_coll)[ifile]
-            map2 = (<cmap[np.uint64_t, ewah_bool_array] **> solf.ewah_coll)[ifile]
+            map1 = (<ewahmap **> self.ewah_coll)[ifile]
+            map2 = (<ewahmap **> solf.ewah_coll)[ifile]
             it_map1 = map1[0].begin()
             while (it_map1 != map1[0].end()):
                 it_map2 = map2[0].find(dereference(it_map1).first)
@@ -362,8 +364,8 @@ cdef class FileBitmasks:
         cdef ewah_map *ewah_coll1 = (<ewah_map **> self.ewah_coll)[ifile]
         cdef ewah_bool_array *ewah_keys2 = <ewah_bool_array *> solf.ewah_keys
         cdef ewah_bool_array *ewah_refn2 = <ewah_bool_array *> solf.ewah_refn
-        cdef cmap[np.uint64_t, ewah_bool_array] *ewah_coll2 = <cmap[np.uint64_t, ewah_bool_array] *> solf.ewah_coll
-        cdef cmap[np.uint64_t, ewah_bool_array].iterator it_map1, it_map2
+        cdef ewahmap *ewah_coll2 = <ewahmap *> solf.ewah_coll
+        cdef ewahmap_it it_map1, it_map2
         cdef ewah_bool_array swap, mi1_ewah1, mi1_ewah2
         cdef np.uint64_t nrefn, mi1
         # Keys
@@ -392,8 +394,8 @@ cdef class FileBitmasks:
         cdef ewah_map *ewah_coll1 = (<ewah_map **> self.ewah_coll)[ifile]
         cdef ewah_bool_array *ewah_keys2 = <ewah_bool_array *> solf.ewah_keys
         cdef ewah_bool_array *ewah_refn2 = <ewah_bool_array *> solf.ewah_refn
-        cdef cmap[np.uint64_t, ewah_bool_array] *ewah_coll2 = <cmap[np.uint64_t, ewah_bool_array] *> solf.ewah_coll
-        cdef cmap[np.uint64_t, ewah_bool_array].iterator it_map1, it_map2
+        cdef ewahmap *ewah_coll2 = <ewahmap *> solf.ewah_coll
+        cdef ewahmap_it it_map1, it_map2
         cdef ewah_bool_array mi1_ewah1, mi1_ewah2
         cdef np.uint64_t mi1
         cdef ewah_bool_array ewah_coar1, ewah_coar2
@@ -427,11 +429,11 @@ cdef class FileBitmasks:
         cdef ewah_map *ewah_coll1 = (<ewah_map **> self.ewah_coll)[ifile]
         cdef ewah_bool_array *ewah_keys2 = <ewah_bool_array *> solf.ewah_keys
         cdef ewah_bool_array *ewah_refn2 = <ewah_bool_array *> solf.ewah_refn
-        cdef cmap[np.uint64_t, ewah_bool_array] *ewah_coll2 = <cmap[np.uint64_t, ewah_bool_array] *> solf.ewah_coll
+        cdef ewahmap *ewah_coll2 = <ewahmap *> solf.ewah_coll
         cdef ewah_bool_array *ewah_keys_out = <ewah_bool_array *> out.ewah_keys
         cdef ewah_bool_array *ewah_refn_out = <ewah_bool_array *> out.ewah_refn
         cdef ewah_map *ewah_coll_out = <ewah_map *> out.ewah_coll
-        cdef cmap[np.uint64_t, ewah_bool_array].iterator it_map1, it_map2
+        cdef ewahmap_it it_map1, it_map2
         cdef ewah_bool_array mi1_ewah1, mi1_ewah2, swap
         cdef np.uint64_t mi1
         cdef ewah_bool_array ewah_coar1, ewah_coar2
@@ -470,11 +472,11 @@ cdef class FileBitmasks:
         cdef ewah_map *ewah_coll1 = (<ewah_map **> self.ewah_coll)[ifile]
         cdef ewah_bool_array *ewah_keys2 = <ewah_bool_array *> solf.ewah_keys
         cdef ewah_bool_array *ewah_refn2 = <ewah_bool_array *> solf.ewah_refn
-        cdef cmap[np.uint64_t, ewah_bool_array] *ewah_coll2 = <cmap[np.uint64_t, ewah_bool_array] *> solf.ewah_coll
+        cdef ewahmap *ewah_coll2 = <ewahmap *> solf.ewah_coll
         cdef ewah_bool_array *ewah_keys_out = <ewah_bool_array *> out.ewah_keys
         cdef ewah_bool_array *ewah_refn_out = <ewah_bool_array *> out.ewah_refn
         cdef ewah_map *ewah_coll_out = <ewah_map *> out.ewah_coll
-        cdef cmap[np.uint64_t, ewah_bool_array].iterator it_map1, it_map2
+        cdef ewahmap_it it_map1, it_map2
         cdef ewah_bool_array mi1_ewah1, mi1_ewah2, swap
         cdef np.uint64_t mi1
         cdef ewah_bool_array ewah_coar1, ewah_coar2
@@ -572,7 +574,7 @@ cdef class FileBitmasks:
         cdef ewah_bool_array *ewah_keys = (<ewah_bool_array **> self.ewah_keys)[ifile]
         cdef ewah_bool_array *ewah_refn = (<ewah_bool_array **> self.ewah_refn)[ifile]
         cdef ewah_map *ewah_coll = (<ewah_map **> self.ewah_coll)[ifile]
-        cdef cmap[np.uint64_t, ewah_bool_array].iterator it_map
+        cdef ewahmap_it it_map
         cdef np.uint64_t nrefn, mi1
         cdef ewah_bool_array mi1_ewah
         # Write mi1 ewah & refinment ewah
@@ -598,7 +600,7 @@ cdef class FileBitmasks:
         cdef ewah_bool_array *ewah_keys = (<ewah_bool_array **> self.ewah_keys)[ifile]
         cdef ewah_bool_array *ewah_refn = (<ewah_bool_array **> self.ewah_refn)[ifile]
         cdef ewah_map *ewah_coll = (<ewah_map **> self.ewah_coll)[ifile]
-        cdef cmap[np.uint64_t, ewah_bool_array].iterator it_map
+        cdef ewahmap_it it_map
         cdef np.uint64_t nrefn, mi1
         cdef ewah_bool_array mi1_ewah
         cdef int i
@@ -691,9 +693,9 @@ cdef class BoolArrayCollection:
 
         cdef ewah_bool_array *arr1
         cdef ewah_bool_array *arr2
-        cdef cmap[np.uint64_t, ewah_bool_array] *map1
-        cdef cmap[np.uint64_t, ewah_bool_array] *map2
-        cdef cmap[np.uint64_t, ewah_bool_array].iterator it_map1, it_map2
+        cdef ewahmap *map1
+        cdef ewahmap *map2
+        cdef ewahmap_it it_map1, it_map2
         # == 
         if op == 2: 
             # Keys
@@ -707,8 +709,8 @@ cdef class BoolArrayCollection:
             if arr1[0] != arr2[0]:
                 return 0
             # Map
-            map1 = <cmap[np.uint64_t, ewah_bool_array] *> self.ewah_coll
-            map2 = <cmap[np.uint64_t, ewah_bool_array] *> solf.ewah_coll
+            map1 = <ewahmap *> self.ewah_coll
+            map2 = <ewahmap *> solf.ewah_coll
             it_map1 = map1[0].begin()
             while (it_map1 != map1[0].end()):
                 it_map2 = map2[0].find(dereference(it_map1).first)
@@ -937,14 +939,14 @@ cdef class BoolArrayCollection:
     cdef void _logicalor(self, BoolArrayCollection solf, BoolArrayCollection out):
         cdef ewah_bool_array *ewah_keys1 = <ewah_bool_array *> self.ewah_keys
         cdef ewah_bool_array *ewah_refn1 = <ewah_bool_array *> self.ewah_refn
-        cdef cmap[np.uint64_t, ewah_bool_array] *ewah_coll1 = <cmap[np.uint64_t, ewah_bool_array] *> self.ewah_coll
+        cdef ewahmap *ewah_coll1 = <ewahmap *> self.ewah_coll
         cdef ewah_bool_array *ewah_keys2 = <ewah_bool_array *> solf.ewah_keys
         cdef ewah_bool_array *ewah_refn2 = <ewah_bool_array *> solf.ewah_refn
-        cdef cmap[np.uint64_t, ewah_bool_array] *ewah_coll2 = <cmap[np.uint64_t, ewah_bool_array] *> solf.ewah_coll
+        cdef ewahmap *ewah_coll2 = <ewahmap *> solf.ewah_coll
         cdef ewah_bool_array *ewah_keys3 = <ewah_bool_array *> out.ewah_keys
         cdef ewah_bool_array *ewah_refn3 = <ewah_bool_array *> out.ewah_refn
-        cdef cmap[np.uint64_t, ewah_bool_array] *ewah_coll3 = <cmap[np.uint64_t, ewah_bool_array] *> out.ewah_coll
-        cdef cmap[np.uint64_t, ewah_bool_array].iterator it_map1, it_map2
+        cdef ewahmap *ewah_coll3 = <ewahmap *> out.ewah_coll
+        cdef ewahmap_it it_map1, it_map2
         cdef ewah_bool_array swap, mi1_ewah1, mi1_ewah2
         cdef np.uint64_t nrefn, mi1
         # Keys
@@ -971,11 +973,11 @@ cdef class BoolArrayCollection:
     cdef void _append(self, BoolArrayCollection solf):
         cdef ewah_bool_array *ewah_keys1 = <ewah_bool_array *> self.ewah_keys
         cdef ewah_bool_array *ewah_refn1 = <ewah_bool_array *> self.ewah_refn
-        cdef cmap[np.uint64_t, ewah_bool_array] *ewah_coll1 = <cmap[np.uint64_t, ewah_bool_array] *> self.ewah_coll
+        cdef ewahmap *ewah_coll1 = <ewahmap *> self.ewah_coll
         cdef ewah_bool_array *ewah_keys2 = <ewah_bool_array *> solf.ewah_keys
         cdef ewah_bool_array *ewah_refn2 = <ewah_bool_array *> solf.ewah_refn
-        cdef cmap[np.uint64_t, ewah_bool_array] *ewah_coll2 = <cmap[np.uint64_t, ewah_bool_array] *> solf.ewah_coll
-        cdef cmap[np.uint64_t, ewah_bool_array].iterator it_map1, it_map2
+        cdef ewahmap *ewah_coll2 = <ewahmap *> solf.ewah_coll
+        cdef ewahmap_it it_map1, it_map2
         cdef ewah_bool_array swap, mi1_ewah1, mi1_ewah2
         cdef np.uint64_t nrefn, mi1
         # Keys
@@ -1004,11 +1006,11 @@ cdef class BoolArrayCollection:
     cdef bint _intersects(self, BoolArrayCollection solf):
         cdef ewah_bool_array *ewah_keys1 = <ewah_bool_array *> self.ewah_keys
         cdef ewah_bool_array *ewah_refn1 = <ewah_bool_array *> self.ewah_refn
-        cdef cmap[np.uint64_t, ewah_bool_array] *ewah_coll1 = <cmap[np.uint64_t, ewah_bool_array] *> self.ewah_coll
+        cdef ewahmap *ewah_coll1 = <ewahmap *> self.ewah_coll
         cdef ewah_bool_array *ewah_keys2 = <ewah_bool_array *> solf.ewah_keys
         cdef ewah_bool_array *ewah_refn2 = <ewah_bool_array *> solf.ewah_refn
-        cdef cmap[np.uint64_t, ewah_bool_array] *ewah_coll2 = <cmap[np.uint64_t, ewah_bool_array] *> solf.ewah_coll
-        cdef cmap[np.uint64_t, ewah_bool_array].iterator it_map1, it_map2
+        cdef ewahmap *ewah_coll2 = <ewahmap *> solf.ewah_coll
+        cdef ewahmap_it it_map1, it_map2
         cdef ewah_bool_array mi1_ewah1, mi1_ewah2
         cdef np.uint64_t mi1
         cdef ewah_bool_array ewah_coar1, ewah_coar2
@@ -1042,11 +1044,11 @@ cdef class BoolArrayCollection:
         cdef ewah_map *ewah_coll1 = <ewah_map *> self.ewah_coll
         cdef ewah_bool_array *ewah_keys2 = <ewah_bool_array *> solf.ewah_keys
         cdef ewah_bool_array *ewah_refn2 = <ewah_bool_array *> solf.ewah_refn
-        cdef cmap[np.uint64_t, ewah_bool_array] *ewah_coll2 = <cmap[np.uint64_t, ewah_bool_array] *> solf.ewah_coll
+        cdef ewahmap *ewah_coll2 = <ewahmap *> solf.ewah_coll
         cdef ewah_bool_array *ewah_keys_out = <ewah_bool_array *> out.ewah_keys
         cdef ewah_bool_array *ewah_refn_out = <ewah_bool_array *> out.ewah_refn
         cdef ewah_map *ewah_coll_out = <ewah_map *> out.ewah_coll
-        cdef cmap[np.uint64_t, ewah_bool_array].iterator it_map1, it_map2
+        cdef ewahmap_it it_map1, it_map2
         cdef ewah_bool_array mi1_ewah1, mi1_ewah2, swap
         cdef np.uint64_t mi1
         cdef ewah_bool_array ewah_coar1, ewah_coar2
@@ -1085,11 +1087,11 @@ cdef class BoolArrayCollection:
         cdef ewah_map *ewah_coll1 = <ewah_map *> self.ewah_coll
         cdef ewah_bool_array *ewah_keys2 = <ewah_bool_array *> solf.ewah_keys
         cdef ewah_bool_array *ewah_refn2 = <ewah_bool_array *> solf.ewah_refn
-        cdef cmap[np.uint64_t, ewah_bool_array] *ewah_coll2 = <cmap[np.uint64_t, ewah_bool_array] *> solf.ewah_coll
+        cdef ewahmap *ewah_coll2 = <ewahmap *> solf.ewah_coll
         cdef ewah_bool_array *ewah_keys_out = <ewah_bool_array *> out.ewah_keys
         cdef ewah_bool_array *ewah_refn_out = <ewah_bool_array *> out.ewah_refn
         cdef ewah_map *ewah_coll_out = <ewah_map *> out.ewah_coll
-        cdef cmap[np.uint64_t, ewah_bool_array].iterator it_map1, it_map2
+        cdef ewahmap_it it_map1, it_map2
         cdef ewah_bool_array mi1_ewah1, mi1_ewah2, swap
         cdef np.uint64_t mi1
         cdef ewah_bool_array ewah_coar1, ewah_coar2
@@ -1165,8 +1167,8 @@ cdef class BoolArrayCollection:
                                bint coarse_ghosts = 0):
         cdef ewah_bool_array *ewah_keys = <ewah_bool_array *> self.ewah_keys
         cdef ewah_bool_array *ewah_refn = <ewah_bool_array *> self.ewah_refn
-        cdef cmap[np.uint64_t, ewah_bool_array] *ewah_coll = <cmap[np.uint64_t, ewah_bool_array] *> self.ewah_coll
-        cdef cmap[np.uint64_t, ewah_bool_array].iterator it_map
+        cdef ewahmap *ewah_coll = <ewahmap *> self.ewah_coll
+        cdef ewahmap_it it_map
         cdef ewah_bool_iterator *iter_set1 = new ewah_bool_iterator(ewah_keys.begin())
         cdef ewah_bool_iterator *iter_end1 = new ewah_bool_iterator(ewah_keys.end())
         cdef ewah_bool_iterator *iter_set2
@@ -1254,8 +1256,8 @@ cdef class BoolArrayCollection:
         cdef sstream ss
         cdef ewah_bool_array *ewah_keys = <ewah_bool_array *> self.ewah_keys
         cdef ewah_bool_array *ewah_refn = <ewah_bool_array *> self.ewah_refn
-        cdef cmap[np.uint64_t, ewah_bool_array] *ewah_coll = <cmap[np.uint64_t, ewah_bool_array] *> self.ewah_coll
-        cdef cmap[np.uint64_t, ewah_bool_array].iterator it_map
+        cdef ewahmap *ewah_coll = <ewahmap *> self.ewah_coll
+        cdef ewahmap_it it_map
         cdef np.uint64_t nrefn, mi1
         cdef ewah_bool_array mi1_ewah
         # Write mi1 ewah & refinment ewah
@@ -1283,8 +1285,8 @@ cdef class BoolArrayCollection:
         cdef sstream ss
         cdef ewah_bool_array *ewah_keys = <ewah_bool_array *> self.ewah_keys
         cdef ewah_bool_array *ewah_refn = <ewah_bool_array *> self.ewah_refn
-        cdef cmap[np.uint64_t, ewah_bool_array] *ewah_coll = <cmap[np.uint64_t, ewah_bool_array] *> self.ewah_coll
-        cdef cmap[np.uint64_t, ewah_bool_array].iterator it_map
+        cdef ewahmap *ewah_coll = <ewahmap *> self.ewah_coll
+        cdef ewahmap_it it_map
         cdef np.uint64_t nrefn, mi1
         cdef ewah_bool_array mi1_ewah
         cdef int i
@@ -1574,9 +1576,9 @@ cdef class BoolArrayCollectionUncompressed:
             cdef bitarrtype *ewah_refn1 = <bitarrtype *> self.ewah_refn
             cdef bitarrtype *ewah_keys2 = <bitarrtype *> solf.ewah_keys
             cdef bitarrtype *ewah_refn2 = <bitarrtype *> solf.ewah_refn
-        cdef cmap[np.uint64_t, ewah_bool_array] *ewah_coll1 = <cmap[np.uint64_t, ewah_bool_array] *> self.ewah_coll
-        cdef cmap[np.uint64_t, ewah_bool_array] *ewah_coll2 = <cmap[np.uint64_t, ewah_bool_array] *> solf.ewah_coll
-        cdef cmap[np.uint64_t, ewah_bool_array].iterator it_map1, it_map2
+        cdef ewahmap *ewah_coll1 = <ewahmap *> self.ewah_coll
+        cdef ewahmap *ewah_coll2 = <ewahmap *> solf.ewah_coll
+        cdef ewahmap_it it_map1, it_map2
         cdef ewah_bool_array swap, mi1_ewah1, mi1_ewah2
         cdef np.uint64_t nrefn, mi1
         # TODO: Check if nele1 is equal?
@@ -1613,9 +1615,9 @@ cdef class BoolArrayCollectionUncompressed:
             cdef bitarrtype *ewah_refn1 = <bitarrtype *> self.ewah_refn
             cdef bitarrtype *ewah_keys2 = <bitarrtype *> solf.ewah_keys
             cdef bitarrtype *ewah_refn2 = <bitarrtype *> solf.ewah_refn
-        cdef cmap[np.uint64_t, ewah_bool_array] *ewah_coll1 = <cmap[np.uint64_t, ewah_bool_array] *> self.ewah_coll
-        cdef cmap[np.uint64_t, ewah_bool_array] *ewah_coll2 = <cmap[np.uint64_t, ewah_bool_array] *> solf.ewah_coll
-        cdef cmap[np.uint64_t, ewah_bool_array].iterator it_map1, it_map2
+        cdef ewahmap *ewah_coll1 = <ewahmap *> self.ewah_coll
+        cdef ewahmap *ewah_coll2 = <ewahmap *> solf.ewah_coll
+        cdef ewahmap_it it_map1, it_map2
         cdef ewah_bool_array mi1_ewah1, mi1_ewah2
         cdef np.uint64_t mi1
         # No intersection

--- a/yt/utilities/lib/ewah_bool_wrap.pyx
+++ b/yt/utilities/lib/ewah_bool_wrap.pyx
@@ -1749,32 +1749,20 @@ cdef class SparseUnorderedBitmaskSet:
     cdef void _fill(self, np.uint8_t[:] mask):
         cdef np.uint64_t ind
         cdef cset[np.uint64_t] *entries = <cset[np.uint64_t]*> self.entries
-        cdef cset[np.uint64_t].iterator it
-        it = entries[0].begin()
-        while it != entries[0].end():
-            ind = dereference(it)
-            mask[ind] = 1
-            preincrement(it)
+        for it in entries[0]:
+            mask[it] = 1
 
     cdef void _fill_ewah(self, BoolArrayCollection mm):
         cdef np.uint64_t ind
         cdef cset[np.uint64_t] *entries = <cset[np.uint64_t]*> self.entries
-        cdef cset[np.uint64_t].iterator it
-        it = entries[0].begin()
-        while it != entries[0].end():
-            ind = dereference(it)
-            mm._set_coarse(ind)
-            preincrement(it)
+        for it in entries[0]:
+            mm._set_coarse(it)
 
     cdef void _fill_bool(self, BoolArrayCollectionUncompressed mm):
         cdef np.uint64_t ind
         cdef cset[np.uint64_t] *entries = <cset[np.uint64_t]*> self.entries
-        cdef cset[np.uint64_t].iterator it
-        it = entries[0].begin()
-        while it != entries[0].end():
-            ind = dereference(it)
-            mm._set_coarse(ind)
-            preincrement(it)
+        for it in entries[0]:
+            mm._set_coarse(it)
 
     cdef void _reset(self):
         cdef cset[np.uint64_t] *entries = <cset[np.uint64_t]*> self.entries
@@ -1821,38 +1809,22 @@ cdef class SparseUnorderedRefinedBitmaskVector:
     cdef void _fill(self, np.uint8_t[:] mask1, np.uint8_t[:] mask2):
         cdef np.uint64_t i, ind
         cdef vector[ind_pair] *entries = <vector[ind_pair]*> self.entries
-        cdef vector[ind_pair].iterator it
-        it = entries[0].begin()
-        while it != entries[0].end():
-            ind = dereference(it).first
-            mask1[ind] = 1
-            ind = dereference(it).second
-            mask2[ind] = 1
-            preincrement(it)
+        for it in entries[0]:
+            mask1[it.first] = mask2[it.second] = 1
 
     cdef void _fill_ewah(self, BoolArrayCollection mm):
         self._remove_duplicates()
         cdef np.uint64_t mi1, mi2
         cdef vector[ind_pair] *entries = <vector[ind_pair]*> self.entries
-        cdef vector[ind_pair].iterator it
-        it = entries[0].begin()
-        while it != entries[0].end():
-            mi1 = dereference(it).first
-            mi2 = dereference(it).second
-            mm._set_refined(mi1, mi2)
-            preincrement(it)
+        for it in entries[0]:
+            mm._set_refined(it.first, it.second)
 
     cdef void _fill_bool(self, BoolArrayCollectionUncompressed mm):
         self._remove_duplicates()
         cdef np.uint64_t mi1, mi2
         cdef vector[ind_pair] *entries = <vector[ind_pair]*> self.entries
-        cdef vector[ind_pair].iterator it
-        it = entries[0].begin()
-        while it != entries[0].end():
-            mi1 = dereference(it).first
-            mi2 = dereference(it).second
-            mm._set_refined(mi1, mi2)
-            preincrement(it)
+        for it in entries[0]:
+            mm._set_refined(it.first, it.second)
 
     cdef void _reset(self):
         cdef vector[ind_pair] *entries = <vector[ind_pair]*> self.entries
@@ -1864,15 +1836,12 @@ cdef class SparseUnorderedRefinedBitmaskVector:
         cdef np.ndarray[np.uint64_t, ndim=2] rv
         self._remove_duplicates()
         cdef vector[ind_pair] *entries = <vector[ind_pair]*> self.entries
-        cdef vector[ind_pair].iterator it
         rv = np.empty((entries[0].size(),2),dtype='uint64')
-        it = entries[0].begin()
         i = 0
-        while it != entries[0].end():
-            rv[i,0] = dereference(it).first
-            rv[i,1] = dereference(it).second
+        for it in entries[0]:
+            rv[i,0] = it.first
+            rv[i,1] = it.second
             i += 1
-            preincrement(it)
         return rv
 
     cdef void _remove_duplicates(self):
@@ -1930,37 +1899,21 @@ cdef class SparseUnorderedRefinedBitmaskSet:
 
     cdef void _fill(self, np.uint8_t[:] mask1, np.uint8_t[:] mask2):
         cdef np.uint64_t ind
-        cdef cset[pair[np.uint64_t,np.uint64_t]] *entries = <cset[pair[np.uint64_t,np.uint64_t]]*> self.entries
-        cdef cset[pair[np.uint64_t,np.uint64_t]].iterator it
-        it = entries[0].begin()
-        while it != entries[0].end():
-            ind = dereference(it).first
-            mask1[ind] = 1
-            ind = dereference(it).second
-            mask2[ind] = 1
-            preincrement(it)
+        cdef cset[ind_pair] *entries = <cset[ind_pair]*> self.entries
+        for p in entries[0]:
+            mask1[p.first] = mask2[p.second] = 1
 
     cdef void _fill_ewah(self, BoolArrayCollection mm):
         cdef np.uint64_t mi1, mi2
         cdef cset[ind_pair] *entries = <cset[ind_pair]*> self.entries
-        cdef cset[ind_pair].iterator it
-        it = entries[0].begin()
-        while it != entries[0].end():
-            mi1 = dereference(it).first
-            mi2 = dereference(it).second
-            mm._set_refined(mi1, mi2)
-            preincrement(it)
+        for it in entries[0]:
+            mm._set_refined(it.first, it.second)
 
     cdef void _fill_bool(self, BoolArrayCollectionUncompressed mm):
         cdef np.uint64_t mi1, mi2
         cdef cset[ind_pair] *entries = <cset[ind_pair]*> self.entries
-        cdef cset[ind_pair].iterator it
-        it = entries[0].begin()
-        while it != entries[0].end():
-            mi1 = dereference(it).first
-            mi2 = dereference(it).second
-            mm._set_refined(mi1, mi2)
-            preincrement(it)
+        for it in entries[0]:
+            mm._set_refined(it.first, it.second)
 
     cdef void _reset(self):
         cdef cset[ind_pair] *entries = <cset[ind_pair]*> self.entries
@@ -1969,16 +1922,13 @@ cdef class SparseUnorderedRefinedBitmaskSet:
     cdef to_array(self):
         cdef int i
         cdef np.ndarray[np.uint64_t, ndim=2] rv
-        cdef cset[pair[np.uint64_t,np.uint64_t]] *entries = <cset[pair[np.uint64_t,np.uint64_t]]*> self.entries
-        cdef cset[pair[np.uint64_t,np.uint64_t]].iterator it
+        cdef cset[ind_pair] *entries = <cset[ind_pair]*> self.entries
         rv = np.empty((entries[0].size(),2),dtype='uint64')
-        it = entries[0].begin()
         i = 0
-        while it != entries[0].end():
-            rv[i,0] = dereference(it).first
-            rv[i,1] = dereference(it).second
+        for it in entries[0]:
+            rv[i,0] = it.first
+            rv[i,1] = it.second
             i += 1
-            preincrement(it)
         return rv
 
     def __dealloc__(self):

--- a/yt/utilities/lib/geometry_utils.pxd
+++ b/yt/utilities/lib/geometry_utils.pxd
@@ -322,7 +322,6 @@ cdef inline np.uint64_t bounded_morton_relative_dds(np.float64_t x, np.float64_t
 @cython.cdivision(True)
 cdef inline np.uint64_t bounded_morton_split_dds(np.float64_t x, np.float64_t y, np.float64_t z,
                                np.float64_t *DLE, np.float64_t *dds, np.uint64_t *p):
-    cdef np.uint64_t x_ind, y_ind, z_ind
     cdef np.uint64_t mi
     p[0] = <np.uint64_t> ((x - DLE[0])/dds[0])
     p[1] = <np.uint64_t> ((y - DLE[1])/dds[1])


### PR DESCRIPTION
This modifies some of the EWAH code to use more cython-like idioms and to reduce some of the lines of code.  It should produce *no* changes, and if it does, that is a bug.  I have not identified changes in my testing.

There are a few other places that we could use Cython idioms for iteration and the like, but I have not yet applied these changes there, as I'm not 100% certain it would improve overall readability (and I want to avoid copy-on-assignment).