### PR TITLE
Store unitful field values and don't compare weight fields

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -1,45 +1,45 @@
 answer_tests:
 
-  local_amrvac_003:
+  local_amrvac_004:
     - yt/frontends/amrvac/tests/test_outputs.py
     
-  local_artio_001:
+  local_artio_002:
     - yt/frontends/artio/tests/test_outputs.py
 
-  local_athena_005:
+  local_athena_006:
     - yt/frontends/athena
 
-  local_athena_pp_001:
+  local_athena_pp_002:
     - yt/frontends/athena_pp
 
-  local_chombo_002:
+  local_chombo_003:
     - yt/frontends/chombo/tests/test_outputs.py
 
-  local_enzo_004:
+  local_enzo_005:
     - yt/frontends/enzo
 
-  local_enzo_p_005:
+  local_enzo_p_006:
     - yt/frontends/enzo_p/tests/test_outputs.py
 
-  local_fits_002:
+  local_fits_003:
     - yt/frontends/fits/tests/test_outputs.py
 
-  local_flash_009:
+  local_flash_010:
     - yt/frontends/flash/tests/test_outputs.py
 
-  local_gadget_001:
+  local_gadget_002:
     - yt/frontends/gadget/tests/test_outputs.py
 
-  local_gamer_005:
+  local_gamer_006:
     - yt/frontends/gamer/tests/test_outputs.py
 
   local_gdf_001:
     - yt/frontends/gdf/tests/test_outputs.py
 
-  local_gizmo_002:
+  local_gizmo_003:
     - yt/frontends/gizmo/tests/test_outputs.py
 
-  local_halos_008:
+  local_halos_009:
     - yt/analysis_modules/halo_analysis/tests/test_halo_finders.py
     - yt/analysis_modules/halo_analysis/tests/test_halo_catalog.py
     - yt/analysis_modules/halo_finding/tests/test_rockstar.py
@@ -48,7 +48,7 @@ answer_tests:
     - yt/frontends/gadget_fof/tests/test_outputs.py:test_fields_g5
     - yt/frontends/gadget_fof/tests/test_outputs.py:test_fields_g42
 
-  local_owls_002:
+  local_owls_003:
     - yt/frontends/owls/tests/test_outputs.py
 
   local_pw_027:
@@ -59,10 +59,10 @@ answer_tests:
     - yt/visualization/tests/test_particle_plot.py:test_particle_phase_answers
     - yt/visualization/tests/test_raw_field_slices.py:test_raw_field_slices
 
-  local_tipsy_002:
+  local_tipsy_003:
     - yt/frontends/tipsy/tests/test_outputs.py
 
-  local_varia_010:
+  local_varia_011:
     - yt/analysis_modules/radmc3d_export
     - yt/frontends/moab/tests/test_c5.py
     - yt/fields/tests/test_xray_fields.py
@@ -89,7 +89,7 @@ answer_tests:
     - yt/visualization/volume_rendering/tests/test_mesh_render.py:test_wedge6_render
     - yt/visualization/volume_rendering/tests/test_mesh_render.py:test_wedge6_render_pyembree
 
-  local_boxlib_008:
+  local_boxlib_009:
     - yt/frontends/boxlib/tests/test_outputs.py:test_radadvect
     - yt/frontends/boxlib/tests/test_outputs.py:test_radtube
     - yt/frontends/boxlib/tests/test_outputs.py:test_star
@@ -99,7 +99,7 @@ answer_tests:
     - yt/frontends/boxlib/tests/test_outputs.py:test_units_override
     - yt/frontends/boxlib/tests/test_outputs.py:test_raw_fields
 
-  local_boxlib_particles_005:
+  local_boxlib_particles_006:
     - yt/frontends/boxlib/tests/test_outputs.py:test_LyA
     - yt/frontends/boxlib/tests/test_outputs.py:test_nyx_particle_io
     - yt/frontends/boxlib/tests/test_outputs.py:test_castro_particle_io
@@ -110,7 +110,7 @@ answer_tests:
     - yt/frontends/boxlib/tests/test_outputs.py:test_NyxDataset
     - yt/frontends/boxlib/tests/test_outputs.py:test_WarpXDataset
 
-  local_ramses_001:
+  local_ramses_002:
     - yt/frontends/ramses/tests/test_outputs.py
 
   local_ytdata_006:

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -459,7 +459,7 @@ class FieldValuesTest(AnswerTestingTest):
         avg = obj.quantities.weighted_average_quantity(
             field, weight=weight_field)
         mi, ma = obj.quantities.extrema(self.field)
-        return np.array([avg, mi, ma])
+        return [avg, mi, ma]
 
     def compare(self, new_result, old_result):
         err_msg = "Field values for %s not equal." % (self.field,)
@@ -499,7 +499,7 @@ class ProjectionValuesTest(AnswerTestingTest):
     _attrs = ("field", "axis", "weight_field")
 
     def __init__(self, ds_fn, axis, field, weight_field = None,
-                 obj_type = None, decimals = None):
+                 obj_type = None, decimals = 10):
         super(ProjectionValuesTest, self).__init__(ds_fn)
         self.axis = axis
         self.field = field
@@ -536,7 +536,10 @@ class ProjectionValuesTest(AnswerTestingTest):
         for k in new_result:
             err_msg = "%s values of %s (%s weighted) projection (axis %s) not equal." % \
               (k, self.field, self.weight_field, self.axis)
-            if k == 'weight_field' and self.weight_field is None:
+            if k == 'weight_field':
+                # Our weight_field can vary between unit systems, whereas we
+                # can do a unitful comparison for the other fields.  So we do
+                # not do the test here.
                 continue
             nres, ores = new_result[k][nind], old_result[k][oind]
             if self.decimals is None:


### PR DESCRIPTION
This changes our testing to *not* compare `weight_field` in our projection values tests, and it also changes our tests to return unitful arrays from the `FieldValues` test.

I believe that this *should* pass as-is, and then I will update the `tests.yaml` to store new versions of the tests so we retain units in them.

Following this, we can unblock #2568 , where we will identify the items that need updates there, as well.