### PR TITLE
Add tests for old ytdata datasets.

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -109,7 +109,7 @@ answer_tests:
   local_ramses_001:
     - yt/frontends/ramses/tests/test_outputs.py
 
-  local_ytdata_005:
+  local_ytdata_006:
     - yt/frontends/ytdata/tests/test_outputs.py
     - yt/frontends/ytdata/tests/test_old_outputs.py
 

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -110,8 +110,8 @@ answer_tests:
     - yt/frontends/ramses/tests/test_outputs.py
 
   local_ytdata_005:
-    - yt/frontends/ytdata/test_outputs.py
-    - yt/frontends/ytdata/test_old_outputs.py
+    - yt/frontends/ytdata/tests/test_outputs.py
+    - yt/frontends/ytdata/tests/test_old_outputs.py
 
   local_absorption_spectrum_007:
     - yt/analysis_modules/absorption_spectrum/tests/test_absorption_spectrum.py:test_absorption_spectrum_non_cosmo

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -109,8 +109,9 @@ answer_tests:
   local_ramses_001:
     - yt/frontends/ramses/tests/test_outputs.py
 
-  local_ytdata_004:
-    - yt/frontends/ytdata
+  local_ytdata_005:
+    - yt/frontends/ytdata/test_outputs.py
+    - yt/frontends/ytdata/test_old_outputs.py
 
   local_absorption_spectrum_007:
     - yt/analysis_modules/absorption_spectrum/tests/test_absorption_spectrum.py:test_absorption_spectrum_non_cosmo

--- a/yt/frontends/ytdata/tests/test_old_outputs.py
+++ b/yt/frontends/ytdata/tests/test_old_outputs.py
@@ -25,6 +25,7 @@ from yt.frontends.ytdata.tests.test_outputs import \
     compare_unit_attributes, \
     YTDataFieldTest
 from yt.testing import \
+    assert_allclose_units, \
     assert_array_equal, \
     assert_fname, \
     requires_file, \
@@ -92,7 +93,7 @@ def test_grid_datacontainer_data():
     fn = "DD0046_proj_frb.h5"
     full_fn = os.path.join(ytdata_dir, fn)
     frb_ds = data_dir_load(full_fn)
-    assert_array_equal(frb["density"], frb_ds.data["density"])
+    assert_allclose_units(frb["density"], frb_ds.data["density"], 1e-7)
     compare_unit_attributes(ds, frb_ds)
     assert isinstance(frb_ds, YTGridDataset)
     yield YTDataFieldTest(full_fn, "density", geometric=False)

--- a/yt/frontends/ytdata/tests/test_old_outputs.py
+++ b/yt/frontends/ytdata/tests/test_old_outputs.py
@@ -13,8 +13,6 @@ ytdata frontend tests using enzo_tiny_cosmology
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-from yt.convenience import \
-    load
 from yt.data_objects.api import \
     create_profile
 from yt.frontends.ytdata.api import \
@@ -22,22 +20,19 @@ from yt.frontends.ytdata.api import \
     YTSpatialPlotDataset, \
     YTGridDataset, \
     YTNonspatialDataset, \
-    YTProfileDataset, \
-    save_as_dataset
+    YTProfileDataset
+from yt.frontends.ytdata.tests.test_outputs import \
+    compare_unit_attributes, \
+    YTDataFieldTest
 from yt.testing import \
     assert_array_equal, \
-    assert_allclose_units, \
-    assert_equal, \
     assert_fname, \
-    fake_random_ds, \
     requires_file, \
     requires_module
 from yt.utilities.answer_testing.framework import \
-    data_dir_load, \
-    AnswerTestingTest
+    data_dir_load
 from yt.units.yt_array import \
-    YTArray, \
-    YTQuantity
+    YTArray
 from yt.visualization.plot_window import \
     SlicePlot, \
     ProjectionPlot
@@ -49,101 +44,44 @@ import tempfile
 import os
 import shutil
 
