### PR TITLE
[bugfix] WeightedVariance is broken in a couple of ways in yt-4.0

### DIFF
--- a/yt/data_objects/derived_quantities.py
+++ b/yt/data_objects/derived_quantities.py
@@ -409,8 +409,8 @@ class WeightedVariance(DerivedQuantity):
             my_var2 = values[i + int(len(values) / 2)]
             all_mean = (my_weight * my_mean).sum(dtype=np.float64) / all_weight
             ret = [(np.sqrt(
-                (my_weight * (my_var2 + (my_mean - all_mean)**2) / all_weight)
-                ).sum(dtype=np.float64)), all_mean]
+                (my_weight * (my_var2 + (my_mean - all_mean)**2)).sum(dtype=np.float64) /
+                all_weight)), all_mean]
             rvals.append(np.array(ret))
         return rvals
 


### PR DESCRIPTION
In the `yt-4.0` branch, the `WeightedVariance` derived quantity (and thus the `std` method of data containers which is downstream from it) has a couple of bugs. 

1. If one runs into a case where some chunks have a weight which sums to zero, the code returns floating-point zeros to be used in the final variance calculation. However, the chunks with data are not dimensionless in general, and so when one attempts to add everything together you get a `IterableUnitCoercionError`. This PR fixes that by dropping the units during the calculating and assigning them at the end. 

2. I also noticed after fixing 1. that the answers given were not the same as if one had simply computed the weighted variance by hand using NumPy on the data object's field. I tracked this second error down to commit https://github.com/yt-project/yt/commit/191056c8eec45debd777643ff5cec2696ad70dc0.

Which was just a mix-up in the reformatting of the line. 

I'll see what I can do about improving test coverage for this.