### PR TITLE
[AMRVAC] add derived fields for hydro runs

### DIFF
--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -45,6 +45,30 @@ A ``ndim``-long ``periodic`` boolean array was also added to improve
 comptatibility with yt. See http://amrvac.org/md_doc_fileformat.html
 for details.
 
+.. rubric:: Auto-setup for derived fields
+
+Yt will attempt to mimic the way AMRVAC internally defines kinetic energy,
+pressure, and sound speed. To see a complete list of fields that are defined after
+loading, one can simply type
+
+.. code-block:: python
+    print(ds.derived_field_list)
+
+Note that for adiabatic (magneto-)hydrodynamics, i.e. `(m)hd_energy = False` in
+AMRVAC, additional input data is required in order to setup some of these fields.
+This is done by passing the corresponding parfile(s) at load time
+
+.. code-block:: python
+    # example using a single parfile
+    ds = yt.load("output0010.dat", parfiles="amrvac.par")
+
+    # ... or using multiple parfiles
+    ds = yt.load("output0010.dat", parfiles=["amrvac.par", "modifier.par"])
+
+In case more than one parfile is passed, yt will create a single namelist by
+replicating AMRVAC's rules (see "Using multiple par files"
+http://amrvac.org/md_doc_commandline.html).
+
 
 .. rubric:: Unit System
 

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -171,16 +171,20 @@ class AMRVACDataset(Dataset):
                                             units_override=units_override, unit_system=unit_system)
 
         self._parfiles = parfiles
+
+        self.c_adiab = None
+        namelist_gamma = None
         if parfiles is not None:
             self.namelist = read_amrvac_namelist(parfiles)
             if "hd_list" in self.namelist:
-                namelist_gamma = self.namelist["hd_list"].get("hd_gamma", None)
-                if namelist_gamma is not None and not self.gamma == namelist_gamma:
-                    mylog.error("Inconsistent values in gamma: datfile {}, parfiles {}".format(self.gamma, namelist_gamma))
+                self.c_adiab = self.namelist["hd_list"].get(["hd_adiab"])
+                namelist_gamma = self.namelist["hd_list"].get("hd_gamma")
+            elif "mhd_list" in self.namelist:
+                self.c_adiab = self.namelist["mhd_list"].get(["mhd_adiab"])
+                namelist_gamma = self.namelist["mhd_list"].get("mhd_gamma")
 
-        else:
-            # todo: add a warning here when having this parameter becomes useful
-            self.namelist = None
+            if namelist_gamma is not None and self.gamma != namelist_gamma:
+                mylog.error("Inconsistent values in gamma: datfile {}, parfiles {}".format(self.gamma, namelist_gamma))
 
         self.fluid_types += ('amrvac',)
         # refinement factor between a grid and its subgrid

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -187,6 +187,10 @@ class AMRVACDataset(Dataset):
             if namelist_gamma is not None and self.gamma != namelist_gamma:
                 mylog.error("Inconsistent values in gamma: datfile {}, parfiles {}".format(self.gamma, namelist_gamma))
 
+        if c_adiab is not None:
+            # this complicated unit is required for the adiabatic equation of state to make physical sense
+            c_adiab *= self.mass_unit**(1-self.gamma) * self.length_unit**(2+3*(self.gamma-1)) / self.time_unit**2
+
         self.namelist = namelist
         self._c_adiab = c_adiab
 

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -178,10 +178,10 @@ class AMRVACDataset(Dataset):
         if parfiles is not None:
             namelist = read_amrvac_namelist(parfiles)
             if "hd_list" in namelist:
-                c_adiab = namelist["hd_list"].get(["hd_adiab"], 1.0)
+                c_adiab = namelist["hd_list"].get("hd_adiab", 1.0)
                 namelist_gamma = namelist["hd_list"].get("hd_gamma")
             elif "mhd_list" in namelist:
-                c_adiab = namelist["mhd_list"].get(["mhd_adiab"], 1.0)
+                c_adiab = namelist["mhd_list"].get("mhd_adiab", 1.0)
                 namelist_gamma = namelist["mhd_list"].get("mhd_gamma")
 
             if namelist_gamma is not None and self.gamma != namelist_gamma:

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -175,6 +175,7 @@ class AMRVACDataset(Dataset):
         namelist = None
         namelist_gamma = None
         c_adiab = None
