### PR TITLE
try to use pip instead of conda-build for develop install

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,8 +30,8 @@ install:
     - "python --version"
 
     # Install specified version of numpy and dependencies
-    - "conda install --yes -c conda-forge numpy scipy nose pytest setuptools ipython Cython sympy fastcache h5py matplotlib mock pandas cartopy conda-build pyyaml"
-    - "conda develop -b ."
+    - "conda install --yes -c conda-forge numpy scipy nose pytest setuptools ipython Cython sympy fastcache h5py matplotlib mock pandas cartopy pyyaml"
+    - "pip install -e . "
 
 # Not a .NET project
 build: false


### PR DESCRIPTION
## PR Summary

A number of recent PRs are failing on appveyor because conda-build can't be installed in the conda environment and needs to be installed in the root environment. It looks like we use conda-build only to be able to do a development build of yt with `conda develop -b`. Maybe the appveyor builds can be fixed by using pip instead. 
