### PR TITLE
fix tipsy IO via ds.all_data()

### DIFF
--- a/yt/frontends/tipsy/io.py
+++ b/yt/frontends/tipsy/io.py
@@ -78,6 +78,8 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
     def _fill_fields(self, fields, vals, hsml, mask, data_file):
         if mask is None:
             size = 0
+        elif isinstance(mask, slice):
+            size = vals[fields[0]].size
         else:
             size = mask.sum()
         rv = {}
@@ -220,18 +222,18 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
                             auxdata.append(aux)
                 if afields:
                     p = append_fields(p, afields, auxdata)
+                if ptype == 'Gas':
+                    hsml = self._read_smoothing_length(data_file, count)
+                else:
+                    hsml = 0.
                 if getattr(selector, 'is_all_data', False):
                     mask = slice(None, None, None)
                 else:
                     x = p["Coordinates"]['x'].astype("float64")
                     y = p["Coordinates"]['y'].astype("float64")
                     z = p["Coordinates"]['z'].astype("float64")
-                    if ptype == 'Gas':
-                        hsml = self._read_smoothing_length(data_file, count)
-                    else:
-                        hsml = 0.
                     mask = selector.select_points(x, y, z, hsml)
-                    del x, y, z, hsml
+                    del x, y, z
                 if mask is None:
                     continue
                 tf = self._fill_fields(field_list, p, hsml, mask, data_file)


### PR DESCRIPTION
#2146 unintentionally broke tipsy I/O as revealed by the tests in #2172. This fixes it by ensuring that `hsml` is always defined by the time we use the selector.