### PR TITLE
Allow for local plugin file (not system wide)

### DIFF
--- a/doc/source/reference/configuration.rst
+++ b/doc/source/reference/configuration.rst
@@ -133,7 +133,8 @@ To enable a plugin file, call the function
 System wise plugin file
 ^^^^^^^^^^^^^^^^^^^^^^^
 yt will look for and recognize the file ``$HOME/.config/yt/my_plugins.py`` as a
-plugin file.
+plugin file. It is possible to rename this file to ``$HOME/.config/yt/<pluginfilename>.py``
+by defining ``pluginfilename`` in your ytrc file, as mentioned above.
 
 .. note::
 

--- a/doc/source/reference/configuration.rst
+++ b/doc/source/reference/configuration.rst
@@ -124,8 +124,8 @@ Plugin Files
 ------------
 
 Plugin files are a means of creating custom fields, quantities, data objects,
-colormaps, and other code classes and objects to be used in futureyt sessions
-without modifying the source code directly.
+colormaps, and other code executable functions or classes to be used in future 
+yt sessions without modifying the source code directly.
 
 To enable a plugin file, call the function
 :func:`~yt.funcs.enable_plugins` at the top of your script.

--- a/doc/source/reference/configuration.rst
+++ b/doc/source/reference/configuration.rst
@@ -130,8 +130,8 @@ yt sessions without modifying the source code directly.
 To enable a plugin file, call the function
 :func:`~yt.funcs.enable_plugins` at the top of your script.
 
-System wise plugin file
-^^^^^^^^^^^^^^^^^^^^^^^
+Global system plugin file
+^^^^^^^^^^^^^^^^^^^^^^^^^
 yt will look for and recognize the file ``$HOME/.config/yt/my_plugins.py`` as a
 plugin file. It is possible to rename this file to ``$HOME/.config/yt/<pluginfilename>.py``
 by defining ``pluginfilename`` in your ytrc file, as mentioned above.

--- a/doc/source/reference/configuration.rst
+++ b/doc/source/reference/configuration.rst
@@ -197,6 +197,10 @@ use this function:
 And because we have used ``yt.enable_plugins`` we have access to the
 ``load_run`` function defined in our plugin file.
 
+.. note::
+    if your convenience function's name colliding with an existing object
+    within yt's namespace, it will be ignored.
+
 Note that using the plugins file implies that your script is no longer fully
 reproducible. If you share your script with someone else and use some of the
 functionality if your plugins file, you will also need to share your plugins

--- a/doc/source/reference/configuration.rst
+++ b/doc/source/reference/configuration.rst
@@ -120,30 +120,40 @@ used internally.
 
 .. _plugin-file:
 
-The Plugin File
----------------
+Plugin Files
+------------
 
-The plugin file is a means of creating custom fields, quantities, data
-objects, colormaps, and other code classes and objects to be used in future
-yt sessions without modifying the source code directly.
+Plugin files are a means of creating custom fields, quantities, data objects,
+colormaps, and other code classes and objects to be used in futureyt sessions
+without modifying the source code directly.
 
-To force the plugin file to be parsed, call the function
+To enable a plugin file, call the function
 :func:`~yt.funcs.enable_plugins` at the top of your script.
+
+System wise plugin file
+^^^^^^^^^^^^^^^^^^^^^^^
+yt will look for and recognize the file ``$HOME/.config/yt/my_plugins.py`` as a
+plugin file.
 
 .. note::
 
-   You can tell that your plugins file is being parsed by watching for a logging
+   You can tell that your system plugin file is being parsed by watching for a logging
    message when you import yt.  Note that both the ``yt load`` and ``iyt``
    command line entry points parse the plugin file, so the ``my_plugins.py``
    file will be parsed if you enter yt that way.
 
+Local project plugin file
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Optionally, :func:`~yt.funcs.enable_plugins` can be passed an argument to specify
+a custom location for a plugin file. This can be useful to define project wise customizations.
+In that use case, any system-level plugin file will be ignored.
+
 Plugin File Format
 ^^^^^^^^^^^^^^^^^^
 
-yt will look for and recognize the file ``$HOME/.config/yt/my_plugins.py`` as a
-plugin file, which should contain python code.  If accessing yt functions and
-classes they will not require the ``yt.`` prefix, because of how they are
-loaded.
+Plugin files should contain pure Python code. If accessing yt functions and classes
+they will not require the ``yt.`` prefix, because of how they are loaded.
 
 For example, if I created a plugin file containing:
 

--- a/doc/source/reference/configuration.rst
+++ b/doc/source/reference/configuration.rst
@@ -124,7 +124,7 @@ Plugin Files
 ------------
 
 Plugin files are a means of creating custom fields, quantities, data objects,
-colormaps, and other code executable functions or classes to be used in future 
+colormaps, and other code executable functions or classes to be used in future
 yt sessions without modifying the source code directly.
 
 To enable a plugin file, call the function
