### PR TITLE
Run tests in temporary directory. Fixes #2123.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
       - proj-data
       - proj-bin
       - libgeos-dev
+      - libopenmpi-dev
 
 env:
   global:

--- a/yt/frontends/gadget/tests/test_outputs.py
+++ b/yt/frontends/gadget/tests/test_outputs.py
@@ -17,6 +17,8 @@ Gadget frontend tests
 from collections import OrderedDict
 from itertools import product
 import os
+import shutil
+import tempfile
 
 import yt
 from yt.testing import requires_file
@@ -57,6 +59,8 @@ iso_kwargs = dict(bounding_box=[[-3, 3], [-3, 3], [-3, 3]])
 
 def test_gadget_binary():
     header_specs = ['default', 'default+pad32', ['default', 'pad32']]
+    curdir = os.getcwd()
+    tmpdir = tempfile.mkdtemp()
     for header_spec, endian, fmt in product(header_specs, '<>', [1, 2]):
         fake_snap = fake_gadget_binary(
             header_spec=header_spec,
@@ -71,6 +75,8 @@ def test_gadget_binary():
         except FileNotFoundError:
             # sometimes this happens for mysterious reasons
             pass
+    os.chdir(curdir)
+    shutil.rmtree(tmpdir)
 
 
 @requires_file(isothermal_h5)

--- a/yt/visualization/volume_rendering/tests/test_scene.py
+++ b/yt/visualization/volume_rendering/tests/test_scene.py
@@ -97,6 +97,9 @@ class RotationTest(TestCase):
 
 def test_annotations():
     from matplotlib.image import imread
+    curdir = os.getcwd()
+    tmpdir = tempfile.mkdtemp()
+    os.chdir(tmpdir)
     ds = fake_vr_orientation_test_ds(N=16)
     sc = create_scene(ds)
     sc.annotate_axes()
@@ -111,4 +114,5 @@ def test_annotations():
     sc.save_annotated('test_scene_annotated.png', text_annotate=[[(.1, 1.05), "test_string"]])
     image = imread('test_scene_annotated.png')
     assert image.shape == sc.camera.resolution + (4,)
-    os.remove('test_scene_annotated.png')
+    os.chdir(curdir)
+    shutil.rmtree(tmpdir)


### PR DESCRIPTION
I tried to add a test for this but couldn't figure out how to straightforwardly make the python environment we run our tests in read-only to emulate the debian build environment. Rather than wasting a bunch more time trying to get that to work I'll just fix the issues @olebole reported and try to be vigilant going forward.