### PR TITLE
install pyyaml on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ install:
     - "python --version"
 
     # Install specified version of numpy and dependencies
-    - "conda install --yes -c conda-forge numpy scipy nose setuptools ipython Cython sympy fastcache h5py matplotlib mock pandas cartopy conda-build"
+    - "conda install --yes -c conda-forge numpy scipy nose setuptools ipython Cython sympy fastcache h5py matplotlib mock pandas cartopy conda-build pyyaml"
     - "conda develop -b ."
 
 # Not a .NET project


### PR DESCRIPTION
The appveyor tests are currently failing with the following error:

```
======================================================================
ERROR: Test cosmology calculator functions against previously calculated values.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\Miniconda36-x64\envs\test\lib\site-packages\nose\case.py", line 197, in runTest
    self.test(*self.arg)
  File "C:\projects\yt\yt\utilities\tests\test_cosmology.py", line 227, in test_cosmology_calculator_answers
    data = yaml.load(open(fn, 'r'), Loader=yaml.FullLoader)
  File "C:\Miniconda36-x64\envs\test\lib\site-packages\yaml\__init__.py", line 70, in load
    loader = Loader(stream)
  File "C:\projects\yt\yt\utilities\on_demand_imports.py", line 32, in __call__
    raise self.error
ImportError: This functionality requires the yaml package to be installed.
----------------------------------------------------------------------
```