### PR TITLE
include load_octree in the API docs

### DIFF
--- a/doc/source/reference/api/api.rst
+++ b/doc/source/reference/api/api.rst
@@ -438,6 +438,7 @@ Loading Data
    ~yt.frontends.stream.data_structures.load_uniform_grid
    ~yt.frontends.stream.data_structures.load_amr_grids
    ~yt.frontends.stream.data_structures.load_particles
+   ~yt.frontends.stream.data_structures.load_octree
    ~yt.frontends.stream.data_structures.load_hexahedral_mesh
    ~yt.frontends.stream.data_structures.load_unstructured_mesh
 


### PR DESCRIPTION
While helping a user I noticed that `load_octree` doesn't show up in the API docs. This fixes that omission.