### PR TITLE
Add missing dependencies for Jenkins

### DIFF
--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -23,3 +23,5 @@ thingking==1.0.2; python_version < '3.0'
 pint==0.8.1
 netCDF4==1.4.2
 libconf==1.0.1
+pyaml==17.10.0
+mpi4py==3.0.0


### PR DESCRIPTION
Those two packages are needed for tests.yt-project.org:

- pyyaml for `test_runner.py`
- mpi4py for some tests/cookbook recipes

