### PR TITLE
hotfix: bug in cylindrical coordinates background color with log norm

### DIFF
--- a/doc/source/developing/testing.rst
+++ b/doc/source/developing/testing.rst
@@ -402,7 +402,7 @@ Here is an example test function:
        yield test
 
 .. note:: The inner function ``create_image`` can create any number of images,
-          as long as the corresponding filenames conform to the prefix.
+   as long as the corresponding filenames conform to the prefix.
 
 Another good example of an image comparison test is the
 ``PlotWindowAttributeTest`` defined in the answer testing framework and used in

--- a/doc/source/developing/testing.rst
+++ b/doc/source/developing/testing.rst
@@ -387,17 +387,10 @@ Here is an example test function:
    def test_my_ds():
        ds = data_dir_load(my_ds)
 
-       def create_images(filename_prefix):
-            plot = yt.SlicePlot(ds, "z", "density")
-            plot.save("%s_log" % filename_prefix)
-
-            plot.set_log("density", False)
-            plot.save("%s_lin" % filename_prefix)
-
-            plt.plot([1, 2], [1, 2])
-            plt.savefig("%s_lineplot" % filename_prefix)
-
-       test = GenericImageTest(ds, create_images, 12)
+       def create_image(filename_prefix):
+           plt.plot([1, 2], [1, 2])
+           plt.savefig("%s_lineplot" % filename_prefix)
+       test = GenericImageTest(ds, create_image, 12)
 
        # this ensures the test has a unique key in the
        # answer test storage file
@@ -407,7 +400,8 @@ Here is an example test function:
        test_my_ds.__name__ = test.description
 
        yield test
-.. note:: The inner function ``create_images`` can create any number of images,
+
+.. note:: The inner function ``create_image`` can create any number of images,
           as long as the corresponding filenames conform to the prefix.
 
 Another good example of an image comparison test is the

--- a/doc/source/developing/testing.rst
+++ b/doc/source/developing/testing.rst
@@ -387,10 +387,17 @@ Here is an example test function:
    def test_my_ds():
        ds = data_dir_load(my_ds)
 
-       def create_image(filename_prefix):
-           plt.plot([1, 2], [1, 2])
-           plt.savefig(filename_prefix)
-       test = GenericImageTest(ds, create_image, 12)
+       def create_images(filename_prefix):
+            plot = yt.SlicePlot(ds, "z", "density")
+            plot.save("%s_log" % filename_prefix)
+
+            plot.set_log("density", False)
+            plot.save("%s_lin" % filename_prefix)
+
+            plt.plot([1, 2], [1, 2])
+            plt.savefig("%s_lineplot" % filename_prefix)
+
+       test = GenericImageTest(ds, create_images, 12)
 
        # this ensures the test has a unique key in the
        # answer test storage file
@@ -400,6 +407,8 @@ Here is an example test function:
        test_my_ds.__name__ = test.description
 
        yield test
+.. note:: The inner function ``create_images`` can create any number of images,
+          as long as the corresponding filenames conform to the prefix.
 
 Another good example of an image comparison test is the
 ``PlotWindowAttributeTest`` defined in the answer testing framework and used in

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -129,8 +129,7 @@ answer_tests:
     - yt/geometry/coordinates/tests/test_axial_pixelization.py:test_axial_pixelization
 
   local_cylindrical_background_000:
-    - yt/geometry/coordinates/tests/test_cylindrical_coordinates.py:test_noise_plot_lin
-    - yt/geometry/coordinates/tests/test_cylindrical_coordinates.py:test_noise_plot_log
+    - yt/geometry/coordinates/tests/test_cylindrical_coordinates.py:test_noise_plots
 
   local_particle_trajectory_001:
     - yt/data_objects/tests/test_particle_trajectories.py

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -128,6 +128,10 @@ answer_tests:
   local_axialpix_006:
     - yt/geometry/coordinates/tests/test_axial_pixelization.py:test_axial_pixelization
 
