### PR TITLE
This breaks for dim > 255, so upcast.

### DIFF
--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -1219,7 +1219,7 @@ cdef class SliceSelector(SelectorObject):
         cdef int total = 0
         cdef int this_level = 0
         cdef int ind[3][2]
-        cdef np.uint8_t icoord
+        cdef np.uint64_t icoord
         cdef np.int32_t level = gobj.Level
         _ensure_code(gobj.LeftEdge)
         _ensure_code(gobj.dds)
@@ -1233,7 +1233,7 @@ cdef class SliceSelector(SelectorObject):
                 this_level = 1
             for i in range(3):
                 if i == self.axis:
-                    icoord = <np.uint8_t>(
+                    icoord = <np.uint64_t>(
                         (self.coord - gobj.LeftEdge.d[i])/gobj.dds[i])
                     # clip coordinate to avoid seg fault below if we're
                     # exactly at a grid boundary


### PR DESCRIPTION
We can't use uint8 for access along a dimension with more than 255
cells.