### PR TITLE
disable OSNI projection answer test

### DIFF
--- a/yt/visualization/tests/test_geo_projections.py
+++ b/yt/visualization/tests/test_geo_projections.py
@@ -40,6 +40,9 @@ def test_geo_slices_amr():
         if transform == 'UTM':
             # requires additional argument so we skip
             continue
+        if transform == 'OSNI':
+            # avoid crashes, see https://github.com/SciTools/cartopy/issues/1177
+            continue
         for field in ds.field_list:
             prefix = "%s_%s_%s" % (field[0], field[1], transform)
             yield compare(ds, field, 'altitude', test_prefix=prefix,


### PR DESCRIPTION
# PR Summary

In the cartopy testing file we've disabled the OSNI projection in the unit tests due to potential incompatibilities that might be caused with shapely/GEOS. However, this wasn't done in the answer tests. I'm guessing that we've been lucky so far to not have encountered this failure, because it was an issue when we first added cartopy support. I think because we've disabled this projection in the unit tests, it's reasonable to also do it in the answer tests.  I've also included a link to the issue as a comment line in the test so it's clear why we've disabled it. 

## PR Checklist

- [x] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
