### PR TITLE
Change py2-style print stmts to py3

### DIFF
--- a/doc/helper_scripts/parse_cb_list.py
+++ b/doc/helper_scripts/parse_cb_list.py
@@ -28,7 +28,7 @@ def write_docstring(f, name, cls):
     sig = sig.replace("**kwargs", "**field_parameters")
     clsproxy = "yt.visualization.plot_modifications.%s" % (cls.__name__)
     #docstring = "\n".join(["   %s" % line for line in docstring.split("\n")])
-    #print docstring
+    #print(docstring)
     f.write(template % dict(clsname = clsname, sig = sig, clsproxy=clsproxy,
                             docstring = "\n".join(tw.wrap(docstring))))
                             #docstring = docstring))

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -418,7 +418,7 @@ class YTQuadTreeProj(YTProj):
 
     >>> ds = load("RedshiftOutput0005")
     >>> prj = ds.proj("density", 0)
-    >>> print proj["density"]
+    >>> print(proj["density"])
     """
     _type_name = "quad_proj"
     def __init__(self, field, axis, weight_field=None, center=None, ds=None,
@@ -1273,8 +1273,8 @@ class YTSurface(YTSelectionContainer3D):
     >>> from yt.units import kpc
     >>> sp = ds.sphere("max", (10, "kpc")
     >>> surf = ds.surface(sp, "density", 5e-27)
-    >>> print surf["temperature"]
-    >>> print surf.vertices
+    >>> print(surf["temperature"])
+    >>> print(surf.vertices)
     >>> bounds = [(sp.center[i] - 5.0*kpc,
     ...            sp.center[i] + 5.0*kpc) for i in range(3)]
     >>> surf.export_ply("my_galaxy.ply", bounds = bounds)
@@ -1908,8 +1908,8 @@ class YTSurface(YTSelectionContainer3D):
         >>> from yt.units import kpc
         >>> sp = ds.sphere("max", (10, "kpc")
         >>> surf = ds.surface(sp, "density", 5e-27)
-        >>> print surf["temperature"]
-        >>> print surf.vertices
+        >>> print(surf["temperature"])
+        >>> print(surf.vertices)
         >>> bounds = [(sp.center[i] - 5.0*kpc,
         ...            sp.center[i] + 5.0*kpc) for i in range(3)]
         >>> surf.export_ply("my_galaxy.ply", bounds = bounds)

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1121,9 +1121,9 @@ class YTDataContainer(metaclass = RegisteredDataContainer):
         >>> sp = ds.sphere("c", 0.1)
         >>> sp_clone = sp.clone()
         >>> sp["density"]
-        >>> print sp.field_data.keys()
+        >>> print(sp.field_data.keys())
         [("gas", "density")]
-        >>> print sp_clone.field_data.keys()
+        >>> print(sp_clone.field_data.keys())
         []
         """
         args = self.__reduce__()
@@ -1842,7 +1842,7 @@ class YTSelectionContainer3D(YTSelectionContainer):
         >>> ds = yt.load("RedshiftOutput0005")
         >>> ad = ds.all_data()
         >>> cr = ad.cut_region(["obj['temperature'] > 1e6"])
-        >>> print cr.quantities.total_quantity("cell_mass").in_units('Msun')
+        >>> print(cr.quantities.total_quantity("cell_mass").in_units('Msun'))
         """
         cr = self.ds.cut_region(self, field_cuts,
                                 field_parameters=field_parameters)

--- a/yt/data_objects/derived_quantities.py
+++ b/yt/data_objects/derived_quantities.py
@@ -114,9 +114,9 @@ class WeightedAverageQuantity(DerivedQuantity):
 
     >>> ds = load("IsolatedGalaxy/galaxy0030/galaxy0030")
     >>> ad = ds.all_data()
-    >>> print(ad.quantities.weighted_average_quantity([("gas", "density"),)
+    >>> print(ad.quantities.weighted_average_quantity([("gas", "density"),
     ...                                                ("gas", "temperature")],
-    ...                                               ("gas", "cell_mass"))
+    ...                                                ("gas", "cell_mass")))
 
     """
     def count_values(self, fields, weight):
@@ -370,9 +370,9 @@ class WeightedVariance(DerivedQuantity):
 
     >>> ds = load("IsolatedGalaxy/galaxy0030/galaxy0030")
     >>> ad = ds.all_data()
