### PR TITLE
[bugfix] Update annotate_timestamp to work with "code" unit system 

### DIFF
--- a/yt/utilities/definitions.py
+++ b/yt/utilities/definitions.py
@@ -37,8 +37,6 @@ formatted_length_unit_names = {'au'      : 'AU',
                                'rsun'    : 'R_\odot',
                                'code_length': 'code\ length'}
 
-formatted_time_unit_names = {'code_time' : 'code\ time'}
-
 # How many seconds are in each thing
 sec_conversion = {'Gyr'   : sec_per_Gyr,
                   'Myr'   : sec_per_Myr,

--- a/yt/utilities/definitions.py
+++ b/yt/utilities/definitions.py
@@ -37,6 +37,8 @@ formatted_length_unit_names = {'au'      : 'AU',
                                'rsun'    : 'R_\odot',
                                'code_length': 'code\ length'}
 
+formatted_time_unit_names = {'code_time' : 'code\ time'}
+
 # How many seconds are in each thing
 sec_conversion = {'Gyr'   : sec_per_Gyr,
                   'Myr'   : sec_per_Myr,

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -2186,8 +2186,17 @@ class TimestampCallback(PlotCallback):
                     raise RuntimeError("'time_offset' must be a float, tuple, or"
                                        "YTQuantity!")
                 t -= toffset.in_units(self.time_unit)
+            if isinstance(self.time_unit, Unit):
+                # here the time unit will be in brackets on the annotation.
+                # This will most likely be in "code_time".
+                un = self.time_unit.latex_representation()
+                time_unit = r'$\ \ ('+un+r')$'
+            else:
+                # the 'smallest_appropriate_unit' function will return a
+                # string, so we shouldn't need to format it further.
+                time_unit = self.time_unit
             self.text += self.time_format.format(time=float(t),
-                                                 units=self.time_unit)
+                                                 units=time_unit)
 
         # If time and redshift both shown, do one on top of the other
         if self.time and self.redshift:


### PR DESCRIPTION
## PR Summary

This resolves the bug reported in yt-project/yt#2432 . Now when a dataset loaded using `unit_system=code` and `annotate_timestamp()` is called, the time returned is in `code_time`. 

With the fix applied, the plot looks like so:
![timestamp_annotated](https://user-images.githubusercontent.com/6745434/73483666-6f858280-4365-11ea-8ed4-47ca5d62fd2c.png)

Let me know if you'd like a test added for this fix. 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

