### PR TITLE
Fix bug with raw fields when there is no ghost cells

### DIFF
--- a/yt/frontends/boxlib/io.py
+++ b/yt/frontends/boxlib/io.py
@@ -90,7 +90,8 @@ class IOHandlerBoxlib(BaseIOHandler):
             f.readline()  # always skip the first line
             arr = np.fromfile(f, 'float64', np.product(shape))
             arr = arr.reshape(shape, order='F')
-        return arr[[slice(nghost[dim],-nghost[dim]) for dim in range(self.ds.dimensionality)]]
+        return arr[[slice(None) if (nghost[dim] == 0) else \
+            slice(nghost[dim],-nghost[dim]) for dim in range(self.ds.dimensionality)]]
 
     def _read_chunk_data(self, chunk, fields):
         data = {}


### PR DESCRIPTION
I was trying to read raw fields from a plotfiles coming from a WarpX simulation and I encountered a bug occuring when there is no ghost cells. The bug occurs when doing something like:

```python
import yt
ds = yt.load("diags/diag100200")
ad = ds.all_data()
Ex_raw = ad['raw','Ex_aux']
```

And the error message is:

```
Traceback (most recent call last):
  File "./analysis_reduced_diags.py", line 58, in <module>
    Ex_raw = ad['raw','Ex_aux'].to_ndarray()[:,0]
  File ".../yt/data_objects/data_containers.py", line 256, in __getitem__
    self.get_data(f)
  File ".../yt/data_objects/data_containers.py", line 1571, in get_data
    fluids, self, self._current_chunk)
  File ".../yt/geometry/geometry_handler.py", line 244, in _read_fluid_fields
    chunk_size)
  File ".../yt/frontends/boxlib/io.py", line 66, in _read_fluid_selection
    nd = g.select(selector, ds, rv[field], ind)
  File ".../yt/data_objects/grid_patch.py", line 421, in select
    dest[offset:offset+count, i] = source[sl][np.squeeze(mask)]
IndexError: boolean index did not match indexed array along dimension 0; dimension is 0 but corresponding boolean dimension is 32
```

The bug happens with yt 3.6 but the same code was running well with version 3.5.1.

After backtracing the error, it seems to be coming from using `slice(nghost[dim],-nghost[dim])` to trim the ghost cells in the function `_read_raw_fields`, which fails when `nghost[dim]=0`. I propose a simple fix in this PR which worked for me.