### PR TITLE
Dataset abstraction: Default unique identifier

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -2,6 +2,7 @@ import functools
 import itertools
 import numpy as np
 import os
+from stat import ST_CTIME
 import time
 import weakref
 import warnings
@@ -165,6 +166,7 @@ class Dataset(metaclass = RegisteredDataset):
     derived_field_list = requires_index("derived_field_list")
     fields = requires_index("fields")
     _instantiated = False
+    _unique_identifier = None
     _particle_type_counts = None
     _proj_type = 'quad_proj'
     _ionization_label_format = 'roman_numeral'
@@ -255,6 +257,16 @@ class Dataset(metaclass = RegisteredDataset):
 
         self._set_derived_attrs()
         self._setup_classes()
+
+    @property
+    def unique_identifier(self):
+        if self._unique_identifier is None:
+            self._unique_identifier = int(os.stat(self.parameter_filename)[ST_CTIME])
+        return self._unique_identifier
+
+    @unique_identifier.setter
+    def unique_identifier(self, value):
+        self._unique_identifier = value
 
     def _set_derived_attrs(self):
         if self.domain_left_edge is None or self.domain_right_edge is None:

--- a/yt/frontends/_skeleton/data_structures.py
+++ b/yt/frontends/_skeleton/data_structures.py
@@ -110,8 +110,6 @@ class SkeletonDataset(Dataset):
         # will be converted to YTArray automatically at a later time.
         # This includes the cosmological parameters.
         #
-        #   self.unique_identifier      <= unique identifier for the dataset
-        #                                  being read (e.g., UUID or ST_CTIME)
         #   self.parameters             <= full of code-specific items of use
         #   self.domain_left_edge       <= array of float64
         #   self.domain_right_edge      <= array of float64
@@ -128,6 +126,10 @@ class SkeletonDataset(Dataset):
         #   self.omega_lambda               <= float
         #   self.omega_matter               <= float
         #   self.hubble_constant            <= float
+
+        # optional (has default implementation)
+        #   self.unique_identifier      <= unique identifier for the dataset
+        #                                  being read (e.g., UUID or ST_CTIME) (int)
         pass
 
     @classmethod

--- a/yt/frontends/ahf/data_structures.py
+++ b/yt/frontends/ahf/data_structures.py
@@ -92,8 +92,6 @@ class AHFHalosDataset(Dataset):
         self.parameters.update(param)
         self.particle_types = ('halos')
         self.particle_types_raw = ('halos')
-        self.unique_identifier = \
-            int(os.stat(self.parameter_filename)[stat.ST_CTIME])
 
         # Set up geometrical information.
         self.refine_by = 2

--- a/yt/frontends/ahf/data_structures.py
+++ b/yt/frontends/ahf/data_structures.py
@@ -1,6 +1,5 @@
 import glob
 import os
-import stat
 
 import numpy as np
 

--- a/yt/frontends/art/data_structures.py
+++ b/yt/frontends/art/data_structures.py
@@ -1,7 +1,6 @@
 import glob
 import numpy as np
 import os
-import stat
 import struct
 import weakref
 

--- a/yt/frontends/art/data_structures.py
+++ b/yt/frontends/art/data_structures.py
@@ -246,8 +246,6 @@ class ARTDataset(Dataset):
         self.periodicity = (True, True, True)
         self.cosmological_simulation = True
         self.parameters = {}
-        self.unique_identifier = \
-            int(os.stat(self.parameter_filename)[stat.ST_CTIME])
         self.parameters.update(constants)
         self.parameters['Time'] = 1.0
         # read the amr header
@@ -499,8 +497,6 @@ class DarkMatterARTDataset(ARTDataset):
         self.periodicity = (True, True, True)
         self.cosmological_simulation = True
         self.parameters = {}
-        self.unique_identifier = \
-            int(os.stat(self.parameter_filename)[stat.ST_CTIME])
         self.parameters.update(constants)
         self.parameters['Time'] = 1.0
         self.file_count = 1

--- a/yt/frontends/artio/data_structures.py
+++ b/yt/frontends/artio/data_structures.py
@@ -1,6 +1,5 @@
 import numpy as np
 import os
-import stat
 import weakref
 
 from collections import defaultdict

