### PR TITLE
[AMRVAC] fix derived unit parsing

### DIFF
--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -254,9 +254,10 @@ class AMRVACDataset(Dataset):
         setdefaultattr(self, "mass_unit", self.quan(1, "g"))
         setdefaultattr(self, "time_unit", self.quan(1, "s"))
 
-        setdefaultattr(self, "velocity_unit", self.quan(self.length_unit/self.time_unit, "cm*s**-1"))
-        setdefaultattr(self, "density_unit", self.quan(self.mass_unit/self.length_unit**3, "g*cm**-3"))
-        setdefaultattr(self, "numberdensity_unit", self.quan(self.length_unit**-3, "cm**-3"))
+        # derived units
+        setdefaultattr(self, "velocity_unit", self.quan(self.length_unit/self.time_unit))
+        setdefaultattr(self, "density_unit", self.quan(self.mass_unit/self.length_unit**3))
+        setdefaultattr(self, "numberdensity_unit", self.quan(self.length_unit**-3))
 
         # TODO: check this
         setdefaultattr(self, "temperature_unit", self.quan(1, "K"))


### PR DESCRIPTION
Solves issue 2361.
Marked as WIP because I realised that I don't see a good reason to use `setdefaultattr` for the three affected dataset attributes, which are derived units, merely aliasing more fondamental units normalisation factors.

I'll wait for the tests to run once before I rewrite this without `setdefaultattr`.