### PR TITLE
Fixing streamlines attribute

### DIFF
--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -103,7 +103,7 @@ class YTStreamline(YTSelectionContainer1D):
 
     """
     _type_name = "streamline"
-    _con_args = ('positions')
+    _con_args = ('positions',)
     sort_by = 't'
     def __init__(self, positions, length = 1.0, fields=None, ds=None, **kwargs):
         YTSelectionContainer1D.__init__(self, ds, fields, **kwargs)


### PR DESCRIPTION
_con_args must be a tuple for our parsing to work in some cases.