### PR TITLE
Improvements to reading / writing FITS images

### DIFF
--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -707,20 +707,44 @@ Types of FITS Datasets Supported by yt
 yt FITS Data Standard
 """""""""""""""""""""
 
+yt has facilities for creating 2 and 3-dimensional FITS images from derived, 
+fixed-resolution data products from other datasets. These include images 
+produced from slices, projections, and 3D covering grids. The resulting
+FITS images are fully-describing in that unit, parameter, and coordinate 
+information is passed from the original dataset. These can be created via the 
+:class:`~yt.visualization.fits_image.FITSImageData` class and its subclasses. 
+For information about how to use these special classes, see 
+:ref:`writing_fits_images`.
+
+Once you have produced a FITS file in this fashion, you can load it using
+yt and it will be detected as a ``YTFITSDataset`` object, and it can be analyzed
+in the same way as any other dataset in yt. 
+
 Astronomical Image Data
 """""""""""""""""""""""
 
 These files are one of three types:
 
 * Generic two-dimensional FITS images in sky coordinates
-* Three dimensional "spectral cubes"
+* Three or four-dimensional "spectral cubes"
 * *Chandra* event files
 
-*Chandra* X-ray event data will be loaded as particle fields in yt, but a 
-grid will be constructed from the WCS information in the FITS header. There 
-is a helper function, ``setup_counts_fields``, which may be used to make 
-deposited image fields from the event data for different energy bands (for 
-an example see :ref:`xray_fits`).
+These FITS images typically are in celestial or galactic coordinates, and
+for 3D spectral cubes the third axis is typically in velocity, wavelength,
+or frequency units. For these datasets, since yt does not yet recognize 
+non-spatial axes, the coordinates are in units of the image pixels. The
+coordinates of these pixels in the WCS coordinate systems will be available
+in separate fields. 
+
+For 4D spectral cubes, the fourth axis is assumed to be composed of different 
+fields altogether (e.g., Stokes parameters for radio data).
+
+*Chandra* X-ray event data, which is in tabular form, will be loaded as 
+particle fields in yt, but a grid will be constructed from the WCS 
+information in the FITS header. There is a helper function, 
+``setup_counts_fields``, which may be used to make deposited image fields 
+from the event data for different energy bands (for an example see 
+:ref:`xray_fits`).
 
 Generic FITS Images
 """""""""""""""""""
@@ -746,7 +770,7 @@ each image HDU the following standard header keywords have sensible values:
 * ``CRPIXx``: The reference pixel along axis ``x``
 * ``CTYPEx``: The projection type of axis ``x``
 * ``CUNITx``: The units of the coordinate along axis ``x``
-* ``BTYPE``: The type of the image
+* ``BTYPE``: The type of the image, this will be used as the field name
 * ``BUNIT``: The units of the image
 
 FITS header keywords can easily be updated using AstroPy. For example,
@@ -761,36 +785,6 @@ to set the ``BTYPE`` and ``BUNIT`` keywords:
    f.flush()
    f.close()
 
-FITS Coordinates
-^^^^^^^^^^^^^^^^
-
-For FITS datasets, the unit of ``code_length`` is always the width of one
-pixel. yt will attempt to use the WCS information in the FITS header to
-construct information about the coordinate system, and provides support for
-the following dataset types:
-
-1. Rectilinear 2D/3D images with length units (e.g., Mpc, AU,
-   etc.) defined in the ``CUNITx`` keywords
-2. 2D images in some celestial coordinate systems (RA/Dec,
-   galactic latitude/longitude, defined in the ``CTYPEx``
-   keywords), and X-ray binary table event files
-3. 3D images with celestial coordinates and a third axis for another
-   quantity, such as velocity, frequency, wavelength, etc.
-4. 4D images with the first three axes like Case 3, where the slices
-   along the 4th axis are interpreted as different fields.
-
-If your data is of the first case, yt will determine the length units based
-on the information in the header. If your data is of the second or third
-cases, no length units will be assigned, but the world coordinate information
-about the axes will be stored in separate fields. If your data is of the
-fourth type, the coordinates of the first three axes will be determined
-according to cases 1-3.
-
-.. note::
-
-  Linear length-based coordinates (Case 1 above) are only supported if all
-  dimensions have the same value for ``CUNITx``. WCS coordinates are only
-  supported for Cases 2-4.
 
 FITS Data Decomposition
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -888,17 +882,6 @@ containing different mask values for different fields:
 Generally, AstroPy may generate a lot of warnings about individual FITS
 files, many of which you may want to ignore. If you want to see these
 warnings, set ``suppress_astropy_warnings = False``.
-
-``spectral_factor``
-"""""""""""""""""""
-
-Often, the aspect ratio of 3D spectral cubes can be far from unity. Because yt
-sets the pixel scale as the ``code_length``, certain visualizations (such as
-volume renderings) may look extended or distended in ways that are
-undesirable. To adjust the width in ``code_length`` of the spectral axis, set
-``spectral_factor`` equal to a constant which gives the desired scaling, or set
-it to ``"auto"`` to make the width the same as the largest axis in the sky
-plane.
 
 Miscellaneous Tools for Use with FITS Data
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -950,7 +950,7 @@ version of AstroPy >= 1.3 must be installed.
 .. code-block:: python
 
   wcs_slc = PlotWindowWCS(slc)
-  wcs_slc.show() # for the IPython notebook
+  wcs_slc.show() # for Jupyter notebooks
   wcs_slc.save()
 
 ``WCSAxes`` is still in an experimental state, but as its functionality

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -994,6 +994,7 @@ which we recommend you look at in the following order:
 
 * :ref:`radio_cubes`
 * :ref:`xray_fits`
+* :ref:`writing_fits_images`
 
 .. _loading-flash-data:
 

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -736,6 +736,18 @@ non-spatial axes, the coordinates are in units of the image pixels. The
 coordinates of these pixels in the WCS coordinate systems will be available
 in separate fields. 
 
+Often, the aspect ratio of 3D spectral cubes can be far from unity. Because yt
+sets the pixel scale as the ``code_length``, certain visualizations (such as
+volume renderings) may look extended or distended in ways that are
+undesirable. To adjust the width in ``code_length`` of the spectral axis, set
+``spectral_factor`` equal to a constant which gives the desired scaling, or set
+it to ``"auto"`` to make the width the same as the largest axis in the sky
+plane:
+
+.. code-block:: python
+
+   ds = yt.load("m33_hi.fits.gz", spectral_factor=0.1)
+
 For 4D spectral cubes, the fourth axis is assumed to be composed of different 
 fields altogether (e.g., Stokes parameters for radio data).
 

