### PR TITLE
[WIP] try fixing appveyor (conda develop -> pip install) ?

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,9 +8,9 @@ environment:
 
   matrix:
       - PYTHON_VERSION: "2.7"
-        MPL_VERSION: "2.2.4"
+        MPL_VERSION: "2.2.4"  # latest MPL version supporting python 2
       - PYTHON_VERSION: "3.6"
-        MPL_VERSION: "3.1.3"
+        MPL_VERSION: "3.1.3"  # pinned because 3.2.0 causes a regression
 
 platform:
     -x64
@@ -33,7 +33,7 @@ install:
 
     # Install specified version of numpy and dependencies
     - "conda install --yes -c conda-forge numpy scipy nose pytest setuptools ipython Cython sympy fastcache h5py matplotlib=%MPL_VERSION% mock pandas cartopy conda-build pyyaml"
-    - "conda develop -b ."
+    - "pip install -e ."
 
 # Not a .NET project
 build: false


### PR DESCRIPTION
## PR Summary
So after @xarthisius successfully fixed the recent issues with appveyor, I’ve rebased most of my branches on master. Two of them (namely #2482 and #2483) are however still failling on appveyor, but the error seems new.  

The failure occurs on py27, where conda develop -b .  fails with 
```bash
WindowsError: [Error 126] The specified module could not be found
597
```

I'm trying `pip install -e .` as a replacement. Let's see what happens.