### PR TITLE
Ramses read namelist

### DIFF
--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -27,3 +27,4 @@ mpi4py==3.0.0
 pyyaml>=4.2b1
 xarray==0.12.3 ; python_version >= '3.0'
 firefly_api>=0.0.2
+f90nml>=1.1.2

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -595,6 +595,9 @@ class RAMSESDataset(Dataset):
                     nml = f90nml.read(f)
             except ImportError as e:
                 nml = "An error occurred when reading the namelist: %s" % str(e)
+            except ValueError as e:
+                mylog.warn("Could not parse `namelist.txt` file as it was malformed.")
+                return
 
             self.parameters['namelist'] = nml
 

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -596,7 +596,7 @@ class RAMSESDataset(Dataset):
             except ImportError as e:
                 nml = "An error occurred when reading the namelist: %s" % str(e)
             except ValueError as e:
-                mylog.warn("Could not parse `namelist.txt` file as it was malformed.")
+                mylog.warn("Could not parse `namelist.txt` file as it was malformed: %s" % str(e))
                 return
 
             self.parameters['namelist'] = nml

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -452,3 +452,11 @@ def test_namelist_reading():
     nml = ds.parameters['namelist']
 
     assert nml == ref
+
+ramses_empty_record = "ramses_empty_record/output_00003/info_00003.txt"
+@requires_ds(ramses_empty_record)
+@requires_module('f90nml')
+def test_namelist_reading_should_not_fail():
+    # Test that the reading does not fail for malformed namelist.txt files
+    ds = data_dir_load(output_00080)
+    ds.index  # should work

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -17,7 +17,8 @@ RAMSES frontend tests
 from yt.testing import \
     assert_equal, \
     requires_file, \
-    units_override_check
+    units_override_check, \
+    requires_module
 from yt.utilities.answer_testing.framework import \
     requires_ds, \
     data_dir_load, \
@@ -441,6 +442,7 @@ def test_ramses_empty_record():
 
 output_00080 = "output_00080/info_00080.txt"
 @requires_ds(output_00080)
+@requires_module('f90nml')
 def test_namelist_reading():
     import f90nml
     ds = data_dir_load(output_00080)

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -440,23 +440,25 @@ def test_ramses_empty_record():
     # Access some field
     ds.r[('gas', 'density')]
 
-output_00080 = "output_00080/info_00080.txt"
-@requires_ds(output_00080)
+@requires_ds(ramses_new_format)
 @requires_module('f90nml')
 def test_namelist_reading():
     import f90nml
-    ds = data_dir_load(output_00080)
-    with open(os.path.join(output_00080, 'namelist.txt'), 'r') as f:
+    ds = data_dir_load(ramses_new_format)
+    namelist_fname = os.path.join(ds.directory, 'namelist.txt')
+    with open(namelist_fname, 'r') as f:
         ref = f90nml.read(f)
 
     nml = ds.parameters['namelist']
 
     assert nml == ref
 
-ramses_empty_record = "ramses_empty_record/output_00003/info_00003.txt"
 @requires_ds(ramses_empty_record)
+@requires_ds(output_00080)
 @requires_module('f90nml')
 def test_namelist_reading_should_not_fail():
-    # Test that the reading does not fail for malformed namelist.txt files
-    ds = data_dir_load(output_00080)
-    ds.index  # should work
+
+    for ds_name in (ramses_empty_record, output_00080):
+        # Test that the reading does not fail for malformed namelist.txt files
+        ds = data_dir_load(ds_name)
+        ds.index  # should work

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -438,3 +438,15 @@ def test_ramses_empty_record():
 
     # Access some field
     ds.r[('gas', 'density')]
+
+output_00080 = "output_00080/info_00080.txt"
+@requires_ds(output_00080)
+def test_namelist_reading():
+    import f90nml
+    ds = data_dir_load(output_00080)
+    with open(os.path.join(output_00080, 'namelist.txt'), 'r') as f:
+        ref = f90nml.read(f)
+
+    nml = ds.parameters['namelist']
+
+    assert nml == ref

--- a/yt/utilities/on_demand_imports.py
+++ b/yt/utilities/on_demand_imports.py
@@ -487,3 +487,20 @@ class yaml_imports(object):
         return self._FullLoader
 
 _yaml = yaml_imports()
+
+
+class f90nml_imports(object):
+    _name = "f90nml"
+    _module = None
+
+    def __init__(self):
+        try:
+            import f90nml as myself
+            self._module = myself
+        except ImportError:
+            self._module = NotAModule(self._name)
+
+    def __getattr__(self, attr):
+        return getattr(self._module, attr)
+
+_f90nml = f90nml_imports()


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

This adds the automatic loading of the `namelist.txt` file which contains the parameter file RAMSES used to produce the output.
This relies on the package `f90nml` being installed (for the tests). If the package is absent, `ds.parameters['namelist']` contains an error message.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes flake8 checker
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
