### PR TITLE
Expand documentation of fields and weight_fields in particle plots

### DIFF
--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -1404,6 +1404,12 @@ plot that shows the x and y positions of all the particles in ``ds`` and save th
 result to a file on the disk. The type of plot returned depends on the fields you
 pass in; in this case, ``p`` will be an :class:`~yt.visualization.particle_plots.ParticleProjectionPlot`,
 because the fields are aligned to the coordinate system of the simulation.
+The above example is equivalent to the following:
+
+.. code-block:: python
+
+   p = yt.ParticleProjectionPlot(ds, 'z')
+   p.save()
 
 Most of the callbacks the work for slice and projection plots also work for
 :class:`~yt.visualization.particle_plots.ParticleProjectionPlot`.
@@ -1438,21 +1444,40 @@ Here is a full example that shows the simplest way to use
    p.save()
 
 In the above examples, we are simply splatting particle x and y positions onto
-a plot using some color. We can also supply an additional particle field, and map
-that to a colorbar. For instance:
+a plot using some color. Colors can be applied to the plotted particles by
+providing a ``z_field``, which will be summed along the line of sight in a manner
+similar to a projection.
 
-.. code-block:: python
+.. python-script::
 
+   import yt
+   ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
    p = yt.ParticlePlot(ds, 'particle_position_x', 'particle_position_y',
-                           'particle_mass', width=(0.5, 0.5))
+                       'particle_mass')
    p.set_unit('particle_mass', 'Msun')
+   p.zoom(32)
    p.save()
 
-will create a plot with the particle mass used to set the colorbar.
-Specifically, :class:`~yt.visualization.particle_plots.ParticlePlot`
-shows the total ``z_field`` for all the particles in each pixel on the
-colorbar axis; to plot average quantities instead, one can supply a
-``weight_field`` argument.
+Additionally, a ``weight_field`` can be given such that the value in each
+pixel is the weighted average along the line of sight.
+
+.. python-script::
+
+   import yt
+   ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
+   p = yt.ParticlePlot(ds, 'particle_position_x', 'particle_position_y',
+                       'particle_mass', weight_field='particle_ones')
+   p.set_unit('particle_mass', 'Msun')
+   p.zoom(32)
+   p.save()
+
+Note the difference in the above two plots. The first shows the
+total mass along the line of sight. The density is higher in the
+inner regions, and hence there are more particles and more mass along
+the line of sight. The second plot shows the average mass per particle
+along the line of sight. The inner region is dominated by low mass
+star particles, whereas the outer region is comprised of higher mass
+dark matter particles.
 
 Here is a complete example that uses the ``particle_mass`` field
 to set the colorbar and shows off some of the modification functions for

--- a/yt/visualization/particle_plots.py
+++ b/yt/visualization/particle_plots.py
@@ -95,8 +95,9 @@ class ParticleProjectionPlot(PWViewerMPL):
          or the axis name itself
     fields : string, list or None
          If a string or list, the name of the particle field(s) to be used 
-         one the colorbar. If None, the particle positions will be indicated
-         using a fixed color, instead. Default is None.
+         one the colorbar. The color shown will correspond to the sum of the
+         given field along the line of sight. If None, the particle positions
+         will be indicated using a fixed color, instead. Default is None.
     color : 'b', 'g', 'r', 'c', 'm', 'y', 'k', or 'w'
          One the matplotlib-recognized color strings.
          The color that will indicate the particle locations
@@ -138,6 +139,8 @@ class ParticleProjectionPlot(PWViewerMPL):
          are assumed. Defaults to the entire domain.
     weight_field : string
          The name of the weighting field.  Set to None for no weight.
+         If given, the plot will show a weighted average along the line of
+         sight of the fields given in the ``fields`` argument.
     axes_unit : A string
          The name of the unit for the tick labels on the x and y axes.
          Defaults to None, which automatically picks an appropriate unit.
@@ -277,7 +280,9 @@ class ParticlePhasePlot(PhasePlot):
         If None, particles will be splatted onto the mesh,
         but no colormap will be used.
         If str or list, the name of the field or fields to
-        be displayed on the colorbar.
+        be displayed on the colorbar. The displayed values will
+        correspond to the sum of the field or fields along the
+        line of sight.
         Default: None.
     color : 'b', 'g', 'r', 'c', 'm', 'y', 'k', or 'w'
         One the matplotlib-recognized color strings.
@@ -292,7 +297,9 @@ class ParticlePhasePlot(PhasePlot):
         The number of bins in y field for the mesh.
         Default: 800.
     weight_field : str
-        The field to weight by. Default: None.
+        The field to weight by. If given, the plot will show a weighted
+        average along the line of sight of the fields given in the
+        ``z_fields`` argument. Default: None.
     deposition : str
         Either 'ngp' or 'cic'. Controls what type of
         interpolation will be used to deposit the


### PR DESCRIPTION
This closes Issue #1608. I've added examples of using fields and weight fields so show the difference between the two and expanded the docstrings a bit.