### PR TITLE
Add warning for rays outside domain.

### DIFF
--- a/yt/data_objects/selection_data_containers.py
+++ b/yt/data_objects/selection_data_containers.py
@@ -23,9 +23,19 @@ from yt.data_objects.static_output import Dataset
 from yt.extern.six import string_types
 from yt.frontends.sph.data_structures import \
     SPHDataset
-from yt.funcs import ensure_list, iterable, validate_width_tuple, \
-    fix_length, fix_axis, validate_3d_array, validate_float, \
-    validate_iterable, validate_object, validate_axis, validate_center
+from yt.funcs import \
+    ensure_list, \
+    iterable, \
+    validate_width_tuple, \
+    fix_length, \
+    fix_axis, \
+    mylog, \
+    validate_3d_array, \
+    validate_float, \
+    validate_iterable, \
+    validate_object, \
+    validate_axis, \
+    validate_center
 from yt.units.yt_array import \
     udot, \
     unorm, \
@@ -242,13 +252,11 @@ class YTRay(YTSelectionContainer1D):
             self.end_point = \
               self.ds.arr(end_point, 'code_length',
                           dtype='float64')
-        # FIXME FIXME FIXME don't merge this code if this comment is still here
-        # Right now we don't handle periodic offsets correctly for particle rays
-        # need to check if we do handle it correctly for grid codes and how we
-        # handle it there.
         if ((self.start_point < self.ds.domain_left_edge).any() or
             (self.end_point > self.ds.domain_right_edge).any()):
-            raise RuntimeError("Need to fix case of ray extending beyond edge of domain")
+            mylog.warn(
+                'Ray start or end is outside the domain. ' +
+                'Returned data will only be for the ray section inside the domain.')
         self.vec = self.end_point - self.start_point
         self._set_center(self.start_point)
         self.set_field_parameter('center', self.start_point)


### PR DESCRIPTION
This takes care of another `yt-4.0` FIXME. Support for rays that go outside the domain does not exist in yt 3 either, so for now I just added a warning message. At some point, I would like to return the `periodic_ray` functionality that I moved to trident to create a boolean object that combines all the non-periodic segments together. Getting proper `t` and `dts` fields is non-trivial, so I'd like to save that for later.