### PR TITLE
Remove copyright notices

### DIFF
--- a/tests/report_failed_answers.py
+++ b/tests/report_failed_answers.py
@@ -4,13 +4,6 @@ on cloud platforms like Travis
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2018, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 from __future__ import print_function
 

--- a/yt/api.py
+++ b/yt/api.py
@@ -5,10 +5,3 @@ API for yt
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------

--- a/yt/frontends/_skeleton/__init__.py
+++ b/yt/frontends/_skeleton/__init__.py
@@ -5,10 +5,3 @@ API for yt.frontends._skeleton
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------

--- a/yt/frontends/ahf/__init__.py
+++ b/yt/frontends/ahf/__init__.py
@@ -5,10 +5,3 @@ API for yt.frontends.ahf
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2017, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------

--- a/yt/frontends/art/__init__.py
+++ b/yt/frontends/art/__init__.py
@@ -5,10 +5,3 @@ API for yt.frontends.art
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------

--- a/yt/frontends/artio/__init__.py
+++ b/yt/frontends/artio/__init__.py
@@ -6,10 +6,3 @@ API for yt.frontends.artio
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------

--- a/yt/frontends/athena/definitions.py
+++ b/yt/frontends/athena/definitions.py
@@ -5,10 +5,3 @@ Various definitions for various other modules and routines
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------

--- a/yt/frontends/athena_pp/definitions.py
+++ b/yt/frontends/athena_pp/definitions.py
@@ -5,10 +5,3 @@ Various definitions for various other modules and routines
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------

--- a/yt/frontends/boxlib/__init__.py
+++ b/yt/frontends/boxlib/__init__.py
@@ -5,10 +5,3 @@ API for yt.frontends.boxlib
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------

--- a/yt/frontends/exodus_ii/__init__.py
+++ b/yt/frontends/exodus_ii/__init__.py
@@ -5,10 +5,3 @@ API for yt.frontends.exodus_ii
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------

--- a/yt/frontends/flash/__init__.py
+++ b/yt/frontends/flash/__init__.py
@@ -5,10 +5,3 @@ API for yt.frontends.flash
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------

--- a/yt/frontends/gadget_fof/__init__.py
+++ b/yt/frontends/gadget_fof/__init__.py
@@ -6,10 +6,3 @@ API for HaloCatalog frontend.
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------

--- a/yt/frontends/gamer/__init__.py
+++ b/yt/frontends/gamer/__init__.py
@@ -5,10 +5,3 @@ API for yt.frontends.gamer
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2016, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------

--- a/yt/frontends/gdf/definitions.py
+++ b/yt/frontends/gdf/definitions.py
@@ -5,10 +5,3 @@ Various definitions for various other modules and routines
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------

--- a/yt/frontends/halo_catalog/__init__.py
+++ b/yt/frontends/halo_catalog/__init__.py
@@ -6,10 +6,3 @@ API for HaloCatalog frontend.
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------

--- a/yt/frontends/moab/__init__.py
+++ b/yt/frontends/moab/__init__.py
@@ -5,10 +5,3 @@ Empty __init__.py file.
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------

