### PR TITLE
[bugfix] fix particle index initialization in gadget_fof frontend

### DIFF
--- a/yt/frontends/ahf/io.py
+++ b/yt/frontends/ahf/io.py
@@ -57,6 +57,7 @@ class IOHandlerAHFHalos(BaseIOHandler):
         # Selector objects have a .select_points(x,y,z) that returns a mask, so
         # you need to do your masking here.
         for data_file in self._get_data_files(chunks, ptf):
+            si, ei = data_file.start, data_file.end
             cols = []
             for field_list in ptf.values():
                 cols.extend(field_list)
@@ -70,7 +71,7 @@ class IOHandlerAHFHalos(BaseIOHandler):
             if mask is None: continue
             for ptype, field_list in sorted(ptf.items()):
                 for field in field_list:
-                    data = halos[field][mask].astype('float64')
+                    data = halos[field][si:ei][mask].astype('float64')
                     yield (ptype, field), data
 
     def _initialize_index(self, data_file, regions):

--- a/yt/frontends/gadget_fof/data_structures.py
+++ b/yt/frontends/gadget_fof/data_structures.py
@@ -44,15 +44,6 @@ from yt.utilities.logger import ytLogger as \
     mylog
 
 class GadgetFOFParticleIndex(ParticleIndex):
