### PR TITLE
[bugfix] yt-4.0 random order particle loading fix

### DIFF
--- a/yt/frontends/flash/io.py
+++ b/yt/frontends/flash/io.py
@@ -186,7 +186,7 @@ class IOHandlerFLASHParticle(BaseIOHandler):
         px, py, pz = self._position_fields
         p_fields = self._handle["/tracer particles"]
         assert(len(data_files) == 1)
-        for data_file in sorted(data_files):
+        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
             pcount = self._count_particles(data_file)["io"]
             for ptype, field_list in sorted(ptf.items()):
                 total = 0
@@ -208,7 +208,7 @@ class IOHandlerFLASHParticle(BaseIOHandler):
         px, py, pz = self._position_fields
         p_fields = self._handle["/tracer particles"]
         assert(len(data_files) == 1)
-        for data_file in sorted(data_files):
+        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
             pcount = self._count_particles(data_file)["io"]
             for ptype, field_list in sorted(ptf.items()):
                 total = 0

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -60,7 +60,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
-        for data_file in sorted(data_files, key=lambda x: x.filename):
+        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
             si, ei = data_file.start, data_file.end
             f = h5py.File(data_file.filename, "r")
             # This double-reads
@@ -123,7 +123,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
-        for data_file in sorted(data_files, key=lambda x: x.filename):
+        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
             si, ei = data_file.start, data_file.end
             f = h5py.File(data_file.filename, "r")
             for ptype, field_list in sorted(ptf.items()):
@@ -285,7 +285,7 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
-        for data_file in sorted(data_files):
+        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
             poff = data_file.field_offsets
             tp = data_file.total_particles
             f = open(data_file.filename, "rb")
@@ -304,7 +304,7 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
-        for data_file in sorted(data_files):
+        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
             poff = data_file.field_offsets
             tp = data_file.total_particles
             f = open(data_file.filename, "rb")

--- a/yt/frontends/gadget_fof/io.py
+++ b/yt/frontends/gadget_fof/io.py
@@ -43,7 +43,7 @@ class IOHandlerGadgetFOFHDF5(BaseIOHandler):
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
-        for data_file in sorted(data_files):
+        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
             with h5py.File(data_file.filename, "r") as f:
                 for ptype, field_list in sorted(ptf.items()):
                     pcount = data_file.total_particles[ptype]
@@ -89,7 +89,7 @@ class IOHandlerGadgetFOFHDF5(BaseIOHandler):
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
-        for data_file in sorted(data_files):
+        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
             with h5py.File(data_file.filename, "r") as f:
                 for ptype, field_list in sorted(ptf.items()):
                     pcount = data_file.total_particles[ptype]

--- a/yt/frontends/halo_catalog/io.py
+++ b/yt/frontends/halo_catalog/io.py
@@ -45,7 +45,7 @@ class IOHandlerHaloCatalogHDF5(BaseIOHandler):
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
         pn = "particle_position_%s"
-        for data_file in sorted(data_files):
+        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
             with h5py.File(data_file.filename, "r") as f:
                 units = parse_h5_attr(f[pn % "x"], "units")
                 x, y, z = \
@@ -74,7 +74,7 @@ class IOHandlerHaloCatalogHDF5(BaseIOHandler):
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
         pn = "particle_position_%s"
-        for data_file in sorted(data_files):
+        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
             with h5py.File(data_file.filename, "r") as f:
                 for ptype, field_list in sorted(ptf.items()):
                     units = parse_h5_attr(f[pn % "x"], "units")

--- a/yt/frontends/http_stream/io.py
+++ b/yt/frontends/http_stream/io.py
@@ -63,7 +63,7 @@ class IOHandlerHTTPStream(BaseIOHandler):
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
-        for data_file in sorted(data_files):
+        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
             for ptype in ptf:
                 s = self._open_stream(data_file, (ptype, "Coordinates"))
                 c = np.frombuffer(s, dtype="float64")
@@ -76,7 +76,7 @@ class IOHandlerHTTPStream(BaseIOHandler):
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
-        for data_file in sorted(data_files):
+        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
             for ptype, field_list in sorted(ptf.items()):
                 s = self._open_stream(data_file, (ptype, "Coordinates"))
                 c = np.frombuffer(s, dtype="float64")

