### PR TITLE
Append required FITS keywords in header

### DIFF
--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -660,14 +660,8 @@ class SpectralCubeFITSDataset(SkyDataFITSDataset):
         self.spec_axis = np.where(self.spec_axis)[0][0]
         self.spec_name = spec_names[self.ctypes[self.spec_axis].split("-")[0][0]]
 
-        self.wcs_2d = _astropy.pywcs.WCS(naxis=2)
-        self.wcs_2d.wcs.crpix = self.wcs.wcs.crpix[[self.lon_axis, self.lat_axis]]
-        self.wcs_2d.wcs.cdelt = self.wcs.wcs.cdelt[[self.lon_axis, self.lat_axis]]
-        self.wcs_2d.wcs.crval = self.wcs.wcs.crval[[self.lon_axis, self.lat_axis]]
-        self.wcs_2d.wcs.cunit = [str(self.wcs.wcs.cunit[self.lon_axis]),
-                                 str(self.wcs.wcs.cunit[self.lat_axis])]
-        self.wcs_2d.wcs.ctype = [self.wcs.wcs.ctype[self.lon_axis],
-                                 self.wcs.wcs.ctype[self.lat_axis]]
+        # Extract a subimage from a WCS object
+        self.wcs_2d = self.wcs.sub(["longitude", "latitude"])
 
         self._p0 = self.wcs.wcs.crpix[self.spec_axis]
         self._dz = self.wcs.wcs.cdelt[self.spec_axis]

--- a/yt/frontends/fits/misc.py
+++ b/yt/frontends/fits/misc.py
@@ -168,9 +168,11 @@ def ds9_region(ds, reg, obj=None, field_parameters=None):
     else:
         r = pyregion.parse(reg)
     reg_name = reg
-    filter = r.get_filter(header=ds.wcs_2d.to_header())
-    nx = ds.domain_dimensions[ds.lon_axis]
-    ny = ds.domain_dimensions[ds.lat_axis]
+    header = ds.wcs_2d.to_header()
+    # The FITS header only contains WCS-related keywords
+    header["NAXIS1"] = nx = ds.domain_dimensions[ds.lon_axis]
+    header["NAXIS2"] = ny = ds.domain_dimensions[ds.lat_axis]
+    filter = r.get_filter(header=header)
     mask = filter.mask((ny, nx)).transpose()
     if isinstance(ds, EventsFITSDataset):
         prefix = "event_"


### PR DESCRIPTION
Creating a ds9 region with `yt.frontends.fits.misc.ds9_region` produces the error below
as in the FITS radio cubes notebook in the documentation:

http://yt-project.org/docs/dev/cookbook/fits_radio_cubes.html


```
~/.local/lib64/python3.6/site-packages/astropy/io/fits/header.py in _cardindex(self, key)
   1652
   1653         if not indices:
-> 1654             raise KeyError("Keyword {!r} not found.".format(keyword))
   1655
   1656         try:
KeyError: "Keyword 'NAXIS1' not found."
```
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->
This fixes the error below when creating a ds9 region. The FITS header created by
the `astropy.wcs.WCS.to_header` only contains WCS related keywords, and the required `NAXIS` keywords have to be supplied after calling `to_header`.

In SpectralCubeFITSDataset, the coordinate description in wcs_2d can be equivalently obtained using `astropy.wcs.WCS.sub` so a few lines a are gone in `data_structures.py`.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
