### PR TITLE
[bugfix] Fix incorrect weight function for cluster temperatures

### DIFF
--- a/yt/fields/astro_fields.py
+++ b/yt/fields/astro_fields.py
@@ -120,12 +120,12 @@ def setup_astro_fields(registry, ftype = "gas", slice_info = None):
         # Spectroscopic-like weighting field for galaxy clusters
         # Only useful as a weight_field for temperature, metallicity, velocity
         ret = data["density"]/mh
-        ret *= ret*data["kT"]**-0.25
+        ret *= ret*data["kT"]**-0.75
         return ret
 
     registry.add_field((ftype,"mazzotta_weighting"), sampling_type="cell", 
                        function=_mazzotta_weighting,
-                       units="keV**-0.25*cm**-6")
+                       units="keV**-0.75*cm**-6")
 
     def _sz_kinetic(field, data):
         scale = 0.88 * sigma_thompson / mh / clight


### PR DESCRIPTION
yt has a derived field known as `"mazzotta_weighting"` whose sole function is to provide a weight for projections which approximates temperature maps of galaxy clusters taken by Chandra or XMM-Newton. Reference is Equation 15 of http://adsabs.harvard.edu/abs/2004MNRAS.354...10M.

I was looking at this field again today and noticed that it has the wrong exponent! I introduced it into yt way-back-when, and I've used it quite a bit, but I don't know who else has. In any case, here is the fix. 