### PR TITLE
[bug fix] allow prj.annotate_marker to add multiple markers at once

### DIFF
--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -220,7 +220,7 @@ class PlotCallback(object):
             coord = self.convert_to_plot(plot, coord)
             # Convert coordinates from a tuple of ndarray to a tuple of floats
             # since not all callbacks are OK with ndarrays as coords (eg arrow)
-            coord = (coord[0][0], coord[1][0])
+            coord = (coord[0], coord[1])
         # if in plot coords, define the transform correctly
         if coord_system == "data" or coord_system == "plot":
             self.transform = plot._axes.transData


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

`sanitize_coord_system` takes in a "set of x,y (and z) coordinates"  and converts them to be ready for plotting.  However, passing in len(N) arrays for the x,y,z coordinates would only return the sanitized version of the first entry in that array.  This allows you to do, e.g., `prj.annotate_marker((xlist, ylist, zlist))` to add multiple markers at once.

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
