### PR TITLE
[bugfix] catch particles on domain edges for Gadget_FOF data

### DIFF
--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -1691,11 +1691,6 @@ the same redshift, additional analysis can be performed for each halo using
 :ref:`halo_catalog`.  The resulting product can be reloaded in a similar manner
 to the other halo catalogs shown here.
 
-For all halo catalog datasets, the halo positions will be cached to speed
-up subsequent field access. For extremely large datasets, this may increase
-memory usage indesirably. If this is the case, the caching of the positions
-can be disabled by providing ``cache_positions=False`` to ``yt.load``.
-
 .. _ahf:
 
 Amiga Halo Finder

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -1691,6 +1691,11 @@ the same redshift, additional analysis can be performed for each halo using
 :ref:`halo_catalog`.  The resulting product can be reloaded in a similar manner
 to the other halo catalogs shown here.
 
+For all halo catalog datasets, the halo positions will be cached to speed
+up subsequent field access. For extremely large datasets, this may increase
+memory usage indesirably. If this is the case, the caching of the positions
+can be disabled by providing ``cache_positions=False`` to ``yt.load``.
+
 .. _ahf:
 
 Amiga Halo Finder

--- a/yt/frontends/ahf/data_structures.py
+++ b/yt/frontends/ahf/data_structures.py
@@ -78,14 +78,13 @@ class AHFHalosDataset(Dataset):
     def __init__(self, filename, dataset_type='ahf',
                  n_ref=16, over_refine_factor=1,
                  units_override=None, unit_system='cgs',
-                 hubble_constant=1.0, cache_positions=True):
+                 hubble_constant=1.0):
         root, _ = os.path.splitext(filename)
         self.log_filename = root + '.log'
         self.hubble_constant = hubble_constant
 
         self.n_ref = n_ref
         self.over_refine_factor = over_refine_factor
-        self.cache_positions = cache_positions
         super(AHFHalosDataset, self).__init__(
             filename, dataset_type=dataset_type,
             units_override=units_override, unit_system=unit_system

--- a/yt/frontends/gadget_fof/data_structures.py
+++ b/yt/frontends/gadget_fof/data_structures.py
@@ -158,12 +158,10 @@ class GadgetFOFDataset(Dataset):
 
     def __init__(self, filename, dataset_type="gadget_fof_hdf5",
                  n_ref=16, over_refine_factor=1, index_ptype="all",
-                 unit_base=None, units_override=None, unit_system="cgs",
-                 cache_positions=True):
+                 unit_base=None, units_override=None, unit_system="cgs"):
         self.n_ref = n_ref
         self.over_refine_factor = over_refine_factor
         self.index_ptype = index_ptype
-        self.cache_positions = cache_positions
         if unit_base is not None and "UnitLength_in_cm" in unit_base:
             # We assume this is comoving, because in the absence of comoving
             # integration the redshift will be zero.

--- a/yt/frontends/gadget_fof/io.py
+++ b/yt/frontends/gadget_fof/io.py
@@ -134,7 +134,7 @@ class IOHandlerGadgetFOFHDF5(BaseIOHandler):
                 if data_file.total_particles[ptype] == 0:
                     continue
                 pos = data_file._read_particle_positions(ptype, f=f)
-                pos = data_file.ds.arr(pos, "code_length")
+                pos = self.ds.arr(pos, "code_length")
 
                 if np.any(pos.min(axis=0) < self.ds.domain_left_edge) or \
                    np.any(pos.max(axis=0) > self.ds.domain_right_edge):
@@ -145,8 +145,8 @@ class IOHandlerGadgetFOFHDF5(BaseIOHandler):
                 regions.add_data_file(pos, data_file.file_id)
                 morton[ind:ind+pos.shape[0]] = compute_morton(
                     pos[:,0], pos[:,1], pos[:,2],
-                    data_file.ds.domain_left_edge,
-                    data_file.ds.domain_right_edge)
+                    self.ds.domain_left_edge,
+                    self.ds.domain_right_edge)
                 ind += pos.shape[0]
         return morton
 

