### PR TITLE
Update documentation to reflect usage of rcfile (no brackets allowed)

### DIFF
--- a/doc/source/reference/configuration.rst
+++ b/doc/source/reference/configuration.rst
@@ -91,7 +91,7 @@ used internally.
 * ``test_data_dir`` (default: ``/does/not/exist``): The default path the
   ``load()`` function searches for datasets when it cannot find a dataset in the
   current directory.
-* ``reconstruct_index`` (default: ``True``): If True, grid edges for patch AMR
+* ``reconstruct_index`` (default: ``True``): If true, grid edges for patch AMR
   datasets will be adjusted such that they fall as close as possible to an
   integer multiple of the local cell width. If you are working with a dataset
   with a large number of grids, setting this to False can speed up loading

--- a/doc/source/reference/configuration.rst
+++ b/doc/source/reference/configuration.rst
@@ -80,15 +80,15 @@ The following external parameters are available.  A number of parameters are
 used internally.
 
 * ``coloredlogs`` (default: ``False``): Should logs be colored?
-* ``default_colormap`` (default: ``"arbre"``): What colormap should be used by
+* ``default_colormap`` (default: ``arbre``): What colormap should be used by
   default for yt-produced images?
 * ``loadfieldplugins`` (default: ``True``): Do we want to load the plugin file?
-* ``pluginfilename``  (default ``"my_plugins.py"``) The name of our plugin file.
+* ``pluginfilename``  (default ``my_plugins.py``) The name of our plugin file.
 * ``logfile`` (default: ``False``): Should we output to a log file in the
   filesystem?
 * ``loglevel`` (default: ``20``): What is the threshold (0 to 50) for
   outputting log files?
-* ``test_data_dir`` (default: ``"/does/not/exist"``): The default path the
+* ``test_data_dir`` (default: ``/does/not/exist``): The default path the
   ``load()`` function searches for datasets when it cannot find a dataset in the
   current directory.
 * ``reconstruct_index`` (default: ``True``): If True, grid edges for patch AMR
@@ -115,7 +115,7 @@ used internally.
   to stdout rather than stderr
 * ``skip_dataset_cache`` (default: ``False``): If true, automatic caching of datasets
   is turned off.
-* ``supp_data_dir`` (default: ``"/does/not/exist"``): The default path certain
+* ``supp_data_dir`` (default: ``/does/not/exist``): The default path certain
   submodules of yt look in for supplemental data files.
 
 .. _plugin-file:

--- a/doc/source/reference/configuration.rst
+++ b/doc/source/reference/configuration.rst
@@ -79,19 +79,19 @@ Available Configuration Options
 The following external parameters are available.  A number of parameters are
 used internally.
 
-* ``coloredlogs`` (default: ``'False'``): Should logs be colored?
-* ``default_colormap`` (default: ``'arbre'``): What colormap should be used by
+* ``coloredlogs`` (default: ``False``): Should logs be colored?
+* ``default_colormap`` (default: ``"arbre"``): What colormap should be used by
   default for yt-produced images?
-* ``loadfieldplugins`` (default: ``'True'``): Do we want to load the plugin file?
-* ``pluginfilename``  (default ``'my_plugins.py'``) The name of our plugin file.
-* ``logfile`` (default: ``'False'``): Should we output to a log file in the
+* ``loadfieldplugins`` (default: ``True``): Do we want to load the plugin file?
+* ``pluginfilename``  (default ``"my_plugins.py"``) The name of our plugin file.
+* ``logfile`` (default: ``False``): Should we output to a log file in the
   filesystem?
-* ``loglevel`` (default: ``'20'``): What is the threshold (0 to 50) for
+* ``loglevel`` (default: ``20``): What is the threshold (0 to 50) for
   outputting log files?
-* ``test_data_dir`` (default: ``'/does/not/exist'``): The default path the
+* ``test_data_dir`` (default: ``"/does/not/exist"``): The default path the
   ``load()`` function searches for datasets when it cannot find a dataset in the
   current directory.
-* ``reconstruct_index`` (default: True): If True, grid edges for patch AMR
+* ``reconstruct_index`` (default: ``True``): If True, grid edges for patch AMR
   datasets will be adjusted such that they fall as close as possible to an
   integer multiple of the local cell width. If you are working with a dataset
   with a large number of grids, setting this to False can speed up loading
@@ -101,21 +101,21 @@ used internally.
   IPython notebook created by ``yt notebook``.  Note that this should be an
   sha512 hash, not a plaintext password.  Starting ``yt notebook`` with no
   setting will provide instructions for setting this.
-* ``requires_ds_strict`` (default: ``'True'``): If true, answer tests wrapped
+* ``requires_ds_strict`` (default: ``True``): If true, answer tests wrapped
   with :func:`~yt.utilities.answer_testing.framework.requires_ds` will raise
   :class:`~yt.utilities.exceptions.YTOutputNotIdentified` rather than consuming
   it if required dataset is not present.
-* ``serialize`` (default: ``'False'``): If true, perform automatic
+* ``serialize`` (default: ``False``): If true, perform automatic
   :ref:`object serialization <object-serialization>`
 * ``sketchfab_api_key`` (default: empty): API key for https://sketchfab.com/ for
   uploading AMRSurface objects.
-* ``suppressStreamLogging`` (default: ``'False'``): If true, execution mode will be
+* ``suppressStreamLogging`` (default: ``False``): If true, execution mode will be
   quiet.
-* ``stdoutStreamLogging`` (default: ``'False'``): If true, logging is directed
+* ``stdoutStreamLogging`` (default: ``False``): If true, logging is directed
   to stdout rather than stderr
-* ``skip_dataset_cache`` (default: ``'False'``): If true, automatic caching of datasets
+* ``skip_dataset_cache`` (default: ``False``): If true, automatic caching of datasets
   is turned off.
-* ``supp_data_dir`` (default: ``'/does/not/exist'``): The default path certain
+* ``supp_data_dir`` (default: ``"/does/not/exist"``): The default path certain
   submodules of yt look in for supplemental data files.
 
 .. _plugin-file:


### PR DESCRIPTION
fix #2439 
It's possible that doing this (stripping `"` and `'` from values in the rcfile) is actually not a good idea for reasons I'm not aware of.