### PR TITLE
[FEATURE] Add "minimal sphere" implementation

### DIFF
--- a/doc/source/analyzing/objects.rst
+++ b/doc/source/analyzing/objects.rst
@@ -405,6 +405,11 @@ for the grid cell to be incorporated.
     | Usage: ``sphere(center, radius, ds=None, field_parameters=None, data_source=None)``
     | A sphere defined by a central coordinate and a radius.
 
+**Minimal Bounding Sphere**
+    | Class :class:`~yt.data_objects.selection_data_containers.YTMinimalSphere`
+    | Usage: ``minimal_sphere(points, ds=None, field_parameters=None, data_source=None)``
+    | A sphere that contains all the points passed as argument.
+
 .. _collection-objects:
 
 Filtering and Collection Objects

--- a/doc/source/analyzing/objects.rst
+++ b/doc/source/analyzing/objects.rst
@@ -395,9 +395,9 @@ for the grid cell to be incorporated.
 **Ellipsoid**
     | Class :class:`~yt.data_objects.selection_data_containers.YTEllipsoid`
     | Usage: ``ellipsoid(center, semi_major_axis_length, semi_medium_axis_length, semi_minor_axis_length, semi_major_vector, tilt, fields=None, ds=None, field_parameters=None, data_source=None)``
-    | An ellipsoid with axis magnitudes set by semi_major_axis_length,
-     semi_medium_axis_length, and semi_minor_axis_length.  semi_major_vector
-     sets the direction of the semi_major_axis.  tilt defines the orientation
+    | An ellipsoid with axis magnitudes set by ``semi_major_axis_length``,
+     ``semi_medium_axis_length``, and ``semi_minor_axis_length``.  ``semi_major_vector``
+     sets the direction of the ``semi_major_axis``.  ``tilt`` defines the orientation
      of the semi-medium and semi_minor axes.
 
 **Sphere**

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -21,3 +21,4 @@ pyaml==17.10.0
 mpi4py==3.0.0
 unyt==2.2.2
 pyyaml>=4.2b1
+MiniballCpp>=0.2.1

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -74,7 +74,8 @@ class RegisteredDataContainer(type):
     def __init__(cls, name, b, d):
         type.__init__(cls, name, b, d)
         if hasattr(cls, "_type_name") and not cls._skip_add:
-            data_object_registry[cls._type_name] = cls
+            name = getattr(cls, "_override_selector_name", cls._type_name)
+            data_object_registry[name] = cls
 
 class YTDataContainer(metaclass = RegisteredDataContainer):
     """

--- a/yt/data_objects/selection_data_containers.py
+++ b/yt/data_objects/selection_data_containers.py
@@ -807,7 +807,7 @@ class YTMinimalSphere(YTSelectionContainer3D):
 
     Parameters
     ----------
-    points : array or YTArray
+    points : YTArray
         The points that the sphere will contain.
 
     Examples
@@ -826,6 +826,7 @@ class YTMinimalSphere(YTSelectionContainer3D):
         validate_object(ds, Dataset)
         validate_object(field_parameters, dict)
         validate_object(data_source, YTSelectionContainer)
+        validate_object(points, YTArray)
 
         points = fix_length(points, ds)
         if len(points) < 2:

--- a/yt/data_objects/selection_data_containers.py
+++ b/yt/data_objects/selection_data_containers.py
@@ -808,7 +808,7 @@ class YTMinimalSphere(YTSelectionContainer3D):
     Parameters
     ----------
     points : array or YTArray
-        The points around that the sphere will contain.
+        The points that the sphere will contain.
 
     Examples
     --------

--- a/yt/data_objects/selection_data_containers.py
+++ b/yt/data_objects/selection_data_containers.py
@@ -27,7 +27,8 @@ from yt.units.yt_array import \
 from yt.utilities.exceptions import \
     YTSphereTooSmall, \
     YTIllDefinedCutRegion, \
-    YTEllipsoidOrdering
+    YTEllipsoidOrdering, \
+    YTException
 from yt.utilities.lib.pixelization_routines import \
     SPHKernelInterpolationTable
 from yt.utilities.minimal_representation import \
@@ -35,7 +36,7 @@ from yt.utilities.minimal_representation import \
 from yt.utilities.math_utils import get_rotation_matrix
 from yt.utilities.orientation import Orientation
 from yt.geometry.selection_routines import points_in_cells
-from yt.utilities.on_demand_imports import _scipy
+from yt.utilities.on_demand_imports import _scipy, _miniball
 
 
 class YTPoint(YTSelectionContainer0D):
@@ -800,6 +801,46 @@ class YTSphere(YTSelectionContainer3D):
         """
         return -self.radius + self.center, self.radius + self.center
 
