### PR TITLE
fix kh2d test name

### DIFF
--- a/yt/frontends/enzo/tests/test_outputs.py
+++ b/yt/frontends/enzo/tests/test_outputs.py
@@ -106,7 +106,7 @@ def test_kh2d():
     ds = data_dir_load(kh2d)
     assert_equal(str(ds), 'DD0011')
     for test in small_patch_amr(ds, ds.field_list):
-        test_toro1d.__name__ = test.description
+        test_kh2d.__name__ = test.description
         yield test
 
 @requires_ds(enzotiny)
@@ -203,7 +203,7 @@ def test_deeply_nested_zoom():
 
     # carefully chosen to just barely miss a grid in the middle of the image
     center = [0.4915073260199302, 0.5052605316800006, 0.4905805557500548]
-    
+
     plot = SlicePlot(ds, 'z', 'density', width=(0.001, 'pc'),
                      center=center)
 


### PR DESCRIPTION
## PR Summary 

I noticed that the `test.__name__()` call in the kh2d test in the enzo frontend referred to the toro1d test rather than the kh2d test. This is a minor fix that updates that line. 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
