### PR TITLE
add a frame rotating method to datasets (only for polar & cylindrical geometries)

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1481,10 +1481,11 @@ class Dataset(object):
         """
         rotating_axes = {"polar": 1, "cylindrical": 2}
         if self.geometry not in rotating_axes.keys():
-            raise ValueError("Unsuported geometry %s" % self.geometry)
+            raise ValueError("Unsupported geometry '%s'" % self.geometry)
         raxis = rotating_axes[self.geometry]
+
         if self.dimensionality < raxis - 1:
-            raise ValueError("How did we get here ?")
+            raise ValueError("Unsupported dimensionality '%s' with geometry '%s'" % (self.dimensionality, self.geometry))
         if deg:
             shift_angle = np.deg2rad(shift_angle)
 

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1480,12 +1480,10 @@ class Dataset(object):
         deg : bool, optional
             set to True to use a *shift_angle* in degrees
         """
-        rotating_axes = {"polar": 1, "cylindrical": 2}
-
-        if self.geometry not in rotating_axes.keys():
+        if self.geometry not in ("polar", "cylindrical"):
             raise ValueError("Unsupported geometry '%s'." % self.geometry)
 
-        theta_axis = rotating_axes[self.geometry]
+        theta_axis = self.coordinates.axis_id["theta"]
 
         if self.dimensionality < theta_axis - 1:
             raise ValueError("Unsupported dimensionality '%s' with geometry '%s'." % (self.dimensionality, self.geometry))

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1467,6 +1467,27 @@ class Dataset(object):
         _define_unit(self.unit_registry, symbol, value, tex_repr=tex_repr,
                      offset=offset, prefixable=prefixable)
 
+    def rotate_frame_by(self, shift_angle, deg=False):
+        """
+        (experimental)
+        Shift azimuth coordinates by *shift_angle*, counter-clockwise, and in radians by default.
+
+        Parameters
+        ----------
+        shift_angle : float
+            angle by which coordinates should be shifted
+        deg : bool, optional
+            state that shift_angle is in degrees
+        """
+        if not self.geometry == "polar":
+            raise ValueError("This feature is only available for polar geometries (for now).")
+        if deg:
+            shift_angle = np.deg2rad(shift_angle)
+
+        for edge in [self.index.grid_left_edge[:, 1], self.index.grid_right_edge[:, 1]]:
+            edge += shift_angle * self.length_unit
+            edge %= 2*np.pi * self.length_unit
+
 def _reconstruct_ds(*args, **kwargs):
     datasets = ParameterFileStore()
     ds = datasets.get_ds_hash(*args)

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1481,6 +1481,7 @@ class Dataset(object):
             set to True to use a *shift_angle* in degrees
         """
         rotating_axes = {"polar": 1, "cylindrical": 2}
+
         if self.geometry not in rotating_axes.keys():
             raise ValueError("Unsupported geometry '%s'." % self.geometry)
 
@@ -1488,10 +1489,11 @@ class Dataset(object):
 
         if self.dimensionality < theta_axis - 1:
             raise ValueError("Unsupported dimensionality '%s' with geometry '%s'." % (self.dimensionality, self.geometry))
+
         if deg:
             shift_angle = np.deg2rad(shift_angle)
 
-        theta_edges = [self.index.grid_left_edge[..., theta_axis], self.index.grid_right_edge[..., theta_axis]]
+        theta_edges = [self.index.grid_left_edge[:, theta_axis], self.index.grid_right_edge[:, theta_axis]]
         for edge in theta_edges:
             edge += shift_angle * self.length_unit
             edge %= 2*np.pi * self.length_unit

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1479,12 +1479,16 @@ class Dataset(object):
         deg : bool, optional
             state that shift_angle is in degrees
         """