+class YTMinimalSphere(YTSelectionContainer3D):
+    """
+    Build the smallest sphere that encompasses a set of points.
+
+    Parameters
+    ----------
+    points : array or YTArray
+        The points around that the sphere will contain.
+
+    Examples
+    --------
+
+    >>> import yt
+    >>> ds = yt.load("output_00080/info_00080.txt")
+    >>> points = ds.r['particle_position']
+    >>> sphere = ds.minimal_sphere(points)
+    """
+    _type_name = "sphere"
+    _override_selector_name = "minimal_sphere"
+    _con_args = ('center', 'radius')
+
+    def __init__(self, points, ds=None, field_parameters=None, data_source=None):
+        validate_object(ds, Dataset)
+        validate_object(field_parameters, dict)
+        validate_object(data_source, YTSelectionContainer)
+
+        points = fix_length(points, ds)
+        if len(points) < 2:
+            raise YTException("Not enough points. Expected at least 2, got %s" % len(points))
+        mylog.debug('Building minimal sphere around points.')
+        mb = _miniball.Miniball(points)
+        if not mb.is_valid():
+            raise YTException("Could not build valid sphere around points.")
+
+        center = ds.arr(mb.center(), points.units)
+        radius = ds.quan(np.sqrt(mb.squared_radius()), points.units)
+        super(YTMinimalSphere, self).__init__(center, ds, field_parameters, data_source)
+        self.set_field_parameter('radius', radius)
+        self.set_field_parameter("center", self.center)
+        self.radius = radius
 
 class YTEllipsoid(YTSelectionContainer3D):
     """

--- a/yt/data_objects/tests/test_spheres.py
+++ b/yt/data_objects/tests/test_spheres.py
@@ -2,7 +2,8 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 from yt.data_objects.profiles import create_profile
-from yt.testing import fake_random_ds, assert_equal, periodicity_cases, assert_raises
+from yt.testing import fake_random_ds, assert_equal, periodicity_cases, \
+    assert_raises, requires_module
 
 from yt.utilities.exceptions import YTException
 
@@ -80,6 +81,7 @@ def test_sphere_center():
     sp2 = ds.sphere("min_density", (0.25, 'unitary'))
     assert_array_equal(sp1.center, sp2.center)
 
+@requires_module("MiniballCpp")
 def test_minimal_sphere():
     ds = fake_random_ds(16, nprocs=8, particles=100)
 
@@ -97,6 +99,7 @@ def test_minimal_sphere():
     N2 = len(sp2['particle_ones'])
     assert N2 < N0
 
+@requires_module("MiniballCpp")
 def test_minimal_sphere_bad_inputs():
     ds = fake_random_ds(16, nprocs=8, particles=100)
     pos = ds.r['particle_position']

--- a/yt/data_objects/tests/test_spheres.py
+++ b/yt/data_objects/tests/test_spheres.py
@@ -2,7 +2,9 @@ import numpy as np
 from numpy.testing import assert_array_equal
 
 from yt.data_objects.profiles import create_profile
-from yt.testing import fake_random_ds, assert_equal, periodicity_cases
+from yt.testing import fake_random_ds, assert_equal, periodicity_cases, assert_raises
+
+from yt.utilities.exceptions import YTException
 
 
 def setup():
@@ -77,3 +79,31 @@ def test_sphere_center():
     sp1 = ds.sphere("min", (0.25, 'unitary'))
     sp2 = ds.sphere("min_density", (0.25, 'unitary'))
     assert_array_equal(sp1.center, sp2.center)
+
+def test_minimal_sphere():
+    ds = fake_random_ds(16, nprocs=8, particles=100)
+
+    pos = ds.r['particle_position']
+    sp1 = ds.minimal_sphere(pos)
+
+    N0 = len(pos)
+
+    # Check all particles have been found
+    N1 = len(sp1['particle_ones'])
+    assert_equal(N0, N1)
+
+    # Check that any smaller sphere is missing some particles
+    sp2 = ds.sphere(sp1.center, sp1.radius*0.9)
+    N2 = len(sp2['particle_ones'])
+    assert N2 < N0
+
+def test_minimal_sphere_bad_inputs():
+    ds = fake_random_ds(16, nprocs=8, particles=100)
+    pos = ds.r['particle_position']
+
+    ## Check number of points >= 2
+    # -> should fail
+    assert_raises(YTException, ds.minimal_sphere, pos[:1, :])
+
+    # -> should not fail
+    ds.minimal_sphere(pos[:2, :])

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -1197,7 +1197,7 @@ def validate_float(obj):
     """Validates if the passed argument is a float value.
 
     Raises an exception if `obj` is a single float value