--- a/doc/source/visualizing/FITSImageData.ipynb
+++ b/doc/source/visualizing/FITSImageData.ipynb
@@ -10,9 +10,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import yt"
@@ -21,9 +19,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "units_override = {\"length_unit\": (1.0, \"Mpc\"),\n",
@@ -49,9 +45,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "prj = yt.ProjectionPlot(ds, \"z\", (\"gas\", \"temperature\"), \n",
@@ -69,9 +63,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "prj_fits = yt.FITSProjection(ds, \"z\", (\"gas\", \"temperature\"), weight_field=(\"gas\", \"density\"))"
@@ -94,9 +86,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "prj_fits = yt.FITSProjection(ds, \"z\", (\"gas\", \"temperature\"), \n",
@@ -113,9 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "prj_fits.info()"
@@ -131,9 +119,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "prj_fits[\"temperature\"].header"
@@ -156,9 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "prj_fits[\"temperature\"].data"
@@ -181,9 +165,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "prj_fits.set_unit(\"temperature\", \"R\")\n",
@@ -241,9 +223,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "prj_fits.writeto(\"sloshing.fits\", overwrite=True)"
@@ -259,9 +239,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ds2 = yt.load(\"sloshing.fits\")"
@@ -277,9 +255,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "slc2 = yt.SlicePlot(ds2, \"z\", (\"gas\", \"temperature\"), width=(500.,\"kpc\"))\n",
@@ -304,9 +280,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "slc3 = ds.slice(0, 0.0)\n",
@@ -318,15 +292,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A 3D FITS cube can also be created from regularly gridded 3D data. In yt, there are covering grids and \"arbitrary grids\". The easiest way to make a grid is using `ds.r`:"
+    "A 3D FITS cube can also be created from regularly gridded 3D data. In yt, there are covering grids and \"arbitrary grids\". The easiest way to make an arbitrary grid object is using `ds.r`, where we can index the dataset like a NumPy array, creating a grid of 1.0 Mpc on a side, centered on the origin, with 64 cells on a side:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "grid = ds.r[(-0.5, \"Mpc\"):(0.5, \"Mpc\"):64j,\n",
@@ -359,9 +331,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fid = yt.FITSImageData.from_file(\"sloshing.fits\")\n",
@@ -378,9 +348,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "prj_fits2 = yt.FITSProjection(ds, \"z\", (\"gas\", \"density\"), width=(500.0, \"kpc\"))\n",
@@ -398,9 +366,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "dens_fits = prj_fits3.pop(\"density\")"
@@ -416,9 +382,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "dens_fits.info()"
@@ -434,9 +398,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "prj_fits3.info()"
@@ -459,9 +421,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "prj_fits[\"temperature\"].header"
@@ -479,9 +439,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sky_center = [30.,45.] # in degrees\n",
@@ -499,9 +457,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "prj_fits[\"temperature\"].header"
@@ -535,9 +491,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "prj_fits3[\"temperature\"].header"
@@ -567,9 +521,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "fid_frb.update_header(\"all\", \"time\", 0.1) # Update all the fields\n",
@@ -579,9 +531,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print (fid_frb[\"density\"].header[\"time\"])\n",

--- a/doc/source/visualizing/FITSImageData.ipynb
+++ b/doc/source/visualizing/FITSImageData.ipynb
@@ -26,9 +26,10 @@
    },
    "outputs": [],
    "source": [
-    "ds = yt.load(\"MHDSloshing/virgo_low_res.0054.vtk\", units_override={\"length_unit\":(1.0,\"Mpc\"),\n",
-    "                                                                   \"mass_unit\":(1.0e14,\"Msun\"),\n",
-    "                                                                   \"time_unit\":(1.0,\"Myr\")})"
+    "units_override = {\"length_unit\": (1.0, \"Mpc\"),\n",
+    "                  \"mass_unit\": (1.0e14, \"Msun\"),\n",
+    "                  \"time_unit\": (1.0, \"Myr\")}\n",
+    "ds = yt.load(\"MHDSloshing/virgo_low_res.0054.vtk\", units_override=units_override)"
    ]
   },
   {
@@ -53,7 +54,8 @@
    },
    "outputs": [],
    "source": [
-    "prj = yt.ProjectionPlot(ds, \"z\", [\"temperature\"], weight_field=\"density\", width=(500., \"kpc\"))\n",
+    "prj = yt.ProjectionPlot(ds, \"z\", (\"gas\", \"temperature\"), \n",
+    "                        weight_field=(\"gas\", \"density\"), width=(500., \"kpc\"))\n",
     "prj.show()"
    ]
   },
@@ -72,7 +74,7 @@
    },
    "outputs": [],
    "source": [
-    "prj_fits = yt.FITSProjection(ds, \"z\", [\"temperature\"], weight_field=\"density\")"
+    "prj_fits = yt.FITSProjection(ds, \"z\", (\"gas\", \"temperature\"), weight_field=(\"gas\", \"density\"))"
    ]
   },
   {
@@ -97,7 +99,8 @@
    },
    "outputs": [],
    "source": [
-    "prj_fits = yt.FITSProjection(ds, \"z\", [\"temperature\"], weight_field=\"density\", width=(500., \"kpc\"))"
+    "prj_fits = yt.FITSProjection(ds, \"z\", (\"gas\", \"temperature\"), \n",
+    "                             weight_field=(\"gas\", \"density\"), width=(500., \"kpc\"))"
    ]
   },
   {
@@ -140,7 +143,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "where we can see that the temperature units are in Kelvin and the cell widths are in kiloparsecs. If we want the raw image data with units, we can use the `data` attribute of this field:"
+    "where we can see that the units of the temperature field are Kelvin and the cell widths are in kiloparsecs. Note that the length, time, mass, velocity, and magnetic field units of the dataset have been copied into the header "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    " If we want the raw image data with units, we can use the `data` attribute of this field:"
    ]
   },
   {
@@ -152,6 +162,13 @@
    "outputs": [],
    "source": [
     "prj_fits[\"temperature\"].data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Changing Aspects of the Images"
    ]
   },
   {
@@ -169,8 +186,49 @@
    },
    "outputs": [],
    "source": [
-    "prj_fits.set_unit(\"temperature\",\"R\")\n",
+    "prj_fits.set_unit(\"temperature\", \"R\")\n",
     "prj_fits[\"temperature\"].data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The length units of the image (and its coordinate system), as well as the resolution of the image, can be adjusted when creating it using the `length_unit` and `image_res` keyword arguments, respectively:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# length_unit defaults to that from the dataset\n",
+    "# image_res defaults to 512\n",
+    "slc_fits = yt.FITSSlice(ds, \"z\", (\"gas\", \"density\"), width=(500,\"kpc\"), length_unit=\"ly\", image_res=256)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now check that this worked by looking at the header, notice in particular the `NAXIS[12]` and `CUNIT[12]` keywords (the `CDELT[12]` and `CRPIX[12]` values also change):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "slc_fits[\"density\"].header"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Saving and Loading Images"
    ]
   },
   {
@@ -188,14 +246,14 @@
    },
    "outputs": [],
    "source": [
-    "prj_fits.writeto(\"sloshing.fits\", clobber=True)"
+    "prj_fits.writeto(\"sloshing.fits\", overwrite=True)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since yt can read FITS image files, it can be loaded up just like any other dataset:"
+    "Since yt can read FITS image files, it can be loaded up just like any other dataset. Since we created this FITS file with `FITSImageData`, the image will contain information about the units and the current time of the dataset:"
    ]
   },
   {
@@ -224,7 +282,7 @@
    },
    "outputs": [],
    "source": [
-    "slc2 = yt.SlicePlot(ds2, \"z\", [\"temperature\"], width=(500.,\"kpc\"))\n",
+    "slc2 = yt.SlicePlot(ds2, \"z\", (\"gas\", \"temperature\"), width=(500.,\"kpc\"))\n",
     "slc2.set_log(\"temperature\", True)\n",
     "slc2.show()"
    ]
@@ -233,7 +291,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Using `FITSImageData` directly"
+    "## Creating `FITSImageData` Instances Directly from FRBs and 3D Grids"
    ]
   },
   {
@@ -253,14 +311,14 @@
    "source": [
     "slc3 = ds.slice(0, 0.0)\n",
     "frb = slc3.to_frb((500.,\"kpc\"), 800)\n",
-    "fid_frb = yt.FITSImageData(frb, fields=[\"density\",\"temperature\"], units=\"pc\")"
+    "fid_frb = frb.to_fits_data(fields=[(\"gas\", \"density\"), (\"gas\", \"temperature\")], length_unit=\"pc\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A 3D FITS cube can also be created from a covering grid:"
+    "A 3D FITS cube can also be created from regularly gridded 3D data. In yt, there are covering grids and \"arbitrary grids\". The easiest way to make a grid is using `ds.r`:"
    ]
   },
   {
@@ -271,8 +329,10 @@
    },
    "outputs": [],
    "source": [
-    "cvg = ds.covering_grid(ds.index.max_level, [-0.5,-0.5,-0.5], [64, 64, 64], fields=[\"density\",\"temperature\"])\n",
-    "fid_cvg = yt.FITSImageData(cvg, fields=[\"density\",\"temperature\"], units=\"Mpc\")"
+    "grid = ds.r[(-0.5, \"Mpc\"):(0.5, \"Mpc\"):64j,\n",
+    "            (-0.5, \"Mpc\"):(0.5, \"Mpc\"):64j,\n",
+    "            (-0.5, \"Mpc\"):(0.5, \"Mpc\"):64j]\n",
+    "fid_grid = grid.to_fits_data(fields=[(\"gas\", \"density\"), (\"gas\", \"temperature\")], length_unit=\"Mpc\")"
    ]
   },
   {
@@ -280,6 +340,13 @@
    "metadata": {},
    "source": [
     "## Other `FITSImageData` Methods"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Creating Images from Others"
    ]
   },
   {
@@ -316,7 +383,7 @@
    },
    "outputs": [],
    "source": [
-    "prj_fits2 = yt.FITSProjection(ds, \"z\", [\"density\"])\n",
+    "prj_fits2 = yt.FITSProjection(ds, \"z\", (\"gas\", \"density\"), width=(500.0, \"kpc\"))\n",
     "prj_fits3 = yt.FITSImageData.from_images([prj_fits, prj_fits2])\n",
     "prj_fits3.info()"
    ]
@@ -373,6 +440,13 @@
    "outputs": [],
    "source": [
     "prj_fits3.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Adding Sky Coordinates to Images"
    ]
   },
   {
@@ -480,7 +554,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally, we can add header keywords to a single field or for all fields in the FITS image using `update_header`:"
+    "### Updating Header Parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also add header keywords to a single field or for all fields in the FITS image using `update_header`:"
    ]
   },
   {
@@ -506,16 +587,117 @@
     "print (fid_frb[\"density\"].header[\"time\"])\n",
     "print (fid_frb[\"temperature\"].header[\"scale\"])"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Changing Image Names"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can use the `change_image_name` method to change the name of an image in a `FITSImageData` instance:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fid_frb.change_image_name(\"density\", \"mass_per_volume\")\n",
+    "fid_frb.info() # now \"density\" should be gone and \"mass_per_volume\" should be in its place"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Convolving FITS Images"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, you can convolve an image inside a `FITSImageData` instance with a kernel, either a Gaussian with a specific standard deviation, or any kernel provided by AstroPy. See AstroPy's [Convolution and filtering](http://docs.astropy.org/en/stable/convolution/index.html) for more details."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dens_fits.writeto(\"not_convolved.fits\", overwrite=True)\n",
+    "# Gaussian kernel with standard deviation of 3.0 kpc\n",
+    "dens_fits.convolve(\"density\", 3.0)\n",
+    "dens_fits.writeto(\"convolved.fits\", overwrite=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's load these up as datasets and see the difference:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds0 = yt.load(\"not_convolved.fits\")\n",
+    "dsc = yt.load(\"convolved.fits\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "slc3 = yt.SlicePlot(ds0, \"z\", (\"gas\", \"density\"), width=(500.,\"kpc\"))\n",
+    "slc3.set_log(\"density\", True)\n",
+    "slc3.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "slc4 = yt.SlicePlot(dsc, \"z\", (\"gas\", \"density\"), width=(500.,\"kpc\"))\n",
+    "slc4.set_log(\"density\", True)\n",
+    "slc4.show()"
+   ]
   }
  ],
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 2
 }

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -958,7 +958,7 @@ class YTCoveringGrid(YTSelectionContainer3D):
         """
         from yt.visualization.fits_image import FITSImageData
         if length_unit is None:
-            length_unit = str(self.ds.unit_system["length"])
+            length_unit = self.ds.length_unit
         fields = ensure_list(fields)
         fid = FITSImageData(self, fields, length_unit=length_unit)
         return fid

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -941,6 +941,29 @@ class YTCoveringGrid(YTSelectionContainer3D):
 
         return bounds, size
 
+    def to_fits_data(self, fields, length_unit=None):
+        r"""Export a set of gridded fields to a FITS file.
+
+        This will export a set of FITS images of either the fields specified
+        or all the fields already in the object.
+
+        Parameters
+        ----------
+        fields : list of strings
+            These fields will be pixelized and output. If "None", the keys of the
+            FRB will be used.
+        length_unit : string, optional
+            the length units that the coordinates are written in. The default
+            is to use the default length unit of the dataset.
+        """
+        from yt.visualization.fits_image import FITSImageData
+        if length_unit is None:
+            length_unit = str(self.ds.unit_system["length"])
+        fields = ensure_list(fields)
+        fid = FITSImageData(self, fields, length_unit=length_unit)
+        return fid
+
+
 class YTArbitraryGrid(YTCoveringGrid):
     """A 3D region with arbitrary bounds and dimensions.
 

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -423,6 +423,7 @@ class YTDataContainer(object):
             obj.field_parameters = old_fp
 
     _key_fields = None