-    >>> print(ad.quantities.weighted_variance([("gas", "density"),)
+    >>> print(ad.quantities.weighted_variance([("gas", "density"),
     ...                                        ("gas", "temperature")],
-    ...                                       ("gas", "cell_mass"))
+    ...                                        ("gas", "cell_mass")))
 
     """
     def count_values(self, fields, weight):
@@ -517,8 +517,8 @@ class Extrema(DerivedQuantity):
 
     >>> ds = load("IsolatedGalaxy/galaxy0030/galaxy0030")
     >>> ad = ds.all_data()
-    >>> print(ad.quantities.extrema([("gas", "density"),)
-    ...                              ("gas", "temperature")])
+    >>> print(ad.quantities.extrema([("gas", "density"),
+    ...                              ("gas", "temperature")]))
 
     """
     def count_values(self, fields, non_zero):
@@ -566,8 +566,8 @@ class SampleAtMaxFieldValues(DerivedQuantity):
 
     >>> ds = load("IsolatedGalaxy/galaxy0030/galaxy0030")
     >>> ad = ds.all_data()
-    >>> print(ad.quantities.sample_at_max_field_values(("gas", "density"),)
-    ...         ["temperature", "velocity_magnitude"])
+    >>> print(ad.quantities.sample_at_max_field_values(("gas", "density"),
+    ...         ["temperature", "velocity_magnitude"]))
 
     """
     def count_values(self, field, sample_fields):
@@ -642,8 +642,8 @@ class SampleAtMinFieldValues(SampleAtMaxFieldValues):
 
     >>> ds = load("IsolatedGalaxy/galaxy0030/galaxy0030")
     >>> ad = ds.all_data()
-    >>> print(ad.quantities.sample_at_min_field_values(("gas", "density"),)
-    ...         ["temperature", "velocity_magnitude"])
+    >>> print(ad.quantities.sample_at_min_field_values(("gas", "density"),
+    ...         ["temperature", "velocity_magnitude"]))
 
     """
     def _func(self, arr):

--- a/yt/data_objects/derived_quantities.py
+++ b/yt/data_objects/derived_quantities.py
@@ -114,7 +114,7 @@ class WeightedAverageQuantity(DerivedQuantity):
 
     >>> ds = load("IsolatedGalaxy/galaxy0030/galaxy0030")
     >>> ad = ds.all_data()
-    >>> print ad.quantities.weighted_average_quantity([("gas", "density"),
+    >>> print(ad.quantities.weighted_average_quantity([("gas", "density"),)
     ...                                                ("gas", "temperature")],
     ...                                               ("gas", "cell_mass"))
 
@@ -153,7 +153,7 @@ class TotalQuantity(DerivedQuantity):
 
     >>> ds = load("IsolatedGalaxy/galaxy0030/galaxy0030")
     >>> ad = ds.all_data()
-    >>> print ad.quantities.total_quantity([("gas", "cell_mass")])
+    >>> print(ad.quantities.total_quantity([("gas", "cell_mass")]))
 
     """
     def count_values(self, fields):
@@ -185,7 +185,7 @@ class TotalMass(TotalQuantity):
 
     >>> ds = load("IsolatedGalaxy/galaxy0030/galaxy0030")
     >>> ad = ds.all_data()
-    >>> print ad.quantities.total_mass()
+    >>> print(ad.quantities.total_mass())
 
     """
     def __call__(self):
@@ -228,7 +228,7 @@ class CenterOfMass(DerivedQuantity):
 
     >>> ds = load("IsolatedGalaxy/galaxy0030/galaxy0030")
     >>> ad = ds.all_data()
-    >>> print ad.quantities.center_of_mass()
+    >>> print(ad.quantities.center_of_mass())
 
     """
     def count_values(self, use_gas = True, use_particles = False, particle_type="nbody"):
@@ -302,7 +302,7 @@ class BulkVelocity(DerivedQuantity):
 
     >>> ds = load("IsolatedGalaxy/galaxy0030/galaxy0030")
     >>> ad = ds.all_data()
-    >>> print ad.quantities.bulk_velocity()
+    >>> print(ad.quantities.bulk_velocity())
 
     """
     def count_values(self, use_gas=True, use_particles=False, particle_type="nbody"):
@@ -370,7 +370,7 @@ class WeightedVariance(DerivedQuantity):
 
     >>> ds = load("IsolatedGalaxy/galaxy0030/galaxy0030")
     >>> ad = ds.all_data()
-    >>> print ad.quantities.weighted_variance([("gas", "density"),
+    >>> print(ad.quantities.weighted_variance([("gas", "density"),)
     ...                                        ("gas", "temperature")],
     ...                                       ("gas", "cell_mass"))
 
@@ -443,13 +443,13 @@ class AngularMomentumVector(DerivedQuantity):
     # Find angular momentum vector of galaxy in grid-based isolated galaxy dataset
     >>> ds = load("IsolatedGalaxy/galaxy0030/galaxy0030")
     >>> ad = ds.all_data()
-    >>> print ad.quantities.angular_momentum_vector()
+    >>> print(ad.quantities.angular_momentum_vector())
 
     # Find angular momentum vector of gas disk in particle-based dataset
     >>> ds = load("FIRE_M12i_ref11/snapshot_600.hdf5")
     >>> _, c = ds.find_max(('gas', 'density'))
     >>> sp = ds.sphere(c, (10, 'kpc'))
-    >>> print sp.quantities.angular_momentum_vector(use_gas=False, use_particles=True, particle_type='PartType0')
+    >>> print(sp.quantities.angular_momentum_vector(use_gas=False, use_particles=True, particle_type='PartType0'))
 
     """
     def count_values(self, use_gas=True, use_particles=True, particle_type='all'):
@@ -517,7 +517,7 @@ class Extrema(DerivedQuantity):
 
     >>> ds = load("IsolatedGalaxy/galaxy0030/galaxy0030")
     >>> ad = ds.all_data()
-    >>> print ad.quantities.extrema([("gas", "density"),
+    >>> print(ad.quantities.extrema([("gas", "density"),)
     ...                              ("gas", "temperature")])
 
     """
@@ -566,7 +566,7 @@ class SampleAtMaxFieldValues(DerivedQuantity):
 
     >>> ds = load("IsolatedGalaxy/galaxy0030/galaxy0030")
     >>> ad = ds.all_data()
-    >>> print ad.quantities.sample_at_max_field_values(("gas", "density"),
+    >>> print(ad.quantities.sample_at_max_field_values(("gas", "density"),)
     ...         ["temperature", "velocity_magnitude"])
 
     """
@@ -612,7 +612,7 @@ class MaxLocation(SampleAtMaxFieldValues):
 
     >>> ds = load("IsolatedGalaxy/galaxy0030/galaxy0030")
     >>> ad = ds.all_data()
-    >>> print ad.quantities.max_location(("gas", "density"))
+    >>> print(ad.quantities.max_location(("gas", "density")))
 
     """
     def __call__(self, field):
@@ -642,7 +642,7 @@ class SampleAtMinFieldValues(SampleAtMaxFieldValues):
 
     >>> ds = load("IsolatedGalaxy/galaxy0030/galaxy0030")
     >>> ad = ds.all_data()
-    >>> print ad.quantities.sample_at_min_field_values(("gas", "density"),
+    >>> print(ad.quantities.sample_at_min_field_values(("gas", "density"),)
     ...         ["temperature", "velocity_magnitude"])
 
     """
@@ -664,7 +664,7 @@ class MinLocation(SampleAtMinFieldValues):
 
     >>> ds = load("IsolatedGalaxy/galaxy0030/galaxy0030")
     >>> ad = ds.all_data()
-    >>> print ad.quantities.min_location(("gas", "density"))
+    >>> print(ad.quantities.min_location(("gas", "density")))
 
     """
     def __call__(self, field):
@@ -710,7 +710,7 @@ class SpinParameter(DerivedQuantity):
 
     >>> ds = load("IsolatedGalaxy/galaxy0030/galaxy0030")
     >>> ad = ds.all_data()
-    >>> print ad.quantities.spin_parameter()
+    >>> print(ad.quantities.spin_parameter())
 
     """
     def count_values(self, **kwargs):

--- a/yt/data_objects/level_sets/clump_handling.py
+++ b/yt/data_objects/level_sets/clump_handling.py
@@ -220,17 +220,17 @@ class Clump(TreeContainer):
         >>> new_ds = yt.load(fn)
         >>> print (ds.tree["clump", "cell_mass"])
         1296926163.91 Msun
-        >>> print ds.tree["grid", "density"]
+        >>> print(ds.tree["grid", "density"])
         [  2.54398434e-26   2.46620353e-26   2.25120154e-26 ...,   1.12879234e-25
            1.59561490e-25   1.09824903e-24] g/cm**3
-        >>> print ds.tree["all", "particle_mass"]
+        >>> print(ds.tree["all", "particle_mass"])
         [  4.25472446e+38   4.25472446e+38   4.25472446e+38 ...,   2.04238266e+38
            2.04523901e+38   2.04770938e+38] g
-        >>> print ds.tree.children[0]["clump", "cell_mass"]
+        >>> print(ds.tree.children[0]["clump", "cell_mass"])
         909636495.312 Msun
-        >>> print ds.leaves[0]["clump", "cell_mass"]
+        >>> print(ds.leaves[0]["clump", "cell_mass"])
         3756566.99809 Msun
-        >>> print ds.leaves[0]["grid", "density"]
+        >>> print(ds.leaves[0]["grid", "density"])
         [  6.97820274e-24   6.58117370e-24   7.32046082e-24   6.76202430e-24
            7.41184837e-24   6.76981480e-24   6.94287213e-24   6.56149658e-24
            6.76584569e-24   6.94073710e-24   7.06713082e-24   7.22556526e-24

--- a/yt/data_objects/particle_trajectories.py
+++ b/yt/data_objects/particle_trajectories.py
@@ -46,7 +46,7 @@ class ParticleTrajectories(object):
     >>> ts = DatasetSeries(my_fns)
     >>> trajs = ts.particle_trajectories(indices, fields=fields)
     >>> for t in trajs :
-    >>>     print t["particle_velocity_x"].max(), t["particle_velocity_x"].min()
+    >>>     print(t["particle_velocity_x"].max(), t["particle_velocity_x"].min())
     """
     def __init__(self, outputs, indices, fields=None, suppress_logging=False, ptype=None):
 

--- a/yt/data_objects/selection_data_containers.py
+++ b/yt/data_objects/selection_data_containers.py
@@ -115,7 +115,7 @@ class YTOrthoRay(YTSelectionContainer1D):
     >>> import yt
     >>> ds = yt.load("RedshiftOutput0005")
     >>> oray = ds.ortho_ray(0, (0.2, 0.74))
-    >>> print oray["Density"]
+    >>> print(oray["Density"])
 
     Note: The low-level data representation for rays are not guaranteed to be 
     spatially ordered.  In particular, with AMR datasets, higher resolution 
@@ -197,7 +197,7 @@ class YTRay(YTSelectionContainer1D):
     >>> import yt
     >>> ds = yt.load("RedshiftOutput0005")
     >>> ray = ds.ray((0.2, 0.74, 0.11), (0.4, 0.91, 0.31))
-    >>> print ray["Density"], ray["t"], ray["dts"]
+    >>> print(ray["Density"], ray["t"], ray["dts"])
 
     Note: The low-level data representation for rays are not guaranteed to be 
     spatially ordered.  In particular, with AMR datasets, higher resolution 
@@ -323,7 +323,7 @@ class YTSlice(YTSelectionContainer2D):
     >>> import yt
     >>> ds = yt.load("RedshiftOutput0005")
     >>> slice = ds.slice(0, 0.25)
-    >>> print slice["Density"]
+    >>> print(slice["Density"])
     """
     _top_node = "/Slices"
     _type_name = "slice"
@@ -446,7 +446,7 @@ class YTCuttingPlane(YTSelectionContainer2D):
     >>> import yt
     >>> ds = yt.load("RedshiftOutput0005")
     >>> cp = ds.cutting([0.1, 0.2, -0.9], [0.5, 0.42, 0.6])
-    >>> print cp["Density"]
+    >>> print(cp["Density"])
     """
     _plane = None
     _top_node = "/CuttingPlanes"

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -127,7 +127,7 @@ class DatasetSeries(object):
     ...     SlicePlot(ds, "x", "Density").save()
     ...
     >>> def print_time(ds):
-    ...     print ds.current_time
+    ...     print(ds.current_time)
     ...
     >>> ts = DatasetSeries(
     ...     "GasSloshingLowRes/sloshing_low_res_hdf5_plt_cnt_0[0-6][0-9]0",
@@ -235,7 +235,7 @@ class DatasetSeries(object):
         This demonstrates how one might store results:
 
         >>> def print_time(ds):
-        ...     print ds.current_time
+        ...     print(ds.current_time)
         ...
         >>> ts = DatasetSeries("DD*/DD*.index",
         ...             setup_function = print_time )
@@ -246,7 +246,7 @@ class DatasetSeries(object):
         ...     sto.result = (v, c)
         ...
         >>> for i, (v, c) in sorted(my_storage.items()):
-        ...     print "% 4i  %0.3e" % (i, v)
+        ...     print("% 4i  %0.3e" % (i, v))
         ...
 
         This shows how to dispatch 4 processors to each dataset:
@@ -341,7 +341,7 @@ class DatasetSeries(object):
         --------
 
         >>> def print_time(ds):
-        ...     print ds.current_time
+        ...     print(ds.current_time)
         ...
         >>> ts = DatasetSeries.from_filenames(
         ...     "GasSloshingLowRes/sloshing_low_res_hdf5_plt_cnt_0[0-6][0-9]0",
@@ -422,7 +422,7 @@ class DatasetSeries(object):
         >>> ts = DatasetSeries(my_fns)
         >>> trajs = ts.particle_trajectories(indices, fields=fields)
         >>> for t in trajs :
-        >>>     print t["particle_velocity_x"].max(), t["particle_velocity_x"].min()
+        >>>     print(t["particle_velocity_x"].max(), t["particle_velocity_x"].min())
 
         Note
         ----

--- a/yt/extern/tqdm/_tqdm.py
+++ b/yt/extern/tqdm/_tqdm.py
@@ -240,7 +240,7 @@ class tqdm(object):
             dynamically resizes the progressbar to stay within this bound.
             If [default: None], attempts to use environment width. The
             fallback is a meter width of 10 and no limit for the counter and
-            statistics. If 0, will not print any meter (only stats).
+            statistics. If 0, will not print(any meter (only stats).)
         mininterval  : float, optional
             Minimum progress update interval, in seconds [default: 0.1].
         maxinterval  : float, optional

--- a/yt/extern/tqdm/_tqdm.py
+++ b/yt/extern/tqdm/_tqdm.py
@@ -240,7 +240,7 @@ class tqdm(object):
             dynamically resizes the progressbar to stay within this bound.
             If [default: None], attempts to use environment width. The
             fallback is a meter width of 10 and no limit for the counter and
-            statistics. If 0, will not print(any meter (only stats).)
+            statistics. If 0, will not print any meter (only stats).
         mininterval  : float, optional
             Minimum progress update interval, in seconds [default: 0.1].
         maxinterval  : float, optional

--- a/yt/frontends/art/data_structures.py
+++ b/yt/frontends/art/data_structures.py
@@ -788,11 +788,11 @@ class ARTDomainFile(object):
             level_oct_offsets.append(f.tell())
 
             # Get the info for this level, skip the rest
-            # print "Reading oct tree data for level", Lev
-            # print 'offset:',f.tell()
+            # print("Reading oct tree data for level", Lev)
+            # print('offset:',f.tell())
             Level[Lev], iNOLL[Lev], iHOLL[Lev] = fpu.read_vector(f, 'i', '>')
-            # print 'Level %i : '%Lev, iNOLL
-            # print 'offset after level record:',f.tell()
+            # print('Level %i : '%Lev, iNOLL)
+            # print('offset after level record:',f.tell())
             nLevel = iNOLL[Lev]
             ntot = ntot + nLevel
 

--- a/yt/frontends/enzo/io.py
+++ b/yt/frontends/enzo/io.py
@@ -67,7 +67,7 @@ class IOHandlerPackedHDF5(BaseIOHandler):
             for g in chunk.objs:
                 if g.filename is None: continue
                 if f is None:
-                    #print "Opening (read) %s" % g.filename
+                    #print("Opening (read) %s" % g.filename)
                     f = h5py.File(g.filename, "r")
                 nap = sum(g.NumberOfActiveParticles.values())
                 if g.NumberOfParticles == 0 and nap == 0:
@@ -307,7 +307,7 @@ class IOHandlerPacked2D(IOHandlerPackedHDF5):
             f = None
             for g in chunk.objs:
                 if f is None:
-                    #print "Opening (count) %s" % g.filename
+                    #print("Opening (count) %s" % g.filename)
                     f = h5py.File(g.filename, "r")
                 gds = f.get("/Grid%08i" % g.id)
                 if gds is None:

--- a/yt/frontends/exodus_ii/simulation_handling.py
+++ b/yt/frontends/exodus_ii/simulation_handling.py
@@ -32,7 +32,7 @@ class ExodusIISimulation(DatasetSeries, metaclass = RegisteredSimulationTimeSeri
     >>> sim = yt.simulation("demo_second", "ExodusII")
     >>> sim.get_time_series()
     >>> for ds in sim:
-    ...     print ds.current_time
+    ...     print(ds.current_time)
 
     """
 

--- a/yt/frontends/fits/misc.py
+++ b/yt/frontends/fits/misc.py
@@ -145,7 +145,7 @@ def ds9_region(ds, reg, obj=None, field_parameters=None):
 
     >>> ds = yt.load("m33_hi.fits")
     >>> circle_region = ds9_region(ds, "circle.reg")
-    >>> print circle_region.quantities.extrema("flux")
+    >>> print(circle_region.quantities.extrema("flux"))
     """
     import pyregion
     from yt.frontends.fits.api import EventsFITSDataset

--- a/yt/frontends/gadget/simulation_handling.py
+++ b/yt/frontends/gadget/simulation_handling.py
@@ -53,7 +53,7 @@ class GadgetSimulation(SimulationTimeSeries):
     >>> gs = yt.simulation("my_simulation.par", "Gadget")
     >>> gs.get_time_series()
     >>> for ds in gs:
-    ...     print ds.current_time
+    ...     print(ds.current_time)
 
     """
 
@@ -189,7 +189,7 @@ class GadgetSimulation(SimulationTimeSeries):
 
         >>> # An example using the setup_function keyword
         >>> def print_time(ds):
-        ...     print ds.current_time
+        ...     print(ds.current_time)
         >>> gs.get_time_series(setup_function=print_time)
         >>> for ds in gs:
         ...     SlicePlot(ds, "x", "Density").save()

--- a/yt/frontends/gadget_fof/data_structures.py
+++ b/yt/frontends/gadget_fof/data_structures.py
@@ -510,22 +510,22 @@ class GagdetFOFHaloContainer(YTSelectionContainer):
     >>> ds = yt.load("gadget_halos/data/groups_298/fof_subhalo_tab_298.0.hdf5")
     >>>
     >>> halo = ds.halo("Group", 0)
-    >>> print halo.mass
+    >>> print(halo.mass)
     13256.5517578 code_mass
-    >>> print halo.position
+    >>> print(halo.position)
     [ 16.18603706   6.95965052  12.52694607] code_length
-    >>> print halo.velocity
+    >>> print(halo.velocity)
     [ 6943694.22793569  -762788.90647454  -794749.63819757] cm/s
-    >>> print halo["Group_R_Crit200"]
+    >>> print(halo["Group_R_Crit200"])
     [ 0.79668683] code_length
     >>>
     >>> # particle ids for this halo
-    >>> print halo["member_ids"]
+    >>> print(halo["member_ids"])
     [  723631.   690744.   854212. ...,   608589.   905551.  1147449.] dimensionless
     >>>
     >>> # get the first subhalo of this halo
     >>> subhalo = ds.halo("Subhalo", (0, 0))
-    >>> print subhalo["member_ids"]
+    >>> print(subhalo["member_ids"])
     [  723631.   690744.   854212. ...,   808362.   956359.  1248821.] dimensionless
 
     """

--- a/yt/frontends/open_pmd/misc.py
+++ b/yt/frontends/open_pmd/misc.py
@@ -30,11 +30,11 @@ def parse_unit_dimension(unit_dimension):
     Examples
     --------
     >>> velocity = [1., 0., -1., 0., 0., 0., 0.]
-    >>> print parse_unit_dimension(velocity)
+    >>> print(parse_unit_dimension(velocity))
     'm**1*s**-1'
 
     >>> magnetic_field = [0., 1., -2., -1., 0., 0., 0.]
-    >>> print parse_unit_dimension(magnetic_field)
+    >>> print(parse_unit_dimension(magnetic_field))
     'kg**1*s**-2*A**-1'
     """
     if len(unit_dimension) is not 7:

--- a/yt/frontends/owls/simulation_handling.py
+++ b/yt/frontends/owls/simulation_handling.py
@@ -29,7 +29,7 @@ class OWLSSimulation(GadgetSimulation):
     >>> es = yt.simulation("my_simulation.par", "OWLS")
     >>> es.get_time_series()
     >>> for ds in es:
-    ...     print ds.current_time
+    ...     print(ds.current_time)
 
     """
 

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -832,11 +832,11 @@ def get_output_filename(name, keyword, suffix):
     Examples
     --------
 
-    >>> print get_output_filename(None, "Projection_x", ".png")
+    >>> print(get_output_filename(None, "Projection_x", ".png"))
     Projection_x.png
-    >>> print get_output_filename("my_file", "Projection_x", ".png")
+    >>> print(get_output_filename("my_file", "Projection_x", ".png"))
     my_file.png
-    >>> print get_output_filename("my_file/", "Projection_x", ".png")
+    >>> print(get_output_filename("my_file/", "Projection_x", ".png"))
     my_file/Projection_x.png
     
     """

--- a/yt/geometry/fake_octree.pyx
+++ b/yt/geometry/fake_octree.pyx
@@ -38,7 +38,7 @@ def create_fake_octree(RAMSESOctreeContainer oct_handler,
     cur_leaf = 8 #we've added one parent...
     mask = np.ones((max_noct,8),dtype='uint8')
     while oct_handler.domains[0].n_assigned < max_noct:
-        print "root: nocts ", oct_handler.domains[0].n_assigned
+        print("root: nocts ", oct_handler.domains[0].n_assigned)
         cur_leaf = subdivide(oct_handler, parent, ind, dd, cur_leaf, 0,
                              max_noct, max_level, fsubdivide, mask)
     return cur_leaf
@@ -50,7 +50,7 @@ cdef long subdivide(RAMSESOctreeContainer oct_handler,
                     long cur_leaf, long cur_level,
                     long max_noct, long max_level, float fsubdivide,
                     np.ndarray[np.uint8_t, ndim=2] mask):
-    print "child", parent.file_ind, ind[0], ind[1], ind[2], cur_leaf, cur_level
+    print("child", parent.file_ind, ind[0], ind[1], ind[2], cur_leaf, cur_level)
     cdef int ddr[3]
     cdef int ii
     cdef long i

--- a/yt/geometry/oct_container.pyx
+++ b/yt/geometry/oct_container.pyx
@@ -531,15 +531,15 @@ cdef class OctreeContainer:
         visitor.dims = dims
         self.visit_all_octs(selector, visitor)
         if (visitor.global_index + 1) * visitor.nz * visitor.dims > source.size:
-            print "GLOBAL INDEX RAN AHEAD.",
+            print("GLOBAL INDEX RAN AHEAD.",)
             print (visitor.global_index + 1) * visitor.nz * visitor.dims - source.size
-            print dest.size, source.size, num_cells
+            print(dest.size, source.size, num_cells)
             raise RuntimeError
         if visitor.index > dest.size:
-            print "DEST INDEX RAN AHEAD.",
-            print visitor.index - dest.size
+            print("DEST INDEX RAN AHEAD.",)
+            print(visitor.index - dest.size)
             print (visitor.global_index + 1) * visitor.nz * visitor.dims, source.size
-            print num_cells
+            print(num_cells)
             raise RuntimeError
         if num_cells >= 0:
             return dest
@@ -858,10 +858,10 @@ cdef class SparseOctreeContainer(OctreeContainer):
         if next != NULL: return next
         cdef OctAllocationContainer *cont = self.domains.get_cont(domain_id - 1)
         if cont.n_assigned >= cont.n:
-            print "Too many assigned."
+            print("Too many assigned.")
             return NULL
         if self.num_root >= self.max_root:
-            print "Too many roots."
+            print("Too many roots.")
             return NULL
         next = &cont.my_objs[cont.n_assigned]
         cont.n_assigned += 1

--- a/yt/geometry/oct_visitors.pyx
+++ b/yt/geometry/oct_visitors.pyx
@@ -300,7 +300,7 @@ cdef class LoadOctree(OctVisitor):
                 self.nfinest[0] += 1
         elif self.ref_mask[self.index] > 0:
             if self.ref_mask[self.index] != 1 and self.ref_mask[self.index] != 8:
-                print "ARRAY CLUE: ", self.ref_mask[self.index], "UNKNOWN"
+                print("ARRAY CLUE: ", self.ref_mask[self.index], "UNKNOWN")
                 raise RuntimeError
             if o.children == NULL:
                 o.children = <Oct **> malloc(sizeof(Oct *) * 8)
@@ -314,7 +314,7 @@ cdef class LoadOctree(OctVisitor):
                 o.children[ii + i].children = NULL
                 self.nocts[0] += 1
         else:
-            print "SOMETHING IS AMISS", self.index
+            print("SOMETHING IS AMISS", self.index)
             raise RuntimeError
         self.index += 1
 

--- a/yt/geometry/particle_deposit.pyx
+++ b/yt/geometry/particle_deposit.pyx
@@ -310,7 +310,7 @@ cdef class StdParticleField(ParticleDepositOperation):
         k = self.i[ii[2], ii[1], ii[0], offset]
         mk = self.mk[ii[2], ii[1], ii[0], offset]
         qk = self.qk[ii[2], ii[1], ii[0], offset]
-        #print k, mk, qk, cell_index
+        #print(k, mk, qk, cell_index)
         if k == 0.0:
             # Initialize cell values
             self.mk[ii[2], ii[1], ii[0], offset] = fields[0]

--- a/yt/geometry/particle_smooth.pyx
+++ b/yt/geometry/particle_smooth.pyx
@@ -192,7 +192,7 @@ cdef class ParticleSmoothOperation:
             # If we have yet to assign the starting index to this oct, we do so
             # now.
             if doff[offset] < 0: doff[offset] = i
-        #print domain_id, domain_offset, moff_p, moff_m
+        #print(domain_id, domain_offset, moff_p, moff_m)
         #raise RuntimeError
         # Now doff is full of offsets to the first entry in the pind that
         # refers to that oct's particles.
@@ -218,8 +218,8 @@ cdef class ParticleSmoothOperation:
                 &nind, pind, pcount, offset, index_field_pointers,
                 particle_octree, domain_id, &nsize, oct_left_edges,
                 oct_dds, dist_queue)
-        #print "VISITED", visited.sum(), visited.size,
-        #print 100.0*float(visited.sum())/visited.size
+        #print("VISITED", visited.sum(), visited.size,)
+        #print(100.0*float(visited.sum())/visited.size)
         if nind != NULL:
             free(nind)
 
@@ -319,7 +319,7 @@ cdef class ParticleSmoothOperation:
             # If we have yet to assign the starting index to this oct, we do so
             # now.
             if doff[offset] < 0: doff[offset] = i
-        #print domain_id, domain_offset, moff_p, moff_m
+        #print(domain_id, domain_offset, moff_p, moff_m)
         #raise RuntimeError
         # Now doff is full of offsets to the first entry in the pind that
         # refers to that oct's particles.
@@ -341,8 +341,8 @@ cdef class ParticleSmoothOperation:
                             doff, &nind, pind, pcount, pind0,
                             NULL, particle_octree, domain_id, &nsize,
                             dist_queue)
-        #print "VISITED", visited.sum(), visited.size,
-        #print 100.0*float(visited.sum())/visited.size
+        #print("VISITED", visited.sum(), visited.size,)
+        #print(100.0*float(visited.sum())/visited.size)
         if nind != NULL:
             free(nind)
 
@@ -535,7 +535,7 @@ cdef class ParticleSmoothOperation:
                             if nind[0][m] < 0: continue
                             nntot += 1
                             ntot += pcounts[nind[0][m]]
-                        print "SOMETHING WRONG", dq.curn, nneighbors, ntot, nntot
+                        print("SOMETHING WRONG", dq.curn, nneighbors, ntot, nntot)
                     self.process(offset, i, j, k, dim, opos, fields,
                                  index_fields, dq)
                     cpos[2] += dds[2]

--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -214,7 +214,7 @@ cdef class SelectorObject:
             sdds[i] = dds[i]/2.0
             LE[i] = pos[i] - dds[i]/2.0
             RE[i] = pos[i] + dds[i]/2.0
-        #print LE[0], RE[0], LE[1], RE[1], LE[2], RE[2]
+        #print(LE[0], RE[0], LE[1], RE[1], LE[2], RE[2])
         res = self.select_grid(LE, RE, level, root)
         if res == 1 and visitor.domain > 0 and root.domain != visitor.domain:
             res = -1
@@ -1790,7 +1790,7 @@ cdef class RaySelector(SelectorObject):
                         dtr[ni] = dt[i, j, k]
                         ni += 1
         if not (ni == ia.hits):
-            print ni, ia.hits
+            print(ni, ia.hits)
         free(ia)
         return dtr, tr
 

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -608,14 +608,14 @@ def expand_keywords(keywords, full=False):
     >>> keywords['dpi'] = (50, 100, 200)
     >>> keywords['cmap'] = ('arbre', 'kelp')
     >>> list_of_kwargs = expand_keywords(keywords)
-    >>> print list_of_kwargs
+    >>> print(list_of_kwargs)
 
     array([{'cmap': 'arbre', 'dpi': 50},
            {'cmap': 'kelp', 'dpi': 100},
            {'cmap': 'arbre', 'dpi': 200}], dtype=object)
 
     >>> list_of_kwargs = expand_keywords(keywords, full=True)
-    >>> print list_of_kwargs
+    >>> print(list_of_kwargs)
 
     array([{'cmap': 'arbre', 'dpi': 50},
            {'cmap': 'arbre', 'dpi': 100},

--- a/yt/utilities/amr_kdtree/amr_kdtree.py
+++ b/yt/utilities/amr_kdtree/amr_kdtree.py
@@ -97,7 +97,7 @@ class Tree(object):
             assert(np.all(grid.LeftEdge <= nle))
             assert(np.all(grid.RightEdge >= nre))
             assert(np.all(dims > 0))
-            # print grid, dims, li, ri
+            # print(grid, dims, li, ri)
 
         # Calculate the Volume
         vol = self.trunk.kd_sum_volume()

--- a/yt/utilities/grid_data_format/conversion/conversion_athena.py
+++ b/yt/utilities/grid_data_format/conversion/conversion_athena.py
@@ -75,7 +75,7 @@ class AthenaDistributedConverter(Converter):
             name = translation_dict[name]
         except:
             pass
-        # print 'Writing %s' % name
+        # print('Writing %s' % name)
         if name not in g.keys():
             g.create_dataset(name,data=data)
         
@@ -84,7 +84,7 @@ class AthenaDistributedConverter(Converter):
     def read_and_write_index(self,basename, ddn, gdf_name):
         """ Read Athena legacy vtk file from multiple cpus """
         proc_names = glob(self.source_dir+'id*')
-        #print 'Reading a dataset from %i Processor Files' % len(proc_names)
+        #print('Reading a dataset from %i Processor Files' % len(proc_names))
         N = len(proc_names)
         grid_dims = np.empty([N,3],dtype='int64')
         grid_left_edges = np.empty([N,3],dtype='float64')
@@ -198,7 +198,7 @@ class AthenaDistributedConverter(Converter):
 
     def read_and_write_data(self, basename, ddn, gdf_name):
         proc_names = glob(self.source_dir+'id*')
-        #print 'Reading a dataset from %i Processor Files' % len(proc_names)
+        #print('Reading a dataset from %i Processor Files' % len(proc_names))
         N = len(proc_names)
         for i in range(N):
             if i == 0:
@@ -206,7 +206,7 @@ class AthenaDistributedConverter(Converter):
             else:
                 fn = self.source_dir+'id%i/'%i + basename + '-id%i'%i + '.%04i'%ddn + '.vtk'
             f = open(fn,'rb')
-            #print 'Reading data from %s' % fn
+            #print('Reading data from %s' % fn)
             line = f.readline()
             while line is not '':
                 if len(line) == 0: break
@@ -242,7 +242,7 @@ class AthenaDistributedConverter(Converter):
                     data = np.fromfile(f, dtype='>f4', count=grid_ncells).reshape(grid_dims,order='F')
                     if i == 0:
                         self.fields.append(field)
-                    # print 'writing field %s' % field
+                    # print('writing field %s' % field)
                     self.write_gdf_field(gdf_name, i, field, data)
                     read_table=False
 
@@ -257,7 +257,7 @@ class AthenaDistributedConverter(Converter):
                         self.fields.append(field+'_y')
                         self.fields.append(field+'_z')
 
-                    # print 'writing field %s' % field
+                    # print('writing field %s' % field)
                     self.write_gdf_field(gdf_name, i, field+'_x', data_x)
                     self.write_gdf_field(gdf_name, i, field+'_y', data_y)
                     self.write_gdf_field(gdf_name, i, field+'_z', data_z)
@@ -334,7 +334,7 @@ class AthenaConverter(Converter):
     def read_grid(self, filename):
         """ Read Athena legacy vtk file from single cpu """
         f = open(filename,'rb')
-        #print 'Reading from %s'%filename
+        #print('Reading from %s'%filename)
         grid = {}
         grid['read_field'] = None
         grid['read_type'] = None

--- a/yt/utilities/lib/amr_kdtools.pyx
+++ b/yt/utilities/lib/amr_kdtools.pyx
@@ -41,12 +41,12 @@ cdef class Node:
 
 
     def print_me(self):
-        print 'Node %i' % self.node_id
-        print '\t le: %e %e %e' % (self.left_edge[0], self.left_edge[1],
-                                   self.left_edge[2])
-        print '\t re: %e %e %e' % (self.right_edge[0], self.right_edge[1],
-                                   self.right_edge[2])
-        print '\t grid: %i' % self.grid
+        print('Node %i' % self.node_id)
+        print('\t le: %e %e %e' % (self.left_edge[0], self.left_edge[1],
+                                   self.left_edge[2]))
+        print('\t re: %e %e %e' % (self.right_edge[0], self.right_edge[1],
+                                   self.right_edge[2]))
+        print('\t grid: %i' % self.grid)
 
     def get_split_dim(self):
         if self.split != NULL:
@@ -228,8 +228,8 @@ cdef class Node:
                 greater_ids[ngreater] = i
                 ngreater += 1
 
-        #print 'nless: %i' % nless
-        #print 'ngreater: %i' % ngreater
+        #print('nless: %i' % nless)
+        #print('ngreater: %i' % ngreater)
 
         if nless > 0:
             less_gles = cvarray(format="d", shape=(nless,3), itemsize=sizeof(np.float64_t))
@@ -298,7 +298,7 @@ cdef class Node:
                 contained *= gres[0,i] >= self.right_edge[i]
 
             if contained == 1:
-                # print 'Node fully contained, setting to grid: %i' % gids[0]
+                # print('Node fully contained, setting to grid: %i' % gids[0])
                 self.grid = gids[0]
                 assert(self.grid != -1)
                 return
@@ -349,13 +349,13 @@ cdef class Node:
         self.divide(split)
 
         # Populate Left Node
-        #print 'Inserting left node', self.left_edge, self.right_edge
+        #print('Inserting left node', self.left_edge, self.right_edge)
         if nless == 1:
             self.left.insert_grid(gle, gre,
                          gid, rank, size)
 
         # Populate Right Node
-        #print 'Inserting right node', self.left_edge, self.right_edge
+        #print('Inserting right node', self.left_edge, self.right_edge)
         if ngreater == 1:
             self.right.insert_grid(gle, gre,
                          gid, rank, size)
@@ -396,7 +396,7 @@ cdef class Node:
         # If best_dim is -1, then we have found a place where there are no choices.
         # Exit out and set the node to None.
         if best_dim == -1:
-            print 'Failed to split grids.'
+            print('Failed to split grids.')
             return -1
 
         split = <Split *> malloc(sizeof(Split))
@@ -433,7 +433,7 @@ cdef class Node:
                     less_gres[i,j] = gres[index,j]
 
             # Populate Left Node
-            #print 'Inserting left node', self.left_edge, self.right_edge
+            #print('Inserting left node', self.left_edge, self.right_edge)
             self.left.insert_grids(nless, less_gles, less_gres,
                          l_ids, rank, size)
 
@@ -450,7 +450,7 @@ cdef class Node:
                     greater_gres[i,j] = gres[index,j]
 
             # Populate Right Node
-            #print 'Inserting right node', self.left_edge, self.right_edge
+            #print('Inserting right node', self.left_edge, self.right_edge)
             self.right.insert_grids(ngreater, greater_gles, greater_gres,
                          g_ids, rank, size)
 
@@ -494,13 +494,13 @@ cdef class Node:
 
         #lnew_gre[big_dim] = new_pos
         # Populate Left Node
-        #print 'Inserting left node', self.left_edge, self.right_edge
+        #print('Inserting left node', self.left_edge, self.right_edge)
         self.left.insert_grid(lnew_gle, lnew_gre,
                 grid_id, rank, size)
 
         #rnew_gle[big_dim] = new_pos
         # Populate Right Node
-        #print 'Inserting right node', self.left_edge, self.right_edge
+        #print('Inserting right node', self.left_edge, self.right_edge)
         self.right.insert_grid(rnew_gle, rnew_gre,
                 grid_id, rank, size)
         return
@@ -777,17 +777,17 @@ cdef kdtree_get_choices(int n_grids,
         for i in range(n_grids):
             # Check for disqualification
             for j in range(2):
-                # print "Checking against", i,j,dim,data[i,j,dim]
+                # print("Checking against", i,j,dim,data[i,j,dim])
                 if not (l_corner[dim] < data[i][j][dim] and
                         data[i][j][dim] < r_corner[dim]):
-                    # print "Skipping ", data[i,j,dim], l_corner[dim], r_corner[dim]
+                    # print("Skipping ", data[i,j,dim], l_corner[dim], r_corner[dim])
                     continue
                 skipit = 0
                 # Add our left ...
                 for k in range(n_unique):
                     if uniques[k] == data[i][j][dim]:
                         skipit = 1
-                        # print "Identified", uniques[k], data[i,j,dim], n_unique
+                        # print("Identified", uniques[k], data[i,j,dim], n_unique)
                         break
                 if skipit == 0:
                     uniques[n_unique] = data[i][j][dim]
@@ -801,7 +801,7 @@ cdef kdtree_get_choices(int n_grids,
     # I recognize how lame this is.
     cdef np.ndarray[np.float64_t, ndim=1] tarr = np.empty(my_max, dtype='float64')
     for i in range(my_max):
-        # print "Setting tarr: ", i, uniquedims[best_dim][i]
+        # print("Setting tarr: ", i, uniquedims[best_dim][i])
         tarr[i] = uniquedims[best_dim][i]
     tarr.sort()
     split = tarr[my_split]

--- a/yt/utilities/lib/basic_octree.pyx
+++ b/yt/utilities/lib/basic_octree.pyx
@@ -428,7 +428,7 @@ cdef class Octree:
                 if this_node is NULL: break
             if this_node is NULL: break
             if truncate and potential > kinetic:
-                print 'Truncating...'
+                print('Truncating...')
                 break
             pair_node = this_node.next
             while pair_node is not NULL:
@@ -538,7 +538,7 @@ cdef class Octree:
                     for k in range(2):
                         nline += "%d," % self.node_ID(node.children[i][j][k])
             line += nline
-        print line
+        print(line)
         return
 
     cdef void iterate_print_nodes(self, OctreeNode *node):
@@ -572,7 +572,7 @@ cdef class Octree:
         for i in range(self.nvals):
             line += "val%d\t\t" % i
         line += "weight\t\tchild?\tparent?\tchildren"
-        print line
+        print(line)
         for i in range(self.top_grid_dims[0]):
             for j in range(self.top_grid_dims[1]):
                 for k in range(self.top_grid_dims[2]):

--- a/yt/utilities/lib/bitarray.pyx
+++ b/yt/utilities/lib/bitarray.pyx
@@ -39,7 +39,7 @@ cdef class bitarray:
         >>> arr_in2 = np.array([False, True, True])
         >>> a = ba.bitarray(arr = arr_in1)
         >>> b = ba.bitarray(arr = arr_in2)
-        >>> print a & b
+        >>> print(a & b)
         >>> print (a & b).as_bool_array()
 
         """
@@ -134,7 +134,7 @@ cdef class bitarray:
 
         >>> arr_in = np.array([True, True, False])
         >>> a = ba.bitarray(arr = arr_in)
-        >>> print a.set_value(2, 1)
+        >>> print(a.set_value(2, 1))
 
         """
         ba_set_value(self.buf, ind, val)
@@ -157,7 +157,7 @@ cdef class bitarray:
 
         >>> arr_in = np.array([True, True, False])
         >>> a = ba.bitarray(arr = arr_in)
-        >>> print a.query_value(2)
+        >>> print(a.query_value(2))
 
         """
         return ba_get_value(self.buf, ind)

--- a/yt/utilities/lib/contour_finding.pyx
+++ b/yt/utilities/lib/contour_finding.pyx
@@ -5,7 +5,7 @@ A two-pass contour finding algorithm
 
 """
 
-
+from __future__ import print_function
 import numpy as np
 cimport numpy as np
 cimport cython
@@ -26,7 +26,7 @@ import sys
 cdef inline ContourID *contour_create(np.int64_t contour_id,
                                ContourID *prev = NULL):
     node = <ContourID *> malloc(sizeof(ContourID))
-    #print "Creating contour with id", contour_id
+    #print("Creating contour with id", contour_id)
     node.contour_id = contour_id
     node.next = node.parent = NULL
     node.prev = prev
@@ -147,7 +147,7 @@ cdef class ContourTree:
         n = contour_ids.shape[0]
         cdef ContourID *cur = self.last
         for i in range(n):
-            #print i, contour_ids[i]
+            #print(i, contour_ids[i])
             cur = contour_create(contour_ids[i], cur)
             if self.first == NULL: self.first = cur
         self.last = cur
@@ -228,15 +228,15 @@ cdef class ContourTree:
         cdef ContourID *c1
         cdef ContourID *c2
         n = join_tree.shape[0]
-        #print "Counting"
-        #print "Checking", self.count()
+        #print("Counting")
+        #print("Checking", self.count())
         for i in range(n):
             ins = 0
             cid1 = join_tree[i, 0]
             cid2 = join_tree[i, 1]
             c1 = c2 = NULL
             cur = self.first
-            #print "Looking for ", cid1, cid2
+            #print("Looking for ", cid1, cid2)
             while c1 == NULL or c2 == NULL:
                 if cur.contour_id == cid1:
                     c1 = contour_find(cur)
@@ -246,9 +246,9 @@ cdef class ContourTree:
                 cur = cur.next
                 if cur == NULL: break
             if c1 == NULL or c2 == NULL:
-                if c1 == NULL: print "  Couldn't find ", cid1
-                if c2 == NULL: print "  Couldn't find ", cid2
-                print "  Inspected ", ins
+                if c1 == NULL: print("  Couldn't find ", cid1)
+                if c2 == NULL: print("  Couldn't find ", cid2)
+                print("  Inspected ", ins)
                 raise RuntimeError
             else:
                 c1.count = c2.count = 0
@@ -562,11 +562,11 @@ cdef class ParticleContourTree(ContourTree):
         cdef np.int64_t *nind = <np.int64_t *> malloc(sizeof(np.int64_t)*nsize)
         counter = 0
         cdef np.int64_t frac = <np.int64_t> (doff.shape[0] / 20.0)
-        if verbose == 1: print >> sys.stderr, "Will be outputting every", frac
+        if verbose == 1: print("Will be outputting every", frac, file=sys.stderr)
         for i in range(doff.shape[0]):
             if verbose == 1 and counter >= frac:
                 counter = 0
-                print >> sys.stderr, "FOF-ing % 5.1f%% done" % ((100.0 * i)/doff.size)
+                print("FOF-ing % 5.1f%% done" % ((100.0 * i)/doff.size), file=sys.stderr)
             counter += 1
             # Any particles found for this oct?
             if doff[i] < 0: continue

--- a/yt/utilities/lib/ewah_bool_wrap.pyx
+++ b/yt/utilities/lib/ewah_bool_wrap.pyx
@@ -614,7 +614,7 @@ cdef class FileBitmasks:
             nchk = tmp2.numberOfOnes()
             if nchk > 0:
                 msg = "File {}: There are {} refined cells that are not set on coarse level.".format(ifile,nchk)
-                print msg
+                print(msg)
                 return 0
                 # raise Exception(msg)
         return 1
@@ -745,8 +745,8 @@ cdef class BoolArrayCollection:
                 raise RuntimeError
             self._set(ids[i])
             last = ids[i]
-        print "Set from %s array and ended up with %s bytes" % (
-            ids.size, ewah_keys[0].sizeInBytes())
+        print("Set from %s array and ended up with %s bytes" % (
+            ids.size, ewah_keys[0].sizeInBytes()))
 
     cdef void _set_coarse(self, np.uint64_t i1):
         cdef ewah_bool_array *ewah_keys = <ewah_bool_array *> self.ewah_keys
@@ -1296,7 +1296,7 @@ cdef class BoolArrayCollection:
         nchk = tmp2.numberOfOnes()
         if nchk > 0:
             msg = "There are {} refined cells that are not set on coarse level.".format(nchk)
-            print msg
+            print(msg)
             return 0
             # raise Exception(msg)
         return 1

--- a/yt/utilities/lib/fortran_reader.pyx
+++ b/yt/utilities/lib/fortran_reader.pyx
@@ -61,11 +61,11 @@ def count_art_octs(char *fn, long offset,
     for _ in range(min_level + 1, max_level + 1):
         fread(dummy_records, sizeof(int), 2, f);
         fread(&nLevel, sizeof(int), 1, f); FIX_LONG(nLevel)
-        print level_info
+        print(level_info)
         level_info.append(nLevel)
         fread(dummy_records, sizeof(int), 2, f);
         fread(&next_record, sizeof(int), 1, f); FIX_LONG(next_record)
-        print "Record size is:", next_record
+        print("Record size is:", next_record)
         # Offset for one record header we just read
         next_record = (nLevel * (next_record + 2*sizeof(int))) - sizeof(int)
         fseek(f, next_record, SEEK_CUR)
@@ -78,7 +78,7 @@ def count_art_octs(char *fn, long offset,
         next_record = (2*sizeof(int) + readin) * (nLevel * nchild)
         next_record -= sizeof(int)
         fseek(f, next_record, SEEK_CUR)
-    print "nhvars",nhydro_vars
+    print("nhvars",nhydro_vars)
     fclose(f)
 
 def read_art_tree(char *fn, long offset,
@@ -115,11 +115,11 @@ def read_art_tree(char *fn, long offset,
         fread(&readin, sizeof(int), 1, f); FIX_LONG(readin)
         iOct = iHOLL[Level] - 1
         nLevel = iNOLL[Level]
-        #print "Reading Hierarchy for Level", Lev, Level, nLevel, iOct
-        #print ftell(f)
+        #print("Reading Hierarchy for Level", Lev, Level, nLevel, iOct)
+        #print(ftell(f))
         for ic1 in range(nLevel):
             iOctMax = max(iOctMax, iOct)
-            #print readin, iOct, nLevel, sizeof(int)
+            #print(readin, iOct, nLevel, sizeof(int))
             next_record = ftell(f)
             fread(&readin, sizeof(int), 1, f); FIX_LONG(readin)
             assert readin==52
@@ -147,11 +147,11 @@ def read_art_tree(char *fn, long offset,
 
         #skip over the hydro variables
         #find the length of one child section
-        #print 'measuring child record ',
+        #print('measuring child record ',)
         fread(&next_record, sizeof(int), 1, f);
-        #print next_record,
+        #print(next_record,)
         FIX_LONG(next_record)
-        #print next_record
+        #print(next_record)
         fseek(f,ftell(f)-sizeof(int),SEEK_SET) #rewind
         #This is a sloppy fix; next_record is 64bit
         #and I don't think FIX_LONG(next_record) is working
@@ -162,7 +162,7 @@ def read_art_tree(char *fn, long offset,
 
         #find the length of all of the children section
         child_record = ftell(f) +  (next_record+2*sizeof(int))*nLevel*nchild
-        #print 'Skipping over hydro vars', ftell(f), child_record
+        #print('Skipping over hydro vars', ftell(f), child_record)
         fseek(f, child_record, SEEK_SET)
 
         # for ic1 in range(nLevel * nchild):
@@ -187,7 +187,7 @@ def read_art_root_vars(char *fn, long root_grid_offset,
     fseek(f, root_grid_offset, SEEK_SET)
     # Now we seet out the cell we want
     cdef int my_offset = (((iz * ny) + iy) * nx + ix)
-    #print cell_record_size, my_offset, ftell(f)
+    #print(cell_record_size, my_offset, ftell(f))
     fseek(f, cell_record_size * my_offset, SEEK_CUR)
     #(((C)*GridDimension[1]+(B))*GridDimension[0]+A)
     for j in range(nhydro_vars):
@@ -216,11 +216,11 @@ cdef void read_art_vars(FILE *f,
     for j in range(8): #iterate over the children
         l = 0
         fread(padding, sizeof(int), 3, f); FIX_LONG(padding[0])
-        #print "Record Size", padding[0]
+        #print("Record Size", padding[0])
         # This should be replaced by an fread of nhydro_vars length
         for k in range(nhydro_vars): #iterate over the record
             fread(&temp, sizeof(float), 1, f); FIX_FLOAT(temp)
-            #print k, temp
+            #print(k, temp)
             if k in fields:
                 var[j,l] = temp
                 l += 1
@@ -272,9 +272,9 @@ def read_art_grid(int varindex,
                     offi = di - start_index[0]
                     offj = dj - start_index[1]
                     offk = dk - start_index[2]
-                    #print offi, filled.shape[0],
-                    #print offj, filled.shape[1],
-                    #print offk, filled.shape[2]
+                    #print(offi, filled.shape[0],)
+                    #print(offj, filled.shape[1],)
+                    #print(offk, filled.shape[2])
                     if filled[offi, offj, offk] == 1: continue
                     if level > 0:
                         odind = (kr*2 + jr)*2 + ir

--- a/yt/utilities/lib/geometry_utils.pyx
+++ b/yt/utilities/lib/geometry_utils.pyx
@@ -185,8 +185,8 @@ def bitwise_addition(np.uint64_t x, np.int64_t y0,
                 mstr[i] = '1'
                 m = int(''.join(mstr[::-1]), 2)
             # Invert portion in mask
-            # print mstr[::-1]
-            # print y,p,(pstart,end+1),bin(m),bin(out),bin(~out)
+            # print(mstr[::-1])
+            # print(y,p,(pstart,end+1),bin(m),bin(out),bin(~out))
             out = masked_merge_64bit(out, ~out, m)
         # Move to next bit
         p += 1
@@ -887,7 +887,7 @@ def compare_morton(np.ndarray[floating, ndim=1] p0, np.ndarray[floating, ndim=1]
         q[j] = q0[j]
         # imp = ifrexp(p[j],&iep)
         # imq = ifrexp(q[j],&ieq)
-        # print j,p[j],q[j],xor_msb(p[j],q[j]),'m=',imp,imq,'e=',iep,ieq
+        # print(j,p[j],q[j],xor_msb(p[j],q[j]),'m=',imp,imq,'e=',iep,ieq)
     return compare_floats_morton(p,q)
 
 @cython.cdivision(True)
@@ -956,7 +956,7 @@ def compute_morton(np.ndarray pos_x, np.ndarray pos_y, np.ndarray pos_z,
                 pos_x, pos_y, pos_z, dds, DLE, DRE, ind,
                 filter)
     else:
-        print "Could not identify dtype.", pos_x.dtype
+        print("Could not identify dtype.", pos_x.dtype)
         raise NotImplementedError
     if rv < pos_x.shape[0]:
         mis = (pos_x.min(), pos_y.min(), pos_z.min())
@@ -1130,7 +1130,7 @@ def csearch_morton(np.ndarray[np.float64_t, ndim=2] P, int k, np.uint64_t i,
     cbox_hl = np.zeros(3,dtype=np.float64)
     rbox_hl = quadtree_box(P[l,:],P[h,:],order,DLE,DRE,cbox_hl)
     if dist_to_box(cbox_sol,cbox_hl,rbox_hl) >= 1.5*rbox_sol:
-        print '{} outside: rad = {}, rbox = {}, dist = {}'.format(m,rad_Ai,rbox_sol,dist_to_box(P[i,:],cbox_hl,rbox_hl))
+        print('{} outside: rad = {}, rbox = {}, dist = {}'.format(m,rad_Ai,rbox_sol,dist_to_box(P[i,:],cbox_hl,rbox_hl)))
         return Ai
     # Expand search to lower/higher indicies as needed 
     if i < m: # They are already sorted...

--- a/yt/utilities/lib/grid_traversal.pyx
+++ b/yt/utilities/lib/grid_traversal.pyx
@@ -317,7 +317,7 @@ def healpix_aitoff_proj(np.ndarray[np.float64_t, ndim=1] pix_image,
     #             for l in range(3):
     #                 v0[k] += v1[l] * irotation[l,k]
     #         healpix_interface.vec2pix_nest(nside, v0, &ipix)
-    #         #print "Rotated", v0[0], v0[1], v0[2], v1[0], v1[1], v1[2], ipix, pix_image[ipix]
+    #         #print("Rotated", v0[0], v0[1], v0[2], v1[0], v1[1], v1[2], ipix, pix_image[ipix])
     #         image[j, i] = pix_image[ipix]
 
 def arr_fisheye_vectors(int resolution, np.float64_t fov, int nimx=1, int

--- a/yt/utilities/lib/marching_cubes.pyx
+++ b/yt/utilities/lib/marching_cubes.pyx
@@ -335,7 +335,7 @@ def march_cubes_grid_flux(
                                 point[m] = (current.p[n][m]-cell_pos[m])*idds[m]
                             # Now we calculate the value at this point
                             temp = offset_interpolate(dims, point, intdata)
-                            #print "something", temp, point[0], point[1], point[2]
+                            #print("something", temp, point[0], point[1], point[2])
                             wval += temp
                             for m in range(3):
                                 center[m] += temp * point[m]

--- a/yt/utilities/lib/mesh_traversal.pyx
+++ b/yt/utilities/lib/mesh_traversal.pyx
@@ -24,9 +24,9 @@ rtc.rtcInit(NULL)
 rtc.rtcSetErrorFunction(error_printer)
 
 cdef void error_printer(const rtc.RTCError code, const char *_str):
-    print "ERROR CAUGHT IN EMBREE"
+    print("ERROR CAUGHT IN EMBREE")
     rtc.print_error(code)
-    print "ERROR MESSAGE:", _str
+    print("ERROR MESSAGE:", _str)
 
 cdef class YTEmbreeScene:
 

--- a/yt/utilities/lib/misc_utilities.pyx
+++ b/yt/utilities/lib/misc_utilities.pyx
@@ -461,17 +461,17 @@ def kdtree_get_choices(np.ndarray[np.float64_t, ndim=3] data,
         for i in range(n_grids):
             # Check for disqualification
             for j in range(2):
-                #print "Checking against", i,j,dim,data[i,j,dim]
+                #print("Checking against", i,j,dim,data[i,j,dim])
                 if not (l_corner[dim] < data[i, j, dim] and
                         data[i, j, dim] < r_corner[dim]):
-                    #print "Skipping ", data[i,j,dim]
+                    #print("Skipping ", data[i,j,dim])
                     continue
                 skipit = 0
                 # Add our left ...
                 for k in range(n_unique):
                     if uniques[k] == data[i, j, dim]:
                         skipit = 1
-                        #print "Identified", uniques[k], data[i,j,dim], n_unique
+                        #print("Identified", uniques[k], data[i,j,dim], n_unique)
                         break
                 if skipit == 0:
                     uniques[n_unique] = data[i, j, dim]
@@ -483,7 +483,7 @@ def kdtree_get_choices(np.ndarray[np.float64_t, ndim=3] data,
     # I recognize how lame this is.
     cdef np.ndarray[np.float64_t, ndim=1] tarr = np.empty(my_max, dtype='float64')
     for i in range(my_max):
-        #print "Setting tarr: ", i, uniquedims[best_dim][i]
+        #print("Setting tarr: ", i, uniquedims[best_dim][i])
         tarr[i] = uniquedims[best_dim][i]
     tarr.sort()
     if my_split < 0:

--- a/yt/utilities/lib/origami.pyx
+++ b/yt/utilities/lib/origami.pyx
@@ -24,8 +24,8 @@ def run_origami(np.ndarray[np.float64_t, ndim=1] pos_x,
     # C-contiguous.
     global printed_citation
     if printed_citation == 0:
-        print "ORIGAMI was developed by Bridget Falck and Mark Neyrinck."
-        print "Please cite Falck, Neyrinck, & Szalay 2012, ApJ, 754, 2, 125."
+        print("ORIGAMI was developed by Bridget Falck and Mark Neyrinck.")
+        print("Please cite Falck, Neyrinck, & Szalay 2012, ApJ, 754, 2, 125.")
         printed_citation = 1
     cdef int npart = pos_x.size
     if npart == 1:

--- a/yt/utilities/lib/points_in_volume.pyx
+++ b/yt/utilities/lib/points_in_volume.pyx
@@ -127,7 +127,7 @@ cdef void get_cross_product(np.float64_t v1[3],
     cp[0] = v1[1]*v2[2] - v1[2]*v2[1]
     cp[1] = v1[3]*v2[0] - v1[0]*v2[3]
     cp[2] = v1[0]*v2[1] - v1[1]*v2[0]
-    #print cp[0], cp[1], cp[2]
+    #print(cp[0], cp[1], cp[2])
 
 cdef int check_projected_overlap(
         np.float64_t sep_ax[3], np.float64_t sep_vec[3], int gi,
@@ -144,8 +144,8 @@ cdef int check_projected_overlap(
         ba += fabs(tba)
         ga += fabs(tga)
         sep_dot += sep_vec[g_ax] * sep_ax[g_ax]
-    #print sep_vec[0], sep_vec[1], sep_vec[2],
-    #print sep_ax[0], sep_ax[1], sep_ax[2]
+    #print(sep_vec[0], sep_vec[1], sep_vec[2],)
+    #print(sep_ax[0], sep_ax[1], sep_ax[2])
     return (fabs(sep_dot) > ba+ga)
     # Now we do
 
@@ -197,7 +197,7 @@ def find_grids_in_inclined_box(
             g_vec[g_ax][g_ax] = 0.5 * (grid_right_edges[gi, g_ax]
                                      - grid_left_edges[gi, g_ax])
         for b_ax in range(15):
-            #print b_ax,
+            #print(b_ax,)
             if check_projected_overlap(
                         sep_ax[b_ax], sep_vec, gi,
                         b_vec,  g_vec):

--- a/yt/utilities/parallel_tools/parallel_analysis_interface.py
+++ b/yt/utilities/parallel_tools/parallel_analysis_interface.py
@@ -455,7 +455,7 @@ def parallel_objects(objects, njobs = 0, storage = None, barrier = True,
     ...     sto.result = sp.quantities["AngularMomentumVector"]()
     ...
     >>> for sphere_id, L in sorted(storage.items()):
-    ...     print centers[sphere_id], L
+    ...     print(centers[sphere_id], L)
     ...
 
     """
@@ -555,7 +555,7 @@ def parallel_ring(objects, generator_func, mutable = False):
     ...
     >>> obj = range(8)
     >>> for obj, arr in parallel_ring(obj, gfunc):
-    ...     print arr['x'].sum(), arr['y'].sum(), arr['z'].sum()
+    ...     print(arr['x'].sum(), arr['y'].sum(), arr['z'].sum())
     ...
 
     """
@@ -960,14 +960,14 @@ class Communicator(object):
         while mask < size:
             if (mask & rank) != 0:
                 target = (rank & ~mask) % size
-                #print "SENDING FROM %02i to %02i" % (rank, target)
+                #print("SENDING FROM %02i to %02i" % (rank, target))
                 buf = qt.tobuffer()
                 self.send_quadtree(target, buf, tgd, args)
                 #qt = self.recv_quadtree(target, tgd, args)
             else:
                 target = (rank | mask)
                 if target < size:
-                    #print "RECEIVING FROM %02i on %02i" % (target, rank)
+                    #print("RECEIVING FROM %02i on %02i" % (target, rank))
                     buf = self.recv_quadtree(target, tgd, args)
                     qto = QuadTree(tgd, args[2], qt.bounds)
                     qto.frombuffer(buf[0], buf[1], buf[2], merge_style)

--- a/yt/utilities/sdf.py
+++ b/yt/utilities/sdf.py
@@ -280,8 +280,8 @@ class SDFRead(dict):
         --------
 
         >>> sdf = SDFRead("data.sdf", header="data.hdr")
-        >>> print sdf.parameters
-        >>> print sdf['x']
+        >>> print(sdf.parameters)
+        >>> print(sdf['x'])
 
         """
         self.filename = filename
@@ -453,8 +453,8 @@ class HTTPSDFRead(SDFRead):
     --------
 
     >>> sdf = SDFRead("data.sdf", header="data.hdr")
-    >>> print sdf.parameters
-    >>> print sdf['x']
+    >>> print(sdf.parameters)
+    >>> print(sdf['x'])
 
     """
 
@@ -515,8 +515,8 @@ def load_sdf(filename, header=None):
     --------
 
     >>> sdf = SDFRead("data.sdf", header="data.hdr")
-    >>> print sdf.parameters
-    >>> print sdf['x']
+    >>> print(sdf.parameters)
+    >>> print(sdf['x'])
 
     """
     if 'http' in filename:
@@ -752,7 +752,7 @@ class SDFIndex(object):
         Given left and right indicies, return a mask and
         set of offsets+lengths into the sdf data.
         """
-        #print 'Getting data from ileft to iright:',  ileft, iright
+        #print('Getting data from ileft to iright:',  ileft, iright)
 
         ix, iy, iz = (iright-ileft)*1j
         mylog.debug('MIDX IBBOX: %s %s %s %s %s' % (ileft, iright, ix, iy, iz))
@@ -779,7 +779,7 @@ class SDFIndex(object):
             dinds = self.get_keyv([X[dmask], Y[dmask], Z[dmask]])
             dinds = dinds[dinds < self._max_key]
             dinds = dinds[self.indexdata['len'][dinds] > 0]
-            #print 'Getting boundary layers for wanderers, cells: %i' % dinds.size
+            #print('Getting boundary layers for wanderers, cells: %i' % dinds.size)
 
         # Correct For periodicity
         X[X < self.domain_buffer] += self.domain_active_dims
@@ -789,7 +789,7 @@ class SDFIndex(object):
         Y[Y >= self.domain_buffer + self.domain_active_dims] -= self.domain_active_dims
         Z[Z >= self.domain_buffer + self.domain_active_dims] -= self.domain_active_dims
 
-        #print 'periodic:',  X.min(), X.max(), Y.min(), Y.max(), Z.min(), Z.max()
+        #print('periodic:',  X.min(), X.max(), Y.min(), Y.max(), Z.min(), Z.max())
 
         indices = self.get_keyv([X, Y, Z])
         # Only mask out if we are actually getting data rather than getting indices into
@@ -851,7 +851,7 @@ class SDFIndex(object):
             stop = self._max_key
         while key < stop:
             if self.indexdata['len'][key] == 0:
-                #print 'Squeezing keys, incrementing'
+                #print('Squeezing keys, incrementing')
                 key += 1
             else:
                 break
@@ -864,7 +864,7 @@ class SDFIndex(object):
             stop = self.indexdata['index'][0]
         while key > stop:
             if self.indexdata['len'][key] == 0:
-                #print 'Squeezing keys, decrementing'
+                #print('Squeezing keys, decrementing')
                 key -= 1
             else:
                 break
@@ -884,7 +884,7 @@ class SDFIndex(object):
             combined = 0
             while nexti < num_inds:
                 nextind = inds[nexti]
-                #        print 'b: %i l: %i end: %i  next: %i' % ( base, length, base + length, self.indexdata['base'][nextind] )
+                #        print('b: %i l: %i end: %i  next: %i' % ( base, length, base + length, self.indexdata['base'][nextind] ))
                 if combined < 1024 and base + length == self.indexdata['base'][nextind]:
                     length += self.indexdata['len'][nextind]
                     i += 1
@@ -933,7 +933,7 @@ class SDFIndex(object):
 
             # Now get all particles that are within the bbox
             mask = np.all(pos >= left, axis=1) * np.all(pos < right, axis=1)
-            #print 'Mask shape, sum:', mask.shape, mask.sum()
+            #print('Mask shape, sum:', mask.shape, mask.sum())
 
             mylog.debug("Filtering particles, returning %i out of %i" % (mask.sum(), mask.shape[0]))
 
@@ -947,7 +947,7 @@ class SDFIndex(object):
                 filtered[f] = data[f][mask]
 
             #for i, ax in enumerate('xyz'):
-            #    #print left, right
+            #    #print(left, right)
             #    assert np.all(filtered[ax] >= left[i])
             #    assert np.all(filtered[ax] < right[i])
 
@@ -1020,7 +1020,7 @@ class SDFIndex(object):
             for f in fields:
                 if f in pos_fields:
                     continue
-                # print 'yielding nonpos field', f
+                # print('yielding nonpos field', f)
                 yield f, data[f][mask]
 
     def iter_bbox_data(self, left, right, fields):
@@ -1121,8 +1121,8 @@ class SDFIndex(object):
         level_rk = self.get_key(cell_iarr + level_buff) + 1
         lmax_lk = (level_lk << shift*3)
         lmax_rk = (((level_rk) << shift*3) -1)
-        #print "Level ", level, np.binary_repr(level_lk, width=self.level*3), np.binary_repr(level_rk, width=self.level*3)
-        #print "Level ", self.level, np.binary_repr(lmax_lk, width=self.level*3), np.binary_repr(lmax_rk, width=self.level*3)
+        #print("Level ", level, np.binary_repr(level_lk, width=self.level*3), np.binary_repr(level_rk, width=self.level*3))
+        #print("Level ", self.level, np.binary_repr(lmax_lk, width=self.level*3), np.binary_repr(lmax_rk, width=self.level*3))
         return lmax_lk, lmax_rk
 
     def find_max_cell(self):
@@ -1189,7 +1189,7 @@ class SDFIndex(object):
         for chunk in midx.iter_padded_bbox_data(
             6, np.array([128]*3), 8.0, ['x','y','z','ident']):
 
-            print chunk['x'].max()
+            print(chunk['x'].max())
 
         """
 

--- a/yt/visualization/eps_writer.py
+++ b/yt/visualization/eps_writer.py
@@ -106,10 +106,10 @@ class DualEPS(object):
             (x,y) position in centimeters of the origin in the figure
         xaxis_side : integer
             Set to 0 for the x-axis annotations to be on the left.  Set
-            to 1 to print(them on the right side.)
+            to 1 to print them on the right side.
         yaxis_side : integer
             Set to 0 for the y-axis annotations to be on the bottom.  Set
-            to 1 to print(them on the top.)
+            to 1 to print them on the top.
         size : tuple of floats
             Size of axis box in units of figsize
 

--- a/yt/visualization/eps_writer.py
+++ b/yt/visualization/eps_writer.py
@@ -106,10 +106,10 @@ class DualEPS(object):
             (x,y) position in centimeters of the origin in the figure
         xaxis_side : integer
             Set to 0 for the x-axis annotations to be on the left.  Set
-            to 1 to print them on the right side.
+            to 1 to print(them on the right side.)
         yaxis_side : integer
             Set to 0 for the y-axis annotations to be on the bottom.  Set
-            to 1 to print them on the top.
+            to 1 to print(them on the top.)
         size : tuple of floats
             Size of axis box in units of figsize
 

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -60,9 +60,9 @@ class FixedResolutionBuffer(object):
     >>> proj = ds.proj(0, "density")
     >>> frb1 = FixedResolutionBuffer(proj, (0.2, 0.3, 0.4, 0.5),
     ...                              (1024, 1024))
-    >>> print frb1["density"].max()
+    >>> print(frb1["density"].max())
     1.0914e-9 g/cm**3
-    >>> print frb1["temperature"].max()
+    >>> print(frb1["temperature"].max())
     104923.1 K
     """
     _exclude_fields = ('pz','pdz','dx','x','y','z',

--- a/yt/visualization/volume_rendering/camera_path.py
+++ b/yt/visualization/volume_rendering/camera_path.py
@@ -234,7 +234,7 @@ class Keyframes(object):
                     current = next
                     self.current_score = next_score
                     if self.current_score > self.best_score:
-                        #print num_eval, self.current_score, self.best_score, current
+                        #print(num_eval, self.current_score, self.best_score, current)
                         self.best_score = self.current_score
                         self.best = current
                     break

--- a/yt/visualization/volume_rendering/glfw_inputhook.py
+++ b/yt/visualization/volume_rendering/glfw_inputhook.py
@@ -70,11 +70,11 @@ def create_inputhook_glfw(mgr, render_loop):
 
                 used_time = glfw.GetTime() - t
                 if used_time > 10.0:
-                    # print 'Sleep for 1 s'  # dbg
+                    # print('Sleep for 1 s'  # dbg)
                     time.sleep(1.0)
                 elif used_time > 0.1:
                     # Few GUI events coming in, so we can sleep longer
-                    # print 'Sleep for 0.05 s'  # dbg
+                    # print('Sleep for 0.05 s'  # dbg)
                     time.sleep(0.05)
                 else:
                     # Many GUI events coming in, so sleep only very little


### PR DESCRIPTION
# PR Summary

Many docstrings as well as cython code were still using Python 2-style prints (without parenthesis). This PR fixes this.

It relies on the following `sed` expression
```bash
sed -i 's/print \([^(].*[^\\]$/print(\1)/g' **/*.{py,pyx,pxd}
```
with some human-based post-processing. Indeed, this regexp is unable to find multi-line print statement, which are found in particular in Cython files.

## PR Checklist

- [x] Code passes flake8 checker