+  local_cylindrical_background_000:
+    - yt/geometry/coordinates/tests/test_cylindrical_coordinates.py:test_noise_plot_lin
+    - yt/geometry/coordinates/tests/test_cylindrical_coordinates.py:test_noise_plot_log
+
   local_particle_trajectory_001:
     - yt/data_objects/tests/test_particle_trajectories.py
 

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -128,7 +128,7 @@ answer_tests:
   local_axialpix_006:
     - yt/geometry/coordinates/tests/test_axial_pixelization.py:test_axial_pixelization
 
-  local_cylindrical_background_000:
+  local_cylindrical_background_001:
     - yt/geometry/coordinates/tests/test_cylindrical_coordinates.py:test_noise_plots
 
   local_particle_trajectory_001:

--- a/yt/geometry/coordinates/coordinate_handler.py
+++ b/yt/geometry/coordinates/coordinate_handler.py
@@ -272,11 +272,11 @@ class CoordinateHandler(object):
 
     def sanitize_buffer_fill_values(self, buff):
         """Replace nans with +inf in buff, if all valid values are positive"""
-        # In buffers with only positive values, maplotlib will raise a warning
+        # In buffer with only positive values, maplotlib will raise a warning
         # if nan is used as a filler, while it tolerates np.inf just fine
-        minval = buff[buff == buff].min()
+        minval = buff[~np.isnan(buff)].min()
         if minval >= 0:
-            buff[buff != buff] = np.inf
+            buff[np.isnan(buff)] = np.inf
 
 def cartesian_to_cylindrical(coord, center = (0,0,0)):
     c2 = np.zeros_like(coord)

--- a/yt/geometry/coordinates/coordinate_handler.py
+++ b/yt/geometry/coordinates/coordinate_handler.py
@@ -275,7 +275,7 @@ class CoordinateHandler(object):
         # In buffers with only positive values, maplotlib will raise a warning
         # if nan is used as a filler, while it tolerates np.inf just fine
         minval = buff[buff == buff].min()
-        if minval > 0:
+        if minval >= 0:
             buff[buff != buff] = np.inf
 
 def cartesian_to_cylindrical(coord, center = (0,0,0)):

--- a/yt/geometry/coordinates/coordinate_handler.py
+++ b/yt/geometry/coordinates/coordinate_handler.py
@@ -270,6 +270,13 @@ class CoordinateHandler(object):
         display_center = self.convert_to_cartesian(center)
         return center, display_center
 
+    def sanitize_buffer_fill_values(self, buff):
+        """Replace nans with +inf in buff, if all valid values are positive"""
+        # In buffers with only positive values, maplotlib will raise a warning
+        # if nan is used as a filler, while it tolerates np.inf just fine
+        minval = buff[buff == buff].min()
+        if minval > 0:
+            buff[buff != buff] = np.inf
 
 def cartesian_to_cylindrical(coord, center = (0,0,0)):
     c2 = np.zeros_like(coord)

--- a/yt/geometry/coordinates/cylindrical_coordinates.py
+++ b/yt/geometry/coordinates/cylindrical_coordinates.py
@@ -128,7 +128,7 @@ class CylindricalCoordinateHandler(CoordinateHandler):
         return buff
 
     def _cyl_pixelize(self, data_source, field, bounds, size, antialias):
