### PR TITLE
extend support of some plot callbacks to polar geometries

### DIFF
--- a/doc/source/visualizing/callbacks.rst
+++ b/doc/source/visualizing/callbacks.rst
@@ -85,6 +85,35 @@ of the x-plane (i.e. with axes in the y and z directions):
                     text_args={'color':'black'})
     s.save()
 
+Note that for non-cartesian geometries and ``coord_system="data"``, the coordinates
+are still interpreted in the corresponding cartesian system. For instance using a polar
+dataset from AMRVAC 
+.. python-script::
+
+    import yt
+
+    ds = yt.load("amrvac/bw_polar_2D0000.dat")
+    s = yt.plot2d(ds, 'density')
+    s.set_background_color("density", "black")
+
+    # Plot marker and text in data coords
+    s.annotate_marker((0.2, 0.5, 0.9), coord_system='data')
+    s.annotate_text((0.2, 0.5, 0.9), 'data: (0.2, 0.5, 0.9)', coord_system='data')
+
+    # Plot marker and text in plot coords
+    s.annotate_marker((0.4, -0.5), coord_system='plot')
+    s.annotate_text((0.4, -0.5), 'plot: (0.4, -0.5)', coord_system='plot')
+
+    # Plot marker and text in axis coords
+    s.annotate_marker((0.1, 0.2), coord_system='axis')
+    s.annotate_text((0.1, 0.2), 'axis: (0.1, 0.2)', coord_system='axis')
+
+    # Plot marker and text in figure coords
+    # N.B. marker will not render outside of axis bounds
+    s.annotate_marker((0.6, 0.2), coord_system='figure')
+    s.annotate_text((0.6, 0.2), 'figure: (0.6, 0.2)', coord_system='figure')
+    s.save()
+
 Available Callbacks
 -------------------
 

--- a/doc/source/visualizing/callbacks.rst
+++ b/doc/source/visualizing/callbacks.rst
@@ -87,7 +87,8 @@ of the x-plane (i.e. with axes in the y and z directions):
 
 Note that for non-cartesian geometries and ``coord_system="data"``, the coordinates
 are still interpreted in the corresponding cartesian system. For instance using a polar
-dataset from AMRVAC 
+dataset from AMRVAC :
+
 .. python-script::
 
     import yt

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -1303,7 +1303,7 @@ class MarkerAnnotateCallback(PlotCallback):
 
     """
     _type_name = "marker"
-    _supported_geometries = ("cartesian", "spectral_cube", "cylindrical")
+    _supported_geometries = ("cartesian", "spectral_cube", "polar", "cylindrical")
     def __init__(self, pos, marker='x', coord_system="data", plot_args=None):
         def_plot_args = {'color':'w', 's':50}
         self.pos = pos
@@ -1489,7 +1489,7 @@ class TextLabelCallback(PlotCallback):
     >>> s.save()
     """
     _type_name = "text"
-    _supported_geometries = ("cartesian", "spectral_cube", "cylindrical")
+    _supported_geometries = ("cartesian", "spectral_cube", "polar", "cylindrical")
     def __init__(self, pos, text, data_coords=False, coord_system='data',
                  text_args=None, inset_box_args=None):
         def_text_args = {'color':'white'}

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -925,7 +925,7 @@ class LinePlotCallback(PlotCallback):
 
     """
     _type_name = "line"
-    _supported_geometries = ("cartesian", "spectral_cube", "cylindrical")
+    _supported_geometries = ("cartesian", "spectral_cube", "polar", "cylindrical")
     def __init__(self, p1, p2, data_coords=False, coord_system="data",
                  plot_args=None):
         PlotCallback.__init__(self)
@@ -1372,7 +1372,7 @@ class SphereCallback(PlotCallback):
 
     """
     _type_name = "sphere"
-    _supported_geometries = ("cartesian", "spectral_cube", "cylindrical")
+    _supported_geometries = ("cartesian", "spectral_cube", "polar", "cylindrical")
     def __init__(self, center, radius, circle_args=None,
                  text=None, coord_system='data', text_args=None):
         def_text_args = {'color':'white'}


### PR DESCRIPTION
## PR Summary

I’m looking to extend support for some of them to non-cartesian geometries.

As an experiment, I’ve just added “polar” to the list of supported geometries in `LinePlotCallback` and `SpherePlotCallback`. It seems to work just fine, though there's one case where the behaviour might not be what the user expects. Namely, with `coord_system="data"`, the start-point and end-point coordinates are passed as cartesian coords, instead of the actual data coordinate system.

For instance
```python
import yt
ds = yt.load("amrvac/bw_polar_2D0000.dat")
p = yt.plot_2d(ds, "density")
p.annotate_line([-2, 1, 0], [2, -1, 0], coord_system="data")
```
![linepolar_Slice_z_density](https://user-images.githubusercontent.com/14075922/75567223-6fa29c00-5a51-11ea-95b7-4af552b80e97.png)

This looks fine-ish to me as long as it is documented as such, which seems to me like the way to go, as of now.

## PR Checklist

- [x] Code passes flake8 checker
- [x] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.