### PR TITLE
[AMRVAC] ensure consistent renormalisation of amrvac datasets

### DIFF
--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -63,6 +63,19 @@ The user has two ways to control displayed units, through
   units_override = dict(length_unit=(100., 'au'), mass_unit=yt.units.mass_sun)
   ds = yt.load("output0010.dat", units_override=units_override, unit_system="mks")
 
+To ensure consistency with normalisations as used in AMRVAC we only allow
+overriding a maximum of three units. Allowed unit combinations at the moment are
+
+.. code-block:: none
+
+  {numberdensity_unit, temperature_unit, length_unit}
+  {mass_unit, temperature_unit, length_unit}
+  {mass_unit, time_unit, length_unit}
+  {numberdensity_unit, velocity_unit, length_unit}
+  {mass_unit, velocity_unit, length_unit}
+
+Appropriate errors are thrown for other combinations.
+
 
 .. rubric:: Partially supported and unsupported features
 
@@ -2385,7 +2398,7 @@ stars might look like this:
 
 For a cosmological simulation, this filter will distinguish between stars and
 dark matter particles.
-        
+
 .. _loading-sph-data:
 
 SPH Particle Data

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -1,6 +1,6 @@
 answer_tests:
 
-  local_amrvac_001:
+  local_amrvac_002:
     - yt/frontends/amrvac/tests/test_outputs.py
     
   local_artio_001:

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -278,19 +278,19 @@ class AMRVACDataset(Dataset):
             # in this case time was supplied
             velocity_unit = length_unit / self.time_unit
         else:
-            # other case: velocity was supplied. Fall back to zero (default) if no overrides supplied
+            # other case: velocity was supplied. Fall back to None if no overrides supplied
             velocity_unit = getattr(self, 'velocity_unit', None)
 
         # 3. calculations for pressure and temperature
         if velocity_unit is None:
             # velocity and time not given, see if temperature is given. Fall back to one (default) if not
             temperature_unit = getattr(self, 'temperature_unit', self.quan(1, 'K'))
-            pressure_unit = ((2.0 + 3.0 * He_abundance) * numberdensity_unit * kb_cgs * temperature_unit).to('dyn*cm**-2')
-            velocity_unit = (np.sqrt(pressure_unit / density_unit)).to('cm*s**-1')
+            pressure_unit = ((2.0 + 3.0 * He_abundance) * numberdensity_unit * kb_cgs * temperature_unit).in_cgs()
+            velocity_unit = (np.sqrt(pressure_unit / density_unit)).in_cgs()
         else:
             # velocity is not zero if either time was given OR velocity was given
-            pressure_unit = (density_unit * velocity_unit ** 2).to('dyn*cm**-2')
-            temperature_unit = (pressure_unit / ((2.0 + 3.0 * He_abundance) * numberdensity_unit * kb_cgs)).to('K')
+            pressure_unit = (density_unit * velocity_unit ** 2).in_cgs()
+            temperature_unit = (pressure_unit / ((2.0 + 3.0 * He_abundance) * numberdensity_unit * kb_cgs)).in_cgs()
 
         # 4. calculations for magnetic unit and time
         time_unit = getattr(self, 'time_unit', length_unit / velocity_unit)  # if time given use it, else calculate

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -286,7 +286,7 @@ class AMRVACDataset(Dataset):
 
         He_abundance = 0.1  # hardcoded parameter in AMRVAC
 
-        # self.length_unit should always be supplied when using units_override
+        # get self.length_unit if overrides are supplied, otherwise use default
         length_unit = getattr(self, 'length_unit', self.quan(1, 'cm'))
 
         # if overrides are not specified, use default values
@@ -365,10 +365,6 @@ class AMRVACDataset(Dataset):
         if hasattr(self, 'temperature_unit') and hasattr(self, 'velocity_unit'):
             raise ValueError('Both temperature and velocity have been supplied as overrides. '
                              'Only one of them is allowed.')
