### PR TITLE
bugfix for numpy 1.18

### DIFF
--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -114,8 +114,8 @@ def get_log_minorticks(vmin, vmax):
     """
     expA = np.floor(np.log10(vmin))
     expB = np.floor(np.log10(vmax))
-    cofA = np.ceil(vmin/10**expA)
-    cofB = np.floor(vmax/10**expB)
+    cofA = np.ceil(vmin/10**expA).astype("int64")
+    cofB = np.floor(vmax/10**expB).astype("int64")
     lmticks = []
     while cofA*10**expA <= cofB*10**expB:
         if expA < expB:


### PR DESCRIPTION
With numpy 1.18.1, np.linspace has become more cautious and won't accept floats as input for an integer number of points.

## PR Summary

explicitly set dtype to int for variables used as the 3rd argument of np.linspace (npoints)

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes flake8 checker
- [x] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

I encountered the bug while creating a yt.plot_2d of a polar dataset, I'll try to reproduce with fake data in order to add a test.