### PR TITLE
Fix projection units

### DIFF
--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -342,7 +342,8 @@ class YTProj(YTSelectionContainer2D):
                 # First time calling a units="auto" field, infer units and cache
                 # for future field accesses.
                 finfo.units = str(chunk[field].units)
-            field_unit = Unit(finfo.units, registry=self.ds.unit_registry)
+            field_unit = Unit(finfo.output_units,
+                              registry=self.ds.unit_registry)
             if self.method == "mip" or self._sum_only:
                 path_length_unit = Unit(registry=self.ds.unit_registry)
             else:


### PR DESCRIPTION
## PR Summary

When a field's `units` and `output_units` are different, the SPH projection would make inconsistent assumptions. In [this line](https://github.com/yt-project/yt/blob/ed52fb30a47b3ef04231eb4f9612a5a75280b510/yt/data_objects/construction_data_containers.py#L345), `units` is assumed, while in [this line](https://github.com/yt-project/yt/blob/ed52fb30a47b3ef04231eb4f9612a5a75280b510/yt/geometry/coordinates/cartesian_coordinates.py#L295), `output_units` is assumed.

This fix makes sure `output_units` is used consistenely.

## PR Checklist

- [x] Code passes flake8 checker
- [ ] Adds a test for any bugs fixed