-
-        # if units are overridden, ask that length should always be specified.
-        if not hasattr(self, 'length_unit'):
-            raise ValueError('Length unit should always be specified when overriding units')
 
         allowed_combinations = [{'numberdensity_unit', 'temperature_unit', 'length_unit'},
                                 {'mass_unit', 'temperature_unit', 'length_unit'},

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -243,22 +243,15 @@ class AMRVACDataset(Dataset):
     # units stuff ===============================================================================
     def _set_code_unit_attributes(self):
         # required method
-        # note: this method is never defined in the parent abstract class Dataset
+        # devnote: this method is never defined in the parent abstract class Dataset
         # but it is called in Dataset.set_code_units(), which is part of Dataset.__init__()
         # so it must be defined here.
 
-        # note2: this gets called later than Dataset._override_code_units()
-        # This is the reason why it uses setdefaultattr: it will only fill the gaps lefts by the "override",
-        # instead of overriding them again
-
-        # note: normalisations in AMRVAC have 3 degrees of freedom. The user can specify a unit length and unit
-        # numberdensity, with the third option either a unit temperature OR unit velocity.
-        # If unit temperature is specified then unit velocity will be calculated accordingly, and vice-versa.
-        # AMRVAC does not allow to specify any other normalisation beside those four.
-
-        # note: _override_code_units() has already been called, so self.units_override has been set.
-        # _override_code_units() sets supplied items in units_override as attributes.
-        # Handled items are length, time, mass, velocity, magnetic, temperature
+        # devnote: this gets called later than Dataset._override_code_units()
+        # This is the reason why it uses setdefaultattr: it will only fill in the gaps left
+        # by the "override", instead of overriding them again.
+        # For the same reason, self.units_override is set, as well as corresponding *_unit instance attributes
+        # which may include up to 3 of the following items: length, time, mass, velocity, number_density, temperature
 
         # note: yt sets hydrogen mass equal to proton mass, amrvac doesn't.
         mp_cgs = self.quan(1.672621898e-24, 'g')  # This value is taken from AstroPy
@@ -325,7 +318,11 @@ class AMRVACDataset(Dataset):
         # frontend specific method
         # YT supports overriding other normalisations, this method ensures consistency between
         # supplied 'units_override' items and those used by AMRVAC.
-        # A maximum of three is allowed, with either velocity_unit or temperature_unit specified.
+
+        # AMRVAC's normlisations/units have 3 degrees of freedom.
+        # Moreover, if temperature unit is specified then velocity unit will be calculated
+        # accordingly, and vice-versa.
+        # Currently we replicate this by allowing a finite set of combinations in units_override
         if not self.units_override:
             return
         overrides = set(self.units_override)

--- a/yt/frontends/amrvac/tests/test_outputs.py
+++ b/yt/frontends/amrvac/tests/test_outputs.py
@@ -4,8 +4,11 @@ import yt # NOQA
 from yt.utilities.answer_testing.framework import \
     requires_ds, \
     data_dir_load, small_patch_amr
-from yt.testing import requires_file
+from yt.testing import requires_file, \
+    assert_allclose_units, \
+    assert_raises
 from yt.frontends.amrvac.api import AMRVACDataset, AMRVACGrid
+from yt.units import YTQuantity
 
 blastwave_spherical_2D = "amrvac/bw_2d0000.dat"
 khi_cartesian_2D = "amrvac/kh_2D0000.dat"
@@ -101,3 +104,98 @@ def test_riemann_cartesian_175D():
     for test in small_patch_amr(ds, ds.field_list):
         test_riemann_cartesian_175D.__name__ = test.description
         yield test
+
+
+
+# Tests for units: verify that overriding certain units yields the correct derived units.
+# The following are correct normalisations based on length, numberdensity and temperature
+length_unit = (1e9, 'cm')
+numberdensity_unit = (1e9, 'cm**-3')
+temperature_unit = (1e6, 'K')
+density_unit = (2.341670657200000e-15, 'g*cm**-3')
+mass_unit = (2.341670657200000e+12, 'g')
+velocity_unit = (1.164508387441102e+07, 'cm*s**-1')
+pressure_unit = (3.175492240000000e-01, 'dyn*cm**-2')
+time_unit = (8.587314705370271e+01, 's')
+magnetic_unit = (1.997608879907716, 'gauss')
+
+def _assert_normalisations_equal(ds):
+    assert_allclose_units(ds.length_unit, YTQuantity(*length_unit))
+    assert_allclose_units(ds.numberdensity_unit, YTQuantity(*numberdensity_unit))
+    assert_allclose_units(ds.temperature_unit, YTQuantity(*temperature_unit))
+    assert_allclose_units(ds.density_unit, YTQuantity(*density_unit))
+    assert_allclose_units(ds.mass_unit, YTQuantity(*mass_unit))
+    assert_allclose_units(ds.velocity_unit, YTQuantity(*velocity_unit))
+    assert_allclose_units(ds.pressure_unit, YTQuantity(*pressure_unit))
+    assert_allclose_units(ds.time_unit, YTQuantity(*time_unit))
+    assert_allclose_units(ds.magnetic_unit, YTQuantity(*magnetic_unit))
+
+@requires_file(khi_cartesian_2D)
+def test_normalisations_length_temp_nb():
+    # overriding length, temperature, numberdensity
+    overrides = dict(length_unit=length_unit, temperature_unit=temperature_unit,
+                     numberdensity_unit=numberdensity_unit)
+    ds = data_dir_load(khi_cartesian_2D, kwargs={'units_override': overrides})
+    _assert_normalisations_equal(ds)
+
+@requires_file(khi_cartesian_2D)
+def test_normalisations_length_temp_mass():
+    # overriding length, temperature, mass
+    overrides = dict(length_unit=length_unit, temperature_unit=temperature_unit,
+                     mass_unit=mass_unit)
+    ds = data_dir_load(khi_cartesian_2D, kwargs={'units_override': overrides})
+    _assert_normalisations_equal(ds)
+
+@requires_file(khi_cartesian_2D)
+def test_normalisations_length_time_mass():
+    # overriding length, time, mass
+    overrides = dict(length_unit=length_unit, time_unit=time_unit, mass_unit=mass_unit)
+    ds = data_dir_load(khi_cartesian_2D, kwargs={'units_override': overrides})
+    _assert_normalisations_equal(ds)
+
+@requires_file(khi_cartesian_2D)
+def test_normalisations_length_vel_nb():
+    # overriding length, velocity, numberdensity
+    overrides = dict(length_unit=length_unit, velocity_unit=velocity_unit,
+                     numberdensity_unit=numberdensity_unit)
+    ds = data_dir_load(khi_cartesian_2D, kwargs={'units_override': overrides})
+    _assert_normalisations_equal(ds)
+
+@requires_file(khi_cartesian_2D)
+def test_normalisations_length_vel_mass():
+    # overriding length, velocity, mass
+    overrides = dict(length_unit=length_unit, velocity_unit=velocity_unit,
+                     mass_unit=mass_unit)
+    ds = data_dir_load(khi_cartesian_2D, kwargs={'units_override': overrides})
+    _assert_normalisations_equal(ds)
+
+@requires_file(khi_cartesian_2D)
+def test_normalisations_default():
+    # test default normalisations, without overrides
+    ds = data_dir_load(khi_cartesian_2D)
+    assert_allclose_units(ds.length_unit, YTQuantity(1, 'cm'))
+    assert_allclose_units(ds.numberdensity_unit, YTQuantity(1, 'cm**-3'))
+    assert_allclose_units(ds.temperature_unit, YTQuantity(1, 'K'))
+    assert_allclose_units(ds.density_unit, YTQuantity(2.341670657200000e-24, 'g*cm**-3'))
+    assert_allclose_units(ds.mass_unit, YTQuantity(2.341670657200000e-24, 'g'))
+    assert_allclose_units(ds.velocity_unit, YTQuantity(1.164508387441102e+04, 'cm*s**-1'))
+    assert_allclose_units(ds.pressure_unit, YTQuantity(3.175492240000000e-16, 'dyn*cm**-2'))
+    assert_allclose_units(ds.time_unit, YTQuantity(8.587314705370271e-05, 's'))
+    assert_allclose_units(ds.magnetic_unit, YTQuantity(6.316993934686148e-08, 'gauss'))
+
+@requires_file(khi_cartesian_2D)
+def test_normalisations_too_many_args():
+    # test forbidden case: too many arguments (max 3 are allowed)
+    overrides = dict(length_unit=length_unit, numberdensity_unit=numberdensity_unit,
+                     temperature_unit=temperature_unit, time_unit=time_unit)
+    with assert_raises(ValueError):
+        data_dir_load(khi_cartesian_2D, kwargs={'units_override': overrides})
+
+@requires_file(khi_cartesian_2D)
+def test_normalisations_vel_and_length():
+    # test forbidden case: both velocity and temperature are specified as overrides
+    overrides = dict(length_unit=length_unit, velocity_unit=velocity_unit,
+                     temperature_unit=temperature_unit)
+    with assert_raises(ValueError):
+        data_dir_load(khi_cartesian_2D, kwargs={'units_override': overrides})
+


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary
The AMRVAC code (amrvac.org) uses specific normalisations based on a helium abundance.
When specifying normalisations, amrvac has only three degrees of freedom: a unit length and unit number density should always be specified, together with either a unit temperature or unit length. These normalisations are however _never_ saved in the dataset and should hence by supplied by the user through `ds = yt.load(amrvacdataset, units_override={})`.

This PR extends the `_set_code_unit_attributes()` method in the newly accepted AMRVAC frontend (#2321) to ensure consistency and correct re-normalisation of code units between AMRVAC and yt. It also provides support for additional yt override possibilities (like time, mass, etc) while maintaining consistency.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes flake8 checker
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
