### PR TITLE
expose buff_size argument to wrappers around PWViewerMPL in plot_window.py

### DIFF
--- a/doc/source/cookbook/complex_plots.rst
+++ b/doc/source/cookbook/complex_plots.rst
@@ -48,17 +48,18 @@ of the four preceding classes.
 2. `figure_size`, which can be altered with either 
 :meth:`~yt.visualization.plot_container.PlotContainer.set_figure_size`
 or with :meth:`~yt.visualization.plot_container.PlotWindow.set_window_size`
-(which simply calls `set_figure_size`), or can be set during image
-creation with the `window_size` argument.  This sets the size of 
-the final image (including the visualization and, if applicable, the
-axes and colorbar as well) in inches.
+(the latter simply calls 
+:meth:`~yt.visualization.plot_container.PlotContainer.set_figure_size`), 
+or can be set during image creation with the `window_size` argument.  
+This sets the size of the final image (including the visualization and, 
+if applicable, the axes and colorbar as well) in inches.
 
 3. `dpi`, i.e. the dots-per-inch in your final file, which can also 
 be thought of as the actual resolution of your image.  This can
 only be set on save via the `mpl_kwargs` parameter to 
 :meth:`~yt.visualization.plot_container.PlotContainer.save`.  The
 `dpi` and `figure_size` together set the true resolution of your 
-image (final image will be :math:`dpi * figure_size` pixels on a
+image (final image will be `dpi` :math:`*` `figure_size` pixels on a
 side), so if these are set too low, then your `buff_size` will not
 matter.  On the other hand, increasing these without increasing
 `buff_size` accordingly will simply blow up your resolution 
@@ -72,11 +73,11 @@ underlying resolution of your simulation.  Regardless, for either
 grid data or deposited particle data, your image will never be 
 higher resolution than your simulation data.  In other words,
 if you are visualizing a region 50 kpc across that includes 
-data that reaches a resolution (or interparticle spacing) of
-100 pc, then there's no reason to set a `buff_size` (or a 
-:math:`dpi * figure_size`) above :math:`50 kpc/ 100 pc = 500`.
+data that reaches a resolution of 100 pc, then there's no reason 
+to set a `buff_size` (or a `dpi` :math:`*` `figure_size`) above 
+50 kpc/ 100 pc = 500.
 
-The included script demonstrates how each of these can be varied.
+The below script demonstrates how each of these can be varied.
 
 .. yt_cookbook:: image_resolution.py
 

--- a/doc/source/cookbook/complex_plots.rst
+++ b/doc/source/cookbook/complex_plots.rst
@@ -15,6 +15,72 @@ See :ref:`slice-plots` for more information.
 
 .. yt_cookbook:: multi_width_image.py
 
