### PR TITLE
install numpy and cython before other dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ install:
     # install dependencies yt
     if [[ $TRAVIS_BUILD_STAGE_NAME != "Lint" ]]; then
       if [[ $MINIMAL == 1 ]]; then
+        $PIP install numpy==1.10.4 cython==0.24
         $PIP install -r tests/test_minimal_requirements.txt
       else
         # Getting cartopy installed requires getting cython and numpy installed
@@ -63,7 +64,7 @@ install:
         # pyproject.toml in cartopy.
         # These versions are pinned, so we will need to update/remove them when
         # the hack is no longer necessary.
-        $PIP install numpy==1.15.3 cython==0.29
+        $PIP install numpy==1.16.2 cython==0.29.6
         $PIP install -r tests/test_requirements.txt
       fi
       $PIP install -e .

--- a/tests/test_minimal_requirements.txt
+++ b/tests/test_minimal_requirements.txt
@@ -1,7 +1,5 @@
-cython==0.24
 ipython==1.0.0
 matplotlib==1.5.3
-numpy==1.10.4
 sympy==1.0
 nose==1.3.7
 nose-timer==0.7.3

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -2,7 +2,6 @@ astropy==3.0.5; python_version >= '3.0'
 astropy==2.0.9; python_version < '3.0'
 codecov==2.0.15
 coverage==4.5.1
-cython==0.29
 fastcache==1.0.2
 glueviz==0.13.3; python_version >= '3.0'
 h5py==2.8.0
@@ -13,7 +12,6 @@ matplotlib==2.2.3; python_version < '3.0'
 mock==2.0.0; python_version < '3.0'
 nose-timer==0.7.3
 nose==1.3.7
-numpy==1.15.3
 pandas==0.23.4
 requests==2.20.0
 scipy==1.1.0


### PR DESCRIPTION
This should hopefully fix the travis build failures in #2169.