### PR TITLE
Fixes for plotting alias fields

### DIFF
--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -263,14 +263,15 @@ class YTDataContainer(metaclass = RegisteredDataContainer):
                 fi = self.ds._get_field_info(*f)
             elif isinstance(f, bytes):
                 fi = self.ds._get_field_info("unknown", f)
-            rv = self.ds.arr(self.field_data[key], fi.units)
+            rv = self.ds.arr(self.field_data[f], fi.units)
         return rv
 
     def __setitem__(self, key, val):
         """
         Sets a field to be some other value.
         """
-        self.field_data[key] = val
+        f = self._determine_fields(key)[0]
+        self.field_data[f] = val
 
     def __delitem__(self, key):
         """

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1219,6 +1219,9 @@ class YTDataContainer(metaclass = RegisteredDataContainer):
                 raise YTFieldTypeNotFound(ftype, ds=self.ds)
             elif not particle_field and ftype not in self.ds.fluid_types:
                 raise YTFieldTypeNotFound(ftype, ds=self.ds)
+            while finfo.alias_field:
+                finfo = self.ds.field_info[finfo.alias_name]
+                ftype, fname = finfo.name
             explicit_fields.append((ftype, fname))
         return explicit_fields
 

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -788,8 +788,11 @@ class Dataset(metaclass = RegisteredDataset):
             if field not in self.field_info.field_aliases.values():
                 return self._last_finfo
         if field in self.field_info:
-            self._last_freq = field
-            self._last_finfo = self.field_info[(ftype, fname)]
+            finfo = self.field_info[field]
+            while finfo.alias_field:
+                finfo = self.field_info[finfo.alias_name]
+            self._last_freq = finfo.name
+            self._last_finfo = finfo
             return self._last_finfo
         if fname in self.field_info:
             # Sometimes, if guessing_type == True, this will be switched for
@@ -814,8 +817,11 @@ class Dataset(metaclass = RegisteredDataset):
             to_guess +=  list(self.fluid_types) + list(self.particle_types)
             for ftype in to_guess:
                 if (ftype, fname) in self.field_info:
-                    self._last_freq = (ftype, fname)
-                    self._last_finfo = self.field_info[(ftype, fname)]
+                    finfo = self.field_info[ftype, fname]
+                    while finfo.alias_field:
+                        finfo = self.field_info[finfo.alias_name]
+                    self._last_freq = finfo.name
+                    self._last_finfo = finfo
                     return self._last_finfo
         raise YTFieldNotFound((ftype, fname), self)
 

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -107,6 +107,7 @@ class FixedResolutionBuffer(object):
         del self.data[item]
 
     def __getitem__(self, item):
+        item = self.data_source._determine_fields(item)[0]
         if item in self.data: return self.data[item]
         mylog.info("Making a fixed resolution buffer of (%s) %d by %d" % \
             (item, self.buff_size[0], self.buff_size[1]))
@@ -541,6 +542,7 @@ class CylindricalFixedResolutionBuffer(FixedResolutionBuffer):
             ds.plots.append(weakref.proxy(self))
 
     def __getitem__(self, item) :
+        item = self.data_source._determine_fields(item)[0]
         if item in self.data: return self.data[item]
         buff = np.zeros(self.buff_size, dtype="f8")
         pixelize_cylinder(buff, self.data_source["r"], self.data_source["dr"],
@@ -561,6 +563,7 @@ class OffAxisProjectionFixedResolutionBuffer(FixedResolutionBuffer):
         FixedResolutionBuffer.__init__(self, data_source, bounds, buff_size, antialias, periodic)
 
     def __getitem__(self, item):
+        item = self.data_source._determine_fields(item)[0]
         if item in self.data: return self.data[item]
         mylog.info("Making a fixed resolution buffer of (%s) %d by %d" % \
             (item, self.buff_size[0], self.buff_size[1]))
@@ -604,6 +607,8 @@ class ParticleImageBuffer(FixedResolutionBuffer):
         self.y_field = ax_field_template % self.ds.coordinates.axis_name[yax]
 
     def __getitem__(self, item):
+        item = self.data_source._determine_fields(item)[0]
+
         if item in self.data:
             return self.data[item]
 


### PR DESCRIPTION
Fixes #2455 

I'm pretty sure the changes to `fixed_resolution.py` are uncontroversial - right now these FRB subclasses make users manually handle dealing with string and tuple field names. Adding calls to `_determine_fields` means this will happen automatically now.

The changes to the implementation of `_determine_fields` itself might be more controversial. This change makes it so that if the guessed field tuple is an alias, it will search for the original non-aliased field. It needs to be a while loop because there can be chains of aliases. This is particularly pernicious for SPH data in yt-4.0 because we use aliases a lot more now to handle SPH fields. I'm not sure if this will break things, let's see what the tests say.