### PR TITLE
Update CI recipes to fix recent failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ install:
         # These versions are pinned, so we will need to update/remove them when
         # the hack is no longer necessary.
         $PIP install numpy==1.18.1 cython==0.29.6
-        $PIP install -r tests/test_requirements.txt
+        CFLAGS="$CFLAGS -DACCEPT_USE_OF_DEPRECATED_PROJ_API_H" $PIP install -r tests/test_requirements.txt
       fi
       $PIP install -e .
     else

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,9 @@ environment:
 
   matrix:
       - PYTHON_VERSION: "2.7"
+        MPL_VERSION: "2.2.4"
       - PYTHON_VERSION: "3.6"
+        MPL_VERSION: "3.1.3"
 
 platform:
     -x64
@@ -30,7 +32,7 @@ install:
     - "python --version"
 
     # Install specified version of numpy and dependencies
-    - "conda install --yes -c conda-forge numpy scipy nose pytest setuptools ipython Cython sympy fastcache h5py matplotlib mock pandas cartopy conda-build pyyaml"
+    - "conda install --yes -c conda-forge numpy scipy nose pytest setuptools ipython Cython sympy fastcache h5py matplotlib=%MPL_VERSION% mock pandas cartopy conda-build pyyaml"
     - "conda develop -b ."
 
 # Not a .NET project

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -7,7 +7,7 @@ glueviz==0.13.3; python_version >= '3.0'
 h5py==2.8.0
 ipython==7.1.1; python_version >= '3.0'
 ipython==5.8.0; python_version < '3.0'
-matplotlib==3.0.1; python_version >= '3.0'
+matplotlib==3.0.3; python_version >= '3.0'
 matplotlib==2.2.3; python_version < '3.0'
 mock==2.0.0; python_version < '3.0'
 nose-timer==0.7.3
@@ -25,7 +25,7 @@ netCDF4==1.4.2
 libconf==1.0.1
 cartopy==0.17.0
 pyaml==17.10.0
-mpi4py==3.0.0
+mpi4py==3.0.3
 pyyaml>=4.2b1
 xarray==0.12.3 ; python_version >= '3.0'
 firefly_api>=0.0.2


### PR DESCRIPTION
Following fixes were applied:

 * Specify the mpl version on appveyor (mpl==3.2.0 contains a bug)
 * Bump mpi4py to fix build failure on Travis
 * Add -DACCEPT_USE_OF_DEPRECATED_PROJ_API_H to CFLAGS to fix Cartopy
 build on Travis