### PR TITLE
Associated arbitrary grid edge unit registry with dataset unit registry for issue #2087

### DIFF
--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -598,7 +598,8 @@ class YTCoveringGrid(YTSelectionContainer3D):
                 "Length of edges must match the dimensionality of the "
                 "dataset")
         if hasattr(edge, 'units'):
-            edge_units = edge.units
+            edge_units = edge.units.copy()
+            edge_units.registry = self.ds.unit_registry
         else:
             edge_units = 'code_length'
         return self.ds.arr(edge, edge_units)

--- a/yt/data_objects/tests/test_covering_grid.py
+++ b/yt/data_objects/tests/test_covering_grid.py
@@ -169,47 +169,32 @@ def test_arbitrary_grid_edge():
     # a YTArray with a unit registry that matches that of the dataset.
     dims = [32,32,32]
     ds = fake_random_ds(dims)
-    # Test when edge is a list
-    left_edge = [0., 0., 0.]
-    right_edge = [1., 1., 1.]
-    ag = ds.arbitrary_grid(left_edge = left_edge, right_edge = right_edge, dims = dims)
-    assert np.array_equal(ag.left_edge, 
-            left_edge * ds.length_unit.to('code_length'))
-    assert np.array_equal(ag.right_edge,
-            right_edge * ds.length_unit.to('code_length'))
-    assert ag.left_edge.units.registry == ds.unit_registry
-    assert ag.right_edge.units.registry == ds.unit_registry
-    ag['density']
-    # Test when edge is a numpy array
-    left_edge = np.array([0., 0., 0.])
-    right_edge = np.array([1., 1., 1.])
-    ag = ds.arbitrary_grid(left_edge = left_edge, right_edge = right_edge, dims = dims)
-    assert np.array_equal(ag.left_edge, 
-            left_edge * ds.length_unit.to('code_length'))
-    assert np.array_equal(ag.right_edge,
-            right_edge * ds.length_unit.to('code_length'))
-    assert ag.left_edge.units.registry == ds.unit_registry
-    assert ag.right_edge.units.registry == ds.unit_registry
-    ag['density']
-    # Test when edge is a YTArray with dataset units
-    left_edge = [0., 0., 0.] * ds.length_unit
-    right_edge = [1., 1., 1.] * ds.length_unit
-    ag = ds.arbitrary_grid(left_edge = left_edge, right_edge = right_edge, dims = dims)
-    assert np.array_equal(ag.left_edge, 
-            left_edge * ds.length_unit)
-    assert np.array_equal(ag.right_edge,
-            right_edge * ds.length_unit)
-    assert ag.left_edge.units.registry == ds.unit_registry
-    assert ag.right_edge.units.registry == ds.unit_registry
-    ag['density']
-    # Test when edge is a YTArray using non-dataset units
-    left_edge = [0., 0., 0.] * kpc
-    right_edge = [1., 1., 1.] * kpc
-    ag = ds.arbitrary_grid(left_edge = left_edge, right_edge = right_edge, dims = dims)
-    assert np.array_equal(ag.left_edge, 
-            left_edge * kpc)
-    assert np.array_equal(ag.right_edge,
-            right_edge * kpc)
-    assert ag.left_edge.units.registry == ds.unit_registry
-    assert ag.right_edge.units.registry == ds.unit_registry
-    ag['density']
+    # Test when edge is a list, numpy array, YTArray with dataset units, and
+    # YTArray with non-dataset units
+    ledge = [ [0., 0., 0.],
+            np.array([0., 0., 0.]),
+            [0., 0., 0.] * ds.length_unit,
+            [0., 0., 0.] * kpc]
+
+    redge = [ [1., 1., 1.],
+            np.array([1., 1., 1.]),
+            [1., 1., 1.] * ds.length_unit,
+            [1., 1., 1.] * kpc]
+
+    ledge_ans = [ [0., 0., 0.] * ds.length_unit.to('code_length'),
+                np.array([0., 0., 0.]) * ds.length_unit.to('code_length'),
+                [0., 0., 0.] * ds.length_unit,
+                [0., 0., 0.] * kpc]
+
+    redge_ans = [ [1., 1., 1.] * ds.length_unit.to('code_length'),
+                np.array([1., 1., 1.]) * ds.length_unit.to('code_length'),
+                [1., 1., 1.] * ds.length_unit,
+                [1., 1., 1.] * kpc]
+
+    for le, re, le_ans, re_ans in zip(ledge, redge, ledge_ans, redge_ans):
+        ag = ds.arbitrary_grid(left_edge = le, right_edge = re, dims = dims)
+        assert np.array_equal(ag.left_edge, le_ans)
+        assert np.array_equal(ag.right_edge, re_ans)
+        assert ag.left_edge.units.registry == ds.unit_registry
+        assert ag.right_edge.units.registry == ds.unit_registry
+        ag['density']

