### PR TITLE
Some updates and additions to astrophysics-related fields

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
 
   matrix:
       - PYTHON_VERSION: "3.6"
-      - NUMPY_VERSION: "1.16"
+        NUMPY_VERSION: "1.16"
 
 platform:
     -x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ environment:
 
   matrix:
       - PYTHON_VERSION: "3.6"
+      - NUMPY_VERSION: "1.16"
 
 platform:
     -x64
@@ -29,7 +30,7 @@ install:
     - "python --version"
 
     # Install specified version of numpy and dependencies
-    - "conda install --yes -c conda-forge numpy scipy nose setuptools ipython
+    - "conda install --yes -c conda-forge numpy==%NUMPY_VERSION% scipy nose setuptools ipython
     Cython sympy fastcache h5py matplotlib mock pandas cartopy conda-build unyt"
     # install yt
     - "conda develop -b ."

--- a/doc/source/analyzing/fields.rst
+++ b/doc/source/analyzing/fields.rst
@@ -426,6 +426,8 @@ Within a field function, these can then be retrieved and used in the same way.
 
 For a practical application of this, see :ref:`cookbook-radial-velocity`.
 
+.. _gradient_fields:
+
 Gradient Fields
 ---------------
 
@@ -448,6 +450,54 @@ of how to create and use these fields, see :ref:`cookbook-complicated-derived-fi
 .. note::
 
     ``add_gradient_fields`` currently only supports Cartesian geometries!
+
+.. _los_fields:
+
+Line of Sight Fields
+--------------------
+
+In astrophysics applications, one often wants to know the component of a vector 
+field along a given line of sight. If you are doing a projection of a vector 
+field along an axis, or just want to obtain the values of a vector field 
+component along an axis, you can use a line-of-sight field. For projections, 
+this will be handled automatically:
+
+.. code-block:: python
+
+    prj = yt.ProjectionPlot(ds, "z", ("gas","velocity_los"), 
+                            weight_field=("gas","density"))
+
+Which, because the axis is ``"z"``, will give you the same result if you had
+projected the `"velocity_z"`` field. This also works for off-axis projections:
+
+.. code-block:: python
+
+    prj = yt.OffAxisProjectionPlot(ds, [0.1, -0.2, 0.3], ("gas","velocity_los"), 
+                                   weight_field=("gas","density"))
+
+
+This shows that the projection axis can be along a principle axis of the domain 
+or an arbitrary off-axis 3-vector (which will be automatically normalized). If 
+you want to examine a line-of-sight vector within a 3-D data object, set the 
+``"axis"`` field parameter:
+
+.. code-block:: python
+
+    dd = ds.all_data()
+    # Set to one of [0, 1, 2] for ["x", "y", "z"] axes
+    dd.set_field_parameter("axis", 1)
+    print(dd["gas","magnetic_field_los"])
+    # Set to a three-vector for an off-axis component
+    dd.set_field_parameter("axis", [0.3, 0.4, -0.7])
+    print(dd["gas","velocity_los"])
+
+At this time, this functionality is enabled for the velocity and magnetic vector
+fields, ``("gas","velocity_los")`` and ``("gas","magnetic_field_los")``. The 
+following fields built into yt make use of these line-of-sight fields:
+
+* ``("gas","sz_kinetic")`` uses ``("gas","velocity_los")``
+* ``("gas","rotation_measure")`` uses ``("gas","magnetic_field_los")``
+
 
 General Particle Fields
 -----------------------

--- a/doc/source/analyzing/fields.rst
+++ b/doc/source/analyzing/fields.rst
@@ -548,6 +548,12 @@ you want to examine a line-of-sight vector within a 3-D data object, set the
     dd.set_field_parameter("axis", [0.3, 0.4, -0.7])
     print(dd["gas","velocity_los"])
 
+.. warning::
+
+    If you need to change the axis of the line of sight on the *same* data container
+    (sphere, box, cylinder, or whatever), you will need to delete the field using
+    ``del dd["velocity_los"]`` and re-generate it. 
+
 At this time, this functionality is enabled for the velocity and magnetic vector
 fields, ``("gas","velocity_los")`` and ``("gas","magnetic_field_los")``. The 
 following fields built into yt make use of these line-of-sight fields:

--- a/doc/source/analyzing/fields.rst
+++ b/doc/source/analyzing/fields.rst
@@ -424,7 +424,9 @@ the following fields are defined:
 The ``mean_molecular_weight`` field will be constructed from the abundances of the elements
 in the dataset. If no element or molecule fields are defined, the above fields for the ionized
 primordial H/He plasma are defined, and the ``mean_molecular_weight`` field is correspondingly set
-to :math:`\mu \approx 0.6`.
+to :math:`\mu \approx 0.6`. Some frontends do not directly store the gas temperature in their
+datasets, in which case it must be computed from the pressure and/or thermal energy as well
+as the mean molecular weight, so check this carefully!
 
 Particle Fields
 ---------------

--- a/doc/source/analyzing/fields.rst
+++ b/doc/source/analyzing/fields.rst
@@ -385,9 +385,12 @@ within the dataset, as well as their abundances and ionization states. Examples 
 
 The naming scheme for the fields starts with prefixes in the form ``MM[_[mp][NN]]``. ``MM``
 is the molecule, defined as a concatenation of atomic symbols and numbers, with no spaces or
-underscores. The second sequence is only required if the ionization state is not neutral,
-and is of the form ``p`` and ``m`` to indicate "plus" or "minus" respectively, followed by
-the number. For the examples above, the prefixes would be:
+underscores. The second sequence is only required if ionization states are present in the
+dataset, and is of the form ``p`` and ``m`` to indicate "plus" or "minus" respectively, 
+followed by the number. If a given species has no ionization states given, the prefix is
+simply ``MM``. 
+
+For the examples above, the prefixes would be:
 
 * ``CO``
 * ``Co``
@@ -408,8 +411,7 @@ defined:
 * ``MM[_[mp][NN]]_mass``
 
 To refer to the number density of the entirety of a single atom or molecule (regardless
-of its ionization state), please use the ``MM_nuclei_density`` fields, as opposed to
-``MM_number_density`` fields.
+of its ionization state), please use the ``MM_nuclei_density`` fields.
 
 Finally, if the abundances of hydrogen and helium are not defined, it is assumed that
 assumed that these elements are fully ionized with primordial abundances In this case,

--- a/doc/source/analyzing/fields.rst
+++ b/doc/source/analyzing/fields.rst
@@ -371,6 +371,61 @@ different magnetic field units in the different :ref:`unit systems <unit_systems
 determine how to set up special magnetic field handling when designing a new frontend, check out
 :ref:`bfields-frontend`.
 
+Species Fields
+--------------
+
+For many types of data, yt is able to detect different chemical elements and molecules
+within the dataset, as well as their abundances and ionization states. Examples include:
+
+* CO (Carbon monoxide)
+* Co (Cobalt)
+* OVI (Oxygen ionized five times)
+* H:math:`^{2+}` (Molecular Hydrogen ionized once)
+* H:math:`^{-}` (Hydrogen atom with an additional electron)
+
+The naming scheme for the fields starts with prefixes in the form ``MM[_[mp][NN]]``. ``MM``
+is the molecule, defined as a concatenation of atomic symbols and numbers, with no spaces or
+underscores. The second sequence is only required if the ionization state is not neutral,
+and is of the form ``p`` and ``m`` to indicate "plus" or "minus" respectively, followed by
+the number. For the examples above, the prefixes would be:
+
+* ``CO``
+* ``Co``
+* ``O_p5``
+* ``H2_p1``
+* ``H_m1``
+
+The name ``El`` is used for electron fields, as it is unambiguous and will not be
+utilized elsewhere. Neutral ionic species (e.g. H I, O I) are represented as ``MM_p0``.
+Additionally, the isotope of :math:`^2`H will be included as ``D``.
+
+Finally, in those frontends which are single-fluid, these fields for each species are
+defined:
+
+* ``MM[_[mp][NN]]_fraction``
+* ``MM[_[mp][NN]]_number_density``
+* ``MM[_[mp][NN]]_density``
+* ``MM[_[mp][NN]]_mass``
+
+To refer to the number density of the entirety of a single atom or molecule (regardless
+of its ionization state), please use the ``MM_nuclei_density`` fields, as opposed to
+``MM_number_density`` fields.
+
+Finally, if the abundances of hydrogen and helium are not defined, it is assumed that
+assumed that these elements are fully ionized with primordial abundances In this case,
+the following fields are defined:
+
+* ``H_p1_number_density``
+* ``H_nuclei_density``
+* ``He_p2_number_density``
+* ``He_nuclei_density``
+* ``El_number_density``
+
+The ``mean_molecular_weight`` field will be constructed from the abundances of the elements
+in the dataset. If no element or molecule fields are defined, the above fields for the ionized
+primordial H/He plasma are defined, and the ``mean_molecular_weight`` field is correspondingly set
+to :math:`\mu \approx 0.6`.
+
 Particle Fields
 ---------------
 

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -1066,9 +1066,12 @@ present, Then the mean molecular weight is the inverse of ``"sumy"``, and the fi
 defined using the following mathematical definitions:
 
 * ``"El_number_density"`` :math:`n_e = N_AY_e\rho`
-* ``"ion_number_density"`` :math:`n_i = N_A\Sigma{Y}\rho`
+* ``"ion_number_density"`` :math:`n_i = N_A\rho/\bar{A}`
 * ``"number_density"`` :math:`n = n_e + n_i`
 
+where :math:`n_e` and :math:`n_i` are the electron and ion number densities, 
+:math:`\rho` is the mass density, :math:`Y_e` is the electron number per baryon,
+:math:`\bar{A}` is the mean molecular weight, and :math:`N_A` is Avogadro's number.
 
 .. rubric:: Caveats
 
@@ -1374,7 +1377,8 @@ value can be changed when loading an Arepo dataset by setting the
 
 Currently, only Arepo HDF5 snapshots are supported. If the "GFM" metal fields are
 present in your dataset, they will be loaded in and aliased to the appropriate 
-species fields. 
+species fields in the `"GFM_Metals"` field on-disk. For more information, see
+the `Illustris TNG documentation <http://www.tng-project.org/data/docs/specifications/#sec1b>`_.
 
 .. _loading-gamer-data:
 

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -186,11 +186,14 @@ larger than this.
 Alternative values for the following simulation parameters may be specified
 using a ``parameters`` dict, accepting the following keys:
 
-* ``Gamma``: ratio of specific heats, Type: Float
+* ``gamma``: ratio of specific heats, Type: Float. If not specified, 
+  :math:`\gamma = 5/3` is assumed.
 * ``geometry``: Geometry type, currently accepts ``"cartesian"`` or
-  ``"cylindrical"``
+  ``"cylindrical"``. Default is ``"cartesian"``.
 * ``periodicity``: Is the domain periodic? Type: Tuple of boolean values
