### PR TITLE
Fixed extra extension added by ImageArray.save()

### DIFF
--- a/yt/data_objects/image_array.py
+++ b/yt/data_objects/image_array.py
@@ -384,9 +384,13 @@ class ImageArray(YTArray):
 
         """
         if png:
+            if not filename.endswith('.png'):
+                filename = filename + '.png'
             if len(self.shape) > 2:
-                self.write_png("%s.png" % filename)
+                self.write_png(filename)
             else:
-                self.write_image("%s.png" % filename)
+                self.write_image(filename)
         if hdf5:
-            self.write_hdf5("%s.h5" % filename, dataset_name)
+            if not filename.endswith('.h5'):
+                filename = filename + '.h5'
+            self.write_hdf5(filename, dataset_name)


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary
This PR addresses Issue #2359, in which ImageArray.save(filename) was appending an extra file extension to filename if one was already present (e.g., my_image.png -> my_image.png.png).
<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->
https://github.com/yt-project/yt/issues/2359
## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
