### PR TITLE
skip blank lines when reading parameters

### DIFF
--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -1114,6 +1114,8 @@ class CastroDataset(BoxlibDataset):
             # skip the "====..." line
             line = next(f)
             for line in f:
+                if line.strip() == "" or "fortin parameters" in line:
+                    continue
                 p, v = line.strip().split("=")
                 self.parameters[p] = v.strip()
 


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

Castro now stores additional parameters in the job_info file, separated with a blank line and or the heading "fortin parameters".  This change has the front end ignore these lines, so we can read in all the parameters.  Without this change, yt crashes while reading the latest Castro plotfiles.


## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