+.. _image-resolution-primer:
+
+Varying the resolution of an image
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This illustrates the various parameters that control the resolution 
+of an image, including the (deprecated) refinement level, the size of
+the :class:`~yt.visualization.fixed_resolution.FixedResolutionBuffer`,
+and the number of pixels in the output image.
+
+In brief, there are three parameters that control the final resolution, 
+with a fourth entering for particle data that is deposited onto a mesh
+(i.e. pre-4.0).  Those are:
+
+1. `buff_size`, which can be altered with 
+:meth:`~yt.visualization.plot_window.PlotWindow.set_buff_size`, which
+is inherited by 
+:class:`~yt.visualization.plot_window.AxisAlignedSlicePlot`,
+:class:`~yt.visualization.plot_window.OffAxisSlicePlot`,
+:class:`~yt.visualization.plot_window.ProjectionPlot`, and
+:class:`~yt.visualization.plot_window.OffAxisProjectionPlot`.  This
+controls the number of resolution elements in the 
+:class:`~yt.visualization.fixed_resolution.FixedResolutionBuffer`,
+which can be thought of as the number of individually colored 
+squares (on a side) in a 2D image.  `buff_size` can be set 
+after creating the image with 
+:meth:`~yt.visualization.plot_window.PlotWindow.set_buff_size`,
+or during image creation with the `buff_size` argument to any
+of the four preceding classes.
+
+2. `figure_size`, which can be altered with either 
+:meth:`~yt.visualization.plot_container.PlotContainer.set_figure_size`
+or with :meth:`~yt.visualization.plot_container.PlotWindow.set_window_size`
+(which simply calls `set_figure_size`), or can be set during image
+creation with the `window_size` argument.  This sets the size of 
+the final image (including the visualization and, if applicable, the
+axes and colorbar as well) in inches.
+
+3. `dpi`, i.e. the dots-per-inch in your final file, which can also 
+be thought of as the actual resolution of your image.  This can
+only be set on save via the `mpl_kwargs` parameter to 
+:meth:`~yt.visualization.plot_container.PlotContainer.save`.  The
+`dpi` and `figure_size` together set the true resolution of your 
+image (final image will be :math:`dpi * figure_size` pixels on a
+side), so if these are set too low, then your `buff_size` will not
+matter.  On the other hand, increasing these without increasing
+`buff_size` accordingly will simply blow up your resolution 
+elements to fill several real pixels.
+
+4. (only for meshed particle data) `n_ref`, the maximum nubmer of 
+particles in a cell in the oct-tree allowed before it is refined
+(removed in yt-4.0 as particle data is no longer deposited onto 
+an oct-tree).  For particle data, `n_ref` effectively sets the 
+underlying resolution of your simulation.  Regardless, for either
+grid data or deposited particle data, your image will never be 
+higher resolution than your simulation data.  In other words,
+if you are visualizing a region 50 kpc across that includes 
+data that reaches a resolution (or interparticle spacing) of
+100 pc, then there's no reason to set a `buff_size` (or a 
+:math:`dpi * figure_size`) above :math:`50 kpc/ 100 pc = 500`.
+
+The included script demonstrates how each of these can be varied.
+
+.. yt_cookbook:: image_resolution.py
+
+
 Multipanel with Axes Labels
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/cookbook/image_resolution.py
+++ b/doc/source/cookbook/image_resolution.py
@@ -1,0 +1,64 @@
+import yt
+import numpy as np
+
+# Load the dataset.  We'll work with a some Gadget data to illustrate all 
+# the different ways in which the effective resolution can vary.  Specifically,
+# we'll use the GadgetDiskGalaxy dataset available at 
+#  http://yt-project.org/data/GadgetDiskGalaxy.tar.gz
+
+# load the data with a refinement criteria of 2 particle per cell
+# n.b. -- in yt-4.0, n_ref no longer exists as the data is no longer
+# deposited only a grid.  At present (03/15/2019), there is no way to
+# handle non-gas data in Gadget snapshots, though that is work in progress
+if int(yt.__version__[0]) < 4:
+    # increasing n_ref will result in a "lower resolution" (but faster) image, 
+    # while decreasing it will go the opposite way
+    ds = yt.load("GadgetDiskGalaxy/snapshot_200.hdf5", n_ref=16)
+else:
+    ds = yt.load("GadgetDiskGalaxy/snapshot_200.hdf5")
+
+# Create projections of the density (max value in each resolution element in the image):
+prj = yt.ProjectionPlot(ds, "x", ("gas", "density"), method='mip', center='max', width=(100, 'kpc'))
+
+# nicen up the plot by using a better interpolation:
+plot = prj.plots[list(prj.plots)[0]]
+ax = plot.axes
+img = ax.images[0]
+img.set_interpolation('bicubic')
+
+# nicen up the plot by setting the background color to the minimum of the colorbar
+prj.set_background_color(('gas', 'density'))
+
+# vary the buff_size -- the number of resolution elements in the actual visualization
+# set it to 2000x2000
+buff_size = 2000
+prj.set_buff_size(buff_size)
+
+# set the figure size in inches
+figure_size = 10
+prj.set_figure_size(figure_size)
+
+# if the image does not fill the plot (as is default, since the axes and 
+# colorbar contribute as well), then figuring out the proper dpi for a given
+# buff_size and figure_size is non-trivial -- it requires finding the bbox 
+# for the actual image:
+bounding_box = ax.get_position()
+# we're going to scale to the larger of the two sides
+image_size = figure_size * max([bounding_box.width, bounding_box.height])
+# now save with a dpi that's scaled to the buff_size:
+dpi = np.rint(np.ceil(buff_size / image_size))
+prj.save('with_axes_colorbar.png', mpl_kwargs=dict(dpi=dpi))
+
+# in the case where the image fills the entire plot (i.e. if the axes and colorbar 
+# are turned off), it's trivial to figure out the correct dpi from the buff_size and
+# figure_size (or vice versa):
+
+# hide the colorbar:
+prj.hide_colorbar()
+
+# hide the axes, while still keeping the background color correct:
+prj.hide_axes(draw_frame=True)
+
+# save with a dpi that makes sense:
+dpi = np.rint(np.ceil(buff_size / figure_size))
+prj.save('no_axes_colorbar.png', mpl_kwargs=dict(dpi=dpi))

