### PR TITLE
Add docstring to PlotWindow.set_antialias()

### DIFF
--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -565,7 +565,13 @@ class PlotWindow(ImagePlotContainer):
         return self
 
     @invalidate_data
-    def set_antialias(self,aa):
+    def set_antialias(self, aa):
+        """Turn antialiasing on or off.
+
+        parameters
+        ----------
+        aa : boolean
+        """
         self.antialias = aa
 
     @invalidate_data


### PR DESCRIPTION
The docstring was missing. It is now documented that the argument of this method is a boolean.