### PR TITLE
Vorticity generalization

### DIFF
--- a/yt/fields/fluid_vector_fields.py
+++ b/yt/fields/fluid_vector_fields.py
@@ -34,8 +34,6 @@ from .vector_operations import \
 
 @register_field_plugin
 def setup_fluid_vector_fields(registry, ftype = "gas", slice_info = None):
-    # Current implementation for gradient is not valid for curvilinear geometries
-    if is_curvilinear(registry.ds.geometry): return
 
     unit_system = registry.ds.unit_system
     # slice_info would be the left, the right, and the factor.

--- a/yt/fields/fluid_vector_fields.py
+++ b/yt/fields/fluid_vector_fields.py
@@ -126,9 +126,7 @@ def setup_fluid_vector_fields(registry, ftype = "gas", slice_info = None):
         return new_field
 
 
-    def get_vort_validators(ax=None):
-        if ax is None:
-            ax = ""
+    def get_vort_validators(ax=""):
         vort_validators = [
             ValidateSpatial(1, [(ftype, "velocity_%s" % d) for d in "xyz".replace(ax, "")]),
             ValidateParameter('bulk_velocity')


### PR DESCRIPTION
## PR Summary

Automatic setup of vorticity fields currently has a bunch of restrictions, that can now be relaxed since gradients are now usable in curvilinear geometries (#2483).

I list the identified restrictions here as a todo list, where a checkmark means I've relaxed the corresponding limitation

- [x] 3D only
- [ ] cartesian only.

The latter requires several very similar refactoring commits, because of the sheer number of 
fields being setup by the same function:
- [ ] `"baroclinic_vorticity_%s` with %s in ("x", "y", "z")
    - [ ] corresponding magnitude
- [ ] `"vorticity_%s` with %s in ("x", "y", "z")
    - [ ] corresponding magnitude
    - [ ] squared
- [ ] `"vorticity_stretching_%s` with %s in ("x", "y", "z")
    - [ ] corresponding magnitude
- [ ] `"vorticity_growth_%s` with %s in ("x", "y", "z")
    - [ ] corresponding magnitude (special case not using `create_magnitude_field`)
- ... a bunch of others that I may deal with later


## PR Checklist

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds tests for new features.