### PR TITLE
[bugfix] yt-4.0 cyoctree fix

### DIFF
--- a/yt/utilities/lib/cyoctree.pyx
+++ b/yt/utilities/lib/cyoctree.pyx
@@ -284,6 +284,7 @@ cdef class CyOctree:
         temp.leaf = 1
         temp.depth = node.depth + 1
         temp.leaf_id = 0
+        temp.children = 0
 
         # Set up the values to be used to set the child boundaries
         dx = (node.right_edge[0] - node.left_edge[0]) / self._num_children_per_dim


### PR DESCRIPTION
## PR Summary

Ensure that `children` get initialised to zero in cyoctree

closes #2196 

## PR Checklist

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.