@@ -132,6 +132,7 @@ To enable a plugin file, call the function
 
 Global system plugin file
 ^^^^^^^^^^^^^^^^^^^^^^^^^
+
 yt will look for and recognize the file ``$HOME/.config/yt/my_plugins.py`` as a
 plugin file. It is possible to rename this file to ``$HOME/.config/yt/<pluginfilename>.py``
 by defining ``pluginfilename`` in your ytrc file, as mentioned above.

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -964,31 +964,35 @@ def deprecated_class(cls):
         return cls(*args, **kwargs)
     return _func
 
-def enable_plugins():
-    """Forces the plugins file to be parsed.
+def enable_plugins(pluginfilename=None):
+    """Forces a plugin file to be parsed.
 
-    This plugin file is a means of creating custom fields, quantities,
+    A plugin file is a means of creating custom fields, quantities,
     data objects, colormaps, and other code classes and objects to be used
     in yt scripts without modifying the yt source directly.
 
-    The file must be located at ``$HOME/.config/yt/my_plugins.py``.
+    If <pluginfilename> is omited, this function will look for a plugin file at
+    ``$HOME/.config/yt/my_plugins.py``, which is the prefered behaviour for a machine-level configuration.
 
     Warning: when you use this function, your script will only be reproducible
-    if you also provide the ``my_plugins.py`` file.
+    if you also provide your plugin file.
     """
     import yt
     from yt.fields.my_plugin_fields import my_plugins_fields
     from yt.config import ytcfg, CONFIG_DIR
-    my_plugin_name = ytcfg.get("yt", "pluginfilename")
-
+    if pluginfilename is None:
+        my_plugin_name = ytcfg.get("yt", "pluginfilename")
+        _fn = None
+    else:
+        _fn = pluginfilename
+    old_config_dir = os.path.join(os.path.expanduser('~'), '.yt')
     # In the following order if pluginfilename is: an absolute path, located in
     # the CONFIG_DIR, located in an obsolete config dir.
-    _fn = None
-    old_config_dir = os.path.join(os.path.expanduser('~'), '.yt')
-    for base_prefix in ('', CONFIG_DIR, old_config_dir):
-        if os.path.isfile(os.path.join(base_prefix, my_plugin_name)):
-            _fn = os.path.join(base_prefix, my_plugin_name)
-            break
+    if _fn is None:
+        for base_prefix in ('', CONFIG_DIR, old_config_dir):
+            if os.path.isfile(os.path.join(base_prefix, my_plugin_name)):
+                _fn = os.path.join(base_prefix, my_plugin_name)
+                break
 
     if _fn is not None and os.path.isfile(_fn):
         if _fn.startswith(old_config_dir):

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -983,32 +983,29 @@ def enable_plugins(pluginfilename=None):
     from yt.config import ytcfg, CONFIG_DIR
 
     use_custom_plugin = (pluginfilename is not None)
+    old_config_dir = os.path.join(os.path.expanduser('~'), '.yt')
 
+    # In the following order if pluginfilename is: an absolute path, located in
+    # the CONFIG_DIR, located in an obsolete config dir.
     if use_custom_plugin:
         _fn = pluginfilename
     else:
-        _fn = None
-
-    old_config_dir = os.path.join(os.path.expanduser('~'), '.yt')
-    # In the following order if pluginfilename is: an absolute path, located in
-    # the CONFIG_DIR, located in an obsolete config dir.
-    if not use_custom_plugin:
         my_plugin_name = ytcfg.get("yt", "pluginfilename")
         for base_prefix in ('', CONFIG_DIR, old_config_dir):
             if os.path.isfile(os.path.join(base_prefix, my_plugin_name)):
                 _fn = os.path.join(base_prefix, my_plugin_name)
                 break
-        
-    if _fn is None:
-        return
-
-    if os.path.isfile(_fn):
-        if _fn.startswith(old_config_dir) and not use_custom_plugin:
+        else:
+            mylog.error("Could not find plugin file")
+            return
+        if _fn.startswith(old_config_dir):
             mylog.warning(
                 'Your plugin file is located in a deprecated directory. '
                 'Please move it from %s to %s',
                 os.path.join(old_config_dir, my_plugin_name),
                 os.path.join(CONFIG_DIR, my_plugin_name))
+
+    if os.path.isfile(_fn):
         mylog.info("Loading plugins from %s", _fn)
         ytdict = yt.__dict__
         execdict = ytdict.copy()

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -975,7 +975,7 @@ def enable_plugins(pluginfilename=None):
     ``$HOME/.config/yt/my_plugins.py``, which is the prefered behaviour for a
     system-level configuration.
 
-    Warning: scripts using this function will only be reproducible if your plugin
+    Warning: a script using this function will only be reproducible if your plugin
     file is shared with it.
     """
     import yt

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -982,16 +982,17 @@ def enable_plugins(pluginfilename=None):
     from yt.fields.my_plugin_fields import my_plugins_fields
     from yt.config import ytcfg, CONFIG_DIR
 
