### PR TITLE
[bugfix] A Dataset's UnitSystem should have its UnitRegistry

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -67,8 +67,9 @@ from yt.utilities.minimal_representation import \
 from yt.units.yt_array import \
     YTArray, \
     YTQuantity
-from yt.units.unit_systems import create_code_unit_system, \
-    UnitSystem
+from yt.units.unit_systems import \
+    create_code_unit_system, \
+    _make_unit_system_copy
 from yt.data_objects.region_expression import \
     RegionExpression
 from yt.geometry.coordinates.api import \
@@ -975,8 +976,7 @@ class Dataset(object):
             unit_system = unit_system_registry[self.unit_registry.unit_system_id]
         else:
             sys_name = str(unit_system).lower()
-            unit_system = UnitSystem.make_dataset_copy(self.unit_registry,
-                                                       sys_name)
+            unit_system = _make_unit_system_copy(self.unit_registry, sys_name)
         self.unit_system = unit_system
 
     def _create_unit_registry(self):

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -67,7 +67,8 @@ from yt.utilities.minimal_representation import \
 from yt.units.yt_array import \
     YTArray, \
     YTQuantity
-from yt.units.unit_systems import create_code_unit_system
+from yt.units.unit_systems import create_code_unit_system, \
+    UnitSystem
 from yt.data_objects.region_expression import \
     RegionExpression
 from yt.geometry.coordinates.api import \
@@ -971,10 +972,12 @@ class Dataset(object):
         create_code_unit_system(self.unit_registry, 
                                 current_mks_unit=current_mks_unit)
         if unit_system == "code":
-            unit_system = self.unit_registry.unit_system_id
+            unit_system = unit_system_registry[self.unit_registry.unit_system_id]
         else:
-            unit_system = str(unit_system).lower()
-        self.unit_system = unit_system_registry[unit_system]
+            sys_name = str(unit_system).lower()
+            unit_system = UnitSystem.make_dataset_copy(self.unit_registry,
+                                                       sys_name)
+        self.unit_system = unit_system
 
     def _create_unit_registry(self):
         self.unit_registry = UnitRegistry()

--- a/yt/frontends/ytdata/utilities.py
+++ b/yt/frontends/ytdata/utilities.py
@@ -112,7 +112,7 @@ def save_as_dataset(ds, filename, data, field_types=None,
 
     if hasattr(ds, "unit_system"):
         _yt_array_hdf5_attr(fh, "unit_system_name",
-                            ds.unit_system.name)
+                            ds.unit_system.name.split("_")[0])
 
     for attr in base_attrs:
         if isinstance(ds, dict):

--- a/yt/units/unit_registry.py
+++ b/yt/units/unit_registry.py
@@ -67,7 +67,7 @@ class UnitRegistry:
             for k, v in self.lut.items():
                 hash_data.extend(k.encode('ascii'))
                 hash_data.extend(repr(v).encode('ascii'))
-            self._unit_system_id = "code_%d" % fnv_hash(hash_data)
+            self._unit_system_id = "us_%d" % fnv_hash(hash_data)
         return self._unit_system_id
 
     def add(self, symbol, base_value, dimensions, tex_repr=None, offset=None):

--- a/yt/units/unit_systems.py
+++ b/yt/units/unit_systems.py
@@ -111,42 +111,39 @@ class UnitSystem(object):
                 repr += "  %s: %s\n" % (key, self.units_map[dim])
         return repr
 
-    @classmethod
-    def make_dataset_copy(cls, unit_registry, unit_system):
-        """
-        Make a copy of a unit system with a different unit registry.
-        To be sure we do it correctly and do not change the input 
-        registry, we create a brand new UnitSystem instance from the
-        input's information.
 
-        Parameters
-        ----------
-        unit_registry : UnitRegistry instance
-            The unit registry we want to use with this unit system,
-            most likely from a dataset.
-        unit_system : string
-            The name of the unit system we want to make a copy of 
-            with the new registry.
-        """
-        unit_system = unit_system_registry[unit_system]
-        base_units = ["length", "mass", "time", "temperature", "angle"]
-        if "current_mks" in unit_system._dims:
-            current_mks_unit = str(unit_system["current_mks"])
-            base_units.append("current_mks")
-        else:
-            current_mks_unit = None
-        sys_name = "{}_{}".format(unit_system.name, unit_registry.unit_system_id)
-        ds_unit_system = UnitSystem(sys_name, str(unit_system["length"]), 
-                                    str(unit_system["mass"]), 
-                                    str(unit_system["time"]), 
-                                    temperature_unit=str(unit_system["temperature"]),
-                                    angle_unit=str(unit_system["angle"]),
-                                    current_mks_unit=current_mks_unit,
-                                    registry=unit_registry)
-        for dim in unit_system._dims:
-            if dim not in base_units:
-                ds_unit_system[dim] = str(unit_system[dim])
-        return ds_unit_system
+def _make_unit_system_copy(unit_registry, unit_system):
+    """
+    Make a copy of a unit system with a different unit registry.
+
+    Parameters
+    ----------
+    unit_registry : UnitRegistry instance
+        The unit registry we want to use with this unit system,
+        most likely from a dataset.
+    unit_system : string
+        The name of the unit system we want to make a copy of 
+        with the new registry.
+    """
+    unit_system = unit_system_registry[unit_system]
+    base_units = ["length", "mass", "time", "temperature", "angle"]
+    if "current_mks" in unit_system._dims:
+        current_mks_unit = str(unit_system["current_mks"])
+        base_units.append("current_mks")
+    else:
+        current_mks_unit = None
+    sys_name = "{}_{}".format(unit_system.name, unit_registry.unit_system_id)
+    ds_unit_system = UnitSystem(sys_name, str(unit_system["length"]), 
+                                str(unit_system["mass"]), 
+                                str(unit_system["time"]), 
+                                temperature_unit=str(unit_system["temperature"]),
+                                angle_unit=str(unit_system["angle"]),
+                                current_mks_unit=current_mks_unit,
+                                registry=unit_registry)
+    for dim in unit_system._dims:
+        if dim not in base_units:
+            ds_unit_system[dim] = str(unit_system[dim])
+    return ds_unit_system
 
 
 def create_code_unit_system(unit_registry, current_mks_unit=None):

