### PR TITLE
Update custom CSS to sphinx>=1.6.1, left justify search bar in nav ba…

### DIFF
--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -113,4 +113,5 @@ Make tables span only half the page.
 
 .navbar-form.navbar-right:last-child {
     margin-right: -60px;
+    float: left !important;
 }

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -255,3 +255,8 @@ intersphinx_mapping = {'http://docs.python.org/': None,
 
 if not on_rtd:
     autosummary_generate = glob.glob("reference/api/api.rst")
+
+# as of Sphinx/1.6.1 this is the supported way to link custom style sheets
+#   see: https://github.com/ryan-roemer/sphinx-bootstrap-theme#adding-custom-css
+def setup(app):
+    app.add_stylesheet("custom.css")


### PR DESCRIPTION
…r so it remains stationary with window resize.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->
Add `setup()` function to `conf.py` in order to invoke custom styles already in `custom.css`. 
Also add left justify for search bar in nav bar so that it remains stationary while window is resized horizontally. 

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->
As of Sphinx 1.6.1 custom CSS styles are invoked by including a `setup()` function in `conf.py`, as it was, `custom.css` was being totally ignored for docs built by Sphinx >= 1.6.1. 
See [here](https://github.com/ryan-roemer/sphinx-bootstrap-theme#adding-custom-css) for details.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
