### PR TITLE
[WIP] yt-4.0 added refined status and cell sizes to cyoctree 

### DIFF
--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -2190,7 +2190,9 @@ class YTOctree(YTSelectionContainer3D):
     _spatial = True
     _type_name = "octree"
     _con_args = ('left_edge', 'right_edge', 'n_ref')
-    _container_fields = (("index", "dx"),
+    _container_fields = (
+                         ("index", "refined"),
+                         ("index", "dx"),
                          ("index", "dy"),
                          ("index", "dz"),
                          ("index", "x"),
@@ -2277,11 +2279,24 @@ class YTOctree(YTSelectionContainer3D):
                 mylog.info('Detected hash mismatch, regenerating Octree')
                 self._generate_tree(fname)
 
+        # Setup some octree indexes
         pos = ds.arr(self._octree.cell_positions, "code_length")
         self[('index', 'coordinates')] = pos
         self[('index', 'x')] = pos[:, 0]
         self[('index', 'y')] = pos[:, 1]
         self[('index', 'z')] = pos[:, 2]
+
+        self[('index', 'refined')] = self._octree.refined
+
+        self[('index', 'dx')] = ds.arr(
+            self._octree.cell_sizes(0), "code_length"
+        )
+        self[('index', 'dy')] = ds.arr(
+            self._octree.cell_sizes(1), "code_length"
+        )
+        self[('index', 'dz')] = ds.arr(
+            self._octree.cell_sizes(2), "code_length"
+        )
 
         return self._octree
 

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -2214,6 +2214,7 @@ class YTOctree(YTSelectionContainer3D):
         self.density_factor = density_factor
         self.over_refine_factor = over_refine_factor
         self.ptypes = self._sanitize_ptypes(ptypes)
+        self.force_build = force_build
 
         self._setup_data_source()
         self.tree
@@ -2266,9 +2267,7 @@ class YTOctree(YTSelectionContainer3D):
         else:
             fname = ds.tree_filename
 
-        if fname is None:
-            self._generate_tree(fname)
-        elif not os.path.exists(fname):
+        if (fname is None) or (not os.path.exists(name)) or (self.force_build):
             self._generate_tree(fname)
         else:
             self.loaded = True

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -2267,7 +2267,7 @@ class YTOctree(YTSelectionContainer3D):
         else:
             fname = ds.tree_filename
 
-        if (fname is None) or (not os.path.exists(name)) or (self.force_build):
+        if (fname is None) or (not os.path.exists(fname)) or (self.force_build):
             self._generate_tree(fname)
         else:
             self.loaded = True

--- a/yt/utilities/lib/cyoctree.pyx
+++ b/yt/utilities/lib/cyoctree.pyx
@@ -409,9 +409,15 @@ cdef class CyOctree:
         z = 0
         for i in range(self.nodes.size()):
             if self.nodes[i].leaf == 0:
+                # Not refined
                 refined[z] = 1
                 z += 1
             else:
+                # Add the cell
+                refined[z] = 1
+                z += 1
+
+                # Add the unrefined next level
                 for j in range(self._num_cells_per_dim):
                     for k in range(self._num_cells_per_dim):
                         for l in range(self._num_cells_per_dim):


### PR DESCRIPTION
## PR Summary

Added the refined field, and the size of cells in various dimensions to the octree
e.g

```
octree = ...
```
in the case of 1 oct, refined into 8 leaves,
```
octree[('index', 'refined')]
```
returns
```
[True, False, False, False, False, False, False, False, False]
```

**this needs tests and docs**

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
