### PR TITLE
Add documentation on how to install dev version within anaconda

### DIFF
--- a/doc/source/installing.rst
+++ b/doc/source/installing.rst
@@ -287,9 +287,9 @@ Clone the yt repository with:
 
   $ git clone https://github.com/yt-project/yt
 
-Once inside the yt directory, update to the appropriate branch and
-run ``pip install -e .``. For example, the following commands will allow you
-to see the tip of the development branch.
+Once inside the yt directory, update to the appropriate branch and run
+``pip install -e .``. For example, the following commands will allow
+you to see the tip of the development branch.
 
 .. code-block:: bash
 
@@ -298,6 +298,11 @@ to see the tip of the development branch.
 
 This will make sure you are running a version of yt corresponding to the
 most up-to-date source code.
+
+.. note::
+
+  Alternatively, you can replace ``pip install -e .`` with ``conda develop -b .``.
+
 
 Installing Support for the Rockstar Halo Finder
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
with `conda` and not `pip`

## PR Summary

Installing yt from sources without `pip`, but using `conda develop` was not documented. In particular, since yt is not a pure python project, some building is required and hence a simple `conda develop .` isn't enough. The additional `-b` flag triggers the build.

## PR Checklist

no code here, just doc...

- [ ] ~Code passes flake8 checker~
- [ ] ~New features are documented, with docstrings and narrative docs~
- [ ] ~Adds a test for any bugs fixed. Adds tests for new features.~
