### PR TITLE
Export data container and profile fields to AstroPy QTables and pandas DataFrames

### DIFF
--- a/doc/source/analyzing/astropy_integrations.rst
+++ b/doc/source/analyzing/astropy_integrations.rst
@@ -1,0 +1,32 @@
+.. _astropy-integrations:
+
+AstroPy Integrations
+====================
+
+yt enables a number of integrations with the AstroPy package. These
+are listed below, but more detailed descriptions are given at the
+given documentation links.
+
+Round-Trip Unit Conversions Between yt and AstroPy
+--------------------------------------------------
+
+
+FITS Image File Writing
+-----------------------
+
+Converting Field Container and 1D Profile Data to AstroPy Tables
+----------------------------------------------------------------
+
+Data in field containers, such as spheres, rectangular regions, rays, 
+cylinders, etc., are represented as 1D YTArrays. A set of these arrays
+can then be exported to an 
+`AstroPy Table <http://docs.astropy.org/en/stable/table/>`_ object, 
+specifically a 
+`QTable <http://docs.astropy.org/en/stable/table/mixin_columns.html#quantity-and-qtable>`_.
+``QTable``s are unit-aware, and can be manipulated in a number of ways
+and written to disk in several formats, including ASCII text or FITS 
+files. For more details, see :ref:`fields-astropy-export`. 
+
+Similarly, 1D profile objects can also be exported to AstroPy 
+``QTable``s, optionally writing all of the profile bins or only the ones
+which are used. For more details, see :ref:`profile-astropy-export`.

--- a/doc/source/analyzing/astropy_integrations.rst
+++ b/doc/source/analyzing/astropy_integrations.rst
@@ -10,9 +10,32 @@ given documentation links.
 Round-Trip Unit Conversions Between yt and AstroPy
 --------------------------------------------------
 
+AstroPy has a `symbolic units implementation <https://docs.astropy.org/en/stable/units/>`_ 
+similar to that in yt. For this reason, we have implemented "round-trip" 
+conversions between :class:`~yt.units.yt_array.YTArray` objects 
+and AstroPy's :class:`~astropy.units.Quantity` objects. These are implemented 
+in the :meth:`~yt.units.yt_array.YTArray.from_astropy` and 
+:meth:`~yt.units.yt_array.YTArray.to_astropy` methods. See
+:ref:`fields_and_unit_conversion` for more information.
 
-FITS Image File Writing
------------------------
+FITS Image File Reading and Writing
+-----------------------------------
+
+Reading and writing FITS files is supported in yt using 
+`AstroPy's FITS file handling. <https://docs.astropy.org/en/stable/io/fits/>`_
+
+yt has basic support for reading two and three-dimensional image data from FITS
+files. Some limited ability to parse certain types of data (e.g., spectral cubes,
+images with sky coordinates, images written using the 
+:class:`~yt.visualization.fits_image.FITSImageData` class described below) is 
+possible. See :ref:`loading-fits-data` for more information. 
+
+Fixed-resolution two-dimensional images generated from datasets using yt (such as 
+slices or projections) and fixed-resolution three-dimensional grids can be written 
+to FITS files using yt's :class:`~yt.visualization.fits_image.FITSImageData` class 
+and its subclasses. Multiple images can be combined into a single file, operations 
+can be performed on the images and their coordinates, etc. See :ref:`writing_fits_images` 
+for more information. 
 
 Converting Field Container and 1D Profile Data to AstroPy Tables
 ----------------------------------------------------------------

--- a/doc/source/analyzing/generating_processed_data.rst
+++ b/doc/source/analyzing/generating_processed_data.rst
@@ -15,9 +15,10 @@ Exporting Container Data
 ------------------------
 
 Fields from data containers such as regions, spheres, cylinders, etc. can be exported
-tabular format using either a pandas DataFrame or an AstroPy Table. 
+tabular format using either a :class:`~pandas.DataFrame` or an :class:`~astropy.table.QTable`. 
 
-To export to a pandas DataFrame, use `to_dataframe`:
+To export to a :class:`~pandas.DataFrame`, use 
+:meth:`~yt.data_objects.data_containers.YTDataContainer.to_dataframe`:
 
 .. code-block:: python
 
@@ -28,7 +29,8 @@ To export to a pandas DataFrame, use `to_dataframe`:
     # Only adds the density and temperature fields
     df2 = sp.to_dataframe(fields=["density","temperature"])
 
-To export to an AstroPy Table, use `to_astropy_table`:
+To export to a :class:`~astropy.table.QTable`, use 
+:meth:`~yt.data_objects.data_containers.YTDataContainer.to_astropy_table`:
 
 .. code-block:: python
 
@@ -39,9 +41,9 @@ To export to an AstroPy Table, use `to_astropy_table`:
     # Only adds the density and temperature fields
     df2 = sp.to_astropy_table(fields=["density","temperature"])
 
-For DataFrames, the unit information is lost, but for AstroPy Tables the YTArrays
-are converted to AstroPy Quantity objects and so units are preserved. See here for
-more information. 
+For exports to :class:`~pandas.DataFrame` objects, the unit information is lost, but for 
+exports to :class:`~astropy.table.QTable` objects, the :class:`~yt.units.yt_array.YTArray`
+objects are converted to :class:`~astropy.units.Quantity` objects.
 
 .. _generating-2d-image-arrays:
 
