### PR TITLE
ensure clump info is calculated when clumps are created

### DIFF
--- a/doc/source/reference/api/api.rst
+++ b/doc/source/reference/api/api.rst
@@ -477,7 +477,6 @@ of topologically disconnected structures, i.e., clump finding.
    ~yt.data_objects.level_sets.clump_handling.Clump.add_validator
    ~yt.data_objects.level_sets.clump_handling.Clump.save_as_dataset
    ~yt.data_objects.level_sets.clump_handling.find_clumps
-   ~yt.data_objects.level_sets.clump_handling.get_lowest_clumps
    ~yt.data_objects.level_sets.clump_info_items.add_clump_info
    ~yt.data_objects.level_sets.clump_validators.add_validator
 

--- a/doc/source/visualizing/callbacks.rst
+++ b/doc/source/visualizing/callbacks.rst
@@ -156,7 +156,7 @@ Clump Finder Callback
    import yt
    import numpy as np
    from yt.data_objects.level_sets.api import \
-       Clump, find_clumps, get_lowest_clumps
+       Clump, find_clumps
 
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
    data_source = ds.disk([0.5, 0.5, 0.5], [0., 0., 1.],
@@ -169,7 +169,7 @@ Clump Finder Callback
    master_clump.add_validator("min_cells", 20)
 
    find_clumps(master_clump, c_min, c_max, 2.0)
-   leaf_clumps = get_lowest_clumps(master_clump)
+   leaf_clumps = master_clump.leaves
 
    prj = yt.ProjectionPlot(ds, 2, 'density', center='c', width=(20,'kpc'))
    prj.annotate_clumps(leaf_clumps)

--- a/yt/data_objects/level_sets/clump_handling.py
+++ b/yt/data_objects/level_sets/clump_handling.py
@@ -76,6 +76,9 @@ class Clump(TreeContainer):
         else:
             self.clump_info = clump_info
 
+        for ci in self.clump_info:
+            ci(self)
+
         self.base = base
         self.clump_id = self.base.total_clumps
         self.base.total_clumps += 1
@@ -117,6 +120,7 @@ class Clump(TreeContainer):
         "Adds an entry to clump_info list and tells children to do the same."
 
         callback = clump_info_registry.find(info_item, *args, **kwargs)
+        callback(self)
         self.clump_info.append(callback)
         for child in self.children:
             child.add_info_item(info_item)
@@ -179,6 +183,7 @@ class Clump(TreeContainer):
             self.children.append(Clump(new_clump, self.field, parent=self,
                                        validators=self.validators,
                                        base=self.base,
+                                       clump_info=self.clump_info,
                                        contour_key=contour_key,
                                        contour_id=cid))
 
@@ -274,7 +279,6 @@ class Clump(TreeContainer):
             clump_info["contour_id"].append(contour_id)
 
             for ci in self.base.clump_info:
-                ci(clump)
                 clump_info[ci.name].append(clump.info[ci.name][1])
         for ci in clump_info:
             if hasattr(clump_info[ci][0], "units"):

--- a/yt/data_objects/level_sets/tests/test_clump_finding.py
+++ b/yt/data_objects/level_sets/tests/test_clump_finding.py
@@ -23,8 +23,7 @@ import tempfile
 from yt.data_objects.level_sets.api import \
     add_clump_info, \
     Clump, \
-    find_clumps, \
-    get_lowest_clumps
+    find_clumps
 from yt.data_objects.level_sets.clump_info_items import clump_info_registry
 from yt.convenience import \
     load
@@ -78,7 +77,7 @@ def test_clump_finding():
     # there should be two children
     assert_equal(len(master_clump.children), 2)
 
-    leaf_clumps = get_lowest_clumps(master_clump)
+    leaf_clumps = master_clump.leaves
 
     for l in leaf_clumps:
         keys = l.info.keys()
@@ -123,7 +122,7 @@ def test_clump_tree_save():
     master_clump.add_validator("min_cells", 20)
 
     find_clumps(master_clump, c_min, c_max, step)
-    leaf_clumps = get_lowest_clumps(master_clump)
+    leaf_clumps = master_clump.leaves
 
     fn = master_clump.save_as_dataset(fields=["density", "x", "y", "z",
                                               "particle_mass"])
@@ -191,8 +190,8 @@ def test_clump_field_parameters():
 
     find_clumps(master_clump_1, c_min, c_max, step)
     find_clumps(master_clump_2, c_min, c_max, step)
-    leaf_clumps_1 = get_lowest_clumps(master_clump_1)
-    leaf_clumps_2 = get_lowest_clumps(master_clump_2)
+    leaf_clumps_1 = master_clump_1.leaves
+    leaf_clumps_2 = master_clump_2.leaves
 
     for c1, c2 in zip(leaf_clumps_1, leaf_clumps_2):
         assert_array_equal(c1["gas", "density"],


### PR DESCRIPTION
Currently the clump `info` attribute is only populated by `clump.save_as_dataset`. This PR makes it so that information is calculated for all clump objects when the clump is initially created.

@brittonsmith I'd very much appreciate any insight you might have on whether this will have unintended consequences elsewhere.