### PR TITLE
Add an instruction to the doc about continuous mesh colormap

### DIFF
--- a/doc/source/visualizing/unstructured_mesh_rendering.rst
+++ b/doc/source/visualizing/unstructured_mesh_rendering.rst
@@ -365,6 +365,46 @@ with two meshes on it:
     im = sc.render()
     sc.save()
 
+However, in the rendered image above, we note that the color is discontinuous on
+in the middle and upper part of the cylinder's side. In the original data,
+there are two parts but the value of `diffused` is continuous at the interface.
+This discontinuous color is due to an independent colormap setting for the two
+mesh sources. To fix it, we can explicitly specify the colormap bound for each
+mesh source as follows:
+
+.. python-script::
+
+    import yt
+    from yt.visualization.volume_rendering.api import MeshSource, Scene
+
+    ds = yt.load("MOOSE_sample_data/out.e-s010")
+
+    # this time we create an empty scene and add sources to it one-by-one
+    sc = Scene()
+
+    # set up our Camera
+    cam = sc.add_camera(ds)
+    cam.focus = ds.arr([0.0, 0.0, 0.0], 'code_length')
+    cam.set_position(ds.arr([-3.0, 3.0, -3.0], 'code_length'),
+                     ds.arr([0.0, -1.0, 0.0], 'dimensionless'))
+    cam.set_width = ds.arr([8.0, 8.0, 8.0], 'code_length')
+    cam.resolution = (800, 800)
+
+    # create two distinct MeshSources from 'connect1' and 'connect2'
+    ms1 = MeshSource(ds, ('connect1', 'diffused'))
+    ms2 = MeshSource(ds, ('connect2', 'diffused'))
+
+    # add the following lines to set the range of the two mesh sources
+    ms1.color_bounds = (0.0, 3.0)
+    ms2.color_bounds = (0.0, 3.0)
+
+    sc.add_source(ms1)
+    sc.add_source(ms2)
+
+    # render and save
+    im = sc.render()
+    sc.save()
+
 Making Movies
 ^^^^^^^^^^^^^
 


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->
The commit included in this PR adds an explanation to the doc about
why the rendered color is not continuous when rendering two-part
unstructured mesh and how to explicitly set each colormap bound
for a continuous color plot.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
