### PR TITLE
Saving Raw Answer Test Arrays in Pytest Framework

### DIFF
--- a/yt/utilities/answer_testing/answer_tests.py
+++ b/yt/utilities/answer_testing/answer_tests.py
@@ -5,7 +5,6 @@ Purpose: Contains answer tests that are used by yt's various frontends
 import os
 import tempfile
 
-import hashlib
 import matplotlib.image as mpimg
 import numpy as np
 

--- a/yt/utilities/answer_testing/utils.py
+++ b/yt/utilities/answer_testing/utils.py
@@ -180,7 +180,6 @@ def generate_hash(data):
             hd = _hash_dict(data)
         elif data is None:
             hd = hashlib.md5(bytes(str(-1).encode('utf-8')))
-        elif isinstance(data, 
         else:
             raise TypeError
     return hd

--- a/yt/utilities/answer_testing/utils.py
+++ b/yt/utilities/answer_testing/utils.py
@@ -8,7 +8,7 @@ import hashlib
 import inspect
 import os
 
-import h5py
+from yt.utilities.on_demand_imports import _h5py as h5py
 import numpy as np
 import pytest
 import yaml

--- a/yt/utilities/answer_testing/utils.py
+++ b/yt/utilities/answer_testing/utils.py
@@ -318,7 +318,24 @@ def _save_raw_arrays(arrays, answer_file, func_name):
     with h5py.File(answer_file, 'a') as f:
         grp = f.create_group(func_name)
         for test_name, test_array in arrays.items():
+            # Some answer tests (e.g., grid_values, projection_values)
+            # return a dictionary, which cannot be handled by h5py
+            if isinstance(test_array, dict):
+                test_array = _dict_to_array(test_array)
             grp.create_dataset(test_name, data=test_array)
+
+
+def _dict_to_array(d):
+    r"""
+    Converts a dictionary into a 2D numpy array, where array[0][0] = key
+    and array[0][1] = value.
+    """
+    nkeys = len(d.keys())
+    arr = np.zeros((nkeys, 2))
+    for i, (k, v) in enumerate(sorted(d.items())):
+        arr[i][0] = k
+        arr[i][1] = v
+    return arr
 
 
 def _compare_raw_arrays(arrays, answer_file, func_name):

--- a/yt/utilities/answer_testing/utils.py
+++ b/yt/utilities/answer_testing/utils.py
@@ -124,13 +124,7 @@ def _hash_results(results):
     # Here, results should be comprised of only the tests, not the test
     # parameters
     for test_name, test_value in results.items():
-        # These tests have issues with python-specific anchors and so
-        # are already hashed
-        # (see their definitions in yt/utilites/answer_testing/answer_tests.py)
-        if test_name in ['projection_values', 'pixelized_projection_values', 'grid_values']:
-            continue
-        else:
-            results[test_name] = generate_hash(test_value)
+        results[test_name] = generate_hash(test_value)
     return results
 
 def _hash_dict(data):
@@ -184,6 +178,9 @@ def generate_hash(data):
     except TypeError:
         if isinstance(data, dict):
             hd = _hash_dict(data)
+        elif data is None:
+            hd = hashlib.md5(bytes(str(-1).encode('utf-8')))
+        elif isinstance(data, 
         else:
             raise TypeError
     return hd

--- a/yt/utilities/answer_testing/utils.py
+++ b/yt/utilities/answer_testing/utils.py
@@ -8,6 +8,7 @@ import hashlib
 import inspect
 import os
 
+import h5py
 import numpy as np
 import pytest
 import yaml
@@ -260,7 +261,7 @@ def _handle_hashes(save_dir_name, fname, hashes, answer_store):
         _compare_result(hashes, answer_file)
 
 
-def _save_arrays(save_dir_name, fbasename, arrays, answer_store):
+def _handle_raw_arrays(save_dir_name, fbasename, arrays, answer_store, func_name):
     r"""
     Driver routine for either saving the raw arrays resulting from the
     tests, or compare them to previously saved results.
@@ -282,8 +283,75 @@ def _save_arrays(save_dir_name, fbasename, arrays, answer_store):
     answer_store : bool
         If true, save the just-generated test results, otherwise,
         compare them to the previously saved results.
+
+    func_name : str
+        The name of the function that created the answers being saved.
     """
-    pass
+    answer_file = os.path.join(save_dir_name, fbasename + '.h5')
+    if answer_store:
+        _save_raw_arrays(arrays, answer_file, func_name)
+    else:
+        _compare_raw_arrays(arrays, answer_file, func_name)
+
+
+def _save_raw_arrays(arrays, answer_file, func_name):
+    r"""
+    Saves the raw arrays produced from answer tests to a file.
+
+    The structure of `answer_file` is: each test function (e.g.,
+    test_toro1d[0-None-None-0]) forms a group. Within each group is a
+    hdf5 dataset named after the test (e.g., field_values). The value
+    stored in each dataset is the raw array corresponding to that
+    test and function.
+
+    Parameters
+    ----------
+    arrays : dict
+        Keys are the test name (e.g. field_values) and the values are
+        the actual answer arrays produced by the test.
+
+    answer_file : str
+        The name of the file to save the answers to, in hdf5 format.
+
+    func_name : str
+        The name of the function (possibly augmented by pytest with
+        test parameters) that called the test functions
+        (e.g, test_toro1d).
+    """
+    with h5py.File(answer_file, 'a') as f:
+        grp = f.create_group(func_name)
+        for test_name, test_array in arrays.items():
+            grp.create_dataset(test_name, data=test_array)
+
+
+def _compare_raw_arrays(arrays, answer_file, func_name):
+    r"""
+    Reads in previously saved raw array data and compares the current
+    results with the old ones.
+
+    The structure of `answer_file` is: each test function (e.g.,
+    test_toro1d[0-None-None-0]) forms a group. Within each group is a
+    hdf5 dataset named after the test (e.g., field_values). The value
+    stored in each dataset is the raw array corresponding to that
+    test and function.
+
+    Parameters
+    ----------
+    arrays : dict
+        Keys are the test name (e.g. field_values) and the values are
+        the actual answer arrays produced by the test.
+
+    answer_file : str
+        The name of the file to load the answers from, in hdf5 format.
+
+    func_name : str
+        The name of the function (possibly augmented by pytest with
+        test parameters) that called the test functions
+        (e.g, test_toro1d).
+    """
+    with h5py.File(answer_file, 'r') as f:
+        for test_name, new_answer in arrays.items():
+            np.testing.assert_array_equal(f[func_name][test_name][:], new_answer)
 
 
 def can_run_ds(ds_fn, file_check = False):


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

This PR adds the ability to save the actual raw arrays produced by answer tests in addition to the hashes.

TODO:

- [x] Check projection_values, grid_values, and pixelized_projection_values, as they are pre-hashed due to python-specific anchors.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ x] Code passes flake8 checker
- [ x] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
