### PR TITLE
putting in units in for the AREPO GFM_StellarFormationTime

### DIFF
--- a/yt/frontends/arepo/fields.py
+++ b/yt/frontends/arepo/fields.py
@@ -28,8 +28,15 @@ class ArepoFieldInfo(GadgetFieldInfo):
                              ("GFM_Metals_06", ("", ["Mg_fraction"], None)),
                              ("GFM_Metals_07", ("", ["Si_fraction"], None)),
                              ("GFM_Metals_08", ("", ["Fe_fraction"], None)),
-                             ("GFM_StellarFormationTime", ("code_length/code_velocity", ["stellar_age"], None)),
                              )
+
+    def __init__(self, ds, field_list, slice_info=None):
+        if ds.cosmological_simulation:
+            GFM_SFT_units = "dimensionless"
+        else:
+            GFM_SFT_units = "code_length/code_velocity"
+        self.known_particle_fields += (("GFM_StellarFormationTime", (GFM_SFT_units, ["stellar_age"], None)), )
+        super(ArepoFieldInfo, self).__init__(ds, field_list, slice_info=slice_info)
 
     def setup_particle_fields(self, ptype):
         FieldInfoContainer.setup_particle_fields(self, ptype)

--- a/yt/frontends/arepo/fields.py
+++ b/yt/frontends/arepo/fields.py
@@ -28,6 +28,7 @@ class ArepoFieldInfo(GadgetFieldInfo):
                              ("GFM_Metals_06", ("", ["Mg_fraction"], None)),
                              ("GFM_Metals_07", ("", ["Si_fraction"], None)),
                              ("GFM_Metals_08", ("", ["Fe_fraction"], None)),
+                             ("GFM_StellarFormationTime",("code_length/code_velocity",["stellar_age"], None))
                              )
 
     def setup_particle_fields(self, ptype):

--- a/yt/frontends/arepo/fields.py
+++ b/yt/frontends/arepo/fields.py
@@ -28,7 +28,7 @@ class ArepoFieldInfo(GadgetFieldInfo):
                              ("GFM_Metals_06", ("", ["Mg_fraction"], None)),
                              ("GFM_Metals_07", ("", ["Si_fraction"], None)),
                              ("GFM_Metals_08", ("", ["Fe_fraction"], None)),
-                             ("GFM_StellarFormationTime",("code_length/code_velocity",["stellar_age"], None))
+                             ("GFM_StellarFormationTime", ("code_length/code_velocity", ["stellar_age"], None)),
                              )
 
     def setup_particle_fields(self, ptype):


### PR DESCRIPTION
Addressing issue #2433

This PR puts the units into the field GFM_StellarFormationTime which is otherwise given as dimensionless. 

