### PR TITLE
turn on mathtext for a plot_window colorbar

### DIFF
--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1782,6 +1782,7 @@ class WindowPlotMPL(ImagePlotMPL):
         self.image.axes.yaxis.set_major_formatter(formatter)
         if cbname == 'linear':
             self.cb.formatter.set_scientific(True)
+            self.cb.formatter.set_useMathText(True)
             self.cb.formatter.set_powerlimits((-2, 3))
             self.cb.update_ticks()
 


### PR DESCRIPTION
## PR Summary

This change turns on mathtext printing for a plot_window colorbar.  This means that any offset text will appear in typeset scientific notation instead of something like 1.e-2.  Here's a before image:

![before](https://user-images.githubusercontent.com/7817509/56584357-9ed2bc00-65a9-11e9-9aa5-93a37746e8f2.png)

and an after:

![after](https://user-images.githubusercontent.com/7817509/56584380-a4c89d00-65a9-11e9-9707-e83584913329.png)

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
