### PR TITLE
Phase plot showhide colorbar

### DIFF
--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -1320,7 +1320,10 @@ Customizing Phase Plots
 Similarly to 1D profile plots, :class:`~yt.visualization.profile_plotter.PhasePlot`
 can be customized via ``set_unit``,
 ``set_xlim``, ``set_ylim``, and ``set_zlim``.  The following example illustrates
-how to manipulate these functions.
+how to manipulate these functions. :class:`~yt.visualization.profile_plotter.PhasePlot`
+can also be customized in a similar manner as 
+:class:`~yt.visualization.plot_window.SlicePlot`, such as with ``hide_colorbar``
+and ``show_colorbar``.
 
 .. python-script::
 

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -713,6 +713,78 @@ class PlotContainer(object):
             self.plots[f].show_colorbar()
         return self
 
+    def hide_axes(self, field=None, draw_frame=False):
+        """
+        Hides the axes for a plot and updates the size of the
+        plot accordingly.  Defaults to operating on all fields for a
+        PlotContainer object.
+
+        Parameters
+        ----------
+
+        field : string, field tuple, or list of strings or field tuples (optional)
+            The name of the field(s) that we want to hide the axes.
+
+        draw_frame : boolean
+            If True, the axes frame will still be drawn. Defaults to False.
+            See note below for more details.
+
+        Examples
+        --------
+
+        This will save an image with no axes.
+
+        >>> import yt
+        >>> ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
+        >>> s = SlicePlot(ds, 2, 'density', 'c', (20, 'kpc'))
+        >>> s.hide_axes()
+        >>> s.save()
+
+        This will save an image with no axis or colorbar.
+
+        >>> import yt
+        >>> ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
+        >>> s = SlicePlot(ds, 2, 'density', 'c', (20, 'kpc'))
+        >>> s.hide_axes()
+        >>> s.hide_colorbar()
+        >>> s.save()
+
+        Note
+        ----
+        By default, when removing the axes, the patch on which the axes are
+        drawn is disabled, making it impossible to later change e.g. the
+        background colour. To force the axes patch to be displayed while still
+        hiding the axes, set the ``draw_frame`` keyword argument to ``True``.
+        """
+        if field is None:
+            field = self.fields
+        field = ensure_list(field)
+        for f in field:
+            self.plots[f].hide_axes(draw_frame)
+        return self
+
+
+    def show_axes(self, field=None):
+        """
+        Shows the axes for a plot and updates the size of the
+        plot accordingly.  Defaults to operating on all fields for a
+        PlotContainer object.  See hide_axes().
+
+        Parameters
+        ----------
+
+        field : string, field tuple, or list of strings or field tuples (optional)
+            The name of the field(s) that we want to show the axes.
+        """
+        if field is None:
+            field = self.fields
+        field = ensure_list(field)
+        for f in field:
+            self.plots[f].show_axes()
+        return self
+
+
+
 class ImagePlotContainer(PlotContainer):
     """A container for plots with colorbars.
 

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -651,6 +651,67 @@ class PlotContainer(object):
                 axes_unit_labels[i] = '\ \ ('+un+')'
         return axes_unit_labels
 
+    
+    def hide_colorbar(self, field=None):
+        """
+        Hides the colorbar for a plot and updates the size of the
+        plot accordingly.  Defaults to operating on all fields for a
+        PlotContainer object.
+
+        Parameters
+        ----------
+
+        field : string, field tuple, or list of strings or field tuples (optional)
+            The name of the field(s) that we want to hide the colorbar. If None
+            is provided, will default to using all fields available for this
+            object.
+
+        Examples
+        --------
+
+        This will save an image with no colorbar.
+
+        >>> import yt
+        >>> ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
+        >>> s = SlicePlot(ds, 2, 'density', 'c', (20, 'kpc'))
+        >>> s.hide_colorbar()
+        >>> s.save()
+
+        This will save an image with no axis or colorbar.
+
+        >>> import yt
+        >>> ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
+        >>> s = SlicePlot(ds, 2, 'density', 'c', (20, 'kpc'))
+        >>> s.hide_axes()
+        >>> s.hide_colorbar()
+        >>> s.save()
+        """
+        if field is None:
+            field = self.fields
+        field = ensure_list(field)
+        for f in field:
+            self.plots[f].hide_colorbar()
+        return self
+
+
+    def show_colorbar(self, field=None):
+        """
+        Shows the colorbar for a plot and updates the size of the
+        plot accordingly.  Defaults to operating on all fields for a
+        PlotContainer object.  See hide_colorbar().
+
+        Parameters
+        ----------
+
+        field : string, field tuple, or list of strings or field tuples (optional)
+        The name of the field(s) that we want to show the colorbar.
+        """
+        if field is None:
+            field = self.fields
+        field = ensure_list(field)
+        for f in field:
+            self.plots[f].show_colorbar()
+        return self
 
 class ImagePlotContainer(PlotContainer):
     """A container for plots with colorbars.

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1129,74 +1129,7 @@ class PWViewerMPL(PlotWindow):
                 if key not in keys:
                     del self.frb[key]
 
