### PR TITLE
Sort .so input file list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -212,10 +212,10 @@ extensions = [
                "yt/analysis_modules/halo_finding/fof/kd.c"],
               libraries=std_libs),
     Extension("yt.analysis_modules.halo_finding.hop.EnzoHop",
-              glob.glob("yt/analysis_modules/halo_finding/hop/*.c")),
+              sorted(glob.glob("yt/analysis_modules/halo_finding/hop/*.c"))),
     Extension("yt.frontends.artio._artio_caller",
               ["yt/frontends/artio/_artio_caller.pyx"] +
-              glob.glob("yt/frontends/artio/artio_headers/*.c"),
+              sorted(glob.glob("yt/frontends/artio/artio_headers/*.c")),
               include_dirs=["yt/frontends/artio/artio_headers/",
                             "yt/geometry/",
                             "yt/utilities/lib/"],


### PR DESCRIPTION
Sort .so input file list
so that EnzoHop.cpython-37m-x86_64-linux-gnu.so builds in a reproducible way
in spite of indeterministic filesystem readdir order
and http://bugs.python.org/issue30461

See https://reproducible-builds.org/ for why this is good.

Without this patch, building the openSUSE python-yt package always had variations in /usr/lib64/python3.7/site-packages/yt/analysis_modules/halo_finding/hop/EnzoHop.cpython-37m-x86_64-linux-gnu.so machine code.


<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

This PR was done while working on reproducible builds for openSUSE.