### PR TITLE
[bugfix] Fix aliases and units for magnetic fields in SPH frontends

### DIFF
--- a/yt/fields/magnetic_field.py
+++ b/yt/fields/magnetic_field.py
@@ -261,7 +261,11 @@ def setup_magnetic_field_aliases(registry, ds_ftype, ds_fields, ftype="gas"):
                 return convert(data[ds_field][:, 'xyz'.index(ax)])
             return _mag_field
         for ax in registry.ds.coordinates.axis_order:
-            registry.add_field((ftype, "particle_magnetic_field_%s" % ax),
+            fname = "particle_magnetic_field_%s" % ax
+            registry.add_field((ds_ftype, fname),
                                sampling_type=sampling_type,
                                function=mag_field(ax),
                                units=units)
+            sph_ptype = getattr(registry.ds, "_sph_ptype", None)
+            if ds_ftype == sph_ptype:
+                registry.alias((ftype, "magnetic_field_%s" % ax), (ds_ftype, fname))

--- a/yt/frontends/arepo/data_structures.py
+++ b/yt/frontends/arepo/data_structures.py
@@ -7,6 +7,7 @@
 #-----------------------------------------------------------------------------
 
 from yt.frontends.gadget.api import GadgetHDF5Dataset
+from yt.funcs import mylog
 from yt.utilities.on_demand_imports import _h5py as h5py
 
 from .fields import \
@@ -54,7 +55,24 @@ class ArepoHDF5Dataset(GadgetHDF5Dataset):
             pass
         return valid
 
+    def _get_uvals(self):
+        handle = h5py.File(self.parameter_filename, mode="r")
+        uvals = {}
+        missing = False
+        for unit in ["UnitLength_in_cm", "UnitMass_in_g", 
+                     "UnitVelocity_in_cm_per_s"]:
+            if unit in handle["/Header"].attrs:
+                uvals[unit] = handle["/Header"].attrs[unit]
+            else:
+                mylog.warning("Arepo header is missing %s!" % unit)
+                missing = True
+        handle.close()
+        if missing:
+            uvals = None
+        return uvals
+
     def _set_code_unit_attributes(self):
+        self._unit_base = self._get_uvals()
         super(ArepoHDF5Dataset, self)._set_code_unit_attributes()
         munit = np.sqrt(self.mass_unit /
                         (self.time_unit**2 * self.length_unit)).to("gauss")

--- a/yt/frontends/arepo/data_structures.py
+++ b/yt/frontends/arepo/data_structures.py
@@ -12,6 +12,8 @@ from yt.utilities.on_demand_imports import _h5py as h5py
 from .fields import \
     ArepoFieldInfo
 
+import numpy as np
+
 
 class ArepoHDF5Dataset(GadgetHDF5Dataset):
     _field_info_class = ArepoFieldInfo
@@ -51,3 +53,12 @@ class ArepoHDF5Dataset(GadgetHDF5Dataset):
             valid = False
             pass
         return valid
+
+    def _set_code_unit_attributes(self):
+        super(ArepoHDF5Dataset, self)._set_code_unit_attributes()
+        munit = np.sqrt(self.mass_unit /
+                        (self.time_unit**2 * self.length_unit)).to("gauss")
+        if self.cosmological_simulation:
+            self.magnetic_unit = self.quan(munit.value, "%s/a**2" % munit.units)
+        else:
+            self.magnetic_unit = munit

--- a/yt/frontends/arepo/fields.py
+++ b/yt/frontends/arepo/fields.py
@@ -7,7 +7,22 @@
 #-----------------------------------------------------------------------------
 
 from yt.frontends.gadget.api import GadgetFieldInfo
+from yt.fields.magnetic_field import \
+    setup_magnetic_field_aliases
+
 
 class ArepoFieldInfo(GadgetFieldInfo):
     known_particle_fields = GadgetFieldInfo.known_particle_fields + \
-                            (("smoothing_length", ("code_length", [], None)),)
+                            (("smoothing_length", ("code_length", [], None)),
+                             ("MagneticField",
+                              ("code_magnetic", ["particle_magnetic_field"], None)),
+                             )
+
+    def setup_gas_particle_fields(self, ptype):
+        super(ArepoFieldInfo, self).setup_gas_particle_fields(ptype)
+
+        magnetic_field = "MagneticField"
+        if (ptype, magnetic_field) in self.field_list:
+            setup_magnetic_field_aliases(
+                self, ptype, magnetic_field, ftype=ptype
+            )

--- a/yt/frontends/arepo/fields.py
+++ b/yt/frontends/arepo/fields.py
@@ -24,5 +24,5 @@ class ArepoFieldInfo(GadgetFieldInfo):
         magnetic_field = "MagneticField"
         if (ptype, magnetic_field) in self.field_list:
             setup_magnetic_field_aliases(
-                self, ptype, magnetic_field, ftype=ptype
+                self, ptype, magnetic_field
             )

--- a/yt/frontends/arepo/tests/test_outputs.py
+++ b/yt/frontends/arepo/tests/test_outputs.py
@@ -23,6 +23,7 @@ from yt.utilities.answer_testing.framework import \
 from yt.frontends.arepo.api import ArepoHDF5Dataset
 
 bullet_h5 = "ArepoBullet/snapshot_150.hdf5"
+tng59_h5 = "TNGHalo/halo_59.hdf5"
 
 
 @requires_file(bullet_h5)
@@ -48,3 +49,29 @@ def test_arepo_bullet():
                            bullet_fields):
         test_arepo_bullet.__name__ = test.description
         yield test
