### PR TITLE
Bugfixes for Exodus II and Semi-Structured Frontends

### DIFF
--- a/yt/frontends/exodus_ii/data_structures.py
+++ b/yt/frontends/exodus_ii/data_structures.py
@@ -318,7 +318,7 @@ class ExodusIIDataset(Dataset):
             else:
                 coords = np.array([coord for coord in
                                    ds.variables["coord"][:]]).transpose().copy()
-            return coords
+            return coords.astype(np.float64)
 
     def _apply_displacement(self, coords, mesh_id):
 

--- a/yt/frontends/exodus_ii/data_structures.py
+++ b/yt/frontends/exodus_ii/data_structures.py
@@ -315,11 +315,11 @@ class ExodusIIDataset(Dataset):
             if "coord" not in ds.variables:
                 coords = np.array([ds.variables["coord%s" % ax][:]
                                    for ax in coord_axes]
-                                  ).transpose().astype(np.float64)
+                                  ).transpose().astype("f8")
             else:
                 coords = np.array([coord for coord in
                                    ds.variables["coord"][:]]
-                                  ).transpose().astype(np.float64)
+                                  ).transpose().astype("f8")
             return coords
 
     def _apply_displacement(self, coords, mesh_id):

--- a/yt/frontends/exodus_ii/data_structures.py
+++ b/yt/frontends/exodus_ii/data_structures.py
@@ -314,11 +314,13 @@ class ExodusIIDataset(Dataset):
         with self._handle.open_ds() as ds:
             if "coord" not in ds.variables:
                 coords = np.array([ds.variables["coord%s" % ax][:]
-                                   for ax in coord_axes]).transpose().copy()
+                                   for ax in coord_axes]
+                                  ).transpose().astype(np.float64)
             else:
                 coords = np.array([coord for coord in
-                                   ds.variables["coord"][:]]).transpose().copy()
-            return coords.astype(np.float64)
+                                   ds.variables["coord"][:]]
+                                  ).transpose().astype(np.float64)
+            return coords
 
     def _apply_displacement(self, coords, mesh_id):
 

--- a/yt/frontends/exodus_ii/io.py
+++ b/yt/frontends/exodus_ii/io.py
@@ -86,7 +86,7 @@ class IOHandlerExodusII(BaseIOHandler):
                                                        (field_ind + 1, mesh_id)][:]
                         data = fdata[self.ds.step, :]
                         ind += g.select(selector, data, rv[field], ind)  # caches
-                rv[field] = rv[field][:ind] # new
+                rv[field] = rv[field][:ind]
             return rv
 
     def _read_chunk_data(self, chunk, fields):

--- a/yt/frontends/exodus_ii/io.py
+++ b/yt/frontends/exodus_ii/io.py
@@ -69,7 +69,7 @@ class IOHandlerExodusII(BaseIOHandler):
                     mesh_ids = [mesh.mesh_id + 1 for mesh in self.ds.index.mesh_union]
                     objs = [mesh for mesh in self.ds.index.mesh_union]
                 else:
-                    mesh_ids = [int(ftype[-1])]
+                    mesh_ids = [int(ftype.replace("connect",""))]
                     chunk = chunks[mesh_ids[0] - 1]
                     objs = chunk.objs
                 if fname in self.node_fields:
@@ -86,7 +86,7 @@ class IOHandlerExodusII(BaseIOHandler):
                                                        (field_ind + 1, mesh_id)][:]
                         data = fdata[self.ds.step, :]
                         ind += g.select(selector, data, rv[field], ind)  # caches
-                rv[field] = rv[field][:ind]
+                rv[field] = rv[field][:ind] # new
             return rv
 
     def _read_chunk_data(self, chunk, fields):

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -1276,7 +1276,7 @@ def hexahedral_connectivity(xgrid, ygrid, zgrid):
     cycle = np.rollaxis(np.indices((nx-1,ny-1,nz-1)), 0, 4)
     cycle.shape = ((nx-1)*(ny-1)*(nz-1), 3)
     off = _cis + cycle[:, np.newaxis]
-    connectivity = ((off[:,:,0] * ny) + off[:,:,1]) * nz + off[:,:,2]
+    connectivity = np.array(((off[:,:,0] * ny) + off[:,:,1]) * nz + off[:,:,2], order='C')
     return coords, connectivity
 
 class StreamHexahedralMesh(SemiStructuredMesh):


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

Certain Exodus II data output would not load properly; fixes to this were supplied by Kris Beckwith. Additionally, annotating mesh lines onto slices of semi-structured data (2D forced to 3D) failed because of how the connectivity matrix was returned.

Issues #2272 and #2273 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [X] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->