### PR TITLE
add ytree frontend

### DIFF
--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -1926,6 +1926,63 @@ available here are similar to other catalogs.  Any addition
    # The halo mass
    print(ad["halos", "particle_mass"])
 
+.. _ytree_data:
+
+ytree Merger Trees
+------------------
+
+`ytree <https://ytree.readthedocs.io/>`_ is an extension of yt for working
+with merger tree data from multiple sources. Merger trees loaded with ytree
+can be re-written to a format that can be loadable by both ytree and yt.
+Loading merger tree data in yt allows one to access halos using yt's geometric
+data containers instead of from within the tree structures used by ytree. For
+example, this can be useful if one wants to quickly access all halos in the
+merger tree at once.
+
+The ytree data format consists of a directory containing a series of HDF5 files.
+To load the dataset, provide the path to the HDF5 file with the same name as
+the directory.
+
+.. code-block:: python
+
+   import yt
+   ds = yt.load("arbor/arbor.h5")
+   # all halo masses
+   print (ds.r['particle_mass'])
+   # all halo redshifts
+   print (ds.r['redshift'])
+
+The fields available will depend on those present in the original data format.
+See the `field_list` (`ds.field_list`) for a list of all available fields. The
+following fields will always be available:
+
++-------------------+---------------------------+
+| HaloCatalog field | yt field name             |
++===================+===========================+
+| universal id      | uid                       |
++-------------------+---------------------------+
+| uid of descendent | desc_uid                  |
++-------------------+---------------------------+
+| catalog halo id   | halo_id                   |
++-------------------+---------------------------+
+| mass              | particle_mass             |
++-------------------+---------------------------+
+| redshift of halo  | redshift                  |
++-------------------+---------------------------+
+| halo position     | particle_position_(x,y,z) |
++-------------------+---------------------------+
+| halo velocity     | particle_velocity_(x,y,z) |
++-------------------+---------------------------+
+
+.. note::
+
+   Because merger trees contain data for objects at multiple redshifts,
+   conversion between proper and comoving coordinates is not possible
+   using symbolic unit conversion. Comoving units (e.g., 'Mpccm') and
+   proper units (e.g., 'Mpc') have been set equal to each other. In general,
+   lengths in merger tree data are in the comoving frame, but users should
+   take care to understand what frame they are using.
+
 .. _loading-openpmd-data:
 
 openPMD Data

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -110,7 +110,10 @@ answer_tests:
     - yt/frontends/ramses/tests/test_outputs.py
 
   local_ytdata_004:
-    - yt/frontends/ytdata
+    - yt/frontends/ytdata/tests/test_outputs.py
+
+  local_ytdata_001:
+    - yt/frontends/ytree/tests/test_outputs.py
 
   local_absorption_spectrum_007:
     - yt/analysis_modules/absorption_spectrum/tests/test_absorption_spectrum.py:test_absorption_spectrum_non_cosmo

--- a/yt/frontends/api.py
+++ b/yt/frontends/api.py
@@ -47,6 +47,7 @@ _frontends = [
     'stream',
     'tipsy',
     'ytdata',
+    'ytree',
 ]
 
 class _frontend_container:

--- a/yt/frontends/halo_catalog/api.py
+++ b/yt/frontends/halo_catalog/api.py
@@ -22,3 +22,5 @@ from .io import \
 
 from .fields import \
      HaloCatalogFieldInfo
+
+from . import tests

--- a/yt/frontends/ytdata/data_structures.py
+++ b/yt/frontends/ytdata/data_structures.py
@@ -520,6 +520,8 @@ class YTGridDataset(YTDataset):
     def _is_valid(self, *args, **kwargs):
         if not args[0].endswith(".h5"): return False
         with h5py.File(args[0], "r") as f:
+            if 'arbor_type' in f.attrs:
+                return False
             data_type = parse_h5_attr(f, "data_type")
             cont_type = parse_h5_attr(f, "container_type")
             if data_type == "yt_frb":
@@ -725,6 +727,8 @@ class YTNonspatialDataset(YTGridDataset):
     def _is_valid(self, *args, **kwargs):
         if not args[0].endswith(".h5"): return False
         with h5py.File(args[0], "r") as f:
+            if 'arbor_type' in f.attrs:
+                return False
             data_type = parse_h5_attr(f, "data_type")
             if data_type == "yt_array_data":
                 return True

