### PR TITLE
export directly from PlotWindow to FITS data

### DIFF
--- a/doc/source/visualizing/FITSImageData.ipynb
+++ b/doc/source/visualizing/FITSImageData.ipynb
@@ -267,7 +267,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Creating `FITSImageData` Instances Directly from FRBs and 3D Grids"
+    "## Creating `FITSImageData` Instances Directly from FRBs, PlowWindow instances, and 3D Grids"
    ]
   },
   {
@@ -286,6 +286,23 @@
     "slc3 = ds.slice(0, 0.0)\n",
     "frb = slc3.to_frb((500.,\"kpc\"), 800)\n",
     "fid_frb = frb.to_fits_data(fields=[(\"gas\", \"density\"), (\"gas\", \"temperature\")], length_unit=\"pc\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If one creates a `PlotWindow` instance, e.g. `SlicePlot`, `ProjectionPlot`, etc., you can also call this same method there:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fid_pw = prj.to_fits_data(fields=[(\"gas\", \"density\"), (\"gas\", \"temperature\")], \n",
+    "                          length_unit=\"pc\")"
    ]
   },
   {

--- a/doc/source/visualizing/FITSImageData.ipynb
+++ b/doc/source/visualizing/FITSImageData.ipynb
@@ -267,7 +267,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Creating `FITSImageData` Instances Directly from FRBs, PlowWindow instances, and 3D Grids"
+    "## Creating `FITSImageData` Instances Directly from FRBs, PlotWindow instances, and 3D Grids"
    ]
   },
   {

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -293,7 +293,8 @@ class FixedResolutionBuffer(object):
 
     def to_fits_data(self, fields=None, other_keys=None, length_unit=None,
                      **kwargs):
-        r"""Export a set of pixelized fields to a FITS file.
+        r"""Export the fields in this FixedResolutionBuffer instance 
+        to a FITSImageData instance.
 
         This will export a set of FITS images of either the fields specified
         or all the fields already in the object.

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -741,6 +741,28 @@ class PlotWindow(ImagePlotContainer):
     def toggle_right_handed(self):
         self._right_handed = not self._right_handed
 
+    def to_fits_data(self, fields=None, other_keys=None, length_unit=None,
+                     **kwargs):
+        r"""Export the fields in this PlotWindow instance 
+        to a FITSImageData instance.
+
+        This will export a set of FITS images of either the fields specified
+        or all the fields already in the object.
+
+        Parameters
+        ----------
+        fields : list of strings
+            These fields will be pixelized and output. If "None", the keys of 
+            the FRB will be used.
+        other_keys : dictionary, optional
+            A set of header keys and values to write into the FITS header.
+        length_unit : string, optional
+            the length units that the coordinates are written in. The default
+            is to use the default length unit of the dataset.
+        """
+        return self.frb.to_fits_data(fields=fields, other_keys=other_keys,
+                                     length_unit=length_unit, **kwargs)
+
 
 class PWViewerMPL(PlotWindow):
     """Viewer using matplotlib as a backend via the WindowPlotMPL.


### PR DESCRIPTION
The `FixedResolutionBuffer` class has a method `to_fits_data` that exports the fields in the buffer to a `FITSImageData` instance. This PR exposes that method to the `PlotWindow` class.