-def make_tempdir():
-    if int(os.environ.get('GENERATE_YTDATA', 0)):
-        return '.'
-    else:
-        return tempfile.mkdtemp()
-
-def compare_unit_attributes(ds1, ds2):
-    attrs = ('length_unit', 'mass_unit', 'time_unit',
-             'velocity_unit', 'magnetic_unit')
-    for attr in attrs:
-        u1 = getattr(ds1, attr, None)
-        u2 = getattr(ds2, attr, None)
-        assert u1 == u2
-
-class YTDataFieldTest(AnswerTestingTest):
-    _type_name = "YTDataTest"
-    _attrs = ("field_name", )
-
-    def __init__(self, ds_fn, field, decimals = 10,
-                 geometric=True):
-        super(YTDataFieldTest, self).__init__(ds_fn)
-        self.field = field
-        if isinstance(field, tuple) and len(field) == 2:
-            self.field_name = field[1]
-        else:
-            self.field_name = field
-        self.decimals = decimals
-        self.geometric = geometric
-
-    def run(self):
-        if self.geometric:
-            obj = self.ds.all_data()
-        else:
-            obj = self.ds.data
-        num_e = obj[self.field].size
-        avg = obj[self.field].mean()
-        return np.array([num_e, avg])
-
-    def compare(self, new_result, old_result):
-        err_msg = "YTData field values for %s not equal." % \
-          (self.field,)
-        if self.decimals is None:
-            assert_equal(new_result, old_result,
-                         err_msg=err_msg, verbose=True)
-        else:
-            assert_allclose_units(new_result, old_result, 
-                                  10.**(-self.decimals),
-                                  err_msg=err_msg, verbose=True)
-
 enzotiny = "enzo_tiny_cosmology/DD0046/DD0046"
+ytdata_dir = "ytdata_test"
+
 @requires_file(enzotiny)
+@requires_file(ytdata_dir)
 def test_datacontainer_data():
-    tmpdir = make_tempdir()
-    curdir = os.getcwd()
-    os.chdir(tmpdir)
     ds = data_dir_load(enzotiny)
     sphere = ds.sphere(ds.domain_center, (10, "Mpc"))
-    fn = sphere.save_as_dataset(fields=["density", "particle_mass"])
-    full_fn = os.path.join(tmpdir, fn)
-    sphere_ds = load(full_fn)
+    fn = "DD0046_sphere.h5"
+    full_fn = os.path.join(ytdata_dir, fn)
+    sphere_ds = data_dir_load(full_fn)
     compare_unit_attributes(ds, sphere_ds)
     assert isinstance(sphere_ds, YTDataContainerDataset)
     yield YTDataFieldTest(full_fn, ("grid", "density"))
     yield YTDataFieldTest(full_fn, ("all", "particle_mass"))
     cr = ds.cut_region(sphere, ['obj["temperature"] > 1e4'])
-    fn = cr.save_as_dataset(fields=["temperature"])
-    full_fn = os.path.join(tmpdir, fn)
-    cr_ds = load(full_fn)
+    fn = "DD0046_cut_region.h5"
+    full_fn = os.path.join(ytdata_dir, fn)
+    cr_ds = data_dir_load(full_fn)
     assert isinstance(cr_ds, YTDataContainerDataset)
     assert (cr["temperature"] == cr_ds.data["temperature"]).all()
-    os.chdir(curdir)
-    if tmpdir != '.':
-        shutil.rmtree(tmpdir)
 
 @requires_file(enzotiny)
+@requires_file(ytdata_dir)
 def test_grid_datacontainer_data():
-    tmpdir = make_tempdir()
-    curdir = os.getcwd()
-    os.chdir(tmpdir)
     ds = data_dir_load(enzotiny)
 
-    cg = ds.covering_grid(level=0, left_edge=[0.25]*3, dims=[16]*3)
-    fn = cg.save_as_dataset(fields=["density", "particle_mass"])
-    full_fn = os.path.join(tmpdir, fn)
-    cg_ds = load(full_fn)
+    fn = "DD0046_covering_grid.h5"
+    full_fn = os.path.join(ytdata_dir, fn)
+    cg_ds = data_dir_load(full_fn)
     compare_unit_attributes(ds, cg_ds)
     assert isinstance(cg_ds, YTGridDataset)
     yield YTDataFieldTest(full_fn, ("grid", "density"))
     yield YTDataFieldTest(full_fn, ("all", "particle_mass"))
 
-    ag = ds.arbitrary_grid(left_edge=[0.25]*3, right_edge=[0.75]*3,
-                           dims=[16]*3)
-    fn = ag.save_as_dataset(fields=["density", "particle_mass"])
-    full_fn = os.path.join(tmpdir, fn)
-    ag_ds = load(full_fn)
+    fn = "DD0046_arbitrary_grid.h5"
+    full_fn = os.path.join(ytdata_dir, fn)
+    ag_ds = data_dir_load(full_fn)
     compare_unit_attributes(ds, ag_ds)
     assert isinstance(ag_ds, YTGridDataset)
     yield YTDataFieldTest(full_fn, ("grid", "density"))
