### PR TITLE
Extend Dataset.add_gradient_fields to curvilinear geometries

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1400,7 +1400,7 @@ class Dataset(object):
         """
         self.index
         if not isinstance(input_field, tuple):
-            raise ValueError
+            raise TypeError
         ftype, input_field = input_field[0], input_field[1]
         units = self.field_info[ftype, input_field].units
         setup_gradient_fields(self.field_info, (ftype, input_field), units)

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1390,13 +1390,17 @@ class Dataset(object):
 
         Examples
         --------
-        with a cartesian dataset ds
+
         >>> grad_fields = ds.add_gradient_fields(("gas","temperature"))
         >>> print(grad_fields)
         [('gas', 'temperature_gradient_x'),
          ('gas', 'temperature_gradient_y'),
          ('gas', 'temperature_gradient_z'),
          ('gas', 'temperature_gradient_magnitude')]
+
+        note that the above example assumes ds.geometry == 'cartesian'
+        In general, the function will create gradients components along the axes of the dataset coordinate system.
+        For instance, with cylindrical data, one gets 'temperature_gradient_<r,theta,z>'
         """
         self.index
         if not isinstance(input_field, tuple):

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1406,9 +1406,8 @@ class Dataset(object):
         setup_gradient_fields(self.field_info, (ftype, input_field), units)
         # Now we make a list of the fields that were just made, to check them
         # and to return them
-        suffixes = self.coordinates.axis_order
         grad_fields = [(ftype,input_field+"_gradient_%s" % suffix)
-                       for suffix in suffixes]
+                       for suffix in self.coordinates.axis_order]
         grad_fields.append((ftype,input_field+"_gradient_magnitude"))
         deps, _ = self.field_info.check_derived_fields(grad_fields)
         self.field_dependencies.update(deps)

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -85,8 +85,6 @@ from yt.geometry.coordinates.api import \
     GeographicCoordinateHandler, \
     SpectralCubeCoordinateHandler, \
     InternalGeographicCoordinateHandler
-from yt.geometry.geometry_handler import \
-    is_curvilinear
 
 # We want to support the movie format in the future.
 # When such a thing comes to pass, I'll move all the stuff that is constant up
@@ -1408,12 +1406,7 @@ class Dataset(object):
         setup_gradient_fields(self.field_info, (ftype, input_field), units)
         # Now we make a list of the fields that were just made, to check them
         # and to return them
-        if not is_curvilinear(self.geometry):
-            suffixes = ["x", "y", "z"]
-        elif self.geometry in ("polar", "cylindrical"):
-            suffixes = ["r", "theta", "z"]
-        else:
-            raise NotImplementedError("Dataset.add_gradient_fields is not implemented for %s geometry." % self.geometry)
+        suffixes = self.coordinates.axis_order
         grad_fields = [(ftype,input_field+"_gradient_%s" % suffix)
                        for suffix in suffixes]
         grad_fields.append((ftype,input_field+"_gradient_magnitude"))

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1398,8 +1398,8 @@ class Dataset(object):
          ('gas', 'temperature_gradient_z'),
          ('gas', 'temperature_gradient_magnitude')]
 