--- a/yt/units/unit_systems.py
+++ b/yt/units/unit_systems.py
@@ -16,6 +16,7 @@ from yt.units import dimensions
 from yt.units.unit_object import Unit, unit_system_registry, _get_system_unit_string
 from yt.utilities import physical_constants as pc
 
+
 class UnitSystemConstants(object):
     """
     A class to facilitate conversions of physical constants into a given unit
@@ -32,6 +33,7 @@ class UnitSystemConstants(object):
 
     def __getattr__(self, item):
         return getattr(pc, item).in_base(self.name)
+
 
 class UnitSystem(object):
     """
@@ -109,6 +111,44 @@ class UnitSystem(object):
                 repr += "  %s: %s\n" % (key, self.units_map[dim])
         return repr
 
+    @classmethod
+    def make_dataset_copy(cls, unit_registry, unit_system):
+        """
+        Make a copy of a unit system with a different unit registry.
+        To be sure we do it correctly and do not change the input 
+        registry, we create a brand new UnitSystem instance from the
+        input's information.
+
+        Parameters
+        ----------
+        unit_registry : UnitRegistry instance
+            The unit registry we want to use with this unit system,
+            most likely from a dataset.
+        unit_system : string
+            The name of the unit system we want to make a copy of 
+            with the new registry.
+        """
+        unit_system = unit_system_registry[unit_system]
+        base_units = ["length", "mass", "time", "temperature", "angle"]
+        if "current_mks" in unit_system._dims:
+            current_mks_unit = str(unit_system["current_mks"])
+            base_units.append("current_mks")
+        else:
+            current_mks_unit = None
+        sys_name = "{}_{}".format(unit_system.name, unit_registry.unit_system_id)
+        ds_unit_system = UnitSystem(sys_name, str(unit_system["length"]), 
+                                    str(unit_system["mass"]), 
+                                    str(unit_system["time"]), 
+                                    temperature_unit=str(unit_system["temperature"]),
+                                    angle_unit=str(unit_system["angle"]),
+                                    current_mks_unit=current_mks_unit,
+                                    registry=unit_registry)
+        for dim in unit_system._dims:
+            if dim not in base_units:
+                ds_unit_system[dim] = str(unit_system[dim])
+        return ds_unit_system
+
+
 def create_code_unit_system(unit_registry, current_mks_unit=None):
     code_unit_system = UnitSystem(unit_registry.unit_system_id, "code_length", 
                                   "code_mass", "code_time", "code_temperature",
@@ -120,6 +160,7 @@ def create_code_unit_system(unit_registry, current_mks_unit=None):
     else:
         code_unit_system["magnetic_field_cgs"] = "code_magnetic"
     code_unit_system["pressure"] = "code_pressure"
+
 
 cgs_unit_system = UnitSystem("cgs", "cm", "g", "s")
 cgs_unit_system["energy"] = "erg"


### PR DESCRIPTION
During the creation of a `Dataset` instance it is assigned a `UnitSystem`, which the end-user can specify. Upon importing `yt` a number of `UnitSystem` instances are automatically created, such as "cgs", "mks", "galactic", etc. One of these is specified to `yt.load` (or the default) and it is assigned as the `Dataset`'s unit system. 

If done in this way, the `UnitSystem` does not have the correct `UnitRegistry` object. This PR fixes that problem by enforcing that a new `UnitSystem` instance is created which is associated with the `Dataset`'s `UnitRegistry`.  

I'm not thrilled about this solution, but the other solutions I came up with were messier than this, and I thought doing a `deepcopy` or something similar of the original `UnitSystem` instance and simply fixing the registry was a bad idea.

Closes Issue #2032.