-    def __init__(self, ds, dataset_type):
-        self.dataset_type = dataset_type
-        self.dataset = weakref.proxy(ds)
-        self.float_type = np.float64
-        self._setup_data_io()
-        self._setup_filenames()
-        super(ParticleIndex, self).__init__(ds, dataset_type)
-        self._initialize_index()
-
     def _calculate_particle_count(self):
         """
         Calculate the total number of each type of particle.
@@ -116,8 +107,9 @@ class GadgetFOFParticleIndex(ParticleIndex):
         ds.field_units.update(units)
         ds.particle_types_raw = ds.particle_types
 
-    def _setup_geometry(self):
-        super(GadgetFOFParticleIndex, self)._setup_geometry()
+    def _setup_data_io(self):
+        super(GadgetFOFParticleIndex, self)._setup_data_io()
+        self._setup_filenames()
         self._calculate_particle_count()
         self._calculate_particle_index_starts()
         self._calculate_file_offset_map()

--- a/yt/frontends/gadget_fof/io.py
+++ b/yt/frontends/gadget_fof/io.py
@@ -161,7 +161,14 @@ class IOHandlerGadgetFOFHDF5(BaseIOHandler):
         return morton
 
     def _count_particles(self, data_file):
-        return data_file.total_particles
+        si, ei = data_file.start, data_file.end
+        pcount = \
+          {"Group": data_file.header["Ngroups_ThisFile"],
+           "Subhalo": data_file.header["Nsubgroups_ThisFile"]}
+        if None not in (si, ei):
+            for ptype in pcount:
+                pcount[ptype] = np.clip(pcount[ptype]-si, 0, ei-si)
+        return pcount
 
     def _identify_fields(self, data_file):
         fields = []

--- a/yt/frontends/gadget_fof/io.py
+++ b/yt/frontends/gadget_fof/io.py
@@ -89,6 +89,7 @@ class IOHandlerGadgetFOFHDF5(BaseIOHandler):
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
         for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+            si, ei = data_file.start, data_file.end
             with h5py.File(data_file.filename, "r") as f:
                 for ptype, field_list in sorted(ptf.items()):
                     pcount = data_file.total_particles[ptype]
@@ -120,7 +121,7 @@ class IOHandlerGadgetFOFHDF5(BaseIOHandler):
                                 if my_div > 1:
                                     findex = int(field[field.rfind("_") + 1:])
                                     field_data = field_data[:, findex]
-                        data = field_data[mask]
+                        data = field_data[si:ei][mask]
                         yield (ptype, field), data
 
     def _initialize_index(self, data_file, regions):

--- a/yt/frontends/halo_catalog/data_structures.py
+++ b/yt/frontends/halo_catalog/data_structures.py
@@ -61,6 +61,10 @@ class HaloCatalogFile(ParticleFile):
         dle = self.ds.domain_left_edge.to('code_length').v
         dw = self.ds.domain_width.to('code_length').v
         pos = self._read_particle_positions(ptype, f=f)
+        si, ei = self.start, self.end
+        if None not in (si, ei):
+            pos = pos[si:ei]
+
         np.subtract(pos, dle, out=pos)
         np.mod(pos, dw, out=pos)
         np.add(pos, dle, out=pos)

--- a/yt/frontends/halo_catalog/io.py
+++ b/yt/frontends/halo_catalog/io.py
@@ -76,6 +76,7 @@ class IOHandlerHaloCatalogHDF5(BaseIOHandler):
                 data_files.update(obj.data_files)
         pn = "particle_position_%s"
         for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+            si, ei = data_file.start, data_file.end
             with h5py.File(data_file.filename, "r") as f:
                 for ptype, field_list in sorted(ptf.items()):
                     units = parse_h5_attr(f[pn % "x"], "units")
@@ -86,7 +87,7 @@ class IOHandlerHaloCatalogHDF5(BaseIOHandler):
                     del x, y, z
                     if mask is None: continue
                     for field in field_list:
-                        data = f[field][mask].astype("float64")
+                        data = f[field][si:ei][mask].astype("float64")
                         yield (ptype, field), data
 
     def _initialize_index(self, data_file, regions):

--- a/yt/frontends/rockstar/io.py
+++ b/yt/frontends/rockstar/io.py
@@ -68,6 +68,7 @@ class IOHandlerRockstarBinary(BaseIOHandler):
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
         for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+            si, ei = data_file.start, data_file.end
             pcount = data_file.header['num_halos']
             if pcount == 0:
                 continue
@@ -81,7 +82,7 @@ class IOHandlerRockstarBinary(BaseIOHandler):
                     halos = np.fromfile(f, dtype=self._halo_dt, count = pcount)
                     if mask is None: continue
                     for field in field_list:
-                        data = halos[field][mask].astype("float64")
+                        data = halos[field][si:ei][mask].astype("float64")
                         yield (ptype, field), data
 
     def _yield_coordinates(self, data_file):


### PR DESCRIPTION
## PR Summary

The `gadget_fof` frontend was giving the following error when loading data:
```
Traceback (most recent call last):
  File "test.py", line 4, in <module>
    ds.field_list
  File "/Users/britton/Documents/work/yt/yt-4.0/yt/data_objects/static_output.py", line 556, in field_list
    return self.index.field_list
  File "/Users/britton/Documents/work/yt/yt-4.0/yt/data_objects/static_output.py", line 514, in index
    self, dataset_type=self.dataset_type)
  File "/Users/britton/Documents/work/yt/yt-4.0/yt/frontends/gadget_fof/data_structures.py", line 48, in __init__
    super(GadgetFOFParticleIndex, self).__init__(ds, dataset_type)
  File "/Users/britton/Documents/work/yt/yt-4.0/yt/geometry/particle_geometry_handler.py", line 42, in __init__
    super(ParticleIndex, self).__init__(ds, dataset_type)
  File "/Users/britton/Documents/work/yt/yt-4.0/yt/geometry/geometry_handler.py", line 49, in __init__
    self._setup_geometry()
  File "/Users/britton/Documents/work/yt/yt-4.0/yt/frontends/gadget_fof/data_structures.py", line 115, in _setup_geometry
    self._calculate_particle_count()
  File "/Users/britton/Documents/work/yt/yt-4.0/yt/frontends/gadget_fof/data_structures.py", line 56, in _calculate_particle_count
    for ptype in self.ds.particle_types_raw])
  File "/Users/britton/Documents/work/yt/yt-4.0/yt/frontends/gadget_fof/data_structures.py", line 56, in <listcomp>
    for ptype in self.ds.particle_types_raw])
AttributeError: 'GadgetFOFParticleIndex' object has no attribute 'data_files'
```

The order of initialization in `ParticleIndex` wasn't quite compatible with the frontend. Additionally, it looks like some io chunking was implemented and so this adds support for that as well.