### PR TITLE
[bugfix] Generate smoothing length if it's needed for frontends which don't have it

### DIFF
--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -128,10 +128,10 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
                 if data_file.total_particles[ptype] == 0:
                     continue
                 g = f["/%s" % ptype]
-                hsmls = None
                 if getattr(selector, 'is_all_data', False):
                     mask = slice(None, None, None)
                     mask_sum = ei-si
+                    hsmls = None
                 else:
                     coords = g["Coordinates"][si:ei].astype("float64")
                     if ptype == 'PartType0':

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -128,6 +128,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
                 if data_file.total_particles[ptype] == 0:
                     continue
                 g = f["/%s" % ptype]
+                hsmls = None
                 if getattr(selector, 'is_all_data', False):
                     mask = slice(None, None, None)
                     mask_sum = ei-si
@@ -167,6 +168,10 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
                         # the smoothing length on-disk, so we do not
                         # attempt to read them, but instead assume
                         # that they are calculated in _get_smoothing_length.
+                        if hsmls is None:
+                            hsmls = self._get_smoothing_length(data_file,
+                                                               g["Coordinates"].dtype,
+                                                               g["Coordinates"].shape).astype("float64")
                         data = hsmls[mask]
                     else:
                         data = g[field][si:ei][mask, ...]


### PR DESCRIPTION
Another nit I discovered by poking around. Some Gadget-based frontends (e.g. Arepo) have to generate their own smoothing lengths. Normally when this field is asked for it's already been generated for data selection purposes, but there is the case of selecting all data where it hasn't. This PR ensures that the smoothing lengths are always generated if they are needed.