@@ -151,45 +89,38 @@ def test_grid_datacontainer_data():
 
     my_proj = ds.proj("density", "x", weight_field="density")
     frb = my_proj.to_frb(1.0, (800, 800))
-    fn = frb.save_as_dataset(fields=["density"])
-    frb_ds = load(fn)
+    fn = "DD0046_proj_frb.h5"
+    full_fn = os.path.join(ytdata_dir, fn)
+    frb_ds = data_dir_load(full_fn)
     assert_array_equal(frb["density"], frb_ds.data["density"])
     compare_unit_attributes(ds, frb_ds)
     assert isinstance(frb_ds, YTGridDataset)
     yield YTDataFieldTest(full_fn, "density", geometric=False)
-    os.chdir(curdir)
-    if tmpdir != '.':
-        shutil.rmtree(tmpdir)
 
 @requires_file(enzotiny)
+@requires_file(ytdata_dir)
 def test_spatial_data():
-    tmpdir = make_tempdir()
-    curdir = os.getcwd()
-    os.chdir(tmpdir)
     ds = data_dir_load(enzotiny)
-    proj = ds.proj("density", "x", weight_field="density")
-    fn = proj.save_as_dataset()
-    full_fn = os.path.join(tmpdir, fn)
-    proj_ds = load(full_fn)
+    fn = "DD0046_proj.h5"
+    full_fn = os.path.join(ytdata_dir, fn)
+    proj_ds = data_dir_load(full_fn)
     compare_unit_attributes(ds, proj_ds)
     assert isinstance(proj_ds, YTSpatialPlotDataset)
     yield YTDataFieldTest(full_fn, ("grid", "density"), geometric=False)
-    os.chdir(curdir)
-    if tmpdir != '.':
-        shutil.rmtree(tmpdir)
 
 @requires_file(enzotiny)
+@requires_file(ytdata_dir)
 def test_profile_data():
-    tmpdir = make_tempdir()
+    tmpdir = tempfile.mkdtemp()
     curdir = os.getcwd()
     os.chdir(tmpdir)
     ds = data_dir_load(enzotiny)
     ad = ds.all_data()
     profile_1d = create_profile(ad, "density", "temperature",
                                 weight_field="cell_mass")
-    fn = profile_1d.save_as_dataset()
-    full_fn = os.path.join(tmpdir, fn)
-    prof_1d_ds = load(full_fn)
+    fn = "DD0046_Profile1D.h5"
+    full_fn = os.path.join(ytdata_dir, fn)
+    prof_1d_ds = data_dir_load(full_fn)
     compare_unit_attributes(ds, prof_1d_ds)
     assert isinstance(prof_1d_ds, YTProfileDataset)
 
@@ -205,12 +136,9 @@ def test_profile_data():
     yield YTDataFieldTest(full_fn, "temperature", geometric=False)
     yield YTDataFieldTest(full_fn, "x", geometric=False)
     yield YTDataFieldTest(full_fn, "density", geometric=False)
-    profile_2d = create_profile(ad, ["density", "temperature"],
-                               "cell_mass", weight_field=None,
-                               n_bins=(128, 128))
-    fn = profile_2d.save_as_dataset()
-    full_fn = os.path.join(tmpdir, fn)
-    prof_2d_ds = load(full_fn)
+    fn = "DD0046_Profile2D.h5"
+    full_fn = os.path.join(ytdata_dir, fn)
+    prof_2d_ds = data_dir_load(full_fn)
     compare_unit_attributes(ds, prof_2d_ds)
     assert isinstance(prof_2d_ds, YTProfileDataset)
 
@@ -224,14 +152,11 @@ def test_profile_data():
     yield YTDataFieldTest(full_fn, "y", geometric=False)
     yield YTDataFieldTest(full_fn, "cell_mass", geometric=False)
     os.chdir(curdir)
-    if tmpdir != '.':
-        shutil.rmtree(tmpdir)
+    shutil.rmtree(tmpdir)
 
 @requires_file(enzotiny)
+@requires_file(ytdata_dir)
 def test_nonspatial_data():
-    tmpdir = make_tempdir()
-    curdir = os.getcwd()
-    os.chdir(tmpdir)
     ds = data_dir_load(enzotiny)
     region = ds.box([0.25]*3, [0.75]*3)
     sphere = ds.sphere(ds.domain_center, (10, "Mpc"))
@@ -239,54 +164,47 @@ def test_nonspatial_data():
     my_data["region_density"] = region["density"]
     my_data["sphere_density"] = sphere["density"]
     fn = "test_data.h5"
