### PR TITLE
[WIP] Adds function for creating particle-based dataset from grid-based dataset

### DIFF
--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -2183,7 +2183,7 @@ def _reconstruct_object(*args, **kwargs):
     obj.field_parameters.update(field_parameters)
     return ReconstructedObject((ds, obj))
 
-def monte_carlo_sample(ds, n_samples=100000, fields=None, n_neighbors=8):
+def monte_carlo_sample(ds, n_samples=100000, fields=None, n_neighbors=1):
     """
     Uses Monte Carlo sampling to create a particle-based dataset out of a
     grid-based dataset.  For each sample, the code probabilistically selects
@@ -2259,7 +2259,6 @@ def monte_carlo_sample(ds, n_samples=100000, fields=None, n_neighbors=8):
             'particle_mass' : (masses.to(m_unit), m_unit),
             'density' : (ds.r[('gas', 'density')][indices].to(d_unit), d_unit),
             'smoothing_length' : (hsml, l_unit)}
-            #'smoothing_length' : (ds.r[('gas', 'dx')][indices].to(l_unit), l_unit)}
 
     # Collect dataset code units
     code_units = {}


### PR DESCRIPTION
## PR Summary

This adds the `monte_carlo_sample()` function for converting grid-based datasets to particle-based datasets.  This can be used in a number of ways including providing a means of direct comparisons between grid-based and particle-based codes using the same starting point.  However, this will help yt to be used with the FIREFly code for real-time visualization in the web-browser for both particle-based as well as grid-based datasets (FIREFly was built for the particle-based FIRE simualtions).

This is a WIP so I'm open to making significant changes to this code, like its location and method.  Couldn't find an obvious place to put it which is why it is here.

This function is reasonably fast at the 1e5-1e6 sampling level, operating in just a few seconds when I use `('gas', 'dx')` as an analog for the `('gas', 'smoothing_length')`.  However, when I use the kdtree to determine the smoothing length field, it introduces some problems.  One, it is a bit slower.  Two, the smoothing lengths appear to be really really large, causing the image generation step to take a lot longer and the image to get all washed out.  I guess I could just arbitrarily shrink the `smoothing_length` value from the one calculated by the kdtree, but I figure either I'm doing something wrong or there is a bug in the `generate_smoothing_length()` code.  Images below.  Also, almost all of the code for the kdtree stuff was taken directly from @qobilidop 's open PR #2186 (thanks, @qobilidop !), so it may make more sense to modularize some of these functions and use them in both pieces of functionality.  

Script to test and generate images:

```
import yt
from yt.data_objects.data_containers import \
    monte_carlo_sample
fn = '~/src/yt-data/IsolatedGalaxy/galaxy0030/galaxy0030'
ds = yt.load(fn)
ds_particle = monte_carlo_sample(ds)

p = yt.ProjectionPlot(ds, 'z', ('gas', 'density'), width=(0.04, 'Mpc'))
p.set_zlim(('gas', 'density'), 1e-4, 1e-2)
p.save('grid.png')

p = yt.ProjectionPlot(ds_particle, 'z', ('gas', 'density'), width=(0.04, 'Mpc'))
p.set_zlim(('gas', 'density'), 1e-4, 1e-2)
p.save('particles.png')
```

original grid dataset -- grid.png:

![grid](https://user-images.githubusercontent.com/8250999/53854231-7a7d3a80-3f7d-11e9-86a5-947abb34ea30.png)

generated particle dataset -- particle.png (incorrectly using `dx` as the `smoothing_length`):

![particle_fixed](https://user-images.githubusercontent.com/8250999/53854271-a8627f00-3f7d-11e9-9081-7fd7bf76a706.png)

generated particle dataset -- particle.png (using the kdtree to generate the `smoothing_length`):

![particles](https://user-images.githubusercontent.com/8250999/53854277-aef0f680-3f7d-11e9-9360-6da1ebb854ff.png)

## PR Checklist

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds tests.