### PR TITLE
Fix SPH answer tests in yt-4.0

### DIFF
--- a/yt/frontends/gadget/tests/test_outputs.py
+++ b/yt/frontends/gadget/tests/test_outputs.py
@@ -50,10 +50,6 @@ iso_fields = OrderedDict(
         (("gas", "temperature"), None),
         (("gas", "temperature"), ('gas', 'density')),
         (('gas', 'velocity_magnitude'), None),
-        (("deposit", "all_density"), None),
-        (("deposit", "all_count"), None),
-        (("deposit", "all_cic"), None),
-        (("deposit", "PartType0_density"), None),
     ]
 )
 iso_kwargs = dict(bounding_box=[[-3, 3], [-3, 3], [-3, 3]])

--- a/yt/frontends/gizmo/tests/test_outputs.py
+++ b/yt/frontends/gizmo/tests/test_outputs.py
@@ -34,9 +34,6 @@ fields = OrderedDict(
         (("gas", "metallicity"), ('gas', 'density')),
         (("gas", "O_metallicity"), ('gas', 'density')),
         (('gas', 'velocity_magnitude'), None),
-        (("deposit", "all_count"), None),
-        (("deposit", "all_cic"), None),
-        (("deposit", "PartType0_density"), None),
     ]
 )
 

--- a/yt/frontends/owls/tests/test_outputs.py
+++ b/yt/frontends/owls/tests/test_outputs.py
@@ -35,11 +35,6 @@ _fields = OrderedDict(
         (("gas", "temperature"), ("gas", "density")),
         (('gas', 'He_p0_number_density'), None),
         (('gas', 'velocity_magnitude'), None),
-        (("deposit", "all_density"), None),
-        (("deposit", "all_count"), None),
-        (("deposit", "all_cic"), None),
-        (("deposit", "PartType0_density"), None),
-        (("deposit", "PartType4_density"), None),
     ]
 )
 

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -31,8 +31,7 @@ import os
 import yt
 import numpy as np
 
-_fields = ("temperature", "density", "velocity_magnitude",
-           ("deposit", "all_density"), ("deposit", "all_count"))
+_fields = ("temperature", "density", "velocity_magnitude")
 
 output_00080 = "output_00080/info_00080.txt"
 @requires_ds(output_00080)

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -463,8 +463,11 @@ class FieldValuesTest(AnswerTestingTest):
     def run(self):
         obj = create_obj(self.ds, self.obj_type)
         field = obj._determine_fields(self.field)[0]
+        fd = self.ds.field_info[field]
         if self.particle_type:
             weight_field = (field[0], "particle_ones")
+        elif fd.is_sph_field:
+            weight_field = (field[0], "ones")
         else:
             weight_field = ("index", "ones")
         avg = obj.quantities.weighted_average_quantity(

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -992,10 +992,6 @@ def sph_answer(ds, ds_str_repr, ds_nparticles, fields):
               for ptype in ds.particle_types_raw)
     assert_equal(tot, ds_nparticles)
     for dobj_name in dso:
-        dobj = create_obj(ds, dobj_name)
-        s1 = dobj["ones"].sum()
-        s2 = sum(mask.sum() for block, mask in dobj.blocks)
-        assert_equal(s1, s2)
         for field, weight_field in fields.items():
             if field[0] in ds.particle_types:
                 particle_type = True

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -989,7 +989,7 @@ def sph_answer(ds, ds_str_repr, ds_nparticles, fields):
     dd = ds.all_data()
     assert_equal(dd["particle_position"].shape, (ds_nparticles, 3))
     tot = sum(dd[ptype, "particle_position"].shape[0]
-              for ptype in ds.particle_types if ptype != "all")
+              for ptype in ds.particle_types_raw)
     assert_equal(tot, ds_nparticles)
     for dobj_name in dso:
         dobj = create_obj(ds, dobj_name)


### PR DESCRIPTION
The `sph_answer` tests need updating for yt-4.0. This PR is a WIP to update them. Things that have to be done:

- [x] Remove deposit fields from testing in SPH frontends (except tipsy, which doesn't use `sph_answer`)
- [x] Use raw particle types to compute particle sizes
- [x] Fix projections for non-region objects