### PR TITLE
Replace deprecated input_units kwarg with units.

### DIFF
--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -179,7 +179,7 @@ class YTDataContainer(metaclass = RegisteredDataContainer):
             arr.units.registry = self.ds.unit_registry
             return arr.to(units)
         except AttributeError:
-            return self.ds.arr(arr, input_units=units)
+            return self.ds.arr(arr, units=units)
 
     def _set_center(self, center):
         if center is None:
@@ -1413,14 +1413,14 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface):
         read_fluids, gen_fluids = self.index._read_fluid_fields(
                                         fluids, self, self._current_chunk)
         for f, v in read_fluids.items():
-            self.field_data[f] = self.ds.arr(v, input_units = finfos[f].units)
+            self.field_data[f] = self.ds.arr(v, units = finfos[f].units)
             self.field_data[f].convert_to_units(finfos[f].output_units)
 
         read_particles, gen_particles = self.index._read_particle_fields(
                                         particles, self, self._current_chunk)
 
         for f, v in read_particles.items():
-            self.field_data[f] = self.ds.arr(v, input_units = finfos[f].units)
+            self.field_data[f] = self.ds.arr(v, units = finfos[f].units)
             self.field_data[f].convert_to_units(finfos[f].output_units)
 
         fields_to_generate += gen_fluids + gen_particles
@@ -1788,14 +1788,14 @@ class YTSelectionContainer2D(YTSelectionContainer):
             if isinstance(w, tuple) and isinstance(u, tuple):
                 height = u
                 w, u = w
-            width = self.ds.quan(w, input_units = u)
+            width = self.ds.quan(w, units = u)
         elif not isinstance(width, YTArray):
             width = self.ds.quan(width, 'code_length')
         if height is None:
             height = width
         elif iterable(height):
             h, u = height
-            height = self.ds.quan(h, input_units = u)
+            height = self.ds.quan(h, units = u)
         elif not isinstance(height, YTArray):
             height = self.ds.quan(height, 'code_length')
         if not iterable(resolution):

--- a/yt/data_objects/image_array.py
+++ b/yt/data_objects/image_array.py
@@ -75,8 +75,8 @@ class ImageArray(YTArray):
     Numpy ndarray documentation appended:
 
     """
-    def __new__(cls, input_array, units=None, input_units=None, registry=None, info=None,
-                bypass_validation=False):
+    def __new__(cls, input_array, units=None, registry=None, info=None,
+                bypass_validation=False, input_units=None):
         if input_units is not None:
             warnings.warn("'input_units' is deprecated. Please use 'units'.")
             units = input_units

--- a/yt/data_objects/image_array.py
+++ b/yt/data_objects/image_array.py
@@ -75,10 +75,13 @@ class ImageArray(YTArray):
     Numpy ndarray documentation appended:
 
     """
