### PR TITLE
Change the default answer test unit system to code

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -15,7 +15,7 @@ answer_tests:
   local_chombo_003:
     - yt/frontends/chombo/tests/test_outputs.py
 
-  local_enzo_005:
+  local_enzo_006:
     - yt/frontends/enzo
 
   local_enzo_p_006:

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -1589,6 +1589,7 @@ class WarpXDataset(BoxlibDataset):
         setdefaultattr(self, 'mass_unit', self.quan(1.0, "kg"))
         setdefaultattr(self, 'time_unit', self.quan(1.0, "s"))
         setdefaultattr(self, 'velocity_unit', self.quan(1.0, "m/s"))
+        setdefaultattr(self, 'magnetic_unit', self.quan(1.0, "T"))
 
 
 class AMReXHierarchy(BoxlibHierarchy):

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -442,14 +442,12 @@ class FieldValuesTest(AnswerTestingTest):
     _attrs = ("field", )
 
     def __init__(self, ds_fn, field, obj_type = None,
-                 particle_type=False, decimals = 10,
-                 unit_system = "cgs"):
+                 particle_type=False, decimals = 10):
         super(FieldValuesTest, self).__init__(ds_fn)
         self.obj_type = obj_type
         self.field = field
         self.particle_type = particle_type
         self.decimals = decimals
-        self.unit_system = unit_system
 
     def run(self):
         obj = create_obj(self.ds, self.obj_type)
@@ -1012,13 +1010,7 @@ def small_patch_amr(ds_fn, fields, input_center="max", input_weight="density"):
                     yield ProjectionValuesTest(
                         ds_fn, axis, field, weight_field,
                         dobj_name)
-                # We convert these to CGS, which will help flush out any issues
-                # with conversions between unit systems.  We don't do that
-                # earlier because *earlier* we want to reduce any possibility
-                # of roundoff error before hashing the values.  Here, we use
-                # decimals, so a tiny bit of roundoff is OK.
-                yield FieldValuesTest(
-                        ds_fn, field, dobj_name, unit_system = "cgs")
+                yield FieldValuesTest(ds_fn, field, dobj_name)
 
 def big_patch_amr(ds_fn, fields, input_center="max", input_weight="density"):
     if not can_run_ds(ds_fn):
@@ -1061,10 +1053,8 @@ def sph_answer(ds, ds_str_repr, ds_nparticles, fields):
                     yield PixelizedProjectionValuesTest(
                         ds, axis, field, weight_field,
                         dobj_name)
-            # See the other note about unit_system
             yield FieldValuesTest(ds, field, dobj_name,
-                                  particle_type=particle_type,
-                                  unit_system = "cgs")
+                                  particle_type=particle_type)
 
 def create_obj(ds, obj_type):
     # obj_type should be tuple of

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -590,7 +590,9 @@ class PixelizedProjectionValuesTest(AnswerTestingTest):
         for k in new_result:
             assert (k in old_result)
         for k in new_result:
-            assert_rel_equal(new_result[k], old_result[k], 10)
+            # weight_field does not have units, so we do not directly compare them
+            if k == "weight_field_sum": continue
+            assert_allclose_units(new_result[k], old_result[k], 1e-10)
 
 class GridValuesTest(AnswerTestingTest):
     _type_name = "GridValues"

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -461,9 +461,9 @@ class FieldValuesTest(AnswerTestingTest):
         avg = obj.quantities.weighted_average_quantity(
             field, weight=weight_field)
         mi, ma = obj.quantities.extrema(self.field)
-        return np.array([avg.in_units(self.unit_system),
-                         mi.in_units(self.unit_system),
-                         ma.in_units(self.unit_system)])
+        return np.array([avg.in_base(self.unit_system),
+                         mi.in_base(self.unit_system),
+                         ma.in_base(self.unit_system)])
 
     def compare(self, new_result, old_result):
         err_msg = "Field values for %s not equal." % (self.field,)

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -461,9 +461,7 @@ class FieldValuesTest(AnswerTestingTest):
         avg = obj.quantities.weighted_average_quantity(
             field, weight=weight_field)
         mi, ma = obj.quantities.extrema(self.field)
-        return np.array([avg.in_base(self.unit_system),
-                         mi.in_base(self.unit_system),
-                         ma.in_base(self.unit_system)])
+        return [avg, mi, ma]
 
     def compare(self, new_result, old_result):
         err_msg = "Field values for %s not equal." % (self.field,)
@@ -471,6 +469,11 @@ class FieldValuesTest(AnswerTestingTest):
             assert_equal(new_result, old_result,
                          err_msg=err_msg, verbose=True)
         else:
+            # What we do here is check if the old_result has units; if not, we
+            # assume they will be the same as the units of new_result.
+            if isinstance(old_result, np.ndarray) and not hasattr(old_result, "in_units"):
+                # coerce it here to the same units
+                old_result = old_result * new_result[0].uq
             assert_allclose_units(new_result, old_result, 10.**(-self.decimals),
                                   err_msg=err_msg, verbose=True)
 

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -335,7 +335,7 @@ class AnswerTestingTest(object):
         elif isinstance(ds_fn, Dataset):
             self.ds = ds_fn
         else:
-            self.ds = data_dir_load(ds_fn)
+            self.ds = data_dir_load(ds_fn, kwargs = {'unit_system': 'code'})
 
     def __call__(self):
         if AnswerTestingTest.result_storage is None:

--- a/yt/utilities/answer_testing/utils.py
+++ b/yt/utilities/answer_testing/utils.py
@@ -329,6 +329,7 @@ def data_dir_load(ds_fn, cls = None, args = None, kwargs = None):
     """
     args = args or ()
     kwargs = kwargs or {}
+    kwargs.setdefault('unit_system', 'code')
     path = ytcfg.get("yt", "test_data_dir")
     if isinstance(ds_fn, Dataset): return ds_fn
     if not os.path.isdir(path):


### PR DESCRIPTION
This is a test PR to see if we get any failures that are not *answer value* failures if we change the base unit system for answer tests to `code` universally.

If this works, I will update this with a bit more of the rationale, and I will post to the yt mailing list.  It is not mergable as-is.