-        if not self.geometry == "polar":
-            raise ValueError("This feature is only available for polar geometries (for now).")
+        rotating_axes = {"polar": 1, "cylindrical": 2}
+        if self.geometry not in rotating_axes.keys():
+            raise ValueError("Unsuported geometry %s" % self.geometry)
+        raxis = rotating_axes[self.geometry]
+        if self.dimensionality < raxis - 1:
+            raise ValueError("How did we get here ?")
         if deg:
             shift_angle = np.deg2rad(shift_angle)
 
-        for edge in [self.index.grid_left_edge[:, 1], self.index.grid_right_edge[:, 1]]:
+        for edge in [self.index.grid_left_edge[..., raxis], self.index.grid_right_edge[..., raxis]]:
             edge += shift_angle * self.length_unit
             edge %= 2*np.pi * self.length_unit
 

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1470,26 +1470,29 @@ class Dataset(object):
     def rotate_frame_by(self, shift_angle, deg=False):
         """
         (experimental)
-        Shift azimuth coordinates by *shift_angle*, counter-clockwise, and in radians by default.
+        Shift azimuth coordinate 'theta' by *shift_angle*, counter-clockwise, and in radians by default.
+        This method is supported for polar and cylindrical geometries, not for spherical.
 
         Parameters
         ----------
         shift_angle : float
             angle by which coordinates should be shifted
         deg : bool, optional
-            state that shift_angle is in degrees
+            set to True to use a *shift_angle* in degrees
         """
         rotating_axes = {"polar": 1, "cylindrical": 2}
         if self.geometry not in rotating_axes.keys():
-            raise ValueError("Unsupported geometry '%s'" % self.geometry)
-        raxis = rotating_axes[self.geometry]
+            raise ValueError("Unsupported geometry '%s'." % self.geometry)
 
-        if self.dimensionality < raxis - 1:
-            raise ValueError("Unsupported dimensionality '%s' with geometry '%s'" % (self.dimensionality, self.geometry))
+        theta_axis = rotating_axes[self.geometry]
+
+        if self.dimensionality < theta_axis - 1:
+            raise ValueError("Unsupported dimensionality '%s' with geometry '%s'." % (self.dimensionality, self.geometry))
         if deg:
             shift_angle = np.deg2rad(shift_angle)
 
-        for edge in [self.index.grid_left_edge[..., raxis], self.index.grid_right_edge[..., raxis]]:
+        theta_edges = [self.index.grid_left_edge[..., theta_axis], self.index.grid_right_edge[..., theta_axis]]
+        for edge in theta_edges:
             edge += shift_angle * self.length_unit
             edge %= 2*np.pi * self.length_unit
 

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1467,7 +1467,7 @@ class Dataset(object):
         _define_unit(self.unit_registry, symbol, value, tex_repr=tex_repr,
                      offset=offset, prefixable=prefixable)
 
