### PR TITLE
store axes background as plot metadata and set in setup_plots. Closes #2016

### DIFF
--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -339,6 +339,10 @@ class ImagePlotMPL(PlotMPL):
             draw_frame = choice
         self._draw_axes = choice
         self._draw_frame = draw_frame
+        if LooseVersion(matplotlib.__version__) < LooseVersion("2.0.0"):
+            fc = self.axes.get_axis_bgcolor()
+        else:
+            fc = self.axes.get_facecolor()
         self.axes.set_frame_on(draw_frame)
         self.axes.get_xaxis().set_visible(choice)
         self.axes.get_yaxis().set_visible(choice)
@@ -346,6 +350,10 @@ class ImagePlotMPL(PlotMPL):
         self.axes.set_position(axrect)
         self.cax.set_position(caxrect)
         self.figure.set_size_inches(*size)
+        if LooseVersion(matplotlib.__version__) < LooseVersion("2.0.0"):
+            self.axes.set_axis_bgcolor(fc)
+        else:
+            self.axes.set_facecolor(fc)
 
     def _toggle_colorbar(self, choice):
         """

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -22,7 +22,6 @@ import numpy as np
 import matplotlib
 import os
 
-from distutils.version import LooseVersion
 from collections import defaultdict
 from functools import wraps
 
@@ -666,6 +665,8 @@ class ImagePlotContainer(PlotContainer):
         self._colormaps = defaultdict(
             lambda: ytcfg.get("yt", "default_colormap"))
         self._cbar_minorticks = {}
+        self._background_color = PlotDictionary(
+            self.data_source, lambda: 'w')
         self._colorbar_label = PlotDictionary(
             self.data_source, lambda: None)
 
@@ -719,10 +720,7 @@ class ImagePlotContainer(PlotContainer):
                 except KeyError:
                     cmap = getattr(matplotlib.cm, cmap)
             color = cmap(0)
-        if LooseVersion(matplotlib.__version__) < LooseVersion("2.0.0"):
-            self.plots[actual_field].axes.set_axis_bgcolor(color)
-        else:
-            self.plots[actual_field].axes.set_facecolor(color)
+        self._background_color[actual_field] = color
         return self
 
     @invalidate_plot

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -889,6 +889,13 @@ class PWViewerMPL(PlotWindow):
             self.plots[f].axes.set_xlabel(labels[0])
             self.plots[f].axes.set_ylabel(labels[1])
 
+            color = self._background_color[f]
+
+            if LooseVersion(matplotlib.__version__) < LooseVersion("2.0.0"):
+                self.plots[f].axes.set_axis_bgcolor(color)
+            else:
+                self.plots[f].axes.set_facecolor(color)
+
             # Determine the units of the data
             units = Unit(self.frb[f].units, registry=self.ds.unit_registry)
             units = units.latex_representation()

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -18,6 +18,7 @@ from yt.extern.six.moves import builtins
 from yt.extern.six.moves import zip as izip
 from yt.extern.six import string_types, iteritems
 from collections import OrderedDict
+from distutils.version import LooseVersion
 import base64
 import os
 from functools import wraps
@@ -1085,6 +1086,13 @@ class PhasePlot(ImagePlotContainer):
 
             self.plots[f].axes.set_xlim(xlim)
             self.plots[f].axes.set_ylim(ylim)
+
+            color = self._background_color[f]
+
+            if LooseVersion(matplotlib.__version__) < LooseVersion("2.0.0"):
+                self.plots[f].axes.set_axis_bgcolor(color)
+            else:
+                self.plots[f].axes.set_facecolor(color)
 
             if f in self._plot_text:
                 self.plots[f].axes.text(self._text_xpos[f], self._text_ypos[f],

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -460,6 +460,7 @@ def test_set_background_color():
     plot = SlicePlot(ds, 2, 'density')
     for field in ['density', ('gas', 'density')]:
         plot.set_background_color(field, 'red')
+        plot._setup_plots()
         ax = plot.plots[field].axes
         if LooseVersion(matplotlib.__version__) < LooseVersion('2.0.0'):
             assert_equal(ax.get_axis_bgcolor(), 'red')


### PR DESCRIPTION
This sets the axis background color to always be set by yt, defaulting to matplotlib's default (white with 100% alpha). When a user customizes it rather than actually manipulating the axis background color then, we store that color as metadata in a private dictionary. Then, when we create the plot, we set the color on the axes for the plot while we initialize it.