### PR TITLE
[bugfix] Fix code magnetic units, etc

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -997,16 +997,21 @@ class Dataset(metaclass = RegisteredDataset):
         else:
             current_mks_unit = 'A'
         magnetic_unit = getattr(self, 'magnetic_unit', None)
-        if magnetic_unit is not None and unit_system == "cgs":
-            # if the magnetic unit is in T, we need to create the code unit
-            # system as an MKS-like system
-            if current_mks in self.magnetic_unit.units.dimensions.free_symbols:
-                # this is perhaps a little funky
-                self.magnetic_unit = self.magnetic_unit.to('T').to('gauss')
-            # The following modification ensures that we get the conversion to 
-            # cgs correct
-            self.unit_registry.modify("code_magnetic", 
-                                      self.magnetic_unit.value*0.1**0.5)
+        if magnetic_unit is not None:
+            if unit_system == "mks":
+                if current_mks not in self.magnetic_unit.units.dimensions.free_symbols:
+                    self.magnetic_unit = self.magnetic_unit.to('gauss').to('T')
+                self.unit_registry.modify("code_magnetic", self.magnetic_unit.value)
+            else:
+                # if the magnetic unit is in T, we need to create the code unit
+                # system as an MKS-like system
+                if current_mks in self.magnetic_unit.units.dimensions.free_symbols:
+                    self.magnetic_unit = self.magnetic_unit.to('T').to('gauss')
+                # The following modification ensures that we get the conversion to 
+                # cgs correct
+                self.unit_registry.modify("code_magnetic", 
+                                          self.magnetic_unit.value*0.1**0.5)
+
         us = create_code_unit_system(
             self.unit_registry, current_mks_unit=current_mks_unit)
         if unit_system != "code":
@@ -1026,10 +1031,10 @@ class Dataset(metaclass = RegisteredDataset):
         self.unit_registry.add("code_specific_energy", 1.0,
                                dimensions.energy / dimensions.mass)
         self.unit_registry.add("code_time", 1.0, dimensions.time)
-        if unit_system == "cgs":
-            self.unit_registry.add("code_magnetic", 0.1**0.5, dimensions.magnetic_field_cgs)
+        if unit_system == "mks":
+            self.unit_registry.add("code_magnetic", 1.0, dimensions.magnetic_field)
         else:
-            self.unit_registry.add("code_magnetic", .0001, dimensions.magnetic_field)
+            self.unit_registry.add("code_magnetic", 0.1**0.5, dimensions.magnetic_field_cgs)
         self.unit_registry.add("code_temperature", 1.0, dimensions.temperature)
         self.unit_registry.add("code_pressure", 0.1, dimensions.pressure)
         self.unit_registry.add("code_velocity", .01, dimensions.velocity)

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1001,9 +1001,12 @@ class Dataset(metaclass = RegisteredDataset):
             # if the magnetic unit is in T, we need to create the code unit
             # system as an MKS-like system
             if current_mks in self.magnetic_unit.units.dimensions.free_symbols:
-                    # this is perhaps a little funky
-                    self.magnetic_unit = self.magnetic_unit.to('T').to('gauss')
-            self.unit_registry.modify("code_magnetic", self.magnetic_unit)
+                # this is perhaps a little funky
+                self.magnetic_unit = self.magnetic_unit.to('T').to('gauss')
+            # The following modification ensures that we get the conversion to 
+            # cgs correct
+            self.unit_registry.modify("code_magnetic", 
+                                      self.magnetic_unit.value*0.1**0.5)
         us = create_code_unit_system(
             self.unit_registry, current_mks_unit=current_mks_unit)
         if unit_system != "code":
@@ -1024,7 +1027,7 @@ class Dataset(metaclass = RegisteredDataset):
                                dimensions.energy / dimensions.mass)
         self.unit_registry.add("code_time", 1.0, dimensions.time)
         if unit_system == "cgs":
-            self.unit_registry.add("code_magnetic", 1.0, dimensions.magnetic_field_cgs)
+            self.unit_registry.add("code_magnetic", 0.1**0.5, dimensions.magnetic_field_cgs)
         else:
             self.unit_registry.add("code_magnetic", .0001, dimensions.magnetic_field)
         self.unit_registry.add("code_temperature", 1.0, dimensions.temperature)

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -112,7 +112,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
                 g = f["/%s" % ptype]
                 if getattr(selector, 'is_all_data', False):
                     mask = slice(None, None, None)
-                    mask_sum = ei-si
+                    mask_sum = data_file.total_particles[ptype]
                     hsmls = None
                 else:
                     coords = g["Coordinates"][si:ei].astype("float64")

--- a/yt/frontends/owls/fields.py
+++ b/yt/frontends/owls/fields.py
@@ -153,6 +153,19 @@ class OWLSFieldInfo(SPHFieldInfo):
                 #---------------------------------------------------
                 add_species_field_by_density(self, ptype, yt_ion)
 