--- a/yt/frontends/ytree/__init__.py
+++ b/yt/frontends/ytree/__init__.py
@@ -1,0 +1,15 @@
+"""
+API for ytree frontend.
+
+
+
+
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) yt Development Team. All rights reserved.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------

--- a/yt/frontends/ytree/api.py
+++ b/yt/frontends/ytree/api.py
@@ -1,0 +1,24 @@
+"""
+API for ytree frontend
+
+
+
+
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) yt Development Team. All rights reserved.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from .data_structures import \
+     YTreeDataset
+
+from .io import \
+     IOHandlerYTreeHDF5
+
+from .fields import \
+     YTreeFieldInfo

--- a/yt/frontends/ytree/api.py
+++ b/yt/frontends/ytree/api.py
@@ -22,3 +22,5 @@ from .io import \
 
 from .fields import \
      YTreeFieldInfo
+
+from . import tests

--- a/yt/frontends/ytree/data_structures.py
+++ b/yt/frontends/ytree/data_structures.py
@@ -1,0 +1,125 @@
+"""
+Data structures for ytree frontend.
+
+
+
+
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) yt Development Team. All rights reserved.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from yt.utilities.on_demand_imports import _h5py as h5py
+import numpy as np
+import json
+import os
+import stat
+
+from .fields import \
+    YTreeFieldInfo
+
+from yt.frontends.halo_catalog.data_structures import \
+    HaloCatalogFile
+from yt.frontends.ytdata.data_structures import \
+    SavedDataset
+from yt.geometry.particle_geometry_handler import \
+    ParticleIndex
+
+class YTreeParticleIndex(ParticleIndex):
+    def _setup_filenames(self):
+        template = self.dataset.filename_template
+        cls = self.dataset._file_class
+        self.data_files = \
+          [cls(self.dataset, self.io, template % i, i)
+           for i in range(self.dataset.file_count)]
+
+class YTreeHDF5File(HaloCatalogFile):
+    def __init__(self, ds, io, filename, file_id):
+        with h5py.File(filename, "r") as f:
+            self.particle_count = f['data'].attrs['num_elements']
+        super(YTreeHDF5File, self).__init__(
+            ds, io, filename, file_id)
+
+    def _read_particle_positions(self, ptype, f=None):
+        """
+        Read all particle positions in this file.
+        """
+
+        if f is None:
+            close = True
+            f = h5py.File(self.filename, "r")
+        else:
+            close = False
+
+        pos = np.empty((self.particle_count, 3), dtype="float64")
+        for i, ax in enumerate('xyz'):
+            pos[:, i] = f["data/position_%s" % ax].value
+
+        if close:
+            f.close()
+
+        return pos
+
+class YTreeDataset(SavedDataset):
+    _index_class = YTreeParticleIndex
+    _file_class = YTreeHDF5File
+    _field_info_class = YTreeFieldInfo
+    _suffix = ".h5"
+    _con_attrs = ("hubble_constant", "omega_matter", "omega_lambda")
+
+    def __init__(self, filename, dataset_type="ytree_arbor",
+                 n_ref = 16, over_refine_factor = 1, units_override=None,
+                 unit_system="cgs"):
+        self.n_ref = n_ref
+        self.over_refine_factor = over_refine_factor
+        super(YTreeDataset, self).__init__(filename, dataset_type,
+                                                 units_override=units_override,
+                                                 unit_system=unit_system)
+
+    def _set_derived_attrs(self):
+        self.domain_center = 0.5 * (self.domain_right_edge +
+                                    self.domain_left_edge)
+        self.domain_width = self.domain_right_edge - self.domain_left_edge
+
+    def _with_parameter_file_open(self, f):
+        self.file_count = f.attrs['total_files']
+        self.particle_count = f.attrs['total_nodes']
+        self.box_size = self.quan(
+            f.attrs['box_size'], f.attrs['box_size_units'])
+        self._field_dict = json.loads(f.attrs['field_info'])
+
+    def _parse_parameter_file(self):
+        self.current_redshift = None
+        self.current_time = None
+        self.cosmological_simulation = 1
+        self.refine_by = 2
+        self.dimensionality = 3
+        nz = 1 << self.over_refine_factor
+        self.domain_dimensions = np.ones(self.dimensionality, "int32") * nz
+        self.periodicity = (True, True, True)
+        self.unique_identifier = \
+          int(os.stat(self.parameter_filename)[stat.ST_CTIME])
+        prefix = self.parameter_filename[:-len(self._suffix)]
+        self.filename_template = "%s_%%04d%s" % (prefix, self._suffix)
+        self.particle_types = ("halos")
+        self.particle_types_raw = ("halos")
+        super(YTreeDataset, self)._parse_parameter_file()
+        # Set this again because unit registry has been updated.
+        self.box_size = self.quan(self.box_size)
+        self.domain_left_edge = self.box_size * \
+          np.zeros(self.dimensionality)
+        self.domain_right_edge = self.box_size * \
+          np.ones(self.dimensionality)
+
+    @classmethod
+    def _is_valid(self, *args, **kwargs):
+        if not args[0].endswith(".h5"): return False
+        with h5py.File(args[0], "r") as f:
+            if "data_type" in f.attrs and "arbor_type" in f.attrs:
+                return True
+        return False

--- a/yt/frontends/ytree/fields.py
+++ b/yt/frontends/ytree/fields.py
@@ -1,0 +1,26 @@
+"""
+ytree-specific fields
+
+
+
+
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) yt Development Team. All rights reserved.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from yt.fields.field_info_container import \
+    FieldInfoContainer
+
+
+class YTreeFieldInfo(FieldInfoContainer):
+    known_other_fields = (
+    )
+
+    known_particle_fields = (
+    )

