### PR TITLE
Fix typo in _vorticity_z field definition

### DIFF
--- a/yt/fields/fluid_vector_fields.py
+++ b/yt/fields/fluid_vector_fields.py
@@ -117,7 +117,7 @@ def setup_fluid_vector_fields(registry, ftype = "gas", slice_info = None):
         vx = data[ftype, "relative_velocity_x"]
         vy = data[ftype, "relative_velocity_y"]
         f  = ((vy[sl_right,sl_center,sl_center] -
-               vx[sl_left,sl_center,sl_center]) /
+               vy[sl_left,sl_center,sl_center]) /
               (div_fac*just_one(data["index", "dx"])))
         f -= ((vx[sl_center,sl_right,sl_center] -
                vx[sl_center,sl_left,sl_center]) /


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->
This PR fixes a typo in the z-component of the vorticity in the field `_vorticity_z`.   

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->
The first term (dvy/dx) in the z-component of the vorticity is incorrect in the `_vorticity_z` field.  Consequently, the field `_vorticity_magnitude` is also affected.  This PR fixes the typo.  

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
