### PR TITLE
[bugfix] fix io chunking for chained cut regions

### DIFF
--- a/yt/data_objects/selection_data_containers.py
+++ b/yt/data_objects/selection_data_containers.py
@@ -871,16 +871,18 @@ class YTCutRegion(YTSelectionContainer3D):
                 raise RuntimeError(
                     "Cannot use both base_object and data_source")
             data_source=base_object
+
+        self.conditionals = ensure_list(conditionals)
         if isinstance(data_source, YTCutRegion):
-            self.__init__(
-                data_source.base_object,
-                data_source.conditionals + conditionals,
-                ds=ds, field_parameters=field_parameters,
-                base_object=base_object)
-            return
+            # If the source is also a cut region, add its conditionals
+            # and set the source to be its source.
+            # Preserve order of conditionals.
+            self.conditionals = data_source.conditionals + \
+              self.conditionals
+            data_source = data_source.base_object
+
         super(YTCutRegion, self).__init__(
             data_source.center, ds, field_parameters, data_source=data_source)
-        self.conditionals = ensure_list(conditionals)
         self.base_object = data_source
         self._selector = None
         # Need to interpose for __getitem__, fwidth, fcoords, icoords, iwidth,

--- a/yt/data_objects/selection_data_containers.py
+++ b/yt/data_objects/selection_data_containers.py
@@ -871,6 +871,13 @@ class YTCutRegion(YTSelectionContainer3D):
                 raise RuntimeError(
                     "Cannot use both base_object and data_source")
             data_source=base_object
+        if isinstance(data_source, YTCutRegion):
+            self.__init__(
+                data_source.base_object,
+                data_source.conditionals + conditionals,
+                ds=ds, field_parameters=field_parameters,
+                base_object=base_object)
+            return
         super(YTCutRegion, self).__init__(
             data_source.center, ds, field_parameters, data_source=data_source)
         self.conditionals = ensure_list(conditionals)

--- a/yt/data_objects/tests/test_extract_regions.py
+++ b/yt/data_objects/tests/test_extract_regions.py
@@ -73,3 +73,18 @@ def test_region_chunked_read():
     dense_sp = sp.cut_region(['obj["H_p0_number_density"]>= 1e-2'])
     dense_sp.quantities.angular_momentum_vector()
     
+@requires_file(ISOGAL)
+def test_chained_cut_region():
+    # see Issue #2233
+    ds = load(ISOGAL)
+    base = ds.disk([0.5,0.5,0.5], [0,0,1], (4,"kpc"), (10,"kpc"))
+    c1 = "(obj['cylindrical_r'].in_units('kpc') > 2.0)"
+    c2 = "(obj['density'].to('g/cm**3') > 1e-26)"
+
+    cr12  = base.cut_region([c1, c2])
+    cr1   = base.cut_region([c1])
+    cr12c =  cr1.cut_region([c2])
+
+    field = ('index', 'cell_volume')
+    assert_equal(cr12.quantities.total_quantity(field),
+                 cr12c.quantities.total_quantity(field))


### PR DESCRIPTION
## PR Summary

This closes Issue #2233.

When chained cut regions do io chunking, only the conditionals of the last cut region are applied. Conditionals from parent cut regions are ignored. This only shows up when calculating derived quantities.

The solution implemented here changes how cut regions derived from other cut regions are initialized. Instead of creating a chain of objects that rely on each's parent, we add the conditionals from the parent cut region and create the new one from the parent's base object. Anecdotally, this also appears to speed up field access as we're only applying conditionals once.

## PR Checklist

- [ ] Code passes flake8 checker
- [ ] Adds a test for any bugs fixed. Adds tests for new features.