### PR TITLE
Extend region expression to 2d datasets

### DIFF
--- a/yt/data_objects/region_expression.py
+++ b/yt/data_objects/region_expression.py
@@ -58,9 +58,6 @@ class RegionExpression(object):
             # implicitly.  Note that this happens *after* the implicit expansion
             # of a single slice.
             raise YTDimensionalityError(len(item), self.ds.dimensionality)
-        #if self.ds.dimensionality != 3:
-            # We'll pass on this for the time being.
-        #    raise YTDimensionalityError(self.ds.dimensionality, '3')
 
         # OK, now we need to look at our slices.  How many are a specific
         # coordinate?

--- a/yt/data_objects/region_expression.py
+++ b/yt/data_objects/region_expression.py
@@ -142,8 +142,8 @@ class RegionExpression(object):
         return l, r
 
     def _create_region(self, bounds_tuple):
-        left_edge = self.ds.domain_left_edge
-        right_edge = self.ds.domain_right_edge
+        left_edge = self.ds.domain_left_edge.copy()
+        right_edge = self.ds.domain_right_edge.copy()
         dims = []
         for ax, b in enumerate(bounds_tuple):
             l, r = self._slice_to_edges(ax, b)

--- a/yt/data_objects/region_expression.py
+++ b/yt/data_objects/region_expression.py
@@ -58,9 +58,9 @@ class RegionExpression(object):
             # implicitly.  Note that this happens *after* the implicit expansion
             # of a single slice.
             raise YTDimensionalityError(len(item), self.ds.dimensionality)
-        if self.ds.dimensionality != 3:
+        #if self.ds.dimensionality != 3:
             # We'll pass on this for the time being.
-            raise YTDimensionalityError(self.ds.dimensionality, '3')
+        #    raise YTDimensionalityError(self.ds.dimensionality, '3')
 
         # OK, now we need to look at our slices.  How many are a specific
         # coordinate?
@@ -101,6 +101,12 @@ class RegionExpression(object):
             else:
                 new_slice.append(v)
         # This new slice doesn't need to be a tuple
+        dim = self.ds.dimensionality
+        if dim < 2:
+            raise ValueError("Can not create a slice from data with dimensionality '%d'" % dim)
+        if dim == 2:
+            coord = self.ds.domain_center[2]
+            axis = 2
         source = self._create_region(new_slice)
         sl = self.ds.slice(axis, coord, data_source = source)
         # Now, there's the possibility that what we're also seeing here
@@ -136,13 +142,13 @@ class RegionExpression(object):
         return l, r
 
     def _create_region(self, bounds_tuple):
-        left_edge = []
-        right_edge = []
+        left_edge = self.ds.domain_left_edge
+        right_edge = self.ds.domain_right_edge
         dims = []
         for ax, b in enumerate(bounds_tuple):
             l, r = self._slice_to_edges(ax, b)
-            left_edge.append(l)
-            right_edge.append(r)
+            left_edge[ax] = l
+            right_edge[ax] = r
             dims.append(getattr(b.step, "imag", None))
         center = [ (cl + cr)/2.0 for cl, cr in zip(left_edge, right_edge)]
         if all(d is not None for d in dims):

--- a/yt/data_objects/tests/test_dataset_access.py
+++ b/yt/data_objects/tests/test_dataset_access.py
@@ -114,13 +114,6 @@ def test_point_from_r():
     assert_equal(str(ex.exception),
                  'Dimensionality specified was 2 but we need 3')
 
-    # Test with ds.dimensionality != 3
-    ds = fake_random_ds([32, 32, 1])
-    with assert_raises(YTDimensionalityError) as ex:
-        ds.r[0.5,0.3]
-    assert_equal(str(ex.exception),
-                 'Dimensionality specified was 2 but we need 3')
-
 def test_ray_from_r():
     ds = fake_amr_ds(fields = ["density"])
     ray1 = ds.r[(0.1,0.2,0.3):(0.4,0.5,0.6)]


### PR DESCRIPTION
## PR Summary

Currently, `ds.r[...]` only works with 3D datasets (hardcoded limitation). I'm extending it to 2D datasets. As I'm writing this, it stands as a proof of concept because some use cases are not treated yet.

## demo with spherical 2d dataset

```python
ds = yt.load("amrvac/bw_2d0000.dat")

p1 = yt.plot_2d(ds, "density")
p1.set_figure_size(3)
p1.save("/tmp/spherical_alldata")

r = ds.r[:, np.pi/3:2/3*np.pi]
p2 = yt.plot_2d(ds, "density", data_source=r)
p2.set_figure_size(3)
p2.save("/tmp/spherical_azim_selection")

r = ds.r[1.3:2.6, np.pi/3:2/3*np.pi]
p3 = yt.plot_2d(ds, "density", data_source=r)
p3.set_figure_size(3)
p3.save("/tmp/spherical_2d_selection")
```

![spherical_alldata_Slice_phi_density](https://user-images.githubusercontent.com/14075922/76708335-50b13480-66f6-11ea-8cfc-25dc490e5543.png)

![spherical_azim_selection_Slice_phi_density](https://user-images.githubusercontent.com/14075922/76708342-5444bb80-66f6-11ea-999f-f2036a7ff0dd.png)

![spherical_2d_selection_Slice_phi_density](https://user-images.githubusercontent.com/14075922/76708346-57d84280-66f6-11ea-857a-e308d52f5512.png)

## To be clarified

- any idea what sort of test should be added ?
- as of now, I don't understand the purpose of the `nslices` variable in `RegionExpression.__getitem__` so I'm only dealing with the `nslices==2` case.

## to do

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.