### PR TITLE
Return p0 alias fields.

### DIFF
--- a/yt/fields/species_fields.py
+++ b/yt/fields/species_fields.py
@@ -243,4 +243,10 @@ def setup_species_fields(registry, ftype = "gas", slice_info = None):
             # Skip it
             continue
         func(registry, ftype, species)
+        # Adds aliases for all neutral species from their raw "MM_"
+        # species to "MM_p0_" species to be explicit.
+        # See YTEP-0003 for more details.
+        if ChemicalFormula(species).charge == 0:
+            alias_species = "%s_p0" % species.split('_')[0]
+            add_species_aliases(registry, "gas", alias_species, species)
     add_nuclei_density_fields(registry, ftype)


### PR DESCRIPTION
This undoes a change that removed the aliasing of `<element>_p0_<field>` to `<element>_<field>` (e.g., H_p0_density to H_density). This has caused a breakage in Trident, where the `p0` field names are used. My understanding was that the decision made in YTEP-0003 to leave out the `p0` in neutral ions was now largely considered to be a mistake. Either way, unless this breaks something in yt, I'd like to bring this back.

@jzuhone made this change. John, is there a reason we can't bring this back? Let me know if I've missed something.