### PR TITLE
[bugfix] Fixing issues with particles

### DIFF
--- a/doc/source/analyzing/fields.rst
+++ b/doc/source/analyzing/fields.rst
@@ -510,6 +510,44 @@ of how to create and use these fields, see :ref:`cookbook-complicated-derived-fi
 
     ``add_gradient_fields`` currently only supports Cartesian geometries!
 
+.. _relative_fields:
+
+Relative Vector Fields
+----------------------
+
+yt makes use of "relative" fields for certain vector fields, which are fields
+which have been defined relative to a particular origin in the space of that
+field. For example, relative particle positions can be specified relative to
+a center coordinate, and relative velocities can be specified relative to a
+bulk velocity. These origin points are specified by setting field parameters
+as detailed below (see :ref:`field_parameters` for more information).
+
+The relative fields which are currently supported for gas fields are:
+
+* ``("gas", "relative_velocity_{xyz}")``, defined by setting the 
+  ``"bulk_velocity"`` field parameter
+* ``("gas", "relative_magnetic_field_{xyz}")``, defined by setting the 
+  ``"bulk_magnetic_field"`` field parameter
+
+For particle fields, for a given particle type ``ptype``, the relative 
+fields which are supported are:
+
+* ``(ptype, "relative_particle_position")``, defined by setting the 
+  ``"center"`` field parameter
+* ``(ptype, "relative_particle_velocity")``, defined by setting the 
+  ``"bulk_velocity"`` field parameter
+* ``(ptype, "relative_particle_position_{xyz}")``, defined by setting the 
+  ``"center"`` field parameter
+* ``(ptype, "relative_particle_velocity_{xyz}")``, defined by setting the 
+  ``"bulk_velocity"`` field parameter
+
+These fields are in use when defining magnitude fields, line-of-sight fields,
+etc.. The ``"bulk_{}"`` field parameters are ``[0.0, 0.0, 0.0]`` by default,
+and the ``"center"`` field parameter depends on the data container in use. 
+
+There is currently no mechanism to create new relative fields, but one may be
+added at a later time. 
+
 .. _los_fields:
 
 Line of Sight Fields
@@ -523,16 +561,16 @@ this will be handled automatically:
 
 .. code-block:: python
 
-    prj = yt.ProjectionPlot(ds, "z", ("gas","velocity_los"), 
-                            weight_field=("gas","density"))
+    prj = yt.ProjectionPlot(ds, "z", ("gas", "velocity_los"), 
+                            weight_field=("gas", "density"))
 
 Which, because the axis is ``"z"``, will give you the same result if you had
 projected the `"velocity_z"`` field. This also works for off-axis projections:
 
 .. code-block:: python
 
-    prj = yt.OffAxisProjectionPlot(ds, [0.1, -0.2, 0.3], ("gas","velocity_los"), 
-                                   weight_field=("gas","density"))
+    prj = yt.OffAxisProjectionPlot(ds, [0.1, -0.2, 0.3], ("gas", "velocity_los"), 
+                                   weight_field=("gas", "density"))
 
 
 This shows that the projection axis can be along a principle axis of the domain 
@@ -545,10 +583,10 @@ you want to examine a line-of-sight vector within a 3-D data object, set the
     dd = ds.all_data()
     # Set to one of [0, 1, 2] for ["x", "y", "z"] axes
     dd.set_field_parameter("axis", 1)
-    print(dd["gas","magnetic_field_los"])
+    print(dd["gas", "magnetic_field_los"])
     # Set to a three-vector for an off-axis component
     dd.set_field_parameter("axis", [0.3, 0.4, -0.7])
-    print(dd["gas","velocity_los"])
+    print(dd["gas", "velocity_los"])
 
 .. warning::
 
@@ -557,11 +595,11 @@ you want to examine a line-of-sight vector within a 3-D data object, set the
     ``del dd["velocity_los"]`` and re-generate it. 
 
 At this time, this functionality is enabled for the velocity and magnetic vector