@@ -223,9 +225,9 @@ for each bin field or ``None`` to use the default settings.
 
 .. _profile-dataframe-export:
 
-One-dimensional profile data can be exported to a pandas DataFrame object using
-the :meth:`yt.data_objects.profiles.Profile1D.to_dataframe` method. Bins which do
-not have data will have their fields filled with `NaN`s, except for the bin field
+One-dimensional profile data can be exported to a :class:`~pandas.DataFrame` object 
+using the :meth:`yt.data_objects.profiles.Profile1D.to_dataframe` method. Bins which 
+do not have data will have their fields filled with `NaN`s, except for the bin field
 itself. If you only want to export the bins which are used, set `only_used=True`.
 
 .. code-block:: python
@@ -237,17 +239,17 @@ itself. If you only want to export the bins which are used, set `only_used=True`
     # Only adds the density and temperature fields
     df2 = profile.to_dataframe(fields=["density","temperature"])
     
-The DataFrame can then analyzed and/or written to disk using pandas methods. Note 
-that unit information is lost in this export.
+The :class:`~pandas.DataFrame` can then analyzed and/or written to disk using pandas 
+methods. Note that unit information is lost in this export.
 
 .. _profile-astropy-export:
 
-One-dimensional profile data also can be exported to an AstroPy Table object. This
-table can then be written to disk in a number of formats, such as ASCII text
+One-dimensional profile data also can be exported to an AstroPy :class:`~astropy.table.QTable`  
+object. This table can then be written to disk in a number of formats, such as ASCII text
 or FITS files, and manipulated in a number of ways. Bins which do not have data 
 will have their mask values set to `False`. If you only want to export the bins 
 which are used, set `only_used=True`. Units are preserved in the table by converting 
-the YTArrays to AstroPy Quantity objects as explained here.
+each :class:`~yt.units.yt_array.YTArray` to an :class:`~astropy.units.Quantity`.
 
 To export the 1D profile to a Table object, simply call 
 :meth:`yt.data_objects.profiles.Profile1D.to_astropy_table`:

--- a/doc/source/analyzing/generating_processed_data.rst
+++ b/doc/source/analyzing/generating_processed_data.rst
@@ -187,6 +187,22 @@ for each bin field or ``None`` to use the default settings.
                                 override_bins = {("gas", "density"):custom_bins,
                                                  ("gas", "temperature"):None}) 
 
+.. _profile-astropy-export:
+
+One-dimensional profile data can be exported to an AstroPy Table object. This
+table can then be written to disk in a number of formats, such as ASCII text
+or FITS files, and manipulated in a number of ways. Units are preserved in the
+table by converting the YTArrays to AstroPy Quantity objects as explained here.
+
+To convert the 1D profile to a Table object, simply call 
+:meth:`yt.data_objects.profiles.Profile1D.to_astropy_table`:
+
+.. code-block:: python
+
+    # Adds all of the data to the table, but non-used bins are masked
+    t = profile.to_astropy_table()
+    # Only adds the used bins to the table
+    t_used = profile.to_astropy_table(only_used=True)
 
 .. _generating-line-queries:
 

--- a/doc/source/analyzing/generating_processed_data.rst
+++ b/doc/source/analyzing/generating_processed_data.rst
@@ -9,6 +9,40 @@ data by hand and construct plots which can then be combined with other plots,
 modified in some way, or even (gasp) created and modified in some other tool or
 program.
 
+.. _exporting-container-data:
+
+Exporting Container Data
+------------------------
+
+Fields from data containers such as regions, spheres, cylinders, etc. can be exported
+tabular format using either a pandas DataFrame or an AstroPy Table. 
+
+To export to a pandas DataFrame, use `to_dataframe`:
+
+.. code-block:: python
+
+    sp = ds.sphere("c", (0.2, "unitary"))
+    # Adds all of the fields to the DataFrame which have been loaded into memory
+    # already
+    df = sp.to_dataframe()
+    # Only adds the density and temperature fields
+    df2 = sp.to_dataframe(fields=["density","temperature"])
+
+To export to an AstroPy Table, use `to_astropy_table`:
+
+.. code-block:: python
+
+    sp = ds.sphere("c", (0.2, "unitary"))
+    # Adds all of the fields to the Table which have been loaded into memory
+    # already
+    df = sp.to_astropy_table()
+    # Only adds the density and temperature fields
+    df2 = sp.to_astropy_table(fields=["density","temperature"])
+
+For DataFrames, the unit information is lost, but for AstroPy Tables the YTArrays
+are converted to AstroPy Quantity objects and so units are preserved. See here for
+more information. 
+
 .. _generating-2d-image-arrays:
 
 2D Image Arrays
@@ -196,9 +230,9 @@ itself. If you only want to export the bins which are used, set `only_used=True`
 
 .. code-block:: python
 
-    # Adds all of the data to the table, but non-used bins are masked
+    # Adds all of the data to the DataFrame, but non-used bins are filled with NaNs
     df = profile.to_dataframe()
-    # Only adds the used bins to the table
+    # Only adds the used bins to the DataFrame
     df_used = profile.to_dataframe(only_used=True)
     # Only adds the density and temperature fields
     df2 = profile.to_dataframe(fields=["density","temperature"])
@@ -220,9 +254,9 @@ To export the 1D profile to a Table object, simply call
 
 .. code-block:: python
 
