### PR TITLE
minor clump refactor

### DIFF
--- a/doc/source/analyzing/analysis_modules/clump_finding.rst
+++ b/doc/source/analyzing/analysis_modules/clump_finding.rst
@@ -150,14 +150,13 @@ The entire clump tree can traversed with a loop syntax:
    for clump in master_clump:
        print(clump.clump_id)
 
-The :func:`~yt.data_objects.level_sets.clump_handling.get_lowest_clumps`
-function will return a list of the individual clumps that have no children
-of their own (the leaf clumps).
+The ``leaves`` attribute of a ``Clump`` object will return a list of the
+individual clumps that have no children of their own (the leaf clumps).
 
 .. code:: python
 
    # Get a list of just the leaf nodes.
-   leaf_clumps = get_lowest_clumps(master_clump)
+   leaf_clumps = master_clump.leaves
 
    print(leaf_clumps[0]["gas", "density"])
    print(leaf_clumps[0]["all", "particle_mass"])

--- a/doc/source/cookbook/find_clumps.py
+++ b/doc/source/cookbook/find_clumps.py
@@ -37,7 +37,7 @@ find_clumps(master_clump, c_min, c_max, step)
 fn = master_clump.save_as_dataset(fields=["density", "particle_mass"])
 
 # We can traverse the clump hierarchy to get a list of all of the 'leaf' clumps
-leaf_clumps = get_lowest_clumps(master_clump)
+leaf_clumps = master_clump.leaves
 
 # If you'd like to visualize these clumps, a list of clumps can be supplied to
 # the "clumps" callback on a plot.  First, we create a projection plot:

--- a/yt/analysis_modules/level_sets/api.py
+++ b/yt/analysis_modules/level_sets/api.py
@@ -28,9 +28,7 @@ from yt.data_objects.level_sets.contour_finder import \
 from yt.data_objects.level_sets.clump_handling import \
     Clump, \
     find_clumps, \
-    get_lowest_clumps, \
-    write_clump_index, \
-    write_clumps
+    get_lowest_clumps
 
 from yt.data_objects.level_sets.clump_info_items import \
     add_clump_info

--- a/yt/data_objects/level_sets/api.py
+++ b/yt/data_objects/level_sets/api.py
@@ -19,9 +19,7 @@ from .contour_finder import \
 from .clump_handling import \
     Clump, \
     find_clumps, \
-    get_lowest_clumps, \
-    write_clump_index, \
-    write_clumps
+    get_lowest_clumps
 
 from .clump_info_items import \
     add_clump_info

--- a/yt/data_objects/level_sets/clump_handling.py
+++ b/yt/data_objects/level_sets/clump_handling.py
@@ -21,11 +21,9 @@ from yt.fields.derived_field import \
 from yt.frontends.ytdata.utilities import \
     save_as_dataset
 from yt.funcs import \
-    deprecate, \
+    issue_deprecation_warning, \
     get_output_filename, \
     mylog
-from yt.extern.six import \
-    string_types
 from yt.utilities.tree_container import \
     TreeContainer
 
@@ -93,6 +91,18 @@ class Clump(TreeContainer):
         # Return value of validity function.
         self.valid = None
 
+    _leaves = None
+    @property
+    def leaves(self):
+        if self._leaves is not None:
+            return self._leaves
+
+        self._leaves = []
+        for clump in self:
+            if not clump.children:
+                self._leaves.append(clump)
+        return self._leaves
+
     def add_validator(self, validator, *args, **kwargs):
         """
         Add a validating function to determine whether the clump should 
@@ -139,14 +149,6 @@ class Clump(TreeContainer):
         self.clump_info = []
         for child in self.children:
             child.clear_clump_info()
-
-    @deprecate("Clump.save_as_dataset")
-    def write_info(self, level, f_ptr):
-        "Writes information for clump using the list of items in clump_info."
-
-        for item in self.base.clump_info:
-            value = item(self)
-            f_ptr.write("%s%s\n" % ('\t'*level, value))
 
     def find_children(self, min_val, max_val = None):
         if self.children:
@@ -440,45 +442,7 @@ def find_clumps(clump, min_val, max_val, d_clump):
 def get_lowest_clumps(clump, clump_list=None):
     "Return a list of all clumps at the bottom of the index."
 
-    if clump_list is None: clump_list = []
-    if len(clump.children) == 0:
-        clump_list.append(clump)
-    else:
-        for child in clump.children:
-            get_lowest_clumps(child, clump_list=clump_list)
-
-    return clump_list
-
-@deprecate("Clump.save_as_dataset")
-def write_clump_index(clump, level, fh):
-    top = False
-    if isinstance(fh, string_types):
-        fh = open(fh, "w")
-        top = True
-    for q in range(level):
-        fh.write("\t")
-    fh.write("Clump at level %d:\n" % level)
-    clump.write_info(level, fh)
-    fh.write("\n")
-    fh.flush()
-    for child in clump.children:
-        write_clump_index(child, (level+1), fh)
-    if top:
-        fh.close()
-
-@deprecate("Clump.save_as_dataset")
-def write_clumps(clump, level, fh):
-    top = False
-    if isinstance(fh, string_types):
-        fh = open(fh, "w")
-        top = True
-    if len(clump.children) == 0:
-        fh.write("%sClump:\n" % ("\t"*level))
-        clump.write_info(level, fh)
-        fh.write("\n")
-        fh.flush()
-    else:
-        for child in clump.children:
-            write_clumps(child, 0, fh)
-    if top:
-        fh.close()
+    issue_deprecation_warning(
+        "This function has been deprecated in favor of accessing a " +
+        "clump's leaf nodes via 'clump.leaves'.")
+    return clump.leaves


### PR DESCRIPTION
## PR Summary

This fixes the issue reported by @stonnes on the mailing list where a clump finding operation would sometimes end with:
```
TypeError: 'NoneType' object is not iterable
```

In doing this, I found the practice of initializing `Clump.children` to None to result in overly cumbersome if statements, so I changed the default to be an empty list. I have also deprecated the `get_lowest_clumps` function in favor of a `Clump.leaves` property. Finally, I removed two functions that have been deprecated for more than few stable releases now.

## PR Checklist

- [x] Code passes flake8 checker
- [x] New features are documented, with docstrings and narrative docs