### PR TITLE
Refactor X-ray emission fields for yt-4.0

### DIFF
--- a/doc/source/analyzing/domain_analysis/XrayEmissionFields.ipynb
+++ b/doc/source/analyzing/domain_analysis/XrayEmissionFields.ipynb
@@ -35,7 +35,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
     "scrolled": false
    },
    "outputs": [],
@@ -67,9 +66,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print (xray_fields)"
@@ -85,13 +82,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sp = ds.sphere(\"c\", (2.0, \"Mpc\"))\n",
-    "print (sp.quantities.total_quantity(\"xray_luminosity_0.5_7.0_keV\"))"
+    "print (sp.quantities.total_quantity((\"gas\",\"xray_luminosity_0.5_7.0_keV\")))"
    ]
   },
   {
@@ -105,12 +100,12 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
     "scrolled": false
    },
    "outputs": [],
    "source": [
-    "slc = yt.SlicePlot(ds, 'z', ['xray_emissivity_0.5_7.0_keV','xray_photon_emissivity_0.5_7.0_keV'],\n",
+    "slc = yt.SlicePlot(ds, 'z', [('gas', 'xray_emissivity_0.5_7.0_keV'),\n",
+    "                             ('gas', 'xray_photon_emissivity_0.5_7.0_keV')],\n",
     "                   width=(0.75, \"Mpc\"))\n",
     "slc.show()"
    ]
@@ -128,7 +123,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
     "scrolled": false
    },
    "outputs": [],
@@ -151,9 +145,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print (xray_fields2)"
@@ -163,22 +155,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note also that the energy range now corresponds to the *observer* frame, whereas in the source frame the energy range is between `emin*(1+redshift)` and `emax*(1+redshift)`. Let's zoom in on a galaxy and make a projection of the intensity fields:"
+    "Note also that the energy range now corresponds to the *observer* frame, whereas in the source frame the energy range is between `emin*(1+redshift)` and `emax*(1+redshift)`. Let's zoom in on a galaxy and make a projection of the energy intensity field:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
     "scrolled": false
    },
    "outputs": [],
    "source": [
-    "prj = yt.ProjectionPlot(ds2, \"x\", [\"xray_intensity_0.5_2.0_keV\", \"xray_photon_intensity_0.5_2.0_keV\"],\n",
+    "prj = yt.ProjectionPlot(ds2, \"x\", (\"gas\",\"xray_intensity_0.5_2.0_keV\"),\n",
     "                        center=\"max\", width=(40, \"kpc\"))\n",
     "prj.set_zlim(\"xray_intensity_0.5_2.0_keV\", 1.0e-32, 5.0e-24)\n",
-    "prj.set_zlim(\"xray_photon_intensity_0.5_2.0_keV\", 1.0e-24, 5.0e-16)\n",
     "prj.show()"
    ]
   },
@@ -193,12 +183,43 @@
     "  abundance information from your dataset. Finally, if your dataset contains no abundance information,\n",
     "  a primordial hydrogen mass fraction (X = 0.76) will be assumed."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, if you want to place the source at a local, non-cosmological distance, you can forego the `redshift` and `cosmology` arguments and supply a `dist` argument instead, which is either a `(value, unit)` tuple or a `YTQuantity`. Note that here the redshift is assumed to be zero. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xray_fields3 = yt.add_xray_emissivity_field(ds2, 0.5, 2.0, dist=(1.0,\"Mpc\"), metallicity=(\"gas\", \"metallicity\"), \n",
+    "                                           table_type='cloudy')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "prj = yt.ProjectionPlot(ds2, \"x\", (\"gas\", \"xray_photon_intensity_0.5_2.0_keV\"),\n",
+    "                        center=\"max\", width=(40, \"kpc\"))\n",
+    "prj.set_zlim(\"xray_photon_intensity_0.5_2.0_keV\", 1.0e-24, 5.0e-16)\n",
+    "prj.show()"
+   ]
   }
  ],
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -212,7 +233,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,

--- a/yt/fields/tests/test_xray_fields.py
+++ b/yt/fields/tests/test_xray_fields.py
@@ -4,9 +4,11 @@ from yt.utilities.answer_testing.framework import \
     requires_ds, can_run_ds, data_dir_load, \
     ProjectionValuesTest, FieldValuesTest
 
+
 def setup():
     from yt.config import ytcfg
     ytcfg["yt","__withintesting"] = "True"
+
 
 def check_xray_fields(ds_fn, fields):
     if not can_run_ds(ds_fn): return
@@ -14,21 +16,25 @@ def check_xray_fields(ds_fn, fields):
     for field in fields:
         for dobj_name in dso:
             for axis in [0, 1, 2]:
-                yield ProjectionValuesTest(ds_fn, axis, field, 
+                yield ProjectionValuesTest(ds_fn, axis, field,
                                            None, dobj_name)
             yield FieldValuesTest(ds_fn, field, dobj_name)
 
+
 sloshing = "GasSloshingLowRes/sloshing_low_res_hdf5_plt_cnt_0300"
+d9p = "D9p_500/10MpcBox_HartGal_csf_a0.500.d"
+
+
 @requires_ds(sloshing, big_data=True)
 def test_sloshing_apec():
     ds = data_dir_load(sloshing)
-    fields = add_xray_emissivity_field(ds, 0.5, 7.0, table_type="apec", 
+    fields = add_xray_emissivity_field(ds, 0.5, 7.0, table_type="apec",
                                        metallicity=0.3)
     for test in check_xray_fields(ds, fields):
         test_sloshing_apec.__name__ = test.description
         yield test
 
-d9p = "D9p_500/10MpcBox_HartGal_csf_a0.500.d"
+
 @requires_ds(d9p, big_data=True)
 def test_d9p_cloudy():
     ds = data_dir_load(d9p)

--- a/yt/fields/tests/test_xray_fields.py
+++ b/yt/fields/tests/test_xray_fields.py
@@ -38,3 +38,13 @@ def test_d9p_cloudy():
     for test in check_xray_fields(ds, fields):
         test_d9p_cloudy.__name__ = test.description
         yield test
+
+@requires_ds(d9p, big_data=True)
+def test_d9p_cloudy_local():
+    ds = data_dir_load(d9p)
+    fields = add_xray_emissivity_field(ds, 0.5, 2.0, dist=(1.0, "Mpc"),
+                                       table_type="cloudy",
+                                       metallicity=("gas", "metallicity"))
+    for test in check_xray_fields(ds, fields):
+        test_d9p_cloudy_local.__name__ = test.description
+        yield test

--- a/yt/fields/xray_emission_fields.py
+++ b/yt/fields/xray_emission_fields.py
@@ -197,19 +197,6 @@ def add_xray_emissivity_field(ds, e_min, e_max, redshift=0.0,
     >>> p = yt.ProjectionPlot(ds, 'x', "xray_emissivity_0.5_2_keV")
     >>> p.save()
     """
-    # The next several if constructs are for backwards-compatibility
-    if "constant_metallicity" in kwargs:
-        issue_deprecation_warning("The \"constant_metallicity\" parameter is deprecated. Set "
-                                  "the \"metallicity\" parameter to a constant float value instead.")
-        metallicity = kwargs["constant_metallicity"]
-    if "with_metals" in kwargs:
-        issue_deprecation_warning("The \"with_metals\" parameter is deprecated. Use the "
-                                  "\"metallicity\" parameter to choose a constant or "
-                                  "spatially varying metallicity.")
-        if kwargs["with_metals"] and isinstance(metallicity, float):
-            raise RuntimeError("\"with_metals=True\", but you specified a constant metallicity!")
-        if not kwargs["with_metals"] and not isinstance(metallicity, float):
-            raise RuntimeError("\"with_metals=False\", but you didn't specify a constant metallicity!")
     if not isinstance(metallicity, float) and metallicity is not None:
         try:
             metallicity = ds._get_field_info(*metallicity)

--- a/yt/fields/xray_emission_fields.py
+++ b/yt/fields/xray_emission_fields.py
@@ -246,7 +246,7 @@ def add_xray_emissivity_field(ds, e_min, e_max, redshift=0.0,
     emiss_name = (ftype, "xray_emissivity_%s_%s_keV" % (e_min, e_max))
     ds.add_field(emiss_name, function=_emissivity_field,
                  display_name=r"\epsilon_{X} (%s-%s keV)" % (e_min, e_max),
-                 sampling_type="cell", units="erg/cm**3/s")
+                 sampling_type="local", units="erg/cm**3/s")
 
     def _luminosity_field(field, data):
         return data[emiss_name] * data["cell_volume"]
@@ -254,7 +254,7 @@ def add_xray_emissivity_field(ds, e_min, e_max, redshift=0.0,
     lum_name = (ftype, "xray_luminosity_%s_%s_keV" % (e_min, e_max))
     ds.add_field(lum_name, function=_luminosity_field,
                  display_name=r"\rm{L}_{X} (%s-%s keV)" % (e_min, e_max),
-                 sampling_type="cell", units="erg/s")
+                 sampling_type="local", units="erg/s")
 
     def _photon_emissivity_field(field, data):
         dd = {"log_nH": np.log10(data[ftype, "H_nuclei_density"]),
@@ -274,7 +274,7 @@ def add_xray_emissivity_field(ds, e_min, e_max, redshift=0.0,
     phot_name = (ftype, "xray_photon_emissivity_%s_%s_keV" % (e_min, e_max))
     ds.add_field(phot_name, function=_photon_emissivity_field,
                  display_name=r"\epsilon_{X} (%s-%s keV)" % (e_min, e_max),
-                 sampling_type="cell", units="photons/cm**3/s")
+                 sampling_type="local", units="photons/cm**3/s")
 
     fields = [emiss_name, lum_name, phot_name]
 
@@ -296,7 +296,7 @@ def add_xray_emissivity_field(ds, e_min, e_max, redshift=0.0,
             return I.in_units("erg/cm**3/s/arcsec**2")
         ds.add_field(ei_name, function=_intensity_field,
                      display_name=r"I_{X} (%s-%s keV)" % (e_min, e_max),
-                     sampling_type="cell", units="erg/cm**3/s/arcsec**2")
+                     sampling_type="local", units="erg/cm**3/s/arcsec**2")
 
         i_name = (ftype, "xray_photon_intensity_%s_%s_keV" % (e_min, e_max))
         def _photon_intensity_field(field, data):
@@ -304,7 +304,7 @@ def add_xray_emissivity_field(ds, e_min, e_max, redshift=0.0,
             return I.in_units("photons/cm**3/s/arcsec**2")
         ds.add_field(i_name, function=_photon_intensity_field,
                      display_name=r"I_{X} (%s-%s keV)" % (e_min, e_max),
-                     sampling_type="cell", units="photons/cm**3/s/arcsec**2")
+                     sampling_type="local", units="photons/cm**3/s/arcsec**2")
 
         fields += [ei_name, i_name]
 

--- a/yt/fields/xray_emission_fields.py
+++ b/yt/fields/xray_emission_fields.py
@@ -23,7 +23,6 @@ from yt.fields.derived_field import DerivedField
 from yt.funcs import \
     mylog, \
     only_on_root, \
-    issue_deprecation_warning, \
     parse_h5_attr
 from yt.utilities.exceptions import YTFieldNotFound
 from yt.utilities.exceptions import YTException
@@ -36,6 +35,7 @@ data_version = {"cloudy": 2,
                 "apec": 2}
 
 data_url = "http://yt-project.org/data"
+
 
 def _get_data_file(table_type, data_dir=None):
     data_file = "%s_emissivity_v%d.h5" % (table_type, data_version[table_type])
@@ -50,6 +50,7 @@ def _get_data_file(table_type, data_dir=None):
         raise IOError(msg)
     return data_path
 
+
 class EnergyBoundsException(YTException):
     def __init__(self, lower, upper):
         self.lower = lower
@@ -59,6 +60,7 @@ class EnergyBoundsException(YTException):
         return "Energy bounds are %e to %e keV." % \
           (self.lower, self.upper)
 
+
 class ObsoleteDataException(YTException):
     def __init__(self, table_type):
         data_file = "%s_emissivity_v%d.h5" % (table_type, data_version[table_type])
@@ -67,6 +69,7 @@ class ObsoleteDataException(YTException):
 
     def __str__(self):
         return self.msg
+
 
 class XrayEmissivityIntegrator(object):
     r"""Class for making X-ray emissivity fields. Uses hdf5 data tables
@@ -149,10 +152,10 @@ class XrayEmissivityIntegrator(object):
 
         return emiss
 
+
 def add_xray_emissivity_field(ds, e_min, e_max, redshift=0.0,
-                              metallicity=("gas", "metallicity"), 
+                              metallicity=("gas", "metallicity"),
                               table_type="cloudy", data_dir=None,
-                              cosmology=None, ftype="gas", **kwargs):
                               cosmology=None, dist=None, ftype="gas"):
     r"""Create X-ray emissivity fields for a given energy range.
 

--- a/yt/fields/xray_emission_fields.py
+++ b/yt/fields/xray_emission_fields.py
@@ -236,7 +236,7 @@ def add_xray_emissivity_field(ds, e_min, e_max, redshift=0.0,
                  sampling_type="local", units="erg/cm**3/s")
 
     def _luminosity_field(field, data):
-        return data[emiss_name] * data["cell_volume"]
+        return data[emiss_name]*data[ftype, "density"]/data[ftype, "mass"]
 
     lum_name = (ftype, "xray_luminosity_%s_%s_keV" % (e_min, e_max))
     ds.add_field(lum_name, function=_luminosity_field,

--- a/yt/fields/xray_emission_fields.py
+++ b/yt/fields/xray_emission_fields.py
@@ -252,7 +252,7 @@ def add_xray_emissivity_field(ds, e_min, e_max, redshift=0.0,
                  sampling_type="local", units="erg/cm**3/s")
 
     def _luminosity_field(field, data):
-        return data[emiss_name]*data[ftype, "density"]/data[ftype, "mass"]
+        return data[emiss_name]*data[ftype, "mass"]/data[ftype, "density"]
 
     lum_name = (ftype, "xray_luminosity_%s_%s_keV" % (e_min, e_max))
     ds.add_field(lum_name, function=_luminosity_field,
@@ -323,6 +323,6 @@ def add_xray_emissivity_field(ds, e_min, e_max, redshift=0.0,
 
         fields += [ei_name, i_name]
 
-    [mylog.info("Adding %s field." % field) for field in fields]
+    [mylog.info("Adding ('%s','%s') field." % field) for field in fields]
 
     return fields


### PR DESCRIPTION
## PR Summary

This PR updates the X-ray emission fields machinery so that it works with all datasets, including SPH, in yt-4.0. It also adds a new `dist` keyword argument so that intensity fields can be created for local, non-cosmological sources.

## PR Checklist

- [x] Code passes flake8 checker
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.