+
     def write_out(self, filename, fields=None, format="%0.16e"):
         """Write out the YTDataContainer object in a text file.
 

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -412,18 +412,13 @@ class FITSDataset(Dataset):
 
         self._determine_wcs()
 
+        self.current_time = 0.0
+
         self.domain_dimensions = np.array(self.dims)[:self.dimensionality]
         if self.dimensionality == 2:
             self.domain_dimensions = np.append(self.domain_dimensions,
                                                [int(1)])
         self._determine_bbox()
-
-        # Get the current time
-        if "time" in self.primary_header:
-            self.current_time = self.quan(self.primary_header["time"],
-                                          self.primary_header.comments["time"])
-        else:
-            self.current_time = self.quan(0.0, "s")
 
         # For now we'll ignore these
         self.periodicity = (False,)*3
@@ -520,6 +515,12 @@ def find_axes(axis_names, prefixes):
 
 class YTFITSDataset(FITSDataset):
     _field_info_class = YTFITSFieldInfo
+
+    def _parse_parameter_file(self):
+        super(YTFITSDataset, self)._parse_parameter_file()
+        # Get the current time
+        if "time" in self.primary_header:
+            self.current_time = self.primary_header["time"]
 
     def _set_code_unit_attributes(self):
         """

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -84,6 +84,7 @@ class FITSGrid(AMRGridPatch):
     def __repr__(self):
         return "FITSGrid_%04i (%s)" % (self.id, self.ActiveDimensions)
 
+
 class FITSHierarchy(GridIndex):
 
     grid = FITSGrid
@@ -109,17 +110,16 @@ class FITSHierarchy(GridIndex):
                 return v
         return None
 
-    def _determine_image_units(self, header, known_units):
+    def _determine_image_units(self, header):
         try:
-            field_units = header["bunit"].lower().strip(" ").replace(" ", "")
             try:
                 # First let AstroPy attempt to figure the unit out
-                u = _astropy.units.Unit(field_units, format="fits")
+                u = _astropy.units.Unit(header["bunit"], format="fits")
                 u = str(YTQuantity.from_astropy(1.0*u).units)
             except ValueError:
                 try:
                     # Let yt try it by itself
-                    u = str(self.ds.quan(1.0, field_units).units)
+                    u = str(self.ds.quan(1.0, header["bunit"]).units)
                 except UnitParseError:
                     u = "dimensionless"
             return u
@@ -163,7 +163,7 @@ class FITSHierarchy(GridIndex):
                 if isinstance(hdu, _astropy.pyfits.BinTableHDU) or hdu.header["naxis"] == 0:
                     continue
                 if self._ensure_same_dims(hdu):
-                    units = self._determine_image_units(hdu.header, known_units)
+                    units = self._determine_image_units(hdu.header)
                     try:
                         # Grab field name from btype
                         fname = hdu.header["btype"]

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -501,9 +501,6 @@ class FITSDataset(Dataset):
     def close(self):
         self._handle.close()
 
-    def __repr__(self):
-        return self.filenames[0].rsplit(".", 1)[0]
-
 
 def find_axes(axis_names, prefixes):
     x = 0

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -440,7 +440,7 @@ class FITSDataset(Dataset):
         # Get the current time
         if "current_time" in self.primary_header:
             self.current_time = self.quan(self.primary_header["current_time"],
-                                          self.primary_comments["current_time"])
+                                          self.primary_header.comments["current_time"])
         else:
             self.current_time = self.quan(0.0, "s")
 
@@ -541,7 +541,7 @@ class YTFITSDataset(FITSDataset):
         """
         for unit in ("length", "time", "mass", "velocity", "magnetic"):
             u = self.quan(self.primary_header["%s_unit" % unit],
-                          self.primary_comments["%s_unit" % unit])
+                          self.primary_header.comments["%s_unit" % unit])
             mylog.info("Found %s units of %s." % (unit, u))
             setdefaultattr(self, '%s_unit' % unit, u)
 
@@ -775,7 +775,6 @@ class EventsFITSDataset(SkyDataFITSDataset):
     def _determine_structure(self):
         self.first_image = 1
         self.primary_header = self._handle[self.first_image].header
-        self.primary_comments = self._handle[self.first_image].comments
         self.naxis = 2
 
     def _determine_wcs(self):

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -419,9 +419,9 @@ class FITSDataset(Dataset):
         self._determine_bbox()
 
         # Get the current time
-        if "current_time" in self.primary_header:
-            self.current_time = self.quan(self.primary_header["current_time"],
-                                          self.primary_header.comments["current_time"])
+        if "time" in self.primary_header:
+            self.current_time = self.quan(self.primary_header["time"],
+                                          self.primary_header.comments["time"])
         else:
             self.current_time = self.quan(0.0, "s")
 
@@ -526,8 +526,12 @@ class YTFITSDataset(FITSDataset):
         Generates the conversion to various physical _units based on the parameter file
         """
         for unit in ("length", "time", "mass", "velocity", "magnetic"):
-            u = self.quan(self.primary_header["%s_unit" % unit],
-                          self.primary_header.comments["%s_unit" % unit])
+            if unit == "magnetic":
+                short_unit = "b"
+            else:
+                short_unit = unit[0]
+            u = self.quan(self.primary_header["%sunit" % short_unit],
+                          self.primary_header.comments["%sunit" % short_unit])
             mylog.info("Found %s units of %s." % (unit, u))
             setdefaultattr(self, '%s_unit' % unit, u)
 

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -569,7 +569,10 @@ class YTFITSDataset(FITSDataset):
         if fileh is None:
             return False
         else:
-            isyt = fileh[0].header["WCSNAME"].strip() == "yt"
+            if "WCSNAME" in fileh[0].header:
+                isyt = fileh[0].header["WCSNAME"].strip() == "yt"
+            else:
+                isyt = False
             fileh.close()
             return isyt
 

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -527,7 +527,7 @@ class YTFITSDataset(FITSDataset):
         """
         for unit in ("length", "time", "mass", "velocity", "magnetic"):
             if unit == "magnetic":
-                short_unit = "b"
+                short_unit = "bf"
             else:
                 short_unit = unit[0]
             u = self.quan(self.primary_header["%sunit" % short_unit],

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -36,7 +36,7 @@ from yt.geometry.geometry_handler import \
 from yt.data_objects.static_output import \
     Dataset
 from yt.units.unit_object import UnitParseError
-from yt.units.YTArray import YTQuantity
+from yt.units.yt_array import YTQuantity
 from yt.utilities.file_handler import \
     FITSFileHandler
 from yt.utilities.io_handler import \

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -46,17 +46,12 @@ from .fields import FITSFieldInfo, \
 from yt.utilities.decompose import \
     decompose_array, get_psize
 from yt.funcs import issue_deprecation_warning
-from yt.units.unit_lookup_table import \
-    prefixable_units
 from yt.units import dimensions
 from yt.utilities.on_demand_imports import \
     _astropy, NotAModule
 
 lon_prefixes = ["X","RA","GLON","LINEAR"]
 lat_prefixes = ["Y","DEC","GLAT","LINEAR"]
-delimiters = ["*", "/", "-", "^", "(", ")"]
-delimiters += [str(i) for i in range(10)]
-regex_pattern = '|'.join(re.escape(_) for _ in delimiters)
 
 spec_names = {"V": "Velocity",
               "F": "Frequency",
@@ -69,8 +64,8 @@ sky_prefixes.difference_update({"X", "Y", "LINEAR"})
 sky_prefixes = list(sky_prefixes)
 spec_prefixes = list(spec_names.keys())
 
-field_from_unit = {"Jy":"intensity",
-                   "K":"temperature"}
+field_from_unit = {"Jy": "intensity",
+                   "K": "temperature"}
 
 class FITSGrid(AMRGridPatch):
     _id_offset = 0
@@ -144,15 +139,6 @@ class FITSHierarchy(GridIndex):
         self._ext_map = {}
         self._scale_map = {}
         dup_field_index = {}
-        # Since FITS header keywords are case-insensitive, we only pick a subset of
-        # prefixes, ones that we expect to end up in headers.
-        known_units = dict(
-            [(unit.lower(), unit) for unit in self.ds.unit_registry.lut]
-        )
-        for unit in list(known_units.values()):
-            if unit in prefixable_units:
-                for p in ["n","u","m","c","k"]:
-                    known_units[(p+unit).lower()] = p+unit
         # We create a field from each slice on the 4th axis
         if self.dataset.naxis == 4:
             naxis4 = self.dataset.primary_header["naxis4"]

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -532,7 +532,7 @@ class YTFITSDataset(FITSDataset):
             if short_unit in self.primary_header:
                 # units should now be in header
                 u = self.quan(self.primary_header[short_unit],
-                              self.primary_header.comments[short_unit])
+                              self.primary_header.comments[short_unit].strip("[]"))
                 mylog.info("Found %s units of %s." % (unit, u))
             else:
                 if unit == "length":

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -88,7 +88,7 @@ class FITSHierarchy(GridIndex):
         self.dataset_type = dataset_type
         self.field_indexes = {}
         self.dataset = weakref.proxy(ds)
-        # for now, the index file is the dataset!
+        # for now, the index file is the dataset
         self.index_filename = self.dataset.parameter_filename
         self.directory = os.path.dirname(self.index_filename)
         self._handle = ds._handle
@@ -529,9 +529,10 @@ class YTFITSDataset(FITSDataset):
             setdefaultattr(self, '%s_unit' % unit, u)
 
     def _determine_bbox(self):
-        dx = self.arr(self.wcs.wcs.cdelt, str(self.wcs.wcs.cunit[0])).v
+        dx = np.zeros(3)
+        dx[:self.dimensionality] = self.wcs.wcs.cdelt
         domain_left_edge = np.zeros(3)
-        domain_left_edge[:self.dimensionality] = self.wcs.wcs.crval-dx*(self.wcs.wcs.crpix-0.5)
+        domain_left_edge[:self.dimensionality] = self.wcs.wcs.crval-dx[:self.dimensionality]*(self.wcs.wcs.crpix-0.5)
         domain_right_edge = domain_left_edge + dx*self.domain_dimensions
 
         if self.dimensionality == 2:

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -506,6 +506,9 @@ class FITSDataset(Dataset):
     def close(self):
         self._handle.close()
 
+    def __repr__(self):
+        return self.filenames[0].rsplit(".", 1)[0]
+
 
 def find_axes(axis_names, prefixes):
     x = 0

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -308,6 +308,8 @@ def check_sky_coords(args, ndim):
                     return False
                 axis_names = [header.get("ctype%d" % (i + 1), "")
                               for i in range(header["naxis"])]
+                if len(axis_names) == 3 and axis_names.count("LINEAR") == 2:
+                    return any(a[0] in spec_prefixes for a in axis_names)
                 x = find_axes(axis_names, sky_prefixes + spec_prefixes)
                 fileh.close()
                 return x >= ndim

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -36,6 +36,7 @@ from yt.geometry.geometry_handler import \
 from yt.data_objects.static_output import \
     Dataset
 from yt.units.unit_object import UnitParseError
+from yt.units.YTArray import YTQuantity
 from yt.utilities.file_handler import \
     FITSFileHandler
 from yt.utilities.io_handler import \
@@ -114,7 +115,7 @@ class FITSHierarchy(GridIndex):
             try:
                 # First let AstroPy attempt to figure the unit out
                 u = _astropy.units.Unit(field_units, format="fits")
-                u = str(self.ds.quan.from_astropy(1.0*u).units)
+                u = str(YTQuantity.from_astropy(1.0*u).units)
             except ValueError:
                 try:
                     # Let yt try it by itself

--- a/yt/frontends/fits/fields.py
+++ b/yt/frontends/fits/fields.py
@@ -58,6 +58,7 @@ class YTFITSFieldInfo(FieldInfoContainer):
     def __init__(self, ds, field_list, slice_info=None):
         super(YTFITSFieldInfo, self).__init__(ds, field_list, slice_info=slice_info)
 
+
 class WCSFITSFieldInfo(FITSFieldInfo):
 
     def setup_fluid_fields(self):

--- a/yt/frontends/fits/fields.py
+++ b/yt/frontends/fits/fields.py
@@ -13,14 +13,16 @@ FITS-specific fields
 from yt.fields.field_info_container import \
     FieldInfoContainer
 
+
 class FITSFieldInfo(FieldInfoContainer):
     known_other_fields = ()
 
     def __init__(self, ds, field_list, slice_info=None):
         super(FITSFieldInfo, self).__init__(ds, field_list, slice_info=slice_info)
         for field in ds.field_list:
-            if field[0] == "fits": 
+            if field[0] == "fits":
                 self[field].take_log = False
+
 
 class YTFITSFieldInfo(FieldInfoContainer):
     known_other_fields = (
@@ -52,6 +54,7 @@ class YTFITSFieldInfo(FieldInfoContainer):
         ("di_density",      ("code_mass/code_length**3", ["di_density"], None)),
         ("dii_density",     ("code_mass/code_length**3", ["dii_density"], None)),
     )
+
     def __init__(self, ds, field_list, slice_info=None):
         super(YTFITSFieldInfo, self).__init__(ds, field_list, slice_info=slice_info)
 
@@ -80,7 +83,7 @@ class WCSFITSFieldInfo(FITSFieldInfo):
                 unit = "degree"
             if unit.lower() == "rad":
                 unit = "radian"
-            self.add_field(("fits",name), sampling_type="cell", 
+            self.add_field(("fits", name), sampling_type="cell", 
                            function=world_f(axis, unit), units=unit)
 
         if self.ds.dimensionality == 3:
@@ -88,5 +91,5 @@ class WCSFITSFieldInfo(FITSFieldInfo):
                 axis = "xyz"[data.ds.spec_axis]
                 sp = (data[axis].ndarray_view()-self.ds._p0)*self.ds._dz + self.ds._z0
                 return data.ds.arr(sp, data.ds.spec_unit)
-            self.add_field(("fits","spectral"), sampling_type="cell",  function=_spec,
+            self.add_field(("fits", "spectral"), sampling_type="cell",  function=_spec,
                            units=self.ds.spec_unit, display_name=self.ds.spec_name)

--- a/yt/frontends/fits/io.py
+++ b/yt/frontends/fits/io.py
@@ -81,17 +81,17 @@ class IOHandlerFITS(BaseIOHandler):
                 for g in chunk.objs:
                     start = ((g.LeftEdge-self.ds.domain_left_edge)/dx).d.astype("int")
                     end = start + g.ActiveDimensions
-                    slices = [slice(start[i],end[i]) for i in range(3)]
+                    slices = [slice(start[i], end[i]) for i in range(3)]
                     if self.ds.dimensionality == 2:
                         nx, ny = g.ActiveDimensions[:2]
                         nz = 1
                         data = np.zeros((nx,ny,nz))
-                        data[:,:,0] = ds.data[slices[1],slices[0]].transpose()
+                        data[:,:,0] = ds.data[slices[1], slices[0]].T
                     elif self.ds.naxis == 4:
                         idx = self.ds.index._axis_map[fname]
-                        data = ds.data[idx,slices[2],slices[1],slices[0]].transpose()
+                        data = ds.data[idx, slices[2], slices[1], slices[0]].T
                     else:
-                        data = ds.data[slices[2],slices[1],slices[0]].transpose()
+                        data = ds.data[slices[2], slices[1], slices[0]].T
                     if fname in self.ds.nan_mask:
                         data[np.isnan(data)] = self.ds.nan_mask[fname]
                     elif "all" in self.ds.nan_mask:

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -696,6 +696,7 @@ def sanitize_fits_unit(unit):
         unit = "AU"
     return unit
 
+
 axis_wcs = [[1,2],[0,2],[0,1]]
 
 
@@ -741,7 +742,7 @@ def construct_image(ds, axis, data_source, center, image_res, width):
     w.wcs.crval = crval
     w.wcs.cunit = cunit
     w.wcs.ctype = ctype
-    return w, frb
+    return w, frb, unit
 
 
 def assert_same_wcs(wcs1, wcs2):
@@ -826,9 +827,10 @@ class FITSSlice(FITSImageData):
         axis = fix_axis(axis, ds)
         center, dcenter = ds.coordinates.sanitize_center(center, axis)
         slc = ds.slice(axis, center[axis], **kwargs)
-        w, frb = construct_image(ds, axis, slc, dcenter, image_res,
-                                 width)
-        super(FITSSlice, self).__init__(frb, fields=fields, wcs=w)
+        w, frb, lunit = construct_image(ds, axis, slc, dcenter, image_res,
+                                        width)
+        super(FITSSlice, self).__init__(frb, fields=fields, 
+                                        length_unit=lunit, wcs=w)
 
 
 class FITSProjection(FITSImageData):
@@ -886,9 +888,10 @@ class FITSProjection(FITSImageData):
         axis = fix_axis(axis, ds)
         center, dcenter = ds.coordinates.sanitize_center(center, axis)
         prj = ds.proj(fields[0], axis, weight_field=weight_field, **kwargs)
-        w, frb = construct_image(ds, axis, prj, dcenter, image_res,
-                                 width)
-        super(FITSProjection, self).__init__(frb, fields=fields, wcs=w)
+        w, frb, lunit = construct_image(ds, axis, prj, dcenter, image_res,
+                                        width)
+        super(FITSProjection, self).__init__(frb, fields=fields, 
+                                             length_unit=lunit, wcs=w)
 
 
 class FITSOffAxisSlice(FITSImageData):
@@ -948,9 +951,10 @@ class FITSOffAxisSlice(FITSImageData):
         center, dcenter = ds.coordinates.sanitize_center(center, 4)
         cut = ds.cutting(normal, center, north_vector=north_vector)
         center = ds.arr([0.0]*2, 'code_length')
-        w, frb = construct_image(ds, normal, cut, center, image_res,
-                                 width)
-        super(FITSOffAxisSlice, self).__init__(frb, fields=fields, wcs=w)
+        w, frb, lunit = construct_image(ds, normal, cut, center, 
+                                        image_res, width)
+        super(FITSOffAxisSlice, self).__init__(frb, fields=fields, 
+                                               length_unit=lunit, wcs=w)
 
 
 class FITSOffAxisProjection(FITSImageData):
@@ -1048,6 +1052,7 @@ class FITSOffAxisProjection(FITSImageData):
                                              res, field, north_vector=north_vector,
                                              method=method, weight=weight_field).swapaxes(0,1)
         center = ds.arr([0.0]*2, 'code_length')
-        w, not_an_frb = construct_image(ds, normal, buf, center, image_res,
-                                        width)
-        super(FITSOffAxisProjection, self).__init__(buf, fields=fields, wcs=w, ds=ds)
+        w, not_an_frb, lunit = construct_image(ds, normal, buf, center, 
+                                               image_res, width)
+        super(FITSOffAxisProjection, self).__init__(buf, fields=fields, wcs=w, 
+                                                    length_unit=lunit, ds=ds)

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -347,15 +347,17 @@ class FITSImageData(object):
             elif isinstance(u, numeric_type):
                 uq = YTQuantity(u, cgs_unit)
             elif isinstance(u, YTQuantity):
-                uq = u
+                uq = u.copy()
             elif isinstance(u, tuple):
                 uq = YTQuantity(u[0], u[1])
             else:
                 uq = None
 
             if uq is not None and uq.units.is_code_unit:
-                raise RuntimeError("Cannot use code units when creating "
-                                   "a FITSImageData instance!")
+                mylog.warning("Cannot use code units of '%s' " % uq.units +
+                              "when creating a FITSImageData instance! "
+                              "Converting to a cgs equivalent.")
+                uq.convert_to_cgs()
 
             if attr == "length_unit" and uq.value != 1.0:
                 mylog.warning("Converting length units "

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -51,9 +51,10 @@ class UnitfulHDU(object):
 
 class FITSImageData(object):
 
-    def __init__(self, data, fields=None, length_unit=None, width=None, img_ctr=None,
-                 wcs=None, current_time=None, time_unit=None, mass_unit=None, 
-                 velocity_unit=None, magnetic_unit=None, ds=None, **kwargs):
+    def __init__(self, data, fields=None, length_unit=None, width=None,
+                 img_ctr=None, wcs=None, current_time=None, time_unit=None,
+                 mass_unit=None, velocity_unit=None, magnetic_unit=None,
+                 ds=None, **kwargs):
         r""" Initialize a FITSImageData object.
 
         FITSImageData contains a collection of FITS ImageHDU instances and
@@ -132,7 +133,7 @@ class FITSImageData(object):
                                       "by the 'length_unit' keyword argument and the "
                                       "former has been deprecated. Setting 'length_unit' "
                                       "to 'units'.")