-        note that the above example assumes ds.geometry == 'cartesian'
-        In general, the function will create gradients components along the axes of the dataset coordinate system.
+        Note that the above example assumes ds.geometry == 'cartesian'. In general, the function
+        will create gradients components along the axes of the dataset coordinate system.
         For instance, with cylindrical data, one gets 'temperature_gradient_<r,theta,z>'
         """
         self.index

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -399,7 +399,8 @@ class FieldInfoContainer(dict):
         fields_to_check = fields_to_check or list(self.keys())
         for field in fields_to_check:
             mylog.debug("Checking %s", field)
-            if field not in self: raise RuntimeError
+            if field not in self:
+                raise RuntimeError("Could not find field %s" % str(field))
             fi = self[field]
             try:
                 fd = fi.get_dependencies(ds = self.ds)

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -398,7 +398,6 @@ class FieldInfoContainer(dict):
         unavailable = []
         fields_to_check = fields_to_check or list(self.keys())
         for field in fields_to_check:
-            mylog.debug("Checking %s", field)
             if field not in self:
                 raise RuntimeError("Could not find field %s" % str(field))
             fi = self[field]

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -399,7 +399,7 @@ class FieldInfoContainer(dict):
         fields_to_check = fields_to_check or list(self.keys())
         for field in fields_to_check:
             if field not in self:
-                raise RuntimeError("Could not find field %s" % str(field))
+                raise YTFieldNotFound(str(field))
             fi = self[field]
             try:
                 fd = fi.get_dependencies(ds = self.ds)

--- a/yt/fields/fluid_fields.py
+++ b/yt/fields/fluid_fields.py
@@ -39,6 +39,8 @@ from yt.utilities.physical_constants import \
 from yt.utilities.lib.misc_utilities import \
     obtain_relative_velocity_vector
 
+from yt.funcs import mylog
+
 @register_field_plugin
 def setup_fluid_fields(registry, ftype = "gas", slice_info = None):
     # slice_info would be the left, the right, and the factor.
@@ -192,9 +194,9 @@ def setup_fluid_fields(registry, ftype = "gas", slice_info = None):
 
 def setup_gradient_fields(registry, grad_field, field_units, slice_info = None):
 
-    #geom = registry.ds.geometry
-    #if is_curvilinear(geom) and geom not in ("polar", "cylindrical"):
-    #    raise NotImplementedError("set_gradient_fields is not implemented for %s geometry." % geom)
+    geom = registry.ds.geometry
+    if is_curvilinear(geom):
+        mylog.warning("In %s geometry, gradient fields may contain artifacts near cartesian axes." % geom)
 
     assert(isinstance(grad_field, tuple))
     ftype, fname = grad_field
@@ -229,12 +231,10 @@ def setup_gradient_fields(registry, grad_field, field_units, slice_info = None):
     for axi, ax in enumerate(registry.ds.coordinates.axis_order):
         f = grad_func(axi, ax)
         registry.add_field((ftype, "%s_gradient_%s" % (fname, ax)),
-                               sampling_type="cell",
-                               function = f,
-                               validators = [ValidateSpatial(1, [grad_field])],
-                               units = grad_units)
-
+                           sampling_type="cell",
+                           function = f,
+                           validators = [ValidateSpatial(1, [grad_field])],
+                           units = grad_units)
     create_magnitude_field(registry, "%s_gradient" % fname,
                            grad_units, ftype=ftype,
                            validators = [ValidateSpatial(1, [grad_field])])
-    

--- a/yt/fields/fluid_fields.py
+++ b/yt/fields/fluid_fields.py
@@ -237,11 +237,10 @@ def setup_gradient_fields(registry, grad_field, field_units, slice_info = None):
 
             f = theta_grad_func
 
-        elif ax == "phi": # spherical geometries
+        elif ax == "phi":  # spherical geometries
             raise NotImplementedError
 
-        else:
-            # non-angular coordinates
+        else:  # non-angular coordinates
             f = grad_func(axi, ax)
 
         registry.add_field((ftype, "%s_gradient_%s" % (fname, ax)),

--- a/yt/fields/fluid_fields.py
+++ b/yt/fields/fluid_fields.py
@@ -192,6 +192,10 @@ def setup_fluid_fields(registry, ftype = "gas", slice_info = None):
 
 def setup_gradient_fields(registry, grad_field, field_units, slice_info = None):
 
+    geom = registry.ds.geometry
+    if is_curvilinear(geom) and geom not in ("polar", "cylindrical"):
+        raise NotImplementedError("set_gradient_fields is not implemented for %s geometry." % geom)
+
     assert(isinstance(grad_field, tuple))
     ftype, fname = grad_field
     if slice_info is None:
@@ -218,59 +222,33 @@ def setup_gradient_fields(registry, grad_field, field_units, slice_info = None):
     field_units = Unit(field_units, registry=registry.ds.unit_registry)
     grad_units = field_units / registry.ds.unit_system["length"]
 
-    geom = registry.ds.geometry
-    if not is_curvilinear(geom):
-        for axi, ax in enumerate('xyz'):
+    for axi, ax in enumerate(registry.ds.coordinates.axis_order):
+        if ax == "theta":
+            def theta_grad_func(field, data):
+                slice_3dl = slice_3d[:axi] + (sl_left,) + slice_3d[axi+1:]
+                slice_3dr = slice_3d[:axi] + (sl_right,) + slice_3d[axi+1:]
+                ds = div_fac * data[ftype, "dtheta"] * data[ftype, "r"]
+                f  = data[grad_field][slice_3dr]/ds[slice_3d]
+                f -= data[grad_field][slice_3dl]/ds[slice_3d]
+                new_field = np.zeros_like(data[grad_field], dtype=np.float64)
+                new_field = data.ds.arr(new_field, f.units)
+                new_field[slice_3d] = f
+                return new_field
+
+            f = theta_grad_func
+
+        elif ax == "phi": # spherical geometries
+            raise NotImplementedError
+
+        else:
+            # non-angular coordinates
             f = grad_func(axi, ax)
-            registry.add_field((ftype, "%s_gradient_%s" % (fname, ax)),
+
+        registry.add_field((ftype, "%s_gradient_%s" % (fname, ax)),
                                sampling_type="cell",
                                function = f,
                                validators = [ValidateSpatial(1, [grad_field])],
                                units = grad_units)
-    elif geom in ("polar", "cylindrical"):
-        # heavy copy pasta here. Refactoring is mandatory
-        ds = registry.ds
-
-        ax = "r"
-        axi = ds.coordinates.axis_id[ax]
-        f = grad_func(axi, ax)
-        registry.add_field((ftype, "%s_gradient_%s" % (fname, ax)),
-                            sampling_type="cell",
-                            function = f,
-                            validators = [ValidateSpatial(1, [grad_field])],
-                            units = grad_units)
-
-        ax = "theta"
-        axi = ds.coordinates.axis_id[ax]
-        def theta_func(field, data):
-            slice_3dl = slice_3d[:axi] + (sl_left,) + slice_3d[axi+1:]
-            slice_3dr = slice_3d[:axi] + (sl_right,) + slice_3d[axi+1:]
-            ds = div_fac * data[ftype, "dtheta"] * data[ftype, "r"]
-            f  = data[grad_field][slice_3dr]/ds[slice_3d]
-            f -= data[grad_field][slice_3dl]/ds[slice_3d]
-            new_field = np.zeros_like(data[grad_field], dtype=np.float64)
-            new_field = data.ds.arr(new_field, f.units)
-            new_field[slice_3d] = f
-            return new_field
-
-        f = theta_func
-        registry.add_field((ftype, "%s_gradient_%s" % (fname, ax)),
-                            sampling_type="cell",
-                            function = f,
-                            validators = [ValidateSpatial(1, [grad_field])],
-                            units = grad_units)
-
-        ax = "z"
-        axi = ds.coordinates.axis_id[ax]
-        f = grad_func(axi, ax)
-        registry.add_field((ftype, "%s_gradient_%s" % (fname, ax)),
-                            sampling_type="cell",
-                            function = f,
-                            validators = [ValidateSpatial(1, [grad_field])],
-                            units = grad_units)
-        
-    else:
-        raise NotImplementedError("Dataset.set_gradient_fields is not implemented for %s geometry." % geom)
 
     create_magnitude_field(registry, "%s_gradient" % fname,
                            grad_units, ftype=ftype,

--- a/yt/fields/tests/test_fields.py
+++ b/yt/fields/tests/test_fields.py
@@ -233,6 +233,27 @@ def test_add_gradient_fields():
         else:
             assert str(ret.units) == "1/cm"
 
+def test_add_gradient_fields_curvilinear():
+    ds = fake_amr_ds(geometry="spherical")
+    gfields = ds.add_gradient_fields(("stream", "density"))
+    gfields += ds.add_gradient_fields(("index", "ones"))
+    field_list = [('stream', 'density_gradient_r'),
+                  ('stream', 'density_gradient_theta'),
+                  ('stream', 'density_gradient_phi'),
+                  ('stream', 'density_gradient_magnitude'),
+                  ('index', 'ones_gradient_x'),
+                  ('index', 'ones_gradient_y'),
+                  ('index', 'ones_gradient_z'),
+                  ('index', 'ones_gradient_magnitude')]
+    assert_equal(gfields, field_list)
+    ad = ds.all_data()
+    for field in field_list:
+        ret = ad[field]
+        if field[0] == 'stream':
+            assert str(ret.units) == "g/cm**4"
+        else:
+            assert str(ret.units) == "1/cm"
+
 def get_data(ds, field_name):
     # Need to create a new data object otherwise the errors we are
     # intentionally raising lead to spurious GenerationInProgress errors

--- a/yt/fields/tests/test_fields.py
+++ b/yt/fields/tests/test_fields.py
@@ -237,7 +237,7 @@ def test_add_gradient_fields_curvilinear():
     def _dimensionful_density(field, data):
         return data.apply_units(data["Density"], "g/cm**3")
     ds = fake_amr_ds(geometry="spherical")
-    ds.add_field("density", _dimensionful_density, units="g/cm**3", sampling_type="cell")
+    ds.add_field(("gas", "density"), _dimensionful_density, units="g/cm**3", sampling_type="cell")
     gfields = ds.add_gradient_fields(("gas", "density"))
     gfields += ds.add_gradient_fields(("index", "ones"))
     field_list = [('gas', 'density_gradient_r'),

--- a/yt/fields/tests/test_fields.py
+++ b/yt/fields/tests/test_fields.py
@@ -241,9 +241,9 @@ def test_add_gradient_fields_curvilinear():
                   ('stream', 'Density_gradient_theta'),
                   ('stream', 'Density_gradient_phi'),
                   ('stream', 'Density_gradient_magnitude'),
-                  ('index', 'ones_gradient_x'),
-                  ('index', 'ones_gradient_y'),
-                  ('index', 'ones_gradient_z'),
+                  ('index', 'ones_gradient_r'),
+                  ('index', 'ones_gradient_theta'),
+                  ('index', 'ones_gradient_phi'),
                   ('index', 'ones_gradient_magnitude')]
     assert_equal(gfields, field_list)
     ad = ds.all_data()

--- a/yt/fields/tests/test_fields.py
+++ b/yt/fields/tests/test_fields.py
@@ -235,12 +235,12 @@ def test_add_gradient_fields():
 
 def test_add_gradient_fields_curvilinear():
     ds = fake_amr_ds(geometry="spherical")
-    gfields = ds.add_gradient_fields(("stream", "density"))
+    gfields = ds.add_gradient_fields(("stream", "Density"))
     gfields += ds.add_gradient_fields(("index", "ones"))
-    field_list = [('stream', 'density_gradient_r'),
-                  ('stream', 'density_gradient_theta'),
-                  ('stream', 'density_gradient_phi'),
-                  ('stream', 'density_gradient_magnitude'),
+    field_list = [('stream', 'Density_gradient_r'),
+                  ('stream', 'Density_gradient_theta'),
+                  ('stream', 'Density_gradient_phi'),
+                  ('stream', 'Density_gradient_magnitude'),
                   ('index', 'ones_gradient_x'),
                   ('index', 'ones_gradient_y'),
                   ('index', 'ones_gradient_z'),

--- a/yt/fields/tests/test_fields.py
+++ b/yt/fields/tests/test_fields.py
@@ -234,13 +234,16 @@ def test_add_gradient_fields():
             assert str(ret.units) == "1/cm"
 
 def test_add_gradient_fields_curvilinear():
+    def _dimensionful_density(field, data):
+        return data.apply_units(data["Density"], "g/cm**3")
     ds = fake_amr_ds(geometry="spherical")
-    gfields = ds.add_gradient_fields(("stream", "Density"))
+    ds.add_field("density", _dimensionful_density, units="g/cm**3", sampling_type="cell")
+    gfields = ds.add_gradient_fields(("gas", "density"))
     gfields += ds.add_gradient_fields(("index", "ones"))
-    field_list = [('stream', 'Density_gradient_r'),
-                  ('stream', 'Density_gradient_theta'),
-                  ('stream', 'Density_gradient_phi'),
-                  ('stream', 'Density_gradient_magnitude'),
+    field_list = [('gas', 'density_gradient_r'),
+                  ('gas', 'density_gradient_theta'),
+                  ('gas', 'density_gradient_phi'),
+                  ('gas', 'density_gradient_magnitude'),
                   ('index', 'ones_gradient_r'),
                   ('index', 'ones_gradient_theta'),
                   ('index', 'ones_gradient_phi'),
@@ -249,7 +252,7 @@ def test_add_gradient_fields_curvilinear():
     ad = ds.all_data()
     for field in field_list:
         ret = ad[field]
-        if field[0] == 'stream':
+        if field[0] == 'gas':
             assert str(ret.units) == "g/cm**4"
         else:
             assert str(ret.units) == "1/cm"


### PR DESCRIPTION
## PR Summary

Gradient computation is marginally more complex in curvilinear geometries.
Here I give a first sketch of an extension for `Dataset.add_gradient_fields` to `cylindrical` and `polar` coordinates.

Note that, for a `"polar"` (2D) dataset, plotting a meaningful gradient field in the radial direction is currently tricky because of boundary issues. Indeed the two usual workarounds are compromised, respectively because
- it makes little sense to assume/overwrite periodicity in that particular direction
- selecting a radially narrow region with e.g. `ds.r[1:2, :]` is currently not working in 2D, but a fix is in the making here https://github.com/yt-project/yt/pull/2482

I'll add visualisation examples here when this point is solved.

## PR Checklist

- [x] refactoring to minimise duplicated code
- [x] check that the theta gradient makes in practice
- [x] extension to spherical geometries

about the second point: I made a choice in the computation of the theta gradient, where both left and right terms have a common divisor `r` that is the central value. This may not be relevant in practice and I'll check whether or not this is the usual method.