--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -159,6 +159,14 @@ where for the last two objects any spatial field, such as ``"density"``,
 ``"velocity_z"``,
 etc., may be used, e.g. ``center=("min","temperature")``.
 
+The effective resolution of the plot (i.e. the number of resolution elements
+in the image itself) can be controlled with the ``buff_size`` argument:
+
+.. code-block:: python
+
+    yt.SlicePlot(ds, 'z', 'density', buff_size=(1000, 1000))
+
+
 Here is an example that combines all of the options we just discussed.
 
 .. python-script::
@@ -167,7 +175,7 @@ Here is an example that combines all of the options we just discussed.
    from yt.units import kpc
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
    slc = yt.SlicePlot(ds, 'z', 'density', center=[0.5, 0.5, 0.5],
-                      width=(20,'kpc'))
+                      width=(20,'kpc'), buff_size=(1000, 1000))
    slc.save()
 
 The above example will display an annotated plot of a slice of the
@@ -275,11 +283,12 @@ example:
    from yt.units import kpc
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
    prj = yt.ProjectionPlot(ds, 2, 'temperature', width=25*kpc,
-                           weight_field='density')
+                           weight_field='density', buff_size=(1000, 1000))
    prj.save()
 
-will create a density-weighted projection of the temperature field along the x
-axis, plot it, and then save the plot to a png image file.
+will create a density-weighted projection of the temperature field along 
+the x axis with 1000 resolution elements per side, plot it, and then save 
+the plot to a png image file.
 
 Like :ref:`slice-plots`, annotations and modifications can be applied
 after creating the ``ProjectionPlot`` object.  Annotations are
@@ -770,8 +779,8 @@ from black to white depending on the AMR level of the grid.
 
 Annotations are described in :ref:`callbacks`.
 
-Set the size of the plot
-~~~~~~~~~~~~~~~~~~~~~~~~
+Set the size and resolution of the plot
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To set the size of the plot, use the
 :meth:`~yt.visualization.plot_window.AxisAlignedSlicePlot.set_figure_size` function.  The argument
@@ -796,6 +805,9 @@ To change the resolution of the image, call the
    slc = yt.SlicePlot(ds, 'z', 'density', width=(10,'kpc'))
    slc.set_buff_size(1600)
    slc.save()
+
+Also see cookbook recipe :ref:`image-resolution-primer` for more information
+about the parameters that determine the resolution of your images.
 
 Turning off minorticks
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1363,6 +1363,10 @@ class AxisAlignedSlicePlot(PWViewerMPL):
     data_source: YTSelectionContainer object
          Object to be used for data selection. Defaults to ds.all_data(), a
          region covering the full domain
+    buff_size: length 2 sequence
+         Size of the buffer to use for the image, i.e. the number of sight-lines 
+         used.  Effectively sets a resolution limit to the image if buff_size is 
+         smaller than the finest gridding.
 
     Examples
     --------
@@ -1380,7 +1384,7 @@ class AxisAlignedSlicePlot(PWViewerMPL):
 
     def __init__(self, ds, axis, fields, center='c', width=None, axes_unit=None,
                  origin='center-window', right_handed=True, fontsize=18, field_parameters=None,
-                 window_size=8.0, aspect=None, data_source=None):
+                 window_size=8.0, aspect=None, data_source=None, buff_size=(800,800)):
         # this will handle time series data and controllers
         axis = fix_axis(axis, ds)
         (bounds, center, display_center) = \