--- a/yt/frontends/ytree/fields.py
+++ b/yt/frontends/ytree/fields.py
@@ -17,10 +17,19 @@ ytree-specific fields
 from yt.fields.field_info_container import \
     FieldInfoContainer
 
+p_units = 'unitary'
+v_units = 'km/s'
 
 class YTreeFieldInfo(FieldInfoContainer):
     known_other_fields = (
     )
 
     known_particle_fields = (
+        ("position_x", (p_units, ('halos', 'particle_position_x'), None)),
+        ("position_y", (p_units, ('halos', 'particle_position_y'), None)),
+        ("position_z", (p_units, ('halos', 'particle_position_z'), None)),
+        ("velocity_x", (v_units, ('halos', 'particle_velocity_x'), None)),
+        ("velocity_y", (v_units, ('halos', 'particle_velocity_y'), None)),
+        ("velocity_z", (v_units, ('halos', 'particle_velocity_z'), None)),
+        ("mass", ('Msun', ('halos', 'particle_mass'), None)),
     )

--- a/yt/frontends/ytree/fields.py
+++ b/yt/frontends/ytree/fields.py
@@ -33,3 +33,12 @@ class YTreeFieldInfo(FieldInfoContainer):
         ("velocity_z", (v_units, ('halos', 'particle_velocity_z'), None)),
         ("mass", ('Msun', ('halos', 'particle_mass'), None)),
     )
+
+    def setup_particle_fields(self, ptype):
+
+        def _redshift(field, data):
+            return 1. / data[ptype, 'scale_factor'] - 1
+        self.add_field((ptype, 'redshift'), function=_redshift,
+                       sampling_type='particle', units='')
+
+        super(YTreeFieldInfo, self).setup_particle_fields(ptype)

