### PR TITLE
bugfix colormap minorticks

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -71,7 +71,7 @@ answer_tests:
     - yt/analysis_modules/photon_simulator/tests/test_spectra.py
     - yt/analysis_modules/photon_simulator/tests/test_sloshing.py
 
-  local_unstructured_010:
+  local_unstructured_011:
     - yt/visualization/volume_rendering/tests/test_mesh_render.py:test_composite_mesh_render
     - yt/visualization/volume_rendering/tests/test_mesh_render.py:test_composite_mesh_render_pyembree
     - yt/visualization/volume_rendering/tests/test_mesh_render.py:test_hex20_render
@@ -128,7 +128,7 @@ answer_tests:
   local_axialpix_006:
     - yt/geometry/coordinates/tests/test_axial_pixelization.py:test_axial_pixelization
 
-  local_cylindrical_background_001:
+  local_cylindrical_background_002:
     - yt/geometry/coordinates/tests/test_cylindrical_coordinates.py:test_noise_plots
 
   local_particle_trajectory_001:

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -51,7 +51,7 @@ answer_tests:
   local_owls_002:
     - yt/frontends/owls/tests/test_outputs.py
 
-  local_pw_027:
+  local_pw_028:
     - yt/visualization/tests/test_plotwindow.py:test_attributes
     - yt/visualization/tests/test_plotwindow.py:test_attributes_wt
     - yt/visualization/tests/test_particle_plot.py:test_particle_projection_answers

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1078,10 +1078,7 @@ class PWViewerMPL(PlotWindow):
                     self._cbar_minorticks[f] = False
 
             if not self._cbar_minorticks[f]:
-                try:
-                    self.plots[f].cax.minorticks_off()
-                except AttributeError:
-                    pass # todo: logme
+                self.plots[f].cax.minorticks_off()
 
             if draw_axes is False:
                 self.plots[f]._toggle_axes(draw_axes, draw_frame)

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1054,22 +1054,33 @@ class PWViewerMPL(PlotWindow):
                 self._cbar_minorticks[f] = True
 
             if self._cbar_minorticks[f] is True:
-                if (MPL_VERSION < LooseVersion('2.0.0') or self._field_transform[f] == symlog_transform):
-                    vmin = np.float64( self.plots[f].cb.norm.vmin )
-                    vmax = np.float64( self.plots[f].cb.norm.vmax )
-                    if self._field_transform[f] == log_transform:
-                        mticks = self.plots[f].image.norm( get_log_minorticks(vmin, vmax) )
-                    else: # symlog_transform
-                        flinthresh = 10**np.floor( np.log10( self.plots[f].cb.norm.linthresh ) )
-                        mticks = self.plots[f].image.norm( get_symlog_minorticks(flinthresh, vmin, vmax) )
-                    self.plots[f].cax.yaxis.set_ticks(mticks, minor=True)
-                elif self._field_transform[f] in (linear_transform, log_transform):
+                vmin = np.float64(self.plots[f].cb.norm.vmin)
+                vmax = np.float64(self.plots[f].cb.norm.vmax)
+
+                if self._field_transform[f] == linear_transform:
                     self.plots[f].cax.minorticks_on()
+                
+                elif self._field_transform[f] == symlog_transform:
+                    flinthresh = 10**np.floor(np.log10(self.plots[f].cb.norm.linthresh))
+                    mticks = self.plots[f].image.norm(get_symlog_minorticks(flinthresh, vmin, vmax))
+                    self.plots[f].cax.yaxis.set_ticks(mticks, minor=True)
+
+                elif self._field_transform[f] == log_transform:
+                    if MPL_VERSION >= LooseVersion('2.0.0'):
+                        self.plots[f].cax.minorticks_on()
+                    else:
+                        mticks = self.plots[f].image.norm(get_log_minorticks(vmin, vmax))
+                        self.plots[f].cax.yaxis.set_ticks(mticks, minor=True)
+
                 else:
                     mylog.error("Unable to draw cbar minorticks.")
                     self._cbar_minorticks[f] = False
