### PR TITLE
deprecate ImagePlotContainer.set_cbar_minorticks 

### DIFF
--- a/doc/source/reference/api/api.rst
+++ b/doc/source/reference/api/api.rst
@@ -734,6 +734,7 @@ particularly with complicated layouts.
    ~yt.visualization.eps_writer.single_plot
    ~yt.visualization.eps_writer.multiplot
    ~yt.visualization.eps_writer.multiplot_yt
+   ~yt.visualization.eps_writer.return_cmap
    ~yt.visualization.eps_writer.return_colormap
 
 .. _derived-quantities-api:
@@ -804,6 +805,7 @@ See also :ref:`colormaps`.
 
 .. autosummary::
 
+   ~yt.visualization.color_maps.add_cmap
    ~yt.visualization.color_maps.add_colormap
    ~yt.visualization.color_maps.make_colormap
    ~yt.visualization.color_maps.show_colormaps

--- a/doc/source/reference/api/api.rst
+++ b/doc/source/reference/api/api.rst
@@ -734,7 +734,7 @@ particularly with complicated layouts.
    ~yt.visualization.eps_writer.single_plot
    ~yt.visualization.eps_writer.multiplot
    ~yt.visualization.eps_writer.multiplot_yt
-   ~yt.visualization.eps_writer.return_cmap
+   ~yt.visualization.eps_writer.return_colormap
 
 .. _derived-quantities-api:
 
@@ -804,7 +804,7 @@ See also :ref:`colormaps`.
 
 .. autosummary::
 
-   ~yt.visualization.color_maps.add_cmap
+   ~yt.visualization.color_maps.add_colormap
    ~yt.visualization.color_maps.make_colormap
    ~yt.visualization.color_maps.show_colormaps
 

--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -805,7 +805,7 @@ The minorticks may be removed using the
 :meth:`~yt.visualization.plot_window.AxisAlignedSlicePlot.set_minorticks`
 function, which either accepts a specific field name including the 'all' alias
 and the desired state for the plot as 'on' or 'off'. There is also an analogous
-:meth:`~yt.visualization.plot_window.AxisAlignedSlicePlot.set_cbar_minorticks`
+:meth:`~yt.visualization.plot_window.AxisAlignedSlicePlot.set_colorbar_minorticks`
 function for the colorbar axis.
 
 .. python-script::
@@ -814,7 +814,7 @@ function for the colorbar axis.
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
    slc = yt.SlicePlot(ds, 'z', 'density', width=(10,'kpc'))
    slc.set_minorticks('all', False)
-   slc.set_cbar_minorticks('all', False)
+   slc.set_colorbar_minorticks('all', False)
    slc.save()
 
 

--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -813,8 +813,8 @@ function for the colorbar axis.
    import yt
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
    slc = yt.SlicePlot(ds, 'z', 'density', width=(10,'kpc'))
-   slc.set_minorticks('all', 'off')
-   slc.set_cbar_minorticks('all', 'off')
+   slc.set_minorticks('all', False)
+   slc.set_cbar_minorticks('all', False)
    slc.save()
 
 

--- a/yt/__init__.py
+++ b/yt/__init__.py
@@ -107,7 +107,7 @@ from yt.visualization.api import \
     apply_colormap, scale_image, write_projection, \
     SlicePlot, AxisAlignedSlicePlot, OffAxisSlicePlot, LinePlot, \
     LineBuffer, ProjectionPlot, OffAxisProjectionPlot, \
-    show_colormaps, add_cmap, make_colormap, \
+    show_colormaps, add_colormap, make_colormap, \
     ProfilePlot, PhasePlot, ParticlePhasePlot, \
     ParticleProjectionPlot, ParticleImageBuffer, ParticlePlot, \
     FITSImageData, FITSSlice, FITSProjection, FITSOffAxisSlice, \

--- a/yt/visualization/api.py
+++ b/yt/visualization/api.py
@@ -14,9 +14,8 @@ API for yt.visualization
 #-----------------------------------------------------------------------------
 
 from .color_maps import \
-    add_cmap, \
+    add_colormap, \
     show_colormaps, \
