### PR TITLE
Change order of operations.

### DIFF
--- a/yt/frontends/athena/fields.py
+++ b/yt/frontends/athena/fields.py
@@ -100,7 +100,7 @@ class AthenaFieldInfo(FieldInfoContainer):
                            units=unit_system["specific_energy"])
         # Add temperature field
         def _temperature(field, data):
-            return data.ds.mu*mh*data["gas","pressure"]/data["gas","density"]/kboltz
+            return data.ds.mu*data["gas","pressure"]/data["gas","density"]*mh/kboltz
         self.add_field(("gas","temperature"),
                        sampling_type="cell",
                        function=_temperature,


### PR DESCRIPTION
This is necessary so that the primary item in a binary operation in unyt has the necessary entry in the unit registry (specifically code_pressure).