### PR TITLE
Use proper dimensionality in bbox/point selection for meshes. Fixes #2535

### DIFF
--- a/yt/geometry/selection_routines.pxd
+++ b/yt/geometry/selection_routines.pxd
@@ -49,9 +49,13 @@ cdef class SelectorObject:
     cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) nogil
 
     cdef int select_point(self, np.float64_t pos[3]) nogil
+    cdef int select_point_ndims(self, np.float64_t pos[3], np.int32_t ndims) nogil
     cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) nogil
     cdef int select_bbox(self, np.float64_t left_edge[3],
                                np.float64_t right_edge[3]) nogil
+    cdef int select_bbox_ndims(
+        self, np.float64_t left_edge[3], np.float64_t right_edge[3], np.int32_t ndims
+    ) nogil
     cdef int fill_mask_selector(self, np.float64_t left_edge[3],
                                 np.float64_t right_edge[3], 
                                 np.float64_t dds[3], int dim[3],

--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -374,6 +374,7 @@ cdef class SelectorObject:
         cdef np.ndarray[np.uint8_t, ndim=1] mask
         cdef int i, j, k, selected
         cdef int npoints, nv = mesh._connectivity_length
+        cdef int ndim = mesh.connectivity_coords.shape[1]
         cdef int total = 0
         cdef int offset = mesh._index_offset
         coords = _ensure_code(mesh.connectivity_coords)
@@ -383,9 +384,9 @@ cdef class SelectorObject:
         for i in range(npoints):
             selected = 0
             for j in range(nv):
-                for k in range(3):
+                for k in range(ndim):
                     pos[k] = coords[indices[i, j] - offset, k]
-                selected = self.select_point(pos)
+                selected = self.select_point_ndims(pos, ndim)
                 if selected == 1: break
             total += selected
             mask[i] = selected
@@ -421,7 +422,7 @@ cdef class SelectorObject:
                     pos = coords[indices[i, j] - offset, k]
                     le[k] = fmin(pos, le[k])
                     re[k] = fmax(pos, re[k])
-            selected = self.select_bbox(le, re)
+            selected = self.select_bbox_ndims(le, re, ndim)
             total += selected
             mask[i] = selected
         if total == 0: return None

--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -332,23 +332,29 @@ cdef class SelectorObject:
     cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) nogil:
         return 0
 
-    cdef int select_point(self, np.float64_t pos[3]) nogil:
-        return 0
-
     cdef int select_point_ndims(self, np.float64_t pos[3], np.int32_t ndims) nogil:
         return 0
 
-    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) nogil:
-        return 0
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cdef int select_point(self, np.float64_t pos[3]) nogil:
+        return self.select_point_ndims(pos, 3)
 
-    cdef int select_bbox(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
+    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) nogil:
         return 0
 
     cdef int select_bbox_ndims(
         self, np.float64_t left_edge[3], np.float64_t right_edge[3], np.int32_t ndims
     ) nogil:
         return 0
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cdef int select_bbox(self, np.float64_t left_edge[3],
+                               np.float64_t right_edge[3]) nogil:
+        return self.select_bbox_ndims(left_edge, right_edge, 3)
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
@@ -888,13 +894,6 @@ cdef class RegionSelector(SelectorObject):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_bbox(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
-        return self.select_bbox_ndims(left_edge, right_edge, 3)
-
-    @cython.boundscheck(False)
-    @cython.wraparound(False)
-    @cython.cdivision(True)
     cdef int select_bbox_ndims(
         self, np.float64_t left_edge[3], np.float64_t right_edge[3], np.int32_t ndims
     ) nogil:
@@ -930,12 +929,6 @@ cdef class RegionSelector(SelectorObject):
                pos[i] >= self.right_edge[i]:
                 return 0
         return 1
-
-    @cython.boundscheck(False)
-    @cython.wraparound(False)
-    @cython.cdivision(True)
-    cdef int select_point(self, np.float64_t pos[3]) nogil:
-        return self.select_point_ndims(pos, 3)
 
     @cython.boundscheck(False)
     @cython.wraparound(False)

--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -335,11 +335,19 @@ cdef class SelectorObject:
     cdef int select_point(self, np.float64_t pos[3]) nogil:
         return 0
 
+    cdef int select_point_ndims(self, np.float64_t pos[3], np.int32_t ndims) nogil:
+        return 0
+
     cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) nogil:
         return 0
 
     cdef int select_bbox(self, np.float64_t left_edge[3],
                                np.float64_t right_edge[3]) nogil:
+        return 0
+
+    cdef int select_bbox_ndims(
+        self, np.float64_t left_edge[3], np.float64_t right_edge[3], np.int32_t ndims
+    ) nogil:
         return 0
 
     @cython.boundscheck(False)
@@ -881,8 +889,16 @@ cdef class RegionSelector(SelectorObject):
     @cython.cdivision(True)
     cdef int select_bbox(self, np.float64_t left_edge[3],
                                np.float64_t right_edge[3]) nogil:
+        return self.select_bbox_ndims(left_edge, right_edge, 3)
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cdef int select_bbox_ndims(
+        self, np.float64_t left_edge[3], np.float64_t right_edge[3], np.int32_t ndims
+    ) nogil:
         cdef int i
-        for i in range(3):
+        for i in range(ndims):
             if (right_edge[i] < self.left_edge[i] and \
                 left_edge[i] >= self.right_edge_shift[i]) or \
                 left_edge[i] >= self.right_edge[i]:
@@ -906,13 +922,19 @@ cdef class RegionSelector(SelectorObject):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_point(self, np.float64_t pos[3]) nogil:
+    cdef int select_point_ndims(self, np.float64_t pos[3], np.int32_t ndims) nogil:
         cdef int i
-        for i in range(3):
+        for i in range(ndims):
             if (self.right_edge_shift[i] <= pos[i] < self.left_edge[i]) or \
                pos[i] >= self.right_edge[i]:
                 return 0
         return 1
+
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
+    cdef int select_point(self, np.float64_t pos[3]) nogil:
+        return self.select_point_ndims(pos, 3)
 
     @cython.boundscheck(False)
     @cython.wraparound(False)


### PR DESCRIPTION
## PR Summary

Currently for unstructured meshes that consist of 2d points we use selection routines that assume 3d. As a result we check random garbage in memory to e.g. decide whether a region intersects with a mesh or not.

