### PR TITLE
fix x/y mixup in plane parallel projection function. Fixes #1753

### DIFF
--- a/yt/visualization/volume_rendering/lens.py
+++ b/yt/visualization/volume_rendering/lens.py
@@ -131,9 +131,8 @@ class PlaneParallelLens(Lens):
         dy = np.array(np.dot(pos - origin, camera.unit_vectors[0]))
         dz = np.array(np.dot(pos - front_center, -camera.unit_vectors[2]))
         # Transpose into image coords.
-
-        py = (res[0]*(dx/width[0])).astype('int64')
-        px = (res[1]*(dy/width[1])).astype('int64')
+        px = (res[0]*(dy/width[0])).astype('int64')
+        py = (res[1]*(dx/width[1])).astype('int64')
         return px, py, dz
 
     def __repr__(self):


### PR DESCRIPTION
With this patch applied the script in the issue produces this:

![render6_1](https://user-images.githubusercontent.com/3126246/45507723-89b2c680-b758-11e8-8aab-61e864260d09.png)

The rendering with the perspective lens was actually correct, it just didn't look right from the angle used in the issue description. If you zoom out it's pretty clearly correct.