### PR TITLE
Make some annotations work with multiple points

### DIFF
--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -175,8 +175,8 @@ class PlotCallback(object):
 
         # We need a special case for when we are only given one coordinate.
         if ccoord.shape == (2,):
-            return np.array([(ccoord[0]-x0)/(x1-x0)*(xx1-xx0) + xx0,
-                             (ccoord[1]-y0)/(y1-y0)*(yy1-yy0) + yy0])
+            return np.array([((ccoord[0]-x0)/(x1-x0)*(xx1-xx0) + xx0)[0],
+                             ((ccoord[1]-y0)/(y1-y0)*(yy1-yy0) + yy0)[0]])
         else:
             return np.array([(ccoord[0][:]-x0)/(x1-x0)*(xx1-xx0) + xx0,
                              (ccoord[1][:]-y0)/(y1-y0)*(yy1-yy0) + yy0])
@@ -227,7 +227,6 @@ class PlotCallback(object):
         # if in plot coords, define the transform correctly
         if coord_system == "data" or coord_system == "plot":
             self.transform = plot._axes.transData
-            print(coord)
             return coord
         # if in axis coords, define the transform correctly
         if coord_system == "axis":
@@ -235,12 +234,10 @@ class PlotCallback(object):
             if len(coord) > 2:
                 raise SyntaxError("Coordinates in 'axis' coordinate system "
                                   "need to be in 2D")
-            print(coord)
             return coord
         # if in figure coords, define the transform correctly
         elif coord_system == "figure":
             self.transform = plot._figure.transFigure
