### PR TITLE
Enable SPH visualization of filtered particle types

### DIFF
--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -745,14 +745,17 @@ class YTCoveringGrid(YTSelectionContainer3D):
         fields = [f for f in fields if f not in self.field_data]
         if len(fields) == 0: return
 
-        ptype = self.ds._sph_ptype
         smoothing_style = getattr(self.ds, 'sph_smoothing_style', 'scatter')
         normalize = getattr(self.ds, 'use_sph_normalization', True)
 
         bounds, size = self._get_grid_bounds_size()
 
-        if(smoothing_style == "scatter"):
+        if smoothing_style == "scatter":
             for field in fields:
+                fi = self.ds._get_field_info(field)
+                ptype = fi.name[0]
+                if ptype not in self.ds._sph_ptypes:
+                    raise KeyError("%s is not a SPH particle type!" % ptype)
                 buff = np.zeros(size, dtype="float64")
                 if normalize:
                     buff_den = np.zeros(size, dtype="float64")
@@ -778,7 +781,6 @@ class YTCoveringGrid(YTSelectionContainer3D):
                 if normalize:
                     normalization_3d_utility(buff, buff_den)
 
-                fi = self.ds._get_field_info(field)
                 self[field] = self.ds.arr(buff, fi.units)
                 pbar.close()
 
@@ -2328,8 +2330,8 @@ class YTOctree(YTSelectionContainer3D):
         elif isinstance(fields, list):
             fields = fields[0]
 
-        sph_ptype = getattr(self.ds, '_sph_ptype', 'None')
-        if fields[0] == sph_ptype:
+        sph_ptypes = getattr(self.ds, '_sph_ptypes', 'None')
+        if fields[0] in sph_ptypes:
             smoothing_style = getattr(self.ds, 'sph_smoothing_style', 'scatter')
             normalize = getattr(self.ds, 'use_sph_normalization', True)
 

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1190,11 +1190,11 @@ class YTDataContainer(object):
                 finfo = self.ds._get_field_info("unknown", fname)
                 if finfo.sampling_type == "particle":
                     ftype = self._current_particle_type
-                    if hasattr(self.ds, '_sph_ptype'):
-                        ptype = self.ds._sph_ptype
-                        if finfo.name[0] == ptype:
+                    if hasattr(self.ds, '_sph_ptypes'):
+                        ptypes = self.ds._sph_ptypes
+                        if finfo.name[0] in ptypes:
                             ftype = finfo.name[0]
