### PR TITLE
allow loading from path objects (py3.6 or above)

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -140,6 +140,6 @@ answer_tests:
 other_tests:
   unittests:
      - '--exclude=test_mesh_slices'  # disable randomly failing test
-     - '--exclude=test_load_from_path'  # PY2
+     - '--exclude=test_load_from_path'  # py2
   cookbook:
      - 'doc/source/cookbook/tests/test_cookbook.py'

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -140,5 +140,6 @@ answer_tests:
 other_tests:
   unittests:
      - '--exclude=test_mesh_slices'  # disable randomly failing test
+     - '--exclude=test_load_from_path'  # PY2
   cookbook:
      - 'doc/source/cookbook/tests/test_cookbook.py'

--- a/yt/convenience.py
+++ b/yt/convenience.py
@@ -29,8 +29,14 @@ from yt.utilities.exceptions import \
 from yt.utilities.hierarchy_inspection import find_lowest_subclasses
 
 def _sanitize_load_args(*args):
-    """Filter out non-pathlike arguments."""
-    return [os.path.expanduser(arg) if isinstance(arg, (str, os.PathLike))
+    """Filter out non-pathlike arguments, ensure list form, and expand '~' tokens"""
+    try:
+        # os.PathLike is python >= 3.6
+        path_types = str, os.PathLike
+    except AttributeError:
+        path_types = str,
+
+    return [os.path.expanduser(arg) if isinstance(arg, path_types)
             else arg for arg in args]
 
 def load(*args ,**kwargs):

--- a/yt/convenience.py
+++ b/yt/convenience.py
@@ -28,6 +28,11 @@ from yt.utilities.exceptions import \
     YTSimulationNotIdentified
 from yt.utilities.hierarchy_inspection import find_lowest_subclasses
 
+def _sanitize_load_args(*args):
+    """Filter out non-pathlike arguments."""
+    return [os.path.expanduser(arg) if isinstance(arg, (str, os.PathLike))
+            else arg for arg in args]
+
 def load(*args ,**kwargs):
     """
     This function attempts to determine the base data type of a filename or
@@ -36,9 +41,8 @@ def load(*args ,**kwargs):
     match, at which point it returns an instance of the appropriate
     :class:`yt.data_objects.static_output.Dataset` subclass.
     """
+    args = _sanitize_load_args(*args)
     candidates = []
-    args = [os.path.expanduser(arg) if isinstance(arg, string_types)
-            else arg for arg in args]
     valid_file = []
     for argno, arg in enumerate(args):
         if isinstance(arg, string_types):

--- a/yt/tests/test_load_from_path.py
+++ b/yt/tests/test_load_from_path.py
@@ -1,0 +1,26 @@
+from yt.convenience import _sanitize_load_args
+from pathlib import Path
+
+def test_sanitize_from_simple_path():
+    # check for basic path
+    p1 = "not/a/real/datafile.hdf5"
+    p2 = Path(p1)
+    assert _sanitize_load_args(p1) == _sanitize_load_args(p2)
+
+def test_sanitize_from_two_paths():
+    # check for more than one path
+    p1 = ["not/a/real/datafile.hdf5", "not/real/either/datafile.hdf5"]
+    p2 = [Path(p) for p in p1]
+    assert _sanitize_load_args(*p1) == _sanitize_load_args(*p2)
+
+def test_sanitize_from_user_path():
+    # check for user "~" card expansion
+    p1 = "~/not/a/real/datafile.hdf5"
+    p2 = Path(p1)
+    assert _sanitize_load_args(p1) == _sanitize_load_args(p2)
+
+def test_sanitize_from_wildcard_path():
+    # check with wildcards
+    p1 = "not/a/real/directory/*.hdf5"
+    p2 = Path(p1)
+    assert _sanitize_load_args(p1) == _sanitize_load_args(p2)

--- a/yt/tests/test_load_from_path.py
+++ b/yt/tests/test_load_from_path.py
@@ -1,3 +1,4 @@
+import os
 from sys import version_info
 from yt.convenience import _sanitize_load_args
 import pytest
@@ -11,24 +12,24 @@ if PY36:
 class TestSanitizeLoadArgs():
     def test_sanitize_from_simple_path(self):
         # check for basic path
-        p1 = "not/a/real/datafile.hdf5"
+        p1 = os.path.join("not", "a", "real", "datafile.hdf5")
         p2 = Path(p1)
         assert _sanitize_load_args(p1) == _sanitize_load_args(p2)
 
     def test_sanitize_from_two_paths(self):
         # check for more than one path
-        p1 = ["not/a/real/datafile.hdf5", "not/real/either/datafile.hdf5"]
+        p1 = [os.path.join("not", "a", "real", "datafile.hdf5"), os.path.join("not", "real", "either", "datafile.hdf5")]
         p2 = [Path(p) for p in p1]
         assert _sanitize_load_args(*p1) == _sanitize_load_args(*p2)
 
     def test_sanitize_from_user_path(self):
         # check for user "~" card expansion
-        p1 = "~/not/a/real/datafile.hdf5"
+        p1 = os.path.join("~", "not", "a", "real", "datafile.hdf5")
         p2 = Path(p1)
         assert _sanitize_load_args(p1) == _sanitize_load_args(p2)
 
     def test_sanitize_from_wildcard_path(self):
         # check with wildcards
-        p1 = "not/a/real/directory/*.hdf5"
+        p1 = os.path.join("not", "a", "real", "directory", "*.hdf5")
         p2 = Path(p1)
         assert _sanitize_load_args(p1) == _sanitize_load_args(p2)

--- a/yt/tests/test_load_from_path.py
+++ b/yt/tests/test_load_from_path.py
@@ -1,26 +1,34 @@
+from sys import version_info
 from yt.convenience import _sanitize_load_args
-from pathlib import Path
+import pytest
 
-def test_sanitize_from_simple_path():
-    # check for basic path
-    p1 = "not/a/real/datafile.hdf5"
-    p2 = Path(p1)
-    assert _sanitize_load_args(p1) == _sanitize_load_args(p2)
+PY36 = version_info >= (3, 6)
 
-def test_sanitize_from_two_paths():
-    # check for more than one path
-    p1 = ["not/a/real/datafile.hdf5", "not/real/either/datafile.hdf5"]
-    p2 = [Path(p) for p in p1]
-    assert _sanitize_load_args(*p1) == _sanitize_load_args(*p2)
+if PY36:
+    from pathlib import Path
 
-def test_sanitize_from_user_path():
-    # check for user "~" card expansion
-    p1 = "~/not/a/real/datafile.hdf5"
-    p2 = Path(p1)
-    assert _sanitize_load_args(p1) == _sanitize_load_args(p2)
+@pytest.mark.skipif(not PY36, reason="requires python3.6 or higher")
+class TestSanitizeLoadArgs():
+    def test_sanitize_from_simple_path(self):
+        # check for basic path
+        p1 = "not/a/real/datafile.hdf5"
+        p2 = Path(p1)
+        assert _sanitize_load_args(p1) == _sanitize_load_args(p2)
 
-def test_sanitize_from_wildcard_path():
-    # check with wildcards
-    p1 = "not/a/real/directory/*.hdf5"
-    p2 = Path(p1)
-    assert _sanitize_load_args(p1) == _sanitize_load_args(p2)
+    def test_sanitize_from_two_paths(self):
+        # check for more than one path
+        p1 = ["not/a/real/datafile.hdf5", "not/real/either/datafile.hdf5"]
+        p2 = [Path(p) for p in p1]
+        assert _sanitize_load_args(*p1) == _sanitize_load_args(*p2)
+
+    def test_sanitize_from_user_path(self):
+        # check for user "~" card expansion
+        p1 = "~/not/a/real/datafile.hdf5"
+        p2 = Path(p1)
+        assert _sanitize_load_args(p1) == _sanitize_load_args(p2)
+
+    def test_sanitize_from_wildcard_path(self):
+        # check with wildcards
+        p1 = "not/a/real/directory/*.hdf5"
+        p2 = Path(p1)
+        assert _sanitize_load_args(p1) == _sanitize_load_args(p2)


### PR DESCRIPTION
this is a second try after #2392 
This PR is targeting yt-4.0 as the feature is much more easy to write for python 3.6 and above.

if we want to support python 3.5 too, an additional step is required to convert pathlike-non-str input to str. 