### PR TITLE
[WIP] Add a volume field for non-grid datasets

### DIFF
--- a/yt/fields/fluid_fields.py
+++ b/yt/fields/fluid_fields.py
@@ -65,6 +65,14 @@ def setup_fluid_fields(registry, ftype = "gas", slice_info = None):
                        units=unit_system["mass"])
     registry.alias((ftype, "mass"), (ftype, "cell_mass"))
 
+    if (ftype, "volume") not in registry:
+        def _volume(field, data):
+            return data[ftype, "mass"]/data[ftype, "density"]
+        registry.add_field((ftype, "volume"),
+                           sampling_type="local",
+                           function=_volume,
+                           units=unit_system["volume"])
+
     def _sound_speed(field, data):
         tr = data.ds.gamma * data[ftype, "pressure"] / data[ftype, "density"]
         return np.sqrt(tr)


### PR DESCRIPTION
We lack a volume field for non-grid datasets. We have `"cell_volume"` for the latter, which is aliased to `"volume"`. There is also the notion of `"cell_mass"`, which is aliased to `"mass"`, but that field also does work for non-grid datasets. 

This PR adds a definition for a `"volume"` field for non-grid datasets. This closes Issue #1494. 

I'm leaving it as WIP since I'm sure others may have ideas on how to best do this. Once we have settled on an agreed-upon way, I'd like to run through the code and replace instances of `"cell_mass"` with `"mass"` and `"cell_volume"` with `"volume"` in field definitions and other places. 