### PR TITLE
install sympy 1.4 on appveyor to work around regression in 1.5

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ install:
     - "python --version"
 
     # Install specified version of numpy and dependencies
-    - "conda install --yes -c conda-forge numpy scipy nose setuptools ipython Cython sympy fastcache h5py matplotlib mock pandas cartopy conda-build pyyaml"
+    - "conda install --yes -c conda-forge numpy scipy nose setuptools ipython Cython sympy=1.4 fastcache h5py matplotlib mock pandas cartopy conda-build pyyaml"
     - "conda develop -b ."
 
 # Not a .NET project


### PR DESCRIPTION
This should fix the failures that started cropping up on appveyor recently. I'm going to report this upstream as a regression.