### PR TITLE
clip slice integer coordinates to avoid seg fault in slice selector

### DIFF
--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -1219,6 +1219,7 @@ cdef class SliceSelector(SelectorObject):
         cdef int total = 0
         cdef int this_level = 0
         cdef int ind[3][2]
+        cdef np.uint8_t icoord
         cdef np.int32_t level = gobj.Level
         _ensure_code(gobj.LeftEdge)
         _ensure_code(gobj.dds)
@@ -1232,9 +1233,12 @@ cdef class SliceSelector(SelectorObject):
                 this_level = 1
             for i in range(3):
                 if i == self.axis:
-                    ind[i][0] = \
-                        <int> ((self.coord - (gobj.LeftEdge[i]).to_ndarray()) /
-                               gobj.dds[i])
+                    icoord = <np.uint8_t>(
+                        (self.coord - gobj.LeftEdge.d[i])/gobj.dds[i])
+                    # clip coordinate to avoid seg fault below if we're
+                    # exactly at a grid boundary
+                    icoord = min(icoord, gobj.ActiveDimensions[i]-1)
+                    ind[i][0] = max(icoord, 0)
                     ind[i][1] = ind[i][0] + 1
                 else:
                     ind[i][0] = 0

--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -1237,8 +1237,8 @@ cdef class SliceSelector(SelectorObject):
                         (self.coord - gobj.LeftEdge.d[i])/gobj.dds[i])
                     # clip coordinate to avoid seg fault below if we're
                     # exactly at a grid boundary
-                    icoord = min(icoord, gobj.ActiveDimensions[i]-1)
-                    ind[i][0] = max(icoord, 0)
+                    ind[i][0] = iclip(
+                        icoord, 0, gobj.ActiveDimensions[i]-1)
                     ind[i][1] = ind[i][0] + 1
                 else:
                     ind[i][0] = 0


### PR DESCRIPTION
Thanks to @centipete for the original report.

The issue was that the default slice coordinate (0, the middle of the domain) happens to fall exactly at a grid boundary. This was triggering pathological behavior in the slice selector which led to an out of bounds access. The fix here was to clip the integer coordinates calculated by the slice selector to prevent out of bounds access. This clipping should only be an issue for slices exactly at grid boundaries, since otherwise we would be dealing with a different grid where there is some overlap.