### PR TITLE
allow for 'color' kwarg to be passed as a plot argument in annotate_clumps

### DIFF
--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -996,6 +996,8 @@ class ClumpContourCallback(PlotCallback):
     def __init__(self, clumps, plot_args=None):
         self.clumps = clumps
         if plot_args is None: plot_args = {}
+        if 'color' in plot_args:
+            plot_args['colors'] = plot_args.pop('color')
         self.plot_args = plot_args
 
     def __call__(self, plot):


### PR DESCRIPTION
This resolves yt-project/yt#1896. 

If `color` is included in the `plot_args` dictionary it is now changed to `colors`  and the behavior in `annotate_clumps()` is consistent with other annotate_ functions. Previously, passing `color` did nothing if passed as as a plot argument through `annotate_clumps()`. 

- [x] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

