### PR TITLE
ensure gadget binary field data are in native endianness

### DIFF
--- a/yt/frontends/gadget/tests/test_outputs.py
+++ b/yt/frontends/gadget/tests/test_outputs.py
@@ -108,3 +108,9 @@ def test_pid_uniqueness():
     ad = ds.all_data()
     pid = ad['ParticleIDs']
     assert len(pid) == len(set(pid.v))
+
+@requires_ds(BE_Gadget)
+def test_bigendian_field_access():
+    ds = data_dir_load(BE_Gadget)
+    data = ds.all_data()
+    data['Halo', 'Velocities']


### PR DESCRIPTION
Some low-level routines (in the test case in the bug report it was the selection machinery) expect raw field data from the low-level I/O routines to be in native byte order. However, here we're reading bigendian data and pass it directly to those low-level routines. This breaks on little endian architectures.

The fix is to ensure the data are in native byte order after we read it in.

Ping @weiguangcui and maybe @MatthewTurk to look this over?