### PR TITLE
avoid breakage with future cython release by explicitly setting language_level

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -322,7 +322,8 @@ package manager for your python environment.""" %
                 numpy.__version__)
         from Cython.Build import cythonize
         self.distribution.ext_modules[:] = cythonize(
-                self.distribution.ext_modules)
+            self.distribution.ext_modules,
+            compiler_directives={'language_level': 2})
         _build_ext.finalize_options(self)
         # Prevent numpy from thinking it is still in its setup process
         # see http://stackoverflow.com/a/21621493/1382869
@@ -341,7 +342,10 @@ class sdist(_sdist):
     def run(self):
         # Make sure the compiled Cython files in the distribution are up-to-date
         from Cython.Build import cythonize
-        cythonize(cython_extensions)
+        cythonize(
+            cython_extensions,
+            compiler_directives={'language_level': 2},
+        )
         _sdist.run(self)
 
 setup(


### PR DESCRIPTION
In the future cython will be changing the default `language_level` to 3. This may break yt's cython extensions in unpredictable ways. Rather than explicitly trying to deal with that breakage and set `language_level` to 3 right now, let's set it globally to 2. Individual files should be able to override this setting and we will be able to change the `language_level` in a piecemeal fashion going forward.