+        e_is_internal = None
         if parfiles is not None:
             namelist = read_amrvac_namelist(parfiles)
             if "hd_list" in namelist:
@@ -187,12 +188,16 @@ class AMRVACDataset(Dataset):
             if namelist_gamma is not None and self.gamma != namelist_gamma:
                 mylog.error("Inconsistent values in gamma: datfile {}, parfiles {}".format(self.gamma, namelist_gamma))
 
+            if "method_list" in namelist:
+                e_is_internal = namelist["method_list"].get("solve_internal_e", False)
+
         if c_adiab is not None:
             # this complicated unit is required for the adiabatic equation of state to make physical sense
             c_adiab *= self.mass_unit**(1-self.gamma) * self.length_unit**(2+3*(self.gamma-1)) / self.time_unit**2
 
         self.namelist = namelist
         self._c_adiab = c_adiab
+        self._e_is_internal = e_is_internal
 
         self.fluid_types += ('amrvac',)
         # refinement factor between a grid and its subgrid

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -172,19 +172,23 @@ class AMRVACDataset(Dataset):
 
         self._parfiles = parfiles
 
-        self.c_adiab = None
+        namelist = None
         namelist_gamma = None
+        c_adiab = None
         if parfiles is not None:
-            self.namelist = read_amrvac_namelist(parfiles)
-            if "hd_list" in self.namelist:
-                self.c_adiab = self.namelist["hd_list"].get(["hd_adiab"])
-                namelist_gamma = self.namelist["hd_list"].get("hd_gamma")
-            elif "mhd_list" in self.namelist:
-                self.c_adiab = self.namelist["mhd_list"].get(["mhd_adiab"])
-                namelist_gamma = self.namelist["mhd_list"].get("mhd_gamma")
+            namelist = read_amrvac_namelist(parfiles)
+            if "hd_list" in namelist:
+                c_adiab = namelist["hd_list"].get(["hd_adiab"], 1.0)
+                namelist_gamma = namelist["hd_list"].get("hd_gamma")
+            elif "mhd_list" in namelist:
+                c_adiab = namelist["mhd_list"].get(["mhd_adiab"], 1.0)
+                namelist_gamma = namelist["mhd_list"].get("mhd_gamma")
 
             if namelist_gamma is not None and self.gamma != namelist_gamma:
                 mylog.error("Inconsistent values in gamma: datfile {}, parfiles {}".format(self.gamma, namelist_gamma))
+
+        self.namelist = namelist
+        self._c_adiab = c_adiab
 
         self.fluid_types += ('amrvac',)
         # refinement factor between a grid and its subgrid

--- a/yt/frontends/amrvac/fields.py
+++ b/yt/frontends/amrvac/fields.py
@@ -11,7 +11,7 @@ AMRVAC-specific fields
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-from numpy import sqrt, zeros_like
+import numpy as np
 from yt.fields.field_info_container import \
     FieldInfoContainer
 from yt.fields.magnetic_field import setup_magnetic_field_aliases
@@ -150,7 +150,7 @@ class AMRVACFieldInfo(FieldInfoContainer):
 
             # sound speed and temperature depend on thermal pressure
             def _sound_speed(field, data):
-                return sqrt(data.ds.gamma * data["gas", "thermal_pressure"] / data["gas", "density"])
+                return np.sqrt(data.ds.gamma * data["gas", "thermal_pressure"] / data["gas", "density"])
 
             self.add_field(("gas", "sound_speed"), function=_sound_speed,
                             units=us["velocity"],

--- a/yt/frontends/amrvac/fields.py
+++ b/yt/frontends/amrvac/fields.py
@@ -93,13 +93,7 @@ class AMRVACFieldInfo(FieldInfoContainer):
             return (data.ds.gamma - 1) * (data["gas", "energy_density"] - data["gas", "kinetic_energy_density"])
 
         def _adiabatic_thermal_pressure(field, data):
-            ds = data.ds
-            gamma = ds.gamma
-            c_adiab = ds._c_adiab
-            # this complicated unit is required for the equation of state to make physical sense
-            # todo : move this to init ?
-            c_adiab *= ds.mass_unit**(1-gamma) * ds.length_unit**(2+3*(gamma-1)) / ds.time_unit**2
-            return c_adiab * data["gas", "density"]**gamma
+            return data.ds._c_adiab * data["gas", "density"]**data.ds.gamma
 
         if ("amrvac", "e") in self.field_list:
             if ("amrvac", "b1") in self.field_list:
@@ -111,16 +105,16 @@ class AMRVACFieldInfo(FieldInfoContainer):
                                 dimensions=dimensions.density*dimensions.velocity**2,
                                 sampling_type="cell")
 