-    save_as_dataset(ds, fn, my_data)
-    full_fn = os.path.join(tmpdir, fn)
-    array_ds = load(full_fn)
+    full_fn = os.path.join(ytdata_dir, fn)
+    array_ds = data_dir_load(full_fn)
     compare_unit_attributes(ds, array_ds)
     assert isinstance(array_ds, YTNonspatialDataset)
     yield YTDataFieldTest(full_fn, "region_density", geometric=False)
     yield YTDataFieldTest(full_fn, "sphere_density", geometric=False)
 
     my_data = {"density": YTArray(np.linspace(1.,20.,10), "g/cm**3")}
-    fake_ds = {"current_time": YTQuantity(10, "Myr")}
     fn = "random_data.h5"
-    save_as_dataset(fake_ds, fn, my_data)
-    full_fn = os.path.join(tmpdir, fn)
-    new_ds = load(full_fn)
+    full_fn = os.path.join(ytdata_dir, fn)
+    new_ds = data_dir_load(full_fn)
     assert isinstance(new_ds, YTNonspatialDataset)
     yield YTDataFieldTest(full_fn, "density", geometric=False)
-    os.chdir(curdir)
-    if tmpdir != '.':
-        shutil.rmtree(tmpdir)
 
 @requires_module('h5py')
+@requires_file(ytdata_dir)
 def test_plot_data():
-    tmpdir = make_tempdir()
+    tmpdir = tempfile.mkdtemp()
     curdir = os.getcwd()
     os.chdir(tmpdir)
-    ds = fake_random_ds(16)
 
-    plot = SlicePlot(ds, 'z', 'density')
-    fn = plot.data_source.save_as_dataset('slice.h5')
-    ds_slice = load(fn)
+    fn = "slice.h5"
+    full_fn = os.path.join(ytdata_dir, fn)
+    ds_slice = data_dir_load(full_fn)
     p = SlicePlot(ds_slice, 'z', 'density')
     fn = p.save()
     assert_fname(fn[0])
 
-    plot = ProjectionPlot(ds, 'z', 'density')
-    fn = plot.data_source.save_as_dataset('proj.h5')
-    ds_proj = load(fn)
+    fn = "proj.h5"
+    full_fn = os.path.join(ytdata_dir, fn)
+    ds_proj = data_dir_load(full_fn)
     p = ProjectionPlot(ds_proj, 'z', 'density')
     fn = p.save()
     assert_fname(fn[0])
 
-    plot = SlicePlot(ds, [1, 1, 1], 'density')
-    fn = plot.data_source.save_as_dataset('oas.h5')
-    ds_oas = load(fn)
+    fn = "oas.h5"
+    full_fn = os.path.join(ytdata_dir, fn)
+    ds_oas = data_dir_load(full_fn)
     p = SlicePlot(ds_oas, [1, 1, 1], 'density')
     fn = p.save()
     assert_fname(fn[0])
 
     os.chdir(curdir)
-    if tmpdir != '.':
-        shutil.rmtree(tmpdir)
+    shutil.rmtree(tmpdir)

--- a/yt/frontends/ytdata/tests/test_old_outputs.py
+++ b/yt/frontends/ytdata/tests/test_old_outputs.py
@@ -31,6 +31,7 @@ from yt.testing import \
     requires_file, \
     requires_module
 from yt.utilities.answer_testing.framework import \
+    requires_ds, \
     data_dir_load
 from yt.units.yt_array import \
     YTArray
@@ -48,9 +49,9 @@ import shutil
 enzotiny = "enzo_tiny_cosmology/DD0046/DD0046"
 ytdata_dir = "ytdata_test"
 
-@requires_file(enzotiny)
-@requires_file(ytdata_dir)
-def test_datacontainer_data():
+@requires_ds(enzotiny)
+@requires_ds(ytdata_dir)
+def test_old_datacontainer_data():
     ds = data_dir_load(enzotiny)
     sphere = ds.sphere(ds.domain_center, (10, "Mpc"))
     fn = "DD0046_sphere.h5"
@@ -67,9 +68,9 @@ def test_datacontainer_data():
     assert isinstance(cr_ds, YTDataContainerDataset)
     assert (cr["temperature"] == cr_ds.data["temperature"]).all()
 
-@requires_file(enzotiny)
-@requires_file(ytdata_dir)
-def test_grid_datacontainer_data():
+@requires_ds(enzotiny)
+@requires_ds(ytdata_dir)
+def test_old_grid_datacontainer_data():
     ds = data_dir_load(enzotiny)
 
     fn = "DD0046_covering_grid.h5"
