### PR TITLE
[bugfix] Don't apply units to metallicity field.

### DIFF
--- a/yt/fields/fluid_fields.py
+++ b/yt/fields/fluid_fields.py
@@ -33,9 +33,6 @@ from yt.utilities.physical_constants import \
     mh, \
     kboltz
 
-from yt.utilities.physical_ratios import \
-    metallicity_sun
-
 from yt.utilities.lib.misc_utilities import \
     obtain_relative_velocity_vector
 
@@ -149,9 +146,7 @@ def setup_fluid_fields(registry, ftype = "gas", slice_info = None):
                        function=_entropy)
 
     def _metallicity(field, data):
-        tr = data[ftype, "metal_density"] / data[ftype, "density"]
-        tr /= metallicity_sun
-        return data.apply_units(tr, "Zsun")
+        return data[ftype, "metal_density"] / data[ftype, "density"]
     registry.add_field((ftype, "metallicity"),
                        sampling_type="cell",
                        function=_metallicity,


### PR DESCRIPTION
## PR Summary

With the way the metallicity field is currently defined, changing the value of the solar metallicity changes the metallicity field in absolute (i.e., dimensionless units) rather that in units of `Zsun`. for example, the following script:
```
import yt
ds = yt.load("DD0046/DD0046")
print (ds.r['metallicity'].to(""))
del ds

ds = yt.load("DD0046/DD0046")
ds.unit_registry.modify('Zsun', 0.0204)
print (ds.r['metallicity'].to(""))
```
gives:
```
[9.83077184e-11 9.99523614e-11 1.00078951e-10 ... 7.38725398e-11
 8.22170876e-11 8.92656217e-11] dimensionless
[1.54863124e-10 1.57453913e-10 1.57653328e-10 ... 1.16370642e-10
 1.29515721e-10 1.40619203e-10] dimensionless
```
This is incorrect, as the dimensionless value is simply `metal_density / density` and should not change when the units change.

After this fix, the dimensionless values of the metallicity field remain constant and the values in units of `Zsun` change, as is appropriate.

## PR Checklist

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.