-    # Adds all of the data to the table, but non-used bins are masked
+    # Adds all of the data to the Table, but non-used bins are masked
     t = profile.to_astropy_table()
-    # Only adds the used bins to the table
+    # Only adds the used bins to the Table
     t_used = profile.to_astropy_table(only_used=True)
     # Only adds the density and temperature fields
     t2 = profile.to_astropy_table(fields=["density","temperature"])

--- a/doc/source/analyzing/generating_processed_data.rst
+++ b/doc/source/analyzing/generating_processed_data.rst
@@ -187,14 +187,35 @@ for each bin field or ``None`` to use the default settings.
                                 override_bins = {("gas", "density"):custom_bins,
                                                  ("gas", "temperature"):None}) 
 
+.. _profile-dataframe-export:
+
+One-dimensional profile data can be exported to a pandas DataFrame object using
+the :meth:`yt.data_objects.profiles.Profile1D.to_dataframe` method. Bins which do
+not have data will have their fields filled with `NaN`s, except for the bin field
+itself. If you only want to export the bins which are used, set `only_used=True`.
+
+.. code-block:: python
+
+    # Adds all of the data to the table, but non-used bins are masked
+    df = profile.to_dataframe()
+    # Only adds the used bins to the table
+    df_used = profile.to_dataframe(only_used=True)
+    # Only adds the density and temperature fields
+    df2 = profile.to_dataframe(fields=["density","temperature"])
+    
+The DataFrame can then analyzed and/or written to disk using pandas methods. Note 
+that unit information is lost in this export.
+
 .. _profile-astropy-export:
 
-One-dimensional profile data can be exported to an AstroPy Table object. This
+One-dimensional profile data also can be exported to an AstroPy Table object. This
 table can then be written to disk in a number of formats, such as ASCII text
-or FITS files, and manipulated in a number of ways. Units are preserved in the
-table by converting the YTArrays to AstroPy Quantity objects as explained here.
+or FITS files, and manipulated in a number of ways. Bins which do not have data 
+will have their mask values set to `False`. If you only want to export the bins 
+which are used, set `only_used=True`. Units are preserved in the table by converting 
+the YTArrays to AstroPy Quantity objects as explained here.
 
-To convert the 1D profile to a Table object, simply call 
+To export the 1D profile to a Table object, simply call 
 :meth:`yt.data_objects.profiles.Profile1D.to_astropy_table`:
 
 .. code-block:: python
@@ -203,6 +224,8 @@ To convert the 1D profile to a Table object, simply call
     t = profile.to_astropy_table()
     # Only adds the used bins to the table
     t_used = profile.to_astropy_table(only_used=True)
+    # Only adds the density and temperature fields
+    t2 = profile.to_astropy_table(fields=["density","temperature"])
 
 .. _generating-line-queries:
 

--- a/doc/source/analyzing/generating_processed_data.rst
+++ b/doc/source/analyzing/generating_processed_data.rst
@@ -23,11 +23,7 @@ To export to a :class:`~pandas.DataFrame`, use
 .. code-block:: python
 
     sp = ds.sphere("c", (0.2, "unitary"))
-    # Adds all of the fields to the DataFrame which have been loaded into memory
-    # already
-    df = sp.to_dataframe()
-    # Only adds the density and temperature fields
-    df2 = sp.to_dataframe(fields=["density","temperature"])
+    df2 = sp.to_dataframe(["density","temperature"])
 
 To export to a :class:`~astropy.table.QTable`, use 
 :meth:`~yt.data_objects.data_containers.YTDataContainer.to_astropy_table`:
@@ -35,11 +31,7 @@ To export to a :class:`~astropy.table.QTable`, use
 .. code-block:: python
 
     sp = ds.sphere("c", (0.2, "unitary"))
-    # Adds all of the fields to the Table which have been loaded into memory
-    # already
-    df = sp.to_astropy_table()
-    # Only adds the density and temperature fields
-    df2 = sp.to_astropy_table(fields=["density","temperature"])
+    at2 = sp.to_astropy_table(fields=["density","temperature"])
 
 For exports to :class:`~pandas.DataFrame` objects, the unit information is lost, but for 
 exports to :class:`~astropy.table.QTable` objects, the :class:`~yt.units.yt_array.YTArray`

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -246,12 +246,12 @@ man_pages = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/3/': None,
-                       'http://ipython.readthedocs.io/en/stable/': None,
-                       'http://docs.scipy.org/doc/numpy/': None,
-                       'http://matplotlib.org/': None,
-                       'http://docs.astropy.org/en/stable': None,
-                       'http://pandas.pydata.org/pandas-docs/stable': None,
+intersphinx_mapping = {'https://docs.python.org/3/': None,
+                       'https://ipython.readthedocs.io/en/stable/': None,
+                       'https://docs.scipy.org/doc/numpy/': None,
+                       'https://matplotlib.org/': None,
+                       'https://docs.astropy.org/en/stable': None,
+                       'https://pandas.pydata.org/pandas-docs/stable': None,
                        }
 
 if not on_rtd:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -246,11 +246,12 @@ man_pages = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/3/': None,
