### PR TITLE
[bugfix] minor Unyt fixes

### DIFF
--- a/yt/frontends/ytdata/data_structures.py
+++ b/yt/frontends/ytdata/data_structures.py
@@ -322,11 +322,6 @@ class YTDataLightRayDataset(YTDataContainerDataset):
             return
         self.light_ray_solution = \
           [{} for val in self.parameters[lrs_fields[0]]]
-        for sp3 in ["unique_identifier", "filename"]:
-            ksp3 = "%s_%s" % (key, sp3)
-            if ksp3 not in lrs_fields:
-                continue
-            self.parameters[ksp3] = self.parameters[ksp3].astype(str)
         for field in lrs_fields:
             field_name = field[len(key)+1:]
             for i in range(self.parameters[field].shape[0]):


### PR DESCRIPTION
Two fixes:
1. Since Unyt PR, we no longer need to convert `ytdata` parameters into strings manually.
2. `h` is not in the `UnitRegistry` by default, and `prefixable=True` must be added when adding units.