### PR TITLE
find and replace bare excepts

### DIFF
--- a/doc/helper_scripts/run_recipes.py
+++ b/doc/helper_scripts/run_recipes.py
@@ -45,7 +45,7 @@ def run_recipe(payload):
             cmd = ["python", recipe]
         try:
             subprocess.check_call(cmd)
-        except:
+        except Exception:
             trace = "".join(traceback.format_exception(*sys.exc_info()))
             trace += " in module: %s\n" % module_name
             trace += " recipe: %s\n" % recipe

--- a/scripts/iyt
+++ b/scripts/iyt
@@ -77,10 +77,10 @@ def yt_simple_fieldname_completer(self, event):
 
     try:
         obj = eval(expr, self.Completer.namespace)
-    except:
+    except Exception:
         try:
             obj = eval(expr, self.Completer.global_namespace)
-        except:
+        except Exception:
             raise IPython.ipapi.TryNext
 
     if isinstance(obj, YTDataContainer):
@@ -104,10 +104,10 @@ def yt_tuple_fieldname_completer(self, event):
 
     try:
         obj = eval(expr, self.Completer.namespace)
-    except:
+    except Exception:
         try:
             obj = eval(expr, self.Completer.global_namespace)
-        except:
+        except Exception:
             raise IPython.ipapi.TryNext
 
     if isinstance(obj, YTDataContainer):

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1472,7 +1472,7 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface):
                 try:
                     fd = fi.get_dependencies(ds = self.ds)
                     self.ds.field_dependencies[field] = fd
-                except:
+                except Exception:
                     continue
             requested = self._determine_fields(list(set(fd.requested)))
             deps = [d for d in requested if d not in fields_to_get]

--- a/yt/extern/_dummy_thread32.py
+++ b/yt/extern/_dummy_thread32.py
@@ -53,7 +53,7 @@ def start_new_thread(function, args, kwargs={}):
         function(*args, **kwargs)
     except SystemExit:
         pass
-    except:
+    except Exception:
         import traceback
         traceback.print_exc()
     _main = True

--- a/yt/extern/tqdm/_utils.py
+++ b/yt/extern/tqdm/_utils.py
@@ -89,7 +89,7 @@ def _environ_cols_linux(fp):  # pragma: no cover
     # if fp is None:
     #     try:
     #         fp = os.open(os.ctermid(), os.O_RDONLY)
-    #     except:
+    #     except Exception:
     #         pass
     try:
         from termios import TIOCGWINSZ
@@ -100,7 +100,7 @@ def _environ_cols_linux(fp):  # pragma: no cover
     else:
         try:
             return array('h', ioctl(fp, TIOCGWINSZ, '\0' * 8))[1]
-        except:
+        except Exception:
             try:
                 from os.environ import get
             except ImportError:

--- a/yt/extern/tqdm/_utils.py
+++ b/yt/extern/tqdm/_utils.py
@@ -67,8 +67,7 @@ def _environ_cols_windows(fp):  # pragma: no cover
              maxx, maxy) = struct.unpack("hhhhHhhhhhh", csbi.raw)
             # nlines = bottom - top + 1
             return right - left  # +1
-    except:
-        pass
+    except Exception: pass
     return None
 
 
@@ -80,8 +79,7 @@ def _environ_cols_tput(*args):  # pragma: no cover
         cols = int(subprocess.check_call(shlex.split('tput cols')))
         # rows = int(subprocess.check_call(shlex.split('tput lines')))
         return cols
-    except:
-        pass
+    except Exception: pass
     return None
 
 

--- a/yt/frontends/ahf/data_structures.py
+++ b/yt/frontends/ahf/data_structures.py
@@ -151,7 +151,7 @@ class AHFHalosDataset(Dataset):
                     key = name.strip().split('.')[1]
                     try:
                         val = float(val)
-                    except:
+                    except Exception:
                         val = float.fromhex(val)
                     simu[key] = val
         return simu

--- a/yt/frontends/ahf/data_structures.py
+++ b/yt/frontends/ahf/data_structures.py
@@ -166,8 +166,7 @@ class AHFHalosDataset(Dataset):
                     try:
                         val = float(val)
                         param[key] = val
-                    except:
-                        pass
+                    except Exception: pass
         return param
 
     @property

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -220,8 +220,7 @@ class AMRVACDataset(Dataset):
                         istream.seek(0,2)
                         file_size = istream.tell()
                         validation = offset_tree < file_size and offset_blocks < file_size
