### PR TITLE
Simplify and correct tipsy sub-chunking.

### DIFF
--- a/yt/frontends/tipsy/io.py
+++ b/yt/frontends/tipsy/io.py
@@ -43,7 +43,7 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
     _ptypes = ("Gas",
                "DarkMatter",
                "Stars")
-    _chunksize = 64 * 64 * 64
+    _chunksize = CHUNKSIZE
 
     _aux_fields = None
     _fields = (("Gas", "Mass"),
@@ -118,7 +118,9 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
             tp = data_file.total_particles
             f = open(data_file.filename, "rb")
             for ptype, field_list in sorted(ptf.items(),
-                                            key=lambda a: poff[a[0]]):
+                                            key=lambda a: poff.get(a[0], -1)):
+                if data_file.total_particles[ptype] == 0:
+                    continue
                 f.seek(poff[ptype])
                 total = 0
                 while total < tp[ptype]:
@@ -190,14 +192,14 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
                 aux_fh[afield] = open(data_file.filename + '.' + afield, 'rb')
 
             for ptype, field_list in sorted(ptf.items(),
-                                            key=lambda a: poff[a[0]]):
+                                            key=lambda a: poff.get(a[0], -1)):
+                if data_file.total_particles[ptype] == 0:
+                    continue
                 f.seek(poff[ptype])
                 afields = list(set(field_list).intersection(self._aux_fields))
                 count = min(self._chunksize, tp[ptype])
                 p = np.fromfile(f, self._pdtypes[ptype], count=count)
                 auxdata = []
-                if data_file.total_particles[ptype] == 0:
-                    continue
                 for afield in afields:
                     aux_fh[afield].seek(aux_fields_offsets[afield][ptype])
                     if isinstance(self._aux_pdtypes[afield], np.dtype):
@@ -423,22 +425,37 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
         return self._field_list, {}
 
     def _calculate_particle_offsets(self, data_file, pcounts):
+        # This computes the offsets for each particle type into a "data_file."  Note that 
+        # the term "data_file" here is a bit overloaded, and also refers to a
+        # "chunk" of particles inside a data file.
+        # data_file.start represents the *particle count* that we should start at.
+        #
+        # At this point, data_file will have the total number of particles
+        # that this chunk represents located in the property total_particles.
+        # Because in tipsy files the particles are stored sequentially, we can
+        # figure out where each one starts.
+        # We first figure out the global offsets, then offset them by the count
+        # and size of each individual particle type.
         field_offsets = {}
+        # Initialize pos to the point the first particle type would start
         pos = data_file.ds._header_offset
+        global_offsets = {}
+        field_offsets = {}
         for i, ptype in enumerate(self._ptypes):
             if ptype not in self._pdtypes:
+                # This means we don't have any, I think, and so we shouldn't
+                # stick it in the offsets.
                 continue
+            # Note that much of this will be computed redundantly; future
+            # refactorings could fix this.
+            global_offsets[ptype] = pos
             size = self._pdtypes[ptype].itemsize
-            field_offsets[ptype] = pos
             params = self.ds.parameters
-            if params[npart_mapping[ptype]] > CHUNKSIZE:
-                 for j in range(i):
-                     npart = params[npart_mapping[self._ptypes[j]]]
-                     spart = self._pdtypes[self._ptypes[j]].itemsize
-                     if npart > CHUNKSIZE:
-                         field_offsets[ptype] += npart*spart
-                 field_offsets[ptype] += data_file.start*size
-            pos += data_file.total_particles[ptype] * size
+            npart = self.ds.parameters[npart_mapping[ptype]]
+            # Get the offset into just this particle type, and start at data_file.start
+            if npart > data_file.start:
+                field_offsets[ptype] = pos + size * data_file.start
+            pos += npart * size
         return field_offsets
 
     def _calculate_particle_offsets_aux(self, data_file):

--- a/yt/frontends/tipsy/io.py
+++ b/yt/frontends/tipsy/io.py
@@ -450,7 +450,6 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
             # refactorings could fix this.
             global_offsets[ptype] = pos
             size = self._pdtypes[ptype].itemsize
-            params = self.ds.parameters
             npart = self.ds.parameters[npart_mapping[ptype]]
             # Get the offset into just this particle type, and start at data_file.start
             if npart > data_file.start:


### PR DESCRIPTION
Fixes #2276.

The tipsy chunking was not correctly subchunking, and this seemed to only show up when the particular ordering and sizes of the particle types was set in a specific way.  This would always have a "hard fail", so there have to my knowledge this has not been the source of any quiet failures.

What this does is simplify the particle offset calculation.  Instead of our previous way of doing things, which I could not quite parse out (and which was probably dating from before we did any subchunking) the new way is to compute a global offset for *each particle type* and then offset into that based on `data_file.start`.  I also terminate earlier when trying to read particles that aren't in a sub-chunk.

This uses data from @claytonstrawn .

My verification script, which I ran with changing `CHUNKSIZE` in `yt/geometry/particle_geometry_handler.py` to a big number and leaving it at the small number:

```python
import yt
import os

if os.path.isfile("testnihaoinput/g8.26e11/g8.26e11.00320.ewah"):
    print("removing ewah")
    os.unlink("testnihaoinput/g8.26e11/g8.26e11.00320.ewah")
if os.path.isfile("testnihaoinput/g8.26e11/g8.26e11.00320-hsml"):
    print("removing hsml")
    os.unlink("testnihaoinput/g8.26e11/g8.26e11.00320-hsml")

#ds = yt.load("testnihaoinput/g2.63e10/g2.63e10.00320")
ds = yt.load("testnihaoinput/g8.26e11/g8.26e11.00320")

dd = ds.all_data()

import h5py

f = h5py.File("output_big.h5", "w")

for ft, fn in ds.field_list:
    if ft not in f: f.create_group(ft)
    print("Creating ", ft, fn, dd[ft, fn].size)
    f[ft].create_dataset(fn, data=dd[ft, fn])
f.close()
```

The results are identical between the two.  I should note that for some reason reading "smoothing_length" doesn't work, which is a bit confusing for me.