### PR TITLE
make particle deposit machinery use dummy grids when necessary

### DIFF
--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -750,15 +750,20 @@ class YTCoveringGrid(YTSelectionContainer3D):
         cls = getattr(particle_deposit, "deposit_%s" % method, None)
         if cls is None:
             raise YTParticleDepositionNotImplemented(method)
-        # We allocate number of zones, not number of octs. Everything inside
-        # this is fortran ordered because of the ordering in the octree deposit
-        # routines, so we reverse it here to match the convention there
-        op = cls(tuple(self.ActiveDimensions)[::-1], kernel_name)
+        # We allocate number of zones, not number of octs. Everything
+        # inside this is Fortran ordered because of the ordering in the
+        # octree deposit routines, so we reverse it here to match the
+        # convention there
+        nvals = tuple(self.ActiveDimensions[::-1])
+        # append a dummy dimension because we are only depositing onto
+        # one grid
+        op = cls(nvals + (1,), kernel_name)
         op.initialize()
         op.process_grid(self, positions, fields)
-        vals = op.finalize()
         # Fortran-ordered, so transpose.
-        return vals.transpose()
+        vals = op.finalize().transpose()
+        # squeeze dummy dimension we appended above
+        return np.squeeze(vals, axis=0)
 
     def write_to_gdf(self, gdf_path, fields, nprocs=1, field_units=None,
                      **kwargs):

--- a/yt/geometry/particle_deposit.pyx
+++ b/yt/geometry/particle_deposit.pyx
@@ -38,6 +38,9 @@ cdef append_axes(np.ndarray arr, int naxes):
 
 cdef class ParticleDepositOperation:
     def __init__(self, nvals, kernel_name):
+        # nvals is a tuple containing the active dimensions of the
+        # grid to deposit onto and the number of grids,
+        # (nx, ny, nz, ngrids)
         self.nvals = nvals
         self.update_values = 0 # This is the default
         self.sph_kernel = get_kernel_func(kernel_name)
@@ -340,11 +343,11 @@ cdef class CICDeposit(ParticleDepositOperation):
     cdef np.float64_t[:,:,:,:] field
     cdef public object ofield
     def initialize(self):
-        if not all(_ > 1 for _ in self.nvals):
+        if not all(_ > 1 for _ in self.nvals[:-1]):
             from yt.utilities.exceptions import YTBoundsDefinitionError
             raise YTBoundsDefinitionError(
                 "CIC requires minimum of 2 zones in all spatial dimensions.",
-                self.nvals)
+                self.nvals[:-1])
         self.field = append_axes(
             np.zeros(self.nvals, dtype="float64", order='F'), 4)
 

--- a/yt/geometry/tests/test_particle_deposit.py
+++ b/yt/geometry/tests/test_particle_deposit.py
@@ -1,8 +1,11 @@
 from yt.utilities.exceptions import \
     YTBoundsDefinitionError
 
+from yt.convenience import \
+    load
 from yt.testing import \
-    fake_random_ds
+    fake_random_ds, \
+    requires_file
 from numpy.testing import \
     assert_raises
 
@@ -12,3 +15,16 @@ def test_cic_deposit():
             dims=[1, 800, 800])
     f = ("deposit", "all_cic")
     assert_raises(YTBoundsDefinitionError, my_reg.__getitem__, f)
+
+RAMSES = 'output_00080/info_00080.txt'
+
+@requires_file(RAMSES)
+def test_one_zone_octree_deposit():
+    ds = load(RAMSES)
+
+    # Get a sphere centred on the main halo
+    hpos = ds.arr([0.5215110772898429, 0.5215110772898429, 0.5215110772898429], 'code_length')
+    hrvir = ds.quan(0.042307235300540924, 'Mpc')
+
+    sp = ds.sphere(hpos, hrvir*10)
+    assert sp['deposit', 'io_cic'].shape == (1,)


### PR DESCRIPTION
fixes #2129

Currently the octree geometry handler will generate an array of shape (2, 2, 2, nocts) to pass to the deposit machinery, while the grid geometry handlers pass an array of shape np.reverse(grid.ActiveDimensions) (using a reverse because of fortran/C ordering issues).

This leads to an inconsistency in how the `YTBoundsDefinitionError` checks for low-dimensionality grids. If the octree handler only hands one oct to the deposit machinery, it gets detected as a low dimensionality grid. However the fix isn't as simple as just throwing away the last dimension unconditionally because of how the grid geometry handler and covering grids interact with the deposit machinery.

The fix is then to make the grid deposit machinery behave in a uniform way, first appending a dummy dimension, then popping it off after doing the deposit operation. I've added comments to hopefully make it more clear what's going on here as this does add some complexity.

I added a test following the test script in the issue. I tried to make a test script using `fake_octree_ds` but it turned out that doing that required implementing particle I/O for in-memory octree data which I didn't feel like taking on as part of this PR.