### PR TITLE
Allow PY37 and PY38 in the docs

### DIFF
--- a/doc/source/installing.rst
+++ b/doc/source/installing.rst
@@ -431,7 +431,7 @@ source include:
 
 - ``git``
 - A C compiler such as ``gcc`` or ``clang``
-- ``Python 2.7``, ``Python >= 3.5``
+- ``Python >= 3.5``
 
 In addition, building yt from source requires ``numpy`` and ``cython``
 which can be installed with ``pip``:

--- a/doc/source/installing.rst
+++ b/doc/source/installing.rst
@@ -431,7 +431,7 @@ source include:
 
 - ``git``
 - A C compiler such as ``gcc`` or ``clang``
-- ``Python 2.7``, ``Python 3.5``, or ``Python 3.6``
+- ``Python 2.7``, ``Python >= 3.5``
 
 In addition, building yt from source requires ``numpy`` and ``cython``
 which can be installed with ``pip``:


### PR DESCRIPTION
I noticed that the docs states python 3.5 OR 3.6 was required to install from source. I propose to state that 3.5 is the minimal without further detail instead.

It might be a place where we want to drop mentions of python 2 also.