### PR TITLE
avoid use of deprecated field names internally

### DIFF
--- a/yt/fields/particle_fields.py
+++ b/yt/fields/particle_fields.py
@@ -440,9 +440,9 @@ def standard_particle_fields(registry, ptype,
 
     def _get_coord_funcs_relative(axi, _ptype):
         def _particle_pos_rel(field, data):
-            return data[_ptype, "particle_position_relative"][:, axi]
+            return data[_ptype, "relative_particle_position"][:, axi]
         def _particle_vel_rel(field, data):
-            return data[_ptype, "particle_velocity_relative"][:, axi]
+            return data[_ptype, "relative_particle_velocity"][:, axi]
         return _particle_vel_rel, _particle_pos_rel
     for axi, ax in enumerate("xyz"):
         v, p = _get_coord_funcs_relative(axi, ptype)


### PR DESCRIPTION
Currently fields like "particle_angular_momentum" end up going through one of these code paths and triggering deprecation warnings. Let's use the new names for these fields internally. The deprecated field names are still available for use with this change, we just don't use them as dependencies for other fields in the yt field system anymore.