### PR TITLE
Fixing logic in bitarray module

### DIFF
--- a/yt/utilities/lib/bitarray.pxd
+++ b/yt/utilities/lib/bitarray.pxd
@@ -19,8 +19,11 @@ cimport cython
 
 cdef inline void ba_set_value(np.uint8_t *buf, np.uint64_t ind,
                               np.uint8_t val) nogil:
-    if val > 0: val = 1
-    buf[ind >> 3] |= (val << (ind & 7))
+    # This assumes 8 bit buffer
+    if val > 0:
+        buf[ind >> 3] |= (1 << (ind & 7))
+    else:
+        buf[ind >> 3] &= ~(1 << (ind & 7))
 
 cdef inline np.uint8_t ba_get_value(np.uint8_t *buf, np.uint64_t ind) nogil:
     cdef np.uint8_t rv = (buf[ind >> 3] & (1 << (ind & 7)))

--- a/yt/utilities/lib/bitarray.pyx
+++ b/yt/utilities/lib/bitarray.pyx
@@ -23,7 +23,8 @@ cdef class bitarray:
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    def __init__(self, size = -1, arr = None):
+    def __cinit__(self, np.int64_t size = -1, 
+                  np.ndarray[np.uint8_t, ndim=1, cast=True] arr = None):
         r"""This is a bitarray, which flips individual bits to on/off inside a
         uint8 container array.
 
@@ -74,7 +75,7 @@ cdef class bitarray:
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    def set_from_array(self, np.ndarray[np.uint8_t, cast=True] arr):
+    def set_from_array(self, np.ndarray[np.uint8_t, cast=True] arr not None):
         r"""Given an array that is either uint8_t or boolean, set the values of
         this array to match it.
 

--- a/yt/utilities/lib/tests/test_bitarray.py
+++ b/yt/utilities/lib/tests/test_bitarray.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 import yt.utilities.lib.bitarray as ba
-from yt.testing import assert_equal
+from yt.testing import assert_equal, assert_array_equal
 
 def test_inout_bitarray():
     # Check that we can do it for bitarrays that are funny-shaped
@@ -40,3 +40,13 @@ def test_inout_bitarray():
         arr = b.as_bool_array()
         assert_equal(arr[:i+1].all(), True)
         assert_equal(arr[i+1:].any(), False)
+    for i in range(10):
+        b.set_value(i, 0)
+    arr = b.as_bool_array()
+    assert_equal(arr.any(), False)
+    b.set_value(7, 1)
+    arr = b.as_bool_array()
+    assert_array_equal(arr, [0, 0, 0, 0, 0, 0, 0, 1, 0, 0])
+    b.set_value(2, 1)
+    arr = b.as_bool_array()
+    assert_array_equal(arr, [0, 0, 1, 0, 0, 0, 0, 1, 0, 0])


### PR DESCRIPTION
This fixes some logic in the (uncompressed) bitarray module.  This is distinct from the EWAH module in that it doesn't make any effort to compress the arrays and it makes it easy to convert them to and from numpy arrays.  One of the downsides is that right now it's hardcoded to be 8-bit arrays to minimize waste, which also maximizes overhead of doing logical ops.

In the past, there were two major issues -- the first being the `val` was used, which broke things like casting to 0 or 1, and we also were incorrectly turning off bits.  This fixes both, and adds tests for them.

I'm cherry picking this from some grid visitors work to simplify that ultimate pull request.