--- a/yt/frontends/gadget_fof/io.py
+++ b/yt/frontends/gadget_fof/io.py
@@ -46,7 +46,7 @@ class IOHandlerGadgetFOFHDF5(BaseIOHandler):
         for data_file in sorted(data_files):
             with h5py.File(data_file.filename, "r") as f:
                 for ptype, field_list in sorted(ptf.items()):
-                    coords = data_file._read_particle_positions(ptype, f=f)
+                    coords = data_file._get_particle_positions(ptype, f=f)
                     if coords is None:
                         continue
                     x = coords[:, 0]
@@ -84,7 +84,7 @@ class IOHandlerGadgetFOFHDF5(BaseIOHandler):
                     pcount = data_file.total_particles[ptype]
                     if pcount == 0:
                         continue
-                    coords = data_file._read_particle_positions(ptype, f=f)
+                    coords = data_file._get_particle_positions(ptype, f=f)
                     x = coords[:, 0]
                     y = coords[:, 1]
                     z = coords[:, 2]
@@ -133,7 +133,7 @@ class IOHandlerGadgetFOFHDF5(BaseIOHandler):
             for ptype in ptypes:
                 if data_file.total_particles[ptype] == 0:
                     continue
-                pos = data_file._read_particle_positions(ptype, f=f)
+                pos = data_file._get_particle_positions(ptype, f=f)
                 pos = self.ds.arr(pos, "code_length")
 
                 if np.any(pos.min(axis=0) < self.ds.domain_left_edge) or \

--- a/yt/frontends/gadget_fof/io.py
+++ b/yt/frontends/gadget_fof/io.py
@@ -46,11 +46,9 @@ class IOHandlerGadgetFOFHDF5(BaseIOHandler):
         for data_file in sorted(data_files):
             with h5py.File(data_file.filename, "r") as f:
                 for ptype, field_list in sorted(ptf.items()):
-                    pcount = data_file.total_particles[ptype]
-                    if pcount == 0:
+                    coords = data_file._read_particle_positions(ptype, f=f)
+                    if coords is None:
                         continue
-                    coords = f[ptype]["%sPos" % ptype].value.astype("float64")
-                    coords = np.resize(coords, (pcount, 3))
                     x = coords[:, 0]
                     y = coords[:, 1]
                     z = coords[:, 2]
@@ -84,15 +82,16 @@ class IOHandlerGadgetFOFHDF5(BaseIOHandler):
             with h5py.File(data_file.filename, "r") as f:
                 for ptype, field_list in sorted(ptf.items()):
                     pcount = data_file.total_particles[ptype]
-                    if pcount == 0: continue
-                    coords = f[ptype]["%sPos" % ptype].value.astype("float64")
-                    coords = np.resize(coords, (pcount, 3))
+                    if pcount == 0:
+                        continue
+                    coords = data_file._read_particle_positions(ptype, f=f)
                     x = coords[:, 0]
                     y = coords[:, 1]
                     z = coords[:, 2]
                     mask = selector.select_points(x, y, z, 0.0)
                     del x, y, z
-                    if mask is None: continue
+                    if mask is None:
+                        continue
                     for field in field_list:
                         if field in self.offset_fields:
                             field_data = \
@@ -132,16 +131,11 @@ class IOHandlerGadgetFOFHDF5(BaseIOHandler):
             dx = 2.0*self.ds.quan(dx, "code_length")
 
             for ptype in ptypes:
-                if data_file.total_particles[ptype] == 0: continue
-                pos = f[ptype]["%sPos" % ptype].value.astype("float64")
-                pos = np.resize(pos, (data_file.total_particles[ptype], 3))
+                if data_file.total_particles[ptype] == 0:
+                    continue
+                pos = data_file._read_particle_positions(ptype, f=f)
                 pos = data_file.ds.arr(pos, "code_length")
 