-                        elif finfo.alias_field and finfo.alias_name[0] == ptype:
+                        elif finfo.alias_field and finfo.alias_name[0] in ptypes:
                             ftype = self._current_fluid_type
                 else:
                     ftype = self._current_fluid_type

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -1059,7 +1059,7 @@ def create_profile(data_source, bin_fields, fields, n_bins=64,
     override_bins = sanitize_field_tuple_keys(override_bins, data_source)
 
     if any(is_pfield) and not all(is_pfield):
-        if hasattr(data_source.ds, '_sph_ptype'):
+        if hasattr(data_source.ds, '_sph_ptypes'):
             is_local = [data_source.ds.field_info[f].sampling_type == "local"
                         for f in bin_fields + fields]
             is_local_or_pfield = [pf or lf for (pf, lf) in

--- a/yt/data_objects/selection_data_containers.py
+++ b/yt/data_objects/selection_data_containers.py
@@ -283,16 +283,16 @@ class YTRay(YTSelectionContainer1D):
             raise KeyError(field)
 
         length = unorm(self.vec)
-        pos = self[self.ds._sph_ptype, "particle_position"]
+        pos = self[self.ds._sph_ptypes[0], "particle_position"]
         r = pos - self.start_point
         l = udot(r, self.vec/length)
 
         if field == "t":
             return l / length
 
-        hsml = self[self.ds._sph_ptype, "smoothing_length"]
-        mass = self[self.ds._sph_ptype, "particle_mass"]
-        dens = self[self.ds._sph_ptype, "density"]
+        hsml = self[self.ds._sph_ptypes[0], "smoothing_length"]
+        mass = self[self.ds._sph_ptypes[0], "particle_mass"]
+        dens = self[self.ds._sph_ptypes[0], "density"]
         # impact parameter from particle to ray
         b = np.sqrt(np.sum(r**2, axis=1) - l**2)
 

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -730,10 +730,6 @@ class Dataset(object):
             self.known_filters.pop(n, None)
             return False
         self.known_filters[filter.name] = filter
-        if filter.filtered_type == self._sph_ptypes[0]:
-            mylog.warning("It appears that you are filtering on an SPH field "
-                          "type. It is recommended to use 'gas' as the "
-                          "filtered particle type in this case instead.")
         return True
 
     def _setup_filtered_type(self, filter):
@@ -767,6 +763,10 @@ class Dataset(object):
             if filter.name not in self.filtered_particle_types:
                 self.filtered_particle_types.append(filter.name)
             if hasattr(self, '_sph_ptypes'):
+                if filter.filtered_type == self._sph_ptypes[0]:
+                    mylog.warning("It appears that you are filtering on an SPH field "
+                                  "type. It is recommended to use 'gas' as the "
+                                  "filtered particle type in this case instead.")
                 if filter.filtered_type in (self._sph_ptypes + ("gas",)):
                     self._sph_ptypes = self._sph_ptypes + (filter.name,)
             new_fields = self._setup_particle_types([filter.name])

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -763,8 +763,9 @@ class Dataset(object):
                 self.particle_types += (filter.name,)
             if filter.name not in self.filtered_particle_types:
                 self.filtered_particle_types.append(filter.name)
-            if filter.filtered_type in (self._sph_ptypes + ("gas",)):
-                self._sph_ptypes = self._sph_ptypes + (filter.name,)
+            if hasattr(self, '_sph_ptypes'):
+                if filter.filtered_type in (self._sph_ptypes + ("gas",)):
+                    self._sph_ptypes = self._sph_ptypes + (filter.name,)
             new_fields = self._setup_particle_types([filter.name])
             deps, _ = self.field_info.check_derived_fields(new_fields)
             self.field_dependencies.update(deps)

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -763,7 +763,7 @@ class Dataset(object):
                 self.particle_types += (filter.name,)
             if filter.name not in self.filtered_particle_types:
                 self.filtered_particle_types.append(filter.name)
-            if filter.filtered_type in self._sph_ptypes:
+            if filter.filtered_type in (self._sph_ptypes + ("gas",)):
                 self._sph_ptypes = self._sph_ptypes + (filter.name,)
             new_fields = self._setup_particle_types([filter.name])
             deps, _ = self.field_info.check_derived_fields(new_fields)

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -730,7 +730,10 @@ class Dataset(object):
             self.known_filters.pop(n, None)
             return False
         self.known_filters[filter.name] = filter
-        
+        if filter.filtered_type == self._sph_ptypes[0]:
+            mylog.warning("It appears that you are filtering on an SPH field "
+                          "type. It is recommended to use 'gas' as the "
+                          "filtered particle type in this case instead.")
         return True
 
     def _setup_filtered_type(self, filter):

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -579,7 +579,7 @@ class Dataset(object):
             if hasattr(self, '_sph_ptypes'):
                 for sph_ptype in self._sph_ptypes:
                     if sph_ptype in ptypes:
-                        ptypes.remove(self._sph_ptype)
+                        ptypes.remove(sph_ptype)
             if ptypes:
                 nbody_ptypes = []
                 for ptype in ptypes:
@@ -730,6 +730,7 @@ class Dataset(object):
             self.known_filters.pop(n, None)
             return False
         self.known_filters[filter.name] = filter
+        
         return True
 
     def _setup_filtered_type(self, filter):
@@ -762,6 +763,8 @@ class Dataset(object):
                 self.particle_types += (filter.name,)
             if filter.name not in self.filtered_particle_types:
                 self.filtered_particle_types.append(filter.name)
+            if filter.filtered_type in self._sph_ptypes:
+                self._sph_ptypes = self._sph_ptypes + (filter.name,)
             new_fields = self._setup_particle_types([filter.name])
             deps, _ = self.field_info.check_derived_fields(new_fields)
             self.field_dependencies.update(deps)

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -576,8 +576,10 @@ class Dataset(object):
         if "nbody" not in self.particle_types:
             mylog.debug("Creating Particle Union 'nbody'")
             ptypes = list(self.particle_types_raw)
-            if hasattr(self, '_sph_ptype') and self._sph_ptype in ptypes:
-                ptypes.remove(self._sph_ptype)
+            if hasattr(self, '_sph_ptypes'):
+                for sph_ptype in self._sph_ptypes:
+                    if sph_ptype in ptypes:
+                        ptypes.remove(self._sph_ptype)
             if ptypes:
                 nbody_ptypes = []
                 for ptype in ptypes:

--- a/yt/data_objects/tests/test_octree.py
+++ b/yt/data_objects/tests/test_octree.py
@@ -61,7 +61,7 @@ def test_sph_interpolation_scatter():
 
     ds = fake_sph_grid_ds(hsml_factor=26.0)
     ds.use_sph_normalization = False
-    ds._sph_ptype = 'io'
+    ds._sph_ptypes = ('io',)
     octree = ds.octree(n_ref=5, over_refine_factor=0)
     density = octree[('io', 'density')]
     answers = np.array([1.00434706, 1.00434706, 1.00434706, 1.00434706,
@@ -81,7 +81,7 @@ def test_sph_interpolation_gather():
     ds.sph_smoothing_style = 'gather'
     ds.num_neighbors = 5
     ds.use_sph_normalization = False
-    ds._sph_ptype = 'io'
+    ds._sph_ptypes = ('io',)
     octree = ds.octree(n_ref=5, over_refine_factor=0)
     density = octree[('io', 'density')]
     answers = np.array([0.59240874, 0.59240874, 0.59240874, 0.59240874,

--- a/yt/fields/derived_field.py
+++ b/yt/fields/derived_field.py
@@ -192,8 +192,8 @@ class DerivedField(object):
             name = self.alias_name
         else:
             name = self.name
-        if hasattr(self.ds, '_sph_ptype'):
-            is_sph_field |= name[0] in (self.ds._sph_ptype, 'gas')
+        if hasattr(self.ds, '_sph_ptypes'):
+            is_sph_field |= name[0] in (self.ds._sph_ptypes + ('gas',))
         return is_sph_field
 
     @property

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -83,7 +83,7 @@ class FieldInfoContainer(dict):
                 self.alias((ftype, f), ("index", f))
 
     def setup_particle_fields(self, ptype, ftype='gas', num_neighbors=64 ):
-        skip_output_units = ("code_length")
+        skip_output_units = ("code_length",)
         for f, (units, aliases, dn) in sorted(self.known_particle_fields):
             units = self.ds.field_units.get((ptype, f), units)
             output_units = units
@@ -144,7 +144,7 @@ class FieldInfoContainer(dict):
         for units, field in self.extra_union_fields:
             add_union_field(self, ptype, field, units)
 
-    def setup_smoothed_fields(self, ptype, num_neighbors = 64, ftype = "gas"):
+    def setup_smoothed_fields(self, ptype, num_neighbors=64, ftype="gas"):
         # We can in principle compute this, but it is not yet implemented.
         if (ptype, "density") not in self or not hasattr(self.ds, '_sph_ptypes'):
             return

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -146,7 +146,7 @@ class FieldInfoContainer(dict):
 
     def setup_smoothed_fields(self, ptype, num_neighbors = 64, ftype = "gas"):
         # We can in principle compute this, but it is not yet implemented.
-        if (ptype, "density") not in self or not hasattr(self.ds, '_sph_ptype'):
+        if (ptype, "density") not in self or not hasattr(self.ds, '_sph_ptypes'):
             return
         new_aliases = []
         for ptype2, alias_name in list(self):

--- a/yt/fields/tests/test_sph_fields.py
+++ b/yt/fields/tests/test_sph_fields.py
@@ -46,11 +46,11 @@ def sph_fields_validate(ds_fn):
     ad = ds.all_data()
     for gf, pf in gas_fields_to_particle_fields.items():
         gas_field = ad['gas', gf]
-        part_field = ad[ds._sph_ptype, pf]
+        part_field = ad[ds._sph_ptypes[0], pf]
 
         assert_array_almost_equal(gas_field, part_field)
 
-        npart = ds.particle_type_counts[ds._sph_ptype]
+        npart = ds.particle_type_counts[ds._sph_ptypes[0]]
         err_msg = "Field %s is not the correct shape" % (gf,)
         assert_equal(npart, gas_field.shape[0], err_msg=err_msg)
 

--- a/yt/frontends/arepo/io.py
+++ b/yt/frontends/arepo/io.py
@@ -14,7 +14,7 @@ class IOHandlerArepoHDF5(IOHandlerGadgetHDF5):
     _dataset_type = "arepo_hdf5"
 
     def _get_smoothing_length(self, data_file, position_dtype, position_shape):
-        ptype = self.ds._sph_ptype
+        ptype = self.ds._sph_ptypes[0]
         ind = int(ptype[-1])
         si, ei = data_file.start, data_file.end
         with h5py.File(data_file.filename, "r") as f:

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -222,7 +222,7 @@ class GadgetDataset(SPHDataset):
     _particle_mass_name = "Mass"
     _particle_coordinates_name = "Coordinates"
     _particle_velocity_name = "Velocities"
-    _sph_ptype = 'Gas'
+    _sph_ptypes = ('Gas',)
     _suffix = ""
 
     def __init__(self, filename, dataset_type="gadget_binary",
@@ -535,7 +535,7 @@ class GadgetHDF5Dataset(GadgetDataset):
     _index_class = SPHParticleIndex
     _field_info_class = GadgetFieldInfo
     _particle_mass_name = "Masses"
-    _sph_ptype = 'PartType0'
+    _sph_ptypes = ('PartType0',)
     _suffix = ".hdf5"
 
     def __init__(self, filename, dataset_type="gadget_hdf5",

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -67,7 +67,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
                 x = f["/%s/Coordinates" % ptype][si:ei, 0].astype("float64")
                 y = f["/%s/Coordinates" % ptype][si:ei, 1].astype("float64")
                 z = f["/%s/Coordinates" % ptype][si:ei, 2].astype("float64")
-                if ptype == self.ds._sph_ptype:
+                if ptype in self.ds._sph_ptypes:
                     pdtype = f["/%s/Coordinates" % ptype].dtype
                     pshape = f["/%s/Coordinates" % ptype].shape
                     hsml = self._get_smoothing_length(data_file, pdtype, pshape)
@@ -97,7 +97,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
         f.close()
 
     def _get_smoothing_length(self, data_file, position_dtype, position_shape):
-        ptype = self.ds._sph_ptype
+        ptype = self.ds._sph_ptypes[0]
         ind = int(ptype[-1])
         si, ei = data_file.start, data_file.end
         with h5py.File(data_file.filename, "r") as f:
@@ -309,7 +309,7 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
                 f.seek(poff[ptype, "Coordinates"], os.SEEK_SET)
                 pos = self._read_field_from_file(
                     f, tp[ptype], "Coordinates")
-                if ptype == self.ds._sph_ptype:
+                if ptype in self.ds._sph_ptypes:
                     f.seek(poff[ptype, "SmoothingLength"], os.SEEK_SET)
                     hsml = self._read_field_from_file(
                         f, tp[ptype], "SmoothingLength")
@@ -334,7 +334,7 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
                     f.seek(poff[ptype, "Coordinates"], os.SEEK_SET)
                     pos = self._read_field_from_file(
                         f, tp[ptype], "Coordinates")
-                    if ptype == self.ds._sph_ptype:
+                    if ptype in self.ds._sph_ptypes:
                         f.seek(poff[ptype, "SmoothingLength"], os.SEEK_SET)
                         hsml = self._read_field_from_file(
                             f, tp[ptype], "SmoothingLength")

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -67,7 +67,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
                 x = f["/%s/Coordinates" % ptype][si:ei, 0].astype("float64")
                 y = f["/%s/Coordinates" % ptype][si:ei, 1].astype("float64")
                 z = f["/%s/Coordinates" % ptype][si:ei, 2].astype("float64")
-                if ptype in self.ds._sph_ptypes:
+                if ptype == self.ds._sph_ptypes[0]:
                     pdtype = f["/%s/Coordinates" % ptype].dtype
                     pshape = f["/%s/Coordinates" % ptype].shape
                     hsml = self._get_smoothing_length(data_file, pdtype, pshape)
@@ -309,7 +309,7 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
                 f.seek(poff[ptype, "Coordinates"], os.SEEK_SET)
                 pos = self._read_field_from_file(
                     f, tp[ptype], "Coordinates")
-                if ptype in self.ds._sph_ptypes:
+                if ptype == self.ds._sph_ptypes[0]:
                     f.seek(poff[ptype, "SmoothingLength"], os.SEEK_SET)
                     hsml = self._read_field_from_file(
                         f, tp[ptype], "SmoothingLength")
@@ -334,7 +334,7 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
                     f.seek(poff[ptype, "Coordinates"], os.SEEK_SET)
                     pos = self._read_field_from_file(
                         f, tp[ptype], "Coordinates")
-                    if ptype in self.ds._sph_ptypes:
+                    if ptype == self.ds._sph_ptypes[0]:
                         f.seek(poff[ptype, "SmoothingLength"], os.SEEK_SET)
                         hsml = self._read_field_from_file(
                             f, tp[ptype], "SmoothingLength")

--- a/yt/frontends/owls/fields.py
+++ b/yt/frontends/owls/fields.py
@@ -114,7 +114,7 @@ class OWLSFieldInfo(SPHFieldInfo):
             #-----------------------------------------------
             for s in self._elements:
                 field_names = add_species_field_by_fraction(self, ptype, s)
-                if ptype == self.ds._sph_ptype:
+                if ptype == self.ds._sph_ptypes[0]:
                     for fn in field_names:
                         self.alias(("gas", fn[1]), fn)
 

--- a/yt/frontends/sph/data_structures.py
+++ b/yt/frontends/sph/data_structures.py
@@ -104,9 +104,9 @@ class SPHParticleIndex(ParticleIndex):
                     return
         positions = []
         for data_file in self.data_files:
-                for _, ppos in self.io._yield_coordinates(
-                    data_file, needed_ptype=self.ds._sph_ptypes[0]):
-                    positions.append(ppos)
+            for _, ppos in self.io._yield_coordinates(
+                data_file, needed_ptype=self.ds._sph_ptypes[0]):
+                positions.append(ppos)
         if positions == []:
             self._kdtree = None
             return

--- a/yt/frontends/sph/data_structures.py
+++ b/yt/frontends/sph/data_structures.py
@@ -105,7 +105,7 @@ class SPHParticleIndex(ParticleIndex):
         positions = []
         for data_file in self.data_files:
                 for _, ppos in self.io._yield_coordinates(
-                    data_file, needed_ptype=self.ds._sph_ptype):
+                    data_file, needed_ptype=self.ds._sph_ptypes[0]):
                     positions.append(ppos)
         if positions == []:
             self._kdtree = None

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -1137,7 +1137,7 @@ class StreamParticlesDataset(StreamDataset):
         # This is the current method of detecting SPH data.
         # This should be made more flexible in the future.
         if ('io', 'density') in fields and ('io', 'smoothing_length') in fields:
-            self._sph_ptype = 'io'
+            self._sph_ptypes = ('io',)
 
     def add_sph_fields(self, n_neighbors=32, kernel="cubic", sph_ptype="io"):
         """Add SPH fields for the specified particle type.

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -1214,7 +1214,7 @@ class StreamParticlesDataset(StreamDataset):
             data[(sph_ptype, "density")] = (dens, d_unit)
 
         # Add fields
-        self._sph_ptype = sph_ptype
+        self._sph_ptypes = (sph_ptype,)
         self.index.update_data(data)
 
 def load_particles(data, length_unit=None, bbox=None,

--- a/yt/frontends/stream/io.py
+++ b/yt/frontends/stream/io.py
@@ -184,7 +184,7 @@ class StreamParticleIOHandler(BaseIOHandler):
             yield ptype, pos
 
     def _get_smoothing_length(self, data_file, dtype, shape):
-        ptype = self.ds._sph_ptype
+        ptype = self.ds._sph_ptypes[0]
         return self.fields[data_file.filename][ptype, 'smoothing_length']
 
     def _count_particles(self, data_file):

--- a/yt/frontends/swift/data_structures.py
+++ b/yt/frontends/swift/data_structures.py
@@ -33,7 +33,7 @@ class SwiftDataset(SPHDataset):
     _particle_mass_name = "Masses"
     _particle_coordinates_name = "Coordinates"
     _particle_velocity_name = "Velocities"
-    _sph_ptype = "PartType0"
+    _sph_ptypes = ("PartType0",)
     _suffix = ".hdf5"
 
     def __init__(self, filename, dataset_type='swift',

--- a/yt/frontends/swift/io.py
+++ b/yt/frontends/swift/io.py
@@ -51,7 +51,7 @@ class IOHandlerSwift(IOHandlerSPH):
                     continue
                 pos = f["/%s/Coordinates" % ptype][si:ei, :]
                 pos = pos.astype("float64", copy=False)
-                if ptype == self.ds._sph_ptype:
+                if ptype in self.ds._sph_ptypes:
                     hsml = self._get_smoothing_length(sub_file)
                 else:
                     hsml = 0.0
@@ -76,7 +76,7 @@ class IOHandlerSwift(IOHandlerSPH):
     def _get_smoothing_length(self, sub_file, pdtype=None, pshape=None):
         # We do not need the pdtype and the pshape, but some frontends do so we
         # accept them and then just ignore them
-        ptype = self.ds._sph_ptype
+        ptype = self.ds._sph_ptypes[0]
         ind = int(ptype[-1])
         si, ei = sub_file.start, sub_file.end
         with h5py.File(sub_file.filename, "r") as f:

--- a/yt/frontends/swift/io.py
+++ b/yt/frontends/swift/io.py
@@ -51,7 +51,7 @@ class IOHandlerSwift(IOHandlerSPH):
                     continue
                 pos = f["/%s/Coordinates" % ptype][si:ei, :]
                 pos = pos.astype("float64", copy=False)
-                if ptype in self.ds._sph_ptypes:
+                if ptype == self.ds._sph_ptypes[0]:
                     hsml = self._get_smoothing_length(sub_file)
                 else:
                     hsml = 0.0

--- a/yt/frontends/tipsy/data_structures.py
+++ b/yt/frontends/tipsy/data_structures.py
@@ -59,7 +59,7 @@ class TipsyDataset(SPHDataset):
     _field_info_class = TipsyFieldInfo
     _particle_mass_name = "Mass"
     _particle_coordinates_name = "Coordinates"
-    _sph_ptype = "Gas"
+    _sph_ptypes = ("Gas",)
     _header_spec = (('time',    'd'),
                     ('nbodies', 'i'),
                     ('ndim',    'i'),

--- a/yt/frontends/tipsy/io.py
+++ b/yt/frontends/tipsy/io.py
@@ -128,7 +128,7 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
                     d = [p["Coordinates"][ax].astype("float64")
                          for ax in 'xyz']
                     del p
-                    if ptype == self.ds._sph_ptype:
+                    if ptype in self.ds._sph_ptypes:
                         hsml = self._read_smoothing_length(data_file, count)
                     else:
                         hsml = 0.0
@@ -149,7 +149,7 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
         positions = []
         for data_file in data_files:
             for _, ppos in self._yield_coordinates(
-                    data_file, needed_ptype=self.ds._sph_ptype):
+                    data_file, needed_ptype=self.ds._sph_ptypes[0]):
                 positions.append(ppos)
         if positions == []:
             return

--- a/yt/frontends/tipsy/io.py
+++ b/yt/frontends/tipsy/io.py
@@ -128,7 +128,7 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
                     d = [p["Coordinates"][ax].astype("float64")
                          for ax in 'xyz']
                     del p
-                    if ptype in self.ds._sph_ptypes:
+                    if ptype == self.ds._sph_ptypes[0]:
                         hsml = self._read_smoothing_length(data_file, count)
                     else:
                         hsml = 0.0

--- a/yt/geometry/coordinates/cartesian_coordinates.py
+++ b/yt/geometry/coordinates/cartesian_coordinates.py
@@ -292,7 +292,7 @@ class CartesianCoordinateHandler(CoordinateHandler):
         elif isinstance(data_source.ds, particle_datasets) and is_sph_field:
             ptype = field[0]
             if ptype == 'gas':
-                ptype = data_source.ds._sph_ptype
+                ptype = data_source.ds._sph_ptypes[0]
             ounits = data_source.ds.field_info[field].output_units
             px_name = 'particle_position_%s' % self.axis_name[self.x_axis[dim]]
             py_name = 'particle_position_%s' % self.axis_name[self.y_axis[dim]]

--- a/yt/geometry/coordinates/cartesian_coordinates.py
+++ b/yt/geometry/coordinates/cartesian_coordinates.py
@@ -293,9 +293,9 @@ class CartesianCoordinateHandler(CoordinateHandler):
             ptype = field[0]
             if ptype == 'gas':
                 ptype = data_source.ds._sph_ptypes[0]
+            px_name = self.axis_name[self.x_axis[dim]]
+            py_name = self.axis_name[self.y_axis[dim]]
             ounits = data_source.ds.field_info[field].output_units
-            px_name = 'particle_position_%s' % self.axis_name[self.x_axis[dim]]
-            py_name = 'particle_position_%s' % self.axis_name[self.y_axis[dim]]
             if isinstance(data_source, YTParticleProj):
                 weight = data_source.weight_field
                 le, re = data_source.data_source.get_bbox()
@@ -318,7 +318,7 @@ class CartesianCoordinateHandler(CoordinateHandler):
                             chunk[ptype, px_name].in_units('cm'),
                             chunk[ptype, py_name].in_units('cm'),
                             chunk[ptype, 'smoothing_length'].in_units('cm'),
-                            chunk[ptype, 'particle_mass'].in_units('g'),
+                            chunk[ptype, 'mass'].in_units('g'),
                             chunk[ptype, 'density'].in_units('g/cm**3'),
                             chunk[field].in_units(ounits),
                             bnds)
@@ -336,7 +336,7 @@ class CartesianCoordinateHandler(CoordinateHandler):
                             chunk[ptype, px_name].in_units('cm'),
                             chunk[ptype, py_name].in_units('cm'),
                             chunk[ptype, 'smoothing_length'].in_units('cm'),
-                            chunk[ptype, 'particle_mass'].in_units('g'),
+                            chunk[ptype, 'mass'].in_units('g'),
                             chunk[ptype, 'density'].in_units('g/cm**3'),
                             chunk[field].in_units(ounits),
                             bnds,
@@ -350,7 +350,7 @@ class CartesianCoordinateHandler(CoordinateHandler):
                             chunk[ptype, px_name].in_units('cm'),
                             chunk[ptype, py_name].in_units('cm'),
                             chunk[ptype, 'smoothing_length'].in_units('cm'),
-                            chunk[ptype, 'particle_mass'].in_units('g'),
+                            chunk[ptype, 'mass'].in_units('g'),
                             chunk[ptype, 'density'].in_units('g/cm**3'),
                             chunk[weight].in_units(wounits),
                             bnds)
@@ -369,20 +369,20 @@ class CartesianCoordinateHandler(CoordinateHandler):
                     for chunk in data_source.chunks([], 'io'):
                         pixelize_sph_kernel_slice(
                             buff,
-                            chunk[ptype, px_name],
-                            chunk[ptype, py_name],
-                            chunk[ptype, 'smoothing_length'],
-                            chunk[ptype, 'particle_mass'],
+                            chunk[ptype, px_name].to('code_length'),
+                            chunk[ptype, py_name].to('code_length'),
+                            chunk[ptype, 'smoothing_length'].to('code_length'),
+                            chunk[ptype, 'mass'],
                             chunk[ptype, 'density'],
                             chunk[field].in_units(ounits),
                             bounds)
                         if normalize:
                             pixelize_sph_kernel_slice(
                                 buff_den,
-                                chunk[ptype, px_name],
-                                chunk[ptype, py_name],
-                                chunk[ptype, 'smoothing_length'],
-                                chunk[ptype, 'particle_mass'],
+                                chunk[ptype, px_name].to('code_length'),
+                                chunk[ptype, py_name].to('code_length'),
+                                chunk[ptype, 'smoothing_length'].to('code_length'),
+                                chunk[ptype, 'mass'],
                                 chunk[ptype, 'density'],
                                 np.ones(chunk[ptype, 'density'].shape[0]),
                                 bounds)
@@ -412,7 +412,7 @@ class CartesianCoordinateHandler(CoordinateHandler):
                     # then we do the interpolation
                     buff_temp = np.zeros(buff_size, dtype="float64")
 
-                    fields_to_get = ['particle_position', 'density', 'particle_mass',
+                    fields_to_get = ['particle_position', 'density', 'mass',
                                      'smoothing_length', field[1]]
                     all_fields = all_data(self.ds, ptype, fields_to_get, kdtree=True)
 
@@ -421,7 +421,7 @@ class CartesianCoordinateHandler(CoordinateHandler):
                                                 all_fields['particle_position'],
                                                 buff_bounds,
                                                 all_fields['smoothing_length'],
-                                                all_fields['particle_mass'],
+                                                all_fields['mass'],
                                                 all_fields['density'],
                                                 all_fields[field[1]].in_units(ounits),
                                                 self.ds.index.kdtree,

--- a/yt/geometry/particle_geometry_handler.py
+++ b/yt/geometry/particle_geometry_handler.py
@@ -165,7 +165,7 @@ class ParticleIndex(Index):
             pb.update(i)
             for ptype, pos in self.io._yield_coordinates(data_file):
                 ds = self.ds
-                if hasattr(ds, '_sph_ptype') and ptype == ds._sph_ptype:
+                if hasattr(ds, '_sph_ptypes') and ptype == ds._sph_ptypes[0]:
                     hsml = self.io._get_smoothing_length(
                         data_file, pos.dtype, pos.shape)
                 else:
@@ -187,7 +187,7 @@ class ParticleIndex(Index):
             pb.update(i)
             nsub_mi = 0
             for ptype, pos in self.io._yield_coordinates(data_file):
-                if hasattr(self.ds, '_sph_ptype') and ptype == self.ds._sph_ptype:
+                if hasattr(self.ds, '_sph_ptypes') and ptype == self.ds._sph_ptypes[0]:
                     hsml = self.io._get_smoothing_length(
                         data_file, pos.dtype, pos.shape)
                 else:

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -137,7 +137,7 @@ def validate_mesh_fields(data_source, fields):
     for field in canonical_fields:
         finfo = data_source.ds.field_info[field]
         if finfo.sampling_type == "particle":
-            if not hasattr(data_source.ds, '_sph_ptype'):
+            if not hasattr(data_source.ds, '_sph_ptypes'):
                 pass
             elif finfo.is_sph_field:
                 continue

--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -129,11 +129,11 @@ def off_axis_projection(data_source, center, normal_vector,
     if not hasattr(width, "units"):
         width = data_source.ds.arr(width, 'code_length')
 
-    if hasattr(data_source.ds, '_sph_ptype'):
+    if hasattr(data_source.ds, '_sph_ptypes'):
         if method != 'integrate':
             raise NotImplementedError("SPH Only allows 'integrate' method")
 
-        ptype = data_source.ds._sph_ptype
+        sph_ptypes = data_source.ds._sph_ptypes
         fi = data_source.ds.field_info[item]
 
         raise_error = False
@@ -142,13 +142,17 @@ def off_axis_projection(data_source, center, normal_vector,
         # has a field type as the SPH particle type or if the field is an 
         # alias to an SPH field or is a 'gas' field
         if fi.alias_field:
-            if fi.alias_name[0] != ptype:
+            if fi.alias_name[0] not in sph_ptypes:
                 raise_error = True
             elif item[0] != 'gas':
                 ptype = item[0]
+            else:
+                ptype = fi.alias_name[0]
         else:
-            if fi.name[0] != ptype and fi.name[0] != 'gas':
+            if fi.name[0] not in sph_ptypes and fi.name[0] != 'gas':
                 raise_error = True
+            else:
+                ptype = fi.name[0]
 
         if raise_error:
             raise RuntimeError(


### PR DESCRIPTION
This is a WIP PR to enable SPH visualization of filtered particle types which have an original type which is SPH. 

A side effect of the work here will be to (at least in theory) make multiple SPH particle types possible, since the core of it is to change the private attribute `Dataset._sph_ptype` to `Dataset._sph_ptypes`, where the latter is a tuple.

Currently I'm able to make slices and projections correctly but otherwise at the moment I'm sure some things are broken. 

- [x] figure out how to handle smoothing lengths for filtered particles
- [ ] add tests
- [x] figure out what to do about gather vs. scatter smoothing
- [ ] add a note to docs