### PR TITLE
fix an inconsistency between argmax and argmin methods in YTDataContainer class

### DIFF
--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -917,6 +917,8 @@ class YTDataContainer(object):
         if axis is None:
             mv, pos0, pos1, pos2 = self.quantities.min_location(field)
             return pos0, pos1, pos2
+        if isinstance(axis, string_types):
+            axis = [axis]
         rv = self.quantities.sample_at_min_field_values(field, axis)
         if len(rv) == 2:
             return rv[1]


### PR DESCRIPTION
## PR Summary

I was working on #2446 and noticed another bug.
Apparently argmin and argmax are heavily code-duplicated from one another, and some convenience functionality of argmax was not ported to argmin, so this PR fixes it.
It would be healthier to deduplicate this code but for now this hotfix should do :)

- [x] Code passes flake8 checker
- [ ] Adds a test for any bugs fixed. Adds tests for new features.