-            length_unit = kwargs["units"]
+            length_unit = kwargs.pop("units")
 
         if ds is None:
             ds = getattr(data, "ds", None)

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -114,9 +114,6 @@ class FITSImageData(object):
         >>> f_deg.writeto("temp.fits")
         """
 
-        self.fields = []
-        self.field_units = {}
-
         if "units" in kwargs:
             issue_deprecation_warning("The 'units' keyword argument has been replaced "
                                       "by the 'length_unit' keyword argument and the "
@@ -126,6 +123,9 @@ class FITSImageData(object):
 
         if ds is None:
             ds = getattr(data, "ds", None)
+
+        self.fields = []
+        self.field_units = {}
 
         self._set_units(ds, [length_unit, mass_unit, time_unit, velocity_unit,
                              magnetic_unit])

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -131,6 +131,11 @@ class FITSImageData(object):
 
         if width is None:
             width = 1.0
+        if isinstance(width, tuple):
+            if ds is None:
+                width = YTQuantity(width[0], width[1])
+            else:
+                width = ds.quan(width[0], width[1])
         if img_ctr is None:
             img_ctr = np.zeros(3)
 
@@ -207,7 +212,7 @@ class FITSImageData(object):
                     else:
                         short_unit = unit[0]
                     key = "{}unit".format(short_unit)
-                    value = getattr(self, key)
+                    value = getattr(self, "{}_unit".format(unit))
                     hdu.header[key] = float(value.value)
                     hdu.header.comments[key] = value.units
                 if self.current_time is not None:

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -50,7 +50,7 @@ class FITSImageData(object):
 
     def __init__(self, data, fields=None, length_unit=None, width=None, img_ctr=None,
                  wcs=None, current_time=None, time_unit=None, mass_unit=None, 
-                 velocity_unit=None, magnetic_unit=None, **kwargs):
+                 velocity_unit=None, magnetic_unit=None, ds=None, **kwargs):
         r""" Initialize a FITSImageData object.
 
         FITSImageData contains a collection of FITS ImageHDU instances and
@@ -121,7 +121,8 @@ class FITSImageData(object):
                                       "to 'units'.")
             length_unit = kwargs["units"]
 
-        ds = getattr(data, "ds", None)
+        if ds is None:
+            ds = getattr(data, "ds", None)
 
         self._set_units(ds, [length_unit, mass_unit, time_unit, velocity_unit,
                              magnetic_unit])
@@ -268,6 +269,9 @@ class FITSImageData(object):
         if current_time is None:
             if ds is not None:
                 current_time = ds.current_time
+            else:
+                self.current_time = 0.0
+                return
         elif isinstance(current_time, numeric_type):
             current_time = YTQuantity(current_time, tunit)
         elif isinstance(current_time, tuple):
@@ -1031,4 +1035,4 @@ class FITSOffAxisProjection(FITSImageData):
         center = ds.arr([0.0]*2, 'code_length')
         w, not_an_frb = construct_image(ds, normal, buf, center, image_res,
                                         width)
-        super(FITSOffAxisProjection, self).__init__(buf, fields=fields, wcs=w)
+        super(FITSOffAxisProjection, self).__init__(buf, fields=fields, wcs=w, ds=ds)

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -202,10 +202,10 @@ class FITSImageData(object):
                 for unit in ("length", "time", "mass", "velocity", "magnetic"):
                     key = "{}_unit".format(unit)
                     value = getattr(self, key)
-                    hdu.header[key] = value.value
+                    hdu.header[key] = float(value.value)
                     hdu.comments[key] = value.units
                 if self.current_time is not None:
-                    hdu.header["current_time"] = self.current_time.value
+                    hdu.header["current_time"] = float(self.current_time.value)
                     hdu.comments["current_time"] = self.current_time.units
                 self.hdulist.append(hdu)
 

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -626,7 +626,7 @@ class FITSImageBuffer(FITSImageData):
 
 def sanitize_fits_unit(unit):
     if unit == "Mpc":
-        mylog.info("Changing FITS file unit to kpc.")
+        mylog.info("Changing FITS file length unit to kpc.")
         unit = "kpc"
     elif unit == "au":
         unit = "AU"

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -213,8 +213,9 @@ class FITSImageData(object):
                         short_unit = unit[0]
                     key = "{}unit".format(short_unit)
                     value = getattr(self, "{}_unit".format(unit))
-                    hdu.header[key] = float(value.value)
-                    hdu.header.comments[key] = value.units
+                    if value is not None:
+                        hdu.header[key] = float(value.value)
+                        hdu.header.comments[key] = value.units
                 if self.current_time is not None:
                     hdu.header["time"] = float(self.current_time.value)
                     hdu.header.comments["time"] = self.current_time.units
@@ -277,7 +278,7 @@ class FITSImageData(object):
         for unit, attr, cgs_unit in zip(base_units, attrs, cgs_units):
             if unit is None:
                 if ds is not None:
-                    u = getattr(ds, attr)
+                    u = getattr(ds, attr, None)
                 elif attr == "velocity_unit":
                     u = self.length_unit / self.time_unit
                 elif attr == "magnetic_unit":
@@ -287,6 +288,7 @@ class FITSImageData(object):
                     u = cgs_unit
             else:
                 u = unit
+
             if isinstance(u, string_types):
                 uq = YTQuantity(1.0, u)
             elif isinstance(u, numeric_type):
@@ -296,7 +298,7 @@ class FITSImageData(object):
             elif isinstance(u, tuple):
                 uq = YTQuantity(u[0], u[1])
             else:
-                raise RuntimeError("%s (%s) is invalid." % (attr, u))
+                uq = None
             setattr(self, attr, uq)
 
     def set_wcs(self, wcs, wcsname=None, suffix=None):

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -213,6 +213,21 @@ class FITSImageData(object):
             else:
                 self.fields.append(fd)
 
+        # Sanity checking names
+        s = set()
+        duplicates = set(f for f in self.fields if f in s or s.add(f))
+        if len(duplicates) > 0:
+            for i, fd in enumerate(self.fields):
+                if fd in duplicates:
+                    if isinstance(fields[i], tuple):
+                        ftype, fname = fields[i]
+                    elif isinstance(fields[i], DerivedField):
+                        ftype, fname = fields[i].name
+                    else:
+                        raise RuntimeError("Cannot distinguish between fields "
+                                           "with same name %s!" % fd)
+                    self.fields[i] = "%s_%s" % (ftype, fname)
+
         first = True
         for i, name, field in zip(count(), self.fields, fields):
             if name not in exclude_fields:

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -630,6 +630,7 @@ class FITSImageData(object):
         image_list : list of FITSImageData instances
             The images to be combined.
         """
+        image_list = ensure_list(image_list)
         w = image_list[0].wcs
         img_shape = image_list[0].shape
         data = []
@@ -640,7 +641,7 @@ class FITSImageData(object):
                 raise RuntimeError("Images do not have the same shape!")
             for hdu in fid.hdulist:
                 if first:
-                    data.append(hdu)
+                    data.append(_astropy.pyfits.PrimaryHDU(hdu.data, header=hdu.header))
                     first = False
                 else:
                     data.append(_astropy.pyfits.ImageHDU(hdu.data, header=hdu.header))

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -293,7 +293,11 @@ class FITSImageData(object):
             self.set_wcs(wcs)
 
     def _fix_current_time(self, ds, current_time):
-        tunit = Unit(self.time_unit)
+        if ds is None:
+            registry = None
+        else:
+            registry = ds.unit_registry
+        tunit = Unit(self.time_unit, registry=registry)
         if current_time is None:
             if ds is not None:
                 current_time = ds.current_time

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -203,10 +203,10 @@ class FITSImageData(object):
                     key = "{}_unit".format(unit)
                     value = getattr(self, key)
                     hdu.header[key] = float(value.value)
-                    hdu.comments[key] = value.units
+                    hdu.header.comments[key] = value.units
                 if self.current_time is not None:
                     hdu.header["current_time"] = float(self.current_time.value)
-                    hdu.comments["current_time"] = self.current_time.units
+                    hdu.header.comments["current_time"] = self.current_time.units
                 self.hdulist.append(hdu)
 
         self.shape = self.hdulist[0].shape

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -83,13 +83,25 @@ class FITSImageData(object):
             The center coordinates of the image. If a list or NumPy array, 
             it is assumed to be in *units*. Only used if this information 
             is not already provided by *data*.
-        wcs : `astropy.wcs.WCS` instance, optional
+        wcs : `~astropy.wcs.WCS` instance, optional
             Supply an AstroPy WCS instance. Will override automatic WCS
             creation from FixedResolutionBuffers and YTCoveringGrids.
+        current_time : float, tuple, or YTQuantity, optional
+            The current time of the image(s). If not specified, one will
+            be set from the dataset if there is one. If a float, it will
+            be assumed to be in *time_unit* units.
         time_unit : string
             The default time units of the file. Defaults to "s".
         mass_unit : string
             The default time units of the file. Defaults to "g".
+        velocity_unit : string
+            The default velocity units of the file. Defaults to "cm/s".
+        magnetic_unit : string
+            The default magnetic units of the file. Defaults to "gauss".
+        ds : `~yt.static_output.Dataset` instance, optional
+            The dataset associated with the image(s), typically used
+            to transfer metadata to the header(s). Does not need to be
+            specified if *data* has a dataset as an attribute. 
 
         Examples
         --------
@@ -99,7 +111,8 @@ class FITSImageData(object):
         >>> prj = ds.proj(2, "kT", weight_field="density")
         >>> frb = prj.to_frb((0.5, "Mpc"), 800)
         >>> # This example just uses the FRB and puts the coords in kpc.
-        >>> f_kpc = FITSImageData(frb, fields="kT", units="kpc")
+        >>> f_kpc = FITSImageData(frb, fields="kT", length_unit="kpc",
+        ...                       time_unit=(1.0, "Gyr"))
         >>> # This example specifies a specific WCS.
         >>> from astropy.wcs import WCS
         >>> w = WCS(naxis=self.dimensionality)

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -217,10 +217,10 @@ class FITSImageData(object):
         if wcs is None:
             w = _astropy.pywcs.WCS(header=self.hdulist[0].header,
                                    naxis=self.dimensionality)
+            # FRBs and covering grids are special cases where
+            # we have coordinate information, so we take advantage
+            # of this and construct the WCS object
             if isinstance(img_data, FixedResolutionBuffer):
-                # FRBs are a special case where we have coordinate
-                # information, so we take advantage of this and
-                # construct the WCS object
                 dx = (img_data.bounds[1]-img_data.bounds[0]).to_value(wcs_unit)
                 dy = (img_data.bounds[3]-img_data.bounds[2]).to_value(wcs_unit)
                 dx /= self.shape[0]

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -123,9 +123,8 @@ class FITSImageData(object):
         self._set_units(ds, [length_unit, mass_unit, time_unit, velocity_unit,
                              magnetic_unit])
 
-        if self.length_unit.value == 1.0:
-            wcs_unit = str(self.length_unit.units)
-        else:
+        wcs_unit = str(self.length_unit.units)
+        if self.length_unit.value != 1.0:
             wcs_unit = "%g*%s" % wcs_unit
 
         self._fix_current_time(ds, current_time)

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -18,6 +18,7 @@ from yt.visualization.fixed_resolution import FixedResolutionBuffer
 from yt.data_objects.construction_data_containers import YTCoveringGrid
 from yt.utilities.on_demand_imports import _astropy
 from yt.units.yt_array import YTQuantity, YTArray
+from yt.units.unit_object import Unit
 from yt.units import dimensions
 from yt.utilities.parallel_tools.parallel_analysis_interface import \
     parallel_root_only
@@ -262,14 +263,15 @@ class FITSImageData(object):
             self.set_wcs(wcs)
 
     def _fix_current_time(self, ds, current_time):
+        tunit = Unit(self.time_unit)
         if current_time is None:
             if ds is not None:
                 current_time = ds.current_time
         elif isinstance(current_time, numeric_type):
-            current_time = YTQuantity(current_time, self.time_unit)
+            current_time = YTQuantity(current_time, tunit)
         elif isinstance(current_time, tuple):
             current_time = YTQuantity(current_time[0], current_time[1])
-        self.current_time = current_time
+        self.current_time = current_time.to_value(tunit)
 
     def _set_units(self, ds, base_units):
         attrs = ('length_unit', 'mass_unit', 'time_unit', 

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -203,7 +203,7 @@ class FITSImageData(object):
                 hdu.header["bunit"] = re.sub('()', '', self.field_units[name])
                 for unit in ("length", "time", "mass", "velocity", "magnetic"):
                     if unit == "magnetic":
-                        short_unit = "b"
+                        short_unit = "bf"
                     else:
                         short_unit = unit[0]
                     key = "{}unit".format(short_unit)

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -374,6 +374,7 @@ class FITSImageData(object):
         """
         idx = self.fields.index(old_name)
         self.hdulist[idx].name = new_name