--- a/yt/frontends/ytree/io.py
+++ b/yt/frontends/ytree/io.py
@@ -1,0 +1,111 @@
+"""
+ytree data-file handling function
+
+
+
+
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) yt Development Team. All rights reserved.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+from yt.utilities.on_demand_imports import _h5py as h5py
+import numpy as np
+
+from yt.utilities.exceptions import YTDomainOverflow
+from yt.funcs import \
+    mylog
+
+from yt.utilities.io_handler import \
+    BaseIOHandler
+
+from yt.utilities.lib.geometry_utils import \
+    compute_morton
+
+
+class IOHandlerYTreeHDF5(BaseIOHandler):
+    _dataset_type = "ytree_arbor"
+
+    def _read_fluid_selection(self, chunks, selector, fields, size):
+        raise NotImplementedError
+
+    def _read_particle_coords(self, chunks, ptf):
+        # This will read chunks and yield the results.
+        chunks = list(chunks)
+        data_files = set([])
+        # Only support halo reading for now.
+        assert(len(ptf) == 1)
+        assert(list(ptf.keys())[0] == "halos")
+        ptype = 'halos'
+        for chunk in chunks:
+            for obj in chunk.objs:
+                data_files.update(obj.data_files)
+        for data_file in sorted(data_files):
+            with h5py.File(data_file.filename, "r") as f:
+                units = self.ds._field_dict['position_x']['units']
+                pos = data_file._get_particle_positions(ptype, f=f)
+                x, y, z = (self.ds.arr(pos[:, i], units)
+                           for i in range(3))
+                yield "halos", (x, y, z)
+
+    def _read_particle_fields(self, chunks, ptf, selector):
+        # Now we have all the sizes, and we can allocate
+        chunks = list(chunks)
+        data_files = set([])
+        # Only support halo reading for now.
+        assert(len(ptf) == 1)
+        assert(list(ptf.keys())[0] == "halos")
+        for chunk in chunks:
+            for obj in chunk.objs:
+                data_files.update(obj.data_files)
+        for data_file in sorted(data_files):
+            with h5py.File(data_file.filename, "r") as f:
+                for ptype, field_list in sorted(ptf.items()):
+                    units = self.ds._field_dict['position_x']['units']
+                    pos = data_file._get_particle_positions(ptype, f=f)
+                    x, y, z = (self.ds.arr(pos[:, i], units)
+                               for i in range(3))
+                    mask = selector.select_points(x, y, z, 0.0)
+                    del x, y, z
+                    if mask is None: continue
+                    for field in field_list:
+                        data = f['data'][field][mask].astype("float64")
+                        yield (ptype, field), data
+
+    def _initialize_index(self, data_file, regions):
+        pcount = data_file.particle_count
+        morton = np.empty(pcount, dtype='uint64')
+        mylog.debug("Initializing index % 5i (% 7i particles)",
+                    data_file.file_id, pcount)
+        ind = 0
+        if pcount == 0: return None
+        ptype = 'halos'
+        with h5py.File(data_file.filename, "r") as f:
+            units = self.ds._field_dict['position_x']['units']
+            pos = data_file._get_particle_positions(ptype, f=f)
+            pos = data_file.ds.arr(pos, units). to("code_length")
+            dle = self.ds.domain_left_edge.to("code_length")
+            dre = self.ds.domain_right_edge.to("code_length")
+            if np.any(pos.min(axis=0) < dle) or \
+               np.any(pos.max(axis=0) > dre):
+                raise YTDomainOverflow(pos.min(axis=0),
+                                       pos.max(axis=0),
+                                       dle, dre)
+            regions.add_data_file(pos, data_file.file_id)
+            morton[ind:ind+pos.shape[0]] = compute_morton(
+                pos[:,0], pos[:,1], pos[:,2], dle, dre)
+        return morton
+
+    def _count_particles(self, data_file):
+        return {'halos': data_file.particle_count}
+
+    def _identify_fields(self, data_file):
+        fields = [('halos', field) for field in self.ds._field_dict]
+        units = dict((('halos', field), self.ds._field_dict[field]['units'])
+                     for field in self.ds._field_dict)
+        return fields, units

--- a/yt/frontends/ytree/tests/test_outputs.py
+++ b/yt/frontends/ytree/tests/test_outputs.py
@@ -1,0 +1,43 @@
+"""
+ytree frontend tests
+
+
+
+"""
+
+#-----------------------------------------------------------------------------
+# Copyright (c) yt Development Team. All rights reserved.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+import os.path
+from yt.testing import \
+    assert_equal, \
+    requires_file, \
+    requires_module
+from yt.utilities.answer_testing.framework import \
+    FieldValuesTest, \
+    requires_ds, \
+    data_dir_load
+from yt.frontends.ytree.api import YTreeDataset
+
+_fields = ("particle_position_x", "particle_position_y",
+           "particle_position_z", "particle_mass")
+
+arb = "arbor/arbor.h5"
+
+@requires_ds(arb)
+@requires_module('h5py')
+def test_fields_arb():
+    ds = data_dir_load(arb)
+    assert_equal(str(ds), os.path.basename(arb))
+    for field in _fields:
+        yield FieldValuesTest(arb, field, particle_type=True)
+
+@requires_file(arb)
+@requires_module('h5py')
+def test_RockstarDataset():
+    assert isinstance(data_dir_load(arb), YTreeDataset)


### PR DESCRIPTION
## PR Summary

This adds the ability to a load ytree merger-tree dataset as a yt dataset. This is useful for doing geometric selection of halos as opposed to accessing fields through the tree structures that ytree creates. Ultimately, what I would like to do is use the demeshening in yt-4.0 as a means of performing fast halo searches (similar to database queries) from within ytree. ytree has a `select_halos` function that loops through all trees looking for halos matching specific criteria, but this could speed that up by quite a bit.

I've marked this WIP until I get tests, sample data, and docs in place.

## PR Checklist

- [x] Code passes flake8 checker
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.