### PR TITLE
Style: enforce import ordering with isort (YTEP0037 1/6)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,8 @@ detail.  Why is this change required?  What problem does it solve?-->
 
 <!-- Note that some of these check boxes may not apply to all pull requests -->
 
-- [ ] Code passes flake8 checker
+- [ ] pass `flake8 yt/`
+- [ ] pass `isort -rc . --check-only`
 - [ ] New features are documented, with docstrings and narrative docs
 - [ ] Adds a test for any bugs fixed. Adds tests for new features.
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,10 @@ jobs:
       python: 3.6
       script: flake8 yt/
 
+    - stage: Lint
+      python: 3.6
+      script: isort --check-only -rc yt/
+
     - stage: tests
       name: "Python: 3.6 Minimal Dependency Unit Tests"
       python: 3.6

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -747,6 +747,27 @@ error and warning list
 blacklist a large number of the full list of rules that are checked by
 ``flake8`` by default.
 
+Import Formatting
+-----------------
+
+We use ``isort`` to enforce PEP-8 guidelines for import ordering.
+By decreasing priority order:
+FUTURE > STDLIB > THIRD PARTY > FIRST PARTY > EXPLICITLY LOCAL
+
+``isort`` can be installed via ``pip``
+
+.. code-block:: bash
+
+    $ pip install isort
+
+To validate import order, run ``isort`` recursively at the top level
+
+.. code-block:: bash
+
+    $ isort -rc . --check-only
+
+If any error is detected, rerun this without the ``--check-only`` flag to fix them.
+
 Source code style guide
 -----------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,3 +12,16 @@ exclude = doc,benchmarks,*/api.py,*/__init__.py,*/__config__.py,yt/visualization
 max-line-length=999
 ignore = E111,E121,E122,E123,E124,E125,E126,E127,E128,E129,E131,E201,E202,E211,E221,E222,E227,E228,E241,E301,E203,E225,E226,E231,E251,E261,E262,E265,E266,E302,E303,E305,E306,E402,E502,E701,E703,E722,E741,E731,W291,W292,W293,W391,W503,W504,W605
 jobs=8
+
+# To be kept consistent with "Import Formatting" section in CONTRIBUTING.rst
+[tool:isort]
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+combine_as_imports=True
+line_length=88
+# isort can't be applied to yt/__init__.py because it creates circular imports
+skip = venv, doc, benchmarks, yt/__init__.py, yt/extern
+known_third_party = IPython, nose, numpy, sympy, matplotlib, unyt, git, yaml, dateutil, requests, coverage, pytest
+known_first_party = yt
+sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER

--- a/tests/lint_requirements.txt
+++ b/tests/lint_requirements.txt
@@ -2,3 +2,4 @@ flake8==3.6.0
 mccabe==0.6.1
 pycodestyle==2.4.0
 pyflakes==2.0.0
+isort==4.3

--- a/yt/exthook.py
+++ b/yt/exthook.py
@@ -20,8 +20,8 @@
     :license: BSD, see LICENSE for more details.
 """
 # This source code was originally in flask/exthook.py
-import sys
 import os
+import sys
 
 
 class ExtensionImporter:

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -651,7 +651,7 @@ def get_yt_version():
 def get_version_stack():
     version_info = {}
     version_info['yt'] = get_yt_version()
-    version_info['numpy'] = numpy.version.version
+    version_info['numpy'] = np.version.version
     version_info['matplotlib'] = matplotlib.__version__
     return version_info
 

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -15,7 +15,6 @@ import subprocess
 import numpy as np
 import itertools
 import base64
-import numpy
 import matplotlib
 import getpass
 import glob

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -14,12 +14,12 @@ from yt.config import ytcfg
 # we import this in a weird way from numpy.testing to avoid triggering
 # flake8 errors from the unused imports. These test functions are imported
 # elsewhere in yt from here so we want them to be imported here.
-from numpy.testing import assert_array_equal, assert_almost_equal  # NOQA
-from numpy.testing import assert_approx_equal, assert_array_almost_equal  # NOQA
-from numpy.testing import assert_equal, assert_array_less  # NOQA
-from numpy.testing import assert_string_equal  # NOQA
-from numpy.testing import assert_array_almost_equal_nulp  # NOQA
-from numpy.testing import assert_allclose, assert_raises  # NOQA
+from numpy.testing import assert_array_equal, assert_almost_equal  # NOQA isort:skip
+from numpy.testing import assert_approx_equal, assert_array_almost_equal  # NOQA isort:skip
+from numpy.testing import assert_equal, assert_array_less  # NOQA isort:skip
+from numpy.testing import assert_string_equal  # NOQA isort:skip
+from numpy.testing import assert_array_almost_equal_nulp  # NOQA isort:skip
+from numpy.testing import assert_allclose, assert_raises  # NOQA isort:skip
 from numpy.random import RandomState
 from yt.convenience import load
 from yt.units.yt_array import YTArray, YTQuantity


### PR DESCRIPTION
## PR Summary

[isort](https://pypi.org/project/isort/) is a tool that automatically sorts import statements.
It can be configured as a precommit hook too, so it should not be necessary to have this kind of PR, updating the whole code base more than once.

Imo, the 4.0 release would be a nice time to include this kind of nitpicky change, though I can easily imagine how the present PR would clog the yt-4.0 -> master merge, so I wouldn't suggest considering it for a merge ahead of this major task.

CURRENT STATE: This PR should include everything needed to smoothly adopt isort, but doesn't run it on the code base as it used to.

## checklist

### Validation steps
- [x] ensure compatibility with flake8 (noqa lines)
- [x] add minimal black-compatible isort configuration to setup.cfg
- [x] check commutativity with black
- [x] identify and declare files to be ignored by isort
- [x] polish isort configuration : declare unyt as second or third party depending on the outcome of YTEP0037's vote 


### Documentation and workflow
- [x] add "pass isort" to PR template's checklist
- [x] add isort to the Dev guide (https://yt-project.org/docs/dev/developing/developing.html#automatically-checking-code-style)
- ~OPTIONAL: add a precommit hook ?~ (Done in #2600)