### PR TITLE
Adding dynamic parallelism to DatasetSeries piter

### DIFF
--- a/doc/source/analyzing/parallel_computation.rst
+++ b/doc/source/analyzing/parallel_computation.rst
@@ -270,6 +270,16 @@ and you can access the contents:
 
     print(my_dictionary)
 
+By default, the dataset series will be divided as equally as possible
+among the cores.  Often some datasets will require more work than
+others.  We offer the ``dynamic`` keyword in the
+:func:`~yt.data_objects.time_series.DatasetSeries.piter` function to
+enable dynamic load balancing with a task queue.  Dynamic load
+balancing works best with more cores and a variable workload.  Here
+one process will act as a server to assign the next available dataset
+to any free client.  For example, a 16 core job will have 15 cores
+analyzing the data with 1 core acting as the task manager.
+
 .. _parallelizing-your-analysis:
 
 Parallelizing over Multiple Objects

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -237,6 +237,13 @@ class DatasetSeries(object):
             course of the iteration.  The keys will be the dataset
             indices and the values will be whatever is assigned to the *result*
             attribute on the storage during iteration.
+        dynamic : boolean
+            This governs whether or not dynamic load balancing will be
+            enabled.  This requires one dedicated processor; if this
+            is enabled with a set of 128 processors available, only
+            127 will be available to iterate over objects as one will
+            be load balancing the rest.
+
 
         Examples
         --------


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

The DatasetSeries piter() did not have the dynamic option. I've added it in this PR.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
