### PR TITLE
[bugfix] Set max value in contour finder to be max value in clump finder.

### DIFF
--- a/yt/data_objects/level_sets/clump_handling.py
+++ b/yt/data_objects/level_sets/clump_handling.py
@@ -408,8 +408,9 @@ class Clump(TreeContainer):
 def find_clumps(clump, min_val, max_val, d_clump):
     mylog.info("Finding clumps: min: %e, max: %e, step: %f" % 
                (min_val, max_val, d_clump))
-    if min_val >= max_val: return
-    clump.find_children(min_val)
+    if min_val >= max_val:
+        return
+    clump.find_children(min_val, max_val=max_val)
 
     if len(clump.children) == 1:
         find_clumps(clump, min_val*d_clump, max_val, d_clump)


### PR DESCRIPTION
## PR Summary

This fixes the Clump finding issue reported by @stonnes on the mailing list. The contour finder was previously always running with the maximum value as the maximum of the data container and not the maximum value provided by the user. This produced poorly defined behavior. Now, we explicitly provide the min/max values to the contour algorithm.