-                # These are 32 bit numbers, so we give a little lee-way.
-                # Otherwise, for big sets of particles, we often will bump into the
-                # domain edges.  This helps alleviate that.
-                np.clip(pos, self.ds.domain_left_edge + dx,
-                             self.ds.domain_right_edge - dx, pos)
                 if np.any(pos.min(axis=0) < self.ds.domain_left_edge) or \
                    np.any(pos.max(axis=0) > self.ds.domain_right_edge):
                     raise YTDomainOverflow(pos.min(axis=0),

--- a/yt/frontends/halo_catalog/data_structures.py
+++ b/yt/frontends/halo_catalog/data_structures.py
@@ -64,14 +64,13 @@ class HaloCatalogFile(ParticleFile):
                 self._coords[ptype] = None
             return None
 
-        # These are 32 bit numbers, so we give a little lee-way.
-        # Otherwise, for big sets of particles, we often will bump into the
-        # domain edges.  This helps alleviate that.
+        # Correct for periodicity.
         dle = self.ds.domain_left_edge.to('code_length').v
-        dre = self.ds.domain_right_edge.to('code_length').v
-        dx = 2. * np.finfo(np.float32).eps
+        dw = self.ds.domain_width.to('code_length').v
         pos = self._read_particle_positions(ptype, f=f)
-        np.clip(pos, dle + dx, dre - dx, pos)
+        np.subtract(pos, dle, out=pos)
+        np.mod(pos, dw, out=pos)
+        np.add(pos, dle, out=pos)
 
         if cache_pos:
             self._coords[ptype] = pos

--- a/yt/frontends/halo_catalog/data_structures.py
+++ b/yt/frontends/halo_catalog/data_structures.py
@@ -46,7 +46,6 @@ class HaloCatalogParticleIndex(ParticleIndex):
 
 class HaloCatalogFile(ParticleFile):
     def __init__(self, ds, io, filename, file_id):
-        self._coords = {}
         super(HaloCatalogFile, self).__init__(
             ds, io, filename, file_id)
 
@@ -54,14 +53,8 @@ class HaloCatalogFile(ParticleFile):
         raise NotImplementedError
 
     def _get_particle_positions(self, ptype, f=None):
-        if ptype in self._coords:
-            return self._coords[ptype]
-
         pcount = self.total_particles[ptype]
-        cache_pos = getattr(self.ds, "cache_positions", False)
         if pcount == 0:
-            if cache_pos:
-                self._coords[ptype] = None
             return None
 
         # Correct for periodicity.
@@ -72,8 +65,6 @@ class HaloCatalogFile(ParticleFile):
         np.mod(pos, dw, out=pos)
         np.add(pos, dle, out=pos)
 
-        if cache_pos:
-            self._coords[ptype] = pos
         return pos
 
 class HaloCatalogHDF5File(HaloCatalogFile):
@@ -117,10 +108,9 @@ class HaloCatalogDataset(SavedDataset):
 
     def __init__(self, filename, dataset_type="halocatalog_hdf5",
                  n_ref = 16, over_refine_factor = 1, units_override=None,
-                 unit_system="cgs", cache_positions=True):
+                 unit_system="cgs"):
         self.n_ref = n_ref
         self.over_refine_factor = over_refine_factor
-        self.cache_positions = cache_positions
         super(HaloCatalogDataset, self).__init__(filename, dataset_type,
                                                  units_override=units_override,
                                                  unit_system=unit_system)