--- a/yt/frontends/artio/data_structures.py
+++ b/yt/frontends/artio/data_structures.py
@@ -357,8 +357,6 @@ class ARTIODataset(Dataset):
         self.parameters["Time"] = 1.  # default unit is 1...
 
         # read header
-        self.unique_identifier = \
-            int(os.stat(self.parameter_filename)[stat.ST_CTIME])
 
         self.num_grid = self._handle.num_grid
         self.domain_dimensions = np.ones(3, dtype='int32') * self.num_grid

--- a/yt/frontends/chombo/data_structures.py
+++ b/yt/frontends/chombo/data_structures.py
@@ -4,9 +4,6 @@ import os
 import weakref
 import numpy as np
 
-from stat import \
-    ST_CTIME
-
 from yt.funcs import \
     mylog, \
     setdefaultattr

--- a/yt/frontends/chombo/data_structures.py
+++ b/yt/frontends/chombo/data_structures.py
@@ -282,8 +282,6 @@ class ChomboDataset(Dataset):
 
     def _parse_parameter_file(self):
 
-        self.unique_identifier = \
-                               int(os.stat(self.parameter_filename)[ST_CTIME])
         self.dimensionality = self._handle['Chombo_global/'].attrs['SpaceDim']
         self.domain_left_edge = self._calc_left_edge()
         self.domain_right_edge = self._calc_right_edge()
@@ -468,8 +466,6 @@ class PlutoDataset(ChomboDataset):
         pluto_ini_filename = os.path.join(dir_name, "pluto.ini")
         pluto_ini_file_exists = os.path.isfile(pluto_ini_filename)
 
-        self.unique_identifier = \
-                               int(os.stat(self.parameter_filename)[ST_CTIME])
         self.dimensionality = self._handle['Chombo_global/'].attrs['SpaceDim']
         self.domain_dimensions = self._calc_domain_dimensions()
         self.refine_by = self._handle['/level_0'].attrs['ref_ratio']
@@ -608,8 +604,6 @@ class Orion2Dataset(ChomboDataset):
         orion2_ini_file_exists = os.path.isfile(orion2_ini_filename)
 
         if orion2_ini_file_exists: self._parse_inputs_file('orion2.ini')
-        self.unique_identifier = \
-                               int(os.stat(self.parameter_filename)[ST_CTIME])
         self.dimensionality = 3
         self.domain_left_edge = self._calc_left_edge()
         self.domain_right_edge = self._calc_right_edge()
@@ -622,8 +616,6 @@ class Orion2Dataset(ChomboDataset):
         self.fullplotdir = os.path.abspath(self.parameter_filename)
         self.ini_filename = self._localize( \
             self.ini_filename, ini_filename)
-        self.unique_identifier = \
-                               int(os.stat(self.parameter_filename)[ST_CTIME])
         lines = open(self.ini_filename).readlines()
         # read the file line by line, storing important parameters
         for lineI, line in enumerate(lines):

--- a/yt/frontends/enzo/data_structures.py
+++ b/yt/frontends/enzo/data_structures.py
@@ -5,7 +5,6 @@ import io
 import weakref
 import numpy as np
 import os
-import stat
 import string
 import time
 import re

--- a/yt/frontends/enzo/data_structures.py
+++ b/yt/frontends/enzo/data_structures.py
@@ -821,9 +821,6 @@ class EnzoDataset(Dataset):
             self.unique_identifier = self.parameters["MetaDataDatasetUUID"]
         elif "CurrentTimeIdentifier" in self.parameters:
             self.unique_identifier = self.parameters["CurrentTimeIdentifier"]
-        else:
-            self.unique_identifier = \
-                str(int(os.stat(self.parameter_filename)[stat.ST_CTIME]))
         if self.dimensionality > 1:
             self.domain_dimensions = self.parameters["TopGridDimensions"]
             if len(self.domain_dimensions) < 3:

--- a/yt/frontends/enzo_p/data_structures.py
+++ b/yt/frontends/enzo_p/data_structures.py
@@ -402,8 +402,6 @@ class EnzoPDataset(Dataset):
         self.periodicity += (False, ) * (3 - self.dimensionality)
         self.gamma = nested_dict_get(self.parameters, ("Field", "gamma"))
 