-fields, ``("gas","velocity_los")`` and ``("gas","magnetic_field_los")``. The 
+fields, ``("gas", "velocity_los")`` and ``("gas", "magnetic_field_los")``. The 
 following fields built into yt make use of these line-of-sight fields:
 
-* ``("gas","sz_kinetic")`` uses ``("gas","velocity_los")``
-* ``("gas","rotation_measure")`` uses ``("gas","magnetic_field_los")``
+* ``("gas", "sz_kinetic")`` uses ``("gas", "velocity_los")``
+* ``("gas", "rotation_measure")`` uses ``("gas", "magnetic_field_los")``
 
 
 General Particle Fields

--- a/yt/fields/angular_momentum.py
+++ b/yt/fields/angular_momentum.py
@@ -15,6 +15,8 @@ from yt.utilities.lib.misc_utilities import \
 
 @register_field_plugin
 def setup_angular_momentum(registry, ftype = "gas", slice_info = None):
+    # Angular momentum defined here needs to be consistent with
+    # _particle_specific_angular_momentum in particle_fields.py
     unit_system = registry.ds.unit_system
     def _specific_angular_momentum_x(field, data):
         xv, yv, zv = obtain_relative_velocity_vector(data)
@@ -22,7 +24,7 @@ def setup_angular_momentum(registry, ftype = "gas", slice_info = None):
         units = rv.units
         rv = np.rollaxis(rv, 0, len(rv.shape))
         rv = data.ds.arr(rv, units=units)
-        return yv * rv[...,2] - zv * rv[...,1]
+        return rv[..., 1] * zv - rv[..., 2] * yv
 
     def _specific_angular_momentum_y(field, data):
         xv, yv, zv = obtain_relative_velocity_vector(data)
@@ -30,7 +32,7 @@ def setup_angular_momentum(registry, ftype = "gas", slice_info = None):
         units = rv.units
         rv = np.rollaxis(rv, 0, len(rv.shape))
         rv = data.ds.arr(rv, units=units)
-        return - (xv * rv[...,2] - zv * rv[...,0])
+        return rv[..., 2] * xv - rv[..., 0] * zv
 
     def _specific_angular_momentum_z(field, data):
         xv, yv, zv = obtain_relative_velocity_vector(data)
@@ -38,7 +40,7 @@ def setup_angular_momentum(registry, ftype = "gas", slice_info = None):
         units = rv.units
         rv = np.rollaxis(rv, 0, len(rv.shape))
         rv = data.ds.arr(rv, units=units)