-    def hide_axes(self, field=None, draw_frame=False):
-        """
-        Hides the axes for a plot and updates the size of the
-        plot accordingly.  Defaults to operating on all fields for a
-        PlotWindow object.
 
-        Parameters
-        ----------
-
-        field : string, field tuple, or list of strings or field tuples (optional)
-            The name of the field(s) that we want to hide the axes.
-
-        draw_frame : boolean
-            If True, the axes frame will still be drawn. Defaults to False.
-            See note below for more details.
-
-        Examples
-        --------
-
-        This will save an image with no axes.
-
-        >>> import yt
-        >>> ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
-        >>> s = SlicePlot(ds, 2, 'density', 'c', (20, 'kpc'))
-        >>> s.hide_axes()
-        >>> s.save()
-
-        This will save an image with no axis or colorbar.
-
-        >>> import yt
-        >>> ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
-        >>> s = SlicePlot(ds, 2, 'density', 'c', (20, 'kpc'))
-        >>> s.hide_axes()
-        >>> s.hide_colorbar()
-        >>> s.save()
-
-        Note
-        ----
-        By default, when removing the axes, the patch on which the axes are
-        drawn is disabled, making it impossible to later change e.g. the
-        background colour. To force the axes patch to be displayed while still
-        hiding the axes, set the ``draw_frame`` keyword argument to ``True``.
-        """
-        if field is None:
-            field = self.fields
-        field = ensure_list(field)
-        for f in field:
-            self.plots[f].hide_axes(draw_frame)
-        return self
-
-    def show_axes(self, field=None):
-        """
-        Shows the axes for a plot and updates the size of the
-        plot accordingly.  Defaults to operating on all fields for a
-        PlotWindow object.  See hide_axes().
-
-        Parameters
-        ----------
-
-        field : string, field tuple, or list of strings or field tuples (optional)
-            The name of the field(s) that we want to show the axes.
-        """
-        if field is None:
-            field = self.fields
-        field = ensure_list(field)
-        for f in field:
-            self.plots[f].show_axes()
-        return self
 
 class AxisAlignedSlicePlot(PWViewerMPL):
     r"""Creates a slice plot from a dataset

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1129,66 +1129,6 @@ class PWViewerMPL(PlotWindow):
                 if key not in keys:
                     del self.frb[key]
 
-    def hide_colorbar(self, field=None):
-        """
-        Hides the colorbar for a plot and updates the size of the
-        plot accordingly.  Defaults to operating on all fields for a
-        PlotWindow object.
-
-        Parameters
-        ----------
-
-        field : string, field tuple, or list of strings or field tuples (optional)
-            The name of the field(s) that we want to hide the colorbar. If None
-            is provided, will default to using all fields available for this
-            object.
-
-        Examples
-        --------
-
-        This will save an image with no colorbar.
-
-        >>> import yt
-        >>> ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
-        >>> s = SlicePlot(ds, 2, 'density', 'c', (20, 'kpc'))
-        >>> s.hide_colorbar()
-        >>> s.save()
-
-        This will save an image with no axis or colorbar.
-
-        >>> import yt
-        >>> ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
-        >>> s = SlicePlot(ds, 2, 'density', 'c', (20, 'kpc'))
-        >>> s.hide_axes()
-        >>> s.hide_colorbar()
-        >>> s.save()
-        """
-        if field is None:
-            field = self.fields
-        field = ensure_list(field)
-        for f in field:
-            self.plots[f].hide_colorbar()
-        return self
-
-    def show_colorbar(self, field=None):
-        """
-        Shows the colorbar for a plot and updates the size of the
-        plot accordingly.  Defaults to operating on all fields for a
-        PlotWindow object.  See hide_colorbar().
-
-        Parameters
-        ----------
-
-        field : string, field tuple, or list of strings or field tuples (optional)
-            The name of the field(s) that we want to show the colorbar.
-        """
-        if field is None:
-            field = self.fields
-        field = ensure_list(field)
-        for f in field:
-            self.plots[f].show_colorbar()
-        return self
-
     def hide_axes(self, field=None, draw_frame=False):
         """
         Hides the axes for a plot and updates the size of the

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -1019,6 +1019,10 @@ class PhasePlot(ImagePlotContainer):
             self._recreate_profile()
         return self._profile
 
