### PR TITLE
A consistent implementation for Dataset.min_level

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -263,10 +263,6 @@ class Dataset(object):
         self._set_derived_attrs()
         self._setup_classes()
 
-    @property
-    def min_level(self):
-        return self.index.min_level
-
     def _set_derived_attrs(self):
         if self.domain_left_edge is None or self.domain_right_edge is None:
             self.domain_center = np.zeros(3)
@@ -1428,6 +1424,18 @@ class Dataset(object):
     @max_level.setter
     def max_level(self, value):
         self._max_level = value
+
+    _min_level = None
+    @property
+    def min_level(self):
+        if self._min_level is None:
+            self._min_level = self.index.min_level
+
+        return self._min_level
+
+    @min_level.setter
+    def min_level(self, value):
+        self._min_level = value
 
     def define_unit(self, symbol, value, tex_repr=None, offset=None, prefixable=False):
         """

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -242,7 +242,6 @@ class Dataset(object):
         # to get the timing right, do this before the heavy lifting
         self._instantiated = time.time()
 
-        self.min_level = 0
         self.no_cgs_equiv_length = False
 
         self._create_unit_registry()
@@ -263,6 +262,10 @@ class Dataset(object):
 
         self._set_derived_attrs()
         self._setup_classes()
+
+    @property
+    def min_level(self):
+        return self.index.min_level
 
     def _set_derived_attrs(self):
         if self.domain_left_edge is None or self.domain_right_edge is None:

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1418,7 +1418,6 @@ class Dataset(object):
     def max_level(self):
         if self._max_level is None:
             self._max_level = self.index.max_level
-
         return self._max_level
 
     @max_level.setter
@@ -1430,12 +1429,7 @@ class Dataset(object):
     def min_level(self):
         if self._min_level is None:
             self._min_level = self.index.min_level
-
         return self._min_level
-
-    @min_level.setter
-    def min_level(self, value):
-        self._min_level = value
 
     def define_unit(self, symbol, value, tex_repr=None, offset=None, prefixable=False):
         """

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1431,6 +1431,10 @@ class Dataset(object):
             self._min_level = self.index.min_level
         return self._min_level
 
+    @min_level.setter
+    def min_level(self, value):
+        self._min_level = value
+
     def define_unit(self, symbol, value, tex_repr=None, offset=None, prefixable=False):
         """
         Define a new unit and add it to the dataset's unit registry.

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -641,6 +641,10 @@ class GridHierarchyTest(AnswerTestingTest):
         for k in new_result:
             assert_equal(new_result[k], old_result[k])
 
+    def check_index_levels_consistency(self):
+        assert self.ds.index.select_grids(self.ds.min_level).size > 0
+        assert self.ds.index.select_grids(self.ds.max_level).size > 0
+
 class ParentageRelationshipsTest(AnswerTestingTest):
     _type_name = "ParentageRelationships"
     _attrs = ()

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -641,10 +641,6 @@ class GridHierarchyTest(AnswerTestingTest):
         for k in new_result:
             assert_equal(new_result[k], old_result[k])
 
-    def check_index_levels_consistency(self):
-        assert self.ds.index.select_grids(self.ds.min_level).size > 0
-        assert self.ds.index.select_grids(self.ds.max_level).size > 0
-
 class ParentageRelationshipsTest(AnswerTestingTest):
     _type_name = "ParentageRelationships"
     _attrs = ()


### PR DESCRIPTION
## PR Summary

this is a follow up to #2475 
~I added a test to the answer test framework to ensure the error corrected in #2475 doesn't show up again in the future. Admittedly the test is in fact necessary but not sufficient, as broken frontends may consistently pass it, unless there's a test dataset that happens to be fully refined.~

edit : the PR's focus was changed to making the Dataset.min_level attribute consistent with the actual value, mimicking the existing Dataset.max_level property