### PR TITLE
Various species density issues

### DIFF
--- a/yt/fields/species_fields.py
+++ b/yt/fields/species_fields.py
@@ -286,6 +286,8 @@ def setup_species_fields(registry, ftype = "gas", slice_info = None):
         # These are deprecated and will be removed soon.
         if ChemicalFormula(species).charge == 0:
             alias_species = species.split("_")[0]
+            if (ftype, "{}_density".format(alias_species)) in registry:
+                continue
             add_deprecated_species_aliases(
                 registry, "gas", alias_species, species)
 

--- a/yt/frontends/gizmo/fields.py
+++ b/yt/frontends/gizmo/fields.py
@@ -103,6 +103,16 @@ class GizmoFieldInfo(GadgetFieldInfo):
                 field = "%s%s" % (species, suf)
                 self.alias(("gas", field), (ptype, field))
 
+        if (ptype, "ElectronAbundance") in self.field_list:
+            def _el_number_density(field, data):
+                return data[ptype, "ElectronAbundance"] * \
+                       data[ptype, "H_number_density"]
+            self.add_field((ptype, "El_number_density"),
+                           sampling_type="particle",
+                           function=_el_number_density,
+                           units=self.ds.unit_system["number_density"])
+            self.alias(("gas", "El_number_density"), (ptype, "El_number_density"))
+
         for species in self.nuclei_names:
             self.add_field((ptype, "%s_nuclei_mass_density" % species),
                            sampling_type="particle",

--- a/yt/frontends/owls/fields.py
+++ b/yt/frontends/owls/fields.py
@@ -167,6 +167,16 @@ class OWLSFieldInfo(SPHFieldInfo):
                 fname = "H_p1_" + sfx
                 self.alias(("gas", fname), (ptype, fname))
 
+            def _el_number_density(field, data):
+                n_e = data[ptype, "H_p1_number_density"]
+                n_e += data[ptype, "He_p1_number_density"]
+                n_e += 2.0*data[ptype, "He_p2_number_density"]
+            self.add_field((ptype, "El_number_density"),
+                           sampling_type="particle",
+                           function=_el_number_density,
+                           units=self.ds.unit_system["number_density"])
+            self.alias(("gas", "El_number_density"), (ptype, "El_number_density"))
+
             # alias ion fields
             #-----------------------------------------------
             for ion in self._ions:


### PR DESCRIPTION
This is a quick follow-on to PR #2336. 

We should not set up the alias between `X_p0_density` and `X_density` fields if the frontend defines an `X_density` field for abundance information which does not have an ionization state. 

This PR also adds the `El_number_density` field to `OWLSFieldInfo` and `GizmoFieldInfo`.
