### PR TITLE
Doc dev

### DIFF
--- a/doc/source/developing/creating_frontend.rst
+++ b/doc/source/developing/creating_frontend.rst
@@ -226,9 +226,9 @@ that is needed:
     class ChomboGrid(AMRGridPatch):
         _id_offset = 0
         __slots__ = ["_level_id"]
-        def __init__(self, id, index, level = -1):
-            AMRGridPatch.__init__(self, id, filename = index.index_filename,
-                                  index = index)
+        def __init__(self, id, index, level=-1):
+            AMRGridPatch.__init__(self, id, filename=index.index_filename,
+                                  index=index)
             self.Parent = []
             self.Children = []
             self.Level = level

--- a/doc/source/developing/creating_frontend.rst
+++ b/doc/source/developing/creating_frontend.rst
@@ -229,7 +229,7 @@ that is needed:
         def __init__(self, id, index, level=-1):
             AMRGridPatch.__init__(self, id, filename=index.index_filename,
                                   index=index)
-            self.Parent = []
+            self.Parent = None
             self.Children = []
             self.Level = level
 

--- a/yt/frontends/_skeleton/data_structures.py
+++ b/yt/frontends/_skeleton/data_structures.py
@@ -78,12 +78,12 @@ class SkeletonHierarchy(GridIndex):
         pass
 
     def _populate_grid_objects(self):
-        # For each grid, this must call:
-        #   grid._prepare_grid()
-        #   grid._setup_dx()
+        # For each grid g, this must call:
+        #   g._prepare_grid()
+        #   g._setup_dx()
         # This must also set:
-        #   grid.Children <= list of child grids
-        #   grid.Parent   <= parent grid
+        #   g.Children <= list of child grids
+        #   g.Parent   <= parent grid
         # This is handled by the frontend because often the children must be
         # identified.
         pass


### PR DESCRIPTION
Minor revisions and corrections to the documentation for *create a new frontend*.

* Follow PEP8 recommendation regarding spaces around `=` in function arguments (avoid them)
* Following a comment in `frontends/gamer/data_structures.py`, do not initialize `AMRGridPatch.Parent` as `[]` because
    - it's not meant to be a list (I think)
    - some existing functionalities are made to catch a lacking init in this attribute by testing if it's `None`
* workaround a possibly confusing variable naming where `grid` is being used as a local variable in a class method, when the class itself has an attribute `grid`.