-        elif self.ds.c_adiab is not None:
-            mylog.warning("Assuming an adiabatic equation of state since no energy density was found." \
-                          "If your simulation used usr_set_pthermal you should redefine this field.")
+        elif self.ds._c_adiab is not None:
+            mylog.warning("Assuming an adiabatic equation of state since no energy density was found. " \
+                          "If your simulation used usr_set_pthermal you should redefine the thermal_pressure field.")
             self.add_field(("gas", "thermal_pressure"), function=_adiabatic_thermal_pressure,
                             units=us["density"]*us["velocity"]**2,
                             dimensions=dimensions.density*dimensions.velocity**2,
                             sampling_type="cell")
 
         else:
-            mylog.warning("Energy density field not found and parfiles were not passed:"\
+            mylog.warning("Energy density field not found and parfiles were not passed: " \
                           "can not setup adiabatic thermal_pressure")
 
         if ("gas", "thermal_pressure") in self.field_list:

--- a/yt/frontends/amrvac/fields.py
+++ b/yt/frontends/amrvac/fields.py
@@ -136,7 +136,7 @@ class AMRVACFieldInfo(FieldInfoContainer):
             mylog.warning('If you used usr_set_pthermal you should redefine the thermal_pressure field.')
 
         if pressure_recipe is not None:
-            self.add_field(('gas', 'thermal_pressure'), function=pressure_equation,
+            self.add_field(('gas', 'thermal_pressure'), function=pressure_recipe,
                            units=us['density']*us['velocity']**2,
                            dimensions=dimensions.density*dimensions.velocity**2,
                            sampling_type='cell')

--- a/yt/frontends/amrvac/fields.py
+++ b/yt/frontends/amrvac/fields.py
@@ -117,6 +117,7 @@ class AMRVACFieldInfo(FieldInfoContainer):
             mylog.warning("Energy density field not found and parfiles were not passed: " \
                           "can not setup adiabatic thermal_pressure")
 
+
         if ("gas", "thermal_pressure") in self.field_list:
             # sound speed depends on thermal pressure
             def _sound_speed(field, data):
@@ -126,7 +127,6 @@ class AMRVACFieldInfo(FieldInfoContainer):
                             units=us["velocity"],
                             dimensions=dimensions.velocity,
                             sampling_type="cell")
-
 
             # mach number depends on sound speed
             def _mach(field, data):

--- a/yt/frontends/amrvac/fields.py
+++ b/yt/frontends/amrvac/fields.py
@@ -11,7 +11,7 @@ AMRVAC-specific fields
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
-from numpy import sqrt
+from numpy import sqrt, zeros_like
 from yt.fields.field_info_container import \
     FieldInfoContainer
 from yt.fields.magnetic_field import setup_magnetic_field_aliases
@@ -90,7 +90,7 @@ class AMRVACFieldInfo(FieldInfoContainer):
 
         # magnetic energy
         def _magnetic_energy_density(field, data):
-            emag = 0
+            emag = zeros_like(data["density"]) # todo: replace this with "zeros like b1"
             for idim in '123':
                 if not ('amrvac', 'b%s' % idim) in self.field_list:
                     break

--- a/yt/frontends/amrvac/fields.py
+++ b/yt/frontends/amrvac/fields.py
@@ -11,6 +11,7 @@ AMRVAC-specific fields
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
 
+from numpy import sqrt
 from yt.fields.field_info_container import \
     FieldInfoContainer
 from yt.fields.magnetic_field import setup_magnetic_field_aliases
@@ -66,7 +67,7 @@ class AMRVACFieldInfo(FieldInfoContainer):
                             dimensions=dimensions.velocity,
                             sampling_type="cell")
             self.alias(("gas", "velocity_%s" % idir), ("gas", "velocity_%s" % alias),
-                        units=us"velocity"])
+                        units=us["velocity"])
             self.alias(("gas", "moment_%s" % alias), ("gas", "moment_%s" % idir),
                         units=us["density"]*us["velocity"])
 
