### PR TITLE
[bugfix] Various bug fixes which came up in daily use of yt-4.0

### DIFF
--- a/yt/fields/astro_fields.py
+++ b/yt/fields/astro_fields.py
@@ -50,7 +50,7 @@ def setup_astro_fields(registry, ftype = "gas", slice_info = None):
 
     def _emission_measure(field, data):
         dV = data[ftype, "mass"]/data[ftype, "density"]
-        nenhdV = data[ftype, "H_p1_number_density"]*dV
+        nenhdV = data[ftype, "H_nuclei_density"]*dV
         nenhdV *= data[ftype, "El_number_density"]
         return nenhdV
 

--- a/yt/fields/xray_emission_fields.py
+++ b/yt/fields/xray_emission_fields.py
@@ -211,7 +211,7 @@ def add_xray_emissivity_field(ds, e_min, e_max, redshift=0.0,
         # APEC wants to scale by nH*ne
         def _norm_field(field, data):
             return data[ftype, "H_nuclei_density"]*data[ftype, "El_number_density"]
-    ds.add_field((ftype, "norm_field"), _norm_field, units="cm**6",
+    ds.add_field((ftype, "norm_field"), _norm_field, units="cm**-6",
                  sampling_type='local')
 
     my_si = XrayEmissivityIntegrator(table_type, data_dir=data_dir, 

--- a/yt/fields/xray_emission_fields.py
+++ b/yt/fields/xray_emission_fields.py
@@ -15,7 +15,7 @@ from yt.utilities.linear_interpolators import \
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.cosmology import Cosmology
 
-data_version = {"cloudy": 3,
+data_version = {"cloudy": 2,
                 "apec": 3}
 
 data_url = "http://yt-project.org/data"

--- a/yt/fields/xray_emission_fields.py
+++ b/yt/fields/xray_emission_fields.py
@@ -29,7 +29,7 @@ def _get_data_file(table_type, data_dir=None):
     data_path = os.path.join(data_dir, data_file)
     if not os.path.exists(data_path):
         msg = "Failed to find emissivity data file %s! " % data_file + \
-            "Please download from http://yt-project.org/data!"
+              "Please download from %s!" % data_url
         mylog.error(msg)
         raise IOError(msg)
     return data_path

--- a/yt/fields/xray_emission_fields.py
+++ b/yt/fields/xray_emission_fields.py
@@ -203,12 +203,7 @@ def add_xray_emissivity_field(ds, e_min, e_max, redshift=0.0,
             raise RuntimeError("Your dataset does not have a {} field! ".format(metallicity) +
                                "Perhaps you should specify a constant metallicity instead?")
 
-    if table_type == "cloudy":
-        # Cloudy wants to know the total number density of hydrogen
-        H_field = "H_nuclei_density"
-    else:
-        # APEC only wants the free proton density
-        H_field = "H_p1_number_density"
+    H_field = "H_nuclei_density"
 
     my_si = XrayEmissivityIntegrator(table_type, data_dir=data_dir, 
                                      redshift=redshift)

--- a/yt/fields/xray_emission_fields.py
+++ b/yt/fields/xray_emission_fields.py
@@ -15,8 +15,8 @@ from yt.utilities.linear_interpolators import \
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.cosmology import Cosmology
 
-data_version = {"cloudy": 2,
-                "apec": 2}
+data_version = {"cloudy": 3,
+                "apec": 3}
 
 data_url = "http://yt-project.org/data"
 

--- a/yt/frontends/gamer/fields.py
+++ b/yt/frontends/gamer/fields.py
@@ -1,5 +1,5 @@
 from yt.fields.field_info_container import FieldInfoContainer
-from yt.utilities.physical_constants import mh, boltzmann_constant_cgs
+from yt.utilities.physical_constants import mh, kb
 
 b_units   = "code_magnetic"
 pre_units = "code_mass / (code_length*code_time**2)"
@@ -115,8 +115,8 @@ class GAMERFieldInfo(FieldInfoContainer):
 
         # temperature
         def _temperature(field, data):
-            return data.ds.mu*mh*data["gas","pressure"] / \
-                   (data["gas","density"]*boltzmann_constant_cgs)
+            return data.ds.mu*data["gas","pressure"]*mh / \
+                   (data["gas","density"]*kb)
         self.add_field(("gas","temperature"),
                        sampling_type="cell",
                        function = _temperature,

--- a/yt/geometry/coordinates/cartesian_coordinates.py
+++ b/yt/geometry/coordinates/cartesian_coordinates.py
@@ -347,30 +347,31 @@ class CartesianCoordinateHandler(CoordinateHandler):
 
                 if smoothing_style == 'scatter':
                     buff = np.zeros(size, dtype='float64')
-
+                    bnds = data_source.ds.arr(
+                        bounds, 'code_length').in_units('cm').tolist()
                     if normalize:
                         buff_den = np.zeros(size, dtype='float64')
 
                     for chunk in data_source.chunks([], 'io'):
                         pixelize_sph_kernel_slice(
                             buff,
-                            chunk[ptype, px_name].to('code_length'),
-                            chunk[ptype, py_name].to('code_length'),
-                            chunk[ptype, 'smoothing_length'].to('code_length'),
-                            chunk[ptype, 'mass'],
-                            chunk[ptype, 'density'],
+                            chunk[ptype, px_name].to('cm'),
+                            chunk[ptype, py_name].to('cm'),
+                            chunk[ptype, 'smoothing_length'].to('cm'),
+                            chunk[ptype, 'mass'].to('g'),
+                            chunk[ptype, 'density'].to('g/cm**3'),
                             chunk[field].in_units(ounits),
-                            bounds)
+                            bnds)
                         if normalize:
                             pixelize_sph_kernel_slice(
                                 buff_den,
-                                chunk[ptype, px_name].to('code_length'),
-                                chunk[ptype, py_name].to('code_length'),
-                                chunk[ptype, 'smoothing_length'].to('code_length'),
-                                chunk[ptype, 'mass'],
-                                chunk[ptype, 'density'],
+                                chunk[ptype, px_name].to('cm'),
+                                chunk[ptype, py_name].to('cm'),
+                                chunk[ptype, 'smoothing_length'].to('cm'),
+                                chunk[ptype, 'mass'].to('g'),
+                                chunk[ptype, 'density'].to('g/cm**3'),
                                 np.ones(chunk[ptype, 'density'].shape[0]),
-                                bounds)
+                                bnds)
 
                     if normalize:
                         normalization_2d_utility(buff, buff_den)

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -24,6 +24,7 @@ from yt.funcs import \
     enable_plugins, \
     download_file
 import urllib
+import urllib.request
 from urllib.parse import urlparse
 from yt.extern.tqdm import tqdm
 from yt.convenience import load

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -635,7 +635,7 @@ class FITSImageData(object):
             The name of the file to open.
         """
         f = _astropy.pyfits.open(filename, lazy_load_hdus=False)
-        return cls(f)
+        return cls(f, current_time=f[0].header["TIME"])
 
     @classmethod
     def from_images(cls, image_list):
@@ -664,7 +664,7 @@ class FITSImageData(object):
                 else:
                     data.append(_astropy.pyfits.ImageHDU(hdu.data, header=hdu.header))
         data = _astropy.pyfits.HDUList(data)
-        return cls(data)
+        return cls(data, current_time=image_list[0].current_time)
 
     def create_sky_wcs(self, sky_center, sky_scale,
                        ctype=None, crota=None, cd=None,

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -220,7 +220,13 @@ class FITSImageData(object):
             if name not in exclude_fields:
                 this_img = img_data[field]
                 if hasattr(img_data[field], "units"):
-                    self.field_units[name] = str(this_img.units)
+                    if this_img.units.is_code_unit:
+                        mylog.warning("Cannot generate an image with code "
+                                      "units. Converting to units in CGS.")
+                        funits = this_img.units.get_base_equivalent("cgs")
+                    else:
+                        funits = this_img.units
+                    self.field_units[name] = str(funits)
                 else:
                     self.field_units[name] = "dimensionless"
                 mylog.info("Making a FITS image of field %s" % name)

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -312,7 +312,7 @@ class FITSImageData(object):
             if ds is not None:
                 current_time = ds.current_time
             else:
-                self.current_time = 0.0
+                self.current_time = YTQuantity(0.0, 's')
                 return
         elif isinstance(current_time, numeric_type):
             current_time = YTQuantity(current_time, tunit)
@@ -363,8 +363,8 @@ class FITSImageData(object):
             setattr(self, attr, uq)
 
     def _set_units_from_header(self, header):
-        for unit in ["length", "time", "mass", "velocity", "magnetic_field"]:
-            if unit == "magnetic_field":
+        for unit in ["length", "time", "mass", "velocity", "magnetic"]:
+            if unit == "magnetic":
                 key = "BFUNIT"
             else:
                 key = unit[0].upper()+"UNIT"

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -133,8 +133,8 @@ class FITSImageData(object):
         self.field_units = {}
 
         if unit_header is None:
-            self._set_units(ds, [length_unit, mass_unit, time_unit, velocity_unit,
-                                 magnetic_unit])
+            self._set_units(ds, [length_unit, mass_unit, time_unit, 
+                                 velocity_unit, magnetic_unit])
         else:
             self._set_units_from_header(unit_header)
 

--- a/yt/visualization/tests/test_fits_image.py
+++ b/yt/visualization/tests/test_fits_image.py
@@ -43,6 +43,12 @@ def test_fits_image():
 
     assert_equal(fid1["density"].data, new_fid1["density"].data)
     assert_equal(fid1["temperature"].data, new_fid1["temperature"].data)
+    assert fid1.length_unit == new_fid1.length_unit
+    assert fid1.time_unit == new_fid1.time_unit
+    assert fid1.mass_unit == new_fid1.mass_unit
+    assert fid1.velocity_unit == new_fid1.velocity_unit
+    assert fid1.magnetic_unit == new_fid1.magnetic_unit
+    assert fid1.current_time == new_fid1.current_time
 
     ds2 = load("fid1.fits")
     ds2.index
@@ -69,9 +75,13 @@ def test_fits_image():
     dens_img = fid2.pop("density")
     temp_img = fid2.pop("temperature")
 
-    # This already has some assertions in it, so we don't need to do anything
-    # with it other than just make one
-    FITSImageData.from_images([dens_img, temp_img])
+    combined_fid = FITSImageData.from_images([dens_img, temp_img])
+    assert combined_fid.length_unit == dens_img.length_unit
+    assert combined_fid.time_unit == dens_img.time_unit
+    assert combined_fid.mass_unit == dens_img.mass_unit
+    assert combined_fid.velocity_unit == dens_img.velocity_unit
+    assert combined_fid.magnetic_unit == dens_img.magnetic_unit
+    assert combined_fid.current_time == dens_img.current_time
 
     cut = ds.cutting([0.1, 0.2, -0.9], [0.5, 0.42, 0.6])
     cut_frb = cut.to_frb((0.5, "unitary"), 128)


### PR DESCRIPTION
## PR Summary

Sorry for the grab-bag PR. This addresses a number of issues that I came across
in daily use of yt-4.0 over the past couple of months. They are as follows:

* The APEC emissivity models need to be scaled by `n_H*n_e`, where `n_H` is the _total_ hydrogen number density, but I was only scaling it by the free proton density. Similarly, the `emission_measure` field needs to have the same scaling. I have also updated the `apec_emissivity` file, which now has the `n_H*n_e` scaling. 
* When SPH pixelization of any kind is done, one must ensure that all of the arrays being passed to the various Cython routines are in the same base, in this case code units. Otherwise scaling factors might be very off (i.e., because "mass" might be in 'g' and "density" might be in code units unless all of the units are converted to the same base beforehand). 
* I was getting unit registry-related errors when attempting to use the temperature field in the GAMER frontend, due to subtle changes in unit registry handling in `unyt`. Simply swapping the order of multiplication in the field definition fixes this.
* I found I could not use the `yt download` command on certain platforms unless I added `import urllib.request` to the top of the `yt/utilities/command_line.py` because I got an `ImportError`.
* FITSImageData instances don't know about code units, so convert any images with code units to CGS.
* One can create new `FITSImageData` instances from combining others or from reading a FITS file from disk. When I previously set this up, I neglected to check that the units and the current time were being properly set from the previous instance. I have fixed this and added tests.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] Adds a test for any bugs fixed.