-                       'https://ipython.readthedocs.io/en/stable/': None,
-                       'https://docs.scipy.org/doc/numpy/': None,
-                       'https://matplotlib.org/': None,
-                       'https://docs.astropy.org/en/stable': None,
+intersphinx_mapping = {'http://docs.python.org/3/': None,
+                       'http://ipython.readthedocs.io/en/stable/': None,
+                       'http://docs.scipy.org/doc/numpy/': None,
+                       'http://matplotlib.org/': None,
+                       'http://docs.astropy.org/en/stable': None,
+                       'http://pandas.pydata.org/pandas-docs/stable': None,
                        }
 
 if not on_rtd:

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -542,6 +542,7 @@ class YTDataContainer(object):
         from astropy.table import QTable
         t = QTable()
         if fields is not None:
+            fields = ensure_list(fields)
             fields = self._determine_fields(fields)
         else:
             fields = self.field_data.keys()

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1814,6 +1814,24 @@ class YTSelectionContainer1D(YTSelectionContainer):
         self._sorted = {}
 
     def to_astropy_table(self, fields):
+        """
+        Export region data to a :class:~astropy.table.table.QTable,
+        which is a Table object which is unit-aware. The QTable can then
+        be exported to an ASCII file, FITS file, etc.
+
+        See the AstroPy Table docs for more details:
+        http://docs.astropy.org/en/stable/table/
+
+        Parameters
+        ----------
+        fields : list of strings
+            The list of fields to be exported to the QTable.
+
+        Examples
+        --------
+        >>> sp = ds.sphere("c", (1.0, "Mpc"))
+        >>> t = sp.to_astropy_table(["density","temperature"])
+        """
         from astropy.table import QTable
         t = QTable()
         fields = self._determine_fields(fields)

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -482,7 +482,7 @@ class YTDataContainer(object):
         else:
             self.index.save_object(self, name)
 
-    def to_dataframe(self, fields=None):
+    def to_dataframe(self, fields):
         r"""Export a data object to a :class:`~pandas.DataFrame`.
 
         This function will take a data object and an optional list of fields
@@ -491,10 +491,9 @@ class YTDataContainer(object):
 
         Parameters
         ----------
-        fields : list of strings or tuple field names, default None
-            If this is supplied, it is the list of fields to be exported into
-            the DataFrame. If not supplied, whatever fields presently exist
-            will be used.
+        fields : list of strings or tuple field names
+            This is the list of fields to be exported into
+            the DataFrame.
 
         Returns
         -------
@@ -504,22 +503,18 @@ class YTDataContainer(object):
         Examples
         --------
         >>> dd = ds.all_data()
-        >>> df1 = dd.to_dataframe(["density", "temperature"])
-        >>> dd["velocity_magnitude"]
-        >>> df2 = dd.to_dataframe()
+        >>> df = dd.to_dataframe(["density", "temperature"])
         """
         import pandas as pd
         data = {}
-        if fields is not None:
-            fields = self._determine_fields(fields)
-        else:
-            fields = self.field_data.keys()
+        fields = ensure_list(fields)
+        fields = self._determine_fields(fields)
         for field in fields:
             data[field[-1]] = self[field]
         df = pd.DataFrame(data)
         return df
 
-    def to_astropy_table(self, fields=None):
+    def to_astropy_table(self, fields):
         """
         Export region data to a :class:~astropy.table.table.QTable,
         which is a Table object which is unit-aware. The QTable can then
@@ -530,23 +525,19 @@ class YTDataContainer(object):
 
         Parameters
         ----------
-        fields : list of strings or tuple field names, default None
-            If this is supplied, it is the list of fields to be exported into
-            the QTable. If not supplied, whatever fields presently exist
-            will be used.
+        fields : list of strings or tuple field names
+            This is the list of fields to be exported into
+            the QTable. 
 
         Examples
         --------
         >>> sp = ds.sphere("c", (1.0, "Mpc"))
-        >>> t = sp.to_astropy_table(fields=["density","temperature"])
+        >>> t = sp.to_astropy_table(["density","temperature"])
         """
         from astropy.table import QTable
         t = QTable()
-        if fields is not None:
-            fields = ensure_list(fields)
-            fields = self._determine_fields(fields)
-        else:
-            fields = self.field_data.keys()
+        fields = ensure_list(fields)
+        fields = self._determine_fields(fields)
         for field in fields:
             t[field[-1]] = self[field].to_astropy()
         return t

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -483,27 +483,26 @@ class YTDataContainer(object):
             self.index.save_object(self, name)
 
     def to_dataframe(self, fields=None):
-        r"""Export a data object to a pandas DataFrame.
+        r"""Export a data object to a :class:`~pandas.DataFrame`.
 
-        This function will take a data object and construct from it and
-        optionally a list of fields a pandas DataFrame object.  If pandas is
-        not importable, this will raise ImportError.
+        This function will take a data object and an optional list of fields
+        and export them to a :class:`~pandas.DataFrame` object.
+        If pandas is not importable, this will raise ImportError.
 
         Parameters
         ----------
         fields : list of strings or tuple field names, default None
             If this is supplied, it is the list of fields to be exported into
-            the data frame.  If not supplied, whatever fields presently exist
+            the DataFrame. If not supplied, whatever fields presently exist
             will be used.
 
         Returns
         -------
-        df : DataFrame
+        df : :class:`~pandas.DataFrame`
             The data contained in the object.
 
         Examples
         --------
-
         >>> dd = ds.all_data()
         >>> df1 = dd.to_dataframe(["density", "temperature"])
         >>> dd["velocity_magnitude"]
@@ -531,13 +530,15 @@ class YTDataContainer(object):
 
         Parameters
         ----------
