### PR TITLE
Fixing minor issues with some binary-format Gadget

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -574,7 +574,7 @@ class Dataset(object):
         if "nbody" not in self.particle_types:
             mylog.debug("Creating Particle Union 'nbody'")
             ptypes = list(self.particle_types_raw)
-            if hasattr(self, '_sph_ptype'):
+            if hasattr(self, '_sph_ptype') and self._sph_ptype in ptypes:
                 ptypes.remove(self._sph_ptype)
             if ptypes:
                 nbody_ptypes = []

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -183,7 +183,7 @@ class GadgetBinaryHeader(object):
 class GadgetBinaryFile(ParticleFile):
 
     def __init__(self, ds, io, filename, file_id, range=None):
-        header = ds._header
+        header = GadgetBinaryHeader(filename, ds._header.spec)
         self.header = header.value
         self._position_offset = header.position_offset
         with header.open() as f:
@@ -192,9 +192,11 @@ class GadgetBinaryFile(ParticleFile):
         super(GadgetBinaryFile, self).__init__(ds, io, filename, file_id, range)
 
     def _calculate_offsets(self, field_list, pcounts):
+        # Note that we ignore pcounts here because it's the global count.  We
+        # just want the local count, which we store here.
         self.field_offsets = self.io._calculate_field_offsets(
-            field_list, pcounts, self._position_offset, self.start,
-            self._file_size)
+            field_list, self.header['Npart'].copy(), self._position_offset,
+            self.start, self._file_size)
 
 class GadgetBinaryIndex(SPHParticleIndex):
 

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -213,7 +213,7 @@ class GadgetBinaryIndex(SPHParticleIndex):
     def _initialize_frontend_specific(self):
         super(GadgetBinaryIndex, self)._initialize_frontend_specific()
         fname = self.data_files[0].filename
-        self.io._float_type = self.ds._validate_header(fname)[1]
+        self.io._float_type = self.ds._header.float_type
 
 class GadgetDataset(SPHDataset):
     _index_class = GadgetBinaryIndex

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -214,7 +214,6 @@ class GadgetBinaryIndex(SPHParticleIndex):
 
     def _initialize_frontend_specific(self):
         super(GadgetBinaryIndex, self)._initialize_frontend_specific()
-        fname = self.data_files[0].filename
         self.io._float_type = self.ds._header.float_type
 
 class GadgetDataset(SPHDataset):

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -290,9 +290,12 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
                 f.seek(poff[ptype, "Coordinates"], os.SEEK_SET)
                 pos = self._read_field_from_file(
                     f, tp[ptype], "Coordinates")
-                f.seek(poff[ptype, "SmoothingLength"], os.SEEK_SET)
-                hsml = self._read_field_from_file(
-                    f, tp[ptype], "SmoothingLength")
+                if ptype == self.ds._sph_ptype:
+                    f.seek(poff[ptype, "SmoothingLength"], os.SEEK_SET)
+                    hsml = self._read_field_from_file(
+                        f, tp[ptype], "SmoothingLength")
+                else:
+                    hsml = 0.0
                 yield ptype, (pos[:, 0], pos[:, 1], pos[:, 2]), hsml
             f.close()
 
@@ -309,9 +312,12 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
                 f.seek(poff[ptype, "Coordinates"], os.SEEK_SET)
                 pos = self._read_field_from_file(
                     f, tp[ptype], "Coordinates")
-                f.seek(poff[ptype, "SmoothingLength"], os.SEEK_SET)
-                hsml = self._read_field_from_file(
-                    f, tp[ptype], "SmoothingLength")
+                if ptype == self.ds._sph_ptype:
+                    f.seek(poff[ptype, "SmoothingLength"], os.SEEK_SET)
+                    hsml = self._read_field_from_file(
+                        f, tp[ptype], "SmoothingLength")
+                else:
+                    hsml = 0.0
                 mask = selector.select_points(
                     pos[:, 0], pos[:, 1], pos[:, 2], hsml)
                 del pos
@@ -403,6 +409,7 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
             pos = offset
         fs = self._field_size
         offsets = {}
+        pcount = dict(zip(self._ptypes, pcount))
 
         for field in self._fields:
             if field == "ParticleIDs" and self.ds.long_ids:


### PR DESCRIPTION
Using some data from @jcoughlin11 , I found that there were some things for binary data that had not been updated in yt-4.0.  This is just a set of two minor fixes for that that bring it in line -- the first is calling the right header validation and the second is to only remove `_sph_ptype` if it's actually used.