### PR TITLE
Update to matplotlib's current png interface

### DIFF
--- a/yt/utilities/png_writer.py
+++ b/yt/utilities/png_writer.py
@@ -18,13 +18,14 @@ if PY2:
 else:
     from io import BytesIO as StringIO
 
-def call_png_write_png(buffer, width, height, filename, dpi):
+def call_png_write_png(buffer, width, height, fileobj, dpi):
     _png.write_png(buffer, filename, dpi)
 
 def write_png(buffer, filename, dpi=100):
     width = buffer.shape[1]
     height = buffer.shape[0]
-    call_png_write_png(buffer, width, height, filename, dpi)
+    with open(filename, "wb") as fileobj:
+        call_png_write_png(buffer, width, height, fileobj, dpi)
 
 def write_png_to_string(buffer, dpi=100, gray=0):
     width = buffer.shape[1]

--- a/yt/utilities/png_writer.py
+++ b/yt/utilities/png_writer.py
@@ -19,7 +19,7 @@ else:
     from io import BytesIO as StringIO
 
 def call_png_write_png(buffer, width, height, fileobj, dpi):
-    _png.write_png(buffer, filename, dpi)
+    _png.write_png(buffer, fileobj, dpi)
 
 def write_png(buffer, filename, dpi=100):
     width = buffer.shape[1]


### PR DESCRIPTION
As noted in https://github.com/matplotlib/matplotlib/pull/15095,
matplotlib's png module now only takes file-like objects.  This should
fix our usage of it to conform with that.