### PR TITLE
Fixing FLASHParticleFile IO

### DIFF
--- a/yt/frontends/flash/data_structures.py
+++ b/yt/frontends/flash/data_structures.py
@@ -22,6 +22,7 @@ from yt.utilities.file_handler import \
 from yt.utilities.physical_ratios import cm_per_mpc
 from .fields import FLASHFieldInfo
 
+
 class FLASHGrid(AMRGridPatch):
     _id_offset = 1
     #__slots__ = ["_level_id", "stop_index"]
@@ -34,6 +35,7 @@ class FLASHGrid(AMRGridPatch):
 
     def __repr__(self):
         return "FLASHGrid_%04i (%s)" % (self.id, self.ActiveDimensions)
+
 
 class FLASHHierarchy(GridIndex):
 
@@ -163,6 +165,7 @@ class FLASHHierarchy(GridIndex):
             for g in self.grids:
                 g.dds[1] = DD
         self.max_level = self.grid_levels.max()
+
 
 class FLASHDataset(Dataset):
     _index_class = FLASHHierarchy
@@ -439,8 +442,10 @@ class FLASHDataset(Dataset):
     def close(self):
         self._handle.close()
 
+
 class FLASHParticleFile(ParticleFile):
     pass
+
 
 class FLASHParticleDataset(FLASHDataset):
     _index_class = ParticleIndex
@@ -448,13 +453,13 @@ class FLASHParticleDataset(FLASHDataset):
     _file_class = FLASHParticleFile
 
     def __init__(self, filename, dataset_type='flash_particle_hdf5',
-                 storage_filename = None,
-                 units_override = None,
+                 storage_filename=None,
+                 units_override=None,
                  index_order=None,
                  index_filename=None,
-                 unit_system = "cgs"):
+                 unit_system="cgs"):
         self.index_order = validate_index_order(index_order)
-        self.index_filename=index_filename
+        self.index_filename = index_filename
 
         if self._handle is not None: return
         self._handle = HDF5FileHandler(filename)

--- a/yt/frontends/flash/fields.py
+++ b/yt/frontends/flash/fields.py
@@ -23,6 +23,7 @@ pres_units = "code_mass/(code_length*code_time**2)"
 erg_units = "code_mass * (code_length/code_time)**2"
 rho_units = "code_mass / code_length**3"
 
+
 class FLASHFieldInfo(FieldInfoContainer):
     known_other_fields = (
         ("velx", ("code_length/code_time", ["velocity_x"], None)),

--- a/yt/frontends/flash/io.py
+++ b/yt/frontends/flash/io.py
@@ -239,17 +239,6 @@ class IOHandlerFLASHParticle(BaseIOHandler):
             ind += self._chunksize
         return morton
 
-    def _yield_coordinates(self, sub_file, needed_ptype=None):
-        si, ei = sub_file.start, sub_file.end
-        p_fields = self._handle["/tracer particles"]
-        px, py, pz = self._position_fields
-        npart = ei-si
-        pos = np.empty((npart, 3), dtype="=f8")
-        pos[:, 0] = p_fields[si:ei, px]
-        pos[:, 1] = p_fields[si:ei, py]
-        pos[:, 2] = p_fields[si:ei, pz]
-        yield "io", pos
-
     _pcount = None
     def _count_particles(self, data_file):
         if self._pcount is None:

--- a/yt/frontends/flash/io.py
+++ b/yt/frontends/flash/io.py
@@ -172,18 +172,16 @@ class IOHandlerFLASHParticle(BaseIOHandler):
                 data_files.update(obj.data_files)
         px, py, pz = self._position_fields
         p_fields = self._handle["/tracer particles"]
-        assert(len(data_files) == 1)
+        # We used to have this, but it is no longer the case.  We can have
+        # multiple data files, as each data file is a subset.
+        # assert(len(data_files) == 1)
+        ptypes = [_[0] for _ in ptf.items()]
+        # Let's just make sure this is still true, though.
+        assert(len(set(ptypes)) == 1)
+        assert(ptypes[0] == "io")
         for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
-            pcount = self._count_particles(data_file)["io"]
-            for ptype, field_list in sorted(ptf.items()):
-                total = 0
-                while total < pcount:
-                    count = min(self._chunksize, pcount - total)
-                    x = np.asarray(p_fields[total:total+count, px], dtype="=f8")
-                    y = np.asarray(p_fields[total:total+count, py], dtype="=f8")
-                    z = np.asarray(p_fields[total:total+count, pz], dtype="=f8")
-                    total += count
-                    yield ptype, (x, y, z)
+            pxyz = np.asarray(p_fields[data_file.start:data_file.end, (px,py,pz)], dtype="=f8")
+            yield "io", pxyz
 
     def _yield_coordinates(self, data_file, needed_ptype=None):
         px, py, pz = self._position_fields

--- a/yt/frontends/flash/io.py
+++ b/yt/frontends/flash/io.py
@@ -185,9 +185,8 @@ class IOHandlerFLASHParticle(BaseIOHandler):
 
     def _yield_coordinates(self, data_file, needed_ptype=None):
         px, py, pz = self._position_fields
-        si, ei = data_file.start, data_file.end
         p_fields = self._handle["/tracer particles"]
-        pxyz = np.asarray(p_fields[data_file.start:data_file.end, (px, py, pz)], dtype="=f8")
+        pxyz = np.asarray(p_fields[data_file.start:data_file.end], dtype="=f8")
         yield ("io", pxyz)
 
     def _read_particle_fields(self, chunks, ptf, selector):

--- a/yt/frontends/flash/io.py
+++ b/yt/frontends/flash/io.py
@@ -183,6 +183,13 @@ class IOHandlerFLASHParticle(BaseIOHandler):
                     total += count
                     yield ptype, (x, y, z)
 
+    def _yield_coordinates(self, data_file, needed_ptype=None):
+        px, py, pz = self._position_fields
+        si, ei = data_file.start, data_file.end
+        p_fields = self._handle["/tracer particles"]
+        pxyz = np.asarray(p_fields[data_file.start:data_file.end, (px, py, pz)], dtype="=f8")
+        yield ("io", pxyz)
+
     def _read_particle_fields(self, chunks, ptf, selector):
         chunks = list(chunks)
         data_files = set([])

--- a/yt/frontends/flash/io.py
+++ b/yt/frontends/flash/io.py
@@ -186,7 +186,7 @@ class IOHandlerFLASHParticle(BaseIOHandler):
     def _yield_coordinates(self, data_file, needed_ptype=None):
         px, py, pz = self._position_fields
         p_fields = self._handle["/tracer particles"]
-        pxyz = np.asarray(p_fields[data_file.start:data_file.end], dtype="=f8")
+        pxyz = np.asarray(p_fields[data_file.start:data_file.end, (px,py,pz)], dtype="=f8")
         yield ("io", pxyz)
 
     def _read_particle_fields(self, chunks, ptf, selector):


### PR DESCRIPTION
This implements `_yield_coordinates` for the `FLASHParticleDataset` type, which is a blocker for running the tests.

@jzuhone this look reasonable to you?