+        self.hdulist[idx].header['BTYPE'] = new_name
         self.field_units[new_name] = self.field_units.pop(old_name)
         self.fields[idx] = new_name
 

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -218,8 +218,7 @@ class FITSImageData(object):
                         hdu.header[key] = float(value.value)
                         hdu.header.comments[key] = value.units
                 if self.current_time is not None:
-                    hdu.header["time"] = float(self.current_time.value)
-                    hdu.header.comments["time"] = self.current_time.units
+                    hdu.header["time"] = self.current_time
                 self.hdulist.append(hdu)
 
         self.shape = self.hdulist[0].shape

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -384,7 +384,8 @@ class FITSImageData(object):
     def convolve(self, field, kernel, **kwargs):
         """
         Convolve an image with a kernel, either a simple
-        Gaussian kernel or one provided by AstroPy.
+        Gaussian kernel or one provided by AstroPy. Currently,
+        this only works for 2D images.
 
         All keyword arguments are passed to
         :meth:`~astropy.convolution.convolve`.
@@ -406,6 +407,8 @@ class FITSImageData(object):
         >>> fid = FITSSlice(ds, "z", "density")
         >>> fid.convolve("density", (3.0, "kpc"))
         """
+        if self.dimensionality == 3:
+            raise RuntimeError("Convolution currently only works for 2D FITSImageData!")
         conv = _astropy.conv
         if field not in self.keys():
             raise KeyError("%s not an image!" % field)

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -120,10 +120,13 @@ class FITSImageData(object):
 
         ds = getattr(data, "ds", None)
 