--- a/yt/data_objects/tests/test_covering_grid.py
+++ b/yt/data_objects/tests/test_covering_grid.py
@@ -4,6 +4,8 @@ from yt.frontends.stream.data_structures import load_particles
 from yt.testing import fake_random_ds, assert_equal, assert_almost_equal, \
     fake_octree_ds
 
+from yt.units import kpc
+
 def setup():
     from yt.config import ytcfg
     ytcfg["yt","__withintesting"] = "True"

--- a/yt/data_objects/tests/test_covering_grid.py
+++ b/yt/data_objects/tests/test_covering_grid.py
@@ -160,3 +160,54 @@ def test_arbitrary_grid_derived_field():
     galgas = ds.arbitrary_grid([0.4, 0.4, 0.4], [0.99, 0.99, 0.99],
                                dims=[32, 32, 32])
     galgas['tracerf']
+
+def test_arbitrary_grid_edge():
+    # Tests bug fix for issue #2087
+    # Regardless of how left_edge and right_edge are passed, the result should be
+    # a YTArray with a unit registry that matches that of the dataset.
+    dims = [32,32,32]
+    ds = fake_random_ds(dims)
+    # Test when edge is a list
+    left_edge = [0., 0., 0.]
+    right_edge = [1., 1., 1.]
+    ag = ds.arbitrary_grid(left_edge = left_edge, right_edge = right_edge, dims = dims)
+    assert np.array_equal(ag.left_edge, 
+            left_edge * ds.length_unit.to('code_length'))
+    assert np.array_equal(ag.right_edge,
+            right_edge * ds.length_unit.to('code_length'))
+    assert ag.left_edge.units.registry == ds.unit_registry
+    assert ag.right_edge.units.registry == ds.unit_registry
+    ag['density']
+    # Test when edge is a numpy array
+    left_edge = np.array([0., 0., 0.])
+    right_edge = np.array([1., 1., 1.])
+    ag = ds.arbitrary_grid(left_edge = left_edge, right_edge = right_edge, dims = dims)
+    assert np.array_equal(ag.left_edge, 
+            left_edge * ds.length_unit.to('code_length'))
+    assert np.array_equal(ag.right_edge,
+            right_edge * ds.length_unit.to('code_length'))
+    assert ag.left_edge.units.registry == ds.unit_registry
+    assert ag.right_edge.units.registry == ds.unit_registry
+    ag['density']
+    # Test when edge is a YTArray with dataset units
+    left_edge = [0., 0., 0.] * ds.length_unit
+    right_edge = [1., 1., 1.] * ds.length_unit
+    ag = ds.arbitrary_grid(left_edge = left_edge, right_edge = right_edge, dims = dims)
+    assert np.array_equal(ag.left_edge, 
+            left_edge * ds.length_unit)
+    assert np.array_equal(ag.right_edge,
+            right_edge * ds.length_unit)
+    assert ag.left_edge.units.registry == ds.unit_registry
+    assert ag.right_edge.units.registry == ds.unit_registry
+    ag['density']
+    # Test when edge is a YTArray using non-dataset units
+    left_edge = [0., 0., 0.] * kpc
+    right_edge = [1., 1., 1.] * kpc
+    ag = ds.arbitrary_grid(left_edge = left_edge, right_edge = right_edge, dims = dims)
+    assert np.array_equal(ag.left_edge, 
+            left_edge * kpc)
+    assert np.array_equal(ag.right_edge,
+            right_edge * kpc)
+    assert ag.left_edge.units.registry == ds.unit_registry
+    assert ag.right_edge.units.registry == ds.unit_registry
+    ag['density']


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->
This PR associates the unit registry of the YTArray edge in \_sanitize\_edge with that of the dataset that the arbitrary grid is being constructed for. This is needed because if the user passes non-dataset units for the edge, i.e.
```python
ag = ds.arbitrary_grid(left_edge = [0,0,0] * yt.units.kpc,
    right_edge = [1,1,1] * yt.units.kpc,
    dims = [32,32,32])
```
then when yt attempts to get the data, there was a UnitParseError. This fixes that error.

<!--If it fixes an open issue, please link to the issue here.-->
[Issue #2087](https://github.com/yt-project/yt/issues/2087)
## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
