### PR TITLE
[BUGFIX] Fix build failure on Windows

### DIFF
--- a/yt/units/tests/test_ytarray.py
+++ b/yt/units/tests/test_ytarray.py
@@ -1417,3 +1417,14 @@ def test_clip():
 
     assert_array_equal(data, answer)
     assert data.units == answer.units
+
+    left_edge = [0.0, 0.0, 0.0] * km
+    right_edge = [1.0, 1.0, 1.0] * km
+
+    positions = [[0.0, 0.0, 0.0],
+                 [1.0, 1.0, -0.1],
+                 [1.5, 1.0, 0.9]] * km
+    np.clip(positions, left_edge, right_edge, positions)
+    assert positions.units == left_edge.units
+    assert positions.max() == 1.0 * km
+    assert positions.min() == 0.0 * km

--- a/yt/units/yt_array.py
+++ b/yt/units/yt_array.py
@@ -1405,7 +1405,7 @@ class YTArray(np.ndarray):
                 if ufunc is clip:
                     inp = []
                     for i in inputs:
-                        if isinstance(i, unyt_array):
+                        if isinstance(i, YTArray):
                             inp.append(i.to(inputs[0].units).view(np.ndarray))
                         elif _iterable(i):
                             inp.append(np.asarray(i))

--- a/yt/units/yt_array.py
+++ b/yt/units/yt_array.py
@@ -1403,7 +1403,14 @@ class YTArray(np.ndarray):
                         unit, units, out, out_arr)
             else:
                 if ufunc is clip:
-                    inp = (inputs[0].view(np.ndarray), inputs[1], inputs[2])
+                    inp = []
+                    for i in inputs:
+                        if isinstance(i, unyt_array):
+                            inp.append(i.to(inputs[0].units).view(np.ndarray))
+                        elif _iterable(i):
+                            inp.append(np.asarray(i))
+                        else:
+                            inp.append(i)
                     if out is not None:
                         _out = out.view(np.ndarray)
                     else:

--- a/yt/units/yt_array.py
+++ b/yt/units/yt_array.py
@@ -1407,7 +1407,7 @@ class YTArray(np.ndarray):
                     for i in inputs:
                         if isinstance(i, YTArray):
                             inp.append(i.to(inputs[0].units).view(np.ndarray))
-                        elif _iterable(i):
+                        elif iterable(i):
                             inp.append(np.asarray(i))
                         else:
                             inp.append(i)


### PR DESCRIPTION
At present, this adds a diagnostic test for the `np.clip` function that
should help us to identify why builds are now failing on appveyor for
python 3.6 with recursion counts at `yt/frontends/ytdata/io.py` line
351.