-            except:
-                pass
+            except Exception: pass
         return validation
 
     def _parse_geometry(self, geometry_tag):

--- a/yt/frontends/art/data_structures.py
+++ b/yt/frontends/art/data_structures.py
@@ -394,7 +394,7 @@ class ARTDataset(Dataset):
             try:
                 fpu.read_attrs(fh, amr_header_struct, '>')
                 return True
-            except:
+            except Exception:
                 return False
         return False
 
@@ -674,7 +674,7 @@ class DarkMatterARTDataset(ARTDataset):
                 extras = np.fromfile(fh, count=79, dtype='>f4')  # NOQA
                 boxsize = np.fromfile(fh, count=1, dtype='>f4')  # NOQA
                 return True
-            except:
+            except Exception:
                 return False
         return False
 

--- a/yt/frontends/art/data_structures.py
+++ b/yt/frontends/art/data_structures.py
@@ -643,8 +643,7 @@ class DarkMatterARTDataset(ARTDataset):
                     if possible.endswith(amr_suffix):
                         if os.path.basename(possible).startswith(amr_prefix):
                             return False
-            except:
-                pass
+            except Exception: pass
             try:
                 seek = 4
                 fh.seek(seek)

--- a/yt/frontends/artio/data_structures.py
+++ b/yt/frontends/artio/data_structures.py
@@ -245,7 +245,7 @@ class ARTIOIndex(Index):
             try:
                 all_data = all(dobj.left_edge == self.ds.domain_left_edge) and\
                     all(dobj.right_edge == self.ds.domain_right_edge)
-            except:
+            except Exception:
                 all_data = False
             base_region = getattr(dobj, "base_region", dobj)
             sfc_start = getattr(dobj, "sfc_start", None)

--- a/yt/frontends/athena/data_structures.py
+++ b/yt/frontends/athena/data_structures.py
@@ -577,8 +577,7 @@ class AthenaDataset(Dataset):
         try:
             if 'vtk' in args[0]:
                 return True
-        except:
-            pass
+        except Exception: pass
         return False
 
     @property

--- a/yt/frontends/athena_pp/data_structures.py
+++ b/yt/frontends/athena_pp/data_structures.py
@@ -341,8 +341,7 @@ class AthenaPPDataset(Dataset):
         try:
             if args[0].endswith('athdf'):
                 return True
-        except:
-            pass
+        except Exception: pass
         return False
 
     @property

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -1332,7 +1332,7 @@ def _guess_pcast(vals):
     v = vals.split()[0]
     try:
         float(v.upper().replace("D", "E"))
-    except:
+    except Exception:
         pcast = str
         if v in ("F", "T"):
             pcast = bool

--- a/yt/frontends/chombo/data_structures.py
+++ b/yt/frontends/chombo/data_structures.py
@@ -390,8 +390,7 @@ class ChomboDataset(Dataset):
                 valid = valid and not ('Charm_global' in fileh.keys())
                 fileh.close()
                 return valid
-            except:
-                pass
+            except Exception: pass
         return False
 
     @parallel_root_only
@@ -698,8 +697,7 @@ class Orion2Dataset(ChomboDataset):
                 valid = valid and 'CeilVA_mass' in fileh.attrs.keys()
                 fileh.close()
                 return valid
-            except:
-                pass
+            except Exception: pass
         return False
 
 
@@ -757,6 +755,5 @@ class ChomboPICDataset(ChomboDataset):
             valid = "Charm_global" in fileh["/"]
             fileh.close()
             return valid
-        except:
-            pass
+        except Exception: pass
         return False

--- a/yt/frontends/eagle/data_structures.py
+++ b/yt/frontends/eagle/data_structures.py
@@ -93,6 +93,5 @@ class EagleNetworkDataset(EagleDataset):
                 fileh.close()
                 return True
             fileh.close()
-        except:
-            pass
+        except Exception: pass
         return False

--- a/yt/frontends/eagle/data_structures.py
+++ b/yt/frontends/eagle/data_structures.py
@@ -71,7 +71,7 @@ class EagleDataset(GadgetHDF5Dataset):
                 if vg in fileh["/"]:
                     valid = False                    
             fileh.close()
-        except:
+        except Exception:
             valid = False
             pass
         return valid

