### PR TITLE
Test particle selections

### DIFF
--- a/yt/frontends/gadget/tests/test_outputs.py
+++ b/yt/frontends/gadget/tests/test_outputs.py
@@ -5,7 +5,9 @@ import shutil
 import tempfile
 
 import yt
-from yt.testing import requires_file
+from yt.testing import requires_file, \
+    ParticleSelectionComparison, \
+    assert_equal
 from yt.utilities.answer_testing.framework import \
     data_dir_load, \
     requires_ds, \
@@ -106,6 +108,46 @@ def test_multifile_read():
     """
     assert isinstance(data_dir_load(snap_33), GadgetDataset)
     assert isinstance(data_dir_load(snap_33_dir), GadgetDataset)
+
+@requires_file(snap_33)
+def test_particle_subselection():
+    """
+    This checks that we correctly subselect from a dataset, first by making
+    sure we get all the particles, then by comparing manual selections against
+    them.
+    """
+    ds = data_dir_load(snap_33)
+    psc = ParticleSelectionComparison(ds)
+    
+    sp1 = ds.sphere("c", (0.1, "unitary"))
+    assert_equal(psc.compare_dobj_selection(sp1) , True)
+
+    sp2 = ds.sphere("c", (0.1, "unitary"))
+    assert_equal(psc.compare_dobj_selection(sp2) , True)
+
+    sp3 = ds.sphere((1.0, 1.0, 1.0), (0.05, "unitary"))
+    assert_equal(psc.compare_dobj_selection(sp3) , True)
+
+    sp4 = ds.sphere("c", (0.5, "unitary"))
+    assert_equal(psc.compare_dobj_selection(sp4) , True)
+
+    dd = ds.all_data()
+    assert_equal(psc.compare_dobj_selection(dd) , True)
+
+    reg1 = ds.r[ (0.1, 'unitary'):(0.9, 'unitary'),
+                 (0.1, 'unitary'):(0.9, 'unitary'),
+                 (0.1, 'unitary'):(0.9, 'unitary')]
+    assert_equal(psc.compare_dobj_selection(reg1) , True)
+
+    reg2 = ds.r[ (0.8, 'unitary'):(0.85, 'unitary'),
+                 (0.8, 'unitary'):(0.85, 'unitary'),
+                 (0.8, 'unitary'):(0.85, 'unitary')]
+    assert_equal(psc.compare_dobj_selection(reg2) , True)
+
+    reg3 = ds.r[ (0.3, 'unitary'):(0.6, 'unitary'),
+                 (0.2, 'unitary'):(0.8, 'unitary'),
+                 (0.0, 'unitary'):(0.1, 'unitary')]
+    assert_equal(psc.compare_dobj_selection(reg3) , True)
 
 @requires_ds(BE_Gadget)
 def test_bigendian_field_access():

--- a/yt/frontends/gadget/tests/test_outputs.py
+++ b/yt/frontends/gadget/tests/test_outputs.py
@@ -135,12 +135,28 @@ def test_particle_subselection():
     sp3_z = ds.sphere((12.5, 12.5, 1.0), (2.0, "code_length"))
     psc.compare_dobj_selection(sp3_z)
 
-    # Test wrapping around all three axes simultaneously
+    # Test wrapping around all three axes simultaneously on left
     sp3_all = ds.sphere((1.0, 1.0, 1.0), (2.0, "code_length"))
     psc.compare_dobj_selection(sp3_all)
 
-    sp4 = ds.sphere("c", (0.5, "unitary"))
-    psc.compare_dobj_selection(sp4)
+    # Test wrapping around each axis individually on right: x
+    sp4_x = ds.sphere((24.0, 12.5, 12.5), (2.0, "code_length"))
+    psc.compare_dobj_selection(sp4_x)
+
+    # Test wrapping around each axis individually on right: y
+    sp4_y = ds.sphere((12.5, 24.0, 12.5), (2.0, "code_length"))
+    psc.compare_dobj_selection(sp4_y)
+
+    # Test wrapping around each axis individually on right: z
+    sp4_z = ds.sphere((12.5, 12.5, 24.0), (2.0, "code_length"))
+    psc.compare_dobj_selection(sp4_z)
+
+    # Test wrapping around all three axes simultaneously on right
+    sp4_all = ds.sphere((24.0, 24.0, 24.0), (2.0, "code_length"))
+    psc.compare_dobj_selection(sp4_all)
+
+    sp5 = ds.sphere("c", (0.5, "unitary"))
+    psc.compare_dobj_selection(sp5)
 
     dd = ds.all_data()
     psc.compare_dobj_selection(dd)

--- a/yt/frontends/gadget/tests/test_outputs.py
+++ b/yt/frontends/gadget/tests/test_outputs.py
@@ -122,7 +122,7 @@ def test_particle_subselection():
     sp1 = ds.sphere("c", (0.1, "unitary"))
     assert_equal(psc.compare_dobj_selection(sp1) , True)
 
-    sp2 = ds.sphere("c", (0.1, "unitary"))
+    sp2 = ds.sphere("c", (0.2, "unitary"))
     assert_equal(psc.compare_dobj_selection(sp2) , True)
 
     sp3 = ds.sphere((1.0, 1.0, 1.0), (0.05, "unitary"))

--- a/yt/frontends/gadget/tests/test_outputs.py
+++ b/yt/frontends/gadget/tests/test_outputs.py
@@ -111,43 +111,54 @@ def test_multifile_read():
 
 @requires_file(snap_33)
 def test_particle_subselection():
-    """
-    This checks that we correctly subselect from a dataset, first by making
-    sure we get all the particles, then by comparing manual selections against
-    them.
-    """
+    #This checks that we correctly subselect from a dataset, first by making
+    #sure we get all the particles, then by comparing manual selections against
+    #them.
     ds = data_dir_load(snap_33)
     psc = ParticleSelectionComparison(ds)
-    
+
     sp1 = ds.sphere("c", (0.1, "unitary"))
-    assert_equal(psc.compare_dobj_selection(sp1) , True)
+    psc.compare_dobj_selection(sp1)
 
     sp2 = ds.sphere("c", (0.2, "unitary"))
-    assert_equal(psc.compare_dobj_selection(sp2) , True)
+    psc.compare_dobj_selection(sp2)
 
-    sp3 = ds.sphere((1.0, 1.0, 1.0), (0.05, "unitary"))
-    assert_equal(psc.compare_dobj_selection(sp3) , True)
+    # Test wrapping around each axis individually: x
+    sp3_x = ds.sphere((1.0, 12.5, 12.5), (2.0, "code_length"))
+    psc.compare_dobj_selection(sp3_x)
+
+    # Test wrapping around each axis individually: y
+    sp3_y = ds.sphere((12.5, 1.0, 12.5), (2.0, "code_length"))
+    psc.compare_dobj_selection(sp3_y)
+
+    # Test wrapping around each axis individually: z
+    sp3_z = ds.sphere((12.5, 12.5, 1.0), (2.0, "code_length"))
+    psc.compare_dobj_selection(sp3_z)
+
+    # Test wrapping around all three axes simultaneously
+    sp3_all = ds.sphere((1.0, 1.0, 1.0), (2.0, "code_length"))
+    psc.compare_dobj_selection(sp3_all)
 
     sp4 = ds.sphere("c", (0.5, "unitary"))
-    assert_equal(psc.compare_dobj_selection(sp4) , True)
+    psc.compare_dobj_selection(sp4)
 
     dd = ds.all_data()
-    assert_equal(psc.compare_dobj_selection(dd) , True)
+    psc.compare_dobj_selection(dd)
 
     reg1 = ds.r[ (0.1, 'unitary'):(0.9, 'unitary'),
                  (0.1, 'unitary'):(0.9, 'unitary'),
                  (0.1, 'unitary'):(0.9, 'unitary')]
-    assert_equal(psc.compare_dobj_selection(reg1) , True)
+    psc.compare_dobj_selection(reg1)
 
     reg2 = ds.r[ (0.8, 'unitary'):(0.85, 'unitary'),
                  (0.8, 'unitary'):(0.85, 'unitary'),
                  (0.8, 'unitary'):(0.85, 'unitary')]
-    assert_equal(psc.compare_dobj_selection(reg2) , True)
+    psc.compare_dobj_selection(reg2)
 
     reg3 = ds.r[ (0.3, 'unitary'):(0.6, 'unitary'),
                  (0.2, 'unitary'):(0.8, 'unitary'),
                  (0.0, 'unitary'):(0.1, 'unitary')]
-    assert_equal(psc.compare_dobj_selection(reg3) , True)
+    psc.compare_dobj_selection(reg3)
 
 @requires_ds(BE_Gadget)
 def test_bigendian_field_access():

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -1224,8 +1224,13 @@ class TempDirTest(unittest.TestCase):
         os.chdir(self.curdir)
         shutil.rmtree(self.tmpdir)
 
-# We make this a class with a setup so we can cache the particles one time
 class ParticleSelectionComparison:
+    """
+    This is a test helper class that takes a particle dataset, caches the
+    particles it has on disk (manually reading them using lower-level IO
+    routines) and then received a data object that it compares against manually
+    running the data object's selection routines.
+    """
 
     def __init__(self, ds):
         self.ds = ds
@@ -1259,4 +1264,4 @@ class ParticleSelectionComparison:
                 obj_results.append(chunk[ptype, "particle_position"])
             obj_results = np.concatenate(obj_results, axis = 0)
 
-            assert np.all(sel_pos == obj_results)
+            return np.all(sel_pos == obj_results)

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -1259,11 +1259,13 @@ class ParticleSelectionComparison:
             # Set our radii to zero for now, I guess?
             radii = self.hsml.get(ptype, 0.0)
             sel_index = dobj.selector.select_points(x, y, z, radii)
-            sel_pos = self.particles[ptype][sel_index, :]
+            if sel_index is None:
+                sel_pos = np.empty((0, 3))
+            else:
+                sel_pos = self.particles[ptype][sel_index, :]
 
             obj_results = []
             for chunk in dobj.chunks([], "io"):
                 obj_results.append(chunk[ptype, "particle_position"])
             obj_results = np.concatenate(obj_results, axis = 0)
-
-            return np.all(sel_pos == obj_results)
+            assert_equal(sel_pos, obj_results)

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -1229,7 +1229,8 @@ class ParticleSelectionComparison:
     This is a test helper class that takes a particle dataset, caches the
     particles it has on disk (manually reading them using lower-level IO
     routines) and then received a data object that it compares against manually
-    running the data object's selection routines.
+    running the data object's selection routines.  All supplied data objects
+    must be created from the input dataset.
     """
 
     def __init__(self, ds):
@@ -1237,6 +1238,7 @@ class ParticleSelectionComparison:
         # Construct an index so that we get all the data_files
         ds.index
         particles = {}
+        # hsml is the smoothing length we use for radial selection
         hsml = {}
         for data_file in ds.index.data_files:
             for ptype, pos_arr in ds.index.io._yield_coordinates(data_file):


### PR DESCRIPTION
This adds a helper function to manually test particle selections.  I've also implemented it for the `snapshot_033` dataset.

Until #2575 goes in, this will fail.  When #2575 goes in, it should pass.