### PR TITLE
Mask is a slice in some cases, not an array.

### DIFF
--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -334,7 +334,11 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
                     continue
                 for field in field_list:
                     if field == "Mass" and ptype not in self.var_mass:
-                        data = np.empty(mask.sum(), dtype="float64")
+                        if getattr(selector, 'is_all_data', False):
+                            size = data_file.total_particles[ptype]
+                        else:
+                            size = mask.sum()
+                        data = np.empty(size, dtype="float64")
                         m = self.ds.parameters["Massarr"][
                             self._ptypes.index(ptype)]
                         data[:] = m


### PR DESCRIPTION
This hits a corner case of selecting a particle with "all data" in a multi-file binary gadget file where the particle does not have variable mass.