### PR TITLE
Use sorted glob in athena

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -6,7 +6,7 @@ answer_tests:
   local_artio_001:
     - yt/frontends/artio/tests/test_outputs.py
 
-  local_athena_004:
+  local_athena_005:
     - yt/frontends/athena
 
   local_athena_pp_001:

--- a/yt/frontends/athena/data_structures.py
+++ b/yt/frontends/athena/data_structures.py
@@ -20,7 +20,8 @@ import glob
 
 from yt.funcs import \
     mylog, \
-    ensure_tuple
+    ensure_tuple, \
+    sglob
 from yt.data_objects.grid_patch import \
     AMRGridPatch
 from yt.geometry.grid_geometry_handler import \
@@ -247,12 +248,12 @@ class AthenaHierarchy(GridIndex):
             dname = "id0/"+dname
             dataset_dir = dataset_dir[:-3]
 
-        gridlistread = glob.glob(os.path.join(dataset_dir, 'id*/%s-id*%s' % (dname[4:-9],dname[-9:])))
+        gridlistread = sglob(os.path.join(dataset_dir, 'id*/%s-id*%s' % (dname[4:-9],dname[-9:]))))
         gridlistread.insert(0,self.index_filename)
         if 'id0' in dname:
-            gridlistread += glob.glob(os.path.join(dataset_dir, 'id*/lev*/%s*-lev*%s' % (dname[4:-9],dname[-9:])))
+            gridlistread += sglob(os.path.join(dataset_dir, 'id*/lev*/%s*-lev*%s' % (dname[4:-9],dname[-9:])))
         else :
-            gridlistread += glob.glob(os.path.join(dataset_dir, 'lev*/%s*-lev*%s' % (dname[:-9],dname[-9:])))
+            gridlistread += sglob(os.path.join(dataset_dir, 'lev*/%s*-lev*%s' % (dname[:-9],dname[-9:])))
         ndots = dname.count(".")
         gridlistread = [fn for fn in gridlistread if os.path.basename(fn).count(".") == ndots]
         self.num_grids = len(gridlistread)
@@ -552,11 +553,11 @@ class AthenaDataset(Dataset):
             dname = "id0/"+dname
             dataset_dir = dataset_dir[:-3]
 
-        gridlistread = glob.glob(os.path.join(dataset_dir, 'id*/%s-id*%s' % (dname[4:-9],dname[-9:])))
+        gridlistread = sglob(os.path.join(dataset_dir, 'id*/%s-id*%s' % (dname[4:-9],dname[-9:])))
         if 'id0' in dname :
-            gridlistread += glob.glob(os.path.join(dataset_dir, 'id*/lev*/%s*-lev*%s' % (dname[4:-9],dname[-9:])))
+            gridlistread += sglob(os.path.join(dataset_dir, 'id*/lev*/%s*-lev*%s' % (dname[4:-9],dname[-9:])))
         else :
-            gridlistread += glob.glob(os.path.join(dataset_dir, 'lev*/%s*-lev*%s' % (dname[:-9],dname[-9:])))
+            gridlistread += sglob(os.path.join(dataset_dir, 'lev*/%s*-lev*%s' % (dname[:-9],dname[-9:])))
         ndots = dname.count(".")
         gridlistread = [fn for fn in gridlistread if os.path.basename(fn).count(".") == ndots]
         self.nvtk = len(gridlistread)+1

--- a/yt/frontends/athena/data_structures.py
+++ b/yt/frontends/athena/data_structures.py
@@ -16,7 +16,6 @@ Data structures for Athena.
 import numpy as np
 import os
 import weakref
-import glob
 
 from yt.funcs import \
     mylog, \
@@ -248,7 +247,7 @@ class AthenaHierarchy(GridIndex):
             dname = "id0/"+dname
             dataset_dir = dataset_dir[:-3]
 
-        gridlistread = sglob(os.path.join(dataset_dir, 'id*/%s-id*%s' % (dname[4:-9],dname[-9:]))))
+        gridlistread = sglob(os.path.join(dataset_dir, 'id*/%s-id*%s' % (dname[4:-9],dname[-9:])))
         gridlistread.insert(0,self.index_filename)
         if 'id0' in dname:
             gridlistread += sglob(os.path.join(dataset_dir, 'id*/lev*/%s*-lev*%s' % (dname[4:-9],dname[-9:])))

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -34,6 +34,7 @@ import base64
 import numpy
 import matplotlib
 import getpass
+import glob
 from math import floor, ceil
 from numbers import Number as numeric_type
 

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -1263,3 +1263,9 @@ def validate_center(center):
         raise TypeError("Expected 'center' to be a numeric object of type "
                         "list/tuple/np.ndarray/YTArray/YTQuantity, "
                         "received '%s'." % str(type(center)).split("'")[1])
+
+def sglob(pattern):
+    """
+    Return the results of a glob through the sorted() function.
+    """
+    return sorted(glob.glob(pattern))


### PR DESCRIPTION
This problem showed up in the pytest PR (#2286).

We were able to verify that using unsorted glob did *not* result in any differences in *derived* products, only in the actual index order of the grids post-reconstruction.

(Also the view sure was nice up on my [high horse](https://github.com/yt-project/yt/pull/2286), but ... :grimacing:)