@@ -1406,7 +1410,7 @@ class AxisAlignedSlicePlot(PWViewerMPL):
         PWViewerMPL.__init__(self, slc, bounds, origin=origin,
                              fontsize=fontsize, fields=fields,
                              window_size=window_size, aspect=aspect,
-                             right_handed=right_handed)
+                             right_handed=right_handed, buff_size=buff_size)
         if axes_unit is None:
             axes_unit = get_axes_unit(width, ds)
         self.set_axes_unit(axes_unit)
@@ -1542,6 +1546,10 @@ class ProjectionPlot(PWViewerMPL):
     data_source: YTSelectionContainer object
          Object to be used for data selection. Defaults to ds.all_data(), a
          region covering the full domain
+    buff_size: length 2 sequence
+         Size of the buffer to use for the image, i.e. the number of sight-lines 
+         used.  Effectively sets a resolution limit to the image if buff_size is 
+         smaller than the finest gridding.
 
     Examples
     --------
@@ -1560,8 +1568,8 @@ class ProjectionPlot(PWViewerMPL):
     def __init__(self, ds, axis, fields, center='c', width=None, axes_unit=None,
                  weight_field=None, max_level=None, origin='center-window',
                  right_handed=True, fontsize=18, field_parameters=None, data_source=None,
-                 method = "integrate", proj_style = None, window_size=8.0,
-                 aspect=None):
+                 method = "integrate", proj_style = None, window_size=8.0, 
+                 buff_size=(800,800), aspect=None):
         axis = fix_axis(axis, ds)
         # proj_style is deprecated, but if someone specifies then it trumps
         # method.
@@ -1596,7 +1604,7 @@ class ProjectionPlot(PWViewerMPL):
                            max_level=max_level)
         PWViewerMPL.__init__(self, proj, bounds, fields=fields, origin=origin,
                              right_handed=right_handed, fontsize=fontsize, window_size=window_size,
-                             aspect=aspect)
+                             aspect=aspect, buff_size=buff_size)
         if axes_unit is None:
             axes_unit = get_axes_unit(width, ds)
         self.set_axes_unit(axes_unit)
@@ -1671,6 +1679,10 @@ class OffAxisSlicePlot(PWViewerMPL):
     data_source : YTSelectionContainer Object
          Object to be used for data selection.  Defaults ds.all_data(), a
          region covering the full domain.
+    buff_size: length 2 sequence
+         Size of the buffer to use for the image, i.e. the number of sight-lines 
+         used.  Effectively sets a resolution limit to the image if buff_size is 
+         smaller than the finest gridding.
     """
 
     _plot_type = 'OffAxisSlice'
@@ -1678,7 +1690,7 @@ class OffAxisSlicePlot(PWViewerMPL):
 
     def __init__(self, ds, normal, fields, center='c', width=None,
                  axes_unit=None, north_vector=None, right_handed=True, fontsize=18,
-                 field_parameters=None, data_source=None):
+                 field_parameters=None, data_source=None, buff_size=(800,800)):
         (bounds, center_rot) = get_oblique_window_parameters(normal,center,width,ds)
         if field_parameters is None:
             field_parameters = {}
@@ -1697,7 +1709,8 @@ class OffAxisSlicePlot(PWViewerMPL):
         # aren't well-defined for off-axis data objects
         PWViewerMPL.__init__(self, cutting, bounds, fields=fields,
                              origin='center-window',periodic=False,
-                             right_handed=right_handed, oblique=True, fontsize=fontsize)
+                             right_handed=right_handed, oblique=True, 
+                             fontsize=fontsize, buff_size=buff_size)
         if axes_unit is None:
             axes_unit = get_axes_unit(width, ds)
         self.set_axes_unit(axes_unit)
@@ -1826,6 +1839,10 @@ class OffAxisProjectionPlot(PWViewerMPL):
     data_source: YTSelectionContainer object
          Object to be used for data selection. Defaults to ds.all_data(), a
          region covering the full domain
+    buff_size: length 2 sequence
+         Size of the buffer to use for the image, i.e. the number of sight-lines 
+         used.  Effectively sets a resolution limit to the image if buff_size is 
+         smaller than the finest gridding.         
     """
     _plot_type = 'OffAxisProjection'
     _frb_generator = OffAxisProjectionFixedResolutionBuffer
@@ -1835,7 +1852,7 @@ class OffAxisProjectionPlot(PWViewerMPL):
                  max_level=None, north_vector=None, right_handed=True,
                  volume=None, no_ghost=False, le=None, re=None,
                  interpolated=False, fontsize=18, method="integrate",
