### PR TITLE
[bugfix] Make sure Arepo "smoothing length" has correct dtype

### DIFF
--- a/yt/frontends/arepo/io.py
+++ b/yt/frontends/arepo/io.py
@@ -28,7 +28,10 @@ class IOHandlerArepoHDF5(IOHandlerGadgetHDF5):
             hsml *= 3.0/(4.0*np.pi)
             hsml **= (1./3.)
             hsml *= self.ds.smoothing_factor
-            return hsml.astype("float64")
+            dt = hsml.dtype.newbyteorder("N") # Native
+            if position_dtype is not None and dt < position_dtype:
+                dt = position_dtype
+            return hsml.astype(dt)
 
     def _identify_fields(self, data_file):
         fields, _units = super(IOHandlerArepoHDF5, 


### PR DESCRIPTION
In the Gadget frontend we apply a fix if there is a mismatch in precision between the positions and the smoothing length fields stored on-disk. Apparently this fix is also necessary for the Arepo frontend if we construct "smoothing lengths" from the density and mass fields.

Fixes issue #2242.