### PR TITLE
sort image paths before reading them in image comparison tests

### DIFF
--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -913,7 +913,7 @@ class GenericImageTest(AnswerTestingTest):
         tmpdir = tempfile.mkdtemp()
         image_prefix = os.path.join(tmpdir,"test_img")
         self.image_func(image_prefix, *args, **kwargs)
-        imgs = glob.glob(image_prefix+"*")
+        imgs = sorted(glob.glob(image_prefix+"*"))
         assert(len(imgs) > 0)
         for img in imgs:
             img_data = mpimg.imread(img)


### PR DESCRIPTION
This should (hopefully) fix occasional answer test failures for image comparison tests that save more than one image to disk. The sorting of the list returned by `glob.glob` is arbitrary, so the ordering of images we get back is also arbitrary.

I wouldn't be surprised if some of the existing answers were sensitive to this ordering.