-    add_cmap, \
     make_colormap
 
 from .particle_plots import \

--- a/yt/visualization/color_maps.py
+++ b/yt/visualization/color_maps.py
@@ -36,8 +36,8 @@ yt_colormaps = {}
 
 def add_cmap(name, cdict):
     """Deprecated alias, kept for backwards compatibility."""
-    from yt.funcs import mylog
-    mylog.warning("Deprecated alias. Use add_colormap instead.")
+    from yt.funcs import issue_deprecation_warning
+    issue_deprecation_warning("Deprecated alias. Use add_colormap instead.")
     add_colormap(name, cdict)
 
 def add_colormap(name, cdict):

--- a/yt/visualization/color_maps.py
+++ b/yt/visualization/color_maps.py
@@ -34,7 +34,13 @@ def check_color(name):
 
 yt_colormaps = {}
 
-def add_cmap(name, cdict):
+def add_cbar(name, cdict):
+    """Deprecated alias, kept for backwards compatibility."""
+    from yt.funcs import mylog
+    mylog.warning("Deprecated alias. Use add_colormap instead.")
+    add_colormap(name, cdict)
+
+def add_colormap(name, cdict):
     """
     Adds a colormap to the colormaps available in yt for this session
     """
@@ -73,8 +79,8 @@ cdict = {'red':   ((0.0, 80/256., 80/256.),
                    (0.6, 20/256., 20/256.),
                    (1.0, 0.0, 0.0))}
 
-add_cmap('bds_highcontrast', cdict)
-add_cmap('algae', cdict)
+add_colormap('bds_highcontrast', cdict)
+add_colormap('algae', cdict)
 
 # This next colormap was designed by Tune Kamae and converted here by Matt
 _vs = np.linspace(0,1,255)
@@ -90,7 +96,7 @@ _kamae_blu = np.minimum(255,
 cdict = {'red':np.transpose([_vs,_kamae_red,_kamae_red]),
          'green':np.transpose([_vs,_kamae_grn,_kamae_grn]),
          'blue':np.transpose([_vs,_kamae_blu,_kamae_blu])}
-add_cmap('kamae', cdict)
+add_colormap('kamae', cdict)
 
 # This one is a simple black & green map
 
@@ -101,7 +107,7 @@ cdict = {'red':   ((0.0, 0.0, 0.0),
          'blue':  ((0.0, 0.0, 0.0),
                    (1.0, 0.0, 0.0))}
 
-add_cmap('black_green', cdict)
+add_colormap('black_green', cdict)
 
 cdict = {'red':   ((0.0, 0.0, 0.0),
                    (1.0, 0.2, 0.2)),
@@ -110,7 +116,7 @@ cdict = {'red':   ((0.0, 0.0, 0.0),
          'blue':  ((0.0, 0.0, 0.0),
                    (1.0, 1.0, 1.0))}
 
-add_cmap('black_blueish', cdict)
+add_colormap('black_blueish', cdict)
 
 # This one is a variant of a colormap commonly
 # used for X-ray observations by Maxim Markevitch
@@ -136,7 +142,7 @@ cdict = {'red': ((0.0, 0.0, 0.0),
                   (0.391, 1.0, 1.0),
                   (1.0, 1.0, 1.0))}
 
-add_cmap("purple_mm", cdict)
+add_colormap("purple_mm", cdict)
 
 # This one comes from
 # http://permalink.gmane.org/gmane.comp.python.matplotlib.devel/10518
@@ -155,7 +161,7 @@ _cubehelix_data = {
         'blue': lambda x: x**_gamma_cubehelix + (_h_cubehelix * x**_gamma_cubehelix * (1 - x**_gamma_cubehelix) / 2) * (1.97294 * np.cos(2 * np.pi * (_s_cubehelix / 3 + _r_cubehelix * x))),
 }
 
-add_cmap("cubehelix", _cubehelix_data)
+add_colormap("cubehelix", _cubehelix_data)
 
 # The turbo colormap, by Anton Mikhailov.
 # from: https://gist.github.com/mikhailov-work/ee72ba4191942acecc03fe6da94fc73f
@@ -297,7 +303,7 @@ _turbo_data = \
                              _turbo_colormap_data[:, i]]))
        for i, color in enumerate(['red', 'green', 'blue']))
 
