### PR TITLE
Fixed a bug in test_testing.py

### DIFF
--- a/yt/tests/test_testing.py
+++ b/yt/tests/test_testing.py
@@ -25,5 +25,5 @@ def test_requires_backend():
     def plot_b():
         return True
 
-    assert_equal(plot_a(), None)
-    assert_equal(plot_b(), True)
+    assert_equal(plot_a()(), None)
+    assert_equal(plot_b()(), True)


### PR DESCRIPTION
The issue was that requires_backend returned the function objects, but did not actually call the function. As such, when assert_equal was called in test_testing.py, the function object was being compared to the expected correct return result of the function (either None or True). By calling the returned function object, the test now passes. test_testing.py was modified instead of requires_backend (to return the called functions) because other parts of the code use requires_backend and I did not want to break those.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
