### PR TITLE
update the docs to reflect the fact that rays are not ordered.

### DIFF
--- a/doc/source/analyzing/generating_processed_data.rst
+++ b/doc/source/analyzing/generating_processed_data.rst
@@ -206,13 +206,17 @@ along that ray:
    ray = ds.ray((0.3, 0.5, 0.9), (0.1, 0.8, 0.5))
    print(ray["density"])
 
-The points are ordered, but the ray is also traversing cells of varying length,
-as well as taking a varying distance to cross each cell.  To determine the
-distance traveled by the ray within each cell (for instance, for integration)
-the field ``dt`` is available; this field will sum to 1.0, as the ray's path
-will be normalized to 1.0, independent of how far it travels through the domain.
-To determine the value of ``t`` at which the ray enters each cell, the field
-``t`` is available.  For instance:
+The points are not ordered, so you may need to sort the data (see the
+example in the
+:class:`~yt.data_objects.selection_data_containers.YTRay` docs).  Also
+note, the ray is traversing cells of varying length, as well as
+taking a varying distance to cross each cell.  To determine the
+distance traveled by the ray within each cell (for instance, for
+integration) the field ``dt`` is available; this field will sum to
+1.0, as the ray's path will be normalized to 1.0, independent of how
+far it travels through the domain.  To determine the value of ``t`` at
+which the ray enters each cell, the field ``t`` is available.  For
+instance:
 
 .. code-block:: python
 


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

The documentation was incorrect -- YTRay objects are not ordered.  I fixed the docs.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