-add_cmap("turbo", _turbo_data)
+add_colormap("turbo", _turbo_data)
 
 # Add colormaps from cmocean, if it's installed
 if cmocean is not None:
@@ -324,7 +330,7 @@ for k,v in list(_cm.color_map_luts.items()):
         cdict = { 'red': np.transpose([_vs,v[0],v[0]]),
                   'green': np.transpose([_vs,v[1],v[1]]),
                   'blue': np.transpose([_vs,v[2],v[2]]) }
-        add_cmap(k, cdict)
+        add_colormap(k, cdict)
 
 def _extract_lookup_table(cmap_name):
     cmap = mcm.get_cmap(cmap_name)
@@ -556,7 +562,7 @@ def make_colormap(ctuple_list, name=None, interpolate=True):
         rolling_index = next_index
 
     # Return a dictionary with the appropriate RGB channels each consisting of
-    # a 256x3 array in the format that is expected by add_cmap() to add a 
+    # a 256x3 array in the format that is expected by add_colormap() to add a 
     # colormap to the session.
 
     # The format is as follows:
@@ -569,6 +575,6 @@ def make_colormap(ctuple_list, name=None, interpolate=True):
              'blue':  np.transpose([_vs, cmap[:,2], cmap[:,2]])}
 
     if name is not None:
-        add_cmap(name, cdict)
+        add_colormap(name, cdict)
 
     return cdict

--- a/yt/visualization/color_maps.py
+++ b/yt/visualization/color_maps.py
@@ -34,7 +34,7 @@ def check_color(name):
 
 yt_colormaps = {}
 
-def add_cbar(name, cdict):
+def add_cmap(name, cdict):
     """Deprecated alias, kept for backwards compatibility."""
     from yt.funcs import mylog
     mylog.warning("Deprecated alias. Use add_colormap instead.")

--- a/yt/visualization/eps_writer.py
+++ b/yt/visualization/eps_writer.py
@@ -1358,7 +1358,7 @@ def return_cmap(cmap=None, label="", range=(0,1), log=False):
     mylog.warning("Deprecated alias. Use return_colormap instead.")
     return return_colormap(cmap=cmap, label=label, crange=range, log=log)
 
-def return_colormap(cmap=None, label="", crange=(0,1), log=False):
+def return_colormap(cmap=None, label="", range=(0,1), log=False):
     r"""Returns a dict that describes a colorbar.  Exclusively for use with
     multiplot.
 
@@ -1368,7 +1368,7 @@ def return_colormap(cmap=None, label="", crange=(0,1), log=False):
         name of the (matplotlib) colormap to use
     label : string
         colorbar label
-    crange : tuple of floats
+    range : tuple of floats
         min and max of the colorbar's range
     log : boolean
         Flag to use a logarithmic scale
@@ -1379,5 +1379,5 @@ def return_colormap(cmap=None, label="", crange=(0,1), log=False):
     """
     if cmap is None:
         cmap = ytcfg.get("yt", "default_colormap")
-    return {'cmap': cmap, 'name': label, 'range': crange, 'log': log}
+    return {'cmap': cmap, 'name': label, 'range': range, 'log': log}
     