-    or a YTQunatity of size 1.
+    or a YTQuantity of size 1.
 
     Parameters
     ----------

--- a/yt/utilities/on_demand_imports.py
+++ b/yt/utilities/on_demand_imports.py
@@ -480,7 +480,8 @@ class NotMiniball(NotAModule):
         super(NotMiniball, self).__init__(pkg_name)
         str = ("This functionality requires the %s package to be installed. "
                "Installation instructions can be found at "
-               "https://github.com/weddige/miniball.")
+               "https://github.com/weddige/miniball or alternatively you can "
+               "install via `pip install MiniballCpp`.")
         self.error = ImportError(str % self.pkg_name)
 
 class miniball_imports(object):

--- a/yt/utilities/on_demand_imports.py
+++ b/yt/utilities/on_demand_imports.py
@@ -475,6 +475,14 @@ class yaml_imports(object):
 
 _yaml = yaml_imports()
 
+class NotMiniball(NotAModule):
+    def __init__(self, pkg_name):
+        super(NotMiniball, self).__init__(pkg_name)
+        str = ("This functionality requires the %s package to be installed. "
+               "Installation instructions can be found at "
+               "https://github.com/weddige/miniball.")
+        self.error = ImportError(str % self.pkg_name)
+
 class miniball_imports(object):
     _name = 'miniball'
     _Miniball = None
@@ -485,7 +493,7 @@ class miniball_imports(object):
             try:
                 from miniball import Miniball
             except ImportError:
-                Miniball = NotAModule(self._name)
+                Miniball = NotMiniball(self._name)
             self._Miniball = Miniball
         return self._Miniball
 

--- a/yt/utilities/on_demand_imports.py
+++ b/yt/utilities/on_demand_imports.py
@@ -474,3 +474,19 @@ class yaml_imports(object):
         return self._load
 
 _yaml = yaml_imports()
+
+class miniball_imports(object):
+    _name = 'miniball'
+    _Miniball = None
+
+    @property
+    def Miniball(self):
+        if self._Miniball is None:
+            try:
+                from miniball import Miniball
+            except ImportError:
+                Miniball = NotAModule(self._name)
+            self._Miniball = Miniball
+        return self._Miniball
+
+_miniball = miniball_imports()


### PR DESCRIPTION
## PR Summary

This PR adds a "minimum sphere" function that creates a minimum bounding sphere around a set of points. This is useful to get the smallest spherical volume that contains e.g. some particles.

## PR Checklist

- [x] Code passes flake8 checker
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

This is the same as https://github.com/yt-project/yt/pull/2283 but to be merged onto yt-4.0.