### PR TITLE
fix issue 2365

### DIFF
--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -195,7 +195,9 @@ class DatasetSeries(object):
             if isinstance(key.start, float):
                 return self.get_range(key.start, key.stop)
             # This will return a sliced up object!
-            return DatasetSeries(self._pre_outputs[key], self.parallel)
+            return DatasetSeries(self._pre_outputs[key],
+                                 parallel=self.parallel,
+                                 **self.kwargs)
         o = self._pre_outputs[key]
         if isinstance(o, string_types):
             o = self._load(o, **self.kwargs)


### PR DESCRIPTION
fixes https://github.com/yt-project/yt/issues/2365
`DatasetSeries.kwargs` were not properly passed down to child instance created by slicing. This commit fixes it.

Ideally this behaviour should be tested. I never added tests for yt's core yet so guidance might be useful.