### PR TITLE
Boolean comparisons. Fixes #2576

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ if os.path.exists('MANIFEST'):
 with open('README.md') as file:
     long_description = file.read()
 
-if check_for_openmp() is True:
+if check_for_openmp():
     omp_args = ['-fopenmp']
 else:
     omp_args = None

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -84,7 +84,7 @@ def run_install_script(install_script_path, inst_py3, binary_yt=False):
         with open('install_script_edited.sh', 'w') as target:
             data = source.read()
             for dep in OPTIONAL_DEPS:
-                if binary_yt is True and dep in YT_SOURCE_ONLY_DEPS:
+                if binary_yt and dep in YT_SOURCE_ONLY_DEPS:
                     continue
                 if dep == 'rockstar':
                     # compiling rockstar is broken on newer MacOS releases
@@ -92,9 +92,9 @@ def run_install_script(install_script_path, inst_py3, binary_yt=False):
                         continue
                 dname = 'INST_%s' % dep.upper()
                 data = data.replace(dname + '=0', dname + '=1')
-            if inst_py3 is True:
+            if inst_py3:
                 data = data.replace('INST_PY3=0', 'INST_PY3=1')
-            if binary_yt is False:
+            if not binary_yt:
                 data = data.replace('INST_YT_SOURCE=0', 'INST_YT_SOURCE=1')
             target.write(data)
     shutil.copyfile('install_script_edited.sh', 'install_script.sh')
@@ -110,7 +110,7 @@ def verify_yt_installation(binary_yt):
     yt_dir = yt_dir[0]
     python_path = os.sep.join([yt_dir, 'bin', 'python'])
     for dep in OPTIONAL_DEPS + REQUIRED_DEPS:
-        if binary_yt is True and dep in YT_SOURCE_ONLY_DEPS:
+        if binary_yt and dep in YT_SOURCE_ONLY_DEPS:
             continue
         if dep == 'git':
             git_path = os.sep.join([yt_dir, 'bin', 'git'])

--- a/yt/analysis_modules/halo_finding/rockstar/rockstar.py
+++ b/yt/analysis_modules/halo_finding/rockstar/rockstar.py
@@ -199,7 +199,7 @@ class RockstarHaloFinder(ParallelAnalysisInterface):
             mylog.info("https://ui.adsabs.harvard.edu/abs/2013ApJ...762..109B")
         ParallelAnalysisInterface.__init__(self)
         # Decide how we're working.
-        if ytcfg.getboolean("yt", "inline") is True:
+        if ytcfg.getboolean("yt", "inline"):
             self.runner = InlineRunner()
         else:
             self.runner = StandardRunner(num_readers, num_writers)

--- a/yt/analysis_modules/halo_mass_function/halo_mass_function.py
+++ b/yt/analysis_modules/halo_mass_function/halo_mass_function.py
@@ -184,7 +184,7 @@ class HaloMassFcn():
             if log_mass_max is None:
                 self.log_mass_max = 16
         # If we're making the analytic function...
-        if self.make_analytic is True:
+        if self.make_analytic:
             # Try to set cosmological parameters from the simulation dataset
             if simulation_ds is not None:
                 self.omega_matter0 = self.simulation_ds.omega_matter

--- a/yt/data_objects/analyzer_objects.py
+++ b/yt/data_objects/analyzer_objects.py
@@ -22,7 +22,7 @@ analysis_task_registry = {}
 class RegisteredTask(type):
     def __init__(cls, name, b, d):
         type.__init__(cls, name, b, d)
-        if hasattr(cls, "skip") and cls.skip is False:
+        if hasattr(cls, "skip") and not cls.skip:
             return
         analysis_task_registry[cls.__name__] = cls
 

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -338,7 +338,7 @@ class YTQuadTreeProj(YTSelectionContainer2D):
                                           [], "io", local_only = True)):
                 mylog.debug("Adding chunk (%s) to tree (%0.3e GB RAM)",
                             chunk.ires.size, get_memory_usage()/1024.)
-                if _units_initialized is False:
+                if not _units_initialized:
                     self._initialize_projected_units(fields, chunk)
                     _units_initialized = True
                 self._handle_chunk(chunk, fields, tree)

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -75,7 +75,7 @@ data_object_registry = {}
 def sanitize_weight_field(ds, field, weight):
     field_object = ds._get_field_info(field)
     if weight is None:
-        if field_object.particle_type is True:
+        if field_object.particle_type:
             weight_field = (field_object.name[0], 'particle_ones')
         else:
             weight_field = ('index', 'ones')
@@ -1546,7 +1546,7 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface):
             fields_to_get.append(field)
         if len(fields_to_get) == 0 and len(fields_to_generate) == 0:
             return
-        elif self._locked is True:
+        elif self._locked:
             raise GenerationInProgress(fields)
         # Track which ones we want in the end
         ofields = set(list(self.field_data.keys())

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -200,7 +200,7 @@ class Dataset(object):
             obj = object.__new__(cls)
         elif cache_key not in _cached_datasets:
             obj = object.__new__(cls)
-            if obj._skip_cache is False:
+            if not obj._skip_cache:
                 _cached_datasets[cache_key] = obj
         else:
             obj = _cached_datasets[cache_key]
@@ -879,7 +879,7 @@ class Dataset(object):
     @property
     def particle_type_counts(self):
         self.index
-        if self.particles_exist is False:
+        if not self.particles_exist:
             return {}
 
         # frontends or index implementation can populate this dict while

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -283,10 +283,10 @@ class DatasetSeries(object):
         ...
 
         """
-        if self.parallel is False:
+        if not self.parallel:
             njobs = 1
-        elif dynamic is False:
-            if self.parallel is True:
+        elif not dynamic:
+            if self.parallel:
                 njobs = -1
             else:
                 njobs = self.parallel

--- a/yt/fields/derived_field.py
+++ b/yt/fields/derived_field.py
@@ -111,7 +111,7 @@ class DerivedField(object):
         self.display_name = display_name
         self.not_in_all = not_in_all
         self.display_field = display_field
-        if particle_type is True:
+        if particle_type:
             warnings.warn("particle_type for derived fields "
                           "has been replaced with sampling_type = 'particle'",
                           DeprecationWarning)

--- a/yt/fields/field_functions.py
+++ b/yt/fields/field_functions.py
@@ -33,7 +33,7 @@ def get_radius(data, field_prefix, ftype):
         # it from a cm**2 array.
         np.subtract(data[ftype, "%s%s" % (field_prefix, ax)].in_base(unit_system.name),
                     center[i], r)
-        if data.ds.periodicity[i] is True:
+        if data.ds.periodicity[i]:
             np.abs(r, r)
             np.subtract(r, DW[i], rdw)
             np.abs(rdw, rdw)

--- a/yt/fields/vector_operations.py
+++ b/yt/fields/vector_operations.py
@@ -63,7 +63,7 @@ def create_magnitude_field(registry, basename, field_units,
             mag += (data[fn])**2
         return np.sqrt(mag)
 
-    if particle_type is True:
+    if particle_type:
         sampling_type = 'particle'
     else:
         sampling_type = 'cell'
@@ -91,7 +91,7 @@ def create_relative_field(registry, basename, field_units, ftype='gas',
             return d - bulk[iax]
         return _relative_vector
 
-    if particle_type is True:
+    if particle_type:
         sampling_type = 'particle'
     else:
         sampling_type = 'cell'

--- a/yt/frontends/boxlib/tests/test_outputs.py
+++ b/yt/frontends/boxlib/tests/test_outputs.py
@@ -282,10 +282,10 @@ def test_maestro_parameters():
     assert(type(ds.parameters['plot_base_name']) is str)
 
     # Check boolean parameters: T or F
-    assert(ds.parameters['use_thermal_diffusion'] is False)
+    assert(not ds.parameters['use_thermal_diffusion'])
     assert(type(ds.parameters['use_thermal_diffusion']) is bool)
 
-    assert(ds.parameters['do_burning'] is True)
+    assert(ds.parameters['do_burning'])
     assert(type(ds.parameters['do_burning']) is bool)
 
     # Check a float parameter with a decimal point

--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -296,9 +296,11 @@ class GAMERDataset(Dataset):
             periodic_bc = 1
         else:
             periodic_bc = 0
-        self.periodicity = ( parameters['Opt__BC_Flu'][0]==periodic_bc,
-                             parameters['Opt__BC_Flu'][2]==periodic_bc,
-                             parameters['Opt__BC_Flu'][4]==periodic_bc )
+        self.periodicity = (
+            bool(parameters['Opt__BC_Flu'][0]==periodic_bc),
+            bool(parameters['Opt__BC_Flu'][2]==periodic_bc),
+            bool(parameters['Opt__BC_Flu'][4]==periodic_bc),
+        )
 
         # cosmological parameters
         if parameters['Comoving']:

--- a/yt/frontends/ytdata/data_structures.py
+++ b/yt/frontends/ytdata/data_structures.py
@@ -587,7 +587,7 @@ class YTNonspatialGrid(AMRGridPatch):
             fields_to_get.append(field)
         if len(fields_to_get) == 0 and len(fields_to_generate) == 0:
             return
-        elif self._locked is True:
+        elif self._locked:
             raise GenerationInProgress(fields)
         # Track which ones we want in the end
         ofields = set(list(self.field_data.keys())

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -186,7 +186,7 @@ def time_execution(func):
         mylog.debug('%s took %0.3f s', func.__name__, (t2-t1))
         return res
     from yt.config import ytcfg
-    if ytcfg.getboolean("yt","timefunctions") is True:
+    if ytcfg.getboolean("yt","timefunctions"):
         return wrapper
     else:
         return func
@@ -1144,7 +1144,7 @@ interactivity = False
 def toggle_interactivity():
     global interactivity
     interactivity = not interactivity
-    if interactivity is True:
+    if interactivity:
         if '__IPYTHON__' in dir(builtins):
             import IPython
             shell = IPython.get_ipython()

--- a/yt/geometry/coordinates/spec_cube_coordinates.py
+++ b/yt/geometry/coordinates/spec_cube_coordinates.py
@@ -55,7 +55,7 @@ class SpectralCubeCoordinateHandler(CartesianCoordinateHandler):
         self.axis_field[self.ds.spec_axis] = _spec_axis
 
     def setup_fields(self, registry):
-        if self.ds.no_cgs_equiv_length is False:
+        if not self.ds.no_cgs_equiv_length:
             return super(SpectralCubeCoordinateHandler, self
                     ).setup_fields(registry)
         for axi, ax in enumerate("xyz"):

--- a/yt/startup_tasks.py
+++ b/yt/startup_tasks.py
@@ -139,7 +139,7 @@ else:
     help_parser.set_defaults(func=print_help)
 
 
-if parallel_capable is True:
+if parallel_capable:
     pass
 elif exe_name in \
         ["mpi4py", "embed_enzo",

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -461,7 +461,7 @@ def construct_octree_mask(prng=RandomState(0x1d3d3d3), refined=None):
 
     if refined in (None, True):
         refined = [True]
-    if refined is False:
+    if not refined:
         refined = [False]
         return refined
 

--- a/yt/units/unit_object.py
+++ b/yt/units/unit_object.py
@@ -628,7 +628,7 @@ def _lookup_unit_symbol(symbol_str, unit_symbol_lut):
         unit_is_si_prefixable = (symbol_wo_prefix in unit_symbol_lut and
                                  symbol_wo_prefix in prefixable_units)
 
-        if unit_is_si_prefixable is True:
+        if unit_is_si_prefixable:
             # lookup successful, it's a symbol with a prefix
             unit_data = unit_symbol_lut[symbol_wo_prefix]
             prefix_value = unit_prefixes[possible_prefix]

--- a/yt/units/yt_array.py
+++ b/yt/units/yt_array.py
@@ -468,7 +468,7 @@ class YTArray(np.ndarray):
                 bypass_validation=False):
         if dtype is None:
             dtype = getattr(input_array, 'dtype', np.float64)
-        if bypass_validation is True:
+        if bypass_validation:
             obj = np.asarray(input_array, dtype=dtype).view(cls)
             obj.units = input_units
             if registry is not None:

--- a/yt/utilities/answer_testing/answer_tests.py
+++ b/yt/utilities/answer_testing/answer_tests.py
@@ -206,7 +206,7 @@ def sph_answer(ds, ds_str_repr, ds_nparticles, field, weight, ds_obj, axis):
         particle_type = True
     else:
         particle_type = False
-    if particle_type is False:
+    if not particle_type:
         ppv_hd = pixelized_projection_values(ds, axis, field, weight, ds_obj)
         hex_digests['pixelized_projection_values'] = ppv_hd
     fv_hd = field_values(ds, field, ds_obj, particle_type=particle_type)

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -156,7 +156,8 @@ class AnswerTesting(Plugin):
         run_big_data = options.big_data
 
     def finalize(self, result=None):
-        if self.store_results is False: return
+        if not self.store_results:
+            return
         self.storage.dump(self.result_storage)
 
     def help(self):
@@ -968,7 +969,7 @@ def requires_sim(sim_fn, sim_type, big_data = False, file_check = False):
         return lambda: None
     def ftrue(func):
         return func
-    if run_big_data is False and big_data is True:
+    if not run_big_data and big_data:
         return ffalse
     elif not can_run_sim(sim_fn, sim_type, file_check):
         return ffalse
@@ -990,7 +991,7 @@ def requires_ds(ds_fn, big_data = False, file_check = False):
         return lambda: None
     def ftrue(func):
         return func
-    if run_big_data is False and big_data is True:
+    if not run_big_data and big_data:
         return ffalse
     elif not can_run_ds(ds_fn, file_check):
         return ffalse
@@ -1049,7 +1050,7 @@ def sph_answer(ds, ds_str_repr, ds_nparticles, fields):
             else:
                 particle_type = False
             for axis in [0, 1, 2]:
-                if particle_type is False:
+                if not particle_type:
                     yield PixelizedProjectionValuesTest(
                         ds, axis, field, weight_field,
                         dobj_name)

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -96,7 +96,7 @@ def _print_failed_source_update(reinstall=False):
         print("    $ conda update yt")
         print()
         print("to update your yt installation.")
-        if reinstall is True:
+        if reinstall:
             print()
             print("To update all of your packages, you can do:")
             print()
@@ -1081,11 +1081,11 @@ class YTStatsCmd(YTCommand):
         ds.print_stats()
         vals = {}
         if args.field in ds.derived_field_list:
-            if args.max is True:
+            if args.max:
                 vals['min'] = ds.find_max(args.field)
                 print("Maximum %s: %0.5e at %s" % (args.field,
                     vals['min'][0], vals['min'][1]))
-            if args.min is True:
+            if args.min:
                 vals['max'] = ds.find_min(args.field)
                 print("Minimum %s: %0.5e at %s" % (args.field,
                     vals['max'][0], vals['max'][1]))

--- a/yt/utilities/grid_data_format/conversion/conversion_athena.py
+++ b/yt/utilities/grid_data_format/conversion/conversion_athena.py
@@ -343,7 +343,7 @@ class AthenaConverter(Converter):
                 self.parse_line(line, grid)
                 if grid['read_type'] == 'vector':
                     break
-                if table_read is False:             
+                if not table_read:
                     line = f.readline()
                 if 'TABLE' in line.strip().split():
                     table_read = True

--- a/yt/utilities/grid_data_format/writer.py
+++ b/yt/utilities/grid_data_format/writer.py
@@ -222,7 +222,7 @@ def _get_backup_file(ds):
         # backup file already exists, open it. We use parallel
         # h5py if it is available
         if communication_system.communicators[-1].size > 1 and \
-                h5py.get_config().mpi is True:
+                h5py.get_config().mpi:
             mpi4py_communicator = communication_system.communicators[-1].comm
             f = h5py.File(backup_filename, "r+", driver='mpio', 
                           comm=mpi4py_communicator)
@@ -264,7 +264,7 @@ def _create_new_gdf(ds, gdf_path, data_author=None, data_comment=None,
     # h5py if it is available.
     ###
     if communication_system.communicators[-1].size > 1 and \
-            h5py.get_config().mpi is True:
+            h5py.get_config().mpi:
         mpi4py_communicator = communication_system.communicators[-1].comm
         f = h5py.File(gdf_path, "w", driver='mpio', 
                       comm=mpi4py_communicator)

--- a/yt/utilities/math_utils.py
+++ b/yt/utilities/math_utils.py
@@ -129,8 +129,8 @@ def periodic_dist(a, b, period, periodicity=(True, True, True)):
     c = np.empty((2,) + a.shape, dtype="float64")
     c[0,:] = np.abs(a - b)
 
-    p_directions = [i for i,p in enumerate(periodicity) if p is True]
-    np_directions = [i for i,p in enumerate(periodicity) if p is False]
+    p_directions = [i for i,p in enumerate(periodicity) if p]
+    np_directions = [i for i,p in enumerate(periodicity) if not p]
     for d in p_directions:
         c[1,d,:] = period[d,:] - np.abs(a - b)[d,:]
     for d in np_directions:

--- a/yt/utilities/parallel_tools/parallel_analysis_interface.py
+++ b/yt/utilities/parallel_tools/parallel_analysis_interface.py
@@ -124,7 +124,7 @@ def enable_parallelism(suppress_logging=False, communicator=None):
     ytcfg["yt","__global_parallel_size"] = str(communicator.size)
     ytcfg["yt","__parallel"] = "True"
     if exe_name == "embed_enzo" or \
-        ("_parallel" in dir(sys) and sys._parallel is True):
+        ("_parallel" in dir(sys) and sys._parallel):
         ytcfg["yt","inline"] = "True"
     if communicator.rank > 0:
         if ytcfg.getboolean("yt","LogFile"):

--- a/yt/utilities/parameter_file_storage.py
+++ b/yt/utilities/parameter_file_storage.py
@@ -67,7 +67,7 @@ class ParameterFileStore(object):
         Otherwise, use read-only settings.
 
         """
-        if self._register is False: return
+        if not self._register: return
         if ytcfg.getboolean("yt", "StoreParameterFiles"):
             self._read_only = False
             self.init_db()

--- a/yt/visualization/line_plot.py
+++ b/yt/visualization/line_plot.py
@@ -288,7 +288,7 @@ class LinePlot(PlotContainer):
         return plot
 
     def _setup_plots(self):
-        if self._plot_valid is True:
+        if self._plot_valid:
             return
         for plot in self.plots.values():
             plot.axes.cla()

--- a/yt/visualization/particle_plots.py
+++ b/yt/visualization/particle_plots.py
@@ -253,7 +253,7 @@ class ParticleProjectionPlot(PWViewerMPL):
 
         self.set_axes_unit(axes_unit)
 
-        if self._use_cbar is False:
+        if not self._use_cbar:
             self.hide_colorbar()
 
 

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -135,7 +135,7 @@ def validate_mesh_fields(data_source, fields):
     canonical_fields = data_source._determine_fields(fields)
     invalid_fields = []
     for field in canonical_fields:
-        if data_source.ds.field_info[field].particle_type is True:
+        if data_source.ds.field_info[field].particle_type:
             invalid_fields.append(field)
 
     if len(invalid_fields) > 0:
@@ -204,7 +204,7 @@ class PlotWindow(ImagePlotContainer):
 
         self._set_window(bounds) # this automatically updates the data and plot
         self.origin = origin
-        if self.data_source.center is not None and oblique is False:
+        if self.data_source.center is not None and not oblique:
             ax = self.data_source.axis
             xax = self.ds.coordinates.x_axis[ax]
             yax = self.ds.coordinates.y_axis[ax]
@@ -243,7 +243,7 @@ class PlotWindow(ImagePlotContainer):
     def frb():
         doc = "The frb property."
         def fget(self):
-            if self._frb is None or self._data_valid is False:
+            if self._frb is None or not self._data_valid:
                 self._recreate_frb()
             return self._frb
 
@@ -1044,7 +1044,7 @@ class PWViewerMPL(PlotWindow):
             # x-y axes minorticks
             if f not in self._minorticks:
                 self._minorticks[f] = True
-            if self._minorticks[f] is True:
+            if self._minorticks[f]:
                 self.plots[f].axes.minorticks_on()
             else:
                 self.plots[f].axes.minorticks_off()
@@ -1053,7 +1053,7 @@ class PWViewerMPL(PlotWindow):
             if f not in self._cbar_minorticks:
                 self._cbar_minorticks[f] = True
 
-            if self._cbar_minorticks[f] is True:
+            if self._cbar_minorticks[f]:
                 vmin = np.float64(self.plots[f].cb.norm.vmin)
                 vmax = np.float64(self.plots[f].cb.norm.vmax)
 
@@ -1080,10 +1080,10 @@ class PWViewerMPL(PlotWindow):
             if not self._cbar_minorticks[f]:
                 self.plots[f].cax.minorticks_off()
 
-            if draw_axes is False:
+            if not draw_axes:
                 self.plots[f]._toggle_axes(draw_axes, draw_frame)
 
-            if draw_colorbar is False:
+            if not draw_colorbar:
                 self.plots[f]._toggle_colorbar(draw_colorbar)
 
         self._set_font_properties()

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -365,7 +365,7 @@ class ProfilePlot(object):
         return ret
 
     def _setup_plots(self):
-        if self._plot_valid is True:
+        if self._plot_valid:
             return
         for f in self.axes:
             self.axes[f].cla()
@@ -1112,7 +1112,7 @@ class PhasePlot(ImagePlotContainer):
             # x-y axes minorticks
             if f not in self._minorticks:
                 self._minorticks[f] = True
-            if self._minorticks[f] is True:
+            if self._minorticks[f]:
                 self.plots[f].axes.minorticks_on()
             else:
                 self.plots[f].axes.minorticks_off()
@@ -1120,7 +1120,7 @@ class PhasePlot(ImagePlotContainer):
             # colorbar minorticks
             if f not in self._cbar_minorticks:
                 self._cbar_minorticks[f] = True
-            if self._cbar_minorticks[f] is True:
+            if self._cbar_minorticks[f]:
                 if self._field_transform[f] == linear_transform:
                     self.plots[f].cax.minorticks_on()
                 elif MPL_VERSION < LooseVersion("3.0.0"):
@@ -1140,7 +1140,7 @@ class PhasePlot(ImagePlotContainer):
         self._set_font_properties()
 
         # if this is a particle plot with one color only, hide the cbar here
-        if hasattr(self, "use_cbar") and self.use_cbar is False:
+        if hasattr(self, "use_cbar") and not self.use_cbar:
             self.plots[f].hide_colorbar()
 
         self._plot_valid = True

--- a/yt/visualization/tests/test_profile_plots.py
+++ b/yt/visualization/tests/test_profile_plots.py
@@ -248,20 +248,20 @@ def test_phaseplot_set_log():
     # make sure we can set the log-scaling using the tuple without erroring out
     p1.set_log(("gas", "density"), False)
     p2.set_log(("gas", "temperature"), False)
-    assert p1.y_log["gas", "density"] is False
-    assert p2.y_log is False
+    assert not p1.y_log["gas", "density"]
+    assert not p2.y_log
 
     # make sure we can set the log-scaling using a string without erroring out
     p1.set_log("density", True)
     p2.set_log("temperature", True)
-    assert p1.y_log["gas", "density"] is True
-    assert p2.y_log is True
+    assert p1.y_log["gas", "density"]
+    assert p2.y_log
 
     # make sure we can set the log-scaling using a field object
     p1.set_log(ds.fields.gas.density, False)
     p2.set_log(ds.fields.gas.temperature, False)
-    assert p1.y_log["gas", "density"] is False
-    assert p2.y_log is False
+    assert not p1.y_log["gas", "density"]
+    assert not p2.y_log
 
 
 

--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -108,7 +108,7 @@ def off_axis_projection(data_source, center, normal_vector,
     if method not in ['integrate','sum']:
         raise NotImplementedError("Only 'integrate' or 'sum' methods are valid for off-axis-projections")
 
-    if interpolated is True:
+    if interpolated:
         raise NotImplementedError("Only interpolated=False methods are currently implemented for off-axis-projections")
 
 

--- a/yt/visualization/volume_rendering/old_camera.py
+++ b/yt/visualization/volume_rendering/old_camera.py
@@ -636,7 +636,7 @@ class Camera(ParallelAnalysisInterface):
     def finalize_image(self, image):
         view_pos = self.front_center + self.orienter.unit_vectors[2] * 1.0e6 * self.width[2]
         image = self.volume.reduce_tree_images(image, view_pos)
-        if self.transfer_function.grey_opacity is False:
+        if not self.transfer_function.grey_opacity:
             image[:,:,3]=1.0
         return image
 
@@ -1285,7 +1285,7 @@ class PerspectiveCamera(Camera):
         view_pos = self.front_center
         image.shape = self.resolution[0], self.resolution[1], 4
         image = self.volume.reduce_tree_images(image, view_pos)
-        if self.transfer_function.grey_opacity is False:
+        if not self.transfer_function.grey_opacity:
             image[:,:,3]=1.0
         return image
 
@@ -2029,7 +2029,7 @@ class SphericalCamera(Camera):
         view_pos = self.front_center
         image.shape = self.resolution[0], self.resolution[1], 4
         image = self.volume.reduce_tree_images(image, view_pos)
-        if self.transfer_function.grey_opacity is False:
+        if not self.transfer_function.grey_opacity:
             image[:,:,3]=1.0
         image = image[1:-1,1:-1,:]
         return image
@@ -2134,7 +2134,7 @@ class StereoSphericalCamera(Camera):
 
         image = sampler.aimage.copy()
         image.shape = self.resolution[0], self.resolution[1], 4
-        if self.transfer_function.grey_opacity is False:
+        if not self.transfer_function.grey_opacity:
             image[:,:,3]=1.0
         image = image[1:-1,1:-1,:]
         return image

--- a/yt/visualization/volume_rendering/render_source.py
+++ b/yt/visualization/volume_rendering/render_source.py
@@ -70,7 +70,7 @@ def validate_volume(f):
         if obj.weight_field is not None:
             fields.append(obj.weight_field)
             log_fields.append(obj.log_field)
-        if obj._volume_valid is False:
+        if not obj._volume_valid:
             obj.volume.set_fields(fields, log_fields,
                                   no_ghost=(not obj.use_ghost_zones))
         obj._volume_valid = True
@@ -240,7 +240,7 @@ class VolumeSource(RenderSource):
         self._field = value.fields
         self._log_field = value.log_fields
         self._volume = value
-        self._volume_valid is True
+        assert self._volume_valid
 
     @volume.deleter
     def volume(self):
@@ -471,7 +471,7 @@ class VolumeSource(RenderSource):
         image.shape = camera.resolution[0], camera.resolution[1], 4
         # If the call is from VR, the image is rotated by 180 to get correct
         # up direction
-        if self.transfer_function.grey_opacity is False:
+        if not self.transfer_function.grey_opacity:
             image[:, :, 3] = 1
         return image
 

--- a/yt/visualization/volume_rendering/tests/test_varia.py
+++ b/yt/visualization/volume_rendering/tests/test_varia.py
@@ -92,13 +92,13 @@ class VariousVRTests(TestCase):
 
         source.set_log(False)
 
-        assert source.log_field is False
+        assert not source.log_field
         assert source.transfer_function.x_bounds == [0.1, 1]
         assert source._volume is None
 
         source.set_log(True)
 
-        assert source.log_field is True
+        assert source.log_field
         assert source.transfer_function.x_bounds == [-1, 0]
         assert source._volume is None
 
@@ -121,7 +121,7 @@ class VariousVRTests(TestCase):
         source.set_field('density')
 
         assert source.volume is not None
-        assert source.volume._initialized is False
+        assert not source.volume._initialized
         assert source.volume.fields is None
 
         del source.volume
@@ -134,7 +134,7 @@ class VariousVRTests(TestCase):
         sc.render()
 
         assert source.volume is not None
-        assert source.volume._initialized is True
+        assert source.volume._initialized
         assert source.volume.fields == [('gas', 'density')]
         assert source.volume.log_fields == [True]
 
@@ -144,6 +144,6 @@ class VariousVRTests(TestCase):
         sc.render()
 
         assert source.volume is not None
-        assert source.volume._initialized is True
+        assert source.volume._initialized
         assert source.volume.fields == [('gas', 'velocity_x')]
         assert source.volume.log_fields == [False]

--- a/yt/visualization/volume_rendering/transfer_functions.py
+++ b/yt/visualization/volume_rendering/transfer_functions.py
@@ -601,7 +601,7 @@ class ColorTransferFunction(MultiVariateTransferFunction):
         ax.yaxis.set_ticks(xticks)
         def x_format(x, pos):
             val = x * (self.alpha.x[-1] - self.alpha.x[0]) / (self.alpha.x.size-1) + self.alpha.x[0]
-            if log_scale is True:
+            if log_scale:
                 val = 10**val
             if label_fmt is None:
                 if abs(val) < 1.e-3 or abs(val) > 1.e4:


### PR DESCRIPTION
## PR Summary

Original issue (#2576) was caused by the fact that Gamer frontend set up `periodicity` property as a tuple of `np.bool_`s. (see https://github.com/yt-project/yt/blob/master/yt/frontends/gamer/data_structures.py#L299-L301) which later on yielded wrong result when compared with `is True`.

```python
>>> import numpy as np
>>> (np.array([1], dtype=np.int32) == 1)[0]
True
>>> type((np.array([1], dtype=np.int32) == 1)[0])
<class 'numpy.bool_'>
>>> (np.array([1], dtype=np.int32) == 1)[0] is True
False
```

While a0b4b9f is sufficient to fix the reported issue, I went ahead and updated all boolean comparisons with accordance to pep8's recommendations (65219a6) to avoid similar issues in the future.