-  corresponding to each dimension
+  corresponding to each dimension. Defaults to ``True`` in all directions.
+* ``mu``: mean molecular weight, Type: Float. If not specified, :math:`\mu = 0.6`
+  (for a fully ionized primordial plasma) is assumed.
 
 .. code-block:: python
 
@@ -258,6 +261,18 @@ This means that the yt fields, e.g. ``("gas","density")``,
 (or whatever unit system was specified), but the Athena fields, e.g.,
 ``("athena_pp","density")``, ``("athena_pp","vel1")``, ``("athena_pp","Bcc1")``,
 will be in code units.
+
+Alternative values for the following simulation parameters may be specified
+using a ``parameters`` dict, accepting the following keys:
+
+* ``gamma``: ratio of specific heats, Type: Float. If not specified, 
+  :math:`\gamma = 5/3` is assumed.
+* ``geometry``: Geometry type, currently accepts ``"cartesian"`` or
+  ``"cylindrical"``. Default is ``"cartesian"``.
+* ``periodicity``: Is the domain periodic? Type: Tuple of boolean values
+  corresponding to each dimension. Defaults to ``True`` in all directions.
+* ``mu``: mean molecular weight, Type: Float. If not specified, :math:`\mu = 0.6`
+  (for a fully ionized primordial plasma) is assumed.
 
 .. rubric:: Caveats
 
@@ -1032,7 +1047,28 @@ grid structure and are at the same simulation time, the particle data may be loa
 However, if you don't have a corresponding plotfile for a particle file, but would still
 like to load the particle data, you can still call ``yt.load`` on the file. However, the
 grid information will not be available, and the particle data will be loaded in a fashion
-similar to SPH data.
+similar to other particle-based datasets in yt.
+
+Mean Molecular Weight and Number Density Fields
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The way the mean molecular weight and number density fields are defined depends on 
+what type of simulation you are running. If you are running a simulation without 
+species and a :math:`\gamma`-law equation of state, then the mean molecular weight
+is defined using the ``eos_singleSpeciesA`` parameter in the FLASH dataset. If you
+have multiple species and your dataset contains the FLASH field ``"abar"``, then
+this is used as the mean molecular weight. In either case, the number density field
+is calculated using this weight. 
+
+If you are running a FLASH simulation where the fields ``"sumy"`` and ``"ye"`` are 
+present, Then the mean molecular weight is the inverse of ``"sumy"``, and the fields 
+``"El_number_density"``, ``"ion_number_density"``, and ``"number_density"`` are 
+defined using the following mathematical definitions:
+
+* ``"El_number_density"`` :math:`n_e = N_AY_e\rho`
+* ``"ion_number_density"`` :math:`n_i = N_A\Sigma{Y}\rho`
+* ``"number_density"`` :math:`n = n_e + n_i`
+
 
 .. rubric:: Caveats
 
@@ -1336,7 +1372,9 @@ value can be changed when loading an Arepo dataset by setting the
    import yt
    ds = yt.load("snapshot_100.hdf5", smoothing_factor=1.5)
 
-Currently, only Arepo HDF5 snapshots are supported.
+Currently, only Arepo HDF5 snapshots are supported. If the "GFM" metal fields are
+present in your dataset, they will be loaded in and aliased to the appropriate 
+species fields. 
 
 .. _loading-gamer-data:
 

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -1,5 +1,5 @@
 answer_tests:
-  local_arepo_001:
+  local_arepo_002:
     - yt/frontends/arepo/tests/test_outputs.py
 
   local_artio_001:

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -180,6 +180,7 @@ class YTProj(YTSelectionContainer2D):
         self._set_center(center)
         self._projected_units = {}
         if data_source is None: data_source = self.ds.all_data()
+        data_source.set_field_parameter("axis", self.axis)
         if max_level is not None:
             data_source.max_level = max_level
         for k, v in data_source.field_parameters.items():

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -180,7 +180,6 @@ class YTProj(YTSelectionContainer2D):
         self._set_center(center)
         self._projected_units = {}
         if data_source is None: data_source = self.ds.all_data()
-        data_source.set_field_parameter("axis", self.axis)
         if max_level is not None:
             data_source.max_level = max_level
         for k, v in data_source.field_parameters.items():

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -63,7 +63,11 @@ def sanitize_weight_field(ds, field, weight):
     field_object = ds._get_field_info(field)
     if weight is None:
         if field_object.sampling_type == "particle":
-            weight_field = (field_object.name[0], 'particle_ones')
+            if field_object.name[0] == "gas":
+                ptype = ds._sph_ptypes[0]
+            else:
+                ptype = field_object.name[0]
+            weight_field = (ptype, 'particle_ones')
         else:
             weight_field = ('index', 'ones')
     else:

--- a/yt/fields/astro_fields.py
+++ b/yt/fields/astro_fields.py
@@ -62,8 +62,8 @@ def setup_astro_fields(registry, ftype = "gas", slice_info = None):
     def _mazzotta_weighting(field, data):
         # Spectroscopic-like weighting field for galaxy clusters
         # Only useful as a weight_field for temperature, metallicity, velocity