-    def __new__(cls, input_array, input_units=None, registry=None, info=None,
+    def __new__(cls, input_array, units=None, input_units=None, registry=None, info=None,
                 bypass_validation=False):
+        if input_units is not None:
+            warnings.warn("'input_units' is deprecated. Please use 'units'.")
+            units = input_units
         obj = super(ImageArray, cls).__new__(
-            cls, input_array, input_units, registry,
+            cls, input_array, units, registry,
             bypass_validation=bypass_validation)
         if info is None:
             info = {}

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1172,16 +1172,17 @@ class Dataset(metaclass = RegisteredDataset):
         """Converts an array into a :class:`yt.units.yt_array.YTArray`
 
         The returned YTArray will be dimensionless by default, but can be
-        cast to arbitrary units using the ``input_units`` keyword argument.
+        cast to arbitrary units using the ``units`` keyword argument.
 
         Parameters
         ----------
 
         input_array : Iterable
             A tuple, list, or array to attach units to
-        input_units : String unit specification, unit symbol or astropy object
+        units: String unit specification, unit symbol or astropy object
             The units of the array. Powers must be specified using python syntax
             (cm**3, not cm^3).
+        input_units : Deprecated in favor of 'units'
         dtype : string or NumPy dtype object
             The dtype of the returned array data
 
@@ -1218,16 +1219,17 @@ class Dataset(metaclass = RegisteredDataset):
         """Converts an scalar into a :class:`yt.units.yt_array.YTQuantity`
 
         The returned YTQuantity will be dimensionless by default, but can be
-        cast to arbitrary units using the ``input_units`` keyword argument.
+        cast to arbitrary units using the ``units`` keyword argument.
 
         Parameters
         ----------
 
         input_scalar : an integer or floating point scalar
             The scalar to attach units to
-        input_units : String unit specification, unit symbol or astropy object
+        units: String unit specification, unit symbol or astropy object
             The units of the quantity. Powers must be specified using python
             syntax (cm**3, not cm^3).
+        input_units : Deprecated in favor of 'units'
         dtype : string or NumPy dtype object
             The dtype of the array data.
 
@@ -1383,7 +1385,7 @@ class Dataset(metaclass = RegisteredDataset):
             fields = [np.ascontiguousarray(f) for f in fields]
             d = data.deposit(pos, fields, method=method,
                              kernel_name=kernel_name)
-            d = data.ds.arr(d, input_units=units)
+            d = data.ds.arr(d, units=units)
             if method == 'weighted_mean':
                 d[np.isnan(d)] = 0.0
             return d

--- a/yt/data_objects/tests/test_compose.py
+++ b/yt/data_objects/tests/test_compose.py
@@ -16,7 +16,7 @@ def setup():
 # each cell from cell positions
 def _IDFIELD(field, data):
     width = data.ds.domain_right_edge - data.ds.domain_left_edge
-    min_dx = YTArray(1.0/8192, input_units='code_length',
+    min_dx = YTArray(1.0/8192, units='code_length',
                      registry=data.ds.unit_registry)
     delta = width / min_dx
     x = data['x'] - min_dx / 2.

--- a/yt/data_objects/tests/test_image_array.py
+++ b/yt/data_objects/tests/test_image_array.py
@@ -52,7 +52,7 @@ class TestImageArray(unittest.TestCase):
         os.chdir(self.tmpdir)
 
     def test_image_arry_units(self):
-        im_arr = ImageArray(dummy_image(0.3, 3), input_units='cm')
+        im_arr = ImageArray(dummy_image(0.3, 3), units='cm')
 
         assert str(im_arr.units) == 'cm'
 
@@ -67,7 +67,7 @@ class TestImageArray(unittest.TestCase):
                   'normal_vector': np.array([0., 1., 0.]),
                   'width': 0.245, 'type': 'rendering'}
 
-        im_arr = ImageArray(dummy_image(0.3, 3), input_units='cm', info=myinfo)
+        im_arr = ImageArray(dummy_image(0.3, 3), units='cm', info=myinfo)
         im_arr.save('test_3d_ImageArray', png=False)
 
         im = np.zeros([64, 128])
@@ -79,7 +79,7 @@ class TestImageArray(unittest.TestCase):
                   'normal_vector': np.array([0., 1., 0.]),
                   'width': 0.245, 'type': 'rendering'}
 
-        im_arr = ImageArray(im, info=myinfo, input_units='cm')
+        im_arr = ImageArray(im, info=myinfo, units='cm')
         im_arr.save('test_2d_ImageArray', png=False)
 
         im_arr.save('test_2d_ImageArray_ds', png=False, dataset_name='Random_DS')

--- a/yt/fields/angular_momentum.py
+++ b/yt/fields/angular_momentum.py
@@ -38,7 +38,7 @@ def setup_angular_momentum(registry, ftype = "gas", slice_info = None):
         rv = obtain_position_vector(data)
         units = rv.units
         rv = np.rollaxis(rv, 0, len(rv.shape))
-        rv = data.ds.arr(rv, input_units=units)
+        rv = data.ds.arr(rv, units=units)
         return yv * rv[...,2] - zv * rv[...,1]
 
     def _specific_angular_momentum_y(field, data):
@@ -46,7 +46,7 @@ def setup_angular_momentum(registry, ftype = "gas", slice_info = None):
         rv = obtain_position_vector(data)
         units = rv.units
         rv = np.rollaxis(rv, 0, len(rv.shape))
-        rv = data.ds.arr(rv, input_units=units)
+        rv = data.ds.arr(rv, units=units)
         return - (xv * rv[...,2] - zv * rv[...,0])
 
     def _specific_angular_momentum_z(field, data):
@@ -54,7 +54,7 @@ def setup_angular_momentum(registry, ftype = "gas", slice_info = None):
         rv = obtain_position_vector(data)
         units = rv.units
         rv = np.rollaxis(rv, 0, len(rv.shape))
