### PR TITLE
hotfix an inconsistency in annotate_sphere callback

### DIFF
--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -221,7 +221,7 @@ class PlotCallback(object):
                 to (1,1) in upper right.  Same as matplotlib figure coords.
         """
         # Assure coords are either a YTArray or numpy array
-        coord = np.asanyarray(coord)
+        coord = np.asanyarray(coord, dtype="float64")
         # if in data coords, project them to plot coords
         if coord_system == "data":
             if len(coord) < 3:


### PR DESCRIPTION
## PR Summary
I noticed that using a plain list of integers as a "center" argument in plot callback `annotate_sphere` was working as expected with `coordinate_system=plot` but not with  `coordinate_system=data`. I monkey-fix it by forcing conversion to floats during sanitizing.

as an example:
```python
import yt
ds = yt.testing.fake_amr_ds(fields=["density"])
p = yt.SlicePlot(ds, "z", "density")

# already accepted
p.annotate_sphere(radius=0.4, center=[0,0], coord_system="plot")

# will raise UFuncTypeError
p.annotate_sphere(radius=0.4, center=[0,0,0], coord_system="data") 
```
## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes flake8 checker
- [ ] Adds a test for any bugs fixed. Adds tests for new features.