-        ret = data[ftype, "El_nuclei_density"].d
-        ret *= ret*data[ftype, "kT"].d**-0.75
+        ret = data[ftype, "El_nuclei_density"].d**2
+        ret *= data[ftype, "kT"].d**-0.75
         return ret
 
     registry.add_field((ftype,"mazzotta_weighting"),

--- a/yt/fields/astro_fields.py
+++ b/yt/fields/astro_fields.py
@@ -2,13 +2,8 @@ import numpy as np
 
 from .derived_field import \
     ValidateParameter
-from .field_exceptions import \
-    NeedsParameter
 from .field_plugin_registry import \
     register_field_plugin
-
-from yt.funcs import \
-    iterable
 
 
 @register_field_plugin

--- a/yt/fields/astro_fields.py
+++ b/yt/fields/astro_fields.py
@@ -51,7 +51,7 @@ def setup_astro_fields(registry, ftype = "gas", slice_info = None):
     def _emission_measure(field, data):
         dV = data[ftype, "mass"]/data[ftype, "density"]
         nenhdV = data[ftype, "H_p1_number_density"]*dV
-        nenhdV *= data[ftype, "El_nuclei_density"]
+        nenhdV *= data[ftype, "El_number_density"]
         return nenhdV
 
     registry.add_field((ftype, "emission_measure"),
@@ -62,7 +62,7 @@ def setup_astro_fields(registry, ftype = "gas", slice_info = None):
     def _mazzotta_weighting(field, data):
         # Spectroscopic-like weighting field for galaxy clusters
         # Only useful as a weight_field for temperature, metallicity, velocity
-        ret = data[ftype, "El_nuclei_density"].d**2
+        ret = data[ftype, "El_number_density"].d**2
         ret *= data[ftype, "kT"].d**-0.75
         return ret
 
@@ -72,7 +72,7 @@ def setup_astro_fields(registry, ftype = "gas", slice_info = None):
                        units="")
 
     def _optical_depth(field, data):
-        return data[ftype, "El_nuclei_density"]*pc.sigma_thompson
+        return data[ftype, "El_number_density"]*pc.sigma_thompson
 
     registry.add_field((ftype, "optical_depth"), sampling_type="local",
                        function=_optical_depth, units=unit_system["length"]**-1)
@@ -100,7 +100,7 @@ def setup_astro_fields(registry, ftype = "gas", slice_info = None):
 
     def _entropy(field, data):
         mgammam1 = -2./3.
-        tr = data[ftype, "kT"] * data[ftype, "El_nuclei_density"]**mgammam1
+        tr = data[ftype, "kT"] * data[ftype, "El_number_density"]**mgammam1
         return data.apply_units(tr, field.units)
 
     registry.add_field((ftype, "entropy"),

--- a/yt/fields/astro_fields.py
+++ b/yt/fields/astro_fields.py
@@ -82,24 +82,6 @@ def setup_astro_fields(registry, ftype = "gas", slice_info = None):
     registry.add_field((ftype, "optical_depth"), sampling_type="local",
                        function=_optical_depth, units=unit_system["length"]**-1)
 
-    def _velocity_los(field, data):
-        vel_axis = data.get_field_parameter("axis")
-        if iterable(vel_axis):
-            ret = data[ftype, "velocity_x"]*vel_axis[0] + \
-                  data[ftype, "velocity_y"]*vel_axis[1] + \
-                  data[ftype, "velocity_z"]*vel_axis[2]
-        elif vel_axis > 2:
-            raise NeedsParameter(["axis"])
-        else:
-            ret = data[ftype, "velocity_%s" % ({0: "x", 1: "y", 2: "z"}[vel_axis])]
-        return ret
-
-    registry.add_field((ftype, "velocity_los"), sampling_type="local",
-                       function=_velocity_los,
-                       units=unit_system["velocity"],
-                       validators=[
-                           ValidateParameter("axis", {'axis': [0, 1, 2]})])
-
     def _sz_kinetic(field, data):
         # minus sign is because radial velocity is WRT viewer
         # See issue #1225

--- a/yt/fields/astro_fields.py
+++ b/yt/fields/astro_fields.py
@@ -80,7 +80,7 @@ def setup_astro_fields(registry, ftype = "gas", slice_info = None):
     def _sz_kinetic(field, data):
         # minus sign is because radial velocity is WRT viewer
         # See issue #1225
-        return -data[ftype, "velocity_los"]*data[ftype, "tau"]/pc.clight
+        return -data[ftype, "velocity_los"]*data[ftype, "optical_depth"]/pc.clight
 
     registry.add_field((ftype, "sz_kinetic"),
                        sampling_type="local",

--- a/yt/fields/astro_fields.py
+++ b/yt/fields/astro_fields.py
@@ -50,7 +50,7 @@ def setup_astro_fields(registry, ftype = "gas", slice_info = None):
 
     def _emission_measure(field, data):
         dV = data[ftype, "mass"]/data[ftype, "density"]
-        nenhdV = data[ftype, "H_nuclei_density"]*dV
+        nenhdV = data[ftype, "H_p1_number_density"]*dV
         nenhdV *= data[ftype, "El_nuclei_density"]
         return nenhdV
 

--- a/yt/fields/astro_fields.py
+++ b/yt/fields/astro_fields.py
@@ -62,14 +62,14 @@ def setup_astro_fields(registry, ftype = "gas", slice_info = None):
     def _mazzotta_weighting(field, data):
         # Spectroscopic-like weighting field for galaxy clusters
         # Only useful as a weight_field for temperature, metallicity, velocity
-        ret = data[ftype, "density"]/pc.mh
-        ret *= ret*data[ftype, "kT"]**-0.75
+        ret = data[ftype, "El_nuclei_density"].d
+        ret *= ret*data[ftype, "kT"].d**-0.75
         return ret
 
     registry.add_field((ftype,"mazzotta_weighting"),
                        sampling_type="local",
                        function=_mazzotta_weighting,
-                       units="keV**-0.75*cm**-6")
+                       units="")
 
     def _optical_depth(field, data):
         return data[ftype, "El_nuclei_density"]*pc.sigma_thompson

--- a/yt/fields/fluid_fields.py
+++ b/yt/fields/fluid_fields.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from yt.units.unit_object import Unit
+
 from .derived_field import \
     ValidateSpatial, \
     ValidateParameter

--- a/yt/fields/fluid_fields.py
+++ b/yt/fields/fluid_fields.py
@@ -55,7 +55,7 @@ def setup_fluid_fields(registry, ftype = "gas", slice_info = None):
         return data[ftype, "density"] * data[ftype, "cell_volume"]
 
     registry.add_field((ftype, "cell_mass"),
-                       sampling_type="local",
+                       sampling_type="cell",
                        function=_cell_mass,
                        units=unit_system["mass"])
     registry.alias((ftype, "mass"), (ftype, "cell_mass"))
@@ -108,7 +108,7 @@ def setup_fluid_fields(registry, ftype = "gas", slice_info = None):
         return tr
 
     registry.add_field((ftype, "courant_time_step"),
-                       sampling_type="local",
+                       sampling_type="cell",
                        function=_courant_time_step,
                        units=unit_system["time"])
 

--- a/yt/fields/fluid_fields.py
+++ b/yt/fields/fluid_fields.py
@@ -167,17 +167,8 @@ def setup_fluid_fields(registry, ftype = "gas", slice_info = None):
                        function=_number_density,
                        units=unit_system["number_density"])
 
-    if len(registry.ds.field_info.species_names) > 0:
-        def _mean_molecular_weight(field, data):
-            return data[ftype, "density"] / (pc.mh * data[ftype, "number_density"])
-    else:
-        def _mean_molecular_weight(field, data):
-            if data.has_field_parameter("mean_molecular_weight"):
-                mu = data.get_field_parameter("mean_molecular_weight")
-            else:
-                # Assume zero ionization
-                mu = 4.0 / (3.0 * primordial_H_mass_fraction + 1.0)
-            return mu*np.ones_like(data[ftype, "density"].d)
+    def _mean_molecular_weight(field, data):
+        return data[ftype, "density"] / (pc.mh * data[ftype, "number_density"])
 
     registry.add_field((ftype, "mean_molecular_weight"),
                        sampling_type="local",

--- a/yt/fields/fluid_fields.py
+++ b/yt/fields/fluid_fields.py
@@ -15,10 +15,7 @@ from .vector_operations import \
     create_vector_fields
 
 from yt.utilities.chemical_formulas import \
-    ChemicalFormula
-
-from yt.utilities.physical_ratios import \
-    _primordial_mass_fraction
+    default_mu
 
 from yt.utilities.lib.misc_utilities import \
     obtain_relative_velocity_vector
@@ -157,15 +154,8 @@ def setup_fluid_fields(registry, ftype = "gas", slice_info = None):
             return field_data
     else:
         def _number_density(field, data):
-            if data.has_field_parameter("mean_molecular_weight"):
-                muinv = 1.0/data.get_field_parameter("mean_molecular_weight")
-            else:
-                # Assume full ionization
-                muinv = 2.0*_primordial_mass_fraction["H"] / \
-                        ChemicalFormula("H").weight
-                muinv += 3.0*_primordial_mass_fraction["He"] / \
-                         ChemicalFormula("He").weight
-            return data[ftype, "density"]*muinv/pc.mh
+            mu = getattr(data.ds, "mu", default_mu)
+            return data[ftype, "density"]/(pc.mh*mu)
 
     registry.add_field((ftype, "number_density"),
                        sampling_type="local",

--- a/yt/fields/magnetic_field.py
+++ b/yt/fields/magnetic_field.py
@@ -170,7 +170,7 @@ def setup_magnetic_field_fields(registry, ftype="gas", slice_info=None):
     rm_units = registry.ds.quan(1.0, "rad/m**2").units/unit_system["length"]
 
     def _rotation_measure(field, data):
-        return rm_scale*data[ftype, "magnetic_field_los"]*data[ftype, "El_nuclei_density"]
+        return rm_scale*data[ftype, "magnetic_field_los"]*data[ftype, "El_number_density"]
 
     registry.add_field((ftype, "rotation_measure"), sampling_type="local",
                        function=_rotation_measure, units=rm_units,

--- a/yt/fields/magnetic_field.py
+++ b/yt/fields/magnetic_field.py
@@ -54,23 +54,6 @@ def setup_magnetic_field_fields(registry, ftype="gas", slice_info=None):
                        validators=[ValidateParameter('bulk_magnetic_field')],
                        units=u)
 
-    def _magnetic_field_los(field, data):
-        mag_axis = data.get_field_parameter("axis")
-        if iterable(mag_axis):
-            ret = data[ftype, "magnetic_field_x"]*mag_axis[0] + \
-                  data[ftype, "magnetic_field_y"]*mag_axis[1] + \
-                  data[ftype, "magnetic_field_z"]*mag_axis[2]
-        elif mag_axis > 2:
-            raise NeedsParameter(["axis"])
-        else:
-            ret = data[ftype, "magnetic_field_%s" % ({0: "x", 1: "y", 2: "z"}[mag_axis])]
-        return ret
-
-    registry.add_field((ftype, "magnetic_field_los"), sampling_type="local",
-                       function=_magnetic_field_los, units=u,
-                       validators=[
-                           ValidateParameter("axis", {'axis': [0, 1, 2]})])
-
     def _magnetic_energy(field, data):
         B = data[ftype,"magnetic_field_strength"]
         return 0.5*B*B/mag_factors(B.units.dimensions)

--- a/yt/fields/magnetic_field.py
+++ b/yt/fields/magnetic_field.py
@@ -6,12 +6,6 @@ from yt.units.yt_array import ustack
 from yt.fields.derived_field import \
     ValidateParameter
 
-from yt.funcs import \
-    iterable
-
-from .field_exceptions import \
-    NeedsParameter
-
 from .field_plugin_registry import \
     register_field_plugin
 

--- a/yt/fields/magnetic_field.py
+++ b/yt/fields/magnetic_field.py
@@ -265,6 +265,6 @@ def setup_magnetic_field_aliases(registry, ds_ftype, ds_fields, ftype="gas"):
                                sampling_type=sampling_type,
                                function=mag_field(ax),
                                units=units)
-            sph_ptype = getattr(registry.ds, "_sph_ptype", None)
-            if ds_ftype == sph_ptype:
+            sph_ptypes = getattr(registry.ds, "_sph_ptypes", tuple())
+            if ds_ftype in sph_ptypes:
                 registry.alias((ftype, "magnetic_field_%s" % ax), (ds_ftype, fname))

--- a/yt/fields/species_fields.py
+++ b/yt/fields/species_fields.py
@@ -143,6 +143,8 @@ def add_nuclei_density_fields(registry, ftype):
                            function=_nuclei_density,
                            units=unit_system["number_density"])
 
+    # Here, we add default nuclei and number density fields for H and
+    # He if they are not defined above. This assumes full ionization!
     for element in ["H", "He", "El"]:
         if element in elements:
             continue
@@ -150,7 +152,13 @@ def add_nuclei_density_fields(registry, ftype):
                            sampling_type="local",
                            function=_default_nuclei_density,
                            units=unit_system["number_density"])
+        if element == "H":
+            registry.alias((ftype, "H_p1_number_density"),
+                           (ftype, "H_nuclei_density"))
 
+        if element == "He":
+            registry.alias((ftype, "He_p2_number_density"),
+                           (ftype, "He_nuclei_density"))
 
 def _default_nuclei_density(field, data):
     ftype = field.name[0]

--- a/yt/fields/species_fields.py
+++ b/yt/fields/species_fields.py
@@ -148,8 +148,11 @@ def add_nuclei_density_fields(registry, ftype):
     for element in ["H", "He", "El"]:
         if element in elements:
             continue
-        registry.add_field((ftype, "%s_nuclei_density" % element),
-                           sampling_type="local",
+        if element == "El":
+            fname = (ftype, "%s_number_density" % element)
+        else:
+            fname = (ftype, "%s_nuclei_density" % element)
+        registry.add_field(fname, sampling_type="local",
                            function=_default_nuclei_density,
                            units=unit_system["number_density"])
         if element == "H":

--- a/yt/fields/species_fields.py
+++ b/yt/fields/species_fields.py
@@ -4,15 +4,12 @@ import re
 from yt.frontends.sph.data_structures import \
     ParticleDataset
 from yt.utilities.physical_ratios import \
-    primordial_H_mass_fraction
+    _primordial_mass_fraction
 from yt.utilities.chemical_formulas import \
     ChemicalFormula
 from .field_plugin_registry import \
     register_field_plugin
 
-_primordial_mass_fraction = \
-  {"H": primordial_H_mass_fraction,
-   "He": (1 - primordial_H_mass_fraction)}
 
 # See YTEP-0003 for details, but we want to ensure these fields are all
 # populated:
@@ -87,6 +84,7 @@ def add_species_field_by_density(registry, ftype, species):
             (ftype, "%s_density" % species),
             (ftype, "%s_mass" % species)]
 
