### PR TITLE
Fix load_sample function

### DIFF
--- a/yt/utilities/load_sample.py
+++ b/yt/utilities/load_sample.py
@@ -74,7 +74,7 @@ def load_sample(name=None, specific_file=None):
         loaded_file = os.path.join(base_path, "%s.untar" %fileext, name,
                                    specific_file)
 
-    load(loaded_file, **optional_args)
+    return load(loaded_file, **optional_args)
 
 def _validate_sampledata_name(name):
     """


### PR DESCRIPTION
There was an issue with load_sample that a dataset would get loaded, but the ds ended up being a NoneType. The load_sample function wasn't returning the loader, which is fixed in this PR. 

## PR Checklist
- [x] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