--- a/yt/frontends/exodus_ii/data_structures.py
+++ b/yt/frontends/exodus_ii/data_structures.py
@@ -399,5 +399,4 @@ class ExodusIIDataset(Dataset):
             with Dataset(filename, keepweakref=True) as f:
                 f.variables['connect1']
             return True
-        except:
-            pass
+        except Exception: pass

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -302,8 +302,7 @@ def check_fits_valid(args):
             return fileh
         else:
             fileh.close()
-    except:
-        pass
+    except Exception: pass
     return None
 
 def check_sky_coords(args, ndim):
@@ -323,8 +322,7 @@ def check_sky_coords(args, ndim):
                 x = find_axes(axis_names, sky_prefixes + spec_prefixes)
                 fileh.close()
                 return x >= ndim
-        except:
-            pass
+        except Exception: pass
     return False
 
 class FITSDataset(Dataset):
@@ -793,6 +791,5 @@ class EventsFITSDataset(SkyDataFITSDataset):
                 valid = fileh[1].name == "EVENTS"
                 fileh.close()
                 return valid
-            except:
-                pass
+            except Exception: pass
         return False

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -465,7 +465,7 @@ class FITSDataset(Dataset):
         # Get the simulation time
         try:
             self.current_time = self.parameters["time"]
-        except:
+        except Exception:
             mylog.warning("Cannot find time")
             self.current_time = 0.0
             pass

--- a/yt/frontends/flash/data_structures.py
+++ b/yt/frontends/flash/data_structures.py
@@ -206,7 +206,7 @@ class FLASHDataset(Dataset):
             # particle_filename is specified by user
             try:
                 self._particle_handle = HDF5FileHandler(self.particle_filename)
-            except:
+            except Exception:
                 raise IOError(self.particle_filename)
         # Check if the particle file has the same time
         if self._particle_handle != self._handle:
@@ -407,7 +407,7 @@ class FLASHDataset(Dataset):
         # Try to determine Gamma
         try:
             self.gamma = self.parameters["gamma"]
-        except:
+        except Exception:
             mylog.info("Cannot find Gamma")
             pass
 
@@ -427,7 +427,7 @@ class FLASHDataset(Dataset):
             self.omega_matter = self.parameters['omegamatter']
             self.hubble_constant = self.parameters['hubbleconstant']
             self.hubble_constant *= cm_per_mpc * 1.0e-5 * 1.0e-2 # convert to 'h'
-        except:
+        except Exception:
             self.current_redshift = self.omega_lambda = self.omega_matter = \
                 self.hubble_constant = self.cosmological_simulation = 0.0
 

--- a/yt/frontends/flash/fields.py
+++ b/yt/frontends/flash/fields.py
@@ -121,8 +121,7 @@ class FLASHFieldInfo(FieldInfoContainer):
                 ener = data["flash","eint"]+ekin(data)
                 try:
                     ener += data["flash","magp"]/data["flash","dens"]
-                except:
-                    pass
+                except Exception: pass
                 return ener
             self.add_field(("gas","total_energy"), sampling_type="cell",  function=_ener,
                            units=unit_system["specific_energy"])
@@ -136,8 +135,7 @@ class FLASHFieldInfo(FieldInfoContainer):
                 eint = data["flash","ener"]-ekin(data)
                 try:
                     eint -= data["flash","magp"]/data["flash","dens"]
-                except:
-                    pass
+                except Exception: pass
                 return eint
             self.add_field(("gas","thermal_energy"), sampling_type="cell",  function=_eint,
                            units=unit_system["specific_energy"])

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -176,7 +176,7 @@ class GadgetBinaryHeader(object):
             self.open().close()
             self.gadget_format
             self.float_type
-        except:
+        except Exception:
             return False
         return True
 
@@ -578,7 +578,7 @@ class GadgetHDF5Dataset(GadgetDataset):
             valid = all(ng in fh["/"] for ng in need_groups) and \
                 not any(vg in fh["/"] for vg in veto_groups)
             fh.close()
-        except:
+        except Exception:
             valid = False
             pass
         return valid

--- a/yt/frontends/gadget_fof/data_structures.py
+++ b/yt/frontends/gadget_fof/data_structures.py
@@ -306,7 +306,7 @@ class GadgetFOFDataset(Dataset):
             valid = all(ng in fh["/"] for ng in need_groups) and \
               not any(vg in fh["/"] for vg in veto_groups)
             fh.close()
-        except:
+        except Exception:
             valid = False
             pass
         return valid

