### PR TITLE
add a list_annotations() method

### DIFF
--- a/doc/source/visualizing/callbacks.rst
+++ b/doc/source/visualizing/callbacks.rst
@@ -93,7 +93,7 @@ The underlying functions are more thoroughly documented in :ref:`callback-api`.
 .. _annotate-clear:
 
 Clear Callbacks (Some or All)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. function:: annotate_clear(index=None)
 
@@ -114,6 +114,27 @@ Clear Callbacks (Some or All)
     # Oops, I didn't want any of that.
     p.annotate_clear()
     p.save()
+
+.. _annotate-list:
+
+List Currently Applied Callbacks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. function:: annotate_list()
+
+   This function will print a list of each of the currently applied
+   callbacks together with their index.  The index can be used with
+   :ref:`annotate_clear() function <annotate-clear>` to remove a
+   specific callback.
+
+.. python-script::
+
+    import yt
+    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
+    p = yt.SlicePlot(ds, 'z', 'density', center='c', width=(20, 'kpc'))
+    p.annotate_scale()
+    p.annotate_timestamp()
+    p.annotate_list()
 
 .. _annotate-arrow:
 

--- a/doc/source/visualizing/callbacks.rst
+++ b/doc/source/visualizing/callbacks.rst
@@ -120,7 +120,7 @@ Clear Callbacks (Some or All)
 List Currently Applied Callbacks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: annotate_list()
+.. function:: list_annotations()
 
    This function will print a list of each of the currently applied
    callbacks together with their index.  The index can be used with
@@ -134,7 +134,7 @@ List Currently Applied Callbacks
     p = yt.SlicePlot(ds, 'z', 'density', center='c', width=(20, 'kpc'))
     p.annotate_scale()
     p.annotate_timestamp()
-    p.annotate_list()
+    p.list_annotations()
 
 .. _annotate-arrow:
 

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1119,6 +1119,15 @@ class PWViewerMPL(PlotWindow):
         self.setup_callbacks()
         return self
 
+    def annotate_list(self):
+        """
+        List the current callbacks for the plot, along with their index.  This
+        index can be used with annotate_clear to remove a callback from the
+        current plot.
+        """
+        for i, cb in enumerate(self._callbacks):
+            print(i, cb)
+
     def run_callbacks(self):
         for f in self.fields:
             keys = self.frb.keys()

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1119,7 +1119,7 @@ class PWViewerMPL(PlotWindow):
         self.setup_callbacks()
         return self
 
-    def annotate_list(self):
+    def list_annotations(self):
         """
         List the current callbacks for the plot, along with their index.  This
         index can be used with annotate_clear to remove a callback from the


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary


The `annotate_clear()` method takes an optional index of the annotation to remove, but there
is not high-level method to see the indices of the currently applied annotations. This adds a list_annotations() method to allow us to see what annotations are currently applied.

This reissues #2498. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