-        return xv * rv[...,1] - yv * rv[...,0]
+        return rv[..., 0] * yv - rv[..., 1] * xv
 
     registry.add_field((ftype, "specific_angular_momentum_x"),
                        sampling_type="local",

--- a/yt/fields/particle_fields.py
+++ b/yt/fields/particle_fields.py
@@ -640,7 +640,8 @@ def standard_particle_fields(registry, ptype,
         """
         normal = data.get_field_parameter('normal')
         pos = data['relative_particle_position'].T
-        return data.ds.arr(get_cyl_r(pos, normal), 'code_length')
+        pos.convert_to_units("code_length")
+        return data.ds.arr(get_cyl_r(pos, normal), "code_length")
 
     registry.add_field((ptype, "particle_position_cylindrical_radius"),
                        sampling_type="particle",
@@ -674,7 +675,8 @@ def standard_particle_fields(registry, ptype,
         """
         normal = data.get_field_parameter('normal')
         pos = data['relative_particle_position'].T
-        return data.ds.arr(get_cyl_z(pos, normal), 'code_length')
+        pos.convert_to_units("code_length")
+        return data.ds.arr(get_cyl_z(pos, normal), "code_length")
 
     registry.add_field((ptype, "particle_position_cylindrical_z"),
                        sampling_type="particle",

--- a/yt/fields/particle_fields.py
+++ b/yt/fields/particle_fields.py
@@ -297,7 +297,7 @@ def standard_particle_fields(registry, ptype,
         # adding in the unit registry allows us to have a reference to the
         # dataset and thus we will always get the correct units after applying
         # the cross product.
-        return -ucross(r_vec, v_vec, registry=data.ds.unit_registry)
+        return ucross(r_vec, v_vec, registry=data.ds.unit_registry)
 
 
     registry.add_field((ptype, "particle_specific_angular_momentum"),

--- a/yt/fields/particle_fields.py
+++ b/yt/fields/particle_fields.py
@@ -26,6 +26,10 @@ from yt.utilities.math_utils import \
     get_sph_theta, get_sph_phi, \
     modify_reference_frame
 
+from yt.utilities.lib.misc_utilities import \
+    obtain_relative_velocity_vector, \
+    obtain_position_vector
+
 from .vector_operations import \
     create_magnitude_field
 
@@ -361,16 +365,12 @@ def standard_particle_fields(registry, ptype,
     def _relative_particle_position(field, data):
         """The cartesian particle positions in a rotated reference frame
 
-        Relative to the coordinate system defined by the *normal* vector and
-        *center* field parameters.
+        Relative to the coordinate system defined by *center* field parameter.
 
         Note that the orientation of the x and y axes are arbitrary.
         """
-        normal = data.get_field_parameter('normal')
-        center = data.get_field_parameter('center')
-        pos = data.ds.arr([data[ptype, spos % ax] for ax in "xyz"]).T
-        L, pos = modify_reference_frame(center, normal, P=pos)
-        return pos
+        field_names = [(ptype, 'particle_position_%s' % ax) for ax in "xyz"]
+        return obtain_position_vector(data, field_names=field_names).T
 
     def _particle_position_relative(field, data):
         if not isinstance(data, FieldDetector):
@@ -396,19 +396,13 @@ def standard_particle_fields(registry, ptype,
     def _relative_particle_velocity(field, data):
         """The vector particle velocities in an arbitrary coordinate system
 
-        Relative to the coordinate system defined by the *normal* vector,
-        *bulk_velocity* vector and *center* field parameters.
+        Relative to the coordinate system defined by the *bulk_velocity* 
+        vector field parameter.
 
         Note that the orientation of the x and y axes are arbitrary.
         """
-        normal = data.get_field_parameter('normal')
-        center = data.get_field_parameter('center')
-        bv = data.get_field_parameter("bulk_velocity")
-        vel = data.ds.arr(
-            [data[ptype, svel % ax] - bv[iax]
-             for iax, ax in enumerate("xyz")]).T
-        L, vel = modify_reference_frame(center, normal, V=vel)
-        return vel
+        field_names = [(ptype, 'particle_velocity_%s' % ax) for ax in "xyz"]
+        return obtain_relative_velocity_vector(data, field_names=field_names).T
 
     def _particle_velocity_relative(field, data):
         if not isinstance(data, FieldDetector):

--- a/yt/fields/tests/test_angular_momentum.py
+++ b/yt/fields/tests/test_angular_momentum.py
@@ -17,7 +17,7 @@ def test_AM_value():
     X = (ds.arr([sp[k] for k in 'xyz']) - x0[:, None]).T
     V = (ds.arr([sp['velocity_'+k] for k in 'xyz']) - v0[:, None]).T
 
-    sAM_manual = ds.arr(np.cross(V, X), X.units*V.units)
+    sAM_manual = ds.arr(np.cross(X, V), X.units*V.units)
     sAM = ds.arr([sp['specific_angular_momentum_'+k] for k in 'xyz']).T
 
     assert_allclose_units(sAM_manual, sAM)

--- a/yt/fields/tests/test_particle_fields.py
+++ b/yt/fields/tests/test_particle_fields.py
@@ -1,0 +1,20 @@
+import numpy as np
+from yt.testing import \
+    assert_allclose_units, \
+    requires_file
+from yt.utilities.answer_testing.framework import \
+    data_dir_load
+
+g30 = "IsolatedGalaxy/galaxy0030/galaxy0030"
+@requires_file(g30)
+def test_relative_particle_fields():
+    ds = data_dir_load(g30)
+    offset = ds.arr([0.1,-0.2,0.3], "code_length")
+    c = ds.domain_center+offset
+    sp = ds.sphere(c, (10, "kpc"))
+    bv = ds.arr([1.,2.,3.], "code_velocity")
+    sp.set_field_parameter("bulk_velocity", bv)
+    assert_allclose_units(sp["relative_particle_position"],
+                          sp["particle_position"]-c)
+    assert_allclose_units(sp["relative_particle_velocity"],
+                          sp["particle_velocity"]-bv)

--- a/yt/fields/tests/test_particle_fields.py
+++ b/yt/fields/tests/test_particle_fields.py
@@ -1,4 +1,3 @@
-import numpy as np
 from yt.testing import \
     assert_allclose_units, \
     requires_file

--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -1230,7 +1230,7 @@ cdef class DiskSelector(SelectorObject):
         h = d = 0
         for i in range(3):
             temp = self.periodic_difference(pos[i], self.center[i], i)
-            h += pos[i] * self.norm_vec[i]
+            h += temp * self.norm_vec[i]
             d += temp*temp
         r2 = (d - h*h)
         d = self.radius+radius

--- a/yt/utilities/lib/misc_utilities.pyx
+++ b/yt/utilities/lib/misc_utilities.pyx
@@ -568,7 +568,8 @@ def get_box_grids_below_level(
 @cython.cdivision(True)
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def obtain_position_vector(data):
+def obtain_position_vector(
+    data, field_names = ('x', 'y', 'z')):
     # This is just to let the pointers exist and whatnot.  We can't cdef them
     # inside conditionals.
     cdef np.ndarray[np.float64_t, ndim=1] xf
@@ -582,14 +583,14 @@ def obtain_position_vector(data):
     cdef np.float64_t c[3]
     cdef int i, j, k
 
-    units = data['x'].units
+    units = data[field_names[0]].units
     center = data.get_field_parameter("center").to(units)
     c[0] = center[0]; c[1] = center[1]; c[2] = center[2]
-    if len(data['x'].shape) == 1:
+    if len(data[field_names[0]].shape) == 1:
         # One dimensional data
-        xf = data['x']
-        yf = data['y']
-        zf = data['z']
+        xf = data[field_names[0]]
+        yf = data[field_names[1]]
+        zf = data[field_names[2]]
         rf = YTArray(np.empty((3, xf.shape[0]), 'float64'), xf.units)
         for i in range(xf.shape[0]):
             rf[0, i] = xf[i] - c[0]
@@ -598,9 +599,9 @@ def obtain_position_vector(data):
         return rf
     else:
         # Three dimensional data
-        xg = data['x']
-        yg = data['y']
-        zg = data['z']
+        xg = data[field_names[0]]
+        yg = data[field_names[1]]
+        zg = data[field_names[2]]
         shape = (3, xg.shape[0], xg.shape[1], xg.shape[2])
         rg = YTArray(np.empty(shape, 'float64'), xg.units)
         #rg = YTArray(rg, xg.units)


### PR DESCRIPTION
This is one of those PRs which basically led one down a rabbit hole, finding several issues along the way. 

1. The `DiskSelector` was computing selections incorrectly for SPH particles. 
2. The `relative_particle_position` and `relative_particle_velocity` fields were using `modify_reference_frame` to compute the relative fields. This takes a normal vector and then returns the relative coordinates in a rotated coordinate system, in which the new normal vector is the z-axis. However, the fields for particle positions in spherical and cylindrical coordinates (such as radius, etc.) were assuming the `normal` field parameter was the original one instead and using the relative fields, which gave incorrect results. I'm changing here the way the relative fields are computed, consistent with the way we handle relative fields from grid datasets, by only subtracting the center off. As far as I can tell, this only occurs in `particle_fields.py`.  
3. For some reason merges with master did not get the fixes from PR #2043 into the `yt-4.0` branch, this adds them back in.

Open to suggestions about new tests.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes flake8 checker
- [ ] Adds a test for any bugs fixed. 