### PR TITLE
make set_zlim units aware (sanitize zmin and zmax)

### DIFF
--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -895,12 +895,20 @@ class ImagePlotContainer(PlotContainer):
             zmin = zmax / dynamic_range.
 
         """
-        plot_units = self.frb[field].units
+
         def _sanitize_units(z):
+            # convert dimensionful inputs to float
             if isinstance(z, tuple):
                 z = YTQuantity(*z)
             if isinstance(z, YTQuantity):
-                z = z.to(plot_units).value
+                try:
+                    plot_units = self.frb[field].units
+                    z = z.to(plot_units).value
+                except AttributeError:
+                    # only certain subclasses have a frb attribute they can rely on for inspecting units
+                    from yt.funcs import mylog
+                    mylog.warning("%s class doesn't support zmin/zmax set as tuples or YTQuantity" %self.__class__.__name__)
+                    z = z.value
             return z
 
         myzmin = _sanitize_units(zmin)

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -900,7 +900,7 @@ class ImagePlotContainer(PlotContainer):
         def _sanitize_units(z):
             # convert dimensionful inputs to float
             if isinstance(z, tuple):
-                z = YTQuantity(*z)
+                z = self.ds.quan(*z)
             if isinstance(z, YTQuantity):
                 try:
                     plot_units = self.frb[field].units

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -12,6 +12,7 @@ A base class for "image" plots with colorbars.
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
+from yt import YTQuantity
 from yt.extern.six.moves import builtins
 from yt.extern.six import  \
     iteritems, \
@@ -877,10 +878,10 @@ class ImagePlotContainer(PlotContainer):
         field : string
             the field to set a colormap scale
             if field == 'all', applies to all plots.
-        zmin : float
+        zmin : float, tuple, YTQuantity or str
             the new minimum of the colormap scale. If 'min', will
             set to the minimum value in the current view.
-        zmax : float
+        zmax : float, tuple, YTQuantity or str
             the new maximum of the colormap scale. If 'max', will
             set to the maximum value in the current view.
 
@@ -894,8 +895,16 @@ class ImagePlotContainer(PlotContainer):
             zmin = zmax / dynamic_range.
 
         """
-        myzmin = zmin
-        myzmax = zmax
+        plot_units = self.frb[field].units
+        def _sanitize_units(z):
+            if isinstance(z, tuple):
+                z = YTQuantity(*z)
+            if isinstance(z, YTQuantity):
+                z = z.to(plot_units).value
+            return z
+
+        myzmin = _sanitize_units(zmin)
+        myzmax = _sanitize_units(zmax)
         if zmin == 'min':
             myzmin = self.plots[field].image._A.min()
         if zmax == 'max':

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -12,6 +12,7 @@ A base class for "image" plots with colorbars.
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
+from yt.funcs import mylog
 from yt.units import YTQuantity
 from yt.extern.six.moves import builtins
 from yt.extern.six import  \
@@ -906,7 +907,6 @@ class ImagePlotContainer(PlotContainer):
                     z = z.to(plot_units).value
                 except AttributeError:
                     # only certain subclasses have a frb attribute they can rely on for inspecting units
-                    from yt.funcs import mylog
                     mylog.warning("%s class doesn't support zmin/zmax set as tuples or YTQuantity" %self.__class__.__name__)
                     z = z.value
             return z

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -12,7 +12,7 @@ A base class for "image" plots with colorbars.
 #
 # The full license is in the file COPYING.txt, distributed with this software.
 #-----------------------------------------------------------------------------
-from yt import YTQuantity
+from yt.units import YTQuantity
 from yt.extern.six.moves import builtins
 from yt.extern.six import  \
     iteritems, \


### PR DESCRIPTION
## PR Summary

Because `set_zlim` only accepts floats, combining `pw.set_zlim` with `pw.set_unit` can create some unexpected results. For instance, this script is valid though hardly reliable

```python
import yt
ds = yt.testing.fake_amr_ds(fields=["density"])
p = yt.SlicePlot(ds, "z", "density")

my_min, _ = ds.find_min("density")    # returns a YTQuantity in cgs 
p.set_unit("density", "kg/mm**3")


zmin = my_min.value  # naive conversion to float 
p.set_zlim("density", zmin=zmin, zmax=10*zmin)   # <- now, it is incorrectly assumed that zmin is expressed in  "kg/mm**3"
```

With this change, set_zlim correctly handles zmin and zmax if they are YTQuantity objects, or tuples that convert to it.