### PR TITLE
fix attribute error in clump finding tests

### DIFF
--- a/yt/data_objects/level_sets/tests/test_clump_finding.py
+++ b/yt/data_objects/level_sets/tests/test_clump_finding.py
@@ -114,8 +114,8 @@ def test_clump_tree_save():
     t2 = [c for c in ds2.tree]
     mt1 = ds.arr([c.info["cell_mass"][1] for c in t1])
     mt2 = ds2.arr([c["clump", "cell_mass"] for c in t2])
-    it1 = np.argsort(mt1).d.astype(int)
-    it2 = np.argsort(mt2).d.astype(int)
+    it1 = np.array(np.argsort(mt1).astype(int))
+    it2 = np.array(np.argsort(mt2).astype(int))
     assert_array_equal(mt1[it1], mt2[it2])
 
     for i1, i2 in zip(it1, it2):
@@ -131,8 +131,8 @@ def test_clump_tree_save():
     c2 = [c for c in ds2.leaves]
     mc1 = ds.arr([c.info["cell_mass"][1] for c in c1])
     mc2 = ds2.arr([c["clump", "cell_mass"] for c in c2])
-    ic1 = np.argsort(mc1).d.astype(int)
-    ic2 = np.argsort(mc2).d.astype(int)
+    ic1 = np.array(np.argsort(mc1).astype(int))
+    ic2 = np.array(np.argsort(mc2).astype(int))
     assert_array_equal(mc1[ic1], mc2[ic2])
 
     os.chdir(curdir)


### PR DESCRIPTION
This is code from two years ago and I have no idea why we're only noticing this now, but, currently this test fails with the following error:

```
======================================================================
ERROR: yt.data_objects.level_sets.tests.test_clump_finding.test_clump_tree_save
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/nose/case.py", line 198, in runTest
diff --git a/yt/data_objects/level_sets/tests/test_clump_finding.py b/yt/data_objects/level_sets/tests/test_clump_finding.py
index e674ead02..640fe3e72 100644
    self.test(*self.arg)
  File "/Users/goldbaum/Documents/yt-git-fixes/yt/data_objects/level_sets/tests/test_clump_finding.py", line 134, in test_clump_tree_save
    ic1 = np.argsort(mc1).d.astype(int)
AttributeError: 'numpy.ndarray' object has no attribute 'd'
```

The fix is just to not use `.d` at all.