### PR TITLE
[bugfix] Fix Tipsy bug introduced by unyt

### DIFF
--- a/yt/frontends/tipsy/data_structures.py
+++ b/yt/frontends/tipsy/data_structures.py
@@ -249,7 +249,7 @@ class TipsyDataset(SPHDataset):
                 self.hubble_constant /= self.quan(100, 'km/s/Mpc')
                 # If we leave it as a YTQuantity, the cosmology object
                 # used below will add units back on.
-                self.hubble_constant = self.hubble_constant.in_units("").d
+                self.hubble_constant = self.hubble_constant.to_value("")
         else:
             mu = self.parameters.get('dMsolUnit', 1.0)
             self.mass_unit = self.quan(mu, 'Msun')


### PR DESCRIPTION
This PR fixes a very small bug introduced in the Tipsy frontend reported by @ibutsky. The `hubble_constant` was being passed as a NumPy array with one value instead of a floating-point value, which is expected by `unyt` when constructing new units. 

Closes Issue https://github.com/yt-project/yt/issues/2299.