### PR TITLE
chombo frontend :: solved bug related to slice the ghost cells out

### DIFF
--- a/yt/frontends/chombo/io.py
+++ b/yt/frontends/chombo/io.py
@@ -111,7 +111,7 @@ class IOHandlerChomboHDF5(BaseIOHandler):
         data = lev[self._data_string][start:stop]
         data_no_ghost = data.reshape(shape, order='F')
         ghost_slice = tuple(
-            [slice(g, d-g, None) for g, d in zip(self.ghost, dims)])
+            [slice(g, d+g, None) for g, d in zip(self.ghost, dims)])
         ghost_slice = ghost_slice[0:self.dim]
         return data_no_ghost[ghost_slice]
 


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

In the CHOMBO frontend, I encounter a bug when reading datasets containing ghost cells.
The issue is when doing the slice, a minus sign should be a plus sign, in order to filter out only the "right-hand side" ghost cells.  

I tried some of my datasets (from GRChombo) and now the code works well. 

Please check that this (small) change make sense. 


<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
