### PR TITLE
add first cut at export to matplotlib figure

### DIFF
--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1,5 +1,7 @@
 import numpy as np
 import matplotlib
+import matplotlib.pyplot as plt
+from mpl_toolkits.axes_grid1 import ImageGrid
 import types
 import sys
 
@@ -1266,6 +1268,41 @@ class PWViewerMPL(PlotWindow):
         for f in field:
             self.plots[f].show_axes()
         return self
+
+    def export_to_mpl_figure(self, nrows_ncols, axes_pad=1.0, cbar_pad="0%"):
+        r"""
+        Creates a matplotlib figure object with the specified axes arrangment, nrows_ncols,
+        and maps the underlying figures to the matplotlib axes.
+
+        Parameters
+        ----------
+
+        nrows_ncols, tuple: the number of rows and columns of the axis grid (e.g., nrows_ncols=(2,2,)).
+        axes_pad, float: padding between axes--passed onto matplotlib
+        cbar_pad, string, percentage: padding between the axis and colorbar (e.g. "5%")
+        """
+
+        fig = plt.figure()
+        grid = ImageGrid(fig, 111,
+                         nrows_ncols=nrows_ncols,
+                         axes_pad=axes_pad,
+                         label_mode="L",
+                         cbar_mode="each",
+                         cbar_pad=cbar_pad)
+
+        fields = self.fields
+        if len(fields) > len(grid):
+            raise IndexError("not enough axes for the number of fields")
+
+        for i, f in enumerate(self.fields):
+            plot = self.plots[f]
+            plot.figure = fig
+            plot.axes = grid[i].axes
+            plot.cax = grid.cbar_axes[i]
+
+        self._setup_plots()
+
+        return fig
 
 class AxisAlignedSlicePlot(PWViewerMPL):
     r"""Creates a slice plot from a dataset

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1269,25 +1269,57 @@ class PWViewerMPL(PlotWindow):
             self.plots[f].show_axes()
         return self
 
-    def export_to_mpl_figure(self, nrows_ncols, axes_pad=1.0, cbar_pad="0%"):
+    def export_to_mpl_figure(self, nrows_ncols, axes_pad=1.0,
+                             label_mode="L",
+                             cbar_location="right", cbar_size="5%",
+                             cbar_mode="each", cbar_pad="0%"):
         r"""
         Creates a matplotlib figure object with the specified axes arrangment, nrows_ncols,
         and maps the underlying figures to the matplotlib axes.
 
+        The return is a matplotlib figure object.
+
         Parameters
         ----------
 
-        nrows_ncols, tuple: the number of rows and columns of the axis grid (e.g., nrows_ncols=(2,2,)).
-        axes_pad, float: padding between axes--passed onto matplotlib
-        cbar_pad, string, percentage: padding between the axis and colorbar (e.g. "5%")
+        nrows_ncols : tuple
+           the number of rows and columns of the axis grid (e.g., nrows_ncols=(2,2,))
+        axes_pad : float
+           padding between axes in inches
+        label_mode : one of "L", "1", "all"
+           arrangement of axes that are labeled
+        cbar_location : one of "left", "right", "bottom", "top"
+           where to place the colorbar
+        cbar_size : string (percentage)
+           scaling of the colorbar (e.g., "5%")
+        cbar_mode : one of "each", "single", "edge", None
+           how to represent the colorbar
+        cbar_pad : string (percentage)
+           padding between the axis and colorbar (e.g. "5%")
+
+        Examples
+        --------
+
+        >>> import yt
+        >>> ds = yt.load_sample("IsolatedGalaxy")
+        >>> fields = ['density', 'velocity_x', 'velocity_y', 'velocity_magnitude']
+        >>> p = yt.SlicePlot(ds, 'z', fields)
+        >>> p.set_log('velocity_x', False)
+        >>> p.set_log('velocity_y', False)
+        >>> fig = p.export_to_mpl_figure((2,2))
+        >>> fig.tight_layout()
+        >>> fig.savefig("test.png")
+
         """
 
         fig = plt.figure()
         grid = ImageGrid(fig, 111,
                          nrows_ncols=nrows_ncols,
                          axes_pad=axes_pad,
-                         label_mode="L",
-                         cbar_mode="each",
+                         label_mode=label_mode,
+                         cbar_location=cbar_location,
+                         cbar_size=cbar_size,
+                         cbar_mode=cbar_mode,
                          cbar_pad=cbar_pad)
 
         fields = self.fields

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1274,10 +1274,10 @@ class PWViewerMPL(PlotWindow):
                              cbar_location="right", cbar_size="5%",
                              cbar_mode="each", cbar_pad="0%"):
         r"""
-        Creates a matplotlib figure object with the specified axes arrangment, nrows_ncols,
-        and maps the underlying figures to the matplotlib axes.
-
-        The return is a matplotlib figure object.
+        Creates a matplotlib figure object with the specified axes arrangement, nrows_ncols,
+        and maps the underlying figures to the matplotlib axes.  Note that all of these
+        parameters are fed directly to the matplotlib ImageGrid class to create the new figure
+        layout.
 
         Parameters
         ----------
@@ -1296,6 +1296,11 @@ class PWViewerMPL(PlotWindow):
            how to represent the colorbar
         cbar_pad : string (percentage)
            padding between the axis and colorbar (e.g. "5%")
+
+        Returns
+        -------
+
+        The return is a matplotlib figure object.
 
         Examples
         --------


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

A common operation is to make a matplotlib figure and grid of axes to display slice plots or projection plots, e.g., as shown in this cookbook recipe:

https://yt-project.org/docs/dev/cookbook/complex_plots.html#multipanel-with-axes-labels

This adds a method to `PWViewerMPL` to automate a lot of that setup.  E.g., you would now do that recipe as:
```

import yt

ds = yt.load_sample("IsolatedGalaxy")

fields = ['density', 'velocity_x', 'velocity_y', 'velocity_magnitude']
p = yt.SlicePlot(ds, 'z', fields)
p.set_log('velocity_x', False)
p.set_log('velocity_y', False)

fig = p.export_to_mpl_figure((2,2))
fig.tight_layout()

fig.savefig("test.png")
```


<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