-        fields : list of strings
-            The list of fields to be exported to the QTable.
+        fields : list of strings or tuple field names, default None
+            If this is supplied, it is the list of fields to be exported into
+            the QTable. If not supplied, whatever fields presently exist
+            will be used.
 
         Examples
         --------
         >>> sp = ds.sphere("c", (1.0, "Mpc"))
-        >>> t = sp.to_astropy_table(["density","temperature"])
+        >>> t = sp.to_astropy_table(fields=["density","temperature"])
         """
         from astropy.table import QTable
         t = QTable()

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1813,6 +1813,15 @@ class YTSelectionContainer1D(YTSelectionContainer):
         self._sortkey = None
         self._sorted = {}
 
+    def to_astropy_table(self, fields):
+        from astropy.table import QTable
+        t = QTable()
+        fields = self._determine_fields(fields)
+        for field in fields:
+            t[field[-1]] = self[field].to_astropy()
+        return t
+
+
 class YTSelectionContainer2D(YTSelectionContainer):
     _key_fields = ['px','py','pdx','pdy']
     _dimensionality = 2

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -512,14 +512,15 @@ class YTDataContainer(object):
         import pandas as pd
         data = {}
         if fields is not None:
-            for f in fields:
-                data[f] = self[f]
+            fields = self._determine_fields(fields)
         else:
-            data.update(self.field_data)
+            fields = self.field_data.keys()
+        for field in fields:
+            data[field[-1]] = self[field]
         df = pd.DataFrame(data)
         return df
 
-    def to_astropy_table(self, fields):
+    def to_astropy_table(self, fields=None):
         """
         Export region data to a :class:~astropy.table.table.QTable,
         which is a Table object which is unit-aware. The QTable can then
@@ -540,7 +541,10 @@ class YTDataContainer(object):
         """
         from astropy.table import QTable
         t = QTable()
-        fields = self._determine_fields(fields)
+        if fields is not None:
+            fields = self._determine_fields(fields)
+        else:
+            fields = self.field_data.keys()
         for field in fields:
             t[field[-1]] = self[field].to_astropy()
         return t

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -519,6 +519,32 @@ class YTDataContainer(object):
         df = pd.DataFrame(data)
         return df
 
+    def to_astropy_table(self, fields):
+        """
+        Export region data to a :class:~astropy.table.table.QTable,
+        which is a Table object which is unit-aware. The QTable can then
+        be exported to an ASCII file, FITS file, etc.
+
+        See the AstroPy Table docs for more details:
+        http://docs.astropy.org/en/stable/table/
+
+        Parameters
+        ----------
+        fields : list of strings
+            The list of fields to be exported to the QTable.
+
+        Examples
+        --------
+        >>> sp = ds.sphere("c", (1.0, "Mpc"))
+        >>> t = sp.to_astropy_table(["density","temperature"])
+        """
+        from astropy.table import QTable
+        t = QTable()
+        fields = self._determine_fields(fields)
+        for field in fields:
+            t[field[-1]] = self[field].to_astropy()
+        return t
+
     def save_as_dataset(self, filename=None, fields=None):
         r"""Export a data object to a reloadable yt dataset.
 
@@ -1812,32 +1838,6 @@ class YTSelectionContainer1D(YTSelectionContainer):
         self._grids = None
         self._sortkey = None
         self._sorted = {}
-
-    def to_astropy_table(self, fields):
-        """
-        Export region data to a :class:~astropy.table.table.QTable,
-        which is a Table object which is unit-aware. The QTable can then
-        be exported to an ASCII file, FITS file, etc.
-
-        See the AstroPy Table docs for more details:
-        http://docs.astropy.org/en/stable/table/
-
-        Parameters
-        ----------
-        fields : list of strings
-            The list of fields to be exported to the QTable.
-
-        Examples
-        --------
-        >>> sp = ds.sphere("c", (1.0, "Mpc"))
-        >>> t = sp.to_astropy_table(["density","temperature"])
-        """
-        from astropy.table import QTable
-        t = QTable()
-        fields = self._determine_fields(fields)
-        for field in fields:
-            t[field[-1]] = self[field].to_astropy()
-        return t
 
 
 class YTSelectionContainer2D(YTSelectionContainer):

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -528,6 +528,19 @@ class Profile1D(ProfileND):
         from yt.visualization.profile_plotter import ProfilePlot
         return ProfilePlot.from_profiles(self)
 
+    def to_astropy_table(self, only_used=False):
+        from astropy.table import QTable
+        if only_used:
+            idxs = self.used
+        else:
+            idxs = slice(None, None, None)
+        t = QTable()
+        t[self.x_field[-1]] = self.x[idxs].to_astropy()
+        for field, data in self.field_data.items():
+            t[field[-1]] = data[idxs].to_astropy()
+        return t
+
+
 class Profile1DFromDataset(ProfileNDFromDataset, Profile1D):
     """
     A 1D profile object loaded from a ytdata dataset.

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -571,8 +571,9 @@ class Profile1D(ProfileND):
             pdata[field[-1]] = self[field][idxs]
         df = pd.DataFrame(pdata)
         if masked:
-            ncols = len(fields)+1
-            df.mask(np.array([~self.used]*ncols).T, inplace=True)
+            mask = np.zeros(df.shape, dtype='bool')
+            mask[~self.used,1:] = True
+            df.mask(mask, inplace=True)
         return df
 
     def to_astropy_table(self, fields=None, only_used=False):

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -575,14 +575,15 @@ class Profile1D(ProfileND):
         >>> df2 = p.to_dataframe(fields="density", only_used=True)
         """
         import pandas as pd
