### PR TITLE
Fixing enzo-p frontend bugs.

### DIFF
--- a/yt/frontends/enzo_p/io.py
+++ b/yt/frontends/enzo_p/io.py
@@ -162,7 +162,7 @@ class EnzoPIOHandler(BaseIOHandler):
         ftype, fname = field
         node = "/%s/field%s%s" % (obj.block_name, self._sep, fname)
         dg = h5py.h5d.open(fid, b(node))
-        rdata = np.empty(self.ds.grid_dimensions[self.ds.dimensionality::-1],
+        rdata = np.empty(self.ds.grid_dimensions[:self.ds.dimensionality][::-1],
                          dtype=self._field_dtype)
         dg.read(h5py.h5s.ALL, h5py.h5s.ALL, rdata)
         if close:

--- a/yt/frontends/enzo_p/io.py
+++ b/yt/frontends/enzo_p/io.py
@@ -162,7 +162,7 @@ class EnzoPIOHandler(BaseIOHandler):
         ftype, fname = field
         node = "/%s/field%s%s" % (obj.block_name, self._sep, fname)
         dg = h5py.h5d.open(fid, b(node))
-        rdata = np.empty(self.ds.grid_dimensions[:self.ds.dimensionality],
+        rdata = np.empty(self.ds.grid_dimensions[self.ds.dimensionality::-1],
                          dtype=self._field_dtype)
         dg.read(h5py.h5s.ALL, h5py.h5s.ALL, rdata)
         if close:

--- a/yt/frontends/enzo_p/misc.py
+++ b/yt/frontends/enzo_p/misc.py
@@ -57,6 +57,7 @@ def get_block_info(block, min_dim=3):
     left = np.zeros(dim)
     right = np.ones(dim)
     for i, myb in enumerate(mybs):
+        if myb == '': continue
         level, left[i], right[i] = bdecode(myb)
     return level, left, right
 
@@ -65,6 +66,7 @@ def get_root_blocks(block, min_dim=3):
         block, min_dim=min_dim)
     nb = np.ones(dim, dtype=int)
     for i, myb in enumerate(mybs):
+        if myb == '': continue
         s = get_block_level(myb)
         nb[i] = 2**s
     return nb
@@ -74,6 +76,7 @@ def get_root_block_id(block, min_dim=3):
         block, min_dim=min_dim)
     rbid = np.zeros(dim, dtype=int)
     for i, myb in enumerate(mybs):
+        if myb == '': continue
         s = get_block_level(myb)
         rbid[i] = int(myb[:s], 2)
     return rbid


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

This PR fixes the following bugs. It showed up when I read a dataset with 2x2x1 root blocks.

1. Blocks were being read in the incorrect row/column ordering, which wasn't noticeable with cubic blocks.

2. Handle root block splitting with one block in a dimension

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