+            
+            def _h_p1_density(field, data):
+                return data[ptype, "H_density"] - data[ptype, "H_p0_density"]
+
+            self.add_field((ptype, "H_p1_density"),
+                           sampling_type="particle",
+                           function=_h_p1_density,
+                           units=self.ds.unit_system["density"])
+
+            add_species_field_by_density(self, ptype, "H_p1")
+            for sfx in ["mass", "density", "number_density"]:
+                fname = "H_p1_" + sfx
+                self.alias(("gas", fname), (ptype, fname))
 
             # alias ion fields
             #-----------------------------------------------

--- a/yt/units/tests/test_magnetic_code_units.py
+++ b/yt/units/tests/test_magnetic_code_units.py
@@ -8,7 +8,8 @@ def test_magnetic_code_units():
     ddims = (16,)*3
     data = {"density": (np.random.uniform(size=ddims), "g/cm**3")}
 
-    ds1 = load_uniform_grid(data, ddims, magnetic_unit=(sqrt4pi, "gauss"))
+    ds1 = load_uniform_grid(data, ddims, magnetic_unit=(sqrt4pi, "gauss"),
+                            unit_system='cgs')
 
     assert_allclose(ds1.magnetic_unit.value, sqrt4pi)
     assert str(ds1.magnetic_unit.units) == "G"
@@ -17,11 +18,32 @@ def test_magnetic_code_units():
     assert_allclose(mucu.value, 1.0)
     assert str(mucu.units) == "code_magnetic"
 
-    ds2 = load_uniform_grid(data, ddims, magnetic_unit=(1.0, "T"))
+    ds2 = load_uniform_grid(data, ddims, magnetic_unit=(1.0, "T"), 
+                            unit_system='cgs')
 
     assert_allclose(ds2.magnetic_unit.value, 10000.)
     assert str(ds2.magnetic_unit.units) == "G"
 
     mucu = ds2.magnetic_unit.to("code_magnetic")
+    assert_allclose(mucu.value, 1.0)
+    assert str(mucu.units) == "code_magnetic"
+
+    ds3 = load_uniform_grid(data, ddims, magnetic_unit=(1.0, "T"),
+                            unit_system='mks')
+
+    assert_allclose(ds3.magnetic_unit.value, 1.0)
+    assert str(ds3.magnetic_unit.units) == "T"
+
+    mucu = ds3.magnetic_unit.to("code_magnetic")
+    assert_allclose(mucu.value, 1.0)
+    assert str(mucu.units) == "code_magnetic"
+
+    ds4 = load_uniform_grid(data, ddims, magnetic_unit=(1.0, "gauss"),
+                            unit_system='mks')
+
+    assert_allclose(ds4.magnetic_unit.value, 1.0e-4)
+    assert str(ds4.magnetic_unit.units) == "T"
+
+    mucu = ds4.magnetic_unit.to("code_magnetic")
     assert_allclose(mucu.value, 1.0)
     assert str(mucu.units) == "code_magnetic"

--- a/yt/units/tests/test_magnetic_code_units.py
+++ b/yt/units/tests/test_magnetic_code_units.py
@@ -1,0 +1,27 @@
+import numpy as np
+from yt.frontends.stream.api import load_uniform_grid
+from yt.testing import assert_allclose
+
+def test_magnetic_code_units():
+
+    sqrt4pi = np.sqrt(4.0*np.pi)
+    ddims = (16,)*3
+    data = {"density": (np.random.uniform(size=ddims), "g/cm**3")}
+
+    ds1 = load_uniform_grid(data, ddims, magnetic_unit=(sqrt4pi, "gauss"))
+
+    assert_allclose(ds1.magnetic_unit.value, sqrt4pi)
+    assert str(ds1.magnetic_unit.units) == "G"
+
+    mucu = ds1.magnetic_unit.to("code_magnetic")
+    assert_allclose(mucu.value, 1.0)
+    assert str(mucu.units) == "code_magnetic"
+
+    ds2 = load_uniform_grid(data, ddims, magnetic_unit=(1.0, "T"))
+
+    assert_allclose(ds2.magnetic_unit.value, 10000.)
+    assert str(ds2.magnetic_unit.units) == "G"
+
+    mucu = ds2.magnetic_unit.to("code_magnetic")
+    assert_allclose(mucu.value, 1.0)
+    assert str(mucu.units) == "code_magnetic"


### PR DESCRIPTION
This PR fixes incorrect conversions between code units for magnetic fields and other magnetic field units. It ensures that no matter what unit system we are using and no matter what unit the magnetic field has, the conversions happen correctly. I added a test for this.

I threw in two other bug fixes for good measure:

* `OWLSFieldInfo` did not define ionized hydrogen fields.
* Deriving the mass field for Gadget datasets (and their derivatives) was not happening correctly when 1) the mass value is in the mass array and 2) the `is_all_data` selector is being used.