-            print(coord)
             return coord
         else:
             raise SyntaxError("Argument coord_system must have a value of "
@@ -1183,7 +1180,6 @@ class ArrowCallback(PlotCallback):
         if dx == dy == 0:
             warnings.warn("The arrow has zero length.  Not annotating.")
             return
-        #import pdb; pdb.set_trace()
         try:
             plot._axes.arrow(x-dx, y-dy, dx, dy, width=self.width,
                              head_width=self.head_width,

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -220,7 +220,7 @@ class PlotCallback(object):
             coord = self.convert_to_plot(plot, coord)
             # Convert coordinates from a tuple of ndarray to a tuple of floats
             # since not all callbacks are OK with ndarrays as coords (eg arrow)
-            coord = (coord[0][0], coord[1][0])
+            coord = (coord[0], coord[1])
         # if in plot coords, define the transform correctly
         if coord_system == "data" or coord_system == "plot":
             self.transform = plot._axes.transData

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -175,11 +175,11 @@ class PlotCallback(object):
 
         # We need a special case for when we are only given one coordinate.
         if ccoord.shape == (2,):
-            return ((ccoord[0]-x0)/(x1-x0)*(xx1-xx0) + xx0,
-                    (ccoord[1]-y0)/(y1-y0)*(yy1-yy0) + yy0)
+            return np.array([(ccoord[0]-x0)/(x1-x0)*(xx1-xx0) + xx0,
+                             (ccoord[1]-y0)/(y1-y0)*(yy1-yy0) + yy0])
         else:
-            return ((ccoord[0][:]-x0)/(x1-x0)*(xx1-xx0) + xx0,
-                    (ccoord[1][:]-y0)/(y1-y0)*(yy1-yy0) + yy0)
+            return np.array([(ccoord[0][:]-x0)/(x1-x0)*(xx1-xx0) + xx0,
+                             (ccoord[1][:]-y0)/(y1-y0)*(yy1-yy0) + yy0])
 
     def sanitize_coord_system(self, plot, coord, coord_system):
         """
@@ -224,12 +224,10 @@ class PlotCallback(object):
                                   "need to be in 3D")
             coord = self.project_coords(plot, coord)
             coord = self.convert_to_plot(plot, coord)
-            # Convert coordinates from a tuple of ndarray to a tuple of floats
-            # since not all callbacks are OK with ndarrays as coords (eg arrow)
-            #coord = (coord[0], coord[1])
         # if in plot coords, define the transform correctly
         if coord_system == "data" or coord_system == "plot":
             self.transform = plot._axes.transData
+            print(coord)
             return coord
         # if in axis coords, define the transform correctly
         if coord_system == "axis":
@@ -237,10 +235,12 @@ class PlotCallback(object):
             if len(coord) > 2:
                 raise SyntaxError("Coordinates in 'axis' coordinate system "
                                   "need to be in 2D")
+            print(coord)
             return coord
         # if in figure coords, define the transform correctly
         elif coord_system == "figure":
             self.transform = plot._figure.transFigure
+            print(coord)
             return coord
         else:
             raise SyntaxError("Argument coord_system must have a value of "
@@ -1183,11 +1183,20 @@ class ArrowCallback(PlotCallback):
         if dx == dy == 0:
             warnings.warn("The arrow has zero length.  Not annotating.")
             return
-        plot._axes.arrow(x[0]-dx, y[0]-dy, dx, dy, width=self.width,
-                         head_width=self.head_width,
-                         head_length=self.head_length,
-                         transform=self.transform,
-                         length_includes_head=True, **self.plot_args)
+        #import pdb; pdb.set_trace()
+        try:
+            plot._axes.arrow(x-dx, y-dy, dx, dy, width=self.width,
+                             head_width=self.head_width,
+                             head_length=self.head_length,
+                             transform=self.transform,
+                             length_includes_head=True, **self.plot_args)
+        except ValueError:
+            for i in range(len(x)):
+                plot._axes.arrow(x[i]-dx, y[i]-dy, dx, dy, width=self.width,
+                                 head_width=self.head_width,
+                                 head_length=self.head_length,
+                                 transform=self.transform,
+                                 length_includes_head=True, **self.plot_args)
         plot._axes.set_xlim(xx0,xx1)
         plot._axes.set_ylim(yy0,yy1)
 

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -1049,8 +1049,8 @@ class ClumpContourCallback(PlotCallback):
 
 class ArrowCallback(PlotCallback):
     """
-    Overplot an arrow pointing at a position for highlighting a specific
-    feature.  By default, arrow points from lower left to the designated
+    Overplot arrow(s) pointing at position(s) for highlighting specific
+    features.  By default, arrow points from lower left to the designated
     position "pos" with arrow length "length".  Alternatively, if
     "starting_pos" is set, arrow will stretch from "starting_pos" to "pos"
     and "length" will be disregarded.
@@ -1065,8 +1065,9 @@ class ArrowCallback(PlotCallback):
 
     Parameters
     ----------
-    pos : 2- or 3-element tuple, list, or array
-        These are the coordinates to which the arrow is pointing
+    pos : array-like
+        These are the coordinates where the marker(s) will be overplotted
+        Either as [x,y,z] or as [[x1,x2,...],[y1,y2,...],[z1,z2,...]]
 
     length : float, optional
         The length, in axis units, of the arrow.
@@ -1198,12 +1199,13 @@ class ArrowCallback(PlotCallback):
 
 class MarkerAnnotateCallback(PlotCallback):
     """
-    Overplot a marker on a position for highlighting specific features.
+    Overplot marker(s) at a position(s) for highlighting specific features.
 
     Parameters
     ----------
-    pos : 2- or 3-element tuple, list, or array
-        These are the coordinates where the marker will be overplotted
+    pos : array-like
+        These are the coordinates where the marker(s) will be overplotted
+        Either as [x,y,z] or as [[x1,x2,...],[y1,y2,...],[z1,z2,...]]
 
     marker : string, optional
         The shape of the marker to be passed to the MPL scatter function.

--- a/yt/visualization/tests/test_callbacks.py
+++ b/yt/visualization/tests/test_callbacks.py
@@ -227,6 +227,11 @@ def test_arrow_callback():
         # Now we'll check a few additional minor things
         p = SlicePlot(ds, "x", "density")
         p.annotate_arrow([0.5,0.5], coord_system='axis', length=0.05)
+        p.annotate_arrow([[0.5,0.6],[0.5,0.6],[0.5,0.6]], coord_system='data', length=0.05)
+        p.annotate_arrow([[0.5,0.6,0.8],[0.5,0.6,0.8],[0.5,0.6,0.8]], coord_system='data', length=0.05)
+        p.annotate_arrow([[0.5,0.6,0.8],[0.5,0.6,0.8]], coord_system='axis', length=0.05)
+        p.annotate_arrow([[0.5,0.6,0.8],[0.5,0.6,0.8]], coord_system='figure', length=0.05)
+        p.annotate_arrow([[0.5,0.6,0.8],[0.5,0.6,0.8]], coord_system='plot', length=0.05)
         p.save(prefix)
 
     with _cleanup_fname() as prefix:
@@ -255,6 +260,11 @@ def test_marker_callback():
         # Now we'll check a few additional minor things
         p = SlicePlot(ds, "x", "density")
         p.annotate_marker([0.5,0.5], coord_system='axis', marker='*')
+        p.annotate_marker([[0.5,0.6],[0.5,0.6],[0.5,0.6]], coord_system='data')
+        p.annotate_marker([[0.5,0.6,0.8],[0.5,0.6,0.8],[0.5,0.6,0.8]], coord_system='data')
+        p.annotate_marker([[0.5,0.6,0.8],[0.5,0.6,0.8]], coord_system='axis')
+        p.annotate_marker([[0.5,0.6,0.8],[0.5,0.6,0.8]], coord_system='figure')
+        p.annotate_marker([[0.5,0.6,0.8],[0.5,0.6,0.8]], coord_system='plot')
         p.save(prefix)
 
     with _cleanup_fname() as prefix:


### PR DESCRIPTION

## PR Summary

Enables annotate_marker() and annotate_arrow() to work with multiple points.

Code can now be specified as:

```
import yt
ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
p = yt.OffAxisProjectionPlot(ds, [1,0,0], 'temperature', weight_field='density', north_vector=[0,1,0])
p.annotate_arrow([0.6, 0.6, 0.6], coord_system='data')
p.annotate_arrow([[0.6, 0.7], [0.6, 0.7], [0.6, 0.7]], coord_system='data')
p.annotate_arrow([[0.6, 0.7, 0.8], [0.6, 0.7, 0.8], [0.6, 0.7, 0.8]], coord_system='data')
p.annotate_arrow([0.5, 0.5], coord_system='plot')
p.annotate_arrow([[0.5, 0.4], [0.5, 0.4]], coord_system='plot')
p.annotate_arrow([[0.5, 0.4, 0.3], [0.5, 0.4, 0.3]], coord_system='plot')
p.save()
```

## PR Checklist

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
