### PR TITLE
[bugfix] add units to profile weight field

### DIFF
--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -224,6 +224,8 @@ been deprecated, use profile.standard_deviation instead."""
                   array_like_field(self.data_source,
                                    all_std[...,i], field)
                 self.standard_deviation[field][blank] = 0.0
+                self.weight = array_like_field(
+                    self.data_source, self.weight, self.weight_field)
             self.field_data[field][blank] = 0.0
             self.field_units[field] = self.field_data[field].units
             if isinstance(field, tuple):

--- a/yt/data_objects/tests/test_profiles.py
+++ b/yt/data_objects/tests/test_profiles.py
@@ -131,6 +131,7 @@ def test_profiles():
                              extrema={'density': (None, rma*e2)})
         assert_equal(p2d.x_bins[0], rmi - np.spacing(rmi))
         assert_equal(p2d.x_bins[-1], rma*e2)
+        assert str(ds.field_info['gas', 'cell_mass'].units) == str(p2d.weight.units)
 
         p2d = create_profile(dd, ('gas', 'density'), ('gas', 'temperature'),
                              weight_field=('gas', 'cell_mass'),


### PR DESCRIPTION
## PR Summary

This adds units to profile weight fields, so the following works.

```
ds = yt.load(...)
p = yt.create_profile(..., weight_field=<not None>)
print (p.weight.units)
```

Currently `p.weight` is just a numpy array without units.

## PR Checklist

- [x] Code passes flake8 checker
- [x] Adds a test for any bugs fixed. Adds tests for new features.