### PR TITLE
Add a pep8speaks yml file

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,0 +1,85 @@
+# File : .pep8speaks.yml
+# See https://pep8speaks.com
+
+message:  # Customize the comment made by the bot
+    opened:  # Messages when a new PR is submitted
+        header: "Hi there, @{name}! Thanks for opening this PR. "
+                # The keyword {name} is converted into the author's username
+        footer: "Do see both the [yt style guide](http://yt-project.org/doc/developing/developing.html#code-style-guide) )and the [Hitchhiker's guide to code style](https://goo.gl/hqbW4r)"
+                # The messages can be written as they would over GitHub
+    updated:  # Messages when new commits are added to the PR
+        header: "Hi there, @{name}! Thanks for updating this PR. "
+        footer: ""  # Why to comment the link to the style guide everytime? :)
+        no_errors: "There are currently no PEP 8 issues detected in this Pull Request. Hooray! :fireworks: "
+
+scanner:
+    diff_only: True  # If True, errors caused by only the patch are shown
+
+pycodestyle:
+    max-line-length: 999  # Default is 79 in PEP 8
+    ignore:  # Errors and warnings to ignore
+        - E111
+        - E121
+        - E122
+        - E123
+        - E124
+        - E125
+        - E126
+        - E127
+        - E128
+        - E129
+        - E131
+        - E201
+        - E202
+        - E211
+        - E221
+        - E222
+        - E227
+        - E228
+        - E241
+        - E301
+        - E203
+        - E225
+        - E226
+        - E231
+        - E251
+        - E261
+        - E262
+        - E265
+        - E266
+        - E302
+        - E303
+        - E305
+        - E306
+        - E402
+        - E502
+        - E701
+        - E703
+        - E722
+        - E741
+        - E731
+        - W291
+        - W292
+        - W293
+        - W391
+        - W503
+        - W504
+        - W605
+        - E203
+        - W504
+    ignore:
+        - doc
+        - benchmarks
+        - */api.py
+        - */__init__.py
+        - */__config__.py
+        - yt/visualization/_mpl_imports.py
+        - yt/utilities/lodgeit.py
+        - yt/utilities/lru_cache.py
+        - yt/utilities/poster/*
+        - yt/extern/*
+        - yt/mods.py
+        - yt/utilities/fits_image.py
+
+only_mention_files_with_errors: True  # If False, a separate status comment for each file is made.
+descending_issues_order: False  # If True, PEP 8 issues in message will be displayed in descending order of line numbers in the file


### PR DESCRIPTION
This adds a pep8speaks yml configuration file, currently duplicating
some information in setup.cfg.

PEP8-Speaks is a bot that executes *just* PEP-8 style checks and leaves
comments on pull requests.  For more information:

https://pep8speaks.com

This can enable much more concise information about style changes, and
we think it may even be able to provide suggested diffs and changes to
pull requests upon request.  This way, stylistic changes can be done
without a lot of fuss, and one doesn't need to dive into travis results
to figure out what's up.