-        buff = np.zeros((size[1], size[0]), dtype="f8")
+        buff = np.full((size[1], size[0]), np.inf, dtype="f8")
         pixelize_cylinder(buff,
                           data_source['px'],
                           data_source['pdx'],

--- a/yt/geometry/coordinates/cylindrical_coordinates.py
+++ b/yt/geometry/coordinates/cylindrical_coordinates.py
@@ -128,13 +128,14 @@ class CylindricalCoordinateHandler(CoordinateHandler):
         return buff
 
     def _cyl_pixelize(self, data_source, field, bounds, size, antialias):
-        buff = np.full((size[1], size[0]), np.inf, dtype="f8")
+        buff = np.full((size[1], size[0]), np.nan, dtype="f8")
         pixelize_cylinder(buff,
                           data_source['px'],
                           data_source['pdx'],
                           data_source['py'],
                           data_source['pdy'],
                           data_source[field], bounds)
+        self.sanitize_buffer_fill_values(buff)
         return buff
 
     _x_pairs = (('r', 'theta'), ('z', 'r'), ('theta', 'r'))

--- a/yt/geometry/coordinates/geographic_coordinates.py
+++ b/yt/geometry/coordinates/geographic_coordinates.py
@@ -213,11 +213,12 @@ class GeographicCoordinateHandler(CoordinateHandler):
         else:
             # We should never get here!
             raise NotImplementedError
-        buff = np.full((size[1], size[0]), np.inf, dtype="f8")
+        buff = np.full((size[1], size[0]), np.nan, dtype="f8")
         pixelize_cylinder(buff, r, data_source['pdy'],
                           px, pdx, data_source[field], bounds)
         if do_transpose:
             buff = buff.transpose()
+        self.sanitize_buffer_fill_values(buff)
         return buff
 
     def convert_from_cartesian(self, coord):

--- a/yt/geometry/coordinates/geographic_coordinates.py
+++ b/yt/geometry/coordinates/geographic_coordinates.py
@@ -213,7 +213,7 @@ class GeographicCoordinateHandler(CoordinateHandler):
         else:
             # We should never get here!
             raise NotImplementedError
-        buff = np.zeros((size[1], size[0]), dtype="f8")
+        buff = np.full((size[1], size[0]), np.inf, dtype="f8")
         pixelize_cylinder(buff, r, data_source['pdy'],
                           px, pdx, data_source[field], bounds)
         if do_transpose:

--- a/yt/geometry/coordinates/spherical_coordinates.py
+++ b/yt/geometry/coordinates/spherical_coordinates.py
@@ -125,7 +125,7 @@ class SphericalCoordinateHandler(CoordinateHandler):
     def _cyl_pixelize(self, data_source, field, bounds, size, antialias,
                       dimension):
         name = self.axis_name[dimension]
-        buff = np.zeros((size[1], size[0]), dtype="f8")
+        buff = np.full((size[1], size[0]), np.inf, dtype="f8")
         if name == 'theta':
             pixelize_cylinder(buff,
                               data_source['px'],

--- a/yt/geometry/coordinates/spherical_coordinates.py
+++ b/yt/geometry/coordinates/spherical_coordinates.py
@@ -125,7 +125,7 @@ class SphericalCoordinateHandler(CoordinateHandler):
     def _cyl_pixelize(self, data_source, field, bounds, size, antialias,
                       dimension):
         name = self.axis_name[dimension]
-        buff = np.full((size[1], size[0]), np.inf, dtype="f8")
+        buff = np.full((size[1], size[0]), np.nan, dtype="f8")
         if name == 'theta':
             pixelize_cylinder(buff,
                               data_source['px'],
@@ -143,6 +143,7 @@ class SphericalCoordinateHandler(CoordinateHandler):
                              data_source[field], bounds)
         else:
             raise RuntimeError
+        self.sanitize_buffer_fill_values(buff)
         return buff
 
 

--- a/yt/geometry/coordinates/tests/test_axial_pixelization.py
+++ b/yt/geometry/coordinates/tests/test_axial_pixelization.py
@@ -1,9 +1,90 @@
+import matplotlib.pyplot as plt
 from yt.testing import \
-    fake_amr_ds, _geom_transforms
+    fake_amr_ds, _geom_transforms, add_noise_fields
 from yt.utilities.answer_testing.framework import \
-    AxialPixelizationTest
+    AxialPixelizationTest, \
+    GenericImageTest
+from yt import SlicePlot
 
 def test_axial_pixelization():
     for geom in sorted(_geom_transforms):
         ds = fake_amr_ds(geometry=geom)
         yield AxialPixelizationTest(ds)
+
+
+def test_noise_plot_lin():
+    ds = fake_amr_ds()
+    add_noise_fields(ds)
+
+    def create_image_lin(filename_prefix):
+        fields = ['density'] + ['noise%d' % i for i in range(4)]
+        p = SlicePlot(ds, 'z', fields)
+        p.set_log('all', False) # <- the one diff line with test_noise_plot_log
+        # lines bellow can later be replaced with the following snippet (see PR 2497)
+        # 
+        # fig = p.export_to_mpl_figure((2,2))
+        # fig.savefig('noise_plot_lin.png')
+        from mpl_toolkits.axes_grid1 import AxesGrid
+        fig = plt.figure()
+
+        grid = AxesGrid(fig, (0.075,0.075,0.85,0.85),
+                nrows_ncols = (2, 2),
+                axes_pad = 1.0,
+                label_mode = "1",
+                share_all = True,
+                cbar_location="right",
+                cbar_mode="each",
+                cbar_size="3%",
+                cbar_pad="0%")
+
+        for i, field in enumerate(fields):
+            plot = p.plots[field]
+            plot.figure = fig
+            plot.axes = grid[i].axes
+            plot.cax = grid.cbar_axes[i]
+
+        p._setup_plots()
+        plt.savefig('noise_plot_lin.png')
+
+    test = GenericImageTest(ds, create_image_lin, 12)
+    test.prefix = "test_noise_plot_lin"
+    test_noise_plot_lin.__name__ = test.description
+    yield test
+
+def test_noise_plot_log():
+    ds = fake_amr_ds()
+    add_noise_fields(ds)
+
+    def create_image_log(filename_prefix):
+        fields = ['density'] + ['noise%d' % i for i in range(4)]
+        p = SlicePlot(ds, 'z', fields)
+        # lines bellow can later be replaced with the following snippet (see PR 2497)
+        # 
+        # fig = p.export_to_mpl_figure((2,2))
+        # fig.savefig('noise_plot_log.png')
+        from mpl_toolkits.axes_grid1 import AxesGrid
+        fig = plt.figure()
+
+        grid = AxesGrid(fig, (0.075,0.075,0.85,0.85),
+                nrows_ncols = (2, 2),
+                axes_pad = 1.0,
+                label_mode = "1",
+                share_all = True,
+                cbar_location="right",
+                cbar_mode="each",
+                cbar_size="3%",
+                cbar_pad="0%")
+
+        for i, field in enumerate(fields):
+            plot = p.plots[field]
+            plot.figure = fig
+            plot.axes = grid[i].axes
+            plot.cax = grid.cbar_axes[i]
+
+        p._setup_plots()
+        plt.savefig('noise_plot_log.png')
+
+    test = GenericImageTest(ds, create_image_log, 12)
+    test.prefix = "test_noise_plot_log"
+    test_noise_plot_log.__name__ = test.description
+    yield test

--- a/yt/geometry/coordinates/tests/test_axial_pixelization.py
+++ b/yt/geometry/coordinates/tests/test_axial_pixelization.py
@@ -13,7 +13,7 @@ def test_axial_pixelization():
 
 
 def test_noise_plot_lin():
-    ds = fake_amr_ds()
+    ds = fake_amr_ds(geometry="cylindrical")
     add_noise_fields(ds)
 
     def create_image_lin(filename_prefix):
@@ -52,7 +52,7 @@ def test_noise_plot_lin():
     yield test
 
 def test_noise_plot_log():
-    ds = fake_amr_ds()
+    ds = fake_amr_ds(geometry="cylindrical")
     add_noise_fields(ds)
 
     def create_image_log(filename_prefix):

--- a/yt/geometry/coordinates/tests/test_axial_pixelization.py
+++ b/yt/geometry/coordinates/tests/test_axial_pixelization.py
@@ -1,90 +1,9 @@
-import matplotlib.pyplot as plt
 from yt.testing import \
-    fake_amr_ds, _geom_transforms, add_noise_fields
+    fake_amr_ds, _geom_transforms
 from yt.utilities.answer_testing.framework import \
-    AxialPixelizationTest, \
-    GenericImageTest
-from yt import SlicePlot
+    AxialPixelizationTest
 
 def test_axial_pixelization():
     for geom in sorted(_geom_transforms):
         ds = fake_amr_ds(geometry=geom)
         yield AxialPixelizationTest(ds)
-
-
-def test_noise_plot_lin():
-    ds = fake_amr_ds(geometry="cylindrical")
-    add_noise_fields(ds)
-
-    def create_image_lin(filename_prefix):
-        fields = ['density'] + ['noise%d' % i for i in range(4)]
-        p = SlicePlot(ds, 'z', fields)
-        p.set_log('all', False) # <- the one diff line with test_noise_plot_log
-        # lines bellow can later be replaced with the following snippet (see PR 2497)
-        # 
-        # fig = p.export_to_mpl_figure((2,2))
-        # fig.savefig('noise_plot_lin.png')
-        from mpl_toolkits.axes_grid1 import AxesGrid
-        fig = plt.figure()
-
-        grid = AxesGrid(fig, (0.075,0.075,0.85,0.85),
-                nrows_ncols = (2, 2),
-                axes_pad = 1.0,
-                label_mode = "1",
-                share_all = True,
-                cbar_location="right",
-                cbar_mode="each",
-                cbar_size="3%",
-                cbar_pad="0%")
-
-        for i, field in enumerate(fields):
-            plot = p.plots[field]
-            plot.figure = fig
-            plot.axes = grid[i].axes
-            plot.cax = grid.cbar_axes[i]
-
-        p._setup_plots()
-        plt.savefig('noise_plot_lin.png')
-
-    test = GenericImageTest(ds, create_image_lin, 12)
-    test.prefix = "test_noise_plot_lin"
-    test_noise_plot_lin.__name__ = test.description
-    yield test
-
-def test_noise_plot_log():
-    ds = fake_amr_ds(geometry="cylindrical")
-    add_noise_fields(ds)
-
-    def create_image_log(filename_prefix):
-        fields = ['density'] + ['noise%d' % i for i in range(4)]
-        p = SlicePlot(ds, 'z', fields)
-        # lines bellow can later be replaced with the following snippet (see PR 2497)
-        # 
-        # fig = p.export_to_mpl_figure((2,2))
-        # fig.savefig('noise_plot_log.png')
-        from mpl_toolkits.axes_grid1 import AxesGrid
-        fig = plt.figure()
-
-        grid = AxesGrid(fig, (0.075,0.075,0.85,0.85),
-                nrows_ncols = (2, 2),
-                axes_pad = 1.0,
-                label_mode = "1",
-                share_all = True,
-                cbar_location="right",
-                cbar_mode="each",
-                cbar_size="3%",
-                cbar_pad="0%")
-
-        for i, field in enumerate(fields):
-            plot = p.plots[field]
-            plot.figure = fig
-            plot.axes = grid[i].axes
-            plot.cax = grid.cbar_axes[i]
-
-        p._setup_plots()
-        plt.savefig('noise_plot_log.png')
-
-    test = GenericImageTest(ds, create_image_log, 12)
-    test.prefix = "test_noise_plot_log"
-    test_noise_plot_log.__name__ = test.description
-    yield test

--- a/yt/geometry/coordinates/tests/test_cylindrical_coordinates.py
+++ b/yt/geometry/coordinates/tests/test_cylindrical_coordinates.py
@@ -35,7 +35,7 @@ def test_cylindrical_coordinates():
     assert_equal(dd["index", "path_element_theta"],
                  dd["index", "r"] * dd["index", "dtheta"])
 
-def test_noise_plot_lin():
+def test_noise_plots():
     ds = fake_amr_ds(geometry="cylindrical")
     add_noise_fields(ds)
 
@@ -50,5 +50,5 @@ def test_noise_plot_lin():
 
     test = GenericImageTest(ds, create_image, 12)
     test.prefix = "test_noise_plot_lin"
-    test_noise_plot_lin.__name__ = test.description
+    test_noise_plots.__name__ = test.description
     yield test

--- a/yt/geometry/coordinates/tests/test_cylindrical_coordinates.py
+++ b/yt/geometry/coordinates/tests/test_cylindrical_coordinates.py
@@ -1,11 +1,16 @@
 # Some tests for the Cylindrical coordinates handler
 
 import numpy as np
+import matplotlib.pyplot as plt
 
 from yt.testing import \
     fake_amr_ds, \
     assert_equal, \
-    assert_almost_equal
+    assert_almost_equal, \
+    add_noise_fields
+
+from yt.utilities.answer_testing.framework import GenericImageTest
+from yt import SlicePlot
 
 # Our canonical tests are that we can access all of our fields and we can
 # compute our volume correctly.
@@ -30,3 +35,80 @@ def test_cylindrical_coordinates():
     assert_equal(dd["index", "path_element_z"], dd["index", "dz"])
     assert_equal(dd["index", "path_element_theta"],
                  dd["index", "r"] * dd["index", "dtheta"])
+
+def test_noise_plot_lin():
+    ds = fake_amr_ds(geometry="cylindrical")
+    add_noise_fields(ds)
+
+    def create_image_lin(filename_prefix):
+        fields = ['density'] + ['noise%d' % i for i in range(4)]
+        p = SlicePlot(ds, 'z', fields)
+        p.set_log('all', False) # <- the one diff line with test_noise_plot_log
+        # lines bellow can later be replaced with the following snippet (see PR 2497)
+        # 
+        # fig = p.export_to_mpl_figure((2,2))
+        # fig.savefig('noise_plot_lin.png')
+        from mpl_toolkits.axes_grid1 import AxesGrid
+        fig = plt.figure()
+
+        grid = AxesGrid(fig, (0.075,0.075,0.85,0.85),
+                nrows_ncols = (2, 2),
+                axes_pad = 1.0,
+                label_mode = "1",
+                share_all = True,
+                cbar_location="right",
+                cbar_mode="each",
+                cbar_size="3%",
+                cbar_pad="0%")
+
+        for i, field in enumerate(fields):
+            plot = p.plots[field]
+            plot.figure = fig
+            plot.axes = grid[i].axes
+            plot.cax = grid.cbar_axes[i]
+
+        p._setup_plots()
+        plt.savefig('noise_plot_lin.png')
+
+    test = GenericImageTest(ds, create_image_lin, 12)
+    test.prefix = "test_noise_plot_lin"
+    test_noise_plot_lin.__name__ = test.description
+    yield test
+
+def test_noise_plot_log():
+    ds = fake_amr_ds(geometry="cylindrical")
+    add_noise_fields(ds)
+
+    def create_image_log(filename_prefix):
+        fields = ['density'] + ['noise%d' % i for i in range(4)]
+        p = SlicePlot(ds, 'z', fields)
+        # lines bellow can later be replaced with the following snippet (see PR 2497)
+        # 
+        # fig = p.export_to_mpl_figure((2,2))
+        # fig.savefig('noise_plot_log.png')
+        from mpl_toolkits.axes_grid1 import AxesGrid
+        fig = plt.figure()
+
+        grid = AxesGrid(fig, (0.075,0.075,0.85,0.85),
+                nrows_ncols = (2, 2),
+                axes_pad = 1.0,
+                label_mode = "1",
+                share_all = True,
+                cbar_location="right",
+                cbar_mode="each",
+                cbar_size="3%",
+                cbar_pad="0%")
+
+        for i, field in enumerate(fields):
+            plot = p.plots[field]
+            plot.figure = fig
+            plot.axes = grid[i].axes
+            plot.cax = grid.cbar_axes[i]
+
+        p._setup_plots()
+        plt.savefig('noise_plot_log.png')
+
+    test = GenericImageTest(ds, create_image_log, 12)
+    test.prefix = "test_noise_plot_log"
+    test_noise_plot_log.__name__ = test.description
+    yield test

--- a/yt/geometry/coordinates/tests/test_cylindrical_coordinates.py
+++ b/yt/geometry/coordinates/tests/test_cylindrical_coordinates.py
@@ -1,7 +1,6 @@
 # Some tests for the Cylindrical coordinates handler
 
 import numpy as np
-import matplotlib.pyplot as plt
 
 from yt.testing import \
     fake_amr_ds, \
@@ -39,76 +38,19 @@ def test_cylindrical_coordinates():
 def test_noise_plot_lin():
     ds = fake_amr_ds(geometry="cylindrical")
     add_noise_fields(ds)
+    def create_image(filename_prefix):
+        fields = ['noise%d' % i for i in range(4)]
 
-    def create_image_lin(filename_prefix):
-        fields = ['density'] + ['noise%d' % i for i in range(4)]
-        p = SlicePlot(ds, 'z', fields)
-        p.set_log('all', False) # <- the one diff line with test_noise_plot_log
-        # lines bellow can later be replaced with the following snippet (see PR 2497)
-        # 
-        # fig = p.export_to_mpl_figure((2,2))
-        # fig.savefig('noise_plot_lin.png')
-        from mpl_toolkits.axes_grid1 import AxesGrid
-        fig = plt.figure()
+        for f in fields:
+            p = SlicePlot(ds, 'z', f)
+            p.save('%s_%s_log' % (filename_prefix, f))
 
-        grid = AxesGrid(fig, (0.075,0.075,0.85,0.85),
-                nrows_ncols = (2, 2),
-                axes_pad = 1.0,
-                label_mode = "1",
-                share_all = True,
-                cbar_location="right",
-                cbar_mode="each",
-                cbar_size="3%",
-                cbar_pad="0%")
+        p.set_log('all', False)
+        for f in fields:
+            p = SlicePlot(ds, 'z', f)
+            p.save('%s_%s_lin' % (filename_prefix, f))
 
-        for i, field in enumerate(fields):
-            plot = p.plots[field]
-            plot.figure = fig
-            plot.axes = grid[i].axes
-            plot.cax = grid.cbar_axes[i]
-
-        p._setup_plots()
-        plt.savefig('noise_plot_lin.png')
-
-    test = GenericImageTest(ds, create_image_lin, 12)
+    test = GenericImageTest(ds, create_image, 12)
     test.prefix = "test_noise_plot_lin"
     test_noise_plot_lin.__name__ = test.description
-    yield test
-
-def test_noise_plot_log():
-    ds = fake_amr_ds(geometry="cylindrical")
-    add_noise_fields(ds)
-
-    def create_image_log(filename_prefix):
-        fields = ['density'] + ['noise%d' % i for i in range(4)]
-        p = SlicePlot(ds, 'z', fields)
-        # lines bellow can later be replaced with the following snippet (see PR 2497)
-        # 
-        # fig = p.export_to_mpl_figure((2,2))
-        # fig.savefig('noise_plot_log.png')
-        from mpl_toolkits.axes_grid1 import AxesGrid
-        fig = plt.figure()
-
-        grid = AxesGrid(fig, (0.075,0.075,0.85,0.85),
-                nrows_ncols = (2, 2),
-                axes_pad = 1.0,
-                label_mode = "1",
-                share_all = True,
-                cbar_location="right",
-                cbar_mode="each",
-                cbar_size="3%",
-                cbar_pad="0%")
-
-        for i, field in enumerate(fields):
-            plot = p.plots[field]
-            plot.figure = fig
-            plot.axes = grid[i].axes
-            plot.cax = grid.cbar_axes[i]
-
-        p._setup_plots()
-        plt.savefig('noise_plot_log.png')
-
-    test = GenericImageTest(ds, create_image_log, 12)
-    test.prefix = "test_noise_plot_log"
-    test_noise_plot_log.__name__ = test.description
     yield test

--- a/yt/geometry/coordinates/tests/test_cylindrical_coordinates.py
+++ b/yt/geometry/coordinates/tests/test_cylindrical_coordinates.py
@@ -38,17 +38,15 @@ def test_cylindrical_coordinates():
 def test_noise_plot_lin():
     ds = fake_amr_ds(geometry="cylindrical")
     add_noise_fields(ds)
+
     def create_image(filename_prefix):
         fields = ['noise%d' % i for i in range(4)]
 
-        for f in fields:
-            p = SlicePlot(ds, 'z', f)
-            p.save('%s_%s_log' % (filename_prefix, f))
+        p = SlicePlot(ds, 'z', fields)
+        p.save('%s_log' % filename_prefix)
 
         p.set_log('all', False)
-        for f in fields:
-            p = SlicePlot(ds, 'z', f)
-            p.save('%s_%s_lin' % (filename_prefix, f))
+        p.save('%s_lin' % filename_prefix)
 
     test = GenericImageTest(ds, create_image, 12)
     test.prefix = "test_noise_plot_lin"

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -504,6 +504,32 @@ def fake_octree_ds(prng=RandomState(0x1d3d3d3), refined=None, quantities=None,
                      unit_system=unit_system)
     return ds
 
+def add_noise_fields(ds):
+    """Add 4 classes of noise fields to a dataset"""
+    prng = RandomState(0x4d3d3d3)
+    def _binary_noise(field, data):
+        """random binary data"""
+        res = prng.random_integers(0, 1, data.size).astype("float64")
+        return res
+
+    def _positive_noise(field, data):
+        """random strictly positive data"""
+        return prng.random_sample(data.size) + 1e-16
+
+    def _negative_noise(field, data):
+        """random negative data"""
+        return - prng.random_sample(data.size)
+
+    def _even_noise(field, data):
+        """random data with mixed signs"""
+        return 2 * prng.random_sample(data.size) - 1
+
+    ds.add_field("noise0", _binary_noise, sampling_type="cell")
+    ds.add_field("noise1", _positive_noise, sampling_type="cell")
+    ds.add_field("noise2", _negative_noise, sampling_type="cell")
+    ds.add_field("noise3", _even_noise, sampling_type="cell")
+
+
 def expand_keywords(keywords, full=False):
     """
     expand_keywords is a means for testing all possible keyword

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -934,9 +934,9 @@ class AxialPixelizationTest(AnswerTestingTest):
             yax = ds.coordinates.axis_name[ds.coordinates.y_axis[axis]]
             pix_x = ds.coordinates.pixelize(axis, slc, xax, bounds, (512, 512))
             pix_y = ds.coordinates.pixelize(axis, slc, yax, bounds, (512, 512))
-            # Wipe out all NaNs
-            pix_x[np.isnan(pix_x)] = 0.0
-            pix_y[np.isnan(pix_y)] = 0.0
+            # Wipe out invalid values (fillers)
+            pix_x[np.isnan(pix_x) | np.isinf(pix_x)] = 0.0
+            pix_y[np.isnan(pix_y) | np.isinf(pix_y)] = 0.0
             rv['%s_x' % axis] = pix_x
             rv['%s_y' % axis] = pix_y
         return rv

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -935,8 +935,8 @@ class AxialPixelizationTest(AnswerTestingTest):
             pix_x = ds.coordinates.pixelize(axis, slc, xax, bounds, (512, 512))
             pix_y = ds.coordinates.pixelize(axis, slc, yax, bounds, (512, 512))
             # Wipe out invalid values (fillers)
-            pix_x[np.isnan(pix_x) | np.isinf(pix_x)] = 0.0
-            pix_y[np.isnan(pix_y) | np.isinf(pix_y)] = 0.0
+            pix_x[~np.isfinite(pix_x)] = 0.0
+            pix_y[~np.isfinite(pix_y)] = 0.0
             rv['%s_x' % axis] = pix_x
             rv['%s_y' % axis] = pix_y
         return rv


### PR DESCRIPTION
## PR Summary

Fix #2480 
@matthewturk was **one** character away from this fix in the embedded discussion.
I spent an unreasonable amount of time trying to find _where_ I could write a workaround the matplotlib warning triggered by using `np.nan` as a filler value, but in the end I discovered that, while `-np.inf` indeed breaks everything (as noted by @chverbeke)  `np.inf` will do the job perfectly.
Issue solved, no warning, no problem 👏 

For closure, I tested this using
- matplotlib 3.1.3
- 1.18.1