@@ -103,7 +104,7 @@ class AMRVACFieldInfo(FieldInfoContainer):
 
                 # this complicated unit is required for the equation of state to make physical sense
                 hd_adiab *= ds.mass_unit**(1-gamma) * ds.length_unit**(2+3*(gamma-1)) / ds.time_unit**2
-                pth = hd_adiab * entropy_unit * data["gas", "density"]**gamma
+                pth = hd_adiab * data["gas", "density"]**gamma
             return pth
 
         self.add_field(("gas", "thermal_pressure"), function=_thermal_pressure,
@@ -114,7 +115,7 @@ class AMRVACFieldInfo(FieldInfoContainer):
 
         # sound speed depends on thermal pressure
         def _sound_speed(field, data):
-            return np.sqrt(data.ds.gamma * data["thermal_pressure"] / data["gas", "density"])
+            return sqrt(data.ds.gamma * data["thermal_pressure"] / data["gas", "density"])
 
         self.add_field(("gas", "sound_speed"), function=_sound_speed,
                         units=us["velocity"],

--- a/yt/frontends/amrvac/fields.py
+++ b/yt/frontends/amrvac/fields.py
@@ -96,18 +96,22 @@ class AMRVACFieldInfo(FieldInfoContainer):
             ds = data.ds
             gamma = ds.gamma
             try:
-                hd_adiab = ds.namelist["mhd_list"]["hd_adiab"]
+                c_adiab = ds.namelist["hd_list"]["hd_adiab"]
             except KeyError:
-                hd_adiab = ds.namelist["hd_list"]["hd_adiab"]
+                c_adiab = ds.namelist["mhd_list"]["hd_adiab"]
             # this complicated unit is required for the equation of state to make physical sense
-            hd_adiab *= ds.mass_unit**(1-gamma) * ds.length_unit**(2+3*(gamma-1)) / ds.time_unit**2
-            return hd_adiab * data["gas", "density"]**gamma
+            c_adiab *= ds.mass_unit**(1-gamma) * ds.length_unit**(2+3*(gamma-1)) / ds.time_unit**2
+            return c_adiab * data["gas", "density"]**gamma
 
         if ("amrvac", "e") in self.field_list:
-            self.add_field(("gas", "thermal_pressure"), function=_full_thermal_pressure,
-                            units=us["density"]*us["velocity"]**2,
-                            dimensions=dimensions.density*dimensions.velocity**2,
-                            sampling_type="cell")
+            if ("amrvac", "b1") in self.field_list:
+                #Not implemented yet
+                mylog.warning("Magnetic fields are not yet taken into account to setup thermal pressure !")
+            else:
+                self.add_field(("gas", "thermal_pressure"), function=_full_thermal_pressure,
+                                units=us["density"]*us["velocity"]**2,
+                                dimensions=dimensions.density*dimensions.velocity**2,
+                                sampling_type="cell")
 
         elif self.data.namelist is not None:
             mylog.warning("Assuming an adiabatic equation of state since no energy density was found." \

--- a/yt/frontends/amrvac/fields.py
+++ b/yt/frontends/amrvac/fields.py
@@ -95,6 +95,7 @@ class AMRVACFieldInfo(FieldInfoContainer):
         def _adiabatic_thermal_pressure(field, data):
             return data.ds._c_adiab * data["gas", "density"]**data.ds.gamma
 
+        pressure_is_defined = False
         if ("amrvac", "e") in self.field_list:
             if ("amrvac", "b1") in self.field_list:
                 #Not implemented yet
@@ -104,6 +105,7 @@ class AMRVACFieldInfo(FieldInfoContainer):
                                 units=us["density"]*us["velocity"]**2,
                                 dimensions=dimensions.density*dimensions.velocity**2,
                                 sampling_type="cell")
+                pressure_is_defined = True
 
         elif self.ds._c_adiab is not None:
             mylog.warning("Assuming an adiabatic equation of state since no energy density was found. " \
@@ -112,6 +114,7 @@ class AMRVACFieldInfo(FieldInfoContainer):
                             units=us["density"]*us["velocity"]**2,
                             dimensions=dimensions.density*dimensions.velocity**2,
                             sampling_type="cell")
+            pressure_is_defined = True
 
         else:
             mylog.warning("Energy density field not found and parfiles were not passed: " \
@@ -119,7 +122,7 @@ class AMRVACFieldInfo(FieldInfoContainer):
 
 
         # sound speed depends on thermal pressure
-        if ("gas", "thermal_pressure") in self.field_list:
+        if pressure_is_defined:
             def _sound_speed(field, data):
                 return sqrt(data.ds.gamma * data["thermal_pressure"] / data["gas", "density"])
 

--- a/yt/frontends/amrvac/fields.py
+++ b/yt/frontends/amrvac/fields.py
@@ -56,57 +56,77 @@ class AMRVACFieldInfo(FieldInfoContainer):
         def _v3(field, data):
             return data["gas", "moment_3"] / data["gas", "density"]
 
-        unit_system = self.ds.unit_system
+        us = self.ds.unit_system
         aliases = direction_aliases[self.ds.geometry]
         for idir, alias, func in zip("123", aliases, (_v1, _v2, _v3)):
             if not ("amrvac", "m%s" % idir) in self.field_list:
                 break
             self.add_field(("gas", "velocity_%s" % alias), function=func,
-                            units=unit_system['velocity'], dimensions=dimensions.velocity, sampling_type="cell")
+                            units=us['velocity'],
+                            dimensions=dimensions.velocity,
+                            sampling_type="cell")
             self.alias(("gas", "velocity_%s" % idir), ("gas", "velocity_%s" % alias),
-                        units=unit_system["velocity"])
+                        units=us"velocity"])
             self.alias(("gas", "moment_%s" % alias), ("gas", "moment_%s" % idir),
-                        units=unit_system["density"]*unit_system["velocity"])
+                        units=us["density"]*us["velocity"])
 
 
         setup_magnetic_field_aliases(self, "amrvac", ["mag%s" % ax for ax in "xyz"])
 
 
