### PR TITLE
Enzo-p Frontend Bugfix to Load Single Block Datasets

### DIFF
--- a/yt/frontends/enzo_p/data_structures.py
+++ b/yt/frontends/enzo_p/data_structures.py
@@ -207,12 +207,18 @@ class EnzoPHierarchy(GridIndex):
                 line = buff[bnl:nnl]
                 block_name, block_file = line.split()
 
-                # The B__ block is a negative refinement level
-                # that cannot be used.
                 if "0" not in block_name and "1" not in block_name:
-                    level = -1
-                    left = self.ds.domain_left_edge.d
-                    right = self.ds.domain_right_edge.d
+                    if self.num_grids == 1:
+                        # Because the B__ block is the only block in the grid,
+                        # it has a refinement level of 0
+                        level = 0
+                        rbid = 0
+                    else:
+                        # The B__ block is a negative refinement level
+                        # that cannot be used.
+                        level = -1
+                    left = np.zeros(self.ds.dimensionality)
+                    right = np.ones(self.ds.dimensionality)
                 else:
                     level, left, right = get_block_info(block_name)
                     rbindex = get_root_block_id(block_name)

--- a/yt/frontends/enzo_p/data_structures.py
+++ b/yt/frontends/enzo_p/data_structures.py
@@ -207,23 +207,12 @@ class EnzoPHierarchy(GridIndex):
                 line = buff[bnl:nnl]
                 block_name, block_file = line.split()
 
-                if "0" not in block_name and "1" not in block_name:
-                    if self.num_grids == 1:
-                        # Because the B__ block is the only block in the grid,
-                        # it has a refinement level of 0
-                        level = 0
-                        rbid = 0
-                    else:
-                        # The B__ block is a negative refinement level
-                        # that cannot be used.
-                        level = -1
-                    left = np.zeros(self.ds.dimensionality)
-                    right = np.ones(self.ds.dimensionality)
-                else:
-                    level, left, right = get_block_info(block_name)
-                    rbindex = get_root_block_id(block_name)
-                    rbid = rbindex[0] * rbdim[1:].prod() + \
-                      rbindex[1] * rbdim[2:].prod() + rbindex[2]
+                # Handling of the B, B_, and B__ blocks is consistent with
+                # other unrefined blocks
+                level, left, right = get_block_info(block_name)
+                rbindex = get_root_block_id(block_name)
+                rbid = rbindex[0] * rbdim[1:].prod() + \
+                  rbindex[1] * rbdim[2:].prod() + rbindex[2]
 
                 # There are also blocks at lower level than the
                 # real root blocks. These can be ignored.

--- a/yt/frontends/enzo_p/misc.py
+++ b/yt/frontends/enzo_p/misc.py
@@ -52,6 +52,19 @@ def get_block_level(block):
     return l
 
 def get_block_info(block, min_dim=3):
+    """Decode a block name to get its left and right sides and level.
+
+    Given a block name, this function returns the locations of the block's left
+    and right edges (measured as binary fractions of the domain along each
+    axis) and level.
+
+    Unrefined blocks in the root array (which can each hold an of octree) have
+    a refinement level of 0 while their ancestors (used internally by Enzo-p's
+    solvers - they don't actually hold meaningful data) have negative levels.
+    Because identification of negative refinement levels requires knowledge of
+    the root array shape (the 'root_blocks' value specified in the parameter
+    file), all unrefined blocks are assumed to have a level of 0.
+    """
     mybs, dim = get_block_string_and_dim(
         block, min_dim=min_dim)
     left = np.zeros(dim)
@@ -79,6 +92,7 @@ def get_root_block_id(block, min_dim=3):
     for i, myb in enumerate(mybs):
         if myb == '': continue
         s = get_block_level(myb)
+        if s == 0: continue
         rbid[i] = int(myb[:s], 2)
     return rbid
 
@@ -91,7 +105,7 @@ def get_child_index(anc_id, desc_id):
     return cid
 
 def is_parent(anc_block, desc_block):
-    dim = anc_block.count("_")
+    dim = anc_block.count("_") + 1
     if ( len(desc_block.replace(":", "")) -
          len( anc_block.replace(":", "")) ) / dim != 1:
         return False

--- a/yt/frontends/enzo_p/misc.py
+++ b/yt/frontends/enzo_p/misc.py
@@ -56,6 +56,7 @@ def get_block_info(block, min_dim=3):
         block, min_dim=min_dim)
     left = np.zeros(dim)
     right = np.ones(dim)
+    level = 0
     for i, myb in enumerate(mybs):
         if myb == '': continue
         level, left[i], right[i] = bdecode(myb)

--- a/yt/frontends/enzo_p/tests/test_misc.py
+++ b/yt/frontends/enzo_p/tests/test_misc.py
@@ -51,6 +51,11 @@ def test_get_block_info():
         assert left == float(n) / max_n
         assert right == float(n+1) / max_n
 
+    level, left, right = get_block_info("B__")
+    assert level == 0
+    assert (left == np.zeros(3)).all()
+    assert (right == np.ones(3)).all()
+
 def test_root_blocks():
     rs = np.random.RandomState(45652)
     for i in range(2, 6):

