### PR TITLE
Correct computation of angular momentum

### DIFF
--- a/yt/data_objects/selection_data_containers.py
+++ b/yt/data_objects/selection_data_containers.py
@@ -736,7 +736,7 @@ class YTSphere(YTSelectionContainer3D):
         if radius < self.index.get_smallest_dx():
             raise YTSphereTooSmall(ds, radius.in_units("code_length"),
                                    self.index.get_smallest_dx().in_units("code_length"))
-        self.set_field_parameter('radius',radius)
+        self.set_field_parameter('radius', radius)
         self.set_field_parameter("center", self.center)
         self.radius = radius
 

--- a/yt/fields/angular_momentum.py
+++ b/yt/fields/angular_momentum.py
@@ -36,22 +36,25 @@ def setup_angular_momentum(registry, ftype = "gas", slice_info = None):
     def _specific_angular_momentum_x(field, data):
         xv, yv, zv = obtain_relative_velocity_vector(data)
         rv = obtain_position_vector(data)
+        units = rv.units
         rv = np.rollaxis(rv, 0, len(rv.shape))
-        rv = data.ds.arr(rv, input_units = data["index", "x"].units)
+        rv = data.ds.arr(rv, input_units=units)
         return yv * rv[...,2] - zv * rv[...,1]
 
     def _specific_angular_momentum_y(field, data):
         xv, yv, zv = obtain_relative_velocity_vector(data)
         rv = obtain_position_vector(data)
+        units = rv.units
         rv = np.rollaxis(rv, 0, len(rv.shape))
-        rv = data.ds.arr(rv, input_units = data["index", "x"].units)
+        rv = data.ds.arr(rv, input_units=units)
         return - (xv * rv[...,2] - zv * rv[...,0])
 
     def _specific_angular_momentum_z(field, data):
         xv, yv, zv = obtain_relative_velocity_vector(data)
         rv = obtain_position_vector(data)
+        units = rv.units
         rv = np.rollaxis(rv, 0, len(rv.shape))
-        rv = data.ds.arr(rv, input_units = data["index", "x"].units)
+        rv = data.ds.arr(rv, input_units=units)
         return xv * rv[...,1] - yv * rv[...,0]
 
     registry.add_field((ftype, "specific_angular_momentum_x"),
@@ -71,7 +74,7 @@ def setup_angular_momentum(registry, ftype = "gas", slice_info = None):
                        function=_specific_angular_momentum_z,
                        units=unit_system["specific_angular_momentum"],
                        validators=[ValidateParameter("center"),
-                                    ValidateParameter("bulk_velocity")])
+                                   ValidateParameter("bulk_velocity")])
 
     create_magnitude_field(registry, "specific_angular_momentum",
                            unit_system["specific_angular_momentum"], ftype=ftype)

--- a/yt/fields/tests/test_angular_momentum.py
+++ b/yt/fields/tests/test_angular_momentum.py
@@ -8,13 +8,14 @@
 
 import numpy as np
 
+import yt
 from yt.testing import \
     assert_allclose_units, \
-    fake_random_ds, \
     requires_file
 
+@requires_file('output_00080/info_00080.txt')
 def test_AM_value():
-    ds = fake_random_ds(16)
+    ds = yt.load('output_00080/info_00080.txt')
 
     sp = ds.sphere([.5]*3, (0.1, 'code_length'))
 
@@ -30,5 +31,3 @@ def test_AM_value():
     sAM = ds.arr([sp['specific_angular_momentum_'+k] for k in 'xyz']).T
 
     assert_allclose_units(sAM_manual, sAM)
-
-

--- a/yt/fields/tests/test_angular_momentum.py
+++ b/yt/fields/tests/test_angular_momentum.py
@@ -8,14 +8,12 @@
 
 import numpy as np
 
-import yt
 from yt.testing import \
     assert_allclose_units, \
-    requires_file
+    fake_amr_ds
 
-@requires_file('output_00080/info_00080.txt')
 def test_AM_value():
