### PR TITLE
Solve the cython numpy array resizing issue

### DIFF
--- a/yt/utilities/lib/bounded_priority_queue.pxd
+++ b/yt/utilities/lib/bounded_priority_queue.pxd
@@ -43,7 +43,6 @@ cdef class NeighborList:
     cdef np.intp_t size
     cdef np.intp_t _max_size
 
-    cdef int _resize(self) except -1
     cdef int _update_memview(self) except -1
     cdef int _extend(self) nogil except -1
     cdef int add_pid(self, np.float64_t val, np.int64_t ind) nogil except -1

--- a/yt/utilities/lib/bounded_priority_queue.pxd
+++ b/yt/utilities/lib/bounded_priority_queue.pxd
@@ -43,5 +43,7 @@ cdef class NeighborList:
     cdef np.intp_t size
     cdef np.intp_t _max_size
 
+    cdef int _resize(self) except -1
+    cdef int _update_memview(self) except -1
     cdef int _extend(self) nogil except -1
     cdef int add_pid(self, np.float64_t val, np.int64_t ind) nogil except -1

--- a/yt/utilities/lib/bounded_priority_queue.pyx
+++ b/yt/utilities/lib/bounded_priority_queue.pyx
@@ -172,21 +172,6 @@ cdef class NeighborList:
     @cython.wraparound(False)
     @cython.cdivision(True)
     @cython.initializedcheck(False)
-    cdef int _resize(self) except -1:
-        self.data_ptr = <np.float64_t*> PyMem_Realloc(
-            self.data_ptr,
-            self._max_size * sizeof(np.float64_t)
-        )
-        self.pids_ptr = <np.int64_t*> PyMem_Realloc(
-            self.pids_ptr,
-            self._max_size * sizeof(np.int64_t)
-        )
-        self._update_memview()
-
-    @cython.boundscheck(False)
-    @cython.wraparound(False)
-    @cython.cdivision(True)
-    @cython.initializedcheck(False)
     cdef int _update_memview(self) except -1:
         self.data = <np.float64_t[:self._max_size]> self.data_ptr
         self.pids = <np.int64_t[:self._max_size]> self.pids_ptr
@@ -199,7 +184,15 @@ cdef class NeighborList:
         if self.size == self._max_size:
             self._max_size *= 2
             with gil:
-                self._resize()
+                self.data_ptr = <np.float64_t*> PyMem_Realloc(
+                    self.data_ptr,
+                    self._max_size * sizeof(np.float64_t)
+                )
+                self.pids_ptr = <np.int64_t*> PyMem_Realloc(
+                    self.pids_ptr,
+                    self._max_size * sizeof(np.int64_t)
+                )
+                self._update_memview()
         return 0
 
     @cython.boundscheck(False)

--- a/yt/utilities/lib/bounded_priority_queue.pyx
+++ b/yt/utilities/lib/bounded_priority_queue.pyx
@@ -21,6 +21,7 @@ import numpy as np
 cimport numpy as np
 
 cimport cython
+from cpython.mem cimport PyMem_Realloc
 
 cdef class BoundedPriorityQueue:
     def __cinit__(self, np.intp_t max_elements, np.intp_t pids=0):
@@ -168,8 +169,12 @@ cdef class NeighborList:
         if self.size == self._max_size:
             self._max_size *= 2
             with gil:
-                self.data.resize(self._max_size)
-                self.pids.resize(self._max_size)
+                self.data_ptr = <np.float64_t*> PyMem_Realloc(self.data_ptr,
+                    self._max_size * sizeof(np.float64_t))
+                self.data = <np.float64_t[:self._max_size]> self.data_ptr
+                self.pids_ptr = <np.int64_t*> PyMem_Realloc(self.pids_ptr,
+                    self._max_size * sizeof(np.int64_t))
+                self.pids = <np.int64_t[:self._max_size]> self.pids_ptr
         return 0
 
     @cython.boundscheck(False)

--- a/yt/utilities/lib/bounded_priority_queue.pyx
+++ b/yt/utilities/lib/bounded_priority_queue.pyx
@@ -239,3 +239,12 @@ def validate():
 
     return np.asarray(m.heap)
 
+def validate_nblist():
+    nblist = NeighborList(init_size=2)
+
+    for i in range(4):
+        nblist.add_pid(1.0, i)
+
+    # Copy is necessary here. Without it, the allocated memory would be freed.
+    # Leaving random data array.
+    return np.asarray(nblist.data).copy(), np.asarray(nblist.pids).copy()

--- a/yt/utilities/lib/tests/test_nn.py
+++ b/yt/utilities/lib/tests/test_nn.py
@@ -1,6 +1,9 @@
 import numpy as np
 
-from yt.utilities.lib.bounded_priority_queue import validate, validate_pid
+from yt.utilities.lib.bounded_priority_queue import \
+    validate, \
+    validate_pid, \
+    validate_nblist
 
 from yt.testing import assert_array_equal
 
@@ -19,3 +22,9 @@ def test_bounded_priority_queue_pid():
     assert_array_equal(answers, dists)
     assert_array_equal(answers_pids, pids)
 
+def test_neighbor_list():
+    data, pids = validate_nblist()
+    answers_data = np.array([1.0, 1.0, 1.0, 1.0])
+    answers_pids = np.array([0, 1, 2, 3])
+    assert_array_equal(answers_data, data)
+    assert_array_equal(answers_pids, pids)


### PR DESCRIPTION
## PR Summary

This PR fixes #2326. The example code crashes because memoryviews don't have a `resize` method. It's tricky to resize a numpy array in cython.

## PR Checklist

- [x] Code passes flake8 checker.
- [x] Adds a test for any bugs fixed.
