### PR TITLE
[BUGFIX] [Boxlib frontend] Handle the case where the raw_fields were written out with ghost zones

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -85,7 +85,7 @@ answer_tests:
     - yt/visualization/volume_rendering/tests/test_mesh_render.py:test_wedge6_render
     - yt/visualization/volume_rendering/tests/test_mesh_render.py:test_wedge6_render_pyembree
 
-  local_boxlib_007:
+  local_boxlib_008:
     - yt/frontends/boxlib/tests/test_outputs.py:test_radadvect
     - yt/frontends/boxlib/tests/test_outputs.py:test_radtube
     - yt/frontends/boxlib/tests/test_outputs.py:test_star

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -1381,10 +1381,12 @@ def _read_header(raw_file, field):
         header_file = level_file + "/" + field + "_H"
         with open(header_file, "r") as f:
         
-            # skip the first five lines
-            for _ in range(5):
-                f.readline()
-
+            f.readline()  # version
+            f.readline()  # how
+            f.readline()  # ncomp
+            nghost = int(f.readline().strip())  # nghost
+            f.readline()  # num boxes
+            
             # read boxes
             boxes = []
             for line in f:
@@ -1407,7 +1409,7 @@ def _read_header(raw_file, field):
             all_file_names += file_names
             all_offsets += offsets
 
-    return all_boxes, all_file_names, all_offsets
+    return nghost, all_boxes, all_file_names, all_offsets
 
 
 class WarpXHeader(object):
@@ -1481,9 +1483,11 @@ class WarpXHierarchy(BoxlibHierarchy):
         self.field_list += [('raw', f) for f in self.raw_fields]
         self.raw_field_map = {}
         self.ds.nodal_flags = {}
+        self.raw_field_nghost = {}
         for field_name in self.raw_fields:
-            boxes, file_names, offsets = _read_header(self.raw_file, field_name)
-            self.raw_field_map[field_name] = (boxes, file_names, offsets) 
+            nghost, boxes, file_names, offsets = _read_header(self.raw_file, field_name)
+            self.raw_field_map[field_name] = (boxes, file_names, offsets)
+            self.raw_field_nghost[field_name] = nghost
             self.ds.nodal_flags[field_name] = np.array(boxes[0][2])
 
 

--- a/yt/frontends/boxlib/io.py
+++ b/yt/frontends/boxlib/io.py
@@ -72,6 +72,7 @@ class IOHandlerBoxlib(BaseIOHandler):
         field_name = field[1]
         base_dir = self.ds.index.raw_file
 
+        nghost = self.ds.index.raw_field_nghost[field_name]
         box_list = self.ds.index.raw_field_map[field_name][0]
         fn_list = self.ds.index.raw_field_map[field_name][1]
         offset_list = self.ds.index.raw_field_map[field_name][2]
@@ -80,16 +81,16 @@ class IOHandlerBoxlib(BaseIOHandler):
         filename = base_dir + "Level_%d/" % lev + fn_list[grid.id]
         offset = offset_list[grid.id]
         box = box_list[grid.id]
-        
-        lo = box[0]
-        hi = box[1]
+
+        lo = box[0] - nghost
+        hi = box[1] + nghost
         shape = hi - lo + 1
         with open(filename, "rb") as f:
             f.seek(offset)
             f.readline()  # always skip the first line
             arr = np.fromfile(f, 'float64', np.product(shape))
             arr = arr.reshape(shape, order='F')
-        return arr
+        return arr[[slice(nghost,-nghost) for _ in range(self.ds.dimensionality)]]
 
     def _read_chunk_data(self, chunk, fields):
         data = {}


### PR DESCRIPTION
This simply ignores the ghost zones if they are present in the file. 