-        self.unique_identifier = \
-          str(int(os.stat(self.parameter_filename)[stat.ST_CTIME]))
 
     def _set_code_unit_attributes(self):
         if self.cosmological_simulation:

--- a/yt/frontends/enzo_p/data_structures.py
+++ b/yt/frontends/enzo_p/data_structures.py
@@ -7,7 +7,6 @@ from yt.utilities.on_demand_imports import \
 import io as io
 import numpy as np
 import os
-import stat
 import warnings
 
 from yt.data_objects.grid_patch import \

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -422,9 +422,6 @@ class FITSDataset(Dataset):
 
         if self.parameter_filename.startswith("InMemory"):
             self.unique_identifier = time.time()
-        else:
-            self.unique_identifier = \
-                int(os.stat(self.parameter_filename)[stat.ST_CTIME])
 
         # Determine dimensionality
 

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -1,4 +1,3 @@
-import stat
 import numpy as np
 import numpy.core.defchararray as np_char
 import os

--- a/yt/frontends/flash/data_structures.py
+++ b/yt/frontends/flash/data_structures.py
@@ -1,5 +1,4 @@
 import os
-import stat
 import numpy as np
 import weakref
 

--- a/yt/frontends/flash/data_structures.py
+++ b/yt/frontends/flash/data_structures.py
@@ -270,8 +270,6 @@ class FLASHDataset(Dataset):
         raise KeyError(pname)
 
     def _parse_parameter_file(self):
-        self.unique_identifier = \
-            int(os.stat(self.parameter_filename)[stat.ST_CTIME])
         if "file format version" in self._handle:
             self._flash_version = int(
                 self._handle["file format version"][:])

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -331,8 +331,6 @@ class GadgetDataset(SPHDataset):
         self.dimensionality = 3
         self.refine_by = 2
         self.parameters["HydroMethod"] = "sph"
-        self.unique_identifier = \
-            int(os.stat(self.parameter_filename)[stat.ST_CTIME])
         # Set standard values
 
         # We may have an overridden bounding box.

--- a/yt/frontends/gadget_fof/data_structures.py
+++ b/yt/frontends/gadget_fof/data_structures.py
@@ -183,8 +183,6 @@ class GadgetFOFDataset(ParticleDataset):
 
         self.dimensionality = 3
         self.refine_by = 2
-        self.unique_identifier = \
-            int(os.stat(self.parameter_filename)[stat.ST_CTIME])
 
         # Set standard values
         self.domain_left_edge = np.zeros(3, "float64")

--- a/yt/frontends/gadget_fof/data_structures.py
+++ b/yt/frontends/gadget_fof/data_structures.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 from functools import partial
 from yt.utilities.on_demand_imports import _h5py as h5py
 import numpy as np
-import stat
 import os
 import weakref
 

--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -246,8 +246,6 @@ class GAMERDataset(Dataset):
                     mylog.warning("Assuming %8s unit = %f %s", unit, value, cgs)
 
     def _parse_parameter_file(self):
-        self.unique_identifier = \
-            int(os.stat(self.parameter_filename)[stat.ST_CTIME])
 
         # code-specific parameters
         for t in self._handle['Info']:

--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -1,5 +1,4 @@
 import os
-import stat
 import numpy as np
 import weakref
 

--- a/yt/frontends/owls_subfind/data_structures.py
+++ b/yt/frontends/owls_subfind/data_structures.py
@@ -106,8 +106,6 @@ class OWLSSubfindDataset(ParticleDataset):
 
         self.dimensionality = 3
         self.refine_by = 2
-        self.unique_identifier = \
-            int(os.stat(self.parameter_filename)[stat.ST_CTIME])
 
         # Set standard values
         self.current_time = self.quan(hvals["Time_GYR"], "Gyr")

--- a/yt/frontends/owls_subfind/data_structures.py
+++ b/yt/frontends/owls_subfind/data_structures.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 from yt.utilities.on_demand_imports import _h5py as h5py
 import numpy as np
-import stat
 import glob
 import os
 

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -480,8 +480,6 @@ class RAMSESDataset(Dataset):
         self.parameters["HydroMethod"] = 'ramses'
         self.parameters["Time"] = 1. # default unit is 1...
 
