### PR TITLE
[bugfix] Fix field size for array fields in ytdata.

### DIFF
--- a/yt/frontends/ytdata/io.py
+++ b/yt/frontends/ytdata/io.py
@@ -150,7 +150,7 @@ class IOHandlerYTGridHDF5(BaseIOHandler):
                        for ax in "xyz")
                     for field in field_list:
                         if np.asarray(f[ptype][field]).ndim > 1:
-                            self._array_fields[field] = f[ptype][field].shape
+                            self._array_fields[field] = f[ptype][field].shape[1:]
                     yield ptype, (x, y, z)
             if f: f.close()
 

--- a/yt/frontends/ytdata/tests/test_outputs.py
+++ b/yt/frontends/ytdata/tests/test_outputs.py
@@ -131,11 +131,14 @@ def test_grid_datacontainer_data():
     ds = data_dir_load(enzotiny)
 
     cg = ds.covering_grid(level=0, left_edge=[0.25]*3, dims=[16]*3)
-    fn = cg.save_as_dataset(fields=["density", "particle_mass"])
+    fn = cg.save_as_dataset(fields=["density", "particle_mass",
+                                    "particle_position"])
     full_fn = os.path.join(tmpdir, fn)
     cg_ds = load(full_fn)
     compare_unit_attributes(ds, cg_ds)
     assert isinstance(cg_ds, YTGridDataset)
+    assert cg['all', 'particle_position'].shape == \
+      cg_ds.r['all', 'particle_position'].shape
     yield YTDataFieldTest(full_fn, ("grid", "density"))
     yield YTDataFieldTest(full_fn, ("all", "particle_mass"))
 


### PR DESCRIPTION
Without this fix, array fields loaded by the `ytdata` frontend will be calculated to have size `(nparticles, nparticles, dimensions)`, instead of just `(nparticles, dimensions)`.

## PR Checklist

- [x] Code passes flake8 checker
- [x] Adds a test for any bugs fixed. Adds tests for new features.