### PR TITLE
fix crash in check for ramses non-hilbert ordering

### DIFF
--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -530,7 +530,7 @@ class RAMSESDataset(Dataset):
                     dom, mi, ma = f.readline().split()
                     self.hilbert_indices[int(dom)] = (float(mi), float(ma))
 
-        if rheader['ordering type'] != 'hilbert' and self.bbox:
+        if rheader['ordering type'] != 'hilbert' and hasattr(self, 'bbox'):
             raise NotImplementedError(
                 'The ordering %s is not compatible with the `bbox` argument.'
                 % rheader['ordering type'])

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -530,7 +530,7 @@ class RAMSESDataset(Dataset):
                     dom, mi, ma = f.readline().split()
                     self.hilbert_indices[int(dom)] = (float(mi), float(ma))
 
-        if rheader['ordering type'] != 'hilbert' and hasattr(self, 'bbox'):
+        if rheader['ordering type'] != 'hilbert' and self._bbox is not None:
             raise NotImplementedError(
                 'The ordering %s is not compatible with the `bbox` argument.'
                 % rheader['ordering type'])


### PR DESCRIPTION
This fixes a crash reported by @suniverse on yt's slack. I guess we could also make sure `bbox` is initialized to a default value before this line if that makes more sense but I'll defer to @cphyc on this.
