### PR TITLE
[bugfix] Arepo smoothing length is supposed to be float64

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,9 +29,9 @@ install:
     - "python --version"
 
     # Install specified version of numpy and dependencies
-    - "conda install --yes -c conda-forge numpy scipy nose setuptools ipython Cython sympy fastcache h5py matplotlib mock pandas cartopy"
+    - "conda install --yes -c conda-forge numpy scipy nose setuptools ipython Cython sympy fastcache h5py matplotlib mock pandas cartopy conda-build"
     # install yt
-    - "pip install -e ."
+    - "conda develop -b ."
 
 # Not a .NET project
 build: false

--- a/yt/frontends/arepo/io.py
+++ b/yt/frontends/arepo/io.py
@@ -28,7 +28,7 @@ class IOHandlerArepoHDF5(IOHandlerGadgetHDF5):
             hsml *= 3.0/(4.0*np.pi)
             hsml **= (1./3.)
             hsml *= self.ds.smoothing_factor
-            return hsml
+            return hsml.astype("float64")
 
     def _identify_fields(self, data_file):
         fields, _units = super(IOHandlerArepoHDF5, 


### PR DESCRIPTION
This got missed in the final cleanup steps in the recent Arepo frontend merge.