### PR TITLE
[BUGFIX] [OpenPMD frontend] Allow openpmd files that don't have any particles

### DIFF
--- a/yt/frontends/open_pmd/data_structures.py
+++ b/yt/frontends/open_pmd/data_structures.py
@@ -40,7 +40,7 @@ from yt.utilities.on_demand_imports import _h5py as h5
 ompd_known_versions = [StrictVersion("1.0.0"),
                        StrictVersion("1.0.1"),
                        StrictVersion("1.1.0")]
-opmd_required_attributes = ["openPMD", "basePath", "meshesPath", "particlesPath"]
+opmd_required_attributes = ["openPMD", "basePath"]
 
 
 class OpenPMDGrid(AMRGridPatch):
@@ -191,7 +191,7 @@ class OpenPMDHierarchy(GridIndex):
                 self.field_list.extend(
                     [("io",
                       ("particle_" + "_".join(str(field).split("_")[1:]))) for field in particle_fields])
-        except(KeyError):
+        except(KeyError, TypeError, AttributeError):
             pass
 
     def _count_grids(self):
@@ -221,9 +221,8 @@ class OpenPMDHierarchy(GridIndex):
                 offset = tuple(mesh.attrs["gridGlobalOffset"])
                 unit_si = mesh.attrs["gridUnitSI"]
                 self.meshshapes[mname] = (shape, spacing, offset, unit_si)
-        except(KeyError):
+        except(KeyError, TypeError, AttributeError):
             pass
-
         try:
             particles = f[bp + pp]
             for pname in particles.keys():
@@ -237,7 +236,7 @@ class OpenPMDHierarchy(GridIndex):
                         self.numparts[pname] = species["/position/" + axis].attrs["shape"]
                     else:
                         self.numparts[pname] = species["/position/" + axis].len()
-        except(KeyError):
+        except(KeyError, TypeError, AttributeError):
             pass
 
         # Limit values per grid by resulting memory footprint
@@ -423,7 +422,7 @@ class OpenPMDDataset(Dataset):
             mylog.debug("self.particle_types: {}".format(self.particle_types))
             self.particle_types_raw = self.particle_types
             self.particle_types = tuple(self.particle_types)
-        except(KeyError):
+        except(KeyError, TypeError, AttributeError):
             pass
 
     def _set_paths(self, handle, path, iteration):
@@ -459,22 +458,24 @@ class OpenPMDDataset(Dataset):
             mylog.warning("Only chose to load one iteration ({})".format(iteration))
 
         self.base_path = "/data/{}/".format(iteration)
-        self.meshes_path = self._handle["/"].attrs["meshesPath"].decode()
         try:
+            self.meshes_path = self._handle["/"].attrs["meshesPath"].decode()
             handle[self.base_path + self.meshes_path]
         except(KeyError):
             if self.standard_version <= StrictVersion("1.1.0"):
                 mylog.info("meshesPath not present in file."
                            " Assuming file contains no meshes and has a domain extent of 1m^3!")
+                self.meshes_path = None
             else:
                 raise
-        self.particles_path = self._handle["/"].attrs["particlesPath"].decode()
         try:
+            self.particles_path = self._handle["/"].attrs["particlesPath"].decode()
             handle[self.base_path + self.particles_path]
         except(KeyError):
             if self.standard_version <= StrictVersion("1.1.0"):
                 mylog.info("particlesPath not present in file."
                            " Assuming file contains no particles!")
+                self.particles_path = None
             else:
                 raise
 

--- a/yt/frontends/open_pmd/data_structures.py
+++ b/yt/frontends/open_pmd/data_structures.py
@@ -538,7 +538,7 @@ class OpenPMDDataset(Dataset):
             self.domain_dimensions = np.append(fs, np.ones(3 - self.dimensionality))
             self.domain_left_edge = np.append(dle, np.zeros(3 - len(dle)))
             self.domain_right_edge = np.append(dre, np.ones(3 - len(dre)))
-        except(KeyError):
+        except(KeyError, TypeError, AttributeError):
             if self.standard_version <= StrictVersion("1.1.0"):
                 self.dimensionality = 3
                 self.domain_dimensions = np.ones(3, dtype=np.float64)

--- a/yt/frontends/open_pmd/data_structures.py
+++ b/yt/frontends/open_pmd/data_structures.py
@@ -148,7 +148,7 @@ class OpenPMDHierarchy(GridIndex):
                 except AttributeError:
                     # This is a h5.Dataset (i.e. no axes)
                     mesh_fields.append(mname.replace("_", "-"))
-        except(KeyError):
+        except(KeyError, TypeError, AttributeError):
             pass
         self.field_list = [("openPMD", str(field)) for field in mesh_fields]
 

--- a/yt/frontends/open_pmd/fields.py
+++ b/yt/frontends/open_pmd/fields.py
@@ -165,7 +165,7 @@ class OpenPMDFieldInfo(FieldInfoContainer):
                         self.known_other_fields += ((ytname, (unit, aliases, None)),)
             for i in self.known_other_fields:
                 mylog.debug("open_pmd - known_other_fields - {}".format(i))
-        except(KeyError):
+        except(KeyError, TypeError, AttributeError):
             pass
 
         try:

--- a/yt/frontends/open_pmd/fields.py
+++ b/yt/frontends/open_pmd/fields.py
@@ -196,7 +196,7 @@ class OpenPMDFieldInfo(FieldInfoContainer):
                             mylog.info("open_pmd - {}_{} does not seem to have unitDimension".format(pname, recname))
             for i in self.known_particle_fields:
                 mylog.debug("open_pmd - known_particle_fields - {}".format(i))
-        except(KeyError):
+        except(KeyError, TypeError, AttributeError):
             pass
 
         super(OpenPMDFieldInfo, self).__init__(ds, field_list)


### PR DESCRIPTION
As of version 1.1.0, both mesh and particle data are optional in the OpenPMD format. This allows yt to read these datasets. 