### PR TITLE
doc:  Fix minor typo

### DIFF
--- a/doc/source/visualizing/volume_rendering.rst
+++ b/doc/source/visualizing/volume_rendering.rst
@@ -74,7 +74,7 @@ with a series of
 hanging off of it that describe the contents
 of that volume.  It also contains a
 :class:`~yt.visualization.volume_rendering.camera.Camera` for rendering that
-volume..  All of its classes can be
+volume.  All of its classes can be
 accessed and modified as properties hanging off of the scene.
 The scene's most important functions are
 :meth:`~yt.visualization.volume_rendering.scene.Scene.render` for


### PR DESCRIPTION
Remove a double full stop in yt/doc/source/visualizing/volume_rendering.rst

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