@@ -98,9 +99,9 @@ def test_grid_datacontainer_data():
     assert isinstance(frb_ds, YTGridDataset)
     yield YTDataFieldTest(full_fn, "density", geometric=False)
 
-@requires_file(enzotiny)
-@requires_file(ytdata_dir)
-def test_spatial_data():
+@requires_ds(enzotiny)
+@requires_ds(ytdata_dir)
+def test_old_spatial_data():
     ds = data_dir_load(enzotiny)
     fn = "DD0046_proj.h5"
     full_fn = os.path.join(ytdata_dir, fn)
@@ -109,9 +110,9 @@ def test_spatial_data():
     assert isinstance(proj_ds, YTSpatialPlotDataset)
     yield YTDataFieldTest(full_fn, ("grid", "density"), geometric=False)
 
-@requires_file(enzotiny)
-@requires_file(ytdata_dir)
-def test_profile_data():
+@requires_ds(enzotiny)
+@requires_ds(ytdata_dir)
+def test_old_profile_data():
     tmpdir = tempfile.mkdtemp()
     curdir = os.getcwd()
     os.chdir(tmpdir)
@@ -155,9 +156,9 @@ def test_profile_data():
     os.chdir(curdir)
     shutil.rmtree(tmpdir)
 
-@requires_file(enzotiny)
-@requires_file(ytdata_dir)
-def test_nonspatial_data():
+@requires_ds(enzotiny)
+@requires_ds(ytdata_dir)
+def test_old_nonspatial_data():
     ds = data_dir_load(enzotiny)
     region = ds.box([0.25]*3, [0.75]*3)
     sphere = ds.sphere(ds.domain_center, (10, "Mpc"))
@@ -181,7 +182,7 @@ def test_nonspatial_data():
 
 @requires_module('h5py')
 @requires_file(ytdata_dir)
-def test_plot_data():
+def test_old_plot_data():
     tmpdir = tempfile.mkdtemp()
     curdir = os.getcwd()
     os.chdir(tmpdir)

--- a/yt/frontends/ytdata/tests/test_outputs.py
+++ b/yt/frontends/ytdata/tests/test_outputs.py
@@ -30,9 +30,9 @@ from yt.testing import \
     assert_equal, \
     assert_fname, \
     fake_random_ds, \
-    requires_file, \
     requires_module
 from yt.utilities.answer_testing.framework import \
+    requires_ds, \
     data_dir_load, \
     AnswerTestingTest
 from yt.units.yt_array import \
@@ -99,7 +99,7 @@ class YTDataFieldTest(AnswerTestingTest):
                                   err_msg=err_msg, verbose=True)
 
 enzotiny = "enzo_tiny_cosmology/DD0046/DD0046"
-@requires_file(enzotiny)
+@requires_ds(enzotiny)
 def test_datacontainer_data():
     tmpdir = make_tempdir()
     curdir = os.getcwd()
@@ -123,7 +123,7 @@ def test_datacontainer_data():
     if tmpdir != '.':
         shutil.rmtree(tmpdir)
 
-@requires_file(enzotiny)
+@requires_ds(enzotiny)
 def test_grid_datacontainer_data():
     tmpdir = make_tempdir()
     curdir = os.getcwd()
@@ -161,7 +161,7 @@ def test_grid_datacontainer_data():
     if tmpdir != '.':
         shutil.rmtree(tmpdir)
 
-@requires_file(enzotiny)
+@requires_ds(enzotiny)
 def test_spatial_data():
     tmpdir = make_tempdir()
     curdir = os.getcwd()
@@ -178,7 +178,7 @@ def test_spatial_data():
     if tmpdir != '.':
         shutil.rmtree(tmpdir)
 
-@requires_file(enzotiny)
+@requires_ds(enzotiny)
 def test_profile_data():
     tmpdir = make_tempdir()
     curdir = os.getcwd()
@@ -227,7 +227,7 @@ def test_profile_data():
     if tmpdir != '.':
         shutil.rmtree(tmpdir)
 
-@requires_file(enzotiny)
+@requires_ds(enzotiny)
 def test_nonspatial_data():
     tmpdir = make_tempdir()
     curdir = os.getcwd()


### PR DESCRIPTION
## PR Summary

This adds tests for pre-existing `ytdata` datasets. The tests are equivalent to the currently existing tests, except they load testing data instead of create it with `yt.save_as_dataset`.

The test datasets can be generated by running `yt/frontends/ytdata/tests/test_outputs.py` after setting the `GENERATE_YTDATA=1` as an environment variable.

I've opened a [PR on the website repo](https://github.com/yt-project/website/pull/54) to add the relevant testing data.