--- a/yt/frontends/enzo_p/tests/test_misc.py
+++ b/yt/frontends/enzo_p/tests/test_misc.py
@@ -19,16 +19,23 @@ from yt.frontends.enzo_p.misc import \
     get_block_info, \
     get_root_blocks, \
     get_root_block_id, \
+    is_parent, \
     nested_dict_get
 
 def get_random_block_string(max_n=64, random_state=None, level=None):
+    if max_n == 1:
+        assert level is None or level == 0
+        return 0, 0, 'B'
+    elif max_n < 1:
+        raise ValueError('max_n must be a positive integer')
+
     if random_state is None:
         random_state = np.random.RandomState()
 
     max_l = int(np.log2(max_n))
     form = "%0" + str(max_l) + "d"
     num10 = random_state.randint(0, high=max_n)
-    num2 = form % int(bin(num10)[2:])
+    num2 = form % int(bin(num10)[2:]) #the slice clips the '0b' prefix
 
     if level is None:
         level = random_state.randint(0, high=max_l)
@@ -39,6 +46,38 @@ def get_random_block_string(max_n=64, random_state=None, level=None):
     my_block = "B" + my_block
 
     return num10, level, my_block
+
+def flip_random_block_bit(block, rs):
+    """
+    Flips a bit string in one of the block descriptors in a given block name
+    """
+    # split block into descriptors for each dimension
+    descriptors = block[1:].split('_')
+
+    # choose which descriptor to modify
+    flippable = [i for i,descr in enumerate(descriptors) if len(descr) > 0]
+    if len(flippable) == 0: # when block in ['B', 'B_', 'B__']
+        raise ValueError("%s has no bits that can be flipped" % block)
+    descr_index = flippable[rs.randint(0,len(flippable))]
+
+    # split block descriptor into left and right parts
+    parts = descriptors[descr_index].split(':')
+    # select the part to be modified
+    if len(parts) == 1: # block is unrefined
+        part_index = 0
+    elif len(parts[0]) == 0: # The root block index can't be modified
+        part_index = 1
+    else:
+        part_index = rs.randint(0, high = 2)
+    modify_part = parts[part_index]
+
+    # flip a bit in modify_part, and return the new block name with this change
+    flip_index = rs.randint(0, high = len(modify_part))
+    parts[part_index] = "%s%d%s" % (modify_part[:flip_index],
+                                    (int(modify_part[flip_index]) + 1) % 2,
+                                    modify_part[flip_index+1:])
+    descriptors[descr_index] = ':'.join(parts)
+    return 'B' + '_'.join(descriptors)
 
 def test_get_block_info():
     rs = np.random.RandomState(45047)
@@ -51,14 +90,15 @@ def test_get_block_info():
         assert left == float(n) / max_n
         assert right == float(n+1) / max_n
 
-    level, left, right = get_block_info("B__")
-    assert level == 0
-    assert (left == np.zeros(3)).all()
-    assert (right == np.ones(3)).all()
+    for block in ['B', 'B_', 'B__']:
+        level, left, right = get_block_info(block)
+        assert level == 0
+        assert (left == 0.0).all()
+        assert (right == 1.0).all()
 
 def test_root_blocks():
     rs = np.random.RandomState(45652)
-    for i in range(2, 6):
+    for i in range(6):
         max_n = 2**i
         n1, l1, b1 = get_random_block_string(
             max_n=max_n, random_state=rs, level=0)
@@ -70,6 +110,31 @@ def test_root_blocks():
         assert nrb == max_n
         rbid = get_root_block_id(block, min_dim=1)
         assert rbid == n1
+
+def test_is_parent():
+    rs = np.random.RandomState(45652)
+    for dim in [1,2,3]:
+        for i in range(6):
+            max_n = 2**i
+
+            descriptors = []
+            for j in range(dim):
+                n1, l1, b1 = get_random_block_string(
+                    max_n=max_n, random_state=rs, level=0)
+                n2, l2, b2 = get_random_block_string(
+                    max_n=32, random_state=rs, level=0)
+                descriptors.append("%s:%s" % (b1[1:], b2[1:]))
+            block = "B" + "_".join(descriptors)
+            # since b2 is computed with max_n=32 in the for-loop, block always
+            # has a refined great-great-grandparent
+            parent      = "B" + "_".join([elem[:-1] for elem in descriptors])
+            grandparent = "B" + "_".join([elem[:-2] for elem in descriptors])
+
+            assert is_parent(parent,block)
+            assert is_parent(grandparent, parent)
+            assert not is_parent(grandparent, block)
+            assert not is_parent(block, parent)
+            assert not is_parent(flip_random_block_bit(parent, rs), block)
 
 def test_nested_dict_get():
     rs = np.random.RandomState(47988)


### PR DESCRIPTION
## PR Summary
Enzo-p grids are split across one or more "blocks". Previously, the frontend supported loading a dataset with a grid split across multiple blocks. This pull request fixed a bug that had prevented the loading of a grid stored in a single block.

## PR Checklist

- [x] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

I added an additional case to the unit test for the `get_block_info` function. However, I have not added a test demonstrating that the front-end can now load in a single-block dataset because it would involve a new answer test dataset. I'm not sure how necessary that is.
