### PR TITLE
[BUGFIX] Fix for WarpX datasets where 'rigid injected' species are used.

### DIFF
--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -1449,6 +1449,9 @@ class WarpXHeader(object):
             line = f.readline()
             while line:
                 line = line.strip().split()
+                if (len(line) == 1):
+                    line = f.readline()
+                    continue
                 self.data["species_%d" % i] = [float(val) for val in line]
                 i = i + 1
                 line = f.readline()


### PR DESCRIPTION
A recent change to WarpX broke reading the output in yt when "Rigid Injected" particle species were used. This un-breaks it. 
