### PR TITLE
Replace deprecated h5py syntax

### DIFF
--- a/doc/source/cookbook/extract_fixed_resolution_data.py
+++ b/doc/source/cookbook/extract_fixed_resolution_data.py
@@ -30,4 +30,4 @@ f.close()
 
 # If we want to then access this datacube in the h5 file, we can now...
 f = h5py.File("my_data.h5", "r")
-print(f["density"].value)
+print(f["density"][()])

--- a/yt/frontends/chombo/data_structures.py
+++ b/yt/frontends/chombo/data_structures.py
@@ -188,9 +188,9 @@ class ChomboHierarchy(GridIndex):
         for lev_index, lev in enumerate(self._levels):
             level_number = int(re.match('level_(\d+)',lev).groups()[0])
             try:
-                boxes = f[lev]['boxes'].value
+                boxes = f[lev]['boxes'][()]
             except KeyError:
-                boxes = f[lev]['particles:boxes'].value
+                boxes = f[lev]['particles:boxes'][()]
             dx = f[lev].attrs['dx']
             self.dds_list.append(dx * np.ones(3))
 
@@ -421,9 +421,9 @@ class PlutoHierarchy(ChomboHierarchy):
         for lev_index, lev in enumerate(self._levels):
             level_number = int(re.match('level_(\d+)',lev).groups()[0])
             try:
-                boxes = f[lev]['boxes'].value
+                boxes = f[lev]['boxes'][()]
             except KeyError:
-                boxes = f[lev]['particles:boxes'].value
+                boxes = f[lev]['particles:boxes'][()]
             dx = f[lev].attrs['dx']
             self.dds_list.append(dx * np.ones(3))
 

--- a/yt/frontends/chombo/io.py
+++ b/yt/frontends/chombo/io.py
@@ -51,7 +51,7 @@ class IOHandlerChomboHDF5(BaseIOHandler):
         while 1:
             lname = 'level_%i' % level
             if lname not in self._handle: break
-            boxes = self._handle['level_0']['boxes'].value
+            boxes = self._handle['level_0']['boxes'][()]
             box_sizes = np.array([box_size(box) for box in boxes])
 
             offsets = np.cumsum(box_sizes*num_comp, dtype='int64') 
@@ -177,7 +177,7 @@ class IOHandlerChomboHDF5(BaseIOHandler):
         field_index = self.particle_field_index[name]
         lev = 'level_%s' % grid.Level
 
-        particles_per_grid = self._handle[lev]['particles:offsets'].value
+        particles_per_grid = self._handle[lev]['particles:offsets'][()]
         items_per_particle = len(self._particle_field_index)
 
         # compute global offset position

--- a/yt/frontends/enzo/io.py
+++ b/yt/frontends/enzo/io.py
@@ -97,7 +97,7 @@ class IOHandlerPackedHDF5(BaseIOHandler):
                         pds = ds
                     pn = _particle_position_names.get(ptype,
                             r"particle_position_%s")
-                    x, y, z = (np.asarray(pds.get(pn % ax).value, dtype="=f8")
+                    x, y, z = (np.asarray(pds.get(pn % ax)[()], dtype="=f8")
                                for ax in 'xyz')
                     if selector is None:
                         # This only ever happens if the call is made from
@@ -107,7 +107,7 @@ class IOHandlerPackedHDF5(BaseIOHandler):
                     mask = selector.select_points(x, y, z, 0.0)
                     if mask is None: continue
                     for field in field_list:
-                        data = np.asarray(pds.get(field).value, "=f8")
+                        data = np.asarray(pds.get(field)[()], "=f8")
                         if field in _convert_mass:
                             data *= g.dds.prod(dtype="f8")
                         yield (ptype, field), data[mask]
@@ -305,7 +305,7 @@ class IOHandlerPacked2D(IOHandlerPackedHDF5):
             gds = f.get("/Grid%08i" % g.id)
             for ftype, fname in fields:
                 rv[(ftype, fname)] = np.atleast_3d(
-                    gds.get(fname).value.transpose())
+                    gds.get(fname)[()].transpose())
             f.close()
             return rv
         if size is None:
@@ -330,7 +330,7 @@ class IOHandlerPacked2D(IOHandlerPackedHDF5):
                     gds = f
                 for field in fields:
                     ftype, fname = field
-                    ds = np.atleast_3d(gds.get(fname).value.transpose())
+                    ds = np.atleast_3d(gds.get(fname)[()].transpose())
                     nd = g.select(selector, ds, rv[field], ind) # caches
                 ind += nd
             f.close()