+
+
+@requires_file(tng59_h5)
+def test_tng_hdf5():
+    assert isinstance(data_dir_load(tng59_h5),
+                      ArepoHDF5Dataset)
+
+tng59_fields = OrderedDict(
+    [
+        (("gas", "density"), None),
+        (("gas", "temperature"), None),
+        (("gas", "temperature"), ('gas', 'density')),
+        (('gas', 'velocity_magnitude'), None),
+        (('gas', 'magnetic_field_strength'), None)
+    ]
+)
+
+
+@requires_ds(tng59_h5)
+def test_arepo_tng59():
+    ds = data_dir_load(tng59_h5)
+    for test in sph_answer(ds, 'halo_59', 10107142,
+                           tng59_fields):
+        test_arepo_tng59.__name__ = test.description
+        yield test
+

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -130,6 +130,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
                 g = f["/%s" % ptype]
                 if getattr(selector, 'is_all_data', False):
                     mask = slice(None, None, None)
+                    mask_sum = ei-si
                 else:
                     coords = g["Coordinates"][si:ei].astype("float64")
                     if ptype == 'PartType0':
@@ -140,6 +141,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
                         hsmls = 0.0
                     mask = selector.select_points(
                         coords[:,0], coords[:,1], coords[:,2], hsmls)
+                    mask_sum = mask.sum()
                     del coords
                 if mask is None:
                     continue
@@ -147,7 +149,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
 
                     if field in ("Mass", "Masses") and \
                             ptype not in self.var_mass:
-                        data = np.empty(mask.sum(), dtype="float64")
+                        data = np.empty(mask_sum, dtype="float64")
                         ind = self._known_ptypes.index(ptype)
                         data[:] = self.ds["Massarr"][ind]
 

--- a/yt/frontends/gizmo/data_structures.py
+++ b/yt/frontends/gizmo/data_structures.py
@@ -24,8 +24,6 @@ from yt.frontends.gadget.data_structures import \
 from .fields import \
     GizmoFieldInfo
 
-import numpy as np
-
 
 class GizmoDataset(GadgetHDF5Dataset):
     _field_info_class = GizmoFieldInfo

--- a/yt/frontends/gizmo/data_structures.py
+++ b/yt/frontends/gizmo/data_structures.py
@@ -24,6 +24,9 @@ from yt.frontends.gadget.data_structures import \
 from .fields import \
     GizmoFieldInfo
 
+import numpy as np
+
+
 class GizmoDataset(GadgetHDF5Dataset):
     _field_info_class = GizmoFieldInfo
 
@@ -58,3 +61,12 @@ class GizmoDataset(GadgetHDF5Dataset):
             valid = False
             pass
         return valid
+
+    def _set_code_unit_attributes(self):
+        super(GizmoDataset, self)._set_code_unit_attributes()
+        munit = np.sqrt(self.mass_unit /
+                        (self.time_unit**2 * self.length_unit)).to("gauss")
+        if self.cosmological_simulation:
+            self.magnetic_unit = self.quan(munit.value, "%s/a**2" % munit.units)
+        else:
+            self.magnetic_unit = munit

--- a/yt/frontends/gizmo/data_structures.py
+++ b/yt/frontends/gizmo/data_structures.py
@@ -64,9 +64,4 @@ class GizmoDataset(GadgetHDF5Dataset):
 
     def _set_code_unit_attributes(self):
         super(GizmoDataset, self)._set_code_unit_attributes()
-        munit = np.sqrt(self.mass_unit /
-                        (self.time_unit**2 * self.length_unit)).to("gauss")
-        if self.cosmological_simulation:
-            self.magnetic_unit = self.quan(munit.value, "%s/a**2" % munit.units)
-        else:
-            self.magnetic_unit = munit
+        self.magnetic_unit = self.quan(1.0, "gauss")

--- a/yt/frontends/gizmo/fields.py
+++ b/yt/frontends/gizmo/fields.py
@@ -142,7 +142,7 @@ class GizmoFieldInfo(GadgetFieldInfo):
         magnetic_field = "MagneticField"
         if (ptype, magnetic_field) in self.field_list:
             setup_magnetic_field_aliases(
-                self, ptype, magnetic_field, ftype=ptype
+                self, ptype, magnetic_field
             )
 
     def setup_star_particle_fields(self, ptype):

--- a/yt/frontends/gizmo/tests/test_outputs.py
+++ b/yt/frontends/gizmo/tests/test_outputs.py
@@ -105,6 +105,7 @@ def test_gas_particle_fields():
     for species in metal_elements:
         for suffix in ["nuclei_mass_density", "metallicity"]:
             derived_fields += ["%s_%s" % (species, suffix)]
+    derived_fields += ["magnetic_field_%s" % axis for axis in "xyz"]
     for field in derived_fields:
         assert (ptype, field) in ds.derived_field_list
 


### PR DESCRIPTION
## PR Summary

This PR fixes some issues with the Arepo and Gizmo frontends in terms of magnetic fields.

* The aliases to "local" magnetic fields (e.g. `("gas","magnetic_field_x")`) were not being set. This happened because the magnetic fields were being handled after the other aliases had been set up.
* The correct magnetic units were not being set in these frontends. I know that what I have done below is correct for Arepo, someone more familiar with Gizmo (perhaps @chummels?) should check what I have done here for that.
* I added a new test for Arepo with a new dataset, and we also now test the Gizmo MHD dataset for the magnetic field aliases. 
* I fixed an unrelated bug in Gadget's I/O handler (which both of these frontends use) which occurred when the selector was `all_data` and one tried to construct the mass field for a particle type without a variable particle mass.