--- a/yt/frontends/halo_catalog/tests/test_outputs.py
+++ b/yt/frontends/halo_catalog/tests/test_outputs.py
@@ -1,0 +1,99 @@
+"""
+halo_catalog frontend tests
+
+
+
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) yt Development Team. All rights reserved.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+import numpy as np
+
+from yt.convenience import \
+    load as yt_load
+from yt.frontends.halo_catalog.data_structures import \
+    HaloCatalogDataset
+from yt.frontends.ytdata.utilities import \
+    save_as_dataset
+from yt.testing import \
+    assert_array_equal, \
+    TempDirTest
+from yt.units.yt_array import \
+    YTArray, \
+    YTQuantity
+
+def fake_halo_catalog(data):
+    filename = "catalog.0.h5"
+
+    ftypes = dict((field, '.') for field in data)
+    extra_attrs = {"data_type": "halo_catalog",
+                   "num_halos": data['particle_mass'].size}
+
+    ds = {'cosmological_simulation': 1,
+          'omega_lambda': 0.7,
+          'omega_matter': 0.3,
+          'hubble_constant': 0.7,
+          'current_redshift': 0,
+          'current_time': YTQuantity(1, 'yr'),
+          'domain_left_edge': YTArray(np.zeros(3), 'cm'),
+          'domain_right_edge': YTArray(np.ones(3), 'cm')}
+    save_as_dataset(
+        ds, filename, data,
+        field_types=ftypes, extra_attrs=extra_attrs)
+    return filename
+
+class HaloCatalogTest(TempDirTest):
+    def test_halo_catalog(self):
+        rs = np.random.RandomState(3670474)
+        n_halos = 100
+        fields = ['particle_%s' % name for name in
+                  ['mass'] + ['position_%s' % ax for ax in 'xyz']]
+        units = ['g'] + ['cm']*3
+        data = dict((field, YTArray(rs.random_sample(n_halos), unit))
+                    for field, unit in zip(fields, units))
+
+        fn = fake_halo_catalog(data)
+        ds = yt_load(fn)
+
+        assert isinstance(ds, HaloCatalogDataset)
+
+        for field in fields:
+            f1 = data[field].in_base()
+            f1.sort()
+            f2 = ds.r[field].in_base()
+            f2.sort()
+            assert_array_equal(f1, f2)
+
+    def test_halo_catalog_boundary_particles(self):
+        rs = np.random.RandomState(3670474)
+        n_halos = 100
+        fields = ['particle_%s' % name for name in
+                  ['mass'] + ['position_%s' % ax for ax in 'xyz']]
+        units = ['g'] + ['cm']*3
+        data = dict((field, YTArray(rs.random_sample(n_halos), unit))
+                    for field, unit in zip(fields, units))
+
+        data['particle_position_x'][0] = 1.0
+        data['particle_position_x'][1] = 0.0
+        data['particle_position_y'][2] = 1.0
+        data['particle_position_y'][3] = 0.0
+        data['particle_position_z'][4] = 1.0
+        data['particle_position_z'][5] = 0.0
+
+        fn = fake_halo_catalog(data)
+        ds = yt_load(fn)
+
+        assert isinstance(ds, HaloCatalogDataset)
+
+        for field in ['particle_mass']:
+            f1 = data[field].in_base()
+            f1.sort()
+            f2 = ds.r[field].in_base()
+            f2.sort()
+            assert_array_equal(f1, f2)

--- a/yt/frontends/halo_catalog/tests/test_outputs.py
+++ b/yt/frontends/halo_catalog/tests/test_outputs.py
@@ -23,6 +23,7 @@ from yt.frontends.ytdata.utilities import \
     save_as_dataset
 from yt.testing import \
     assert_array_equal, \
+    requires_module, \
     TempDirTest
 from yt.units.yt_array import \
     YTArray, \
@@ -49,6 +50,7 @@ def fake_halo_catalog(data):
     return filename
 
 class HaloCatalogTest(TempDirTest):
+    requires_module('h5py')
     def test_halo_catalog(self):
         rs = np.random.RandomState(3670474)
         n_halos = 100
@@ -70,6 +72,7 @@ class HaloCatalogTest(TempDirTest):
             f2.sort()
             assert_array_equal(f1, f2)
 
+    requires_module('h5py')
     def test_halo_catalog_boundary_particles(self):
         rs = np.random.RandomState(3670474)
         n_halos = 100

--- a/yt/frontends/rockstar/data_structures.py
+++ b/yt/frontends/rockstar/data_structures.py
@@ -77,11 +77,9 @@ class RockstarDataset(Dataset):
 
     def __init__(self, filename, dataset_type="rockstar_binary",
                  n_ref = 16, over_refine_factor = 1,
-                 units_override=None, unit_system="cgs",
-                 cache_positions=True):
+                 units_override=None, unit_system="cgs"):
         self.n_ref = n_ref
         self.over_refine_factor = over_refine_factor
-        self.cache_positions = cache_positions
         super(RockstarDataset, self).__init__(filename, dataset_type,
                                               units_override=units_override,
                                               unit_system=unit_system)

--- a/yt/frontends/rockstar/io.py
+++ b/yt/frontends/rockstar/io.py
@@ -53,6 +53,8 @@ class IOHandlerRockstarBinary(BaseIOHandler):
                 data_files.update(obj.data_files)
         for data_file in sorted(data_files,key=attrgetter("filename")):
             pcount = data_file.header['num_halos']
+            if pcount == 0:
+                continue
             with open(data_file.filename, "rb") as f:
                 pos = data_file._get_particle_positions(ptype, f=f)
                 yield "halos", (pos[:, i] for i in range(3))
@@ -69,6 +71,8 @@ class IOHandlerRockstarBinary(BaseIOHandler):
                 data_files.update(obj.data_files)
         for data_file in sorted(data_files,key=attrgetter("filename")):
             pcount = data_file.header['num_halos']
+            if pcount == 0:
+                continue
             with open(data_file.filename, "rb") as f:
                 for ptype, field_list in sorted(ptf.items()):
                     pos = data_file._get_particle_positions(ptype, f=f)
@@ -87,7 +91,8 @@ class IOHandlerRockstarBinary(BaseIOHandler):
         morton = np.empty(pcount, dtype='uint64')
         mylog.debug("Initializing index % 5i (% 7i particles)",
                     data_file.file_id, pcount)
-        if pcount == 0: return morton
+        if pcount == 0:
+            return morton
         ind = 0
         ptype = 'halos'
         with open(data_file.filename, "rb") as f:

--- a/yt/frontends/rockstar/io.py
+++ b/yt/frontends/rockstar/io.py
@@ -47,18 +47,15 @@ class IOHandlerRockstarBinary(BaseIOHandler):
         # Only support halo reading for now.
         assert(len(ptf) == 1)
         assert(list(ptf.keys())[0] == "halos")
+        ptype = 'halos'
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
         for data_file in sorted(data_files,key=attrgetter("filename")):
             pcount = data_file.header['num_halos']
             with open(data_file.filename, "rb") as f:
-                f.seek(data_file._position_offset, os.SEEK_SET)
-                halos = np.fromfile(f, dtype=self._halo_dt, count = pcount)
-                x = halos['particle_position_x'].astype("float64")
-                y = halos['particle_position_y'].astype("float64")
-                z = halos['particle_position_z'].astype("float64")
-                yield "halos", (x, y, z)
+                pos = data_file._get_particle_positions(ptype, f=f)
+                yield "halos", (pos[:, i] for i in range(3))
 
     def _read_particle_fields(self, chunks, ptf, selector):
         # Now we have all the sizes, and we can allocate
@@ -74,13 +71,12 @@ class IOHandlerRockstarBinary(BaseIOHandler):
             pcount = data_file.header['num_halos']
             with open(data_file.filename, "rb") as f:
                 for ptype, field_list in sorted(ptf.items()):
-                    f.seek(data_file._position_offset, os.SEEK_SET)
-                    halos = np.fromfile(f, dtype=self._halo_dt, count = pcount)
-                    x = halos['particle_position_x'].astype("float64")
-                    y = halos['particle_position_y'].astype("float64")
-                    z = halos['particle_position_z'].astype("float64")
+                    pos = data_file._get_particle_positions(ptype, f=f)
+                    x, y, z = (pos[:, i] for i in range(3))
                     mask = selector.select_points(x, y, z, 0.0)
                     del x, y, z
+                    f.seek(data_file._position_offset, os.SEEK_SET)
+                    halos = np.fromfile(f, dtype=self._halo_dt, count = pcount)
                     if mask is None: continue
                     for field in field_list:
                         data = halos[field][mask].astype("float64")
@@ -93,25 +89,10 @@ class IOHandlerRockstarBinary(BaseIOHandler):
                     data_file.file_id, pcount)
         if pcount == 0: return morton
         ind = 0
+        ptype = 'halos'
         with open(data_file.filename, "rb") as f:
-            f.seek(data_file._position_offset, os.SEEK_SET)
-            halos = np.fromfile(f, dtype=self._halo_dt, count = pcount)
-            pos = np.empty((halos.size, 3), dtype="float64")
-            # These positions are in Mpc, *not* "code" units
+            pos = data_file._get_particle_positions(ptype, f=f)
             pos = data_file.ds.arr(pos, "code_length")
-            eps = np.finfo(halos['particle_position_x'].dtype).eps
-            # Make sure eps is not larger than the domain itself
-            eps = eps*self.ds.domain_right_edge
-            dx = np.abs(eps).max()
-            pos[:,0] = halos["particle_position_x"]
-            pos[:,1] = halos["particle_position_y"]
-            pos[:,2] = halos["particle_position_z"]
-            # These are 32 bit numbers, so we give a little lee-way.
-            # Otherwise, for big sets of particles, we often will bump into the
-            # domain edges.  This helps alleviate that.
-            np.clip(pos, self.ds.domain_left_edge + dx,
-                         self.ds.domain_right_edge - dx, pos)
-            del halos
             if np.any(pos.min(axis=0) < self.ds.domain_left_edge) or \
                np.any(pos.max(axis=0) > self.ds.domain_right_edge):
                 raise YTDomainOverflow(pos.min(axis=0),

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -22,6 +22,8 @@ import numpy as np
 import functools
 import importlib
 import os
+import shutil
+import tempfile
 import unittest
 from yt.funcs import iterable
 from yt.config import ytcfg
@@ -1143,3 +1145,18 @@ def requires_backend(backend):
     if backend.lower() == matplotlib.get_backend().lower():
         return ftrue
     return ffalse
+
+class TempDirTest(unittest.TestCase):
+    """
+    A test class that runs in a temporary directory and
+    removes it afterward.
+    """
+
+    def setUp(self):
+        self.curdir = os.getcwd()
+        self.tmpdir = tempfile.mkdtemp()
+        os.chdir(self.tmpdir)
+
+    def tearDown(self):
+        os.chdir(self.curdir)
+        shutil.rmtree(self.tmpdir)


### PR DESCRIPTION
## PR Summary

In this frontend, and likely others, particles on domain boundaries were being lost because the code to bump them in from the edges only existed in `_initialize_index` and none of the other functions in the io handler that read particles. This fixes that by implementing a class method on the data file for reading particle positions and doing the correction there rather than have three copies of the same code.

In addition, I implemented this with a cache since particle positions need to be read in for every field read. For the rather large dataset I was testing, this reduced the load time for a field from ~3.5s to ~0.5s (after the positions had been read in once). Of course, this will increase the steady-state memory use, but I think it's probably worth it (although I'm open to other opinions).

Like many bugs of this nature, it took a pretty large dataset (73 GB) to find it, so including it for a test is probably difficult.

I suspect that this affects all similar frontends (all the halo catalogs at least). I'm open to porting this fix around if that's desirable. I could also implement some sort of `correct_positions` function at a higher class level.

## PR Checklist

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.