+        from collections import OrderedDict
         idxs, masked, fields = self._export_prep(fields, only_used)
-        pdata = {self.x_field[-1]: self.x[idxs]}
+        pdata = OrderedDict([(self.x_field[-1], self.x[idxs])])
         for field in fields:
             pdata[field[-1]] = self[field][idxs]
         df = pd.DataFrame(pdata)
         if masked:
             mask = np.zeros(df.shape, dtype='bool')
-            mask[~self.used,1:] = True
+            mask[~self.used, 1:] = True
             df.mask(mask, inplace=True)
         return df
 

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -550,10 +550,16 @@ class Profile1D(ProfileND):
             idxs = self.used
         else:
             idxs = slice(None, None, None)
-        t = QTable()
+        if not only_used and not np.all(self.used):
+            masked = True
+        else:
+            masked = False
+        t = QTable(masked=masked)
         t[self.x_field[-1]] = self.x[idxs].to_astropy()
         for field, data in self.field_data.items():
             t[field[-1]] = data[idxs].to_astropy()
+            if masked:
+                t[field[-1]].mask = ~self.used
         return t
 
 

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -540,6 +540,7 @@ class Profile1D(ProfileND):
         if fields is None:
             fields = self.field_data.keys()
         else:
+            fields = ensure_list(fields)
             fields = self.data_source._determine_fields(fields)
         return idxs, masked, fields
 

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -528,6 +528,21 @@ class Profile1D(ProfileND):
         from yt.visualization.profile_plotter import ProfilePlot
         return ProfilePlot.from_profiles(self)
 
+    def _export_prep(self, fields, only_used):
+        if only_used:
+            idxs = self.used
+        else:
+            idxs = slice(None, None, None)
+        if not only_used and not np.all(self.used):
+            masked = True
+        else:
+            masked = False
+        if fields is None:
+            fields = self.field_data.keys()
+        else:
+            fields = self.data_source._determine_fields(fields)
+        return idxs, masked, fields
+
     def to_dataframe(self, fields=None, only_used=False):
         r"""Export a profile object to a pandas DataFrame.
 
@@ -550,18 +565,7 @@ class Profile1D(ProfileND):
         >>> df2 = dd.to_dataframe()
         """
         import pandas as pd
-        if only_used:
-            idxs = self.used
-        else:
-            idxs = slice(None, None, None)
-        if not only_used and not np.all(self.used):
-            masked = True
-        else:
-            masked = False
-        if fields is None:
-            fields = self.field_data.keys()
-        else:
-            fields = self.data_source._determine_fields(fields)
+        idxs, masked, fields = self._export_prep(fields, only_used)
         pdata = {self.x_field[-1]: self.x[idxs]}
         for field in fields:
             pdata[field[-1]] = self[field][idxs]
@@ -589,18 +593,7 @@ class Profile1D(ProfileND):
             Default: False
         """
         from astropy.table import QTable
-        if only_used:
-            idxs = self.used
-        else:
-            idxs = slice(None, None, None)
-        if not only_used and not np.all(self.used):
-            masked = True
-        else:
-            masked = False
-        if fields is None:
-            fields = self.field_data.keys()
-        else:
-            fields = self.data_source._determine_fields(fields)
+        idxs, masked, fields = self._export_prep(fields, only_used)
         qt = QTable(masked=masked)
         qt[self.x_field[-1]] = self.x[idxs].to_astropy()
         if masked:

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -551,19 +551,28 @@ class Profile1D(ProfileND):
         optionally a list of fields a pandas DataFrame object.  If pandas is
         not importable, this will raise ImportError.
 
+        Parameters
+        ----------
+        fields : list of strings or tuple field names, default None
+            If this is supplied, it is the list of fields to be exported into
+            the DataFrame. If not supplied, whatever fields exist in the 
+            profile, along with the bin field, will be exported.
+        only_used : boolean, default False
+            If True, only the bins which have data will be exported. If False,
+            all of the bins will be exported, but the elements for those bins
+            in the data arrays will be filled with NaNs. 
 
         Returns
         -------
-        df : DataFrame
-            The data contained in the object.
+        df : :class:`~pandas.DataFrame`
+            The data contained in the profile.
 
         Examples
         --------
-
-        >>> dd = ds.all_data()
-        >>> df1 = dd.to_dataframe(["density", "temperature"])
-        >>> dd["velocity_magnitude"]
-        >>> df2 = dd.to_dataframe()
+        >>> sp = ds.sphere("c", (0.1, "unitary"))
+        >>> p = sp.profile("radius", ["density", "temperature"])
+        >>> df1 = p.to_dataframe()
+        >>> df2 = p.to_dataframe(fields="density", only_used=True)
         """
         import pandas as pd
         idxs, masked, fields = self._export_prep(fields, only_used)
@@ -588,11 +597,27 @@ class Profile1D(ProfileND):
 
         Parameters
         ----------
+        fields : list of strings or tuple field names, default None
+            If this is supplied, it is the list of fields to be exported into
+            the DataFrame. If not supplied, whatever fields exist in the 
+            profile, along with the bin field, will be exported.
         only_used : boolean, optional
             If True, only the bins which are used are copied
             to the QTable as rows. If False, all bins are
             copied, but the bins which are not used are masked.
             Default: False
