### PR TITLE
Travis build improvements

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,7 +3,8 @@ plugins = Cython.Coverage
 branch = True
 
 [report]
-omit=*/api.py
+omit=*.yml
+     */api.py
 	 */__init__.py
 	 */__config__.py
 	 */tests/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,9 +93,9 @@ jobs:
       after_failure: python tests/report_failed_answers.py -f -m --xunit-file "answer_nosetests.xml"
 
     - stage: tests
-      name: "MacOS: xcode7.3 Unit Tests"
+      name: "MacOS: xcode10.1 Unit Tests"
       os: osx
-      osx_image: xcode7.3
+      osx_image: xcode10.1
       language: generic  # https://github.com/travis-ci/travis-ci/issues/2312
       cache:
         pip: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,12 @@ before_install:
       source venv/bin/activate
       export PATH=/usr/lib/ccache:$PATH
     else
+      sudo mkdir -p /usr/local/man
+      sudo chown -R "${USER}:admin" /usr/local/man
       brew update
+      brew uninstall numpy
       brew install python ccache hdf5 openmpi netcdf
+      brew uninstall gdal postgis numpy
       export PATH=/usr/local/opt/ccache/libexec:$PATH
     fi
     mkdir -p $HOME/.config/yt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: xenial
 sudo: required
 cache:
   pip: true
@@ -10,16 +11,20 @@ addons:
     packages:
       - libhdf5-serial-dev
 
+env:
+  global:
+    PIP=pip
+
 before_install:
   - |
     if [[ $TRAVIS_OS_NAME != 'osx' ]]; then
-      pip install --upgrade virtualenv
+      $PIP install --upgrade virtualenv
       python -m virtualenv venv
       source venv/bin/activate
       export PATH=/usr/lib/ccache:$PATH
     else
       brew update
-      brew install ccache hdf5
+      brew install python ccache hdf5 openmpi netcdf
       export PATH=/usr/local/opt/ccache/libexec:$PATH
     fi
     mkdir -p $HOME/.config/yt
@@ -33,19 +38,19 @@ install:
     # setup environment
     ccache -s
     # Upgrade pip and setuptools and wheel to get clean install
-    pip install --upgrade pip
-    pip install --upgrade wheel
-    pip install --upgrade setuptools
+    $PIP install --upgrade pip
+    $PIP install --upgrade wheel
+    $PIP install --upgrade setuptools
     # install dependencies yt
     if [[ $TRAVIS_BUILD_STAGE_NAME != "Lint" ]]; then
       if [[ $MINIMAL == 1 ]]; then
-        pip install -r tests/test_minimal_requirements.txt
+        $PIP install -r tests/test_minimal_requirements.txt
       else
-        pip install -r tests/test_requirements.txt
+        $PIP install -r tests/test_requirements.txt
       fi
-      pip install -e .
+      $PIP install -e .
     else
-      pip install -r tests/lint_requirements.txt
+      $PIP install -r tests/lint_requirements.txt
     fi
 
 jobs:
@@ -80,7 +85,7 @@ jobs:
       script: coverage run $(which nosetests) -c nose_unit.cfg
 
     - stage: tests
-      name: "Python: 2.7 Answer Tests"
+      name: "Python: 2.7 Minimal Dependency Answer Tests"
       python: 2.7
       env: MINIMAL=1
       script: coverage run $(which nosetests) -c nose_answer.cfg
@@ -93,7 +98,7 @@ jobs:
       after_failure: python tests/report_failed_answers.py -f -m --xunit-file "answer_nosetests.xml"
 
     - stage: tests
-      name: "MacOS: xcode10.1 Unit Tests"
+      name: "MacOS: Unit Tests"
       os: osx
       osx_image: xcode10.1
       language: generic  # https://github.com/travis-ci/travis-ci/issues/2312

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,6 +106,7 @@ jobs:
       os: osx
       osx_image: xcode10.1
       language: generic  # https://github.com/travis-ci/travis-ci/issues/2312
+      env: PIP=pip3
       cache:
         pip: false
         directories:


### PR DESCRIPTION
This updates the travis configuration to use newer base images on Linux and MacOS and fixes a couple issues I noticed while working on #1966.

In particular:

* Use xcode 10.1 as the base image on MacOS. Homebrew only supports the most recent versions of MacOS with binaries and now that xcode7.3 is no longer supported, we have to build a bunch of dependencies from source. On xcode 10.1 we'll get binaries so the builds will be much faster.

* Ensure we're using the correct name for the pip executable in the test environment

* Use a xenial (16.06) base image on linux for faster builds and access to newer packages.