+        # fields with nested dependencies are defined thereafter by increasing level of complexity
+
+        # kinetic energy depends on velocities
         def _kinetic_energy_density(field, data):
             # devnote : have a look at issue 1301
             return 0.5 * data["gas", "density"] * data["gas", "velocity_amplitude"]**2
 
         self.add_field(("gas", "kinetic_energy_density"), function=_kinetic_energy_density,
-                       ...)
+                        units=us["density"]*us["velocity"]**2,
+                        dimensions=dimensions.density*dimensions.velocity**2,
+                        sampling_type="cell")
 
 
+        # thermal pressure depends kinetic energy and equation of state
         def _thermal_pressure(field, data):
-            gamma = data.ds.gamma
-            namelist = data.ds.namelist
+            ds = data.ds
+            gamma = ds.gamma
+            namelist = ds.namelist
             if namelist.get(["hd_list"], {}).get("hd_ernergy", True):
+                # important note : energy density and pressure are actually expressed in the same unit
                 pth = (gamma - 1) * data["gas", "energy_density"] - data["gas", "kinetic_energy_density"]
-                pth *= unit_factor # no idea what this should be :(
             else:
+                # todo: move this warning so it's only triggered once ?
                 mylog.warning("thermal_pressure field is assumed polytropic when hd_energy = False." \
                               "If your simulation used usr_set_pthermal you should redefine this field.")
                 hd_adiab = namelist.get("hd_list", {}).get("hd_adiab", 1.)
-                #entropy_unit = ... # todo: writeme
+
+                # this complicated unit is required for the equation of state to make physical sense
+                hd_adiab *= ds.mass_unit**(1-gamma) * ds.length_unit**(2+3*(gamma-1)) / ds.time_unit**2
                 pth = hd_adiab * entropy_unit * data["gas", "density"]**gamma
             return pth
 
         self.add_field(("gas", "thermal_pressure"), function=_thermal_pressure,
-                       ...)
+                        units=us["density"]*us["velocity"]**2,
+                        dimensions=dimensions.density*dimensions.velocity**2,
+                        sampling_type="cell")
 
 
+        # sound speed depends on thermal pressure
         def _sound_speed(field, data):
             return np.sqrt(data.ds.gamma * data["thermal_pressure"] / data["gas", "density"])
 
         self.add_field(("gas", "sound_speed"), function=_sound_speed,
-                       ...)
+                        units=us["velocity"],
+                        dimensions=dimensions.velocity,
+                        sampling_type="cell")
 
 
+        # mach number depends on sound speed
         def _mach(field, data):
             return data["gas", "velocity_magnitude"] / data["sound_speed"]
 
         self.add_field(("gas", "mach"), function=_mach,
-                       ...)
+                        units="auto",
+                        dimensions=dimensions.dimensionless,
+                        sampling_type="cell")

