### PR TITLE
add explicit support for jpeg exports

### DIFF
--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -815,7 +815,11 @@ def fix_axis(axis, ds):
 def get_image_suffix(name):
     suffix = os.path.splitext(name)[1]
     supported_suffixes = ['.png', '.eps', '.ps', '.pdf', '.jpg', '.jpeg']
-    return suffix if suffix in supported_suffixes else ''
+    if suffix in supported_suffixes or suffix == '':
+        return suffix
+    else:
+        mylog.warning('Unsupported image suffix requested (%s)' % suffix)
+        return ''
 
 def get_output_filename(name, keyword, suffix):
     r"""Return an appropriate filename for output.

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -814,7 +814,8 @@ def fix_axis(axis, ds):
 
 def get_image_suffix(name):
     suffix = os.path.splitext(name)[1]
-    return suffix if suffix in ['.png', '.eps', '.ps', '.pdf'] else ''
+    supported_suffixes = ['.png', '.eps', '.ps', '.pdf', '.jpg', '.jpeg']
+    return suffix if suffix in supported_suffixes else ''
 
 def get_output_filename(name, keyword, suffix):
     r"""Return an appropriate filename for output.


### PR DESCRIPTION
With recent enough versions of matplotlib and if PIL (pillow) is installed, matplotlib is able to export to jpeg.
When it's not, it raises perfectly sensible errors such as
```
ValueError: Format "jpg" is not supported.
Supported formats: eps, pdf, pgf, png, ps, raw, rgba, svg, svgz.
```

Thus, I don't think there's a good case for preventing exporting to jpg within yt, which is currently the case because of how `get_image_suffix` is implemented.