+
+        Returns
+        -------
+        df : :class:`~astropy.table.QTable`
+            The data contained in the profile.
+
+        Examples
+        --------
+        >>> sp = ds.sphere("c", (0.1, "unitary"))
+        >>> p = sp.profile("radius", ["density", "temperature"])
+        >>> qt1 = p.to_astropy_table()
+        >>> qt2 = p.to_astropy_table(fields="density", only_used=True)
         """
         from astropy.table import QTable
         idxs, masked, fields = self._export_prep(fields, only_used)
@@ -614,6 +639,7 @@ class Profile1DFromDataset(ProfileNDFromDataset, Profile1D):
 
     def __init(self, ds):
         ProfileNDFromDataset.__init__(self, ds)
+
 
 class Profile2D(ProfileND):
     """An object that represents a 2D profile.

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -522,13 +522,29 @@ class Profile1D(ProfileND):
 
     def plot(self):
         r"""
-        This returns a :class:~yt.visualization.profile_plotter.ProfilePlot
+        This returns a :class:`~yt.visualization.profile_plotter.ProfilePlot`
         with the fields that have been added to this object.
         """
         from yt.visualization.profile_plotter import ProfilePlot
         return ProfilePlot.from_profiles(self)
 
     def to_astropy_table(self, only_used=False):
+        """
+        Export the profile data to a :class:`~astropy.table.table.QTable`,
+        which is a Table object which is unit-aware. The QTable can then
+        be exported to an ASCII file, FITS file, etc.
+
+        See the AstroPy Table docs for more details:
+        http://docs.astropy.org/en/stable/table/
+
+        Parameters
+        ----------
+        only_used : boolean, optional
+            If True, only the bins which are used are copied
+            to the QTable as rows. If False, all bins are
+            copied, but the bins which are not used are masked.
+            Default: False
+        """
         from astropy.table import QTable
         if only_used:
             idxs = self.used

--- a/yt/data_objects/tests/test_data_containers.py
+++ b/yt/data_objects/tests/test_data_containers.py
@@ -103,6 +103,12 @@ class TestDataContainers(unittest.TestCase):
         df1 = dd.to_dataframe(fields)
         assert_array_equal(dd[fields[0]], df1[fields[0]])
         assert_array_equal(dd[fields[1]], df1[fields[1]])
+        sp = ds.sphere("c", (0.5, "unitary"))
+        sp["velocity_x"]
+        sp["velocity_y"]
+        df2 = sp.to_dataframe()
+        assert_array_equal(sp["velocity_x"], df2["velocity_x"])
+        assert_array_equal(sp["velocity_y"], df2["velocity_y"])
 
     @requires_module("astropy")
     def test_to_astropy_table(self):
@@ -110,11 +116,19 @@ class TestDataContainers(unittest.TestCase):
         fields = ["density", "velocity_z"]
         ds = fake_random_ds(6)
         dd = ds.all_data()
-        at = dd.to_astropy_table(fields)
-        assert_array_equal(dd[fields[0]].d, at[fields[0]].value)
-        assert_array_equal(dd[fields[1]].d, at[fields[1]].value)
-        assert dd[fields[0]].units == YTArray.from_astropy(at[fields[0]]).units
-        assert dd[fields[1]].units == YTArray.from_astropy(at[fields[1]]).units
+        at1 = dd.to_astropy_table(fields)
+        assert_array_equal(dd[fields[0]].d, at1[fields[0]].value)
+        assert_array_equal(dd[fields[1]].d, at1[fields[1]].value)
+        assert dd[fields[0]].units == YTArray.from_astropy(at1[fields[0]]).units
+        assert dd[fields[1]].units == YTArray.from_astropy(at1[fields[1]]).units
+        sp = ds.sphere("c", (0.5, "unitary"))
+        sp["velocity_x"]
+        sp["velocity_y"]
+        at2 = sp.to_astropy_table()
+        assert_array_equal(sp["velocity_x"].d, at2["velocity_x"].value)
+        assert_array_equal(sp["velocity_y"].d, at2["velocity_y"].value)
+        assert sp["velocity_x"].units == YTArray.from_astropy(at2["velocity_x"]).units
+        assert sp["velocity_y"].units == YTArray.from_astropy(at2["velocity_y"]).units
 
     def test_std(self):
         ds = fake_random_ds(3)

--- a/yt/data_objects/tests/test_data_containers.py
+++ b/yt/data_objects/tests/test_data_containers.py
@@ -104,6 +104,18 @@ class TestDataContainers(unittest.TestCase):
         assert_array_equal(dd[fields[0]], df1[fields[0]])
         assert_array_equal(dd[fields[1]], df1[fields[1]])
 
+    @requires_module("astropy")
+    def test_to_astropy_table(self):
+        from yt.units.yt_array import YTArray
+        fields = ["density", "velocity_z"]
+        ds = fake_random_ds(6)
+        dd = ds.all_data()
+        at = dd.to_astropy_table(fields)
+        assert_array_equal(dd[fields[0]].d, at[fields[0]].value)
+        assert_array_equal(dd[fields[1]].d, at[fields[1]].value)
+        assert dd[fields[0]].units == YTArray.from_astropy(at[fields[0]]).units
+        assert dd[fields[1]].units == YTArray.from_astropy(at[fields[1]]).units
+
     def test_std(self):
         ds = fake_random_ds(3)
         ds.all_data().std('density', weight="velocity_z")