--- a/yt/frontends/amrvac/fields.py
+++ b/yt/frontends/amrvac/fields.py
@@ -95,7 +95,7 @@ class AMRVACFieldInfo(FieldInfoContainer):
         def _adiabatic_thermal_pressure(field, data):
             ds = data.ds
             gamma = ds.gamma
-            c_adiab = ds.c_adiab
+            c_adiab = ds._c_adiab
             # this complicated unit is required for the equation of state to make physical sense
             # todo : move this to init ?
             c_adiab *= ds.mass_unit**(1-gamma) * ds.length_unit**(2+3*(gamma-1)) / ds.time_unit**2

--- a/yt/frontends/amrvac/fields.py
+++ b/yt/frontends/amrvac/fields.py
@@ -130,12 +130,3 @@ class AMRVACFieldInfo(FieldInfoContainer):
                             units=us["velocity"],
                             dimensions=dimensions.velocity,
                             sampling_type="cell")
-
-            # mach number depends on sound speed
-            def _mach(field, data):
-                return data["gas", "velocity_magnitude"] / data["sound_speed"]
-
-            self.add_field(("gas", "mach"), function=_mach,
-                            units="auto",
-                            dimensions=dimensions.dimensionless,
-                            sampling_type="cell")

--- a/yt/frontends/amrvac/fields.py
+++ b/yt/frontends/amrvac/fields.py
@@ -118,8 +118,8 @@ class AMRVACFieldInfo(FieldInfoContainer):
                           "can not setup adiabatic thermal_pressure")
 
 
+        # sound speed depends on thermal pressure
         if ("gas", "thermal_pressure") in self.field_list:
-            # sound speed depends on thermal pressure
             def _sound_speed(field, data):
                 return sqrt(data.ds.gamma * data["thermal_pressure"] / data["gas", "density"])
 

--- a/yt/frontends/amrvac/fields.py
+++ b/yt/frontends/amrvac/fields.py
@@ -95,7 +95,7 @@ class AMRVACFieldInfo(FieldInfoContainer):
             namelist = ds.namelist
             if namelist.get(["hd_list"], {}).get("hd_ernergy", True):
                 # important note : energy density and pressure are actually expressed in the same unit
-                pth = (gamma - 1) * data["gas", "energy_density"] - data["gas", "kinetic_energy_density"]
+                pth = (gamma - 1) * (data["gas", "energy_density"] - data["gas", "kinetic_energy_density"])
             else:
                 # todo: move this warning so it's only triggered once ?
                 mylog.warning("thermal_pressure field is assumed polytropic when hd_energy = False." \


### PR DESCRIPTION
**note:**
~For now, this branch is based on #2376, I'll rebase it onto master once the former is merged.~ ✅ 

## PR Summary
Add kinetic energy density, thermal pressure, sound speed, and mach number to derived fields.
This is made possible since there's an api for passing configuration "parfiles" at load time, so we can now reconstruct the equation of state that was used in the run.

## PR Checklist
- [x] Code passes flake8 checker
- [x] internal documentation (docstrings, comments)
- [x] finish implementing various related "todos" in the frontend (there should be 2)
- [x] website documentation (add entry to `doc/examining/loading_data.rst`)


I suppose it would suffice to update the answer tests to cover this. However, I am not certain that derived fields are thoroughly tested for. Any clue on this @munkm ?

~This will need immediate extension to the mhd case, but I'd suggest to keep that for a following PR.~
**edit:** actually, the mhd case is the only missing bit to make this PR complete and it does not look that much more work, so I might as well include it here once I fully understand how it works in AMRVAC.