### PR TITLE
fix error message for low dimensionality data in CIC deposit

### DIFF
--- a/yt/geometry/particle_deposit.pyx
+++ b/yt/geometry/particle_deposit.pyx
@@ -343,7 +343,7 @@ cdef class CICDeposit(ParticleDepositOperation):
         if not all(_ > 1 for _ in self.nvals):
             from yt.utilities.exceptions import YTBoundsDefinitionError
             raise YTBoundsDefinitionError(
-                "CIC requires minimum of 2 zones in all spatial dimensions",
+                "CIC requires minimum of 2 zones in all spatial dimensions.",
                 self.nvals)
         self.field = append_axes(
             np.zeros(self.nvals, dtype="float64", order='F'), 4)

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -636,7 +636,7 @@ class YTBoundsDefinitionError(YTException):
     def __str__(self):
         v  = "This operation has encountered a bounds error: "
         v += self.message
-        v += " Specified bounds are %s" % self.bounds
+        v += " Specified bounds are '%s'." % (self.bounds,)
         return v
 
 def screen_one_element_list(lis):


### PR DESCRIPTION
The error was generating a string formatting exception. The fix is to make sure we use a formatted string.