--- a/yt/frontends/open_pmd/__init__.py
+++ b/yt/frontends/open_pmd/__init__.py
@@ -5,11 +5,3 @@ API for yt.frontends.open_pmd
 
 """
 
-# -----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-# Copyright (c) 2015, Daniel Grassinger (HZDR)
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-# -----------------------------------------------------------------------------

--- a/yt/frontends/owls_subfind/__init__.py
+++ b/yt/frontends/owls_subfind/__init__.py
@@ -6,10 +6,3 @@ API for HaloCatalog frontend.
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------

--- a/yt/frontends/ramses/__init__.py
+++ b/yt/frontends/ramses/__init__.py
@@ -5,10 +5,3 @@ API for yt.frontends.ramses
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------

--- a/yt/frontends/rockstar/__init__.py
+++ b/yt/frontends/rockstar/__init__.py
@@ -6,10 +6,3 @@ API for Rockstar frontend.
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------

--- a/yt/frontends/sdf/__init__.py
+++ b/yt/frontends/sdf/__init__.py
@@ -6,10 +6,3 @@ __init__ for yt.frontends.sdf
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------

--- a/yt/frontends/sph/__init__.py
+++ b/yt/frontends/sph/__init__.py
@@ -6,10 +6,3 @@ API for yt.frontends.gadget
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------

--- a/yt/frontends/sph/api.py
+++ b/yt/frontends/sph/api.py
@@ -6,10 +6,3 @@ API for general SPH frontend machinery
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------

--- a/yt/frontends/ytdata/__init__.py
+++ b/yt/frontends/ytdata/__init__.py
@@ -6,10 +6,3 @@ API for ytData frontend.
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2015, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------

--- a/yt/geometry/fake_octree.pyx
+++ b/yt/geometry/fake_octree.pyx
@@ -6,13 +6,6 @@ Make a fake octree, deposit particle at every leaf
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 from libc.stdlib cimport malloc, free, rand, RAND_MAX
 cimport numpy as np

--- a/yt/geometry/grid_container.pxd
+++ b/yt/geometry/grid_container.pxd
@@ -5,13 +5,6 @@ Matching points on the grid to specific grids
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import numpy as np
 cimport numpy as np

--- a/yt/geometry/grid_container.pyx
+++ b/yt/geometry/grid_container.pyx
@@ -5,13 +5,6 @@ Matching points on the grid to specific grids
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import numpy as np
 cimport numpy as np

--- a/yt/geometry/grid_visitors.pxd
+++ b/yt/geometry/grid_visitors.pxd
@@ -6,13 +6,6 @@ Grid visitor definitions file
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2015, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 cimport numpy as np
 

--- a/yt/geometry/grid_visitors.pyx
+++ b/yt/geometry/grid_visitors.pyx
@@ -6,13 +6,6 @@ Grid visitor functions
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2015, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 cimport numpy as np
 cimport cython

--- a/yt/geometry/oct_container.pxd
+++ b/yt/geometry/oct_container.pxd
@@ -6,13 +6,6 @@ Oct definitions file
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 cimport cython
 cimport numpy as np

--- a/yt/geometry/oct_container.pyx
+++ b/yt/geometry/oct_container.pyx
@@ -6,13 +6,6 @@ Oct container
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 cimport cython
 cimport numpy as np

--- a/yt/geometry/oct_visitors.pxd
+++ b/yt/geometry/oct_visitors.pxd
@@ -6,13 +6,6 @@ Oct visitor definitions file
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 cimport numpy as np
 

--- a/yt/geometry/oct_visitors.pyx
+++ b/yt/geometry/oct_visitors.pyx
@@ -6,13 +6,6 @@ Oct visitor functions
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 cimport cython
 cimport numpy

--- a/yt/geometry/particle_deposit.pxd
+++ b/yt/geometry/particle_deposit.pxd
@@ -6,13 +6,6 @@ Particle Deposition onto Octs
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 cimport numpy as np
 import numpy as np

--- a/yt/geometry/particle_deposit.pyx
+++ b/yt/geometry/particle_deposit.pyx
@@ -6,13 +6,6 @@ Particle Deposition onto Cells
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 cimport numpy as np
 import numpy as np

--- a/yt/geometry/particle_oct_container.pyx
+++ b/yt/geometry/particle_oct_container.pyx
@@ -6,13 +6,6 @@ Oct container tuned for Particles
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 from oct_container cimport OctreeContainer, Oct, OctInfo, ORDER_MAX, \
     SparseOctreeContainer, OctKey, OctAllocationContainer

--- a/yt/geometry/particle_smooth.pxd
+++ b/yt/geometry/particle_smooth.pxd
@@ -6,13 +6,6 @@ Particle Deposition onto Octs
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 cimport numpy as np
 import numpy as np

--- a/yt/geometry/particle_smooth.pyx
+++ b/yt/geometry/particle_smooth.pyx
@@ -6,13 +6,6 @@ Particle smoothing in cells
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 cimport numpy as np
 import numpy as np

--- a/yt/geometry/selection_routines.pxd
+++ b/yt/geometry/selection_routines.pxd
@@ -6,13 +6,6 @@ Geometry selection routine imports.
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 cimport numpy as np
 from oct_visitors cimport Oct, OctVisitor

--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -6,13 +6,6 @@ Geometry selection routines.
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import numpy as np
 cimport numpy as np

--- a/yt/utilities/amr_kdtree/__init__.py
+++ b/yt/utilities/amr_kdtree/__init__.py
@@ -3,10 +3,3 @@ Initialize amr_kdtree
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------

--- a/yt/utilities/answer_testing/__init__.py
+++ b/yt/utilities/answer_testing/__init__.py
@@ -5,10 +5,3 @@ The components of the Enzo testing mechanism
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------

--- a/yt/utilities/api.py
+++ b/yt/utilities/api.py
@@ -5,10 +5,3 @@ API for yt.utilities
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------

--- a/yt/utilities/lib/allocation_container.pxd
+++ b/yt/utilities/lib/allocation_container.pxd
@@ -5,13 +5,6 @@ An allocation container and memory pool
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2016, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 cimport numpy as np
 from libc.stdlib cimport malloc, free, realloc

--- a/yt/utilities/lib/allocation_container.pyx
+++ b/yt/utilities/lib/allocation_container.pyx
@@ -5,13 +5,6 @@ An allocation container and memory pool
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2016, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 cimport numpy as np
 import numpy as np

--- a/yt/utilities/lib/alt_ray_tracers.pyx
+++ b/yt/utilities/lib/alt_ray_tracers.pyx
@@ -5,13 +5,6 @@
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import numpy as np
 cimport numpy as np

--- a/yt/utilities/lib/amr_kdtools.pxd
+++ b/yt/utilities/lib/amr_kdtools.pxd
@@ -5,13 +5,6 @@ AMR kD-Tree Cython Tools
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 cimport numpy as np
 

--- a/yt/utilities/lib/amr_kdtools.pyx
+++ b/yt/utilities/lib/amr_kdtools.pyx
@@ -5,13 +5,6 @@ AMR kD-Tree Cython Tools
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import numpy as np
 cimport numpy as np

--- a/yt/utilities/lib/basic_octree.pyx
+++ b/yt/utilities/lib/basic_octree.pyx
@@ -5,13 +5,6 @@ A refine-by-two AMR-specific octree
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 
 import numpy as np

--- a/yt/utilities/lib/bitarray.pxd
+++ b/yt/utilities/lib/bitarray.pxd
@@ -5,13 +5,6 @@ Bit array functions
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2015, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import numpy as np
 cimport numpy as np

--- a/yt/utilities/lib/bitarray.pyx
+++ b/yt/utilities/lib/bitarray.pyx
@@ -5,13 +5,6 @@ Bit array functions
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2015, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import numpy as np
 cimport numpy as np

--- a/yt/utilities/lib/bounded_priority_queue.pxd
+++ b/yt/utilities/lib/bounded_priority_queue.pxd
@@ -7,13 +7,6 @@ been added to it.
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2017, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 import numpy as np
 cimport numpy as np
 

--- a/yt/utilities/lib/bounded_priority_queue.pyx
+++ b/yt/utilities/lib/bounded_priority_queue.pyx
@@ -9,13 +9,6 @@ element at the beginning - this exploited to store nearest neighbour lists.
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2017, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import numpy as np
 cimport numpy as np

--- a/yt/utilities/lib/contour_finding.pxd
+++ b/yt/utilities/lib/contour_finding.pxd
@@ -5,13 +5,6 @@ Contour finding exports
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 
 cimport numpy as np

--- a/yt/utilities/lib/contour_finding.pyx
+++ b/yt/utilities/lib/contour_finding.pyx
@@ -5,13 +5,6 @@ A two-pass contour finding algorithm
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import numpy as np
 cimport numpy as np

--- a/yt/utilities/lib/cyoctree.pyx
+++ b/yt/utilities/lib/cyoctree.pyx
@@ -5,13 +5,6 @@ CyOctree building, loading and refining routines
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2018, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 cimport numpy as np
 import numpy as np

--- a/yt/utilities/lib/depth_first_octree.pyx
+++ b/yt/utilities/lib/depth_first_octree.pyx
@@ -5,13 +5,6 @@ This is a recursive function to return a depth-first octree
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import numpy as np
 cimport numpy as np

--- a/yt/utilities/lib/distance_queue.pxd
+++ b/yt/utilities/lib/distance_queue.pxd
@@ -6,13 +6,6 @@ A queue for evaluating distances to discrete points
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2016, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 cimport cython
 cimport numpy as np

--- a/yt/utilities/lib/distance_queue.pyx
+++ b/yt/utilities/lib/distance_queue.pyx
@@ -6,13 +6,6 @@ Distance queue implementation
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2016, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 cimport numpy as np
 import numpy as np
 cimport cython

--- a/yt/utilities/lib/element_mappings.pyx
+++ b/yt/utilities/lib/element_mappings.pyx
@@ -6,13 +6,6 @@ interpolation on finite element data.
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2015, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 cimport numpy as np
 from numpy cimport ndarray

--- a/yt/utilities/lib/ewah_bool_array.pxd
+++ b/yt/utilities/lib/ewah_bool_array.pxd
@@ -5,13 +5,6 @@ Wrapper for EWAH Bool Array: https://github.com/lemire/EWAHBoolArray
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 cimport numpy as np
 cimport cython

--- a/yt/utilities/lib/ewah_bool_wrap.pyx
+++ b/yt/utilities/lib/ewah_bool_wrap.pyx
@@ -5,13 +5,6 @@ Wrapper for EWAH Bool Array: https://github.com/lemire/EWAHBoolArray
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import struct
 from libcpp.map cimport map as cmap

--- a/yt/utilities/lib/field_interpolation_tables.pxd
+++ b/yt/utilities/lib/field_interpolation_tables.pxd
@@ -5,13 +5,6 @@ Field Interpolation Tables
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 cimport cython
 cimport numpy as np

--- a/yt/utilities/lib/fixed_interpolator.c
+++ b/yt/utilities/lib/fixed_interpolator.c
@@ -1,9 +1,4 @@
 /*******************************************************************************
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
 *******************************************************************************/
 
 //

--- a/yt/utilities/lib/fixed_interpolator.h
+++ b/yt/utilities/lib/fixed_interpolator.h
@@ -1,9 +1,4 @@
 /*******************************************************************************
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
 *******************************************************************************/
 //
 // A small, tiny, itty bitty module for computation-intensive interpolation

--- a/yt/utilities/lib/fixed_interpolator.pxd
+++ b/yt/utilities/lib/fixed_interpolator.pxd
@@ -5,13 +5,6 @@ Fixed interpolator includes
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 cimport numpy as np
 

--- a/yt/utilities/lib/fnv_hash.pxd
+++ b/yt/utilities/lib/fnv_hash.pxd
@@ -6,13 +6,6 @@ Definitions for fnv_hash
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2017, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 
 import numpy as np

--- a/yt/utilities/lib/fnv_hash.pyx
+++ b/yt/utilities/lib/fnv_hash.pyx
@@ -4,13 +4,6 @@ Fast hashing routines
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2017, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import numpy as np
 cimport numpy as np

--- a/yt/utilities/lib/fortran_reader.pyx
+++ b/yt/utilities/lib/fortran_reader.pyx
@@ -5,13 +5,6 @@ Simple readers for fortran unformatted data, specifically for the Tiger code.
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import numpy as np
 cimport numpy as np

--- a/yt/utilities/lib/fp_utils.pxd
+++ b/yt/utilities/lib/fp_utils.pxd
@@ -5,13 +5,6 @@ Shareable definitions for common fp/int Cython utilities
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 cimport numpy as np
 cimport cython

--- a/yt/utilities/lib/geometry_utils.pxd
+++ b/yt/utilities/lib/geometry_utils.pxd
@@ -6,13 +6,6 @@ Particle Deposition onto Octs
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 cimport numpy as np
 cimport cython
 from libc.float cimport DBL_MANT_DIG

--- a/yt/utilities/lib/geometry_utils.pyx
+++ b/yt/utilities/lib/geometry_utils.pyx
@@ -5,13 +5,6 @@ Simple integrators for the radiative transfer equation
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import numpy as np
 cimport numpy as np

--- a/yt/utilities/lib/grid_traversal.pxd
+++ b/yt/utilities/lib/grid_traversal.pxd
@@ -6,13 +6,6 @@ Definitions for the traversal code
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import numpy as np
 cimport numpy as np

--- a/yt/utilities/lib/grid_traversal.pyx
+++ b/yt/utilities/lib/grid_traversal.pyx
@@ -5,13 +5,6 @@ Simple integrators for the radiative transfer equation
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import numpy as np
 cimport numpy as np

--- a/yt/utilities/lib/healpix_interface.pxd
+++ b/yt/utilities/lib/healpix_interface.pxd
@@ -5,13 +5,6 @@ A light interface to a few HEALPix routines
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import numpy as np
 cimport numpy as np

--- a/yt/utilities/lib/image_samplers.pxd
+++ b/yt/utilities/lib/image_samplers.pxd
@@ -6,13 +6,6 @@ Definitions for image samplers
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2016, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import numpy as np
 cimport numpy as np

--- a/yt/utilities/lib/image_samplers.pyx
+++ b/yt/utilities/lib/image_samplers.pyx
@@ -5,13 +5,6 @@ Image sampler definitions
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2016, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import numpy as np
 cimport numpy as np

--- a/yt/utilities/lib/image_utilities.pyx
+++ b/yt/utilities/lib/image_utilities.pyx
@@ -2,13 +2,6 @@
 Utilities for images
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import numpy as np
 cimport numpy as np

--- a/yt/utilities/lib/interpolators.pyx
+++ b/yt/utilities/lib/interpolators.pyx
@@ -5,13 +5,6 @@ Simple interpolators
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import numpy as np
 cimport numpy as np

--- a/yt/utilities/lib/lenses.pxd
+++ b/yt/utilities/lib/lenses.pxd
@@ -6,13 +6,6 @@ Definitions for the lens code
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2016, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import numpy as np
 cimport numpy as np

--- a/yt/utilities/lib/lenses.pyx
+++ b/yt/utilities/lib/lenses.pyx
@@ -5,13 +5,6 @@ Functions for computing the extent of lenses and whatnot
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2016, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import numpy as np
 cimport numpy as np

--- a/yt/utilities/lib/line_integral_convolution.pyx
+++ b/yt/utilities/lib/line_integral_convolution.pyx
@@ -5,17 +5,6 @@ Utilities for line integral convolution annotation
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2015, yt Development Team.
-#
-# Code originally from Scipy Cookbook (http://wiki.scipy.org/Cookbook/LineIntegralConvolution),
-# with bug fixed which leads to crash when non equal-size vector field in two
-# dimensions is provided.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 
 import numpy as np

--- a/yt/utilities/lib/marching_cubes.pyx
+++ b/yt/utilities/lib/marching_cubes.pyx
@@ -5,13 +5,6 @@ Marching cubes implementation
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 cimport numpy as np
 cimport cython

--- a/yt/utilities/lib/mesh_construction.pyx
+++ b/yt/utilities/lib/mesh_construction.pyx
@@ -8,13 +8,6 @@ Note - this file is only used for the Embree-accelerated ray-tracer.
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2015, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import numpy as np
 cimport cython

--- a/yt/utilities/lib/mesh_intersection.pyx
+++ b/yt/utilities/lib/mesh_intersection.pyx
@@ -6,13 +6,6 @@ Note - this file is only used for the Embree-accelerated ray-tracer.
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2015, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 cimport pyembree.rtcore as rtc
 cimport pyembree.rtcore_ray as rtcr

--- a/yt/utilities/lib/mesh_samplers.pyx
+++ b/yt/utilities/lib/mesh_samplers.pyx
@@ -6,13 +6,6 @@ Note - this file is only used for the Embree-accelerated ray-tracer.
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2015, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 cimport pyembree.rtcore as rtc
 cimport pyembree.rtcore_ray as rtcr

--- a/yt/utilities/lib/mesh_traversal.pyx
+++ b/yt/utilities/lib/mesh_traversal.pyx
@@ -5,13 +5,6 @@ mesh source using either pyembree or the cython ray caster.
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2015, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 cimport cython
 cimport numpy as np

--- a/yt/utilities/lib/mesh_utilities.pyx
+++ b/yt/utilities/lib/mesh_utilities.pyx
@@ -5,13 +5,6 @@ Utilities for unstructured and semi-structured meshes
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import numpy as np
 cimport numpy as np

--- a/yt/utilities/lib/misc_utilities.pyx
+++ b/yt/utilities/lib/misc_utilities.pyx
@@ -5,13 +5,6 @@ Simple utilities that don't fit anywhere else
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 from yt.funcs import get_pbar
 import numpy as np

--- a/yt/utilities/lib/origami.pyx
+++ b/yt/utilities/lib/origami.pyx
@@ -5,13 +5,6 @@ This calls the ORIGAMI routines
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import numpy as np
 cimport numpy as np

--- a/yt/utilities/lib/particle_kdtree_tools.pyx
+++ b/yt/utilities/lib/particle_kdtree_tools.pyx
@@ -5,13 +5,6 @@ Cython tools for working with the PyKDTree particle KDTree.
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2017, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import numpy as np
 cimport numpy as np

--- a/yt/utilities/lib/particle_mesh_operations.pyx
+++ b/yt/utilities/lib/particle_mesh_operations.pyx
@@ -5,13 +5,6 @@ Simple integrators for the radiative transfer equation
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 cimport numpy as np
 cimport cython

--- a/yt/utilities/lib/partitioned_grid.pxd
+++ b/yt/utilities/lib/partitioned_grid.pxd
@@ -6,13 +6,6 @@ Definitions for the partitioned grid
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2016, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import numpy as np
 cimport numpy as np

--- a/yt/utilities/lib/partitioned_grid.pyx
+++ b/yt/utilities/lib/partitioned_grid.pyx
@@ -5,13 +5,6 @@ Image sampler definitions
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2016, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import numpy as np
 cimport numpy as np

--- a/yt/utilities/lib/perftools_wrap.pyx
+++ b/yt/utilities/lib/perftools_wrap.pyx
@@ -5,13 +5,6 @@ Turn on and off perftools profiling
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 # For more info:
 # https://pygabriel.wordpress.com/2010/04/14/profiling-python-c-extensions/

--- a/yt/utilities/lib/pixelization_constants.c
+++ b/yt/utilities/lib/pixelization_constants.c
@@ -1,9 +1,4 @@
 /*******************************************************************************
-# Copyright (c) 2015, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
 *******************************************************************************/
 //
 // Some Cython versions don't like module-level constants, so we'll put them

--- a/yt/utilities/lib/pixelization_constants.h
+++ b/yt/utilities/lib/pixelization_constants.h
@@ -1,9 +1,4 @@
 /*******************************************************************************
-# Copyright (c) 2015, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
 *******************************************************************************/
 //
 // Some Cython versions don't like module-level constants, so we'll put them

--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -5,13 +5,6 @@ Pixelization routines
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import numpy as np
 cimport numpy as np

--- a/yt/utilities/lib/points_in_volume.pyx
+++ b/yt/utilities/lib/points_in_volume.pyx
@@ -5,13 +5,6 @@ Checks for points contained in a volume
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 
 import numpy as np

--- a/yt/utilities/lib/quad_tree.pyx
+++ b/yt/utilities/lib/quad_tree.pyx
@@ -5,13 +5,6 @@ A refine-by-two AMR-specific quadtree
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 
 import numpy as np

--- a/yt/utilities/lib/ragged_arrays.pyx
+++ b/yt/utilities/lib/ragged_arrays.pyx
@@ -5,13 +5,6 @@ Some simple operations for operating on ragged arrays
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2014, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import numpy as np
 cimport numpy as np

--- a/yt/utilities/lib/volume_container.pxd
+++ b/yt/utilities/lib/volume_container.pxd
@@ -6,13 +6,6 @@ A volume container
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2016, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 cimport numpy as np
 

--- a/yt/utilities/lib/write_array.pyx
+++ b/yt/utilities/lib/write_array.pyx
@@ -5,13 +5,6 @@ Faster, cythonized file IO
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 import numpy as np
 cimport numpy as np

--- a/yt/utilities/parallel_tools/__init__.py
+++ b/yt/utilities/parallel_tools/__init__.py
@@ -5,10 +5,3 @@ Tools for parallelism.
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------

--- a/yt/utilities/voropp.pyx
+++ b/yt/utilities/voropp.pyx
@@ -5,13 +5,6 @@ Wrapping code for voro++
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
 
 from cython.operator cimport dereference as deref, preincrement as inc
 from libc.stdlib cimport malloc, free, abs, calloc, labs

--- a/yt/visualization/__init__.py
+++ b/yt/visualization/__init__.py
@@ -10,10 +10,3 @@ Who knows?
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------

--- a/yt/visualization/tests/test_filters.py
+++ b/yt/visualization/tests/test_filters.py
@@ -1,9 +1,3 @@
-#-----------------------------------------------------------------------------
-# Copyright (c) 2015, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-#-----------------------------------------------------------------------------
 
 """
 Tests for frb filters

