### PR TITLE
Bump netcdf4 requirement

### DIFF
--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -21,7 +21,7 @@ sympy==1.5
 pyqt5==5.11.3; python_version >= '3.0'
 thingking==1.0.2; python_version < '3.0'
 pint==0.8.1
-netCDF4==1.4.2
+netCDF4==1.5.3
 libconf==1.0.1
 cartopy==0.17.0
 pyaml==17.10.0


### PR DESCRIPTION
This fixes confusing failures when running the cookbook, as FLASH datasets on py38 seem to cause issues with netCDF4 < 1.5.2.