### PR TITLE
Improve doc + fix docstring in deposition

### DIFF
--- a/doc/source/analyzing/fields.rst
+++ b/doc/source/analyzing/fields.rst
@@ -532,7 +532,7 @@ Possible deposition methods are:
 * ``count`` - counts the number of particles in each cell.
 
 In addition, the :meth:`~yt.data_objects.static_outputs.add_deposited_particle_field` function
-returns the name of the newly created field
+returns the name of the newly created field.
 
 
 .. _mesh-sampling-particle-fields:

--- a/doc/source/analyzing/fields.rst
+++ b/doc/source/analyzing/fields.rst
@@ -440,7 +440,7 @@ Gradient Fields
 ---------------
 
 yt provides a way to compute gradients of spatial fields using the
-:meth:`~yt.frontends.flash.data_structures.FLASHDataset.add_gradient_fields`
+:meth:`~yt.data_objects.static_output.Dataset.add_gradient_fields`
 method. If you have a spatially-based field such as density or temperature,
 and want to calculate the gradient of that field, you can do it like so:
 
@@ -501,6 +501,40 @@ available are:
 * ``smoothed`` - this is a special deposition type.  See discussion below for
   more information, in :ref:`sph-fields`.
 
+You can also directly use the
+:meth:`~yt.data_objects.static_outputs.add_deposited_particle_field` function
+defined on each dataset to depose any particle field onto the mesh like so:
+
+.. code-block:: python
+
+   import yt
+
+   ds = yt.load("output_00080/info_00080.txt")
+   fname = ds.add_deposited_particle_field(('all', 'particle_velocity_x'), method='nearest')
+
+   print('The velocity of the particles are (stored in %s)' % fname)
+   print(ds.r['deposit', 'all_nn_particle_velocity_x'])
+
+Possible deposition methods are:
+
+* ``simple_smooth`` - perform an SPH-like deposition of the field onto the mesh
+  optionally accepting a ``kernel_name``.
+* ``sum`` - sums the value of the particle field for all particles found in
+  each cell.
+* ``std`` - computes the standard deviation of the value of the particle field
+  for all particles found in each cell.
+* ``cic`` - performs cloud-in-cell interpolation (see `Section 2.2
+  <http://ta.twi.tudelft.nl/dv/users/lemmens/MThesis.TTH/chapter4.html>`_ for more
+  information) of the particle field on a given mesh zone.
+* ``weighted_mean`` - computes the mean of the particle field, weighted by
+  the field passed into ``weight_field`` (by default, it uses the particle
+  mass).
+* ``count`` - counts the number of particles in each cell.
+
+In addition, the :meth:`~yt.data_objects.static_outputs.add_deposited_particle_field` function
+returns the name of the newly created field
+
+
 .. _mesh-sampling-particle-fields:
 
 Mesh Sampling Particle Fields
@@ -518,8 +552,8 @@ The particle fields are named ``(ptype, cell_ftype_fname)`` where
 ``ptype`` is the particle type onto which the deposition occurs,
 ``ftype`` is the mesh field type (e.g. ``gas``) and ``fname`` is the
 field (e.g. ``temperature``, ``density``, ...). You can directly use
-the ``add_mesh_sampling_particle_field`` function defined on each dataset to
-impose a field onto the particles like so:
+the :meth:`~yt.data_objects.static_output.Dataset.add_mesh_sampling_particle_field`
+function defined on each dataset to impose a field onto the particles like so:
 
 .. code-block:: python
 
@@ -531,7 +565,7 @@ impose a field onto the particles like so:
    print('The temperature at the location of the particles is')
    print(ds.r['all', 'cell_gas_temperature'])
 
-For octree codes (e.g. RAMSES), you can trigger the build of an index so 
+For octree codes (e.g. RAMSES), you can trigger the build of an index so
 that the next sampling operations will be mush faster
 
 .. code-block:: python

--- a/doc/source/analyzing/fields.rst
+++ b/doc/source/analyzing/fields.rst
@@ -530,6 +530,7 @@ Possible deposition methods are:
   the field passed into ``weight_field`` (by default, it uses the particle
   mass).
 * ``count`` - counts the number of particles in each cell.
+* ``nearest`` - assign to each cell the value of the closest particle.
 
 In addition, the :meth:`~yt.data_objects.static_outputs.add_deposited_particle_field` function
 returns the name of the newly created field.

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1254,7 +1254,7 @@ class Dataset(object):
         method : string
            This is the "method name" which will be looked up in the
            `particle_deposit` namespace as `methodname_deposit`.  Current
-           methods include `simple_smooth`, `sum`, `std`, `cic`, `weighted_mean` 
+           methods include `simple_smooth`, `sum`, `std`, `cic`, `weighted_mean`,
            `nearest` and `count`.
         kernel_name : string, default 'cubic'
            This is the name of the smoothing kernel to use. It is only used for

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1254,8 +1254,8 @@ class Dataset(object):
         method : string
            This is the "method name" which will be looked up in the
            `particle_deposit` namespace as `methodname_deposit`.  Current
-           methods include `simple_smooth`, `sum`, `std`, `cic`, `weighted_mean`,
-           `mesh_id`, and `nearest`.
+           methods include `simple_smooth`, `sum`, `std`, `cic`, `weighted_mean` 
+           `nearest` and `count`.
         kernel_name : string, default 'cubic'
            This is the name of the smoothing kernel to use. It is only used for
            the `simple_smooth` method and is otherwise ignored. Current
@@ -1277,7 +1277,7 @@ class Dataset(object):
 
         units = self.field_info[ptype, deposit_field].units
         take_log = self.field_info[ptype, deposit_field].take_log
-        name_map = {"sum": "sum", "std":"std", "cic": "cic", "weighted_mean": "avg",
+        name_map = {"sum": "sum", "std": "std", "cic": "cic", "weighted_mean": "avg",
                     "nearest": "nn", "simple_smooth": "ss", "count": "count"}
         field_name = "%s_" + name_map[method] + "_%s"
         field_name = field_name % (ptype, deposit_field.replace('particle_', ''))


### PR DESCRIPTION
## PR Summary

Expands the doc about particle field deposition. Previously, the function `ds.add_deposited_particle_field` was never mentioned in the doc.

It also updates the docstring of the deposition method to match its accepted values.