+
 def add_species_field_by_fraction(registry, ftype, species):
     """
     This takes a field registry, a fluid type, and a species name and then
@@ -153,6 +151,7 @@ def add_nuclei_density_fields(registry, ftype):
                            function=_default_nuclei_density,
                            units=unit_system["number_density"])
 
+
 def _default_nuclei_density(field, data):
     ftype = field.name[0]
     element = field.name[1][:field.name[1].find("_")]
@@ -160,13 +159,13 @@ def _default_nuclei_density(field, data):
     if element == "El":
         # This assumes full ionization!
         muinv = 1.0*_primordial_mass_fraction["H"] / \
-          ChemicalFormula("H").weight / amu_cgs
+          ChemicalFormula("H").weight
         muinv += 2.0*_primordial_mass_fraction["He"] / \
-          ChemicalFormula("He").weight / amu_cgs
+          ChemicalFormula("He").weight
     else:
         muinv = _primordial_mass_fraction[element] / \
-          ChemicalFormula(element).weight / amu_cgs
-    return data[ftype, "density"] * muinv
+          ChemicalFormula(element).weight
+    return data[ftype, "density"] * muinv / amu_cgs
 
 
 def _nuclei_density(field, data):

--- a/yt/fields/species_fields.py
+++ b/yt/fields/species_fields.py
@@ -239,10 +239,4 @@ def setup_species_fields(registry, ftype = "gas", slice_info = None):
             # Skip it
             continue
         func(registry, ftype, species)
-        # Adds aliases for all neutral species from their raw "MM_"
-        # species to "MM_p0_" species to be explicit.
-        # See YTEP-0003 for more details.
-        if ChemicalFormula(species).charge == 0:
-            alias_species = "%s_p0" % species.split('_')[0]
-            add_species_aliases(registry, "gas", alias_species, species)
     add_nuclei_density_fields(registry, ftype)

--- a/yt/fields/species_fields.py
+++ b/yt/fields/species_fields.py
@@ -145,14 +145,11 @@ def add_nuclei_density_fields(registry, ftype):
 
     # Here, we add default nuclei and number density fields for H and
     # He if they are not defined above. This assumes full ionization!
-    for element in ["H", "He", "El"]:
+    for element in ["H", "He"]:
         if element in elements:
             continue
-        if element == "El":
-            fname = (ftype, "%s_number_density" % element)
-        else:
-            fname = (ftype, "%s_nuclei_density" % element)
-        registry.add_field(fname, sampling_type="local",
+        registry.add_field((ftype, "%s_nuclei_density" % element), 
+                           sampling_type="local",
                            function=_default_nuclei_density,
                            units=unit_system["number_density"])
         if element == "H":
@@ -162,6 +159,13 @@ def add_nuclei_density_fields(registry, ftype):
         if element == "He":
             registry.alias((ftype, "He_p2_number_density"),
                            (ftype, "He_nuclei_density"))
+
+    if (ftype, "El_number_density") not in registry:
+        registry.add_field((ftype, "El_number_density"),
+                           sampling_type="local",
+                           function=_default_nuclei_density,
+                           units=unit_system["number_density"])
+
 
 def _default_nuclei_density(field, data):
     ftype = field.name[0]

--- a/yt/fields/tests/test_species_fields.py
+++ b/yt/fields/tests/test_species_fields.py
@@ -1,0 +1,39 @@
+from yt.testing import requires_file, \
+    assert_allclose_units, assert_equal
+from yt.utilities.answer_testing.framework import \
+    data_dir_load
+from yt.utilities.physical_ratios import \
+    _primordial_mass_fraction
+from yt.utilities.chemical_formulas import \
+    ChemicalFormula
+
+sloshing = "GasSloshing/sloshing_nomag2_hdf5_plt_cnt_0100"
+
+@requires_file(sloshing)
+def test_default_species_fields():
+    ds = data_dir_load(sloshing)
+    sp = ds.sphere("c", (0.2, "unitary"))
+    amu_cgs = ds.units.physical_constants.amu_cgs
+
+    mueinv = 1.0*_primordial_mass_fraction["H"] / \
+             ChemicalFormula("H").weight
+    mueinv *= sp["index","ones"]
+    mueinv += 2.0*_primordial_mass_fraction["He"] / \
+              ChemicalFormula("He").weight
+    mupinv =  _primordial_mass_fraction["H"] / \
+              ChemicalFormula("H").weight
+    mupinv *= sp["index","ones"]
+    muainv =  _primordial_mass_fraction["He"] / \
+              ChemicalFormula("He").weight
+    muainv *= sp["index","ones"]
+    mueinv2 = sp["gas","El_nuclei_density"]*amu_cgs/sp["gas","density"]
+    mupinv2 = sp["gas","H_p1_number_density"]*amu_cgs/sp["gas","density"]
+    muainv2 = sp["gas","He_p2_number_density"]*amu_cgs/sp["gas","density"]
+
+
+    assert_allclose_units(mueinv, mueinv2)
+    assert_allclose_units(mupinv, mupinv2)
+    assert_allclose_units(muainv, muainv2)
+
+    assert_equal(sp["gas","H_p1_number_density"], sp["gas","H_nuclei_density"])
+    assert_equal(sp["gas","He_p2_number_density"], sp["gas","He_nuclei_density"])

--- a/yt/fields/tests/test_species_fields.py
+++ b/yt/fields/tests/test_species_fields.py
@@ -26,7 +26,7 @@ def test_default_species_fields():
     muainv =  _primordial_mass_fraction["He"] / \
               ChemicalFormula("He").weight
     muainv *= sp["index","ones"]
-    mueinv2 = sp["gas","El_nuclei_density"]*amu_cgs/sp["gas","density"]
+    mueinv2 = sp["gas","El_number_density"]*amu_cgs/sp["gas","density"]
     mupinv2 = sp["gas","H_p1_number_density"]*amu_cgs/sp["gas","density"]
     muainv2 = sp["gas","He_p2_number_density"]*amu_cgs/sp["gas","density"]
 

--- a/yt/fields/tests/test_vector_fields.py
+++ b/yt/fields/tests/test_vector_fields.py
@@ -69,6 +69,22 @@ def compare_vector_conversions(data_source):
                     data_source['velocity_%s' % d] - bulk_velocity[i],
                     data_source['relative_velocity_%s' % d])
 
+        for i, ax in enumerate('xyz'):
+            data_source.set_field_parameter("axis", i)
+            data_source.clear_data()
+            assert_allclose_units(data_source["velocity_los"], 
+                                  data_source["relative_velocity_%s" % ax])
+
+        data_source.clear_data()
+        ax = [0.1, 0.2, -0.3]
+        data_source.set_field_parameter("axis", ax)
+        ax /= np.sqrt(np.dot(ax,ax))
+        vlos = data_source["relative_velocity_x"]*ax[0]
+        vlos += data_source["relative_velocity_y"]*ax[1]
+        vlos += data_source["relative_velocity_z"]*ax[2]
+        assert_allclose_units(data_source["velocity_los"], vlos)
+
+
 def test_vector_component_conversions_fake():
     ds = fake_random_ds(16)
     ad = ds.all_data()

--- a/yt/fields/tests/test_vector_fields.py
+++ b/yt/fields/tests/test_vector_fields.py
@@ -75,6 +75,10 @@ def compare_vector_conversions(data_source):
             assert_allclose_units(data_source["velocity_los"], 
                                   data_source["relative_velocity_%s" % ax])
 
+        for i, ax in enumerate("xyz"):
+            prj = data_source.ds.proj("velocity_los", i, weight_field="density")
+            assert_allclose_units(prj["velocity_los"], prj["velocity_%s" % ax])
+
         data_source.clear_data()
         ax = [0.1, 0.2, -0.3]
         data_source.set_field_parameter("axis", ax)

--- a/yt/fields/vector_operations.py
+++ b/yt/fields/vector_operations.py
@@ -93,6 +93,8 @@ def create_los_field(registry, basename, field_units,
             fns = field_comps
         ax = data.get_field_parameter("axis")
         if iterable(ax):
+            # Make sure this is a unit vector
+            ax /= np.sqrt(np.dot(ax, ax))
             ret = data[fns[0]]*ax[0] + \
                   data[fns[1]]*ax[1] + \
                   data[fns[2]]*ax[2]

--- a/yt/fields/vector_operations.py
+++ b/yt/fields/vector_operations.py
@@ -99,7 +99,7 @@ def create_los_field(registry, basename, field_units,
         elif axis > 2:
             raise NeedsParameter(["axis"])
         else:
-            ret = data[ftype, fns[axis]]
+            ret = data[fns[axis]]
         return ret
 
     registry.add_field((ftype, "%s_los" % basename),

--- a/yt/fields/vector_operations.py
+++ b/yt/fields/vector_operations.py
@@ -2,7 +2,8 @@ import numpy as np
 
 from .derived_field import \
     ValidateParameter, \
-    ValidateSpatial
+    ValidateSpatial, \
+    NeedsParameter
 
 from yt.utilities.math_utils import \
     get_sph_r_component, \
@@ -12,7 +13,7 @@ from yt.utilities.math_utils import \
     get_cyl_z_component, \
     get_cyl_theta_component
 
-from yt.funcs import just_one
+from yt.funcs import just_one, iterable
 
 from yt.utilities.lib.misc_utilities import obtain_relative_velocity_vector
 
@@ -76,6 +77,37 @@ def create_relative_field(registry, basename, field_units, ftype='gas',
                            units=field_units,
                            validators=validators)
 
+def create_los_field(registry, basename, field_units, 
+                     ftype='gas', slice_info=None,
+                     validators=None):
+    axis_order = registry.ds.coordinates.axis_order
+
+    field_comps = [(ftype, "%s_%s" % (basename, ax)) for ax in axis_order]
+    field_comps_rel = [(ftype, "relative_%s_%s" % (basename, ax)) 
+                       for ax in axis_order]
+
+    def _los_field(field, data):
+        axis = data.get_field_parameter("axis")
+        if data.has_field_parameter('bulk_%s' % basename):
+            fns = field_comps_rel
+        else:
+            fns = field_comps
+        if iterable(axis):
+            ret = data[fns[0]]*axis[0] + \
+                  data[fns[1]]*axis[1] + \
+                  data[fns[2]]*axis[2]
+        elif axis > 2:
+            raise NeedsParameter(["axis"])
+        else:
+            ret = data[ftype, fns[axis]]
+        return ret
+
+    registry.add_field((ftype, "%s_los" % basename),
+                       sampling_type='local',
+                       function=_los_field,
+                       units=field_units,
+                       validators=validators)
+
 def create_squared_field(registry, basename, field_units,
                          ftype="gas", slice_info=None,
                          validators=None):
@@ -131,6 +163,11 @@ def create_vector_fields(registry, basename, field_units,
     create_magnitude_field(
         registry, basename, field_units, ftype=ftype, slice_info=slice_info,
         validators=[ValidateParameter('bulk_%s' % basename)])
+
+    create_los_field(
+        registry, basename, field_units, ftype=ftype, slice_info=slice_info,
+        validators=[ValidateParameter('bulk_%s' % basename),
+                    ValidateParameter('axis')])
 
     def _spherical_radius_component(field, data):
         """The spherical radius component of the vector field