+    @property
+    def fields(self):
+        return list(self.plots.keys())
+
     def _setup_plots(self):
         if self._plot_valid:
             return

--- a/yt/visualization/tests/test_profile_plots.py
+++ b/yt/visualization/tests/test_profile_plots.py
@@ -262,3 +262,29 @@ def test_phaseplot_set_log():
     p2.set_log(ds.fields.gas.temperature, False)
     assert p1.y_log["gas", "density"] is False
     assert p2.y_log is False
+
+
+
+def test_phaseplot_showhide_colorbar():
+    fields = ('density', 'temperature')
+    units = ('g/cm**3', 'K',)
+    ds = fake_random_ds(16, fields=fields, units=units)
+    ad = ds.all_data()
+    plot = yt.PhasePlot(ad, ("gas", "density"), ("gas", "temperature"), "cell_mass")
+
+    # make sure we can hide colorbar
+    plot.hide_colorbar()
+
+    with tempfile.NamedTemporaryFile(suffix='png') as f1:
+        plot.save(f1.name)
+
+    # make sure we can show colorbar
+    plot.show_colorbar()
+
+    with tempfile.NamedTemporaryFile(suffix='png') as f2:
+        plot.save(f2.name)
+
+
+
+
+

--- a/yt/visualization/tests/test_profile_plots.py
+++ b/yt/visualization/tests/test_profile_plots.py
@@ -265,7 +265,7 @@ def test_phaseplot_set_log():
 
 
 
-def test_phaseplot_showhide_colorbar():
+def test_phaseplot_showhide_colorbar_axes():
     fields = ('density', 'temperature')
     units = ('g/cm**3', 'K',)
     ds = fake_random_ds(16, fields=fields, units=units)
@@ -274,16 +274,23 @@ def test_phaseplot_showhide_colorbar():
 
     # make sure we can hide colorbar
     plot.hide_colorbar()
-
     with tempfile.NamedTemporaryFile(suffix='png') as f1:
         plot.save(f1.name)
 
     # make sure we can show colorbar
     plot.show_colorbar()
-
     with tempfile.NamedTemporaryFile(suffix='png') as f2:
         plot.save(f2.name)
 
+    # make sure we can hide axes
+    plot.hide_axes()
+    with tempfile.NamedTemporaryFile(suffix='png') as f3:
+        plot.save(f3.name)
+
+    # make sure we can show axes
+    plot.show_axes()
+    with tempfile.NamedTemporaryFile(suffix='png') as f4:
+        plot.save(f4.name)
 
 
 


### PR DESCRIPTION
Moved show/hide_colorbar and show/hide_axes from PlotWindow to PlotContainer. Added property function in profile_plotter.py so that PlotWindow implementation of these functions works with ProfilePlot.

Added note in yt document that PhasePlot has similar attributes, such as show and hide colorbar, as SlicePlot.

Resolves #1736 

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->