--- a/yt/visualization/volume_rendering/__init__.py
+++ b/yt/visualization/volume_rendering/__init__.py
@@ -5,10 +5,3 @@ API for yt.visualization.volume_rendering
 
 """
 
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------

--- a/yt/visualization/volume_rendering/_cuda_caster.cu
+++ b/yt/visualization/volume_rendering/_cuda_caster.cu
@@ -1,11 +1,3 @@
-/*******************************************************************************
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-*******************************************************************************/
-
 // An attempt at putting the ray-casting operation into CUDA
 //extern __shared__ float array[];
 


### PR DESCRIPTION
This follows #2298 and removes some copyright notices that went unnoticed so far.

Can be done with the following command:
```bash
$ find tests yt -name -name '*.py' -or -name '*.pyx' -or -name '*.pxd' |\
    xargs -I % perl -0777 -i.original -pe s'/(#[^\n]*\n)*# Copyright \(c\) 20.., yt Development Team.\n(#[^\n]*\n)*//igs' %
```

One can check that no file contains any mention of `Copyright (c) 20xx` using:
```bash
$ ack 'Copyright \(c\) 20..' --ignore-dir doc/build  | grep -i "yt development"               
COPYING.txt:8:Copyright (c) 2013-, yt Development Team
COPYING.txt:76:# Copyright (c) 2013, yt Development Team.
```
