### PR TITLE
Raise exception for profile fields of unequal shape.

### DIFF
--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -265,6 +265,10 @@ been deprecated, use profile.standard_deviation instead."""
             units = chunk.ds.field_info[field].output_units
             arr[:,i] = chunk[field][pfilter].in_units(units)
         if self.weight_field is not None:
+            if pfilter.shape != chunk[self.weight_field].shape:
+                raise YTProfileDataShape(
+                    self.bin_fields[0], bin_fields[0].shape,
+                    self.weight_field, chunk[self.weight_field].shape)
             units = chunk.ds.field_info[self.weight_field].output_units
             weight_data = chunk[self.weight_field].in_units(units)
         else:

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -30,7 +30,9 @@ from yt.units.yt_array import \
 from yt.units.unit_object import Unit
 from yt.data_objects.field_data import YTFieldData
 from yt.utilities.exceptions import \
-    YTIllDefinedProfile, YTIllDefinedBounds
+    YTIllDefinedProfile, \
+    YTIllDefinedBounds, \
+    YTProfileDataShape
 from yt.utilities.lib.misc_utilities import \
     new_bin_profile1d, \
     new_bin_profile2d, \
@@ -235,30 +237,39 @@ been deprecated, use profile.standard_deviation instead."""
     def _filter(self, bin_fields):
         # cut_points is set to be everything initially, but
         # we also want to apply a filtering based on min/max
-        filter = np.ones(bin_fields[0].shape, dtype='bool')
+        pfilter = np.ones(bin_fields[0].shape, dtype='bool')
         for (mi, ma), data in zip(self.bounds, bin_fields):
-            filter &= (data > mi)
-            filter &= (data < ma)
-        return filter, [data[filter] for data in bin_fields]
+            pfilter &= (data > mi)
+            pfilter &= (data < ma)
+        return pfilter, [data[pfilter] for data in bin_fields]
 
     def _get_data(self, chunk, fields):
         # We are using chunks now, which will manage the field parameters and
         # the like.
         bin_fields = [chunk[bf] for bf in self.bin_fields]
+        for i in range(1, len(bin_fields)):
+            if bin_fields[0].shape != bin_fields[i].shape:
+                    raise YTProfileDataShape(
+                        self.bin_fields[0], bin_fields[0].shape,
+                        self.bin_fields[i], bin_fields[i].shape)
         # We want to make sure that our fields are within the bounds of the
         # binning
-        filter, bin_fields = self._filter(bin_fields)
-        if not np.any(filter): return None
+        pfilter, bin_fields = self._filter(bin_fields)
+        if not np.any(pfilter): return None
         arr = np.zeros((bin_fields[0].size, len(fields)), dtype="float64")
         for i, field in enumerate(fields):
+            if pfilter.shape != chunk[field].shape:
+                raise YTProfileDataShape(
+                    self.bin_fields[0], bin_fields[0].shape,
+                    field, chunk[field].shape)
             units = chunk.ds.field_info[field].output_units
-            arr[:,i] = chunk[field][filter].in_units(units)
+            arr[:,i] = chunk[field][pfilter].in_units(units)
         if self.weight_field is not None:
             units = chunk.ds.field_info[self.weight_field].output_units
             weight_data = chunk[self.weight_field].in_units(units)
         else:
-            weight_data = np.ones(filter.shape, dtype="float64")
-        weight_data = weight_data[filter]
+            weight_data = np.ones(pfilter.shape, dtype="float64")
+        weight_data = weight_data[pfilter]
         # So that we can pass these into
         return arr, weight_data, bin_fields
 

--- a/yt/data_objects/tests/test_profiles.py
+++ b/yt/data_objects/tests/test_profiles.py
@@ -5,9 +5,6 @@ import tempfile
 import unittest
 import yt
 
-from nose.tools import \
-    assert_raises
-
 from yt.utilities.exceptions import \
     YTProfileDataShape
 from yt.data_objects.particle_filters import add_particle_filter

--- a/yt/data_objects/tests/test_profiles.py
+++ b/yt/data_objects/tests/test_profiles.py
@@ -5,13 +5,20 @@ import tempfile
 import unittest
 import yt
 
+from nose.tools import \
+    assert_raises
+
 from yt.utilities.exceptions import \
     YTProfileDataShape
 from yt.data_objects.particle_filters import add_particle_filter
 from yt.data_objects.profiles import Profile1D, Profile2D, Profile3D,\
     create_profile
-from yt.testing import fake_random_ds, assert_equal, assert_raises,\
-    assert_rel_equal
+from yt.testing import \
+    assert_equal, \
+    assert_raises,\
+    assert_rel_equal, \
+    fake_random_ds, \
+    requires_module
 from yt.utilities.exceptions import YTIllDefinedProfile
 from yt.visualization.profile_plotter import ProfilePlot, PhasePlot
 
@@ -341,6 +348,7 @@ class TestBadProfiles(unittest.TestCase):
         # clean up
         shutil.rmtree(self.tmpdir)
 
+    @requires_module('h5py')
     def test_unequal_data_shape_profile(self):
         density = np.random.random(128)
         temperature = np.random.random(128)
@@ -355,14 +363,11 @@ class TestBadProfiles(unittest.TestCase):
 
         ds = yt.load('mydata.h5')
 
-        # We want this to fail with a YTProfileDataShape exception.
-        try:
-            yt.PhasePlot(ds.data, 'temperature', 'density', 'cell_mass')
-        except YTProfileDataShape:
-            return
+        assert_raises(
+            YTProfileDataShape,
+            yt.PhasePlot, ds.data, 'temperature', 'density', 'cell_mass')
 
-        assert False
-
+    @requires_module('h5py')
     def test_unequal_bin_field_profile(self):
         density = np.random.random(128)
         temperature = np.random.random(127)
@@ -377,10 +382,6 @@ class TestBadProfiles(unittest.TestCase):
 
         ds = yt.load('mydata.h5')
 
-        # We want this to fail with a YTProfileDataShape exception.
-        try:
-            yt.PhasePlot(ds.data, 'temperature', 'density', 'cell_mass')
-        except YTProfileDataShape:
-            return
-
-        assert False
+        assert_raises(
+            YTProfileDataShape,
+            yt.PhasePlot, ds.data, 'temperature', 'density', 'cell_mass')

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -679,6 +679,17 @@ class YTIllDefinedProfile(YTException):
 
         return msg + weight_msg
 
+class YTProfileDataShape(YTException):
+    def __init__(self, field1, shape1, field2, shape2):
+        self.field1 = field1
+        self.shape1 = shape1
+        self.field2 = field2
+        self.shape2 = shape2
+
+    def __str__(self):
+        return "Profile fields must have same shape: %s is %s and %s is %s." % \
+          (self.field1, self.shape1, self.field2, self.shape2)
+
 class YTBooleanObjectError(YTException):
     def __init__(self, bad_object):
         self.bad_object = bad_object

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -687,8 +687,9 @@ class YTProfileDataShape(YTException):
         self.shape2 = shape2
 
     def __str__(self):
-        return "Profile fields must have same shape: %s is %s and %s is %s." % \
-          (self.field1, self.shape1, self.field2, self.shape2)
+        return ("Profile fields must have same shape: %s has " +
+                "shape %s and %s has shape %s.") % \
+                (self.field1, self.shape1, self.field2, self.shape2)
 
 class YTBooleanObjectError(YTException):
     def __init__(self, bad_object):


### PR DESCRIPTION
This fixes Issue #1609. We check that bin fields and profile fields are all of the correct shape. I also changed all instances of `filter` to `pfilter` since `filter` is a reserved word. Tests added as well.