-            if self._cbar_minorticks[f] is False:
-                self.plots[f].cax.minorticks_off()
+
+            if not self._cbar_minorticks[f]:
+                try:
+                    self.plots[f].cax.minorticks_off()
+                except AttributeError:
+                    pass # todo: logme
 
             if draw_axes is False:
                 self.plots[f]._toggle_axes(draw_axes, draw_frame)

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1066,7 +1066,7 @@ class PWViewerMPL(PlotWindow):
                     self.plots[f].cax.yaxis.set_ticks(mticks, minor=True)
 
                 elif self._field_transform[f] == log_transform:
-                    if MPL_VERSION >= LooseVersion('2.0.0'):
+                    if MPL_VERSION >= LooseVersion('3.0.0'):
                         self.plots[f].cax.minorticks_on()
                         self.plots[f].cax.xaxis.set_visible(False)  # experimental
                     else:

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1074,7 +1074,7 @@ class PWViewerMPL(PlotWindow):
                         self.plots[f].cax.yaxis.set_ticks(mticks, minor=True)
 
                 else:
-                    mylog.error("Unable to draw cbar minorticks.")
+                    mylog.error("Unable to draw cbar minorticks for field {} with transform {} ".format(f, self._field_transform[f]))
                     self._cbar_minorticks[f] = False
 
             if not self._cbar_minorticks[f]:

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1068,6 +1068,7 @@ class PWViewerMPL(PlotWindow):
                 elif self._field_transform[f] == log_transform:
                     if MPL_VERSION >= LooseVersion('2.0.0'):
                         self.plots[f].cax.minorticks_on()
+                        self.plots[f].cax.xaxis.set_visible(False)  # experimental
                     else:
                         mticks = self.plots[f].image.norm(get_log_minorticks(vmin, vmax))
                         self.plots[f].cax.yaxis.set_ticks(mticks, minor=True)

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1052,11 +1052,9 @@ class PWViewerMPL(PlotWindow):
             # colorbar minorticks
             if f not in self._cbar_minorticks:
                 self._cbar_minorticks[f] = True
-            if (self._cbar_minorticks[f] is True and MPL_VERSION < LooseVersion('2.0.0')
-                or self._field_transform[f] == symlog_transform):
-                if self._field_transform[f] == linear_transform:
-                    self.plots[f].cax.minorticks_on()
-                else:
+
+            if self._cbar_minorticks[f] is True:
+                if (MPL_VERSION < LooseVersion('2.0.0') or self._field_transform[f] == symlog_transform):
                     vmin = np.float64( self.plots[f].cb.norm.vmin )
                     vmax = np.float64( self.plots[f].cb.norm.vmax )
                     if self._field_transform[f] == log_transform:
@@ -1065,7 +1063,12 @@ class PWViewerMPL(PlotWindow):
                         flinthresh = 10**np.floor( np.log10( self.plots[f].cb.norm.linthresh ) )
                         mticks = self.plots[f].image.norm( get_symlog_minorticks(flinthresh, vmin, vmax) )
                     self.plots[f].cax.yaxis.set_ticks(mticks, minor=True)
-            else:
+                elif self._field_transform[f] in (linear_transform, log_transform):
+                    self.plots[f].cax.minorticks_on()
+                else:
+                    mylog.error("Unable to draw cbar minorticks.")
+                    self._cbar_minorticks[f] = False
+            if self._cbar_minorticks[f] is False:
                 self.plots[f].cax.minorticks_off()
 
             if draw_axes is False:

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1068,7 +1068,7 @@ class PWViewerMPL(PlotWindow):
                 elif self._field_transform[f] == log_transform:
                     if MPL_VERSION >= LooseVersion('3.0.0'):
                         self.plots[f].cax.minorticks_on()
-                        self.plots[f].cax.xaxis.set_visible(False)  # experimental
+                        self.plots[f].cax.xaxis.set_visible(False)
                     else:
                         mticks = self.plots[f].image.norm(get_log_minorticks(vmin, vmax))
                         self.plots[f].cax.yaxis.set_ticks(mticks, minor=True)


### PR DESCRIPTION
## PR Summary

fix #2543 

I tried respecting the original intended logic tree but I didn't test in the case `MPL_VERSION < 2.0`.
I expect a lot of image comparison tests should fail because, as it turns out, colorbar minor ticks are in fact supposed to be _on_ by default, althewhile being impossible to actually draw in log transforms with MPL > 2.
A work around those failure would be to embrace the de facto default behaviour (no colorbar minor ticks).