### PR TITLE
Migrate from use.yt/with_conda

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you want the latest nightly build, you can manually install from our
 repository:
 
 ```
-conda install -c http://use.yt/with_conda yt
+conda install -c yt-project/label/dev yt
 ```
 
 To get set up with a development version, you want to clone this repository:

--- a/doc/source/installing.rst
+++ b/doc/source/installing.rst
@@ -245,7 +245,7 @@ it from our custom anaconda channel:
 
 .. code-block:: bash
 
-  $ conda install -c http://use.yt/with_conda/ -c conda-forge yt
+  $ conda install -c yt-project/label/dev -c conda-forge yt
 
 New packages for development branch are built after every pull request is
 merged. In order to make sure you are running latest version, it's recommended
@@ -253,7 +253,7 @@ to update frequently:
 
 .. code-block:: bash
 
-  $ conda update -c http://use.yt/with_conda/ -c conda-forge yt
+  $ conda update -c yt-project/label/dev -c conda-forge yt
 
 We recommend trying to install dependencies from conda-forge as indicated above
 since focused individual communities stand a better chance of successfully

--- a/doc/source/visualizing/interactive_data_visualization.rst
+++ b/doc/source/visualizing/interactive_data_visualization.rst
@@ -38,13 +38,6 @@ dependencies, e.g. `glfw3 <http://www.glfw.org/>`_ is required to be installed
 before you can ``pip install cyglfw3``. Please carefully read installation
 instructions provided on pypi pages of both packages. 
 
-If you are using conda, ``cyglfw3`` is provided in our conda channel
-(``pyopengl`` is shipped by Continuum already) and can be installed via:
-
-.. code-block:: bash
-
-    conda install -c http://use.yt/with_conda/ cyglfw3 pyopengl
-
 Using the interactive renderer
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/doc/source/visualizing/unstructured_mesh_rendering.rst
+++ b/doc/source/visualizing/unstructured_mesh_rendering.rst
@@ -15,17 +15,10 @@ below, or you can skip to the examples.
 Optional Embree Installation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The easiest way to install yt with Embree support is to use conda to install the
-most recent development version of yt from our channel:
-
-.. code-block:: bash
-
-    conda install -c http://use.yt/with_conda/ yt
-
-Alternatively, you can install yt from source using the ``install_script.sh``
-script. Be sure to set the ``INST_YT_SOURCE``, ``INST_EMBREE``, and
-``INST_NETCDF4`` flags to 1 at the top of the script. The ``install_script.sh``
-script can be downloaded by doing:
+To install yt with Embree support, you can install yt from source using the
+``install_script.sh`` script. Be sure to set the ``INST_YT_SOURCE``,
+``INST_EMBREE``, and ``INST_NETCDF4`` flags to 1 at the top of the script. The
+``install_script.sh`` script can be downloaded by doing:
 
 .. code-block:: bash
 
@@ -37,7 +30,7 @@ and then run like so:
 
   bash install_script.sh
 
-Finally, you can install the additional dependencies by hand.
+Alternatively, you can install the additional dependencies by hand.
 First, you will need to install Embree, either by compiling from source 
 or by using one of the pre-built binaries available at Embree's 
 `downloads <https://embree.github.io/downloads.html>`_ page.


### PR DESCRIPTION
Resolves #1718.

For the packages no longer hosted on `use.yt/with_conda`, I removed the references to installing from `use.yt/with_conda` in documents.

For the nightly builds, I've set up a new [repository](https://github.com/yt-project/conda-dev) for it.

