### PR TITLE
make FortranFile open files in binary mode. closes #2147

### DIFF
--- a/yt/utilities/cython_fortran_utils.pyx
+++ b/yt/utilities/cython_fortran_utils.pyx
@@ -25,7 +25,7 @@ cdef class FortranFile:
     the docstrings.
     """
     def __cinit__(self, str fname):
-        self.cfile = fopen(fname.encode('utf-8'), 'r')
+        self.cfile = fopen(fname.encode('utf-8'), 'rb')
         self._closed = False
 
     def __enter__(self):


### PR DESCRIPTION
According to https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/fopen-wfopen?view=vs-2017, on windows, fopen will do locale-specific translations if you open the file in "r" mode. If you open it in "rb" mode this will not happen, which is the behavior we want.

I tested this on a windows box and am now able to load the file linked in the issue. We don't appear to have tests for `FortranFile` so it's not clear to me how to add a test for this.