--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -336,6 +336,5 @@ class GAMERDataset(Dataset):
             f = HDF5FileHandler(args[0])
             if 'Info' in f['/'].keys() and 'KeyInfo' in f['/Info'].keys():
                 return True
-        except:
-            pass
+        except Exception: pass
         return False

--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -228,7 +228,7 @@ class GAMERDataset(Dataset):
         else:
             try:
                 self._particle_handle = HDF5FileHandler(self.particle_filename)
-            except:
+            except Exception:
                 raise IOError(self.particle_filename)
 
         # currently GAMER only supports refinement by a factor of 2

--- a/yt/frontends/gdf/data_structures.py
+++ b/yt/frontends/gdf/data_structures.py
@@ -299,8 +299,7 @@ class GDFDataset(Dataset):
                 fileh.close()
                 return True
             fileh.close()
-        except:
-            pass
+        except Exception: pass
         return False
 
     def __repr__(self):

--- a/yt/frontends/gizmo/data_structures.py
+++ b/yt/frontends/gizmo/data_structures.py
@@ -38,7 +38,7 @@ class GizmoDataset(GadgetHDF5Dataset):
             if dmetal not in fh or fh[dmetal].shape[1] not in (11, 17):
                 valid = False
             fh.close()
-        except:
+        except Exception:
             valid = False
             pass
         return valid

--- a/yt/frontends/owls/data_structures.py
+++ b/yt/frontends/owls/data_structures.py
@@ -67,7 +67,7 @@ class OWLSDataset(GadgetHDF5Dataset):
                 if vg in fileh["/"]:
                     valid = False                    
             fileh.close()
-        except:
+        except Exception:
             valid = False
             pass
         return valid

--- a/yt/frontends/owls_subfind/data_structures.py
+++ b/yt/frontends/owls_subfind/data_structures.py
@@ -225,7 +225,7 @@ class OWLSSubfindDataset(Dataset):
             valid = all(ng in fh["/"] for ng in need_groups) and \
               not any(vg in fh["/"] for vg in veto_groups)
             fh.close()
-        except:
+        except Exception:
             valid = False
             pass
         return valid

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -354,8 +354,7 @@ class RAMSESIndex(OctreeIndex):
         dx = self.get_smallest_dx()
         try:
             print("z = %0.8f" % (self.dataset.current_redshift))