-                 data_source=None):
+                 data_source=None, buff_size=(800,800)):
         (bounds, center_rot) = \
           get_oblique_window_parameters(normal,center,width,ds,depth=depth)
         fields = ensure_list(fields)[:]
@@ -1863,7 +1880,7 @@ class OffAxisProjectionPlot(PWViewerMPL):
         PWViewerMPL.__init__(
             self, OffAxisProj, bounds, fields=fields, origin='center-window',
             periodic=False, oblique=True, right_handed=right_handed,
-            fontsize=fontsize)
+            fontsize=fontsize, buff_size=buff_size)
         if axes_unit is None:
             axes_unit = get_axes_unit(width, ds)
         self.set_axes_unit(axes_unit)

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1364,7 +1364,7 @@ class AxisAlignedSlicePlot(PWViewerMPL):
          Object to be used for data selection. Defaults to ds.all_data(), a
          region covering the full domain
     buff_size: length 2 sequence
-         Size of the buffer to use for the image, i.e. the number of sight-lines 
+         Size of the buffer to use for the image, i.e. the number of resolution elements 
          used.  Effectively sets a resolution limit to the image if buff_size is 
          smaller than the finest gridding.
 
@@ -1547,7 +1547,7 @@ class ProjectionPlot(PWViewerMPL):
          Object to be used for data selection. Defaults to ds.all_data(), a
          region covering the full domain
     buff_size: length 2 sequence
-         Size of the buffer to use for the image, i.e. the number of sight-lines 
+         Size of the buffer to use for the image, i.e. the number of resolution elements 
          used.  Effectively sets a resolution limit to the image if buff_size is 
          smaller than the finest gridding.
 
@@ -1680,7 +1680,7 @@ class OffAxisSlicePlot(PWViewerMPL):
          Object to be used for data selection.  Defaults ds.all_data(), a
          region covering the full domain.
     buff_size: length 2 sequence
-         Size of the buffer to use for the image, i.e. the number of sight-lines 
+         Size of the buffer to use for the image, i.e. the number of resolution elements 
          used.  Effectively sets a resolution limit to the image if buff_size is 
          smaller than the finest gridding.
     """
@@ -1840,7 +1840,7 @@ class OffAxisProjectionPlot(PWViewerMPL):
          Object to be used for data selection. Defaults to ds.all_data(), a
          region covering the full domain
     buff_size: length 2 sequence
-         Size of the buffer to use for the image, i.e. the number of sight-lines 
+         Size of the buffer to use for the image, i.e. the number of resolution elements 
          used.  Effectively sets a resolution limit to the image if buff_size is 
          smaller than the finest gridding.         
     """

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -137,6 +137,8 @@ PROJECTION_METHODS = (
     'mip'
 )
 
+BUFF_SIZES = [(800, 800), (1600, 1600), (1254, 1254), (800, 600)]
+
 def simple_contour(test_obj, plot):
     plot.annotate_contour(test_obj.plot_field)
 
@@ -334,6 +336,15 @@ class TestPlotWindowSave(unittest.TestCase):
         for method in PROJECTION_METHODS:
             proj = ProjectionPlot(test_ds, 0, 'density', method=method)
             proj.save()
+
+    def test_projection_plot_bs(self):
+        test_ds = fake_random_ds(16)
+        for bf in BUFF_SIZES:
+            proj = ProjectionPlot(test_ds, 0, ('gas', 'density'), buff_size=bf)
+            image = proj.frb['gas', 'density']
+
+            # note that image.shape is inverted relative to the passed in buff_size
+            assert_equal(image.shape[::-1], bf)
 
     def test_offaxis_slice_plot(self):
         test_ds = fake_random_ds(16)


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

Added `buff_size` argument (and added to docstring) for `ProjectionPlot`, `OffAxisSlicePlot`, `OffAxisProjectionPlot`, and `AxisAlignedSlicePlot`, which gets passed along to `PWViewerMPL`, which then gets passed on to `FixedResolutionBuffer`.

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

Wasn't a way to create a higher resolution image with the `ProjectionPlot` command (at least, not that I could find).  Your refinement was effectively limited by the `buff_size`.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