--- a/yt/visualization/eps_writer.py
+++ b/yt/visualization/eps_writer.py
@@ -1016,7 +1016,7 @@ def multiplot(ncol, nrow, yt_plots=None, fields=None, images=None,
         Labels for the y-axes
     colorbars : list of dicts
         Dicts that describe the type of colorbar to be used in each
-        figure.  Use the function return_cmap() to create these dicts.
+        figure.  Use the function return_colormap() to create these dicts.
     shrink_cb : float
         Factor by which the colorbar is shrunk.
     figsize : tuple of floats
@@ -1047,10 +1047,10 @@ def multiplot(ncol, nrow, yt_plots=None, fields=None, images=None,
     >>> images = ["density.jpg", "hi_density.jpg", "entropy.jpg",
     >>>           "special.jpg"]
     >>> cbs=[]
-    >>> cbs.append(return_cmap("arbre", "Density [cm$^{-3}$]", (0,10), False))
-    >>> cbs.append(return_cmap("kelp", "HI Density", (0,5), False))
-    >>> cbs.append(return_cmap("hot", r"Entropy [K cm$^2$]", (1e-2,1e6), True))
-    >>> cbs.append(return_cmap("Spectral", "Stuff$_x$!", (1,300), True))
+    >>> cbs.append(return_colormap("arbre", "Density [cm$^{-3}$]", (0,10), False))
+    >>> cbs.append(return_colormap("kelp", "HI Density", (0,5), False))
+    >>> cbs.append(return_colormap("hot", r"Entropy [K cm$^2$]", (1e-2,1e6), True))
+    >>> cbs.append(return_colormap("Spectral", "Stuff$_x$!", (1,300), True))
     >>> 
     >>> mp = multiplot(2,2, images=images, margins=(0.1,0.1),
     >>>                titles=["1","2","3","4"],
@@ -1278,7 +1278,7 @@ def multiplot_yt(ncol, nrow, plots, fields=None, **kwargs):
     >>>
     >>> p2 = SlicePlot(ds, 0, 'temperature')
     >>> p2.set_width(10, 'kpc')
-    >>> p2.set_cmap('temperature', 'hot')
+    >>> p2.set_colormap('temperature', 'hot')
     >>>
     >>> sph = ds.sphere(ds.domain_center, (10, 'kpc'))
     >>> p3 = PhasePlot(sph, 'radius', 'density', 'temperature',
@@ -1355,6 +1355,10 @@ def single_plot(plot, field=None, figsize=(12,12), cb_orient="right",
 
 #=============================================================================
 def return_cmap(cmap=None, label="", range=(0,1), log=False):
+    mylog.warning("Deprecated alias. Use return_colormap instead.")
+    return return_colormap(cmap=cmap, label=label, crange=range, log=log)
+
+def return_colormap(cmap=None, label="", crange=(0,1), log=False):
     r"""Returns a dict that describes a colorbar.  Exclusively for use with
     multiplot.
 
@@ -1364,7 +1368,7 @@ def return_cmap(cmap=None, label="", range=(0,1), log=False):
         name of the (matplotlib) colormap to use
     label : string
         colorbar label
-    range : tuple of floats
+    crange : tuple of floats
         min and max of the colorbar's range
     log : boolean
         Flag to use a logarithmic scale
@@ -1375,5 +1379,5 @@ def return_cmap(cmap=None, label="", range=(0,1), log=False):
     """
     if cmap is None:
         cmap = ytcfg.get("yt", "default_colormap")
-    return {'cmap': cmap, 'name': label, 'range': range, 'log': log}
+    return {'cmap': cmap, 'name': label, 'range': crange, 'log': log}
     

--- a/yt/visualization/eps_writer.py
+++ b/yt/visualization/eps_writer.py
@@ -1355,7 +1355,8 @@ def single_plot(plot, field=None, figsize=(12,12), cb_orient="right",
 
 #=============================================================================
 def return_cmap(cmap=None, label="", range=(0,1), log=False):
-    mylog.warning("Deprecated alias. Use return_colormap instead.")
+    from yt.funcs import issue_deprecation_warning
+    issue_deprecation_warning("Deprecated alias. Use return_colormap instead.")
     return return_colormap(cmap=cmap, label=label, crange=range, log=log)
 
 def return_colormap(cmap=None, label="", range=(0,1), log=False):

--- a/yt/visualization/eps_writer.py
+++ b/yt/visualization/eps_writer.py
@@ -1375,7 +1375,7 @@ def return_colormap(cmap=None, label="", crange=(0,1), log=False):
 
     Examples
     --------
-    >>> cb = return_cmap("arbre", "Density [cm$^{-3}$]", (0,10), False)
+    >>> cb = return_colormap("arbre", "Density [cm$^{-3}$]", (0,10), False)
     """
     if cmap is None:
         cmap = ytcfg.get("yt", "default_colormap")

--- a/yt/visualization/eps_writer.py
+++ b/yt/visualization/eps_writer.py
@@ -25,6 +25,7 @@ from .plot_window import PlotWindow
 from .profile_plotter import PhasePlot, ProfilePlot
 from yt.units.yt_array import YTQuantity
 from yt.units.unit_object import Unit
+from yt.funcs import issue_deprecation_warning
 
 def convert_frac_to_tex(string):
     frac_pos = string.find(r'\frac')
@@ -1355,7 +1356,6 @@ def single_plot(plot, field=None, figsize=(12,12), cb_orient="right",
 
 #=============================================================================
 def return_cmap(cmap=None, label="", range=(0,1), log=False):
-    from yt.funcs import issue_deprecation_warning
     issue_deprecation_warning("Deprecated alias. Use return_colormap instead.")
     return return_colormap(cmap=cmap, label=label, crange=range, log=log)
 

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -906,17 +906,9 @@ class ImagePlotContainer(PlotContainer):
 
     @invalidate_plot
     def set_cbar_minorticks(self, field, state):
-        """Deprecated alias, kept for backward compatibility."""
-        from yt.funcs import mylog
-        mylog.warning("Deprecated alias, use set_colorbar_minorticks instead.")
-        return self.set_colorbar_minorticks(field, state)
+        """Deprecated alias, kept for backward compatibility.
 
-    @invalidate_plot
-    def set_colorbar_minorticks(self, field, state):
-        """turn colorbar minor ticks on or off in the current plot
-
-        Displaying minor ticks reduces performance; turn them off
-        using set_colorbar_minorticks('all', 'off') if drawing speed is a problem.
+        turn colorbar minor ticks "on" or "off" in the current plot, according to *state*
 
         Parameters
         ----------
@@ -924,17 +916,33 @@ class ImagePlotContainer(PlotContainer):
             the field to remove colorbar minorticks
         state : string
             the state indicating 'on' or 'off'
+        """
+        from yt.funcs import mylog
+        mylog.warning("Deprecated alias, use set_colorbar_minorticks instead.")
 
+        boolstate = {"on": True, "off": False}[state.lower()]
+        return self.set_colorbar_minorticks(field, boolstate)
+
+    @invalidate_plot
+    def set_colorbar_minorticks(self, field, state):
+        """turn colorbar minor ticks on or off in the current plot
+
+        Displaying minor ticks reduces performance; turn them off
+        using set_colorbar_minorticks('all', False) if drawing speed is a problem.
+
+        Parameters
+        ----------
+        field : string
+            the field to remove colorbar minorticks
+        state : bool
+            the state indicating 'on' (True) or 'off' (False)
         """
         if field == 'all':
             fields = list(self.plots.keys())
         else:
             fields = [field]
         for field in self.data_source._determine_fields(fields):
-            if isinstance(state, str):
-                self._cbar_minorticks[field] = {"on": True, "off": False}[state.lower()]
-            else:
-                self._cbar_minorticks[field] = bool(state)
+            self._cbar_minorticks[field] = state
         return self
 
     @invalidate_plot

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -264,22 +264,27 @@ class PlotContainer(object):
             raise KeyError(name)
         self._field_transform[field] = field_transforms[name]
         return self
-
+        
     @invalidate_plot
     def set_minorticks(self, field, state):
-        """turn minor ticks on or off in the current plot
+        """Turn minor ticks on or off in the current plot.
 
         Displaying minor ticks reduces performance; turn them off
-        using set_minorticks('all', 'off') if drawing speed is a problem.
+        using set_minorticks('all', False) if drawing speed is a problem.
 
         Parameters
         ----------
         field : string
             the field to remove minorticks
-        state : string
-            the state indicating 'on' or 'off'
+        state : bool
+            the state indicating 'on' (True) or 'off' (False)
 
         """
+        if isinstance(state, str):
+            from yt import mylog
+            mylog.warning("Deprecated api, use bools for *state*.")
+            state = {"on": True, "off": False}[state.lower()]
+
         if field == 'all':
             fields = list(self.plots.keys())
         else:

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -931,7 +931,7 @@ class ImagePlotContainer(PlotContainer):
         else:
             fields = [field]
         for field in self.data_source._determine_fields(fields):
-            if state == 'on':
+            if state in ('on', True):
                 self._cbar_minorticks[field] = True
             else:
                 self._cbar_minorticks[field] = False

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -33,7 +33,8 @@ from yt.funcs import \
     get_image_suffix, \
     iterable, \
     ensure_dir, \
-    ensure_list
+    ensure_list, \
+    issue_deprecation_warning
 from yt.units.unit_lookup_table import \
     prefixable_units, latex_prefixes
 from yt.units.unit_object import \
@@ -922,7 +923,6 @@ class ImagePlotContainer(PlotContainer):
         state : string
             the state indicating 'on' or 'off'
         """
-        from yt.funcs import issue_deprecation_warning
         issue_deprecation_warning("Deprecated alias, use set_colorbar_minorticks instead.")
 
         boolstate = {"on": True, "off": False}[state.lower()]

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -264,7 +264,7 @@ class PlotContainer(object):
             raise KeyError(name)
         self._field_transform[field] = field_transforms[name]
         return self
-        
+
     @invalidate_plot
     def set_minorticks(self, field, state):
         """Turn minor ticks on or off in the current plot.

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -281,8 +281,8 @@ class PlotContainer(object):
 
         """
         if isinstance(state, str):
-            from yt import mylog
-            mylog.warning("Deprecated api, use bools for *state*.")
+            from yt.funcs import issue_deprecation_warning
+            issue_deprecation_warning("Deprecated api, use bools for *state*.")
             state = {"on": True, "off": False}[state.lower()]
 
         if field == 'all':
@@ -922,8 +922,8 @@ class ImagePlotContainer(PlotContainer):
         state : string
             the state indicating 'on' or 'off'
         """
-        from yt.funcs import mylog
-        mylog.warning("Deprecated alias, use set_colorbar_minorticks instead.")
+        from yt.funcs import issue_deprecation_warning
+        issue_deprecation_warning("Deprecated alias, use set_colorbar_minorticks instead.")
 
         boolstate = {"on": True, "off": False}[state.lower()]
         return self.set_colorbar_minorticks(field, boolstate)

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -906,10 +906,17 @@ class ImagePlotContainer(PlotContainer):
 
     @invalidate_plot
     def set_cbar_minorticks(self, field, state):
+        """Deprecated alias, kept for backward compatibility."""
+        from yt.funcs import mylog
+        mylog.warning("Deprecated alias, use set_colorbar_minorticks instead.")
+        return self.set_colorbar_minorticks(field, state)
+
+    @invalidate_plot
+    def set_colorbar_minorticks(self, field, state):
         """turn colorbar minor ticks on or off in the current plot
 
         Displaying minor ticks reduces performance; turn them off
-        using set_cbar_minorticks('all', 'off') if drawing speed is a problem.
+        using set_colorbar_minorticks('all', 'off') if drawing speed is a problem.
 
         Parameters
         ----------

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -931,10 +931,10 @@ class ImagePlotContainer(PlotContainer):
         else:
             fields = [field]
         for field in self.data_source._determine_fields(fields):
-            if state in ('on', True):
-                self._cbar_minorticks[field] = True
+            if isinstance(state, str):
+                self._cbar_minorticks[field] = {"on": True, "off": False}[state.lower()]
             else:
-                self._cbar_minorticks[field] = False
+                self._cbar_minorticks[field] = bool(state)
         return self
 
     @invalidate_plot


### PR DESCRIPTION
The idea here is to uniformise the existing Colorbar api by using a single naming convention ('cbar' -> 'colorbar')

Considering the existing methods
- set_colorbar_label
- show_colorbar
- set_cbar_minorticks

I propose to just use "colorbar" everywhere with one change.
I'm keeping the old method for backwards compatibility but I also set a deprecation warning. I don't think this is common practice around here so it's unclear when the "deprecated" method should be removed (I'd suggest yt 4.0 to make it cleaner, but since I'm not sure we'll get a release before this one, it may be a bit of a rush).