--- a/yt/frontends/enzo_p/io.py
+++ b/yt/frontends/enzo_p/io.py
@@ -110,7 +110,7 @@ class EnzoPIOHandler(BaseIOHandler):
                     if g.particle_count[ptype] == 0:
                         continue
                     coords = \
-                      tuple(np.asarray(group.get(pn % ax).value, dtype="=f8")
+                      tuple(np.asarray(group.get(pn % ax)[()], dtype="=f8")
                             for ax in 'xyz'[:self.ds.dimensionality])
                     for i in range(self.ds.dimensionality, 3):
                         coords += \
@@ -125,7 +125,7 @@ class EnzoPIOHandler(BaseIOHandler):
                     if mask is None:
                         continue
                     for field in field_list:
-                        data = np.asarray(group.get(pn % field).value, "=f8")
+                        data = np.asarray(group.get(pn % field)[()], "=f8")
                         yield (ptype, field), data[mask]
             if f: f.close()
 

--- a/yt/frontends/gadget_fof/data_structures.py
+++ b/yt/frontends/gadget_fof/data_structures.py
@@ -122,9 +122,9 @@ class GadgetFOFHDF5File(HaloCatalogFile):
             self.header = \
               dict((str(field), val)
                    for field, val in f["Header"].attrs.items())
-            self.group_length_sum = f["Group/GroupLen"].value.sum() \
+            self.group_length_sum = f["Group/GroupLen"][()].sum() \
               if "Group/GroupLen" in f else 0
-            self.group_subs_sum = f["Group/GroupNsubs"].value.sum() \
+            self.group_subs_sum = f["Group/GroupNsubs"][()].sum() \
               if "Group/GroupNsubs" in f else 0
         self.total_ids = self.header["Nids_ThisFile"]
         self.total_particles = \
@@ -144,7 +144,7 @@ class GadgetFOFHDF5File(HaloCatalogFile):
         else:
             close = False
 
-        pos = f[ptype]["%sPos" % ptype].value.astype("float64")
+        pos = f[ptype]["%sPos" % ptype][()].astype("float64")
 
         if close:
             f.close()
@@ -431,7 +431,7 @@ class GadgetFOFHaloParticleIndex(GadgetFOFParticleIndex):
 
             for field in fields:
                 data[field][target] = \
-                  my_f[os.path.join(ptype, field)].value[scalar_indices[target]]
+                  my_f[os.path.join(ptype, field)][()][scalar_indices[target]]
 
             if self.data_files[i_scalar].filename != filename: my_f.close()
 

--- a/yt/frontends/gadget_fof/io.py
+++ b/yt/frontends/gadget_fof/io.py
@@ -102,10 +102,10 @@ class IOHandlerGadgetFOFHDF5(BaseIOHandler):
                                   np.arange(data_file.total_particles[ptype]) + \
                                   data_file.index_start[ptype]
                             elif field in f[ptype]:
-                                field_data = f[ptype][field].value.astype("float64")
+                                field_data = f[ptype][field][()].astype("float64")
                             else:
                                 fname = field[:field.rfind("_")]
-                                field_data = f[ptype][fname].value.astype("float64")
+                                field_data = f[ptype][fname][()].astype("float64")
                                 my_div = field_data.size / pcount
                                 if my_div > 1:
                                     findex = int(field[field.rfind("_") + 1:])
@@ -238,10 +238,10 @@ class IOHandlerGadgetFOFHaloHDF5(IOHandlerGadgetFOFHDF5):
                           np.arange(dobj.scalar_data_file.total_particles[ptype]) + \
                           dobj.scalar_data_file.index_start[ptype]
                     elif field in f[ptype]:
-                        field_data = f[ptype][field].value.astype("float64")
+                        field_data = f[ptype][field][()].astype("float64")
                     else:
                         fname = field[:field.rfind("_")]
-                        field_data = f[ptype][fname].value.astype("float64")
+                        field_data = f[ptype][fname][()].astype("float64")
                         my_div = field_data.size / pcount
                         if my_div > 1:
                             findex = int(field[field.rfind("_") + 1:])

--- a/yt/frontends/gdf/io.py
+++ b/yt/frontends/gdf/io.py
@@ -49,9 +49,9 @@ class IOHandlerGDFHDF5(BaseIOHandler):
             gds = h5f.get(_grid_dname(grid.id))
             for ftype, fname in fields:
                 if self.ds.field_ordering == 1:
-                    rv[(ftype, fname)] = gds.get(fname).value.swapaxes(0, 2)
+                    rv[(ftype, fname)] = gds.get(fname)[()].swapaxes(0, 2)
                 else:
-                    rv[(ftype, fname)] = gds.get(fname).value
+                    rv[(ftype, fname)] = gds.get(fname)[()]
             h5f.close()
             return rv
         if size is None:

--- a/yt/frontends/halo_catalog/data_structures.py
+++ b/yt/frontends/halo_catalog/data_structures.py
@@ -89,7 +89,7 @@ class HaloCatalogHDF5File(HaloCatalogFile):
         pcount = self.header["num_halos"]
         pos = np.empty((pcount, 3), dtype="float64")
         for i, ax in enumerate('xyz'):
-            pos[:, i] = f["particle_position_%s" % ax].value
+            pos[:, i] = f["particle_position_%s" % ax][()]
 
         if close:
             f.close()

--- a/yt/frontends/open_pmd/data_structures.py
+++ b/yt/frontends/open_pmd/data_structures.py
@@ -328,7 +328,7 @@ class OpenPMDHierarchy(GridIndex):
                 patch = f[bp + pp + "/" + spec[0] + "/particlePatches"]
                 domain_dimension = np.ones(3, dtype=np.int32)
                 for (ind, axis) in enumerate(list(patch["extent"].keys())):
-                    domain_dimension[ind] = patch["extent/" + axis].value[int(spec[1])]
+                    domain_dimension[ind] = patch["extent/" + axis][()][int(spec[1])]
                 num_grids = int(np.ceil(count * self.vpg**-1))
                 gle = []
                 for axis in patch["offset"].keys():
@@ -341,7 +341,7 @@ class OpenPMDHierarchy(GridIndex):
                 gre = np.asarray(gre)
                 gre = np.append(gre, np.ones(3 - len(gre)))
                 np.add(gle, gre, gre)
-                npo = patch["numParticlesOffset"].value.item(int(spec[1]))
+                npo = patch["numParticlesOffset"][()].item(int(spec[1]))
                 particle_count = np.linspace(npo, npo + count, num_grids + 1,
                                              dtype=np.int32)
                 particle_names = [str(spec[0])]

--- a/yt/frontends/owls_subfind/io.py
+++ b/yt/frontends/owls_subfind/io.py
@@ -46,7 +46,7 @@ class IOHandlerOWLSSubfindHDF5(BaseIOHandler):
             with h5py.File(data_file.filename, "r") as f:
                 for ptype, field_list in sorted(ptf.items()):
                     pcount = data_file.total_particles[ptype]
-                    coords = f[ptype]["CenterOfMass"].value.astype("float64")
+                    coords = f[ptype]["CenterOfMass"][()].astype("float64")
                     coords = np.resize(coords, (pcount, 3))
                     x = coords[:, 0]
                     y = coords[:, 1]
@@ -81,7 +81,7 @@ class IOHandlerOWLSSubfindHDF5(BaseIOHandler):
                 for ptype, field_list in sorted(ptf.items()):
                     pcount = data_file.total_particles[ptype]
                     if pcount == 0: continue
-                    coords = f[ptype]["CenterOfMass"].value.astype("float64")
+                    coords = f[ptype]["CenterOfMass"][()].astype("float64")
                     coords = np.resize(coords, (pcount, 3))
                     x = coords[:, 0]
                     y = coords[:, 1]
@@ -99,10 +99,10 @@ class IOHandlerOWLSSubfindHDF5(BaseIOHandler):
                                   np.arange(data_file.total_particles[ptype]) + \
                                   data_file.index_start[ptype]
                             elif field in f[ptype]:
-                                field_data = f[ptype][field].value.astype("float64")
+                                field_data = f[ptype][field][()].astype("float64")
                             else:
                                 fname = field[:field.rfind("_")]
-                                field_data = f[ptype][fname].value.astype("float64")
+                                field_data = f[ptype][fname][()].astype("float64")
                                 my_div = field_data.size / pcount
                                 if my_div > 1:
                                     field_data = np.resize(field_data, (int(pcount), int(my_div)))
@@ -125,7 +125,7 @@ class IOHandlerOWLSSubfindHDF5(BaseIOHandler):
 
             for ptype in data_file.ds.particle_types_raw:
                 if data_file.total_particles[ptype] == 0: continue
-                pos = f[ptype]["CenterOfMass"].value.astype("float64")
+                pos = f[ptype]["CenterOfMass"][()].astype("float64")
                 pos = np.resize(pos, (data_file.total_particles[ptype], 3))
                 pos = data_file.ds.arr(pos, "code_length")
                 

--- a/yt/frontends/ytdata/io.py
+++ b/yt/frontends/ytdata/io.py
@@ -51,7 +51,7 @@ class IOHandlerYTNonspatialhdf5(BaseIOHandler):
                     continue
                 self._misses += 1
                 ftype, fname = field
-                rv[(ftype, fname)] = f[ftype][fname].value
+                rv[(ftype, fname)] = f[ftype][fname][()]
             if self._cache_on:
                 for gid in rv:
                     self._cached_fields.setdefault(gid, {})
@@ -87,7 +87,7 @@ class IOHandlerYTGridHDF5(BaseIOHandler):
                     continue
                 self._misses += 1
                 ftype, fname = field
-                rv[(ftype, fname)] = gds[fname].value
+                rv[(ftype, fname)] = gds[fname][()]
             if self._cache_on:
                 for gid in rv:
                     self._cached_fields.setdefault(gid, {})
@@ -121,7 +121,7 @@ class IOHandlerYTGridHDF5(BaseIOHandler):
                     self._misses += 1
                     ftype, fname = field
                     # add extra dimensions to make data 3D
-                    data = f[ftype][fname].value.astype(self._field_dtype)
+                    data = f[ftype][fname][()].astype(self._field_dtype)
                     for dim in range(len(data.shape), 3):
                         data = np.expand_dims(data, dim)
                     if self._cache_on:
@@ -146,7 +146,7 @@ class IOHandlerYTGridHDF5(BaseIOHandler):
                 for ptype, field_list in sorted(ptf.items()):
                     units = parse_h5_attr(f[ptype][pn % "x"], "units")
                     x, y, z = \
-                      (self.ds.arr(f[ptype][pn % ax].value.astype("float64"), units)
+                      (self.ds.arr(f[ptype][pn % ax][()].astype("float64"), units)
                        for ax in "xyz")
                     for field in field_list:
                         if np.asarray(f[ptype][field]).ndim > 1:
@@ -168,12 +168,12 @@ class IOHandlerYTGridHDF5(BaseIOHandler):
                 for ptype, field_list in sorted(ptf.items()):
                     units = parse_h5_attr(f[ptype][pn % "x"], "units")
                     x, y, z = \
-                      (self.ds.arr(f[ptype][pn % ax].value.astype("float64"), units)
+                      (self.ds.arr(f[ptype][pn % ax][()].astype("float64"), units)
                        for ax in "xyz")
                     mask = selector.select_points(x, y, z, 0.0)
                     if mask is None: continue
                     for field in field_list:
-                        data = np.asarray(f[ptype][field].value, "=f8")
+                        data = np.asarray(f[ptype][field][()], "=f8")
                         yield (ptype, field), data[mask]
             if f: f.close()
 
@@ -235,7 +235,7 @@ class IOHandlerYTDataContainerHDF5(BaseIOHandler):
                 pos = np.empty((all_count[ptype], 3), dtype="float64")
                 units = _get_position_array_units(ptype, f, "x")
                 if ptype == "grid":
-                    dx = f["grid"]["dx"].value.min()
+                    dx = f["grid"]["dx"][()].min()
                     dx = self.ds.quan(
                         dx, parse_h5_attr(f["grid"]["dx"], "units")).to("code_length")
                 else:
@@ -333,7 +333,7 @@ class IOHandlerYTSpatialPlotHDF5(IOHandlerYTDataContainerHDF5):
                 pos = np.empty((all_count[ptype], 3), dtype="float64")
                 pos = self.ds.arr(pos, "code_length")
                 if ptype == "grid":
-                    dx = f["grid"]["pdx"].value.min()
+                    dx = f["grid"]["pdx"][()].min()
                     dx = self.ds.quan(
                         dx, parse_h5_attr(f["grid"]["pdx"], "units")).to("code_length")
                 else:
@@ -365,7 +365,7 @@ def _get_position_array(ptype, f, ax):
         pos_name = ""
     else:
         pos_name = "particle_position_"
-    return f[ptype][pos_name + ax].value.astype("float64")
+    return f[ptype][pos_name + ax][()].astype("float64")
 
 def _get_position_array_units(ptype, f, ax):
     if ptype == "grid":

--- a/yt/frontends/ytdata/utilities.py
+++ b/yt/frontends/ytdata/utilities.py
@@ -181,7 +181,7 @@ def _hdf5_yt_array(fh, field, ds=None):
     if "units" in fh[field].attrs:
         units = fh[field].attrs["units"]
     if units == "dimensionless": units = ""
-    return new_arr(fh[field].value, units)
+    return new_arr(fh[field][()], units)
 
 def _yt_array_hdf5(fh, field, data):
     r"""Save a YTArray to an open hdf5 file or group.


### PR DESCRIPTION
As of h5py 2.9.0, reading a dataset via `dataset.value` has been deprecated in favor of `dataset[()]`. This updates all `.value` calls to get rid of the deprecation warning. This syntax is supported in h5py 2.8.0, which I believe is what we have listed for the minimum h5py version.