-    ds = yt.load('output_00080/info_00080.txt')
+    ds = fake_amr_ds(fields=("Density", "velocity_x", "velocity_y", "velocity_z"), length_unit=0.5)
 
     sp = ds.sphere([.5]*3, (0.1, 'code_length'))
 

--- a/yt/fields/tests/test_angular_momentum.py
+++ b/yt/fields/tests/test_angular_momentum.py
@@ -1,0 +1,34 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2016, yt Development Team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+
+import numpy as np
+
+from yt.testing import \
+    assert_allclose_units, \
+    fake_random_ds, \
+    requires_file
+
+def test_AM_value():
+    ds = fake_random_ds(16)
+
+    sp = ds.sphere([.5]*3, (0.1, 'code_length'))
+
+    x0 = sp.center
+    v0 = ds.arr([1, 2, 3], 'km/s')
+
+    sp.set_field_parameter('bulk_velocity', v0)
+
+    X = (ds.arr([sp[k] for k in 'xyz']) - x0[:, None]).T
+    V = (ds.arr([sp['velocity_'+k] for k in 'xyz']) - v0[:, None]).T
+
+    sAM_manual = ds.arr(np.cross(V, X), X.units*V.units)
+    sAM = ds.arr([sp['specific_angular_momentum_'+k] for k in 'xyz']).T
+
+    assert_allclose_units(sAM_manual, sAM)
+
+

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -236,7 +236,7 @@ _geom_transforms = {
                    ( (-90.0, -180.0, 0.0), (90.0, 180.0, 1000.0) ), # latlondep
 }
 
-def fake_amr_ds(fields = ("Density",), geometry = "cartesian", particles=0):
+def fake_amr_ds(fields = ("Density",), geometry = "cartesian", particles=0, length_unit=None):
     from yt.frontends.stream.api import load_amr_grids
     prng = RandomState(0x4d3d3d3)
     LE, RE = _geom_transforms[geometry]
@@ -264,7 +264,7 @@ def fake_amr_ds(fields = ("Density",), geometry = "cartesian", particles=0):
             gdata['io', 'particle_mass'] = (prng.random_sample(particles), 'g')
         data.append(gdata)
     bbox = np.array([LE, RE]).T
-    return load_amr_grids(data, [32, 32, 32], geometry=geometry, bbox=bbox)
+    return load_amr_grids(data, [32, 32, 32], geometry=geometry, bbox=bbox, length_unit=length_unit)
 
 def fake_particle_ds(
         fields = ("particle_position_x",

--- a/yt/utilities/lib/misc_utilities.pyx
+++ b/yt/utilities/lib/misc_utilities.pyx
@@ -582,7 +582,9 @@ def obtain_position_vector(data):
     cdef np.ndarray[np.float64_t, ndim=4] rg
     cdef np.float64_t c[3]
     cdef int i, j, k
-    center = data.get_field_parameter("center")
+
+    units = data['x'].units
+    center = data.get_field_parameter("center").to(units)
     c[0] = center[0]; c[1] = center[1]; c[2] = center[2]
     if len(data['x'].shape) == 1:
         # One dimensional data
@@ -629,7 +631,9 @@ def obtain_relative_velocity_vector(
     cdef np.ndarray[np.float64_t, ndim=4] rvg
     cdef np.float64_t bv[3]
     cdef int i, j, k
-    bulk_vector = data.get_field_parameter(bulk_vector)
+
+    units = data[field_names[0]].units
+    bulk_vector = data.get_field_parameter(bulk_vector).to(units)
     if len(data[field_names[0]].shape) == 1:
         # One dimensional data
         vxf = data[field_names[0]].astype("float64")


### PR DESCRIPTION
## PR Summary

Until now, there was a mistake in the computation of angular momentum which was leading to the angular momentum units being messed up.

## PR Checklist

- [x] Code passes flake8 checker
- [x] Adds a test for any bugs fixed. Adds tests for new features.