--- a/yt/frontends/owls_subfind/io.py
+++ b/yt/frontends/owls_subfind/io.py
@@ -42,7 +42,7 @@ class IOHandlerOWLSSubfindHDF5(BaseIOHandler):
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
-        for data_file in sorted(data_files, key=lambda f: f.filename):
+        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
             with h5py.File(data_file.filename, "r") as f:
                 for ptype, field_list in sorted(ptf.items()):
                     pcount = data_file.total_particles[ptype]
@@ -76,7 +76,7 @@ class IOHandlerOWLSSubfindHDF5(BaseIOHandler):
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
-        for data_file in sorted(data_files, key=lambda f: f.filename):
+        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
             with h5py.File(data_file.filename, "r") as f:
                 for ptype, field_list in sorted(ptf.items()):
                     pcount = data_file.total_particles[ptype]

--- a/yt/frontends/rockstar/io.py
+++ b/yt/frontends/rockstar/io.py
@@ -28,8 +28,6 @@ from yt.utilities.io_handler import \
 from .definitions import halo_dts
 from yt.utilities.lib.geometry_utils import compute_morton
 
-from operator import attrgetter
-
 class IOHandlerRockstarBinary(BaseIOHandler):
     _dataset_type = "rockstar_binary"
 
@@ -50,7 +48,7 @@ class IOHandlerRockstarBinary(BaseIOHandler):
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
-        for data_file in sorted(data_files,key=attrgetter("filename")):
+        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
             pcount = data_file.header['num_halos']
             with open(data_file.filename, "rb") as f:
                 f.seek(data_file._position_offset, os.SEEK_SET)
@@ -70,7 +68,7 @@ class IOHandlerRockstarBinary(BaseIOHandler):
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
-        for data_file in sorted(data_files,key=attrgetter("filename")):
+        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
             pcount = data_file.header['num_halos']
             with open(data_file.filename, "rb") as f:
                 for ptype, field_list in sorted(ptf.items()):

--- a/yt/frontends/sdf/io.py
+++ b/yt/frontends/sdf/io.py
@@ -44,7 +44,7 @@ class IOHandlerSDF(BaseIOHandler):
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
         assert(len(data_files) == 1)
-        for data_file in sorted(data_files):
+        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
             yield "dark_matter", (
                 self._handle['x'], self._handle['y'], self._handle['z'])
 
@@ -57,7 +57,7 @@ class IOHandlerSDF(BaseIOHandler):
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
         assert(len(data_files) == 1)
-        for data_file in sorted(data_files):
+        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
             for ptype, field_list in sorted(ptf.items()):
                 x = self._handle['x']
                 y = self._handle['y']

--- a/yt/frontends/stream/io.py
+++ b/yt/frontends/stream/io.py
@@ -108,9 +108,9 @@ class StreamParticleIOHandler(BaseIOHandler):
         super(StreamParticleIOHandler, self).__init__(ds)
 
     def _read_particle_coords(self, chunks, ptf):
-        for data_file in sorted(self._get_data_files(chunks,
+        for data_file in sorted(self._get_data_files(chunks),
                                                      key=lambda x: (x.filename,
-                                                                    x.start))):
+                                                                    x.start)):
             f = self.fields[data_file.filename]
             # This double-reads
             for ptype, field_list in sorted(ptf.items()):
@@ -119,9 +119,9 @@ class StreamParticleIOHandler(BaseIOHandler):
                               f[ptype, "particle_position_z"])
 
     def _read_smoothing_length(self, chunks, ptf, ptype):
-        for data_file in sorted(self._get_data_files(chunks,
+        for data_file in sorted(self._get_data_files(chunks),
                                                      key=lambda x: (x.filename,
-                                                                    x.start))):
+                                                                    x.start)):
             f = self.fields[data_file.filename]
             return f[ptype, 'smoothing_length']
             
@@ -142,9 +142,9 @@ class StreamParticleIOHandler(BaseIOHandler):
         return psize
 
     def _read_particle_fields(self, chunks, ptf, selector):
-        for data_file in sorted(self._get_data_files(chunks,
+        for data_file in sorted(self._get_data_files(chunks),
                                                      key=lambda x: (x.filename,
-                                                                    x.start))):
+                                                                    x.start)):
             f = self.fields[data_file.filename]
             for ptype, field_list in sorted(ptf.items()):
                 if (ptype, "particle_position") in f:

--- a/yt/frontends/stream/io.py
+++ b/yt/frontends/stream/io.py
@@ -108,7 +108,9 @@ class StreamParticleIOHandler(BaseIOHandler):
         super(StreamParticleIOHandler, self).__init__(ds)
 
     def _read_particle_coords(self, chunks, ptf):
-        for data_file in sorted(self._get_data_files(chunks)):
+        for data_file in sorted(self._get_data_files(chunks,
+                                                     key=lambda x: (x.filename,
+                                                                    x.start))):
             f = self.fields[data_file.filename]
             # This double-reads
             for ptype, field_list in sorted(ptf.items()):
@@ -117,7 +119,9 @@ class StreamParticleIOHandler(BaseIOHandler):
                               f[ptype, "particle_position_z"])
 
     def _read_smoothing_length(self, chunks, ptf, ptype):
-        for data_file in sorted(self._get_data_files(chunks)):
+        for data_file in sorted(self._get_data_files(chunks,
+                                                     key=lambda x: (x.filename,
+                                                                    x.start))):
             f = self.fields[data_file.filename]
             return f[ptype, 'smoothing_length']
             
@@ -138,7 +142,9 @@ class StreamParticleIOHandler(BaseIOHandler):
         return psize
 
     def _read_particle_fields(self, chunks, ptf, selector):
-        for data_file in sorted(self._get_data_files(chunks)):
+        for data_file in sorted(self._get_data_files(chunks,
+                                                     key=lambda x: (x.filename,
+                                                                    x.start))):
             f = self.fields[data_file.filename]
             for ptype, field_list in sorted(ptf.items()):
                 if (ptype, "particle_position") in f:

--- a/yt/frontends/tipsy/io.py
+++ b/yt/frontends/tipsy/io.py
@@ -111,7 +111,7 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
-        for data_file in sorted(data_files):
+        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
             poff = data_file.field_offsets
             tp = data_file.total_particles
             f = open(data_file.filename, "rb")
@@ -176,7 +176,7 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
-        for data_file in sorted(data_files):
+        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
             poff = data_file.field_offsets
             aux_fields_offsets = self._calculate_particle_offsets_aux(data_file)
             tp = data_file.total_particles

--- a/yt/frontends/ytdata/io.py
+++ b/yt/frontends/ytdata/io.py
@@ -204,7 +204,7 @@ class IOHandlerYTDataContainerHDF5(BaseIOHandler):
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
-        for data_file in sorted(data_files):
+        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
             with h5py.File(data_file.filename, "r") as f:
                 for ptype, field_list in sorted(ptf.items()):
                     pcount = data_file.total_particles[ptype]
@@ -222,7 +222,7 @@ class IOHandlerYTDataContainerHDF5(BaseIOHandler):
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
-        for data_file in sorted(data_files):
+        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
             with h5py.File(data_file.filename, "r") as f:
                 for ptype, field_list in sorted(ptf.items()):
                     units = _get_position_array_units(ptype, f, "x")
@@ -308,7 +308,7 @@ class IOHandlerYTSpatialPlotHDF5(IOHandlerYTDataContainerHDF5):
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
-        for data_file in sorted(data_files):
+        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
             with h5py.File(data_file.filename, "r") as f:
                 for ptype, field_list in sorted(ptf.items()):
                     pcount = data_file.total_particles[ptype]
@@ -326,7 +326,7 @@ class IOHandlerYTSpatialPlotHDF5(IOHandlerYTDataContainerHDF5):
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
-        for data_file in sorted(data_files):
+        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
             all_count = self._count_particles(data_file)
             with h5py.File(data_file.filename, "r") as f:
                 for ptype, field_list in sorted(ptf.items()):


### PR DESCRIPTION
## PR Summary

Added an extra keyword to the datafiles sort, so they don't just use the filename, but also use the start particle as well - this should fix subfiles loading in a random order.

fixes #2059 

## PR Checklist

- [x] Code passes flake8 checker
- **NA** New features are documented, with docstrings and narrative docs
- **NA** Adds a test for any bugs fixed. Adds tests for new features.