### PR TITLE
Add support for spherical geometries in plot_2d

### DIFF
--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -2066,6 +2066,8 @@ def plot_2d(ds, fields, center='c', width=None, axes_unit=None,
         axis = "z"
     elif ds.geometry == "cylindrical":
         axis = "theta"
+    elif ds.geometry == "spherical":
+        axis = "phi"
     # Part of the convenience of plot_2d is to eliminate the use of the
     # superfluous coordinate, so we do that also with the center argument
     if not isinstance(center, string_types) and obj_length(center) == 2:

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -2068,6 +2068,8 @@ def plot_2d(ds, fields, center='c', width=None, axes_unit=None,
         axis = "theta"
     elif ds.geometry == "spherical":
         axis = "phi"
+    else:
+        raise NotImplementedError("plot_2d does not yet support datasets with {} geometries".format(ds.geometry))
     # Part of the convenience of plot_2d is to eliminate the use of the
     # superfluous coordinate, so we do that also with the center argument
     if not isinstance(center, string_types) and obj_length(center) == 2:

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -23,6 +23,7 @@ from distutils.version import LooseVersion
 from nose.tools import assert_true
 
 from yt.testing import \
+    requires_file,
     fake_random_ds, assert_equal, assert_rel_equal, assert_array_equal, \
     assert_array_almost_equal, assert_raises, assert_fname
 from yt.utilities.answer_testing.framework import \
@@ -510,8 +511,10 @@ def test_set_unit():
     assert str(slc.frb['gas', 'temperature'].units) == 'keV'
 
 WD = "WDMerger_hdf5_chk_1000/WDMerger_hdf5_chk_1000.hdf5"
+blast_wave = "amrvac/bw_2d0000.dat"
 
 @requires_ds(WD)
+@requires_file(blast_wave)
 def test_plot_2d():
     # Cartesian
     ds = fake_random_ds((32,32,1), fields=('temperature',), units=('K',))
@@ -527,6 +530,12 @@ def test_plot_2d():
     ds = data_dir_load(WD)
     slc = SlicePlot(ds, "theta", ["density"], width=(30000.0, "km"))
     slc2 = plot_2d(ds, "density", width=(30000.0, "km"))
+    assert_array_equal(slc.frb['density'], slc2.frb['density'])
+
+    # Spherical
+    ds = data_dir_load(blast_wave)
+    slc = SlicePlot(ds, "phi", ["density"], width=(1, "unitary"))
+    slc2 = plot_2d(ds, "density", width=(1, "unitary"))
     assert_array_equal(slc.frb['density'], slc2.frb['density'])
 
 def test_symlog_colorbar():

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -513,7 +513,7 @@ def test_set_unit():
 WD = "WDMerger_hdf5_chk_1000/WDMerger_hdf5_chk_1000.hdf5"
 blast_wave = "amrvac/bw_2d0000.dat"
 
-@requires_ds(WD)
+@requires_file(WD)
 @requires_file(blast_wave)
 def test_plot_2d():
     # Cartesian

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -23,7 +23,7 @@ from distutils.version import LooseVersion
 from nose.tools import assert_true
 
 from yt.testing import \
-    requires_file,
+    requires_file, \
     fake_random_ds, assert_equal, assert_rel_equal, assert_array_equal, \
     assert_array_almost_equal, assert_raises, assert_fname
 from yt.utilities.answer_testing.framework import \


### PR DESCRIPTION
Fix issue #2370 

Simply add an if statement to cover the spherical 2D case, and it works like a charm.
See for example :

![2d_sphere p jpg_Slice_phi_density](https://user-images.githubusercontent.com/14075922/69577287-5ca1ab00-0fce-11ea-9eca-2c7117ba8fd0.png)
