### PR TITLE
[bugfix] fix unit error for au in docs build

### DIFF
--- a/doc/helper_scripts/show_fields.py
+++ b/doc/helper_scripts/show_fields.py
@@ -54,8 +54,10 @@ ds.cosmology = Cosmology(hubble_constant=ds.hubble_constant,
                          unit_registry=ds.unit_registry)
 for my_unit in ["m", "pc", "AU", "au"]:
     new_unit = "%scm" % my_unit
-    ds.unit_registry.add(new_unit, base_ds.unit_registry.lut[my_unit][0],
-                         dimensions.length, "\\rm{%s}/(1+z)" % my_unit)
+    my_u = Unit(my_unit, registry=ds.unit_registry)
+    ds.unit_registry.add(new_unit, my_u.base_value,
+                         dimensions.length, "\\rm{%s}/(1+z)" % my_unit,
+                         prefixable=True)
 
 
 


### PR DESCRIPTION
## PR Summary

This PR fixes an error that I encountered while trying to build the documentation locally for the yt-4.0 branch on my machine with Python 3.6.5 and unyt 2.3.0. When trying to build the html documentation with sphinx I encountered this error (I've only copied the last part):

```
Exception occurred:
  File "/Users/madicken/python/anaconda/envs/ytdev/lib/python3.6/subprocess.py", line 418, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['/Users/madicken/python/anaconda/envs/ytdev/bin/python3.6', './helper_scripts/show_fields.py']' returned non-zero exit status 1. 
```

running this file with python showed an issue with our list of units in the `./doc/helper_scripts/show_fields.py` file. 

```
$ python ./helper_scripts/show_fields.py
yt : [INFO     ] 2019-08-19 15:19:07,569 Parameters: current_time              = 0.0
yt : [INFO     ] 2019-08-19 15:19:07,569 Parameters: domain_dimensions         = [4 4 4]
yt : [INFO     ] 2019-08-19 15:19:07,570 Parameters: domain_left_edge          = [0. 0. 0.]
yt : [INFO     ] 2019-08-19 15:19:07,570 Parameters: domain_right_edge         = [1. 1. 1.]
yt : [INFO     ] 2019-08-19 15:19:07,570 Parameters: cosmological_simulation   = 0.0
yt : [INFO     ] 2019-08-19 15:19:09,400 Parameters: current_time              = 0.0
yt : [INFO     ] 2019-08-19 15:19:09,400 Parameters: domain_dimensions         = [16 16 16]
yt : [INFO     ] 2019-08-19 15:19:09,400 Parameters: domain_left_edge          = [0. 0. 0.]
yt : [INFO     ] 2019-08-19 15:19:09,401 Parameters: domain_right_edge         = [1. 1. 1.]
yt : [INFO     ] 2019-08-19 15:19:09,401 Parameters: cosmological_simulation   = 0.0
Traceback (most recent call last):
  File "./helper_scripts/show_fields.py", line 57, in <module>
    ds.unit_registry.add(new_unit, base_ds.unit_registry.lut[my_unit][0],
KeyError: 'au'
```

Neither "Au" or "au" are used in the generated md file, so I could have removed them but instead opted to be consistent with how other files were changed with the unyt update. This PR should update the file to be compatible with unyt and generate the html documentation without error. 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

