### PR TITLE
disable coverage on mac builds for now to avoid timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,7 +114,7 @@ jobs:
       after_failure: python tests/report_failed_answers.py -f -m --xunit-file "answer_nosetests.xml"
 
     - stage: tests
-      name: "Xcode: xcode7.3 Unit Tests"
+      name: "MacOS: xcode7.3 Unit Tests"
       os: osx
       osx_image: xcode7.3
       language: generic  # https://github.com/travis-ci/travis-ci/issues/2312
@@ -125,7 +125,7 @@ jobs:
           - $HOME/Library/Caches/pip
           # `cache` does not support `env`-like `global` so copy-paste from top
           - $HOME/.ccache  # https://github.com/travis-ci/travis-ci/issues/5853
-      script: coverage run $(which nosetests) -c nose_unit.cfg
+      script: nosetests -c nose_unit.cfg
 
 after_success:
   - |


### PR DESCRIPTION
Since github's downtime Sunday and yesterday all of our mac builds have been timing out. I'm not sure why this is happening now and not before this weekend, but one way to speed up the builds is to skip generating the coverage reports which require a lot of disk churning on the very very slow disks that the travis mac builders have.

Hopefully this is a temporary thing and we can turn this back on later.