--- a/yt/data_objects/tests/test_data_containers.py
+++ b/yt/data_objects/tests/test_data_containers.py
@@ -100,15 +100,9 @@ class TestDataContainers(unittest.TestCase):
         fields = ["density", "velocity_z"]
         ds = fake_random_ds(6)
         dd = ds.all_data()
-        df1 = dd.to_dataframe(fields)
-        assert_array_equal(dd[fields[0]], df1[fields[0]])
-        assert_array_equal(dd[fields[1]], df1[fields[1]])
-        sp = ds.sphere("c", (0.5, "unitary"))
-        sp["velocity_x"]
-        sp["velocity_y"]
-        df2 = sp.to_dataframe()
-        assert_array_equal(sp["velocity_x"], df2["velocity_x"])
-        assert_array_equal(sp["velocity_y"], df2["velocity_y"])
+        df = dd.to_dataframe(fields)
+        assert_array_equal(dd[fields[0]], df[fields[0]])
+        assert_array_equal(dd[fields[1]], df[fields[1]])
 
     @requires_module("astropy")
     def test_to_astropy_table(self):
@@ -121,14 +115,6 @@ class TestDataContainers(unittest.TestCase):
         assert_array_equal(dd[fields[1]].d, at1[fields[1]].value)
         assert dd[fields[0]].units == YTArray.from_astropy(at1[fields[0]]).units
         assert dd[fields[1]].units == YTArray.from_astropy(at1[fields[1]]).units
-        sp = ds.sphere("c", (0.5, "unitary"))
-        sp["velocity_x"]
-        sp["velocity_y"]
-        at2 = sp.to_astropy_table()
-        assert_array_equal(sp["velocity_x"].d, at2["velocity_x"].value)
-        assert_array_equal(sp["velocity_y"].d, at2["velocity_y"].value)
-        assert sp["velocity_x"].units == YTArray.from_astropy(at2["velocity_x"]).units
-        assert sp["velocity_y"].units == YTArray.from_astropy(at2["velocity_y"]).units
 
     def test_std(self):
         ds = fake_random_ds(3)

--- a/yt/data_objects/tests/test_profiles.py
+++ b/yt/data_objects/tests/test_profiles.py
@@ -404,8 +404,7 @@ def test_export_astropy():
     from yt.units.yt_array import YTArray
     ds = fake_random_ds(64)
     ad = ds.all_data()
-    prof = ad.profile('radius',
-                      [('gas', 'density'), ('gas', 'velocity_x')],
+    prof = ad.profile('radius', [('gas', 'density'), ('gas', 'velocity_x')],
                       weight_field=('index','ones'), n_bins=32)
     # export to AstroPy table
     at1 = prof.to_astropy_table()
@@ -428,11 +427,9 @@ def test_export_astropy():
 
 @requires_module("pandas")
 def test_export_pandas():
-    from yt.units.yt_array import YTArray
     ds = fake_random_ds(64)
     ad = ds.all_data()
-    prof = ad.profile('radius',
-                      [('gas', 'density'), ('gas', 'velocity_x')],
+    prof = ad.profile('radius', [('gas', 'density'), ('gas', 'velocity_x')],
                       weight_field=('index','ones'), n_bins=32)
     # export to pandas DataFrame
     df1 = prof.to_dataframe()

--- a/yt/data_objects/tests/test_profiles.py
+++ b/yt/data_objects/tests/test_profiles.py
@@ -399,14 +399,15 @@ def test_index_field_units():
     assert str(prof['gas', 'cell_volume'].units) == 'cm**3'
 
 
-def test_export_profiles():
+@requires_module("astropy")
+def test_export_astropy():
     from yt.units.yt_array import YTArray
     ds = fake_random_ds(64)
     ad = ds.all_data()
-    # export to AstroPy table
     prof = ad.profile('radius',
                       [('gas', 'density'), ('gas', 'velocity_x')],
                       weight_field=('index','ones'), n_bins=32)
+    # export to AstroPy table
     at1 = prof.to_astropy_table()
     assert 'radius' in at1.colnames
     assert 'density' in at1.colnames
@@ -423,6 +424,16 @@ def test_export_profiles():
     assert 'velocity_x' not in at2.colnames
     assert_equal(prof.x.d[prof.used], at2["radius"].value)
     assert_equal(prof["density"].d[prof.used], at2["density"].value)
+
+
+@requires_module("pandas")
+def test_export_pandas():
+    from yt.units.yt_array import YTArray
+    ds = fake_random_ds(64)
+    ad = ds.all_data()
+    prof = ad.profile('radius',
+                      [('gas', 'density'), ('gas', 'velocity_x')],
+                      weight_field=('index','ones'), n_bins=32)
     # export to pandas DataFrame
     df1 = prof.to_dataframe()
     assert 'radius' in df1.columns


### PR DESCRIPTION
## PR Summary

yt already has some capability to export fields from a data container to [pandas `DataFrame`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html) objects. This PR adds the capability to export the same kind of data to an [AstroPy QTable](https://docs.astropy.org/en/stable/api/astropy.table.QTable.html), which is a similar object and preserves the unit information. 

I've also added this export capability for both types to 1D profile objects, with an option for exporting unused bins (with masking) or leaving them out. 

I've added documentation for all of these features and new tests. 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
