### PR TITLE
[bugfix] allow code units in two derived fields

### DIFF
--- a/yt/fields/astro_fields.py
+++ b/yt/fields/astro_fields.py
@@ -50,7 +50,7 @@ def setup_astro_fields(registry, ftype = "gas", slice_info = None):
         """
         sqrt(3 pi / (16 G rho))
         """
-        return np.sqrt(3.0 * np.pi / (16.0 * G * data[ftype, "density"]))
+        return np.sqrt(3.0 * np.pi / (16.0 * data[ftype, "density"] * G))
 
     registry.add_field((ftype, "dynamical_time"), sampling_type="cell", 
                        function=_dynamical_time,
@@ -59,10 +59,9 @@ def setup_astro_fields(registry, ftype = "gas", slice_info = None):
     def _jeans_mass(field, data):
         MJ_constant = (((5.0 * kboltz) / (G * mh)) ** (1.5)) * \
           (3.0 / (4.0 * np.pi)) ** (0.5)
-        u = (MJ_constant * \
-             ((data[ftype, "temperature"] /
+        u = ((data[ftype, "temperature"] /
                data[ftype, "mean_molecular_weight"])**(1.5)) * \
-             (data[ftype, "density"]**(-0.5)))
+             (data[ftype, "density"]**(-0.5)) * MJ_constant
         return u
 
     registry.add_field((ftype, "jeans_mass"), sampling_type="cell", 


### PR DESCRIPTION
For the two fields below (`dynamical_time` and `jeans_mass`), conversion to code units was not possible because the constants don't use the unit registry of the dataset and when you do `x = a * b`, `x` has the unit registry of `a`. I fix this issue by moving the constants to after the arrays that use the dataset's unit registry.