### PR TITLE
Gadget read

### DIFF
--- a/yt/convenience.py
+++ b/yt/convenience.py
@@ -50,11 +50,6 @@ def load(*args ,**kwargs):
                 if os.path.exists(os.path.join(ytcfg.get("yt", "test_data_dir"), arg)):
                     valid_file.append(True)
                     args[argno] = os.path.join(ytcfg.get("yt", "test_data_dir"), arg)
-                # Check for multi-file gadget snapshot that's been passed without the
-                # '.0' extension
-                elif os.path.exists(arg + '.0'):
-                    args[argno] = arg + '.0'
-                    valid_file.append(True)
                 else:
                     valid_file.append(False)
         else:
@@ -79,6 +74,7 @@ def load(*args ,**kwargs):
             mylog.error("None of the arguments provided to load() is a valid file")
             mylog.error("Please check that you have used a correct path")
             raise YTOutputNotIdentified(args, kwargs)
+    import pdb; pdb.set_trace()
     for n, c in types_to_check.items():
         if n is None: continue
         if c._is_valid(*args, **kwargs): candidates.append(n)

--- a/yt/convenience.py
+++ b/yt/convenience.py
@@ -74,7 +74,6 @@ def load(*args ,**kwargs):
             mylog.error("None of the arguments provided to load() is a valid file")
             mylog.error("Please check that you have used a correct path")
             raise YTOutputNotIdentified(args, kwargs)
-    import pdb; pdb.set_trace()
     for n, c in types_to_check.items():
         if n is None: continue
         if c._is_valid(*args, **kwargs): candidates.append(n)

--- a/yt/convenience.py
+++ b/yt/convenience.py
@@ -36,6 +36,7 @@ def load(*args ,**kwargs):
     match, at which point it returns an instance of the appropriate
     :class:`yt.data_objects.static_output.Dataset` subclass.
     """
+    import pdb; pdb.set_trace()
     candidates = []
     args = [os.path.expanduser(arg) if isinstance(arg, string_types)
             else arg for arg in args]
@@ -50,6 +51,11 @@ def load(*args ,**kwargs):
                 if os.path.exists(os.path.join(ytcfg.get("yt", "test_data_dir"), arg)):
                     valid_file.append(True)
                     args[argno] = os.path.join(ytcfg.get("yt", "test_data_dir"), arg)
+                # Check for multi-file gadget snapshot that's been passed without the
+                # '.0' extension
+                elif os.path.exists(arg + '.0'):
+                    args[argno] = arg + '.0'
+                    valid_file.append(True)
                 else:
                     valid_file.append(False)
         else:

--- a/yt/convenience.py
+++ b/yt/convenience.py
@@ -36,7 +36,6 @@ def load(*args ,**kwargs):
     match, at which point it returns an instance of the appropriate
     :class:`yt.data_objects.static_output.Dataset` subclass.
     """
-    import pdb; pdb.set_trace()
     candidates = []
     args = [os.path.expanduser(arg) if isinstance(arg, string_types)
             else arg for arg in args]

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -246,6 +246,8 @@ class GadgetDataset(SPHDataset):
                  w_a = 0.0):
         if self._instantiated:
             return
+        # Check to see if passed filename is a directory and set filename accordingly
+        filename = self._set_filename(filename)
         self._header = GadgetBinaryHeader(filename, header_spec)
         header_size = self._header.size
         if header_size != [256]:
@@ -498,8 +500,23 @@ class GadgetDataset(SPHDataset):
             header_spec = kwargs['header_spec']
         else:
             header_spec = 'default'
+        # Check to see if passed filename is a directory. If so, use it to get
+        # appropriate snapshot file
+        args[0] = cls._set_filename(args[0])
         header = GadgetBinaryHeader(args[0], header_spec)
         return header.validate()
+
+    @classmethod
+    def _set_filename(cls, fname):
+        # Check to see if passed filename is a directory. If so, look for valid
+        # snapshot files in that directory. Assumes directory name is base name of
+        # snapshot
+        if os.path.isdir(fname):
+            pass
+        else:
+            filename = fname
+        return filename
+            
 
 
 class GadgetHDF5Dataset(GadgetDataset):

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -516,9 +516,9 @@ class GadgetDataset(SPHDataset):
                 if ('.0' in f) and ('.ewah' not in f) and os.path.isfile(fname):
                     valid_files.append(f)
             if len(valid_files) == 0:
-                raise('No valid snapshot file found in given directory!')
+                return False
             elif len(valid_files) > 1:
-                raise('Multiple valid snapshots found. Please specify.')
+                return False
             else:
                 validated_file = os.path.join(args[0], valid_files[0])
         else:

--- a/yt/frontends/gadget/tests/test_outputs.py
+++ b/yt/frontends/gadget/tests/test_outputs.py
@@ -32,6 +32,8 @@ isothermal_bin = "IsothermalCollapse/snap_505"
 BE_Gadget = "BigEndianGadgetBinary/BigEndianGadgetBinary"
 LE_SnapFormat2 = "Gadget3-snap-format2/Gadget3-snap-format2"
 keplerian_ring = "KeplerianRing/keplerian_ring_0020.hdf5"
+snap_33 = "snapshot_033/snap_033.0.hdf5"
+snap_33_dir = "snapshot_033/"
 
 # This maps from field names to weight field names to use for projections
 iso_fields = OrderedDict(
@@ -98,3 +100,13 @@ def test_pid_uniqueness():
     ad = ds.all_data()
     pid = ad['ParticleIDs']
     assert len(pid) == len(set(pid.v))
+
+@requires_file(snap_33)
+@requires_file(snap_33_dir)
+def test_multifile_read():
+    """
+    Tests to make sure multi-file gadget snapshot can be loaded by passing '.0' file
+    or by passing the directory containing the multi-file snapshot.
+    """
+    assert isinstance(data_dir_load(snap_33), GadgetDataset)
+    assert isinstance(data_dir_load(snap_33_dir), GadgetDataset)

--- a/yt/frontends/gizmo/data_structures.py
+++ b/yt/frontends/gizmo/data_structures.py
@@ -14,6 +14,8 @@ Data structures for Gizmo frontend.
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
+import os
+
 from yt.utilities.on_demand_imports import _h5py as h5py
 
 from yt.frontends.gadget.data_structures import \
@@ -30,8 +32,22 @@ class GizmoDataset(GadgetHDF5Dataset):
         need_groups = ['Header']
         veto_groups = ['FOF', 'Group', 'Subhalo']
         valid = True
+        valid_fname = args[0]
+        # If passed arg is a directory, look for the .0 file in that dir
+        if os.path.isdir(args[0]):
+            valid_files = []
+            for f in os.listdir(args[0]):
+                fname = os.path.join(args[0], f)
+                if ('.0' in f) and ('.ewah' not in f) and os.path.isfile(fname):
+                    valid_files.append(fname)
+            if len(valid_files) == 0:
+                valid = False
+            elif len(valid_files) > 1:
+                valid = False
+            else:
+                valid_fname = valid_files[0]
         try:
-            fh = h5py.File(args[0], mode='r')
+            fh = h5py.File(valid_fname, mode='r')
             valid = all(ng in fh["/"] for ng in need_groups) and \
               not any(vg in fh["/"] for vg in veto_groups)
             dmetal = "/PartType0/Metallicity"

--- a/yt/frontends/owls/data_structures.py
+++ b/yt/frontends/owls/data_structures.py
@@ -15,6 +15,8 @@ from __future__ import print_function
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
+import os
+
 from yt.utilities.on_demand_imports import _h5py as h5py
 
 import yt.units
@@ -58,8 +60,22 @@ class OWLSDataset(GadgetHDF5Dataset):
                        'PartType0/ChemicalAbundances',
                        'RuntimePars', 'HashTable']
         valid = True
+        valid_fname = args[0]
+        # If passed arg is a directory, look for the .0 file in that dir
+        if os.path.isdir(args[0]):
+            valid_files = []
+            for f in os.listdir(args[0]):
+                fname = os.path.join(args[0], f)
+                if ('.0' in f) and ('.ewah' not in f) and os.path.isfile(fname):
+                    valid_files.append(fname)
+            if len(valid_files) == 0:
+                valid = False
+            elif len(valid_files) > 1:
+                valid = False
+            else:
+                valid_fname = valid_files[0]
         try:
-            fileh = h5py.File(args[0], mode='r')
+            fileh = h5py.File(valid_fname, mode='r')
             for ng in need_groups:
                 if ng not in fileh["/"]:
                     valid = False


### PR DESCRIPTION
## PR Summary

Currently, for a multi-file Gadget snapshot, yt requires that the first file be passed, e.g. snapshot_000.0, to yt.load(). This is a straightforward fix for that. It allows multi-file snapshots to be passed by the base name of the snapshot. The only thing I'm not sure of is how other data formats handle multi-file outputs, so it might be better to delegate this to a separate function that can have a different case for each code, rather than simply putting it directly in load().

## PR Checklist

- [ x] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
