### PR TITLE
Add API documentation path to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,10 @@ yt/utilities/lib/image_samplers.c
 tests/results/*
 doc/build/*
 doc/source/reference/api/generated/*
+doc/source/reference/api/yt*
+doc/cheatsheet.aux
+doc/cheatsheet.log
+doc/cheatsheet.pdf
 doc/_temp/*
 doc/source/quickstart/.ipynb_checkpoints/
 dist


### PR DESCRIPTION
Documenation files are generated by sphinx-apidoc

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
