### PR TITLE
add tests to ytdata frontend api

### DIFF
--- a/yt/frontends/ytdata/api.py
+++ b/yt/frontends/ytdata/api.py
@@ -39,3 +39,5 @@ from .fields import \
 
 from .utilities import \
     save_as_dataset
+
+from . import tests


### PR DESCRIPTION
This makes it possible to do something like `nosetests yt.frontends.ytdata.tests.test_outputs:test_plot_data` to only run one of the tests in the ytdata frontend. Due to the magic we use to avoid exposing the skeleton frontend publicly, this needs to be manually added, see here if you don't know what I'm talking about: https://github.com/yt-project/yt/blob/master/yt/frontends/api.py#L52-L58