### PR TITLE
Fix python 3.8 warnings

### DIFF
--- a/yt/frontends/flash/data_structures.py
+++ b/yt/frontends/flash/data_structures.py
@@ -318,7 +318,7 @@ class FLASHDataset(Dataset):
             for hn in hns:
                 if hn not in self._handle:
                     continue
-                if hn is 'simulation parameters':
+                if hn == 'simulation parameters':
                     zipover = ((name, self._handle[hn][name][0])
                                for name in self._handle[hn].dtype.names)
                 else:

--- a/yt/frontends/open_pmd/data_structures.py
+++ b/yt/frontends/open_pmd/data_structures.py
@@ -444,7 +444,7 @@ class OpenPMDDataset(Dataset):
         elif "fileBased" in encoding:
             itformat = handle.attrs["iterationFormat"].decode().split("/")[-1]
             regex = "^" + itformat.replace("%T", "[0-9]+") + "$"
-            if path is "":
+            if path == "":
                 mylog.warning("For file based iterations, please use absolute file paths!")
                 pass
             for filename in listdir(path):

--- a/yt/frontends/open_pmd/misc.py
+++ b/yt/frontends/open_pmd/misc.py
@@ -45,7 +45,7 @@ def parse_unit_dimension(unit_dimension):
     >>> print parse_unit_dimension(magnetic_field)
     'kg**1*s**-2*A**-1'
     """
-    if len(unit_dimension) is not 7:
+    if len(unit_dimension) != 7:
         mylog.error("SI must have 7 base dimensions!")
     unit_dimension = np.asarray(unit_dimension, dtype=np.int)
     dim = []

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -318,7 +318,7 @@ class RAMSESIndex(OctreeIndex):
     def _get_particle_type_counts(self):
         npart = 0
         npart = {k: 0 for k in self.ds.particle_types
-                 if k is not 'all'}
+                 if k != 'all'}
         for dom in self.domains:
             for fh in dom.particle_handlers:
                 count = fh.local_particle_count

--- a/yt/utilities/grid_data_format/conversion/conversion_athena.py
+++ b/yt/utilities/grid_data_format/conversion/conversion_athena.py
@@ -208,7 +208,7 @@ class AthenaDistributedConverter(Converter):
             f = open(fn,'rb')
             #print 'Reading data from %s' % fn
             line = f.readline()
-            while line is not '':
+            while line != '':
                 if len(line) == 0: break
                 splitup = line.strip().split()
 
@@ -231,7 +231,7 @@ class AthenaDistributedConverter(Converter):
                     del line
                     line = f.readline()
             read_table = False
-            while line is not '':
+            while line != '':
                 if len(line) == 0: break
                 splitup = line.strip().split()
                 if 'SCALARS' in splitup:
@@ -340,10 +340,10 @@ class AthenaConverter(Converter):
         grid['read_type'] = None
         table_read=False
         line = f.readline()
-        while line is not '':
+        while line != '':
             while grid['read_field'] is None:
                 self.parse_line(line, grid)
-                if grid['read_type'] is 'vector':
+                if grid['read_type'] == 'vector':
                     break
                 if table_read is False:             
                     line = f.readline()
@@ -359,11 +359,11 @@ class AthenaConverter(Converter):
                       (np.prod(grid['dimensions']), grid['ncells']))
                 raise TypeError
 
-            if grid['read_type'] is 'scalar':
+            if grid['read_type'] == 'scalar':
                 grid[grid['read_field']] = \
                     np.fromfile(f, dtype='>f4', count=grid['ncells']).reshape(grid['dimensions'],order='F')
                 self.fields.append(grid['read_field'])
-            elif grid['read_type'] is 'vector':
+            elif grid['read_type'] == 'vector':
                 data = np.fromfile(f, dtype='>f4', count=3*grid['ncells'])
                 grid[grid['read_field']+'_x'] = data[0::3].reshape(grid['dimensions'],order='F')
                 grid[grid['read_field']+'_y'] = data[1::3].reshape(grid['dimensions'],order='F')

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -883,7 +883,7 @@ class ImagePlotContainer(PlotContainer):
             zmin = zmax / dynamic_range.
 
         """
-        if field is 'all':
+        if field == 'all':
             fields = list(self.plots.keys())
         else:
             fields = ensure_list(field)

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -684,7 +684,7 @@ class ProfilePlot(object):
         >>> pp.save()
 
         """
-        if field is 'all':
+        if field == 'all':
             fields = list(self.axes.keys())
         else:
             fields = ensure_list(field)
@@ -770,7 +770,7 @@ class ProfilePlot(object):
                                 ["temperature", "dark_matter_density"])
 
         """
-        if field is 'all':
+        if field == 'all':
             fields = list(self.axes.keys())
         else:
             fields = ensure_list(field)
@@ -823,7 +823,7 @@ class ProfilePlot(object):
         >>>  plot.save()
 
         """
-        if field is 'all':
+        if field == 'all':
             fields = list(self.axes.keys())
         else:
             fields = ensure_list(field)
@@ -986,7 +986,7 @@ class PhasePlot(ImagePlotContainer):
             field_name = r'$\rm{'+field_name+r'}$'
         if fractional:
             label = field_name + r'$\rm{\ Probability\ Density}$'
-        elif field_unit is None or field_unit is '':
+        elif field_unit is None or field_unit == '':
             label = field_name
         else:
             label = field_name+r'$\ \ ('+field_unit+r')$'


### PR DESCRIPTION
In Python 3.8, the usage of `is` in some context raises a
warning. This is due to the fact that `is` checks for equality of
object, while `==` checks for equality of their value (as is expected
in the code).