--- a/yt/fields/xray_emission_fields.py
+++ b/yt/fields/xray_emission_fields.py
@@ -203,7 +203,12 @@ def add_xray_emissivity_field(ds, e_min, e_max, redshift=0.0,
             raise RuntimeError("Your dataset does not have a {} field! ".format(metallicity) +
                                "Perhaps you should specify a constant metallicity instead?")
 
-    H_field = "H_nuclei_density" if table_type == "cloudy" else "H_p1_number_density"
+    if table_type == "cloudy":
+        # Cloudy wants to know the total number density of hydrogen
+        H_field = "H_nuclei_density"
+    else:
+        # APEC only wants the free proton density
+        H_field = "H_p1_number_density"
 
     my_si = XrayEmissivityIntegrator(table_type, data_dir=data_dir, 
                                      redshift=redshift)

--- a/yt/fields/xray_emission_fields.py
+++ b/yt/fields/xray_emission_fields.py
@@ -203,6 +203,8 @@ def add_xray_emissivity_field(ds, e_min, e_max, redshift=0.0,
             raise RuntimeError("Your dataset does not have a {} field! ".format(metallicity) +
                                "Perhaps you should specify a constant metallicity instead?")
 
+    H_field = "H_nuclei_density" if table_type == "cloudy" else "H_p1_number_density"
+
     my_si = XrayEmissivityIntegrator(table_type, data_dir=data_dir, 
                                      redshift=redshift)
 
@@ -214,7 +216,7 @@ def add_xray_emissivity_field(ds, e_min, e_max, redshift=0.0,
 
     def _emissivity_field(field, data):
         with np.errstate(all='ignore'):
-            dd = {"log_nH": np.log10(data[ftype, "H_nuclei_density"]),
+            dd = {"log_nH": np.log10(data[ftype, H_field]),
                   "log_T": np.log10(data[ftype, "temperature"])}
 
         my_emissivity = np.power(10, em_0(dd))
@@ -227,7 +229,7 @@ def add_xray_emissivity_field(ds, e_min, e_max, redshift=0.0,
 
         my_emissivity[np.isnan(my_emissivity)] = 0
 
-        return data[ftype, "H_nuclei_density"]**2 * \
+        return data[ftype, H_field]**2 * \
             YTArray(my_emissivity, "erg*cm**3/s")
 
     emiss_name = (ftype, "xray_emissivity_%s_%s_keV" % (e_min, e_max))
@@ -244,7 +246,7 @@ def add_xray_emissivity_field(ds, e_min, e_max, redshift=0.0,
                  sampling_type="local", units="erg/s")
 
     def _photon_emissivity_field(field, data):
-        dd = {"log_nH": np.log10(data[ftype, "H_nuclei_density"]),
+        dd = {"log_nH": np.log10(data[ftype, H_field]),
               "log_T": np.log10(data[ftype, "temperature"])}
 
         my_emissivity = np.power(10, emp_0(dd))
@@ -255,7 +257,7 @@ def add_xray_emissivity_field(ds, e_min, e_max, redshift=0.0,
                 my_Z = metallicity
             my_emissivity += my_Z * np.power(10, emp_Z(dd))
 
-        return data[ftype, "H_nuclei_density"]**2 * \
+        return data[ftype, H_field]**2 * \
             YTArray(my_emissivity, "photons*cm**3/s")
 
     phot_name = (ftype, "xray_photon_emissivity_%s_%s_keV" % (e_min, e_max))

--- a/yt/fields/xray_emission_fields.py
+++ b/yt/fields/xray_emission_fields.py
@@ -277,7 +277,7 @@ def add_xray_emissivity_field(ds, e_min, e_max, redshift=0.0,
                     cosmology = Cosmology()
             D_L = cosmology.luminosity_distance(0.0, redshift)
             angular_scale = 1.0/cosmology.angular_scale(0.0, redshift)
-            dist_fac = 1.0/(4.0*np.pi*D_L*D_L*angular_scale*angular_scale)
+            dist_fac = ds.quan(1.0/(4.0*np.pi*D_L*D_L*angular_scale*angular_scale).v, "rad**-2")
         else:
             redshift = 0.0  # Only for local sources!
             if not isinstance(dist, YTQuantity):
@@ -289,7 +289,7 @@ def add_xray_emissivity_field(ds, e_min, e_max, redshift=0.0,
             else:
                 dist = ds.quan(dist.value, dist.units)
             angular_scale = dist/ds.quan(1.0, "radian")
-            dist_fac = 1.0/(4.0*np.pi*dist*dist*angular_scale*angular_scale)
+            dist_fac = ds.quan(1.0/(4.0*np.pi*dist*dist*angular_scale*angular_scale).v, "rad**-2")
 
         ei_name = (ftype, "xray_intensity_%s_%s_keV" % (e_min, e_max))
         def _intensity_field(field, data):

--- a/yt/fields/xray_emission_fields.py
+++ b/yt/fields/xray_emission_fields.py
@@ -220,7 +220,7 @@ def add_xray_emissivity_field(ds, e_min, e_max, redshift=0.0,
         my_emissivity = np.power(10, em_0(dd))
         if metallicity is not None:
             if isinstance(metallicity, DerivedField):
-                my_Z = data[metallicity.name]
+                my_Z = data[metallicity.name].to("Zsun")
             else:
                 my_Z = metallicity
             my_emissivity += my_Z * np.power(10, em_Z(dd))
@@ -250,7 +250,7 @@ def add_xray_emissivity_field(ds, e_min, e_max, redshift=0.0,
         my_emissivity = np.power(10, emp_0(dd))
         if metallicity is not None:
             if isinstance(metallicity, DerivedField):
-                my_Z = data[metallicity.name]
+                my_Z = data[metallicity.name].to("Zsun")
             else:
                 my_Z = metallicity
             my_emissivity += my_Z * np.power(10, emp_Z(dd))

--- a/yt/frontends/arepo/fields.py
+++ b/yt/frontends/arepo/fields.py
@@ -1,11 +1,11 @@
-from yt.fields.field_info_container import \
-    FieldInfoContainer
 from yt.frontends.gadget.api import GadgetFieldInfo
 from yt.fields.magnetic_field import \
     setup_magnetic_field_aliases
 from yt.fields.species_fields import \
     add_species_field_by_fraction, \
     setup_species_fields
+from yt.fields.field_info_container import \
+    FieldInfoContainer
 
 metal_elements = ["He", "C", "N", "O", "Ne",
                   "Mg", "Si", "Fe"]

--- a/yt/frontends/arepo/fields.py
+++ b/yt/frontends/arepo/fields.py
@@ -28,7 +28,10 @@ class ArepoFieldInfo(GadgetFieldInfo):
         super(ArepoFieldInfo, self).setup_gas_particle_fields(ptype)
         if ("PartType0", "GFM_Metals_00") in self.field_list:
             self.nuclei_names = metal_elements
-            self.species_names = ["H", "H_p1"] + metal_elements
+            self.species_names = ["H"]
+            if (ptype, "NeutralHydrogenAbundance") in self.field_list:
+                self.species_names += ["H_p0", "H_p1"]
+            self.species_names += metal_elements
 
         if (ptype, "MagneticField") in self.field_list:
             setup_magnetic_field_aliases(

--- a/yt/frontends/arepo/fields.py
+++ b/yt/frontends/arepo/fields.py
@@ -2,19 +2,35 @@ from yt.frontends.gadget.api import GadgetFieldInfo
 from yt.fields.magnetic_field import \
     setup_magnetic_field_aliases
 
+metal_elements = ["He", "C", "N", "O", "Ne",
+                  "Mg", "Si", "Fe"]
 
 class ArepoFieldInfo(GadgetFieldInfo):
     known_particle_fields = GadgetFieldInfo.known_particle_fields + \
                             (("smoothing_length", ("code_length", [], None)),
                              ("MagneticField",
                               ("code_magnetic", ["particle_magnetic_field"], None)),
+                             ("GFM_Metallicity", ("", ["metallicity"], None)),
+                             ("GFM_Metals_00", ("", ["H_fraction"], None)),
+                             ("GFM_Metals_01", ("", ["He_fraction"], None)),
+                             ("GFM_Metals_02", ("", ["C_fraction"], None)),
+                             ("GFM_Metals_03", ("", ["N_fraction"], None)),
+                             ("GFM_Metals_04", ("", ["O_fraction"], None)),
+                             ("GFM_Metals_05", ("", ["Ne_fraction"], None)),
+                             ("GFM_Metals_06", ("", ["Mg_fraction"], None)),
+                             ("GFM_Metals_07", ("", ["Si_fraction"], None)),
+                             ("GFM_Metals_08", ("", ["Fe_fraction"], None)),
                              )
 
     def setup_gas_particle_fields(self, ptype):
         super(ArepoFieldInfo, self).setup_gas_particle_fields(ptype)
+        if ("PartType0", "GFM_Metals_00") in self.field_list:
+            self.nuclei_names = metal_elements
+            self.species_names = ["H"] + metal_elements
 
         magnetic_field = "MagneticField"
         if (ptype, magnetic_field) in self.field_list:
             setup_magnetic_field_aliases(
                 self, ptype, magnetic_field
             )
+

--- a/yt/frontends/arepo/fields.py
+++ b/yt/frontends/arepo/fields.py
@@ -58,10 +58,10 @@ class ArepoFieldInfo(GadgetFieldInfo):
             add_species_field_by_fraction(self, ptype, "H_p1")
 
         if (ptype, "ElectronAbundance") in self.field_list:
-            def _el_nuclei_density(field, data):
+            def _el_number_density(field, data):
                 return data[ptype, "ElectronAbundance"] * \
                        data[ptype, "H_number_density"]
-            self.add_field((ptype, "El_nuclei_density"),
+            self.add_field((ptype, "El_number_density"),
                            sampling_type="particle",
-                           function=_el_nuclei_density,
+                           function=_el_number_density,
                            units=self.ds.unit_system["number_density"])

--- a/yt/frontends/arepo/tests/test_outputs.py
+++ b/yt/frontends/arepo/tests/test_outputs.py
@@ -45,6 +45,11 @@ tng59_fields = OrderedDict(
         (("gas", "density"), None),
         (("gas", "temperature"), None),
         (("gas", "temperature"), ('gas', 'density')),
+        (("gas", "H_number_density"), None),
+        (("gas", "H_p0_number_density"), None),
+        (("gas", "H_p1_number_density"), None),
+        (("gas", "El_number_density"), None),
+        (("gas", "C_number_density"), None),
         (('gas', 'velocity_magnitude'), None),
         (('gas', 'magnetic_field_strength'), None)
     ]

--- a/yt/frontends/athena/data_structures.py
+++ b/yt/frontends/athena/data_structures.py
@@ -12,6 +12,8 @@ from yt.geometry.grid_geometry_handler import \
     GridIndex
 from yt.data_objects.static_output import \
     Dataset
+from yt.utilities.chemical_formulas import \
+    default_mu
 from yt.utilities.lib.misc_utilities import \
     get_box_grids_level
 from yt.geometry.geometry_handler import \
@@ -531,9 +533,9 @@ class AthenaDataset(Dataset):
             dataset_dir = dataset_dir[:-3]
 
         gridlistread = glob.glob(os.path.join(dataset_dir, 'id*/%s-id*%s' % (dname[4:-9],dname[-9:])))
-        if 'id0' in dname :
+        if 'id0' in dname:
             gridlistread += glob.glob(os.path.join(dataset_dir, 'id*/lev*/%s*-lev*%s' % (dname[4:-9],dname[-9:])))
-        else :
+        else:
             gridlistread += glob.glob(os.path.join(dataset_dir, 'lev*/%s*-lev*%s' % (dname[:-9],dname[-9:])))
         ndots = dname.count(".")
         gridlistread = [fn for fn in gridlistread if os.path.basename(fn).count(".") == ndots]
@@ -549,6 +551,7 @@ class AthenaDataset(Dataset):
             self.parameters["Gamma"] = 5./3.
         self.geometry = self.specified_parameters.get("geometry", "cartesian")
         self._handle.close()
+        self.mu = self.specified_parameters.get("mu", default_mu)
 
     @classmethod
     def _is_valid(self, *args, **kwargs):

--- a/yt/frontends/athena/fields.py
+++ b/yt/frontends/athena/fields.py
@@ -100,11 +100,7 @@ class AthenaFieldInfo(FieldInfoContainer):
                            units=unit_system["specific_energy"])
         # Add temperature field
         def _temperature(field, data):
-            if data.has_field_parameter("mu"):
-                mu = data.get_field_parameter("mu")
-            else:
-                mu = 0.6
-            return mu*mh*data["gas","pressure"]/data["gas","density"]/kboltz
+            return data.ds.mu*mh*data["gas","pressure"]/data["gas","density"]/kboltz
         self.add_field(("gas","temperature"),
                        sampling_type="cell",
                        function=_temperature,

--- a/yt/frontends/athena_pp/data_structures.py
+++ b/yt/frontends/athena_pp/data_structures.py
@@ -21,6 +21,8 @@ from yt.data_objects.unstructured_mesh import \
     SemiStructuredMesh
 from itertools import chain, product
 from .fields import AthenaPPFieldInfo
+from yt.utilities.chemical_formulas import \
+    default_mu
 
 geom_map = {"cartesian": "cartesian",
             "cylindrical": "cylindrical",
@@ -320,6 +322,7 @@ class AthenaPPDataset(Dataset):
             self.parameters["Gamma"] = self.specified_parameters["gamma"]
         else:
             self.parameters["Gamma"] = 5./3.
+        self.parameters["mu"] = self.specified_parameters.get("mu", default_mu)
 
     @classmethod
     def _is_valid(self, *args, **kwargs):

--- a/yt/frontends/athena_pp/data_structures.py
+++ b/yt/frontends/athena_pp/data_structures.py
@@ -322,7 +322,7 @@ class AthenaPPDataset(Dataset):
             self.parameters["Gamma"] = self.specified_parameters["gamma"]
         else:
             self.parameters["Gamma"] = 5./3.
-        self.parameters["mu"] = self.specified_parameters.get("mu", default_mu)
+        self.mu = self.specified_parameters.get("mu", default_mu)
 
     @classmethod
     def _is_valid(self, *args, **kwargs):

--- a/yt/frontends/athena_pp/fields.py
+++ b/yt/frontends/athena_pp/fields.py
@@ -66,11 +66,7 @@ class AthenaPPFieldInfo(FieldInfoContainer):
                            units=unit_system["specific_energy"])
         # Add temperature field
         def _temperature(field, data):
-            if data.has_field_parameter("mu"):
-                mu = data.get_field_parameter("mu")
-            else:
-                mu = 0.6
-            return (data["gas","pressure"]/data["gas","density"])*mu*mh/kboltz
+            return (data["gas","pressure"]/data["gas","density"])*data.ds.mu*mh/kboltz
         self.add_field(("gas", "temperature"), sampling_type="cell", function=_temperature,
                        units=unit_system["temperature"])
 

--- a/yt/frontends/enzo/fields.py
+++ b/yt/frontends/enzo/fields.py
@@ -276,8 +276,18 @@ class EnzoFieldInfo(FieldInfoContainer):
                 function=_tot_minus_kin,
                 units=unit_system["specific_energy"])
         if multi_species == 0 and 'Mu' in params:
+            def _mean_molecular_weight(field, data):
+                return params["Mu"]*data['index', 'ones']
+
+            self.add_field(
+                ("gas", "mean_molecular_weight"),
+                sampling_type="cell",
+                function=_mean_molecular_weight,
+                units=unit_system["number_density"])
+
             def _number_density(field, data):
                 return data['gas', 'density']/(mp*params['Mu'])
+
             self.add_field(
                 ("gas", "number_density"),
                 sampling_type="cell",

--- a/yt/frontends/enzo/fields.py
+++ b/yt/frontends/enzo/fields.py
@@ -283,7 +283,7 @@ class EnzoFieldInfo(FieldInfoContainer):
                 ("gas", "mean_molecular_weight"),
                 sampling_type="cell",
                 function=_mean_molecular_weight,
-                units=unit_system["number_density"])
+                units="")
 
             def _number_density(field, data):
                 return data['gas', 'density']/(mp*params['Mu'])

--- a/yt/frontends/flash/fields.py
+++ b/yt/frontends/flash/fields.py
@@ -159,7 +159,7 @@ class FLASHFieldInfo(FieldInfoContainer):
             def _nele(field, data):
                 return data["flash", "dens"] * data["flash", "ye"] * Na
 
-            self.add_field(('gas', 'El_nuclei_density'),
+            self.add_field(('gas', 'El_number_density'),
                            sampling_type="cell",
                            function=_nele,
                            units=unit_system["number_density"])
@@ -167,13 +167,13 @@ class FLASHFieldInfo(FieldInfoContainer):
             def _nion(field, data):
                 return data["flash", "dens"] * data["flash", "sumy"] * Na
 
-            self.add_field(('gas', 'ion_nuclei_density'),
+            self.add_field(('gas', 'ion_number_density'),
                            sampling_type="cell",
                            function=_nion,
                            units=unit_system["number_density"])
 
             def _number_density(field, data):
-                return data["gas","El_nuclel_density"]+data["gas","ion_nuclei_density"]
+                return data["gas","El_number_density"]+data["gas","ion_number_density"]
         else:
             def _number_density(field, data):
                 return data["flash", "dens"]*Na/data["gas", "mean_molecular_weight"]

--- a/yt/frontends/flash/fields.py
+++ b/yt/frontends/flash/fields.py
@@ -168,12 +168,13 @@ class FLASHFieldInfo(FieldInfoContainer):
                            function=_abar,
                            units="1")
 
-        def _number_density(fields,data):
-            return (data["nele"]+data["nion"])
-        self.add_field(("gas","number_density"),
-                       sampling_type="cell",
-                       function=_number_density,
-                       units=unit_system["number_density"])
+        if "ye" in self.field_list:
+            def _number_density(fields,data):
+                return (data["nele"]+data["nion"])
+            self.add_field(("gas","number_density"),
+                           sampling_type="cell",
+                           function=_number_density,
+                           units=unit_system["number_density"])
 
         setup_magnetic_field_aliases(
             self, "flash", ["mag%s" % ax for ax in "xyz"])

--- a/yt/frontends/flash/fields.py
+++ b/yt/frontends/flash/fields.py
@@ -89,7 +89,7 @@ class FLASHFieldInfo(FieldInfoContainer):
         for i in range(1, 1000):
             self.add_output_field(("flash", "r{0:03}".format(i)),
                                   sampling_type="cell",
-                                  units = "",
+                                  units="",
                                   display_name="Energy Group {0}".format(i))
         # Add energy fields
         def ekin(data):
@@ -162,40 +162,35 @@ class FLASHFieldInfo(FieldInfoContainer):
                        units="code_length**-3")
 
         if ("flash", "abar") in self.field_list:
-            self.add_output_field(("flash", "abar"),
-                                  sampling_type="cell",
-                                  units="")
+            self.alias(("gas", "mean_molecular_weight"), ("flash", "abar"))
         elif ("flash", "sumy") in self.field_list:
             def _abar(field, data):
                 return 1.0 / data["flash","sumy"]
-            self.add_field(("flash","abar"),
+            self.add_field(("gas", "mean_molecular_weight"),
                            sampling_type="cell",
                            function=_abar,
                            units="")
         elif "eos_singlespeciesa" in self.ds.parameters:
             def _abar(field, data):
                 return data.ds.parameters["eos_singlespeciesa"]*data["index", "ones"]
-            self.add_field(("flash","abar"),
+            self.add_field(("gas", "mean_molecular_weight"),
                            sampling_type="cell",
                            function=_abar,
                            units="")
 
-        if ("flash", "abar") in self:
-
-            self.alias(("gas", "mean_molecular_weight"), ("flash", "abar"))
-
+        if ("flash", "nele") in self.field_list and ("flash", "nion") in self.field_list:
             def _number_density(field, data):
-                Na_code = data.ds.quan(Na, '1/code_mass')
-                return data["flash", "dens"]*Na_code/data["flash", "abar"]
+                return data["flash", "nele"]+data["flash","nion"]
 
             self.add_field(("gas", "number_density"),
                            sampling_type="cell",
                            function=_number_density,
                            units=unit_system["number_density"])
 
-        if "ye" in self.field_list:
+        else:
             def _number_density(field, data):
-                return data["nele"]+data["nion"]
+                Na_code = data.ds.quan(Na, '1/code_mass')
+                return data["flash", "dens"]*Na_code/data["gas", "mean_molecular_weight"]
 
             self.add_field(("gas", "number_density"),
                            sampling_type="cell",

--- a/yt/frontends/flash/fields.py
+++ b/yt/frontends/flash/fields.py
@@ -138,22 +138,6 @@ class FLASHFieldInfo(FieldInfoContainer):
 
         ## Derived FLASH Fields
 
-        def _nele(field, data):
-            return data["flash","dens"]*data["flash","ye"]*Na
-
-        self.add_field(('gas','El_nuclei_density'),
-                       sampling_type="cell",
-                       function=_nele,
-                       units=unit_system["number_density"])
-
-        def _nion(field, data):
-            return data["flash","dens"]*data["flash","sumy"]*Na
-
-        self.add_field(('gas','ion_nuclei_density'),
-                       sampling_type="cell",
-                       function=_nion,
-                       units=unit_system["number_density"])
-
         if ("flash", "abar") in self.field_list:
             self.alias(("gas", "mean_molecular_weight"), ("flash", "abar"))
         elif ("flash", "sumy") in self.field_list:
@@ -172,6 +156,22 @@ class FLASHFieldInfo(FieldInfoContainer):
                            units="")
 
         if ("flash", "sumy") in self.field_list:
+            def _nele(field, data):
+                return data["flash", "dens"] * data["flash", "ye"] * Na
+
+            self.add_field(('gas', 'El_nuclei_density'),
+                           sampling_type="cell",
+                           function=_nele,
+                           units=unit_system["number_density"])
+
+            def _nion(field, data):
+                return data["flash", "dens"] * data["flash", "sumy"] * Na
+
+            self.add_field(('gas', 'ion_nuclei_density'),
+                           sampling_type="cell",
+                           function=_nion,
+                           units=unit_system["number_density"])
+
             def _number_density(field, data):
                 return data["gas","El_nuclel_density"]+data["gas","ion_nuclei_density"]
         else:

--- a/yt/frontends/flash/fields.py
+++ b/yt/frontends/flash/fields.py
@@ -42,7 +42,7 @@ class FLASHFieldInfo(FieldInfoContainer):
         ("eion", (erg_units, [], "Ion Internal Energy")),
         ("eele", (erg_units, [], "Electron Internal Energy")),
         ("erad", (erg_units, [], "Radiation Internal Energy")),
-        ("pden", (rho_units, [], None)),
+        ("pden", (rho_units, [], "Particle Mass Density")),
         ("depo", ("code_length**2/code_time**2", [], None)),
         ("ye", ("", [], "Y_e")),
         ("magp", (pres_units, [], None)),

--- a/yt/frontends/flash/fields.py
+++ b/yt/frontends/flash/fields.py
@@ -84,7 +84,8 @@ class FLASHFieldInfo(FieldInfoContainer):
         from yt.fields.magnetic_field import \
             setup_magnetic_field_aliases
         unit_system = self.ds.unit_system
-        pc = self.ds.units.physical_constants
+        # Adopt FLASH 4.6 value for Na
+        Na = self.ds.quan(6.022140857e23, "g**-1")
         for i in range(1, 1000):
             self.add_output_field(("flash", "r{0:03}".format(i)),
                                   sampling_type="cell",
@@ -138,7 +139,7 @@ class FLASHFieldInfo(FieldInfoContainer):
         ## Derived FLASH Fields
 
         def _nele(field, data):
-            return data["flash","dens"]*data["flash","ye"]*pc.Na
+            return data["flash","dens"]*data["flash","ye"]*Na
 
         self.add_field(('gas','El_nuclei_density'),
                        sampling_type="cell",
@@ -146,7 +147,7 @@ class FLASHFieldInfo(FieldInfoContainer):
                        units=unit_system["number_density"])
 
         def _nion(field, data):
-            return data["flash","dens"]*data["flash","sumy"]*pc.Na
+            return data["flash","dens"]*data["flash","sumy"]*Na
 
         self.add_field(('gas','ion_nuclei_density'),
                        sampling_type="cell",
@@ -175,7 +176,7 @@ class FLASHFieldInfo(FieldInfoContainer):
                 return data["gas","El_nuclel_density"]+data["gas","ion_nuclei_density"]
         else:
             def _number_density(field, data):
-                return data["flash", "dens"]*pc.Na/data["gas", "mean_molecular_weight"]
+                return data["flash", "dens"]*Na/data["gas", "mean_molecular_weight"]
 
         self.add_field(("gas", "number_density"),
                        sampling_type="cell",

--- a/yt/frontends/flash/tests/test_outputs.py
+++ b/yt/frontends/flash/tests/test_outputs.py
@@ -42,6 +42,13 @@ def test_FLASHDataset():
 def test_units_override():
     units_override_check(sloshing)
 
+@requires_file(sloshing)
+def test_mu():
+    ds = data_dir_load(sloshing)
+    sp = ds.sphere("c", (0.1, "unitary"))
+    assert np.all(sp["gas","mean_molecular_weight"] == 
+                  ds.parameters["eos_singlespeciesa"])
+
 fid_1to3_b1 = "fiducial_1to3_b1/fiducial_1to3_b1_hdf5_part_0080"
 
 fid_1to3_b1_fields = OrderedDict(

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -10,6 +10,7 @@ from yt.data_objects.static_output import \
 from yt.frontends.sph.data_structures import \
     SPHDataset, \
     SPHParticleIndex
+from yt.utilities.chemical_formulas import default_mu
 from yt.utilities.cosmology import \
     Cosmology
 from yt.utilities.fortran_utils import read_record
@@ -301,7 +302,10 @@ class GadgetDataset(SPHDataset):
             self.time_unit.convert_to_units('s')
             self.length_unit.convert_to_units('kpc')
             self.mass_unit.convert_to_units('Msun')
-        self.mean_molecular_weight = mean_molecular_weight
+        if mean_molecular_weight is None:
+            self.mu = default_mu
+        else:
+            self.mu = mean_molecular_weight
 
     @classmethod
     def _setup_binary_spec(cls, spec, spec_dict):

--- a/yt/frontends/gadget/fields.py
+++ b/yt/frontends/gadget/fields.py
@@ -1,7 +1,5 @@
 from yt.frontends.sph.fields import SPHFieldInfo
 from yt.utilities.physical_constants import mp, kb
-from yt.utilities.chemical_formulas import \
-    ChemicalFormula
 from yt.utilities.physical_ratios import \
     _primordial_mass_fraction
 

--- a/yt/frontends/gadget/fields.py
+++ b/yt/frontends/gadget/fields.py
@@ -68,15 +68,13 @@ class GadgetFieldInfo(SPHFieldInfo):
                 return ret.in_units(self.ds.unit_system["temperature"])
         else:
             def _temperature(field, data):
-                # Assume cosmic abundances
-                x_H = 0.76
                 gamma = 5.0/3.0
                 if self.ds.mean_molecular_weight is not None:
                     mu = self.ds.mean_molecular_weight
                 elif data.has_field_parameter("mean_molecular_weight"):
                     mu = data.get_field_parameter("mean_molecular_weight")
                 else:
-                    # Assume full ionization
+                    # Assume full ionization and cosmic abundances
                     mu = ChemicalFormula("H").weight / \
                          (2.0*_primordial_mass_fraction["H"])
                     mu += ChemicalFormula("He").weight / \

--- a/yt/frontends/gadget/fields.py
+++ b/yt/frontends/gadget/fields.py
@@ -60,7 +60,7 @@ class GadgetFieldInfo(SPHFieldInfo):
         if (ptype, "ElectronAbundance") in self.ds.field_list:
             def _temperature(field, data):
                 # Assume cosmic abundances
-                x_H = 0.76
+                x_H = _primordial_mass_fraction["H"]
                 gamma = 5.0/3.0
                 a_e = data[ptype, 'ElectronAbundance']
                 mu = 4.0 / (3.0 * x_H + 1.0 + 4.0 * x_H * a_e)
@@ -69,17 +69,7 @@ class GadgetFieldInfo(SPHFieldInfo):
         else:
             def _temperature(field, data):
                 gamma = 5.0/3.0
-                if self.ds.mean_molecular_weight is not None:
-                    mu = self.ds.mean_molecular_weight
-                elif data.has_field_parameter("mean_molecular_weight"):
-                    mu = data.get_field_parameter("mean_molecular_weight")
-                else:
-                    # Assume full ionization and cosmic abundances
-                    mu = ChemicalFormula("H").weight / \
-                         (2.0*_primordial_mass_fraction["H"])
-                    mu += ChemicalFormula("He").weight / \
-                          (3.0*_primordial_mass_fraction["He"])
-                ret = data[ptype, "InternalEnergy"]*(gamma-1)*mu*mp/kb
+                ret = data[ptype, "InternalEnergy"]*(gamma-1)*data.ds.mu*mp/kb
                 return ret.in_units(self.ds.unit_system["temperature"])
 
         self.add_field((ptype, "Temperature"),

--- a/yt/frontends/gadget/fields.py
+++ b/yt/frontends/gadget/fields.py
@@ -1,5 +1,10 @@
 from yt.frontends.sph.fields import SPHFieldInfo
 from yt.utilities.physical_constants import mp, kb
+from yt.utilities.chemical_formulas import \
+    ChemicalFormula
+from yt.utilities.physical_ratios import \
+    _primordial_mass_fraction
+
 
 class GadgetFieldInfo(SPHFieldInfo):
 
@@ -71,8 +76,11 @@ class GadgetFieldInfo(SPHFieldInfo):
                 elif data.has_field_parameter("mean_molecular_weight"):
                     mu = data.get_field_parameter("mean_molecular_weight")
                 else:
-                    # Assume zero ionization
-                    mu = 4.0 / (3.0 * x_H + 1.0)
+                    # Assume full ionization
+                    mu = ChemicalFormula("H").weight / \
+                         (2.0*_primordial_mass_fraction["H"])
+                    mu += ChemicalFormula("He").weight / \
+                          (3.0*_primordial_mass_fraction["He"])
                 ret = data[ptype, "InternalEnergy"]*(gamma-1)*mu*mp/kb
                 return ret.in_units(self.ds.unit_system["temperature"])
 
@@ -82,6 +90,6 @@ class GadgetFieldInfo(SPHFieldInfo):
                        units=self.ds.unit_system["temperature"])
         self.alias((ptype, 'temperature'), (ptype, 'Temperature'))
         # need to do this manually since that automatic aliasing that happens
-        # in the FieldInfoContainer base class has already hapenned at this
+        # in the FieldInfoContainer base class has already happened at this
         # point
         self.alias(('gas', 'temperature'), (ptype, 'Temperature'))

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -142,6 +142,9 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
                     elif field.startswith("Metallicity_"):
                         col = int(field.rsplit("_", 1)[-1])
                         data = g["Metallicity"][si:ei, col][mask]
+                    elif field.startswith("GFM_Metals_"):
+                        col = int(field.rsplit("_", 1)[-1])
+                        data = g["GFM_Metals"][si:ei, col][mask]
                     elif field.startswith("Chemistry_"):
                         col = int(field.rsplit("_", 1)[-1])
                         data = g["ChemistryAbundances"][si:ei, col][mask]
@@ -206,10 +209,10 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
                     for j in gp.keys():
                         kk = j
                         fields.append((ptype, str(kk)))
-                elif k == 'Metallicity' and len(g[k].shape) > 1:
+                elif k in ['Metallicity', 'GFM_Metals'] and len(g[k].shape) > 1:
                     # Vector of metallicity
                     for i in range(g[k].shape[1]):
-                        fields.append((ptype, "Metallicity_%02i" % i))
+                        fields.append((ptype, "%s_%02i" % (k, i)))
                 elif k == "ChemistryAbundances" and len(g[k].shape) > 1:
                     for i in range(g[k].shape[1]):
                         fields.append((ptype, "Chemistry_%03i" % i))

--- a/yt/frontends/gamer/fields.py
+++ b/yt/frontends/gamer/fields.py
@@ -103,6 +103,16 @@ class GAMERFieldInfo(FieldInfoContainer):
                        function = _pressure,
                        units = unit_system["pressure"] )
 
+        # mean molecular weight
+        if hasattr(self.ds, "mu"):
+            def _mu(field, data):
+                return data.ds.mu*data["index", "ones"]
+
+            self.add_field(("gas", "mean_molecular_weight"),
+                           sampling_type="cell",
+                           function=_mu,
+                           units="")
+
         # temperature
         def _temperature(field, data):
             return data.ds.mu*mh*data["gas","pressure"] / \

--- a/yt/geometry/coordinates/cartesian_coordinates.py
+++ b/yt/geometry/coordinates/cartesian_coordinates.py
@@ -291,6 +291,7 @@ class CartesianCoordinateHandler(CoordinateHandler):
                     left_edge=le, right_edge=re, center=data_source.center,
                     data_source=data_source.data_source
                 )
+                proj_reg.set_field_parameter("axis", data_source.axis)
                 bnds = data_source.ds.arr(
                     bounds, 'code_length').in_units('cm').tolist()
                 buff = np.zeros(size, dtype='float64')

--- a/yt/utilities/chemical_formulas.py
+++ b/yt/utilities/chemical_formulas.py
@@ -34,10 +34,11 @@ class ChemicalFormula:
 
 def compute_mu():
     # Assume full ionization and cosmic abundances
-    mu = ChemicalFormula("H").weight / \
-         (2.0 * _primordial_mass_fraction["H"])
-    mu += ChemicalFormula("He").weight / \
-          (3.0 * _primordial_mass_fraction["He"])
-
+    # This assumes full ionization!
+    muinv = 2.0 * _primordial_mass_fraction["H"] / \
+        ChemicalFormula("H").weight
+    muinv += 3.0 * _primordial_mass_fraction["He"] / \
+        ChemicalFormula("He").weight
+    return 1.0/muinv
 
 default_mu = compute_mu()

--- a/yt/utilities/chemical_formulas.py
+++ b/yt/utilities/chemical_formulas.py
@@ -1,5 +1,7 @@
 import re
 from .periodic_table import periodic_table
+from .physical_ratios import _primordial_mass_fraction
+
 
 class ChemicalFormula:
     def __init__(self, formula_string):
@@ -28,3 +30,14 @@ class ChemicalFormula:
 
     def __repr__(self):
         return self.formula_string
+
+
+def compute_mu():
+    # Assume full ionization and cosmic abundances
+    mu = ChemicalFormula("H").weight / \
+         (2.0 * _primordial_mass_fraction["H"])
+    mu += ChemicalFormula("He").weight / \
+          (3.0 * _primordial_mass_fraction["He"])
+
+
+default_mu = compute_mu()

--- a/yt/utilities/physical_ratios.py
+++ b/yt/utilities/physical_ratios.py
@@ -122,6 +122,10 @@ jansky_cgs = 1.0e-23
 rho_crit_g_cm3_h2 = 1.8784710838431654e-29
 primordial_H_mass_fraction = 0.76
 
+_primordial_mass_fraction = \
+    {"H": primordial_H_mass_fraction,
+     "He": (1 - primordial_H_mass_fraction)}
+
 # Misc. Approximations
 mass_mean_atomic_cosmology = 1.22
 mass_mean_atomic_galactic = 2.3

--- a/yt/utilities/tests/test_chemical_formulas.py
+++ b/yt/utilities/tests/test_chemical_formulas.py
@@ -1,5 +1,5 @@
-from yt.testing import assert_equal
-from yt.utilities.chemical_formulas import ChemicalFormula
+from yt.testing import assert_equal, assert_allclose
+from yt.utilities.chemical_formulas import ChemicalFormula, default_mu
 from yt.utilities.periodic_table import periodic_table
 
 _molecules = (
@@ -21,3 +21,7 @@ def test_formulas():
         for (n, c1), (e, c2) in zip(components, f.elements):
             assert_equal(n, e.symbol)
             assert_equal(c1, c2)
+
+
+def test_default_mu():
+    assert_allclose(default_mu, 0.5924489101195808)

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -116,6 +116,9 @@ class FITSImageData(object):
         >>> f_deg.writeto("temp.fits")
         """
 
+        if fields is not None:
+            fields = ensure_list(fields)
+
         if "units" in kwargs:
             issue_deprecation_warning("The 'units' keyword argument has been replaced "
                                       "by the 'length_unit' keyword argument and the "
@@ -174,9 +177,6 @@ class FITSImageData(object):
             return
 
         self.hdulist = _astropy.pyfits.HDUList()
-
-        if isinstance(fields, str):
-            fields = [fields]
 
         if hasattr(data, 'keys'):
             img_data = data

--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -129,12 +129,16 @@ def off_axis_projection(data_source, center, normal_vector,
         raise_error = False
 
         ptype = sph_ptypes[0]
+        ppos = ["particle_position_%s" % ax for ax in "xyz"]
         # Assure that the field we're trying to off-axis project 
         # has a field type as the SPH particle type or if the field is an 
         # alias to an SPH field or is a 'gas' field
         if item[0] in data_source.ds.known_filters:
             if item[0] not in sph_ptypes:
                 raise_error = True
+            else:
+                ptype = item[0]
+                ppos = ["x", "y", "z"]
         elif fi.alias_field:
             if fi.alias_name[0] not in sph_ptypes:
                 raise_error = True
@@ -184,10 +188,10 @@ def off_axis_projection(data_source, center, normal_vector,
         if weight is None:
             for chunk in data_source.chunks([], 'io'):
                 off_axis_projection_SPH(
-                    chunk[ptype, "particle_position_x"].to('code_length').d,
-                    chunk[ptype, "particle_position_y"].to('code_length').d,
-                    chunk[ptype, "particle_position_z"].to('code_length').d,
-                    chunk[ptype, "particle_mass"].to('code_mass').d,
+                    chunk[ptype, ppos[0]].to('code_length').d,
+                    chunk[ptype, ppos[1]].to('code_length').d,
+                    chunk[ptype, ppos[2]].to('code_length').d,
+                    chunk[ptype, "mass"].to('code_mass').d,
                     chunk[ptype, "density"].to('code_density').d,
                     chunk[ptype, "smoothing_length"].to('code_length').d,
                     bounds,
@@ -216,10 +220,10 @@ def off_axis_projection(data_source, center, normal_vector,
 
             for chunk in data_source.chunks([], 'io'):
                 off_axis_projection_SPH(
-                    chunk[ptype, "particle_position_x"].to('code_length').d,
-                    chunk[ptype, "particle_position_y"].to('code_length').d,
-                    chunk[ptype, "particle_position_z"].to('code_length').d,
-                    chunk[ptype, "particle_mass"].to('code_mass').d,
+                    chunk[ptype, ppos[0]].to('code_length').d,
+                    chunk[ptype, ppos[1]].to('code_length').d,
+                    chunk[ptype, ppos[2]].to('code_length').d,
+                    chunk[ptype, "mass"].to('code_mass').d,
                     chunk[ptype, "density"].to('code_density').d,
                     chunk[ptype, "smoothing_length"].to('code_length').d,
                     bounds,
@@ -233,10 +237,10 @@ def off_axis_projection(data_source, center, normal_vector,
 
             for chunk in data_source.chunks([], 'io'):
                 off_axis_projection_SPH(
-                    chunk[ptype, "particle_position_x"].to('code_length').d,
-                    chunk[ptype, "particle_position_y"].to('code_length').d,
-                    chunk[ptype, "particle_position_z"].to('code_length').d,
-                    chunk[ptype, "particle_mass"].to('code_mass').d,
+                    chunk[ptype, ppos[0]].to('code_length').d,
+                    chunk[ptype, ppos[1]].to('code_length').d,
+                    chunk[ptype, ppos[2]].to('code_length').d,
+                    chunk[ptype, "mass"].to('code_mass').d,
                     chunk[ptype, "density"].to('code_density').d,
                     chunk[ptype, "smoothing_length"].to('code_length').d,
                     bounds,

--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -150,6 +150,10 @@ def off_axis_projection(data_source, center, normal_vector,
         normal = np.array(normal_vector)
         normal = normal / np.linalg.norm(normal)
 
+        # Add the normal as a field parameter to the data source
+        # so line of sight fields can use it
+        data_source.set_field_parameter("axis", normal)
+
         # If north_vector is None, we set the default here.
         # This is chosen so that if normal_vector is one of the
         # cartesian coordinate axes, the projection will match

--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -128,21 +128,21 @@ def off_axis_projection(data_source, center, normal_vector,
 
         raise_error = False
 
+        ptype = sph_ptypes[0]
         # Assure that the field we're trying to off-axis project 
         # has a field type as the SPH particle type or if the field is an 
         # alias to an SPH field or is a 'gas' field
-        if fi.alias_field:
+        if item[0] in data_source.ds.known_filters: 
+            if item[0] not in sph_ptypes:
+                raise_error = True
+        elif fi.alias_field:
             if fi.alias_name[0] not in sph_ptypes:
                 raise_error = True
             elif item[0] != 'gas':
                 ptype = item[0]
-            else:
-                ptype = fi.alias_name[0]
         else:
             if fi.name[0] not in sph_ptypes and fi.name[0] != 'gas':
                 raise_error = True
-            else:
-                ptype = fi.name[0]
 
         if raise_error:
             raise RuntimeError(

--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -132,7 +132,7 @@ def off_axis_projection(data_source, center, normal_vector,
         # Assure that the field we're trying to off-axis project 
         # has a field type as the SPH particle type or if the field is an 
         # alias to an SPH field or is a 'gas' field
-        if item[0] in data_source.ds.known_filters: 
+        if item[0] in data_source.ds.known_filters:
             if item[0] not in sph_ptypes:
                 raise_error = True
         elif fi.alias_field:

--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -109,6 +109,9 @@ def off_axis_projection(data_source, center, normal_vector,
     normal_vector = np.array(normal_vector, dtype='float64')
     if north_vector is not None:
         north_vector = np.array(north_vector, dtype='float64')
+    # Add the normal as a field parameter to the data source
+    # so line of sight fields can use it
+    data_source.set_field_parameter("axis", normal_vector)
 
     # Sanitize units
     if not hasattr(center, "units"):
@@ -149,10 +152,6 @@ def off_axis_projection(data_source, center, normal_vector,
 
         normal = np.array(normal_vector)
         normal = normal / np.linalg.norm(normal)
-
-        # Add the normal as a field parameter to the data source
-        # so line of sight fields can use it
-        data_source.set_field_parameter("axis", normal)
 
         # If north_vector is None, we set the default here.
         # This is chosen so that if normal_vector is one of the


### PR DESCRIPTION
## PR Summary

This PR updates a number of the astronomy/astrophysics-specific fields in yt. In detail:

* Wherever possible, change `"cell_mass"` to `"mass"` so that fields are not only defined for grid-based datasets. Similarly, if possible, do not use `"cell_volume"` for fields which are meant to be general. 
* Add a computation for the number density fields for free electrons, protons, and helium nuclei for when there are no species fields, assuming primordial abundances and full ionization. 
* Redefine `"number_density"` and `"mean_molecular_weight"` fields so that they can be calculated even if no species are defined, by assuming a constant mean molecular weight and primordial abundances. 
* Add an `"optical_depth"` field which depends on the `"El_number_density"` field. Redefine the two SZ fields in terms of this field (otherwise they just assume full ionization, which may not be true).
* Add a `"velocity_los"` field for projections, which computes the velocity component along a line of sight, on-axis or off-axis. Use it in the `"sz_kinetic"` field. 
* Add a `"magnetic_field_los"` field for projections, which computes the magnetic field strength component along a line of sight, on-axis or off-axis. This is used for the Faraday rotation measure field, which is also added here. 
* Add an alias for the `"particle_gpot"` field in the FLASH frontend.
* Move the `"entropy"` field to `astro_fields`, since its field definition is very astro-specific (and in fact it's very high-energy-astro-specific). Make it depend on the `"El_number_density"` field (otherwise it just assumes full ionization, which may not be true). 
* Remove `chandra_emissivity` field. It's not well-documented and it is not clear at all what it represents (i.e. what is the energy band? what is the instrument assumed?), so it's misleading. 
* Remove extra whitespace and parentheses in various places
* Set up a function which computes a default mean molecular weight for frontends that may use one for defining things like temperature and number density but don't have one. This default `mu` is now used in the `athena`, `athena_pp`, and `gadget` frontends unless the user passes in a different value when loading the dataset. NOTE: This default `mu` assumes _full_ ionization.
* Made sure that the `flash`, `enzo`, and `gamer` frontends get to define fields like `"number_density"` the way they want. 
* Fixed a bug which prevented magnetic fields from being defined properly in SPH frontends.
* The `"cell_mass"` and `"courant_time_step"` fields should have `sampling_type="cell"`.
* Add species fields to the Arepo frontend. 
* Fixed some bugs created in off-axis projections 

## PR Checklist

- [x] Code passes flake8 checker
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.