-        rv = data.ds.arr(rv, input_units=units)
+        rv = data.ds.arr(rv, units=units)
         return xv * rv[...,1] - yv * rv[...,0]
 
     registry.add_field((ftype, "specific_angular_momentum_x"),

--- a/yt/fields/field_detector.py
+++ b/yt/fields/field_detector.py
@@ -200,7 +200,7 @@ class FieldDetector(defaultdict):
             self.requested.append(field_name)
             return np.ones(self.NumberOfParticles)
         return YTArray(defaultdict.__missing__(self, field_name),
-                       input_units=finfo.units,
+                       units=finfo.units,
                        registry=self.ds.unit_registry)
 
     def get_field_parameter(self, param, default = 0.0):
@@ -241,7 +241,7 @@ class FieldDetector(defaultdict):
     id = 1
 
     def apply_units(self, arr, units):
-        return self.ds.arr(arr, input_units = units)
+        return self.ds.arr(arr, units = units)
 
     def has_field_parameter(self, param):
         return param in self.field_parameters
@@ -255,14 +255,14 @@ class FieldDetector(defaultdict):
             fc.shape = (self.nd*self.nd*self.nd, 3)
         else:
             fc = fc.transpose()
-        return self.ds.arr(fc, input_units = "code_length")
+        return self.ds.arr(fc, units = "code_length")
 
     @property
     def fcoords_vertex(self):
         fc = np.random.random((self.nd, self.nd, self.nd, 8, 3))
         if self.flat:
             fc.shape = (self.nd*self.nd*self.nd, 8, 3)
-        return self.ds.arr(fc, input_units = "code_length")
+        return self.ds.arr(fc, units = "code_length")
 
     @property
     def icoords(self):
@@ -287,5 +287,5 @@ class FieldDetector(defaultdict):
         fw = np.ones((self.nd**3, 3), dtype="float64") / self.nd
         if not self.flat:
             fw.shape = (self.nd, self.nd, self.nd, 3)
-        return self.ds.arr(fw, input_units = "code_length")
+        return self.ds.arr(fw, units = "code_length")
 

--- a/yt/fields/particle_fields.py
+++ b/yt/fields/particle_fields.py
@@ -171,7 +171,7 @@ def particle_deposition_functions(ptype, coord_name, mass_name, registry):
             top[bottom == 0] = 0.0
             bnz = bottom.nonzero()
             top[bnz] /= bottom[bnz]
-            d = data.ds.arr(top, input_units=units)
+            d = data.ds.arr(top, units=units)
             return d
         return _deposit_field
 

--- a/yt/frontends/gdf/data_structures.py
+++ b/yt/frontends/gdf/data_structures.py
@@ -126,7 +126,7 @@ class GDFHierarchy(GridIndex):
                 self.dataset.domain_dimensions
             dx[active_dims] /= self.dataset.refine_by ** levels[i]
             dxs.append(dx.in_units("code_length"))
-        dx = self.dataset.arr(dxs, input_units="code_length")
+        dx = self.dataset.arr(dxs, units="code_length")
         self.grid_left_edge = self.dataset.domain_left_edge + dx * glis
         self.grid_dimensions = gdims.astype("int32")
         self.grid_right_edge = self.grid_left_edge + dx * self.grid_dimensions

--- a/yt/frontends/ytdata/data_structures.py
+++ b/yt/frontends/ytdata/data_structures.py
@@ -623,7 +623,7 @@ class YTNonspatialGrid(AMRGridPatch):
                 else:
                     v = v.astype(np.float64)
             if convert:
-                self.field_data[f] = self.ds.arr(v, input_units = finfos[f].units)
+                self.field_data[f] = self.ds.arr(v, units = finfos[f].units)
                 self.field_data[f].convert_to_units(finfos[f].output_units)
 
         read_particles, gen_particles = self.index._read_fluid_fields(
@@ -637,7 +637,7 @@ class YTNonspatialGrid(AMRGridPatch):
                 else:
                     v = v.astype(np.float64)
             if convert:
-                self.field_data[f] = self.ds.arr(v, input_units = finfos[f].units)
+                self.field_data[f] = self.ds.arr(v, units = finfos[f].units)
                 self.field_data[f].convert_to_units(finfos[f].output_units)
 
         fields_to_generate += gen_fluids + gen_particles

--- a/yt/geometry/geometry_handler.py
+++ b/yt/geometry/geometry_handler.py
@@ -308,11 +308,11 @@ class YTDataChunk(object):
         if self._fast_index is not None:
             ci = self._fast_index.select_fcoords(
                 self.dobj.selector, self.data_size)
-            ci = YTArray(ci, input_units = "code_length",
+            ci = YTArray(ci, units = "code_length",
                          registry = self.dobj.ds.unit_registry)
             return ci
         ci = np.empty((self.data_size, 3), dtype='float64')
-        ci = YTArray(ci, input_units = "code_length",
+        ci = YTArray(ci, units = "code_length",
                      registry = self.dobj.ds.unit_registry)
         if self.data_size == 0: return ci
         ind = 0
@@ -344,11 +344,11 @@ class YTDataChunk(object):
         if self._fast_index is not None:
             ci = self._fast_index.select_fwidth(
                 self.dobj.selector, self.data_size)
-            ci = YTArray(ci, input_units = "code_length",
+            ci = YTArray(ci, units = "code_length",
                          registry = self.dobj.ds.unit_registry)
             return ci
         ci = np.empty((self.data_size, 3), dtype='float64')
-        ci = YTArray(ci, input_units = "code_length",
+        ci = YTArray(ci, units = "code_length",
                      registry = self.dobj.ds.unit_registry)
         if self.data_size == 0: return ci
         ind = 0
@@ -400,7 +400,7 @@ class YTDataChunk(object):
         nodes_per_elem = self.dobj.index.meshes[0].connectivity_indices.shape[1]
         dim = self.dobj.ds.dimensionality
         ci = np.empty((self.data_size, nodes_per_elem, dim), dtype='float64')
-        ci = YTArray(ci, input_units = "code_length",
+        ci = YTArray(ci, units = "code_length",
                      registry = self.dobj.ds.unit_registry)
         if self.data_size == 0: return ci
         ind = 0

--- a/yt/utilities/amr_kdtree/amr_kdtree.py
+++ b/yt/utilities/amr_kdtree/amr_kdtree.py
@@ -105,8 +105,8 @@ class Tree(object):
             grid = self.ds.index.grids[node.grid - self._id_offset]
             dds = grid.dds
             gle = grid.LeftEdge
-            nle = self.ds.arr(node.get_left_edge(), input_units="code_length")
-            nre = self.ds.arr(node.get_right_edge(), input_units="code_length")
+            nle = self.ds.arr(node.get_left_edge(), units="code_length")
+            nre = self.ds.arr(node.get_right_edge(), units="code_length")
             li = np.rint((nle-gle)/dds).astype('int32')
             ri = np.rint((nre-gle)/dds).astype('int32')
             dims = (ri - li).astype('int32')
@@ -130,8 +130,8 @@ class Tree(object):
             grid = self.ds.index.grids[node.grid - self._id_offset]
             dds = grid.dds
             gle = grid.LeftEdge
-            nle = self.ds.arr(node.get_left_edge(), input_units="code_length")
-            nre = self.ds.arr(node.get_right_edge(), input_units="code_length")
+            nle = self.ds.arr(node.get_left_edge(), units="code_length")
+            nre = self.ds.arr(node.get_right_edge(), units="code_length")
             li = np.rint((nle-gle)/dds).astype('int32')
             ri = np.rint((nre-gle)/dds).astype('int32')
             dims = (ri - li).astype('int32')

--- a/yt/utilities/parallel_tools/parallel_analysis_interface.py
+++ b/yt/utilities/parallel_tools/parallel_analysis_interface.py
@@ -809,7 +809,7 @@ class Communicator(object):
                     registry = UnitRegistry(lut=info[3], add_default_symbols=False)
                     if info[-1] == "ImageArray":
                         data = ImageArray(np.empty(info[0], dtype=info[1]),
-                                          input_units=info[2],
+                                          units=info[2],
                                           registry=registry)
                     else:
                         data = YTArray(np.empty(info[0], dtype=info[1]), 
@@ -1038,7 +1038,7 @@ class Communicator(object):
         if len(metadata) == 5:
             registry = UnitRegistry(lut=metadata[3], add_default_symbols=False)
             if metadata[-1] == "ImageArray":
-                arr = ImageArray(arr, input_units=metadata[2],
+                arr = ImageArray(arr, units=metadata[2],
                                  registry=registry)
             else:
                 arr = YTArray(arr, metadata[2], registry=registry)
@@ -1061,7 +1061,7 @@ class Communicator(object):
             # We assume send.units is consistent with the units
             # on the receiving end.
             if isinstance(send, ImageArray):
-                recv = ImageArray(recv, input_units=send.units)
+                recv = ImageArray(recv, units=send.units)
             else:
                 recv = YTArray(recv, send.units)
         recv[offset:offset+send.size] = send[:]

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -150,7 +150,7 @@ class FixedResolutionBuffer(object):
         except (KeyError, AttributeError):
             units = self.data_source[item].units
 
-        ia = ImageArray(buff, input_units=units, info=self._get_info(item))
+        ia = ImageArray(buff, units=units, info=self._get_info(item))
         self.data[item] = ia
         return self.data[item]
 
@@ -667,7 +667,7 @@ class ParticleImageBuffer(FixedResolutionBuffer):
                                       splat_vals)
         # remove values in no-particle region
         buff[buff_mask==0] = np.nan
-        ia = ImageArray(buff, input_units=data.units,
+        ia = ImageArray(buff, units=data.units,
                         info=self._get_info(item))
 
         # divide by the weight_field, if needed
@@ -680,7 +680,7 @@ class ParticleImageBuffer(FixedResolutionBuffer):
                                           py[mask],
                                           weight_data[mask])
             weight_array = ImageArray(weight_buff,
-                                      input_units=weight_data.units,
+                                      units=weight_data.units,
                                       info=self._get_info(item))
             # remove values in no-particle region
             weight_buff[weight_buff_mask==0] = np.nan

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -652,8 +652,8 @@ class GridBoundaryCallback(PlotCallback):
             block_ids.append(block.id)
         if len(GLE) == 0: return
         # Retain both units and registry
-        GLE = plot.ds.arr(GLE, input_units = GLE[0].units)
-        GRE = plot.ds.arr(GRE, input_units = GRE[0].units)
+        GLE = plot.ds.arr(GLE, units = GLE[0].units)
+        GRE = plot.ds.arr(GRE, units = GRE[0].units)
         levels = np.array(levels)
         min_level = self.min_level or 0
         max_level = self.max_level or levels.max()

--- a/yt/visualization/volume_rendering/camera.py
+++ b/yt/visualization/volume_rendering/camera.py
@@ -325,17 +325,17 @@ class Camera(Orientation):
         focus = data_source.get_field_parameter('center')
 
         if iterable(width) and len(width) > 1 and isinstance(width[1], str):
-            width = data_source.ds.quan(width[0], input_units=width[1])
+            width = data_source.ds.quan(width[0], units=width[1])
             # Now convert back to code length for subsequent manipulation
             width = width.in_units("code_length")  # .value
         if not iterable(width):
             width = data_source.ds.arr([width, width, width],
-                                       input_units='code_length')
+                                       units='code_length')
             # left/right, top/bottom, front/back
         if not isinstance(width, YTArray):
-            width = data_source.ds.arr(width, input_units="code_length")
+            width = data_source.ds.arr(width, units="code_length")
         if not isinstance(focus, YTArray):
-            focus = data_source.ds.arr(focus, input_units="code_length")
+            focus = data_source.ds.arr(focus, units="code_length")
 
         # We can't use the property setters yet, since they rely on attributes
         # that will not be set up until the base class initializer is called.

--- a/yt/visualization/volume_rendering/old_camera.py
+++ b/yt/visualization/volume_rendering/old_camera.py
@@ -173,15 +173,15 @@ class Camera(ParallelAnalysisInterface):
         self.sub_samples = sub_samples
         self.rotation_vector = north_vector
         if iterable(width) and len(width) > 1 and isinstance(width[1], str):
-            width = self.ds.quan(width[0], input_units=width[1])
+            width = self.ds.quan(width[0], units=width[1])
             # Now convert back to code length for subsequent manipulation
             width = width.in_units("code_length").value
         if not iterable(width):
             width = (width, width, width) # left/right, top/bottom, front/back 
         if not isinstance(width, YTArray):
-            width = self.ds.arr(width, input_units="code_length")
+            width = self.ds.arr(width, units="code_length")
         if not isinstance(center, YTArray):
-            center = self.ds.arr(center, input_units="code_length")
+            center = self.ds.arr(center, units="code_length")
         # Ensure that width and center are in the same units
         # Cf. https://bitbucket.org/yt_analysis/yt/issue/1080
         width.convert_to_units("code_length")
@@ -925,13 +925,13 @@ class Camera(ParallelAnalysisInterface):
         """
         dW = None
         if not isinstance(final, YTArray):
-            final = self.ds.arr(final, input_units = "code_length")
+            final = self.ds.arr(final, units = "code_length")
         if exponential:
             if final_width is not None:
                 if not iterable(final_width):
                     final_width = [final_width, final_width, final_width] 
                 if not isinstance(final_width, YTArray):
-                    final_width = self.ds.arr(final_width, input_units="code_length")
+                    final_width = self.ds.arr(final_width, units="code_length")
                     # left/right, top/bottom, front/back 
                 if (self.center == 0.0).all():
                     self.center += (final - self.center) / (10. * n_steps)
@@ -946,7 +946,7 @@ class Camera(ParallelAnalysisInterface):
                 if not iterable(final_width):
                     final_width = [final_width, final_width, final_width] 
                 if not isinstance(final_width, YTArray):
-                    final_width = self.ds.arr(final_width, input_units="code_length")
+                    final_width = self.ds.arr(final_width, units="code_length")
                     # left/right, top/bottom, front/back
                 dW = (1.0*final_width-self.width)/n_steps
             else:
@@ -1250,7 +1250,7 @@ class PerspectiveCamera(Camera):
         positions[:,:,1] = self.center[1]
         positions[:,:,2] = self.center[2]
 
-        positions = self.ds.arr(positions, input_units="code_length")
+        positions = self.ds.arr(positions, units="code_length")
 
         dummy = np.ones(3, dtype='float64')
         image.shape = (self.resolution[0], self.resolution[1],4)
@@ -1297,7 +1297,7 @@ class PerspectiveCamera(Camera):
         for i in range(0, sight_vector.shape[0]):
             sight_vector_norm = np.sqrt(np.dot(sight_vector[i], sight_vector[i]))
             sight_vector[i] = sight_vector[i]/sight_vector_norm
-        sight_vector = self.ds.arr(sight_vector.value, input_units='dimensionless')
+        sight_vector = self.ds.arr(sight_vector.value, units='dimensionless')
         sight_center = self.center + self.width[2] * self.orienter.unit_vectors[2]
 
         for i in range(0, sight_vector.shape[0]):
@@ -2040,8 +2040,8 @@ class StereoSphericalCamera(Camera):
     def __init__(self, *args, **kwargs):
         self.disparity = kwargs.pop('disparity', 0.)
         Camera.__init__(self, *args, **kwargs)
-        self.disparity = self.ds.arr(self.disparity, input_units="code_length")
-        self.disparity_s = self.ds.arr(0., input_units="code_length")
+        self.disparity = self.ds.arr(self.disparity, units="code_length")
+        self.disparity_s = self.ds.arr(0., units="code_length")
         if(self.resolution[0]/self.resolution[1] != 2):
             mylog.info('Warning: It\'s recommended to set the aspect ratio to be 2:1')
         self.resolution = np.asarray(self.resolution) + 2

--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -839,15 +839,16 @@ class Scene(object):
         """Converts an array into a :class:`yt.units.yt_array.YTArray`
 
         The returned YTArray will be dimensionless by default, but can be
-        cast to arbitrary units using the ``input_units`` keyword argument.
+        cast to arbitrary units using the ``units`` keyword argument.
 
         Parameters
         ----------
 
         input_array : Iterable
             A tuple, list, or array to attach units to
-        input_units : String unit specification, unit symbol object, or astropy
-                      units object
+        units: String unit specification, unit symbol object, or astropy
+            units object
+        input_units : deprecated in favor of 'units'
             The units of the array. Powers must be specified using python syntax
             (cm**3, not cm^3).
         dtype : string or NumPy dtype object
@@ -882,15 +883,16 @@ class Scene(object):
         """Converts an scalar into a :class:`yt.units.yt_array.YTQuantity`
 
         The returned YTQuantity will be dimensionless by default, but can be
-        cast to arbitrary units using the ``input_units`` keyword argument.
+        cast to arbitrary units using the ``units`` keyword argument.
 
         Parameters
         ----------
 
         input_scalar : an integer or floating point scalar
             The scalar to attach units to
-        input_units : String unit specification, unit symbol object, or astropy
-                      units
+        units : String unit specification, unit symbol object, or astropy
+            units
+        input_units : deprecated in favor of 'units'
             The units of the quantity. Powers must be specified using python
             syntax (cm**3, not cm^3).
         dtype : string or NumPy dtype object


### PR DESCRIPTION
The `input_units` kwarg is deprecated in unyt. This was giving enough deprecation warnings to cause tests of other packages to fail because the logs were too long.