### PR TITLE
Cache the result of _identify_fields to improve dataset initialization speed

### DIFF
--- a/yt/geometry/particle_geometry_handler.py
+++ b/yt/geometry/particle_geometry_handler.py
@@ -207,8 +207,13 @@ class ParticleIndex(Index):
         dsl = []
         units = {}
         pcounts = self._get_particle_type_counts()
+        field_cache = {}
         for dom in self.data_files:
-            fl, _units = self.io._identify_fields(dom)
+            if dom.filename in field_cache:
+                fl, _units = field_cache[dom.filename]
+            else:
+                fl, _units = self.io._identify_fields(dom)
+                field_cache[dom.filename] = fl, _units
             units.update(_units)
             dom._calculate_offsets(fl, pcounts)
             for f in fl:


### PR DESCRIPTION
This is a follow-on to #2146; I'm trying to cut down the overhead of yt to increase its usability in similar-looking applications (datasets >10 GB, but few operations on the dataset).

This PR halves the runtime of scripts such as mentioned in #2146 on our system, for 4-file MassiveFIRE snapshots. On such snapshots yt used to redundantly scan the backing HDF5 files 243 times for what Datasets they contain.