### PR TITLE
update pressure units for artio frontend

### DIFF
--- a/yt/frontends/artio/fields.py
+++ b/yt/frontends/artio/fields.py
@@ -30,13 +30,14 @@ vel_units = "code_velocity"
 # NOTE: ARTIO uses momentum density.
 mom_units = "code_mass / (code_length**2 * code_time)"
 en_units = "code_mass*code_velocity**2/code_length**3"
+p_units = "code_mass / (code_length * code_time**2)"
 
 class ARTIOFieldInfo(FieldInfoContainer):
     known_other_fields = (
         ("HVAR_GAS_DENSITY", (rho_units, ["density"], None)),
         ("HVAR_GAS_ENERGY", (en_units, ["total_energy"], None)),
         ("HVAR_INTERNAL_ENERGY", (en_units, ["thermal_energy"], None)),
-        ("HVAR_PRESSURE", ("", ["pressure"], None)), # Unused
+        ("HVAR_PRESSURE", (p_units, ["pressure"], None)),
         ("HVAR_MOMENTUM_X", (mom_units, ["momentum_x"], None)),
         ("HVAR_MOMENTUM_Y", (mom_units, ["momentum_y"], None)),
         ("HVAR_MOMENTUM_Z", (mom_units, ["momentum_z"], None)),


### PR DESCRIPTION
This resolves the issue reported in yt-project/yt#2481

I've added pressure units based on the discussion in that PR, but I'd love for any users or contributors that are familiar with that code to weigh in here. Does this introduce any weird changes? I've looked at the logs and it seems like @matthewturk was the last to touch the units part of this frontend, but the commit message for the comment seems to stem from a conversation with Sam and Doug? 

Anyways, let me know if this works. 

## PR Summary

Updates the pressure field units in the artio frontend to be `code_mass / (code_length * code_time**2)`. With this patch, the pressure field has the units talked about in the issue. 

input:
```
ds.field_info['gas','temperature']
ds.field_info['gas','density']
ds.field_info['gas','pressure']
```

output:
```
In [6]: ds.field_info['gas', 'temperature']
Out[6]: Derived Field (gas, temperature): (units: K)

In [7]: ds.field_info['gas', 'density']
Out[7]: Alias Field for "('artio', 'HVAR_GAS_DENSITY')" (gas, density): (units: g/cm**3)

In [8]: ds.field_info['gas', 'pressure']
Out[8]: Alias Field for "('artio', 'HVAR_PRESSURE')" (gas, pressure): (units: dyne/cm**2)
```



## PR Checklist

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