-        self.unique_identifier = \
-            int(os.stat(self.parameter_filename)[stat.ST_CTIME])
         # We now execute the same logic Oliver's code does
         rheader = {}
 

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -1,6 +1,5 @@
 import os
 import numpy as np
-import stat
 import weakref
 from collections import defaultdict
 from glob import glob

--- a/yt/frontends/rockstar/data_structures.py
+++ b/yt/frontends/rockstar/data_structures.py
@@ -74,8 +74,6 @@ class RockstarDataset(ParticleDataset):
             hvals.pop("unused")
         self.dimensionality = 3
         self.refine_by = 2
-        self.unique_identifier = \
-            int(os.stat(self.parameter_filename)[stat.ST_CTIME])
         prefix = ".".join(self.parameter_filename.rsplit(".", 2)[:-2])
         self.filename_template = "%s.%%(num)s%s" % (prefix, self._suffix)
         self.file_count = len(glob.glob(prefix + ".*" + self._suffix))

--- a/yt/frontends/rockstar/data_structures.py
+++ b/yt/frontends/rockstar/data_structures.py
@@ -1,5 +1,4 @@
 import numpy as np
-import stat
 import glob
 import os
 

--- a/yt/frontends/sdf/data_structures.py
+++ b/yt/frontends/sdf/data_structures.py
@@ -1,7 +1,5 @@
 
 import numpy as np
-import stat
-import time
 import os
 import sys
 import contextlib

--- a/yt/frontends/sdf/data_structures.py
+++ b/yt/frontends/sdf/data_structures.py
@@ -102,11 +102,6 @@ class SDFDataset(ParticleDataset):
         self.parameters = self.sdf_container.parameters
         self.dimensionality = 3
         self.refine_by = 2
-        try:
-            self.unique_identifier = \
-                int(os.stat(self.parameter_filename)[stat.ST_CTIME])
-        except Exception:
-            self.unique_identifier = time.time()
 
         if self.domain_left_edge is None or self.domain_right_edge is None:
             R0 = self.parameters['R0']

--- a/yt/frontends/tipsy/data_structures.py
+++ b/yt/frontends/tipsy/data_structures.py
@@ -123,9 +123,6 @@ class TipsyDataset(SPHDataset):
         self.parameters["HydroMethod"] = "sph"
 
 
-        self.unique_identifier = \
-            int(os.stat(self.parameter_filename)[stat.ST_CTIME])
-
         # Read in parameter file, if available.
         if self._param_file is None:
             pfn = glob.glob(os.path.join(self.directory, "*.param"))

--- a/yt/frontends/tipsy/data_structures.py
+++ b/yt/frontends/tipsy/data_structures.py
@@ -1,5 +1,4 @@
 import numpy as np
-import stat
 import struct
 import glob
 import os

--- a/yt/frontends/ytdata/data_structures.py
+++ b/yt/frontends/ytdata/data_structures.py
@@ -4,7 +4,6 @@ from numbers import \
     Number as numeric_type
 import numpy as np
 import os
-import stat
 import weakref
 
 from .fields import \

--- a/yt/frontends/ytdata/data_structures.py
+++ b/yt/frontends/ytdata/data_structures.py
@@ -119,8 +119,6 @@ class SavedDataset(Dataset):
 
         for attr in self._con_attrs:
             setattr(self, attr, self.parameters.get(attr))
-        self.unique_identifier = \
-          int(os.stat(self.parameter_filename)[stat.ST_CTIME])
 
     def _with_parameter_file_open(self, f):
         # This allows subclasses to access the parameter file


### PR DESCRIPTION
## PR Summary
(Originally intended as part of #2556, but this change affects a lot of files and is much easier to review separately so I'm opening a dedicated PR.)

Most code frontends copy-paste the same exact line to set up `Dataset.unique_identifier`.
By making it a property, with a setter for rare cases where we _don't_ want to use the widespread implementation, we keep flexibility while reducing copied code.

⚠️ The following frontends required very minor adjustments that _may_ change the behaviour for this attribute, though I think it's unlikely. Namely
- sdf : had a try/except block with no specific exception to catch, I don't see what's there to be caught so I just removed it
- enzo : was defaulting to the same exact identifier constructor than default _except_ it was converting it to `str`. Unless typeerrors are raised in tests, I'll assume it's okay to rely on the "int" default.