-    use_custom_plugin = (pluginfilename is not None)
     old_config_dir = os.path.join(os.path.expanduser('~'), '.yt')
 
-    # In the following order if pluginfilename is: an absolute path, located in
-    # the CONFIG_DIR, located in an obsolete config dir.
-    if use_custom_plugin:
+    if pluginfilename is not None:
         _fn = pluginfilename
         if not os.path.isfile(_fn):
             raise FileNotFoundError(_fn)
     else:
+        # Determine global plugin location. By decreasing priority order:
+        # - absolute path
+        # - CONFIG_DIR
+        # - obsolete config dir.
         my_plugin_name = ytcfg.get("yt", "pluginfilename")
         for base_prefix in ('', CONFIG_DIR, old_config_dir):
             if os.path.isfile(os.path.join(base_prefix, my_plugin_name)):

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -972,10 +972,11 @@ def enable_plugins(pluginfilename=None):
     in yt scripts without modifying the yt source directly.
 
     If <pluginfilename> is omited, this function will look for a plugin file at
-    ``$HOME/.config/yt/my_plugins.py``, which is the prefered behaviour for a machine-level configuration.
+    ``$HOME/.config/yt/my_plugins.py``, which is the prefered behaviour for a
+    system-level configuration.
 
-    Warning: when you use this function, your script will only be reproducible
-    if you also provide your plugin file.
+    Warning: scripts using this function will only be reproducible if your plugin
+    file is shared with it.
     """
     import yt
     from yt.fields.my_plugin_fields import my_plugins_fields

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -982,8 +982,6 @@ def enable_plugins(pluginfilename=None):
     from yt.fields.my_plugin_fields import my_plugins_fields
     from yt.config import ytcfg, CONFIG_DIR
 
-    old_config_dir = os.path.join(os.path.expanduser('~'), '.yt')
-
     if pluginfilename is not None:
         _fn = pluginfilename
         if not os.path.isfile(_fn):
@@ -994,6 +992,7 @@ def enable_plugins(pluginfilename=None):
         # - CONFIG_DIR
         # - obsolete config dir.
         my_plugin_name = ytcfg.get("yt", "pluginfilename")
+        old_config_dir = os.path.join(os.path.expanduser('~'), '.yt')
         for base_prefix in ('', CONFIG_DIR, old_config_dir):
             if os.path.isfile(os.path.join(base_prefix, my_plugin_name)):
                 _fn = os.path.join(base_prefix, my_plugin_name)

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -981,22 +981,29 @@ def enable_plugins(pluginfilename=None):
     import yt
     from yt.fields.my_plugin_fields import my_plugins_fields
     from yt.config import ytcfg, CONFIG_DIR
-    if pluginfilename is None:
-        my_plugin_name = ytcfg.get("yt", "pluginfilename")
-        _fn = None
-    else:
+
+    use_custom_plugin = (pluginfilename is not None)
+
+    if use_custom_plugin:
         _fn = pluginfilename
+    else:
+        _fn = None
+
     old_config_dir = os.path.join(os.path.expanduser('~'), '.yt')
     # In the following order if pluginfilename is: an absolute path, located in
     # the CONFIG_DIR, located in an obsolete config dir.
-    if _fn is None:
+    if not use_custom_plugin:
+        my_plugin_name = ytcfg.get("yt", "pluginfilename")
         for base_prefix in ('', CONFIG_DIR, old_config_dir):
             if os.path.isfile(os.path.join(base_prefix, my_plugin_name)):
                 _fn = os.path.join(base_prefix, my_plugin_name)
                 break
+        
+    if _fn is None:
+        return
 
-    if _fn is not None and os.path.isfile(_fn):
-        if _fn.startswith(old_config_dir):
+    if os.path.isfile(_fn):
+        if _fn.startswith(old_config_dir) and not use_custom_plugin:
             mylog.warning(
                 'Your plugin file is located in a deprecated directory. '
                 'Please move it from %s to %s',


### PR DESCRIPTION
## PR Summary

As a user, I find the plugin feature of yt too restrictive as it currently allows to have only *one* plugin file per system, which makes it a unsuited for more local definitions. Say I have a project-specific-folder full of notebooks to analyse closely related datasets, then it makes sense to me to have companion a plugin file within the same folder. It would make it easier for me to work with collaborators if we simply share the notebooks' folder, and none of us would have to worry about collisions with our own private, system-wide plugins.

This change makes this use-case possible so that a user can organise a folder such as:
```bash
.
└── notebooks
    ├── yt_pluging.py
    └── notebook.ipynb
```

where `notebook.ipynb` would open as
```python
import yt
yt.enable_plugins("yt_pluging.py")
```

## PR Checklist

- [x] Code passes flake8 checker
- [x] New features are documented, with docstrings and narrative docs