### PR TITLE
[bugfix] use dict.get to pull attributes that may not exist

### DIFF
--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -415,7 +415,7 @@ class ProfileNDFromDataset(ProfileND):
     An ND profile object loaded from a ytdata dataset.
     """
     def __init__(self, ds):
-        ProfileND.__init__(self, ds.data, ds.parameters["weight_field"])
+        ProfileND.__init__(self, ds.data, ds.parameters.get("weight_field", None))
         self.fractional = ds.parameters.get("fractional", False)
         self.accumulation = ds.parameters.get("accumulation", False)
         exclude_fields = ["used", "weight"]
@@ -425,11 +425,11 @@ class ProfileNDFromDataset(ProfileND):
             ax_field = "%s_field" % ax
             ax_log = "%s_log" % ax
             setattr(self, ax_bins, ds.data[ax_bins])
-            field_name = tuple(ds.parameters[ax_field])
+            field_name = tuple(ds.parameters.get(ax_field, (None, None)))
             setattr(self, ax_field, field_name)
             self.field_info[field_name] = ds.field_info[field_name]
             setattr(self, ax_log, ds.parameters.get(ax_log, False))
-            exclude_fields.extend([ax, ax_bins, ds.parameters[ax_field][1]])
+            exclude_fields.extend([ax, ax_bins, field_name[1]])
         self.weight = ds.data["weight"]
         self.used = ds.data["used"].d.astype(bool)
         profile_fields = [f for f in ds.field_list

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -288,7 +288,7 @@ been deprecated, use profile.standard_deviation instead."""
                 fname = self.field_map.get(field[1], None)
                 if fname != field:
                     raise KeyError("Asked for field '{}' but only have data for "
-                                   "field '{}'".format(field, fname))
+                                   "fields '{}'".format(field, list(self.field_data.keys())))
             elif isinstance(field, DerivedField):
                 fname = self.field_map.get(field.name[1], None)
             if fname is None:
@@ -416,18 +416,20 @@ class ProfileNDFromDataset(ProfileND):
     """
     def __init__(self, ds):
         ProfileND.__init__(self, ds.data, ds.parameters["weight_field"])
-        self.fractional = ds.parameters["fractional"]
-        self.accumulation = ds.parameters["accumulation"]
+        self.fractional = ds.parameters.get("fractional", False)
+        self.accumulation = ds.parameters.get("accumulation", False)
         exclude_fields = ["used", "weight"]
         for ax in "xyz"[:ds.dimensionality]:
             setattr(self, ax, ds.data[ax])
-            setattr(self, "%s_bins" % ax, ds.data["%s_bins" % ax])
-            field_name = tuple(ds.parameters["%s_field" % ax])
-            setattr(self, "%s_field" % ax, field_name)
+            ax_bins = "%s_bins" % ax
+            ax_field = "%s_field" % ax
+            ax_log = "%s_log" % ax
+            setattr(self, ax_bins, ds.data[ax_bins])
+            field_name = tuple(ds.parameters[ax_field])
+            setattr(self, ax_field, field_name)
             self.field_info[field_name] = ds.field_info[field_name]
-            setattr(self, "%s_log" % ax, ds.parameters["%s_log" % ax])
-            exclude_fields.extend([ax, "%s_bins" % ax,
-                                   ds.parameters["%s_field" % ax][1]])
+            setattr(self, ax_log, ds.parameters.get(ax_log, False))
+            exclude_fields.extend([ax, ax_bins, ds.parameters[ax_field][1]])
         self.weight = ds.data["weight"]
         self.used = ds.data["used"].d.astype(bool)
         profile_fields = [f for f in ds.field_list


### PR DESCRIPTION
It seems that some old profiles that were saved with `yt.save_as_dataset` did not save the `accumulation` attribute and so loading them fails with a `KeyError`. This fixes that by using the `get` function with an appropriate default. I also took the opportunity to do some small code cleanup in the surrounding lines.