-        self._set_units(ds, [length_unit, time_unit, mass_unit, velocity_unit,
+        self._set_units(ds, [length_unit, mass_unit, time_unit, velocity_unit,
                              magnetic_unit])
 
-        wcs_unit = "%g*%s" % (self.length_unit.value, self.length_unit.units)
+        if self.length_unit.value == 1.0:
+            wcs_unit = str(self.length_unit.units)
+        else:
+            wcs_unit = "%g*%s" % wcs_unit
 
         self._fix_current_time(ds, current_time)
 

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -599,9 +599,8 @@ class FITSImageData(object):
         return cls(data)
 
     def create_sky_wcs(self, sky_center, sky_scale,
-                       ctype=["RA---TAN","DEC--TAN"],
-                       crota=None, cd=None, pc=None,
-                       wcsname="celestial",
+                       ctype=None, crota=None, cd=None,
+                       pc=None, wcsname="celestial",
                        replace_old_wcs=True):
         """
         Takes a Cartesian WCS and converts it to one in a
@@ -615,7 +614,8 @@ class FITSImageData(object):
             Conversion between an angle unit and a length unit,
             e.g. (3.0, "arcsec/kpc")
         ctype : list of strings, optional
-            The type of the coordinate system to create.
+            The type of the coordinate system to create. Default:
+            A "tangential" projection. 
         crota : 2-element ndarray, optional
             Rotation angles between cartesian coordinates and
             the celestial coordinates.
@@ -630,6 +630,8 @@ class FITSImageData(object):
             FITSImageData instance. If false, a second WCS will 
             be added to the header. Default: True.
         """
+        if ctype is None:
+            ctype = ["RA---TAN", "DEC--TAN"]
         old_wcs = self.wcs
         naxis = old_wcs.naxis
         crval = [sky_center[0], sky_center[1]]

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -381,10 +381,13 @@ class FITSImageData(object):
         self.field_units[new_name] = self.field_units.pop(old_name)
         self.fields[idx] = new_name
 
-    def convolve(self, field, kernel):
+    def convolve(self, field, kernel, **kwargs):
         """
         Convolve an image with a kernel, either a simple
-        Gaussian or one provided by AstroPy.
+        Gaussian kernel or one provided by AstroPy.
+
+        All keyword arguments are passed to
+        :meth:`~astropy.convolution.convolve`.
 
         Parameters
         ----------
@@ -418,7 +421,7 @@ class FITSImageData(object):
                 kernel = stddev/pix_scale
             kernel = conv.Gaussian2DKernel(x_stddev=kernel)
         self.hdulist[idx].data = conv.convolve(self.hdulist[idx].data, 
-                                               kernel)
+                                               kernel, **kwargs)
 
     def update_header(self, field, key, value):
         """

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -125,7 +125,7 @@ class FITSImageData(object):
 
         wcs_unit = "%g*%s" % (self.length_unit.value, self.length_unit.units)
 
-        self._fix_current_time(current_time)
+        self._fix_current_time(ds, current_time)
 
         if width is None:
             width = 1.0

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -248,7 +248,7 @@ class FITSImageData(object):
                     value = getattr(self, "{}_unit".format(unit))
                     if value is not None:
                         hdu.header[key] = float(value.value)
-                        hdu.header.comments[key] = value.units
+                        hdu.header.comments[key] = "[%s]" % value.units
                 if self.current_time is not None:
                     hdu.header["time"] = self.current_time
                 self.hdulist.append(hdu)

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -341,6 +341,9 @@ class FITSImageData(object):
                 uq = YTQuantity(u[0], u[1])
             else:
                 uq = None
+            if uq is not None and uq.units.is_code_unit:
+                raise RuntimeError("Cannot use code units when creating "
+                                   "a FITSImageData instance!")
             setattr(self, attr, uq)
 
     def set_wcs(self, wcs, wcsname=None, suffix=None):

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -202,13 +202,17 @@ class FITSImageData(object):
                 hdu.header["btype"] = name
                 hdu.header["bunit"] = re.sub('()', '', self.field_units[name])
                 for unit in ("length", "time", "mass", "velocity", "magnetic"):
-                    key = "{}_unit".format(unit)
+                    if unit == "magnetic":
+                        short_unit = "b"
+                    else:
+                        short_unit = unit[0]
+                    key = "{}unit".format(short_unit)
                     value = getattr(self, key)
                     hdu.header[key] = float(value.value)
                     hdu.header.comments[key] = value.units
                 if self.current_time is not None:
-                    hdu.header["current_time"] = float(self.current_time.value)
-                    hdu.header.comments["current_time"] = self.current_time.units
+                    hdu.header["time"] = float(self.current_time.value)
+                    hdu.header.comments["time"] = self.current_time.units
                 self.hdulist.append(hdu)
 
         self.shape = self.hdulist[0].shape

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -362,6 +362,16 @@ class FITSImageData(object):
                 img.header[kk] = v
 
     def change_image_name(self, old_name, new_name):
+        """
+        Change the name of a FITS image.
+
+        Parameters
+        ----------
+        old_name : string
+            The old name of the image.
+        new_name : string
+            The new name of the image. 
+        """
         idx = self.fields.index(old_name)
         self.hdulist[idx].name = new_name
         self.field_units[new_name] = self.field_units.pop(old_name)
@@ -819,35 +829,34 @@ class FITSSlice(FITSImageData):
         used for both axes, whereas a tuple of values will be used for the
         individual axes. Default: 512
     center : A sequence of floats, a string, or a tuple.
-         The coordinate of the center of the image. If set to 'c', 'center' or
-         left blank, the plot is centered on the middle of the domain. If set 
-         to 'max' or 'm', the center will be located at the maximum of the
-         ('gas', 'density') field. Centering on the max or min of a specific
-         field is supported by providing a tuple such as ("min","temperature")
-         or ("max","dark_matter_density"). Units can be specified by passing in
-         *center* as a tuple containing a coordinate and string unit name or by
-         passing in a YTArray. If a list or unitless array is supplied, code 
-         units are assumed.
+        The coordinate of the center of the image. If set to 'c', 'center' or
+        left blank, the plot is centered on the middle of the domain. If set 
+        to 'max' or 'm', the center will be located at the maximum of the
+        ('gas', 'density') field. Centering on the max or min of a specific
+        field is supported by providing a tuple such as ("min","temperature")
+        or ("max","dark_matter_density"). Units can be specified by passing in
+        *center* as a tuple containing a coordinate and string unit name or by
+        passing in a YTArray. If a list or unitless array is supplied, code 
+        units are assumed.
     width : tuple or a float.
-         Width can have four different formats to support windows with variable
-         x and y widths.  They are:
+        Width can have four different formats to support variable
+        x and y widths.  They are:
 
-         ==================================     =======================
-         format                                 example
-         ==================================     =======================
-         (float, string)                        (10,'kpc')
-         ((float, string), (float, string))     ((10,'kpc'),(15,'kpc'))
-         float                                  0.2
-         (float, float)                         (0.2, 0.3)
-         ==================================     =======================
+        ==================================     =======================
+        format                                 example
+        ==================================     =======================
+        (float, string)                        (10,'kpc')
+        ((float, string), (float, string))     ((10,'kpc'),(15,'kpc'))
+        float                                  0.2
+        (float, float)                         (0.2, 0.3)
+        ==================================     =======================
 
-         For example, (10, 'kpc') requests a plot window that is 10 kiloparsecs
-         wide in the x and y directions, ((10,'kpc'),(15,'kpc')) requests a
-         window that is 10 kiloparsecs wide along the x axis and 15
-         kiloparsecs wide along the y axis.  In the other two examples, code
-         units are assumed, for example (0.2, 0.3) requests a plot that has an
-         x width of 0.2 and a y width of 0.3 in code units.  If units are
-         provided the resulting plot axis labels will use the supplied units.
+        For example, (10, 'kpc') specifies a width that is 10 kiloparsecs
+        wide in the x and y directions, ((10,'kpc'),(15,'kpc')) specifies a
+        width that is 10 kiloparsecs wide along the x axis and 15
+        kiloparsecs wide along the y axis.  In the other two examples, code
+        units are assumed, for example (0.2, 0.3) specifies a width that has an
+        x width of 0.2 and a y width of 0.3 in code units.
     length_unit : string, optional
         the length units that the coordinates are written in. The default
         is to use the default length unit of the dataset.
@@ -881,35 +890,34 @@ class FITSProjection(FITSImageData):
         used for both axes, whereas a tuple of values will be used for the
         individual axes. Default: 512
     center : A sequence of floats, a string, or a tuple.
-         The coordinate of the center of the image. If set to 'c', 'center' or
-         left blank, the plot is centered on the middle of the domain. If set 
-         to 'max' or 'm', the center will be located at the maximum of the
-         ('gas', 'density') field. Centering on the max or min of a specific
-         field is supported by providing a tuple such as ("min","temperature") 
-         or ("max","dark_matter_density"). Units can be specified by passing in
-         *center* as a tuple containing a coordinate and string unit name or by
-         passing in a YTArray. If a list or unitless array is supplied, code 
-         units are assumed.
+        The coordinate of the center of the image. If set to 'c', 'center' or
+        left blank, the plot is centered on the middle of the domain. If set 
+        to 'max' or 'm', the center will be located at the maximum of the
+        ('gas', 'density') field. Centering on the max or min of a specific
+        field is supported by providing a tuple such as ("min","temperature")
+        or ("max","dark_matter_density"). Units can be specified by passing in
+        *center* as a tuple containing a coordinate and string unit name or by
+        passing in a YTArray. If a list or unitless array is supplied, code 
+        units are assumed.
     width : tuple or a float.
-         Width can have four different formats to support windows with variable
-         x and y widths.  They are:
+        Width can have four different formats to support variable
+        x and y widths.  They are:
 
-         ==================================     =======================
-         format                                 example
-         ==================================     =======================
-         (float, string)                        (10,'kpc')
-         ((float, string), (float, string))     ((10,'kpc'),(15,'kpc'))
-         float                                  0.2
-         (float, float)                         (0.2, 0.3)
-         ==================================     =======================
+        ==================================     =======================
+        format                                 example
+        ==================================     =======================
+        (float, string)                        (10,'kpc')
+        ((float, string), (float, string))     ((10,'kpc'),(15,'kpc'))
+        float                                  0.2
+        (float, float)                         (0.2, 0.3)
+        ==================================     =======================
 
-         For example, (10, 'kpc') requests a plot window that is 10 kiloparsecs
-         wide in the x and y directions, ((10,'kpc'),(15,'kpc')) requests a
-         window that is 10 kiloparsecs wide along the x axis and 15
-         kiloparsecs wide along the y axis.  In the other two examples, code
-         units are assumed, for example (0.2, 0.3) requests a plot that has an
-         x width of 0.2 and a y width of 0.3 in code units.  If units are
-         provided the resulting plot axis labels will use the supplied units.
+        For example, (10, 'kpc') specifies a width that is 10 kiloparsecs
+        wide in the x and y directions, ((10,'kpc'),(15,'kpc')) specifies a
+        width that is 10 kiloparsecs wide along the x axis and 15
+        kiloparsecs wide along the y axis.  In the other two examples, code
+        units are assumed, for example (0.2, 0.3) specifies a width that has an
+        x width of 0.2 and a y width of 0.3 in code units.
     weight_field : string
         The field used to weight the projection.
     length_unit : string, optional
@@ -947,16 +955,16 @@ class FITSOffAxisSlice(FITSImageData):
         individual axes. Default: 512
     center : A sequence of floats, a string, or a tuple.
         The coordinate of the center of the image. If set to 'c', 'center' or
-        left blank, the plot is centered on the middle of the domain. If set to
-        'max' or 'm', the center will be located at the maximum of the
+        left blank, the plot is centered on the middle of the domain. If set 
+        to 'max' or 'm', the center will be located at the maximum of the
         ('gas', 'density') field. Centering on the max or min of a specific
-        field is supported by providing a tuple such as ("min","temperature") 
-        or ("max","dark_matter_density"). Units can be specified by passing in 
-        *center* as a tuple containing a coordinate and string unit name or by 
+        field is supported by providing a tuple such as ("min","temperature")
+        or ("max","dark_matter_density"). Units can be specified by passing in
+        *center* as a tuple containing a coordinate and string unit name or by
         passing in a YTArray. If a list or unitless array is supplied, code 
         units are assumed.
     width : tuple or a float.
-        Width can have four different formats to support windows with variable
+        Width can have four different formats to support variable
         x and y widths.  They are:
 
         ==================================     =======================
@@ -968,13 +976,12 @@ class FITSOffAxisSlice(FITSImageData):
         (float, float)                         (0.2, 0.3)
         ==================================     =======================
 
-        For example, (10, 'kpc') requests a plot window that is 10 kiloparsecs
-        wide in the x and y directions, ((10,'kpc'),(15,'kpc')) requests a
-        window that is 10 kiloparsecs wide along the x axis and 15
+        For example, (10, 'kpc') specifies a width that is 10 kiloparsecs
+        wide in the x and y directions, ((10,'kpc'),(15,'kpc')) specifies a
+        width that is 10 kiloparsecs wide along the x axis and 15
         kiloparsecs wide along the y axis.  In the other two examples, code
-        units are assumed, for example (0.2, 0.3) requests a plot that has an
-        x width of 0.2 and a y width of 0.3 in code units.  If units are
-        provided the resulting plot axis labels will use the supplied units.
+        units are assumed, for example (0.2, 0.3) specifies a width that has an
+        x width of 0.2 and a y width of 0.3 in code units.
     north_vector : a sequence of floats
         A vector defining the 'up' direction in the plot.  This
         option sets the orientation of the slicing plane.  If not
@@ -1014,39 +1021,38 @@ class FITSOffAxisProjection(FITSImageData):
         used for both axes, whereas a tuple of values will be used for the
         individual axes. Default: 512
     center : A sequence of floats, a string, or a tuple.
-         The coordinate of the center of the image. If set to 'c', 'center' or
-         left blank, the plot is centered on the middle of the domain. If set 
-         to 'max' or 'm', the center will be located at the maximum of the
-         ('gas', 'density') field. Centering on the max or min of a specific
-         field is supported by providing a tuple such as ("min","temperature") 
-         or ("max","dark_matter_density"). Units can be specified by passing in
-         *center* as a tuple containing a coordinate and string unit name or by
-         passing in a YTArray. If a list or unitless array is supplied, code 
-         units are assumed.
+        The coordinate of the center of the image. If set to 'c', 'center' or
+        left blank, the plot is centered on the middle of the domain. If set 
+        to 'max' or 'm', the center will be located at the maximum of the
+        ('gas', 'density') field. Centering on the max or min of a specific
+        field is supported by providing a tuple such as ("min","temperature")
+        or ("max","dark_matter_density"). Units can be specified by passing in
+        *center* as a tuple containing a coordinate and string unit name or by
+        passing in a YTArray. If a list or unitless array is supplied, code 
+        units are assumed.
     width : tuple or a float.
-         Width can have four different formats to support windows with variable
-         x and y widths.  They are:
+        Width can have four different formats to support variable
+        x and y widths.  They are:
 
-         ==================================     =======================
-         format                                 example
-         ==================================     =======================
-         (float, string)                        (10,'kpc')
-         ((float, string), (float, string))     ((10,'kpc'),(15,'kpc'))
-         float                                  0.2
-         (float, float)                         (0.2, 0.3)
-         ==================================     =======================
+        ==================================     =======================
+        format                                 example
+        ==================================     =======================
+        (float, string)                        (10,'kpc')
+        ((float, string), (float, string))     ((10,'kpc'),(15,'kpc'))
+        float                                  0.2
+        (float, float)                         (0.2, 0.3)
+        ==================================     =======================
 
-         For example, (10, 'kpc') requests a plot window that is 10 kiloparsecs
-         wide in the x and y directions, ((10,'kpc'),(15,'kpc')) requests a
-         window that is 10 kiloparsecs wide along the x axis and 15
-         kiloparsecs wide along the y axis.  In the other two examples, code
-         units are assumed, for example (0.2, 0.3) requests a plot that has an
-         x width of 0.2 and a y width of 0.3 in code units.  If units are
-         provided the resulting plot axis labels will use the supplied units.
+        For example, (10, 'kpc') specifies a width that is 10 kiloparsecs
+        wide in the x and y directions, ((10,'kpc'),(15,'kpc')) specifies a
+        width that is 10 kiloparsecs wide along the x axis and 15
+        kiloparsecs wide along the y axis.  In the other two examples, code
+        units are assumed, for example (0.2, 0.3) specifies a width that has an
+        x width of 0.2 and a y width of 0.3 in code units.
     depth : A tuple or a float
-         A tuple containing the depth to project through and the string
-         key of the unit: (width, 'unit').  If set to a float, code units
-         are assumed
+        A tuple containing the depth to project through and the string
+        key of the unit: (width, 'unit').  If set to a float, code units
+        are assumed
     weight_field : string
          The name of the weighting field.  Set to None for no weight.
     north_vector : a sequence of floats

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -361,6 +361,12 @@ class FITSImageData(object):
                     kk += suffix
                 img.header[kk] = v
 
+    def change_image_name(self, old_name, new_name):
+        idx = self.fields.index(old_name)
+        self.hdulist[idx].name = new_name
+        self.field_units[new_name] = self.field_units.pop(old_name)
+        self.fields[idx] = new_name
+
     def convolve(self, field, kernel):
         """
         Convolve an image with a kernel, either a simple

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -130,9 +130,11 @@ class FITSImageData(object):
         self._set_units(ds, [length_unit, mass_unit, time_unit, velocity_unit,
                              magnetic_unit])
 
-        wcs_unit = str(self.length_unit.units)
         if self.length_unit.value != 1.0:
-            wcs_unit = "%g*%s" % wcs_unit
+            wcs_unit = "%g*%s" % (self.length_unit.value,
+                                  self.length_unit.units)
+        else:
+            wcs_unit = str(self.length_unit.units)
 
         self._fix_current_time(ds, current_time)
 

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -601,7 +601,7 @@ class FITSImageData(object):
                        replace_old_wcs=True):
         """
         Takes a Cartesian WCS and converts it to one in a
-        celestial coordinate system.
+        sky-based coordinate system.
 
         Parameters
         ----------
@@ -619,6 +619,8 @@ class FITSImageData(object):
             Dimensioned coordinate transformation matrix.
         pc : 2x2-element ndarray, optional
             Coordinate transformation matrix.
+        wcsname : string, optional
+            The name of the WCS to be stored in the FITS header.
         replace_old_wcs : boolean, optional
             Whether or not to overwrite the default WCS of the 
             FITSImageData instance. If false, a second WCS will 

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -327,7 +327,7 @@ class FixedResolutionBuffer(object):
         from yt.visualization.fits_image import FITSImageData
 
         if length_unit is None:
-            length_unit = str(self.ds.unit_system["length"])
+            length_unit = self.ds.length_unit
 
         if "units" in kwargs:
             issue_deprecation_warning("The 'units' keyword argument has been "

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -306,7 +306,7 @@ class FixedResolutionBuffer(object):
             output.create_dataset(field,data=self[field])
         output.close()
 
-    def to_fits(self, fields=None, other_keys=None, length_unit="cm",
+    def to_fits(self, fields=None, other_keys=None, length_unit=None,
                 **kwargs):
         r"""Export a set of pixelized fields to a FITS file.
 
@@ -316,14 +316,18 @@ class FixedResolutionBuffer(object):
         Parameters
         ----------
         fields : list of strings
-            These fields will be pixelized and output. If "None", the keys of the
-            FRB will be used.
+            These fields will be pixelized and output. If "None", the keys of 
+            the FRB will be used.
         other_keys : dictionary, optional
             A set of header keys and values to write into the FITS header.
         length_unit : string, optional
-            the length units that the coordinates are written in, default 'cm'.
+            the length units that the coordinates are written in. The default
+            is to use the default length unit of the dataset.
         """
         from yt.visualization.fits_image import FITSImageData
+
+        if length_unit is None:
+            length_unit = str(self.ds.unit_system["length"])
 
         if "units" in kwargs:
             issue_deprecation_warning("The 'units' keyword argument has been "
@@ -352,7 +356,7 @@ class FixedResolutionBuffer(object):
         return fid
 
     def export_fits(self, filename, fields=None, overwrite=False,
-                    other_keys=None, length_unit="cm", **kwargs):
+                    other_keys=None, length_unit=None, **kwargs):
         r"""Export a set of pixelized fields to a FITS file.
 
         This will export a set of FITS images of either the fields specified
@@ -370,7 +374,8 @@ class FixedResolutionBuffer(object):
         other_keys : dictionary, optional
             A set of header keys and values to write into the FITS header.
         length_unit : string, optional
-            the length units that the coordinates are written in, default 'cm'.
+            the length units that the coordinates are written in. The default
+            is to use the default length unit of the dataset.
         """
         issue_deprecation_warning("The 'export_fits' method of "
                                   "FixedResolutionBuffer is deprecated. "

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -306,8 +306,8 @@ class FixedResolutionBuffer(object):
             output.create_dataset(field,data=self[field])
         output.close()
 
-    def to_fits(self, fields=None, other_keys=None, length_unit=None,
-                **kwargs):
+    def to_fits_data(self, fields=None, other_keys=None, length_unit=None,
+                     **kwargs):
         r"""Export a set of pixelized fields to a FITS file.
 
         This will export a set of FITS images of either the fields specified

--- a/yt/visualization/tests/test_fits_image.py
+++ b/yt/visualization/tests/test_fits_image.py
@@ -45,7 +45,7 @@ def test_fits_image():
     prj = ds.proj("density", 2)
     prj_frb = prj.to_frb((0.5, "unitary"), 128)
 
-    fid1 = prj_frb.to_fits_data(fields=[("gas", "density"), ("gas","temperature")],
+    fid1 = prj_frb.to_fits_data(fields=[("gas", "density"), ("gas", "temperature")],
                                 length_unit="cm")
     fits_prj = FITSProjection(ds, "z", [ds.fields.gas.density,"temperature"],
                               image_res=128, width=(0.5, "unitary"))
@@ -91,10 +91,10 @@ def test_fits_image():
     cut = ds.cutting([0.1, 0.2, -0.9], [0.5, 0.42, 0.6])
     cut_frb = cut.to_frb((0.5, "unitary"), 128)
 
-    fid3 = cut_frb.to_fits_data(fields=[("gas","density"),
+    fid3 = cut_frb.to_fits_data(fields=[("gas", "density"),
                                         ds.fields.gas.temperature],
                                 length_unit="cm")
-    fits_cut = FITSOffAxisSlice(ds, [0.1, 0.2, -0.9], ["density","temperature"],
+    fits_cut = FITSOffAxisSlice(ds, [0.1, 0.2, -0.9], ["density", "temperature"],
                                 image_res=128, center=[0.5, 0.42, 0.6],
                                 width=(0.5, "unitary"))
 

--- a/yt/visualization/tests/test_fits_image.py
+++ b/yt/visualization/tests/test_fits_image.py
@@ -43,9 +43,10 @@ def test_fits_image():
     prj = ds.proj("density", 2)
     prj_frb = prj.to_frb((0.5, "unitary"), 128)
 
-    fid1 = FITSImageData(prj_frb, fields=["density","temperature"], units="cm")
-    fits_prj = FITSProjection(ds, "z", [ds.fields.gas.density,"temperature"], image_res=128,
-                              width=(0.5,"unitary"))
+    fid1 = FITSImageData(prj_frb, fields=["density","temperature"],
+                         length_unit="cm")
+    fits_prj = FITSProjection(ds, "z", [ds.fields.gas.density,"temperature"],
+                              image_res=128, width=(0.5, "unitary"))
 
     assert_equal(fid1["density"].data, fits_prj["density"].data)
     assert_equal(fid1["temperature"].data, fits_prj["temperature"].data)
@@ -70,9 +71,10 @@ def test_fits_image():
     slc = ds.slice(2, 0.5)
     slc_frb = slc.to_frb((0.5, "unitary"), 128)
 
-    fid2 = FITSImageData(slc_frb, fields=["density","temperature"], units="cm")
-    fits_slc = FITSSlice(ds, "z", ["density",("gas","temperature")], image_res=128,
-                         width=(0.5,"unitary"))
+    fid2 = FITSImageData(slc_frb, fields=["density","temperature"],
+                         length_unit="cm")
+    fits_slc = FITSSlice(ds, "z", ["density",("gas","temperature")],
+                         image_res=128, width=(0.5,"unitary"))
 
     assert_equal(fid2["density"].data, fits_slc["density"].data)
     assert_equal(fid2["temperature"].data, fits_slc["temperature"].data)
@@ -87,10 +89,11 @@ def test_fits_image():
     cut = ds.cutting([0.1, 0.2, -0.9], [0.5, 0.42, 0.6])
     cut_frb = cut.to_frb((0.5, "unitary"), 128)
 
-    fid3 = FITSImageData(cut_frb, fields=[("gas","density"), ds.fields.gas.temperature], units="cm")
+    fid3 = FITSImageData(cut_frb, fields=[("gas","density"), ds.fields.gas.temperature], 
+                         length_unit="cm")
     fits_cut = FITSOffAxisSlice(ds, [0.1, 0.2, -0.9], ["density","temperature"],
                                 image_res=128, center=[0.5, 0.42, 0.6],
-                                width=(0.5,"unitary"))
+                                width=(0.5, "unitary"))
 
     assert_equal(fid3["density"].data, fits_cut["density"].data)
     assert_equal(fid3["temperature"].data, fits_cut["temperature"].data)


### PR DESCRIPTION
This PR introduces improvements to FITS file writing and reading. Specifically:

1. Specifies a new standard for writing metadata to FITS files using the `FITSImageData` class and its subclasses. This standard uses the header to write unit information and other metadata to the FITS file so that when it is read back into yt as a dataset it is more self-describing. 
2. Defines a new class, `YTFITSDataset`, which is a subclass of `FITSDataset` which looks specifically for this header metadata.
3. Simplifies the logic in `FITSHierarchy` for determining units.
4. Makes the `"beam"` unit part of `SkyDataFITSDataset`. 
5. Adds a `convolve` method to `FITSImageData` instances to convolve them with any kernel created using AstroPy or a simple Gaussian kernel.
6. Specifies that the default image resolution for `FITSImageData` subclasses should be 512. The previous behavior was inconsistent across the various subclasses.

The new yt-based standard for writing FITS datasets with self-describing information and reading them back in as datasets is set out in a YTEP:

https://github.com/yt-project/ytep/pull/5

Things left to do:

- [x] add built-in method to `YTCoveringGrid` to write these grids to FITS files
- [x] change docs
- [x] fix / add more tests