### PR TITLE
Update for Castro git hash prefix in plotfiles

### DIFF
--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -1102,8 +1102,9 @@ class CastroDataset(BoxlibDataset):
                 if any(b in line for b in bcs):
                     p, v = line.strip().split(":")
                     self.parameters[p] = v.strip()
-                if "git describe" in line:
-                    # line format: codename git describe:  the-hash
+                if "git describe" in line or "git hash" in line:
+                    # Castro release 17.02 and later - line format: codename git describe:  the-hash
+                    # Castro before release 17.02    - line format: codename git hash:  the-hash
                     fields = line.split(":")
                     self.parameters[fields[0]] = fields[1].strip()
                 line = next(f)

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -1102,8 +1102,8 @@ class CastroDataset(BoxlibDataset):
                 if any(b in line for b in bcs):
                     p, v = line.strip().split(":")
                     self.parameters[p] = v.strip()
-                if "git hash" in line:
-                    # line format: codename git hash:  the-hash
+                if "git describe" in line:
+                    # line format: codename git describe:  the-hash
                     fields = line.split(":")
                     self.parameters[fields[0]] = fields[1].strip()
                 line = next(f)


### PR DESCRIPTION
Updates search string for git hashes in the BoxLib frontend for Castro to account for a change made to this string in Castro release 17.02.

## PR Summary

In release 17.02, Castro changed the string used to prefix git hashes in plotfiles to use the words "git describe" instead of "git hash". This PR updates the search string for these git hashes accordingly.

This test script prints the git hashes from a Castro dataset:

```
import yt

ds = yt.load("ignition_16_plt00001")

for k in ds.parameters.keys():
    if "git" in k:
        print("{} = {}".format(k, ds.parameters[k]))
```

Presently, no git hashes are printed in the following output:

```
yt : [INFO     ] 2019-04-10 16:12:02,751 Parameters: current_time              = 0.1
yt : [INFO     ] 2019-04-10 16:12:02,751 Parameters: domain_dimensions         = [16 16 16]
yt : [INFO     ] 2019-04-10 16:12:02,751 Parameters: domain_left_edge          = [-1. -1. -1.]
yt : [INFO     ] 2019-04-10 16:12:02,751 Parameters: domain_right_edge         = [1. 1. 1.]
```

With this change, git hashes are stored in the dataset parameters:

```
yt : [INFO     ] 2019-04-10 16:11:06,603 Parameters: current_time              = 0.1
yt : [INFO     ] 2019-04-10 16:11:06,603 Parameters: domain_dimensions         = [16 16 16]
yt : [INFO     ] 2019-04-10 16:11:06,604 Parameters: domain_left_edge          = [-1. -1. -1.]
yt : [INFO     ] 2019-04-10 16:11:06,604 Parameters: domain_right_edge         = [1. 1. 1.]
Castro       git describe = 19.04-13-g25ac3d33d-dirty
Microphysics git describe = flame_wave-16-g58c6ce4f
AMReX        git describe = 19.04.2-141-g498a82e89
```

This does not affect the MAESTRO or Nyx frontends, as they still use "git hash" in their plotfiles.

## PR Checklist

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
