### PR TITLE
fix a bug in PlotContainer.set_minorticks 

### DIFF
--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -291,10 +291,7 @@ class PlotContainer(object):
         else:
             fields = [field]
         for field in self.data_source._determine_fields(fields):
-            if state == 'on':
-                self._minorticks[field] = True
-            else:
-                self._minorticks[field] = False
+            self._minorticks[field] = state
         return self
 
     def _setup_plots(self):


### PR DESCRIPTION
fix a bug in PlotContainer.set_minorticks  where passing booleans would always set the property to `False`.
This is cherry picked from https://github.com/yt-project/yt/pull/2525, to be applicable independently.