### PR TITLE
ensure the global namespace in the plugins file is preserved

### DIFF
--- a/yt/fields/tests/test_fields_plugins.py
+++ b/yt/fields/tests/test_fields_plugins.py
@@ -20,9 +20,10 @@ def _myfunc(field, data):
     return np.random.random(data['density'].shape)
 add_field('random', dimensions='dimensionless',
           function=_myfunc, units='auto', sampling_type='cell')
+constant = 3
 def myfunc():
-    return 4
-foobar = 12
+    return constant*4
+foobar = 17
 '''
 
 class TestPluginFile(unittest.TestCase):
@@ -73,5 +74,5 @@ class TestPluginFile(unittest.TestCase):
         dd = ds.all_data()
         self.assertEqual(str(dd['random'].units), 'dimensionless')
         self.assertEqual(dd['random'].shape, dd['density'].shape)
-        assert yt.myfunc() == 4
+        assert yt.myfunc() == 12
         assert_raises(AttributeError, getattr, yt, 'foobar')

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -997,15 +997,14 @@ def enable_plugins():
         ytdict = yt.__dict__
         execdict = ytdict.copy()
         execdict['add_field'] = my_plugins_fields.add_field
-        localdict = {}
         with open(_fn) as f:
             code = compile(f.read(), _fn, 'exec')
-            exec(code, execdict, localdict)
+            exec(code, execdict, execdict)
         ytnamespace = list(ytdict.keys())
-        for k in localdict.keys():
+        for k in execdict.keys():
             if k not in ytnamespace:
-                if callable(localdict[k]):
-                    setattr(yt, k, localdict[k])
+                if callable(execdict[k]):
+                    setattr(yt, k, execdict[k])
 
 def fix_unitary(u):
     if u == '1':


### PR DESCRIPTION
This fixes an issue that @drenniks reported today on slack.

Without this fix, the test I modified fails with the following traceback:

```
======================================================================
ERROR: testCustomField (yt.fields.tests.test_fields_plugins.TestPluginFile)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/goldbaum/Documents/yt-git-fixes/yt/fields/tests/test_fields_plugins.py", line 77, in testCustomField
    assert yt.myfunc() == 12
  File "/Users/goldbaum/.config/yt/my_plugins.py", line 8, in myfunc
    return constant*4
NameError: name 'constant' is not defined
```

The problem is that, as noted in the exec documentation:

> If exec gets two separate objects as globals and locals, the code will be executed as if it were embedded in a class definition.

So the global variables defined in the function will not be accessible in the scope of the function. See https://stackoverflow.com/questions/29979313/python-weird-nameerror-name-is-not-defined-in-an-exec-environment for more details.

The fix is to pass the same object as `locals` and `globals` to `exec`.

@drenniks, a workaround for your issue would be to either run the development version of yt with this patch applied until we do a bugfix release or you could rewrite the fields in your plugins file to not make use of variables in the global scope or use the `global` keyword to tell python to insert the variables you need into the local scope. Something like:

```
def _J21_LW(field, data):
    global J21_norm, E_LW, sigma_H2I, nu_H
    return J21_norm * data['enzo', 'H2I_kdiss'] * E_LW / (4.0 * pi*pi * sigma_H2I * nu_H)
```

Thanks again for the detailed report, it made it really easy to see what was going wrong.