-    def rotate_frame_by(self, shift_angle, deg=False):
+    def rotate_frame_by(self, shift_angle, deg=False, safe_=True):
         """
         (experimental)
         Shift azimuth coordinate 'theta' by *shift_angle*, counter-clockwise, and in radians by default.
@@ -1494,12 +1494,17 @@ class Dataset(object):
         # convert to length unit for internal operations compatibility
         shift_angle *= self.length_unit
         
-        # only rotate by a multiple of the coarsest angular step
-        # devnote: not sure this is necessary, though it should help making sure
-        # the feature's flow is controlled
+        
         dx = self.index.select_grids(level=self.min_level)[0].dds
         dtheta = dx[theta_index]
-        shift_angle_ = np.sign(shift_angle) * (np.abs(shift_angle) - np.abs(shift_angle) % dtheta)
+        if safe_:
+            # only rotate by a multiple of the coarsest angular step
+
+            # I'm pretty confident that this is not necessary as well as limiting, but I'm keeping
+            # it as an option while this is not working
+            shift_angle_ = np.sign(shift_angle) * (np.abs(shift_angle) - np.abs(shift_angle) % dtheta)
+        else:
+            shift_angle_ = shift_angle
 
         # two seemingly equivalent possibilities here (both broken)
         # note that combining them only result in doubling the desired rotation

--- a/yt/data_objects/tests/test_dataset_rotation.py
+++ b/yt/data_objects/tests/test_dataset_rotation.py
@@ -1,0 +1,56 @@
+# writeme
+
+import yt
+from yt.testing import fake_amr_ds
+import numpy as np
+
+
+def count_invalid_values(arr):
+    return len(arr[~np.isfinite(arr)])
+
+def get_buffer(ds):
+    slc = ds.r[:,0.5,:] # zslice
+    buff = ds.coordinates.pixelize(dimension=1, data_source=slc,
+            field=('stream', 'Density'), bounds=[-1., 1., -1., 1.], size=(800, 800))
+    return buff
+
+
+def test_dont_corrupt_data():
+    ds = fake_amr_ds(geometry="cylindrical")
+
+    ndiv = 11 # arbitrary, not a power of two on purpose
+
+    buff = get_buffer(ds)
+    ref_invalid_count = count_invalid_values(buff)
+    assert ref_invalid_count < 800*800
+
+    for i in range(ndiv+1):
+        ds.rotate_frame_by(-np.pi/ndiv)
+        slc = ds.r[:,0.5,:] # zslice
+        assert count_invalid_values(slc["Density"]) == 0
+
+        buff = get_buffer(ds)
+        new_invalid_count = count_invalid_values(buff)
+        assert new_invalid_count == ref_invalid_count
+    
+        slc.to_pw()
+
+def test_dont_corrupt_data_SlicePlots():
+    ds = fake_amr_ds(geometry="cylindrical")
+
+    ndiv = 11 # arbitrary, not a power of two on purpose
+
+    buff = get_buffer(ds)
+    ref_invalid_count = count_invalid_values(buff)
+    assert ref_invalid_count < 800*800
+
+    for i in range(ndiv+1):
+        ds.rotate_frame_by(-np.pi/ndiv)
+        slc = ds.r[:,0.5,:] # zslice
+        assert count_invalid_values(slc["Density"]) == 0
+
+        buff = get_buffer(ds)
+        new_invalid_count = count_invalid_values(buff)
+        assert new_invalid_count == ref_invalid_count
+
+        yt.SlicePlot(ds, "z", "Density") # <- THIS is the line that actually corrupts data, so it seems

--- a/yt/data_objects/tests/test_dataset_rotation.py
+++ b/yt/data_objects/tests/test_dataset_rotation.py
@@ -29,7 +29,7 @@ methods = [lambda x: None, plot_topw, plot_SlicePlot]
 def test_dont_corrupt_data(plot_method, touch):
     ds = fake_amr_ds(geometry="cylindrical")
 
-    ndiv = 11 # arbitrary, not a power of two on purpose
+    ndiv = 3 # arbitrary, not a power of two on purpose
 
     if touch:
         # devnote : I do not understand why, but creating a buffer NOW affects the end result
@@ -55,14 +55,22 @@ def test_dont_corrupt_data(plot_method, touch):
         assert count_invalid_values(slc["Density"]) == 0
 
         if touch:
-            buff = get_buffer(ds)
-            new_invalid_count = count_invalid_values(buff)
+            buff1 = get_buffer(ds)
+            new_invalid_count = count_invalid_values(buff1)
             # although the exact number of filler pixels may slighlty vary, a variation greater than 0.1%
             # is very suspicious in this test case
             assert_almost_equal(new_invalid_count/ref_invalid_count, 1, decimal=3)
 
-        p = plot_method(ds)
+        plot = plot_method(ds)
 
         # tmp
-        #if p is not None:
-        #   p.save(f'/tmp/{plot_method.__name__}_{i}')
+        if plot is not None:
+            if touch:
+                buff2 = get_buffer(ds)
+                new_invalid_count = count_invalid_values(buff2)
+                assert_almost_equal(new_invalid_count/ref_invalid_count, 1, decimal=3)
+
+                assert_almost_equal(buff1, buff2)
+                assert_almost_equal(buff2, plot.frb.data['Density'])
+
+        #   p.save(f'/tmp/{plot_method.__name__}_{touch}_{i}')

--- a/yt/data_objects/tests/test_dataset_rotation.py
+++ b/yt/data_objects/tests/test_dataset_rotation.py
@@ -1,9 +1,11 @@
 # writeme
 
+from itertools import product
 import yt
-from yt.testing import fake_amr_ds
+from yt.testing import fake_amr_ds, assert_almost_equal
 import numpy as np
 
+import pytest
 
 def count_invalid_values(arr):
     return len(arr[~np.isfinite(arr)])
@@ -14,43 +16,53 @@ def get_buffer(ds):
             field=('stream', 'Density'), bounds=[-1., 1., -1., 1.], size=(800, 800))
     return buff
 
+def plot_topw(ds):
+    slc = ds.r[:,0.5,:]
+    return slc.to_pw('Density')
 
-def test_dont_corrupt_data():
+def plot_SlicePlot(ds):
+    return yt.SlicePlot(ds, 'z', 'Density')
+
+methods = [lambda x: None, plot_topw, plot_SlicePlot]
+
+@pytest.mark.parametrize('plot_method,touch', list(product(methods, [True, False])))
+def test_dont_corrupt_data(plot_method, touch):
     ds = fake_amr_ds(geometry="cylindrical")
 
     ndiv = 11 # arbitrary, not a power of two on purpose
 
-    buff = get_buffer(ds)
-    ref_invalid_count = count_invalid_values(buff)
-    assert ref_invalid_count < 800*800
+    if touch:
+        # devnote : I do not understand why, but creating a buffer NOW affects the end result
+        # later when convert a rotated slice to a plot,
+        # however this only works in combination with plotting_method=plot_topw
+        buff = get_buffer(ds)
+
+        # invalid values (nan, inf) are used to fill the buffer in the absence of data,
+        # typically in the corners of a plot window for cylindrical data seen from the z axis
+        ref_invalid_count = count_invalid_values(buff)
+        assert ref_invalid_count < 800*800
+
+        # the minimal code with identical effect simply consist in touching (hence caching ?)
+        # the pixel-x coord in the slice object
+        """
+        slc = ds.r[:,0.5,:] # zslice
+        slc["px"]
+        """
 
     for i in range(ndiv+1):
-        ds.rotate_frame_by(-np.pi/ndiv)
+        ds.rotate_frame_by(-np.pi/ndiv, safe_=False)
         slc = ds.r[:,0.5,:] # zslice
         assert count_invalid_values(slc["Density"]) == 0
 
-        buff = get_buffer(ds)
-        new_invalid_count = count_invalid_values(buff)
-        assert new_invalid_count == ref_invalid_count
-    
-        slc.to_pw()
+        if touch:
+            buff = get_buffer(ds)
+            new_invalid_count = count_invalid_values(buff)
+            # although the exact number of filler pixels may slighlty vary, a variation greater than 0.1%
+            # is very suspicious in this test case
+            assert_almost_equal(new_invalid_count/ref_invalid_count, 1, decimal=3)
 
-def test_dont_corrupt_data_SlicePlots():
-    ds = fake_amr_ds(geometry="cylindrical")
+        p = plot_method(ds)
 
-    ndiv = 11 # arbitrary, not a power of two on purpose
-
-    buff = get_buffer(ds)
-    ref_invalid_count = count_invalid_values(buff)
-    assert ref_invalid_count < 800*800
-
-    for i in range(ndiv+1):
-        ds.rotate_frame_by(-np.pi/ndiv)
-        slc = ds.r[:,0.5,:] # zslice
-        assert count_invalid_values(slc["Density"]) == 0
-
-        buff = get_buffer(ds)
-        new_invalid_count = count_invalid_values(buff)
-        assert new_invalid_count == ref_invalid_count
-
-        yt.SlicePlot(ds, "z", "Density") # <- THIS is the line that actually corrupts data, so it seems
+        # tmp
+        #if p is not None:
+        #   p.save(f'/tmp/{plot_method.__name__}_{i}')

--- a/yt/data_objects/tests/test_dataset_rotation.py
+++ b/yt/data_objects/tests/test_dataset_rotation.py
@@ -2,7 +2,7 @@
 
 from itertools import product
 import yt
-from yt.testing import fake_amr_ds, assert_almost_equal, assert_allclose
+from yt.testing import fake_amr_ds, assert_allclose
 import numpy as np
 
 import pytest

--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -528,7 +528,6 @@ def pixelize_cylinder(np.float64_t[:,:] buff,
     if y0 < 0 and y1 > 0:
         rbounds[0] = 0.0
     dthetamin = dx / rmax
-
     for i in range(radius.shape[0]):
 
         r0 = radius[i]

--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -528,6 +528,7 @@ def pixelize_cylinder(np.float64_t[:,:] buff,
     if y0 < 0 and y1 > 0:
         rbounds[0] = 0.0
     dthetamin = dx / rmax
+
     for i in range(radius.shape[0]):
 
         r0 = radius[i]


### PR DESCRIPTION
## PR Summary
*experimental, feedback is most welcome*

I'm adding a method to the Dataset class that overrides the on-disk azimuthal coordinates with a given shifting angle. Although it's primarily useful for direct visualisation, I found it also has other applications. For example, as yt automatically adds a `"velocity_cartesian_x"` (and y) derived field to polar datasets, this methods provides a way for the user to redefine the x and y axis as they please.

This function was originally meant for my personal yt plugin, but since it affects parts of the dataset that I believe should not be touched by users (updating the grid edges !), I think it makes sense to contribute it to the shared api.
Another motivation was that I found a lot of *bad* ways to do this, so I think it's best to have one built-in way to do it rather that letting all potential users reinvent it and probably break stuff along the way.

In principle it could be applied to other non-cartesian geometries, but for now I want to know if other devs think it's worth adding to the shared codebase, and if so, I'd have to find relevant ways to test this doesn't break anything.
 

## PR Checklist

- [x] Code passes flake8 checker
- [ ] New features are documented
   - [x] with docstrings
   - [ ] and narrative docs
- [ ] Adds tests for new features.

## Example application

```python
import numpy as np
import yt
yt.mylog.setLevel(30)

# using radians
ds = yt.load("amrvac/bw_polar_2D0000.dat")
assert ds.geometry == "polar"
for i in range(3):
    ds.rotate_frame_by(np.pi/4)
    p = yt.plot_2d(ds, "density")
    p.set_figure_size(3)
    p.save(f"/tmp/rad_{i}.png")

# using degrees
for i in range(3):
    ds.rotate_frame_by(45, deg=True)
    p = yt.plot_2d(ds, "density")
    p.set_figure_size(3)
    p.save(f"/tmp/deg_{i}.png")
```

![rad_0](https://user-images.githubusercontent.com/14075922/74052816-e3193680-49da-11ea-8607-4b6ff009a437.png)
![rad_1](https://user-images.githubusercontent.com/14075922/74052827-e90f1780-49da-11ea-9036-4deb0a12ea3a.png)
![rad_2](https://user-images.githubusercontent.com/14075922/74052837-f0cebc00-49da-11ea-9455-5ae17be9a4cb.png)
![deg_0](https://user-images.githubusercontent.com/14075922/74052858-fa582400-49da-11ea-9fd5-d4d2426184a1.png)
![deg_1](https://user-images.githubusercontent.com/14075922/74052866-ffb56e80-49da-11ea-8fba-1a3946a969b6.png)
![deg_2](https://user-images.githubusercontent.com/14075922/74052870-0348f580-49db-11ea-8041-84a723fb42e9.png)
