### PR TITLE
[WIP] Load from path objects

### DIFF
--- a/yt/convenience.py
+++ b/yt/convenience.py
@@ -34,7 +34,7 @@ def _sanitize_load_args(*args):
     if PY3:
         from pathlib import PosixPath
         acceptable_input_types.append(PosixPath)
-    args = [os.path.expanduser(arg) if isinstance(arg, tuple(acceptable_input_types))
+    args = [os.path.expanduser(str(arg)) if isinstance(arg, tuple(acceptable_input_types))
             else arg for arg in args]
     return args
 

--- a/yt/convenience.py
+++ b/yt/convenience.py
@@ -28,6 +28,16 @@ from yt.utilities.exceptions import \
     YTSimulationNotIdentified
 from yt.utilities.hierarchy_inspection import find_lowest_subclasses
 
+def _sanitize_load_args(args):
+    """Filter out non-string-like arguments and replace "~" with user name"""
+    acceptable_input_types = list(string_types)
+    if PY3:
+        from pathlib import PosixPath
+        acceptable_input_types.append(PosixPath)
+    args = [os.path.expanduser(arg) if isinstance(arg, tuple(acceptable_input_types))
+            else arg for arg in args]
+    return args
+
 def load(*args ,**kwargs):
     """
     This function attempts to determine the base data type of a filename or
@@ -38,12 +48,7 @@ def load(*args ,**kwargs):
     """
     candidates = []
 
-    acceptable_input_types = list(string_types)
-    if PY3:
-        from pathlib import PosixPath
-        acceptable_input_types.append(PosixPath)
-    args = [os.path.expanduser(arg) if isinstance(arg, tuple(acceptable_input_types))
-            else arg for arg in args]
+    args = _sanitize_load_args(args)
     valid_file = []
     for argno, arg in enumerate(args):
         if isinstance(arg, string_types):

--- a/yt/convenience.py
+++ b/yt/convenience.py
@@ -28,7 +28,7 @@ from yt.utilities.exceptions import \
     YTSimulationNotIdentified
 from yt.utilities.hierarchy_inspection import find_lowest_subclasses
 
-def _sanitize_load_args(args):
+def _sanitize_load_args(*args):
     """Filter out non-string-like arguments and replace "~" with user name"""
     acceptable_input_types = list(string_types)
     if PY3:
@@ -48,7 +48,7 @@ def load(*args ,**kwargs):
     """
     candidates = []
 
-    args = _sanitize_load_args(args)
+    args = _sanitize_load_args(*args)
     valid_file = []
     for argno, arg in enumerate(args):
         if isinstance(arg, string_types):

--- a/yt/convenience.py
+++ b/yt/convenience.py
@@ -14,13 +14,9 @@ Some convenience functions, objects, and iterators
 #-----------------------------------------------------------------------------
 
 import os
-try:
-    from pathlib import PosixPath
-except ImportError: # python2
-    from pathlib2 import PosixPath
 
 # Named imports
-from yt.extern.six import string_types
+from yt.extern.six import string_types, PY3
 from yt.config import ytcfg
 from yt.funcs import mylog
 from yt.utilities.parameter_file_storage import \
@@ -41,7 +37,12 @@ def load(*args ,**kwargs):
     :class:`yt.data_objects.static_output.Dataset` subclass.
     """
     candidates = []
-    args = [os.path.expanduser(arg) if isinstance(arg, tuple((list(string_types) + [PosixPath])))
+
+    acceptable_input_types = list(string_types)
+    if PY3:
+        from pathlib import PosixPath
+        acceptable_input_types.append(PosixPath)
+    args = [os.path.expanduser(arg) if isinstance(arg, tuple(acceptable_input_types))
             else arg for arg in args]
     valid_file = []
     for argno, arg in enumerate(args):

--- a/yt/convenience.py
+++ b/yt/convenience.py
@@ -38,7 +38,7 @@ def load(*args ,**kwargs):
     :class:`yt.data_objects.static_output.Dataset` subclass.
     """
     candidates = []
-    args = [os.path.expanduser(arg) if isinstance(arg, (PosixPath, *string_types))
+    args = [os.path.expanduser(arg) if isinstance(arg, tuple((list(string_types) + [PosixPath])))
             else arg for arg in args]
     valid_file = []
     for argno, arg in enumerate(args):

--- a/yt/convenience.py
+++ b/yt/convenience.py
@@ -14,7 +14,10 @@ Some convenience functions, objects, and iterators
 #-----------------------------------------------------------------------------
 
 import os
-from pathlib import PosixPath
+try:
+    from pathlib import PosixPath
+except ImportError: # python2
+    from pathlib2 import PosixPath
 
 # Named imports
 from yt.extern.six import string_types

--- a/yt/convenience.py
+++ b/yt/convenience.py
@@ -14,6 +14,7 @@ Some convenience functions, objects, and iterators
 #-----------------------------------------------------------------------------
 
 import os
+from pathlib import PosixPath
 
 # Named imports
 from yt.extern.six import string_types
@@ -37,7 +38,7 @@ def load(*args ,**kwargs):
     :class:`yt.data_objects.static_output.Dataset` subclass.
     """
     candidates = []
-    args = [os.path.expanduser(arg) if isinstance(arg, string_types)
+    args = [os.path.expanduser(arg) if isinstance(arg, (PosixPath, *string_types))
             else arg for arg in args]
     valid_file = []
     for argno, arg in enumerate(args):

--- a/yt/tests/test_load.py
+++ b/yt/tests/test_load.py
@@ -1,0 +1,27 @@
+from yt.convenience import _sanitize_load_args
+from pathlib import Path
+
+def test_sanitize_from_simple_path():
+    # check for basic path
+    p1 = "not/a/real/datafile.hdf5"
+    p2 = Path(p1)
+    assert _sanitize_load_args(p1) == _sanitize_load_args(p2)
+
+def test_sanitize_from_two_paths():
+    # check for more than one path
+    p1 = ["not/a/real/datafile.hdf5", "not/real/either/datafile.hdf5"]
+    p2 = [Path(p) for p in p1]
+    assert _sanitize_load_args(*p1) == _sanitize_load_args(*p2)
+
+def test_sanitize_from_user_path():
+    # check for user "~" card expansion
+    p1 = "~/not/a/real/datafile.hdf5"
+    p2 = Path(p1)
+    assert _sanitize_load_args(p1) == _sanitize_load_args(p2)
+
+def test_sanitize_from_wildcard_path():
+    # check with wildcards
+    p1 = "not/a/real/directory/*.hdf5"
+    p2 = Path(p1)
+    assert _sanitize_load_args(p1) == _sanitize_load_args(p2)
+    


### PR DESCRIPTION
## PR Summary

Allow yt to load from path objects. The fix was extremely simple for python 3.7, but I expect I'll need to change the syntax and maybe the import statement for compatibility with python 2.

**Important note :**
From Python 3.6, `os.path.expandusers()` accepts paths as input and still returns strings, so `yt.load()` sanitizes the input really well as is.
https://docs.python.org/3.7/library/os.path.html#os.path.expanduser

I don't know what's the current oldest python 3 supported version, but I expect that it will be compatible with all Python versions once I make it work for 2.7


In particular, I checked that it still works with timeseries from wildcards, e.g.
```python
from pathlib import Path
ts1 = yt.load("output*.dat")
ts2 = yt.load(Path("output*.dat"))
```