### PR TITLE
 remove caching for particle indices in cut region. fixes #2104 

### DIFF
--- a/yt/data_objects/selection_data_containers.py
+++ b/yt/data_objects/selection_data_containers.py
@@ -876,7 +876,6 @@ class YTCutRegion(YTSelectionContainer3D):
         self.conditionals = ensure_list(conditionals)
         self.base_object = data_source
         self._selector = None
-        self._particle_mask = {}
         # Need to interpose for __getitem__, fwidth, fcoords, icoords, iwidth,
         # ires and get_data
 
@@ -992,18 +991,14 @@ class YTCutRegion(YTSelectionContainer3D):
         return mask
 
     def _part_ind(self, ptype):
-        if self._particle_mask.get(ptype) is None:
-            # If scipy is installed, use the fast KD tree
-            # implementation. Else, fall back onto the direct
-            # brute-force algorithm.
-            try:
-                _scipy.spatial.KDTree
-                mask = self._part_ind_KDTree(ptype)
-            except ImportError:
-                mask = self._part_ind_brute_force(ptype)
-
-            self._particle_mask[ptype] = mask
-        return self._particle_mask[ptype]
+        # If scipy is installed, use the fast KD tree
+        # implementation. Else, fall back onto the direct
+        # brute-force algorithm.
+        try:
+            _scipy.spatial.KDTree
+            return self._part_ind_KDTree(ptype)
+        except ImportError:
+            return self._part_ind_brute_force(ptype)
 
     @property
     def icoords(self):

--- a/yt/data_objects/tests/test_extract_regions.py
+++ b/yt/data_objects/tests/test_extract_regions.py
@@ -1,10 +1,12 @@
 import numpy as np
 
+from yt.convenience import load
 from yt.testing import \
     fake_random_ds, \
     fake_amr_ds, \
     assert_equal, \
-    assert_almost_equal
+    assert_almost_equal, \
+    requires_file
 
 def setup():
     from yt.config import ytcfg
@@ -59,3 +61,15 @@ def test_region_and_particles():
 
     assert_equal(expected.shape, result.shape)
     assert_equal(expected, result)
+
+ISOGAL = 'IsolatedGalaxy/galaxy0030/galaxy0030'
+    
+@requires_file(ISOGAL)
+def test_region_chunked_read():
+    # see #2104
+    ds = load("IsolatedGalaxy/galaxy0030/galaxy0030")
+
+    sp = ds.sphere((0.5, 0.5, 0.5), (2, "kpc"))
+    dense_sp = sp.cut_region(['obj["H_p0_number_density"]>= 1e-2'])
+    dense_sp.quantities.angular_momentum_vector()
+    


### PR DESCRIPTION
In a chunked read (e.g. what happens when finding the value of a derived quantity), the size of a data object can change depending on which chunk we're looking at. This breaks the caching in the `_part_ind` property of the cut region data object. My quick and dirty fix is just to get rid of the caching. I *could* cache based on the underlying data chunk, which will be unique for each chunk, but then I'd blow up the memory requirements for doing any read on a cut_region, since that will require storing a mask for each chunk.

Suggestions from e.g. @brittonsmith would be great, particularly if the caching is a big performance win for the clump finder. Perhaps we could do the caching over there instead of on the cut region data object itself?