### PR TITLE
Added support for multiresolution N-body particles for artio frontend

### DIFF
--- a/yt/frontends/artio/data_structures.py
+++ b/yt/frontends/artio/data_structures.py
@@ -396,9 +396,10 @@ class ARTIODataset(Dataset):
             # A particle union will be created later to hold all N-BODY 
             # particles and will take the name "N-BODY"
             labels = self.artio_parameters["particle_species_labels"]
-            for species, label in enumerate(labels):
-                if label == "N-BODY":
-                    labels[species] = "N-BODY_{}".format(species)
+            if labels.count("N-BODY") > 1:
+                for species, label in enumerate(labels):
+                    if label == "N-BODY":
+                        labels[species] = "N-BODY_{}".format(species)
 
             self.particle_types_raw = \
                 self.artio_parameters["particle_species_labels"]
@@ -466,13 +467,17 @@ class ARTIODataset(Dataset):
 
     def create_field_info(self):
         super(ARTIODataset, self).create_field_info()
-        dm_labels = [label for label in self.particle_types_raw 
-                     if "N-BODY" in label]
-        # Use the N-BODY label for the union to be consistent with the 
-        # previous single mass N-BODY case, where this label was used for all
-        # N-BODY particles by default
-        pu = ParticleUnion("N-BODY", dm_labels)
-        self.add_particle_union(pu)
+        # only make the particle union if there are multiple DM species.
+        # If there are multiple, "N-BODY_0" will be the first species. If there
+        # are not multiple, they will be all under "N-BODY"
+        if "N-BODY_0" in self.particle_types_raw:
+            dm_labels = [label for label in self.particle_types_raw 
+                        if "N-BODY" in label]
+            # Use the N-BODY label for the union to be consistent with the 
+            # previous single mass N-BODY case, where this label was used for 
+            # all N-BODY particles by default
+            pu = ParticleUnion("N-BODY", dm_labels)
+            self.add_particle_union(pu)
 
     @classmethod
     def _is_valid(self, *args, **kwargs):


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

[Fixes issue 2137](https://github.com/yt-project/yt/issues/2137)

ARTIO datasets with multiple N-body species were not working correctly. This update allows the individual species to be accessed individually, but also creates a particle union to access all N-body species at once. 

I have not added tests for this, as this problems does not happen with the currently available ARTIO datasets. 

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
