### PR TITLE
Read new RAMSES info_rt format (compatible with old)

### DIFF
--- a/yt/frontends/ramses/field_handlers.py
+++ b/yt/frontends/ramses/field_handlers.py
@@ -491,10 +491,10 @@ class RTFieldFileHandler(FieldFileHandler):
                 read_rhs(int)
             # Try to read rtprecision
             try:
-		read_rhs(int)
-		f.readline()
+                read_rhs(int)
+                f.readline()
             except Exception:
-                pass    
+                pass
 
             # Read X and Y fractions
             for _ in range(2):

--- a/yt/frontends/ramses/field_handlers.py
+++ b/yt/frontends/ramses/field_handlers.py
@@ -489,6 +489,11 @@ class RTFieldFileHandler(FieldFileHandler):
             # Read nRTvar, nions, ngroups, iions
             for _ in range(4):
                 read_rhs(int)
+            # Try to read new rtprecision
+            try:
+                read_rhs(int)
+            except Exception:
+                pass                
             f.readline()
 
             # Read X and Y fractions

--- a/yt/frontends/ramses/field_handlers.py
+++ b/yt/frontends/ramses/field_handlers.py
@@ -489,11 +489,15 @@ class RTFieldFileHandler(FieldFileHandler):
             # Read nRTvar, nions, ngroups, iions
             for _ in range(4):
                 read_rhs(int)
-            # Try to read rtprecision
+
+            # Try to read rtprecision.
+            # Either it is present or the line is simply blank, so
+            # we try to parse the line as an int, and if it fails,
+            # we simply ignore it.
             try:
                 read_rhs(int)
                 f.readline()
-            except Exception:
+            except ValueError:
                 pass
 
             # Read X and Y fractions

--- a/yt/frontends/ramses/field_handlers.py
+++ b/yt/frontends/ramses/field_handlers.py
@@ -489,12 +489,12 @@ class RTFieldFileHandler(FieldFileHandler):
             # Read nRTvar, nions, ngroups, iions
             for _ in range(4):
                 read_rhs(int)
-            # Try to read new rtprecision
+            # Try to read rtprecision
             try:
                 read_rhs(int)
+		f.readline()
             except Exception:
-                pass                
-            f.readline()
+                pass    
 
             # Read X and Y fractions
             for _ in range(2):

--- a/yt/frontends/ramses/field_handlers.py
+++ b/yt/frontends/ramses/field_handlers.py
@@ -491,7 +491,7 @@ class RTFieldFileHandler(FieldFileHandler):
                 read_rhs(int)
             # Try to read rtprecision
             try:
-                read_rhs(int)
+		read_rhs(int)
 		f.readline()
             except Exception:
                 pass    


### PR DESCRIPTION
New RAMSES-RT info files contain information about the RT precision. This can be read in a backwards-compatible manner with a simple try / except.