### PR TITLE
Check if pluginfilename option is specified in ytrc

### DIFF
--- a/yt/utilities/configure.py
+++ b/yt/utilities/configure.py
@@ -12,6 +12,7 @@ import shutil
 import sys
 import argparse
 from yt.config import CURRENT_CONFIG_FILE, _OLD_CONFIG_FILE, YTConfigParser
+from yt.extern.six.moves import configparser
 
 CONFIG = YTConfigParser()
 CONFIG.read([CURRENT_CONFIG_FILE])
@@ -46,16 +47,19 @@ def migrate_config():
     os.rename(_OLD_CONFIG_FILE, _OLD_CONFIG_FILE + '.bak')
 
     old_config_dir = os.path.dirname(_OLD_CONFIG_FILE)
-    plugin_file = CONFIG.get('yt', 'pluginfilename')
-    if plugin_file and \
-            os.path.exists(os.path.join(old_config_dir, plugin_file)):
-        print('Migrating plugin file {} to new location'.format(plugin_file))
-        shutil.copyfile(
-            os.path.join(old_config_dir, plugin_file),
-            os.path.join(os.path.dirname(CURRENT_CONFIG_FILE), plugin_file))
-        print('Backing up the old plugin file: {}.bak'.format(_OLD_CONFIG_FILE))
-        plugin_file = os.path.join(old_config_dir, plugin_file)
-        os.rename(plugin_file, plugin_file + '.bak')
+    try:
+        plugin_file = CONFIG.get('yt', 'pluginfilename')
+        if plugin_file and \
+                os.path.exists(os.path.join(old_config_dir, plugin_file)):
+            print('Migrating plugin file {} to new location'.format(plugin_file))
+            shutil.copyfile(
+                os.path.join(old_config_dir, plugin_file),
+                os.path.join(os.path.dirname(CURRENT_CONFIG_FILE), plugin_file))
+            print('Backing up the old plugin file: {}.bak'.format(_OLD_CONFIG_FILE))
+            plugin_file = os.path.join(old_config_dir, plugin_file)
+            os.rename(plugin_file, plugin_file + '.bak')
+    except configparser.NoOptionError:
+        pass
 
 
 def rm_config(section, option):


### PR DESCRIPTION
Running `yt config migrate` on a config file without the `pluginfilename`
option returns the following error.

```python
Writing a new config file to: /home/mdevalbo/.config/yt/ytrc
Backing up the old config file: /home/mdevalbo/.yt/config.bak
Traceback (most recent call last):
  File "/usr/lib/python3.7/configparser.py", line 788, in get
    value = d[option]
  File "/usr/lib/python3.7/collections/__init__.py", line 916, in __getitem__
    return self.__missing__(key)            # support subclasses that define __missing__
  File "/usr/lib/python3.7/collections/__init__.py", line 908, in __missing__
    raise KeyError(key)
KeyError: 'pluginfilename'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/mdevalbo/.local/bin/yt", line 11, in <module>
    load_entry_point('yt', 'console_scripts', 'yt')()
  File "/home/mdevalbo/project/yt-project/yt/yt/utilities/command_line.py", line 1409, in run_main
    args.func(args)
  File "/home/mdevalbo/project/yt-project/yt/yt/utilities/command_line.py", line 237, in run
    self(args)
  File "/home/mdevalbo/project/yt-project/yt/yt/utilities/command_line.py", line 1276, in __call__
    migrate_config()
  File "/home/mdevalbo/project/yt-project/yt/yt/utilities/configure.py", line 49, in migrate_config
    plugin_file = CONFIG.get('yt', 'pluginfilename')
  File "/home/mdevalbo/project/yt-project/yt/yt/config.py", line 137, in get
    val = super(YTConfigParser, self).get(section, option, *args, **kwargs)
  File "/usr/lib/python3.7/configparser.py", line 791, in get
    raise NoOptionError(option, section)
configparser.NoOptionError: No option 'pluginfilename' in section: 'yt'

```

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

Using a try statement to handle the `NoOptionError` exception when the option `pluginfilename` is not specified in the config file.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
