### PR TITLE
update imports to use utility function 

### DIFF
--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -25,6 +25,7 @@ from yt.utilities.answer_testing.framework import \
     PixelizedProjectionValuesTest, \
     FieldValuesTest, \
     create_obj
+from yt.utilities.on_demand_imports import _f90nml as f90nml
 from yt.frontends.ramses.api import RAMSESDataset
 from yt.config import ytcfg
 from yt.frontends.ramses.field_handlers import DETECTED_FIELDS, HydroFieldFileHandler
@@ -443,7 +444,6 @@ def test_ramses_empty_record():
 @requires_ds(ramses_new_format)
 @requires_module('f90nml')
 def test_namelist_reading():
-    import f90nml
     ds = data_dir_load(ramses_new_format)
     namelist_fname = os.path.join(ds.directory, 'namelist.txt')
     with open(namelist_fname, 'r') as f:

--- a/yt/units/yt_array.py
+++ b/yt/units/yt_array.py
@@ -49,6 +49,7 @@ from yt.utilities.exceptions import \
     YTInvalidUnitEquivalence, YTEquivalentDimsError, \
     YTArrayTooLargeToDisplay
 from yt.utilities.lru_cache import lru_cache
+from yt.utilities.on_demand_imports import _h5py as h5py
 from numbers import Number as numeric_type
 from yt.utilities.on_demand_imports import _astropy
 try:
@@ -949,7 +950,6 @@ class YTArray(np.ndarray):
         >>> a.write_hdf5('test_array_data.h5', dataset_name='dinosaurs',
         ...              info=myinfo)
         """
-        from yt.utilities.on_demand_imports import _h5py as h5py
         from yt.extern.six.moves import cPickle as pickle
         if info is None:
             info = {}
@@ -1004,7 +1004,6 @@ class YTArray(np.ndarray):
             arrays are datasets at the top level by default.
 
         """
-        from yt.utilities.on_demand_imports import _h5py as h5py
         from yt.extern.six.moves import cPickle as pickle
 
         if dataset_name is None:

--- a/yt/units/yt_array.py
+++ b/yt/units/yt_array.py
@@ -1004,7 +1004,7 @@ class YTArray(np.ndarray):
             arrays are datasets at the top level by default.
 
         """
-        import h5py
+        from yt.utilities.on_demand_imports import _h5py as h5py
         from yt.extern.six.moves import cPickle as pickle
 
         if dataset_name is None:

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -289,7 +289,7 @@ class FixedResolutionBuffer(object):
         fields : list of strings
             These fields will be pixelized and output.
         """
-        import h5py
+        from yt.utilities.on_demand_imports import _h5py as h5py
         if fields is None: fields = list(self.data.keys())
         output = h5py.File(filename, "a")
         for field in fields:

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -26,6 +26,7 @@ from yt.data_objects.image_array import ImageArray
 from yt.utilities.lib.pixelization_routines import \
     pixelize_cylinder
 from yt.utilities.lib.api import add_points_to_greyscale_image
+from yt.utilities.on_demand_imports import _h5py as h5py
 from yt.frontends.stream.api import load_uniform_grid
 
 import numpy as np
@@ -289,7 +290,6 @@ class FixedResolutionBuffer(object):
         fields : list of strings
             These fields will be pixelized and output.
         """
-        from yt.utilities.on_demand_imports import _h5py as h5py
         if fields is None: fields = list(self.data.keys())
         output = h5py.File(filename, "a")
         for field in fields:


### PR DESCRIPTION

## PR Summary

I noticed in a few places we have imports of packages that are defined in `on_demand_imports` being imported without that functionality. This PR updates them to use the utility function available for the specified package.

## PR Checklist

- [x] Code passes flake8 checker