### PR TITLE
remove noise from line integral convolution in zero-value regions

### DIFF
--- a/yt/utilities/lib/line_integral_convolution.pyx
+++ b/yt/utilities/lib/line_integral_convolution.pyx
@@ -81,6 +81,8 @@ def line_integral_convolution_2d(
 
     for i in range(w):
         for j in range(h):
+            if vectors[i,j,0]==0 and vectors[i,j,1]==0:
+                continue
             x = i
             y = j
             fx = 0.5
@@ -104,8 +106,5 @@ def line_integral_convolution_2d(
                         &x, &y, &fx, &fy, w, h)
                 l-=1
                 result[i,j] += kernel[l]*texture[x,y]
-
-            if vectors[i,j,0]==0 and vectors[i,j,1]==0:
-                result[i,j] = 0.
 
     return result

--- a/yt/utilities/lib/line_integral_convolution.pyx
+++ b/yt/utilities/lib/line_integral_convolution.pyx
@@ -104,5 +104,8 @@ def line_integral_convolution_2d(
                         &x, &y, &fx, &fy, w, h)
                 l-=1
                 result[i,j] += kernel[l]*texture[x,y]
-                    
+
+            if vectors[i,j,0]==0 and vectors[i,j,1]==0:
+                result[i,j] = 0.
+
     return result


### PR DESCRIPTION
## PR Summary

In the regions with zero vector field values, the line integral convolution (LIC) just creates noise. This PR removes these regions from LIC, which is particular useful when the non-cartesian simulation region does not fill the entire plot canvas.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->