### PR TITLE
Switch logic for using all-data in particle IO

### DIFF
--- a/yt/geometry/particle_geometry_handler.py
+++ b/yt/geometry/particle_geometry_handler.py
@@ -218,12 +218,12 @@ class ParticleIndex(Index):
             else:
                 # TODO: only return files
                 if getattr(dobj.selector, 'is_all_data', False):
+                    nfiles = self.regions.nfiles
+                    dfi = np.arange(nfiles)
+                else:
                     dfi, file_masks, addfi = self.regions.identify_file_masks(
                         dobj.selector)
                     nfiles = len(file_masks)
-                else:
-                    nfiles = self.regions.nfiles
-                    dfi = np.arange(nfiles)
                 dobj._chunk_info = [None for _ in range(nfiles)]
                 for i in range(nfiles):
                     domain_id = i+1


### PR DESCRIPTION
After examining #2383, I came to believe that this logic was inverted.
In short, I believe that if `is_all_data` is `True`, we should be using
all of the data without validating.  If it is `False`, we should check
for collisions.