-        except:
-            pass
+        except Exception: pass
         print("t = %0.8e = %0.8e s = %0.8e years" % (
             self.ds.current_time.in_units("code_time"),
             self.ds.current_time.in_units("s"),

--- a/yt/frontends/sdf/data_structures.py
+++ b/yt/frontends/sdf/data_structures.py
@@ -118,7 +118,7 @@ class SDFDataset(ParticleDataset):
         try:
             self.unique_identifier = \
                 int(os.stat(self.parameter_filename)[stat.ST_CTIME])
-        except:
+        except Exception:
             self.unique_identifier = time.time()
 
         if self.domain_left_edge is None or self.domain_right_edge is None:

--- a/yt/frontends/tipsy/data_structures.py
+++ b/yt/frontends/tipsy/data_structures.py
@@ -294,7 +294,7 @@ class TipsyDataset(SPHDataset):
         '''
         try:
             f = open(filename,'rb')
-        except:
+        except Exception:
             return False, 1
         try:
             f.seek(0, os.SEEK_END)

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -56,7 +56,7 @@ def iterable(obj):
     *obj* iterable.
     """
     try: len(obj)
-    except: return False
+    except Exception: return False
     return True
 
 def ensure_list(obj):
@@ -669,7 +669,7 @@ def get_script_contents():
     if not os.path.exists(finfo[0]): return None
     try:
         contents = open(finfo[0]).read()
-    except:
+    except Exception:
         contents = None
     return contents
 
@@ -1047,7 +1047,7 @@ def get_hash(infile, algorithm='md5', BLOCKSIZE=65536):
 
     try:
         hasher = getattr(hashlib, algorithm)()
-    except:
+    except Exception:
         raise NotImplementedError("'%s' not available!  Available algorithms: %s" %
                                   (algorithm, hashlib.algorithms))
 

--- a/yt/geometry/geometry_handler.py
+++ b/yt/geometry/geometry_handler.py
@@ -129,8 +129,7 @@ class Index(ParallelAnalysisInterface):
                 del self._data_file[node][name]
             elif name in node_loc and passthrough:
                 return
-        except:
-            pass
+        except Exception: pass
         myGroup = self._data_file['/']
         for q in node.split('/'):
             if q: myGroup = myGroup.require_group(q)

--- a/yt/geometry/grid_geometry_handler.py
+++ b/yt/geometry/grid_geometry_handler.py
@@ -191,8 +191,7 @@ class GridIndex(Index):
         print("\n")
         try:
             print("z = %0.8f" % (self["CosmologyCurrentRedshift"]))
-        except:
-            pass
+        except Exception: pass
         print("t = %0.8e = %0.8e s = %0.8e years" % \
             (self.ds.current_time.in_units("code_time"),
              self.ds.current_time.in_units("s"),

--- a/yt/units/unit_object.py
+++ b/yt/units/unit_object.py
@@ -110,7 +110,7 @@ def get_latex_representation(expr, registry):
     for ex in expr.free_symbols:
         try:
             symbol_table[ex] = registry.lut[str(ex)][3]
-        except:
+        except Exception:
             symbol_table[ex] = r"\rm{" + str(ex).replace('_', '\ ') + "}"
 
     # invert the symbol table dict to look for keys with identical values

--- a/yt/units/yt_array.py
+++ b/yt/units/yt_array.py
@@ -69,7 +69,7 @@ POWER_SIGN_MAPPING = {multiply: 1, divide: -1}
 # redefine this here to avoid a circular import from yt.funcs
 def iterable(obj):
     try: len(obj)
-    except: return False
+    except Exception: return False
     return True
 
 def return_arr(func):

--- a/yt/utilities/amr_kdtree/amr_kdtree.py
+++ b/yt/utilities/amr_kdtree/amr_kdtree.py
@@ -446,8 +446,7 @@ class AMRKDTree(ParallelAnalysisInterface):
                     try:
                         f.create_dataset("/brick_%s_%s" % (hex(i),field),
                                          data = node.data.my_data[fi].astype('float64'))
-                    except:
-                        pass
+                    except Exception: pass
         f.close()
         del f
         if self.comm.rank != (self.comm.size-1):
@@ -479,8 +478,7 @@ class AMRKDTree(ParallelAnalysisInterface):
             self._initialized=True
             f.close()
             del f
-        except:
-            pass
+        except Exception: pass
         if self.comm.rank != (self.comm.size-1):
             self.comm.send_array([0],self.comm.rank+1, tag=self.comm.rank)
 

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -78,7 +78,7 @@ class AnswerTesting(Plugin):
         if version is None:
             try:
                 version = get_yt_version()
-            except:
+            except Exception:
                 version = "UNKNOWN%s" % (time.time())
         self._my_version = version
         return self._my_version
@@ -185,7 +185,7 @@ class AnswerTestCloudStorage(AnswerTestStorage):
             for this_try in range(3):
                 try:
                     data = resp.read()
-                except:
+                except Exception:
                     time.sleep(0.01)
                 else:
                     # We were succesful

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -525,8 +525,7 @@ class YTBugreportCmd(YTCommand):
             content = open(fn).read()
             try:
                 os.unlink(fn)
-            except:
-                pass
+            except Exception: pass
         else:
             print()
             print("Couldn't find an $EDITOR variable.  So, let's just take")

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -503,7 +503,7 @@ class YTBugreportCmd(YTCommand):
         print()
         try:
             current_version = get_yt_version()
-        except:
+        except Exception:
             current_version = "Unavailable"
         summary = input("Summary? ")
         bugtype = "bug"

--- a/yt/utilities/file_handler.py
+++ b/yt/utilities/file_handler.py
@@ -24,7 +24,7 @@ def valid_hdf5_signature(fn):
         with open(fn, 'rb') as f:
             header = f.read(8)
             return header == signature
-    except:
+    except Exception:
         return False
 
 
@@ -96,7 +96,7 @@ def valid_netcdf_classic_signature(filename):
         with open(filename, 'rb') as f:
             header = f.read(4)
             return (header == signature_v1 or header == signature_v2)
-    except:
+    except Exception:
         return False
 
 

--- a/yt/utilities/grid_data_format/conversion/conversion_athena.py
+++ b/yt/utilities/grid_data_format/conversion/conversion_athena.py
@@ -440,7 +440,7 @@ class AthenaConverter(Converter):
         pars_g.attrs['domain_dimensions'] = grid['dimensions']
         try:
             pars_g.attrs['current_time'] = grid['time']
-        except:
+        except Exception:
             pars_g.attrs['current_time'] = 0.0
         pars_g.attrs['domain_left_edge'] = grid['left_edge'] # For Now
         pars_g.attrs['domain_right_edge'] = grid['right_edge'] # For Now

--- a/yt/utilities/grid_data_format/conversion/conversion_athena.py
+++ b/yt/utilities/grid_data_format/conversion/conversion_athena.py
@@ -73,8 +73,7 @@ class AthenaDistributedConverter(Converter):
         name = field
         try:
             name = translation_dict[name]
-        except:
-            pass
+        except Exception: pass
         # print 'Writing %s' % name
         if name not in g.keys():
             g.create_dataset(name,data=data)
@@ -274,8 +273,7 @@ class AthenaDistributedConverter(Converter):
             tname = name
             try:
                 tname = translation_dict[name]
-            except:
-                pass
+            except Exception: pass
             this_field = field_g.create_group(tname)
             if name in self.field_conversions.keys():
                 this_field.attrs['field_to_cgs'] = self.field_conversions[name]
@@ -461,8 +459,7 @@ class AthenaConverter(Converter):
             tname = name
             try:
                 tname = translation_dict[name]
-            except:
-                pass
+            except Exception: pass
             this_field = field_g.create_group(tname)
         if name in self.field_conversions.keys():
             this_field.attrs['field_to_cgs'] = self.field_conversions[name]

--- a/yt/utilities/parallel_tools/io_runner.py
+++ b/yt/utilities/parallel_tools/io_runner.py
@@ -82,7 +82,7 @@ class IOCommunicator(BaseIOHandler):
             return np.array([],dtype='float64')
         try:
             temp = self.ds.index.io._read_data_set(g, f)
-        except:# self.ds.index.io._read_exception as exc:
+        except Exception:# self.ds.index.io._read_exception as exc:
             if fi.not_in_all:
                 temp = np.zeros(g.ActiveDimensions, dtype='float64')
             else:

--- a/yt/utilities/particle_generator.py
+++ b/yt/utilities/particle_generator.py
@@ -33,7 +33,7 @@ class ParticleGenerator(object):
             self.posx_index = self.field_list.index(self.default_fields[0])
             self.posy_index = self.field_list.index(self.default_fields[1])
             self.posz_index = self.field_list.index(self.default_fields[2])
-        except:
+        except Exception:
             raise KeyError("You must specify position fields: " +
                            " ".join(["particle_position_%s" % ax for ax in "xyz"]))
         self.index_index = self.field_list.index((ptype, "particle_index"))

--- a/yt/utilities/poster/encode.py
+++ b/yt/utilities/poster/encode.py
@@ -112,7 +112,7 @@ class MultipartParam(object):
                     fileobj.seek(0, 2)
                     self.filesize = fileobj.tell()
                     fileobj.seek(0)
-                except:
+                except Exception:
                     raise ValueError("Could not determine filesize")
 
     def __lt__(self, other):

--- a/yt/utilities/rpdb.py
+++ b/yt/utilities/rpdb.py
@@ -108,8 +108,7 @@ class rpdb_cmd(cmd.Cmd):
     def postloop(self):
         try:
             self.proxy.shutdown()
-        except:
-            pass
+        except Exception: pass
 
 __header = \
 """
@@ -123,7 +122,7 @@ def run_rpdb(task = None):
     if task is None:
         try:
             task + int(sys.argv[-1])
-        except: pass
+        except Exception: pass
     port += task
     sp = ServerProxy("http://localhost:%s/" % port)
     try:

--- a/yt/utilities/sdf.py
+++ b/yt/utilities/sdf.py
@@ -308,7 +308,7 @@ class SDFRead(dict):
             if k == 'byteorder': continue
             try:
                 t = _rev_types[v.dtype.name]
-            except:
+            except Exception:
                 t = type(v).__name__
             if t == str.__name__:
                 f.write("parameter %s = \"%s\";\n" % (k, v))


### PR DESCRIPTION
## PR Summary

replace bare excepts to only catch `Exception` subclasses instead of `BaseException`.

`except:` catches `KeyboardInterrupt` while `except Excetption:` doesn't.
See for instance
https://stackoverflow.com/questions/22408098/in-python-why-ever-use-except

I started with the simple `except: pass`, then I extended it to all remaining bare excepts. I did this with automatic find and replace tools (vscode) matching `except:\n\s+pass` then simply `except:`
