### PR TITLE
[bugfix] fix numpy 1.16 future warning.

### DIFF
--- a/yt/frontends/stream/io.py
+++ b/yt/frontends/stream/io.py
@@ -171,8 +171,8 @@ class StreamParticleIOHandler(BaseIOHandler):
         morton = []
         for ptype in self.ds.particle_types_raw:
             try:
-                pos = np.column_stack(self.fields[data_file.filename][
-                    (ptype, "particle_position_%s" % ax)] for ax in 'xyz')
+                pos = np.column_stack([self.fields[data_file.filename][
+                    (ptype, "particle_position_%s" % ax)] for ax in 'xyz'])
             except KeyError:
                 pos = self.fields[data_file.filename][ptype, "particle_position"]
             if np.any(pos.min(axis=0) < data_file.ds.domain_left_edge) or \


### PR DESCRIPTION
## PR Summary

This fixes the following `FutureWarning` issued in numpy 1.16:
```
yt/yt/frontends/stream/io.py:175: FutureWarning: arrays to stack must be passed as a "sequence" type such as list or tuple. Support for non-sequence iterables such as generators is deprecated as of NumPy 1.16 and will raise an error in the future.
```

This shows up when running halo finders using the yt_astro_analysis `HaloCatalog`, which uses the stream frontend.

## PR Checklist

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.