### PR TITLE
Add mode argument to h5py.File

### DIFF
--- a/doc/source/analyzing/analysis_modules/absorption_spectrum.rst
+++ b/doc/source/analyzing/analysis_modules/absorption_spectrum.rst
@@ -195,7 +195,7 @@ errors produced in saving to a ascii file will negatively impact fit quality.
 
 .. code-block:: python
 
-    f = h5py.File('spectrum.h5')
+    f = h5py.File('spectrum.h5', 'r')
     wavelength = f["wavelength"][:]
     flux = f['flux'][:]
     f.close()

--- a/doc/source/developing/external_analysis.rst
+++ b/doc/source/developing/external_analysis.rst
@@ -395,7 +395,7 @@ import, and then save things out into a file.
 .. code-block:: python
 
    import h5py
-   f = h5py.File("some_file.h5")
+   f = h5py.File("some_file.h5", "w")
    f.create_dataset("/data", data=some_data)
 
 This will create ``some_file.h5`` if necessary and add a new dataset

--- a/yt/analysis_modules/cosmological_observation/light_cone/tests/test_light_cone.py
+++ b/yt/analysis_modules/cosmological_observation/light_cone/tests/test_light_cone.py
@@ -60,7 +60,7 @@ class LightConeProjectionTest(AnswerTestingTest):
             (600.0, "arcmin"), (60.0, "arcsec"), "density",
             weight_field=None, save_stack=True)
 
-        fh = h5py.File("LC/LightCone.h5")
+        fh = h5py.File("LC/LightCone.h5", "r")
         data = fh["density_None"].value
         units = fh["density_None"].attrs["units"]
         assert units == "g/cm**2"

--- a/yt/units/yt_array.py
+++ b/yt/units/yt_array.py
@@ -962,7 +962,7 @@ class YTArray(np.ndarray):
         if dataset_name is None:
             dataset_name = 'array_data'
 
-        f = h5py.File(filename)
+        f = h5py.File(filename, "w")
         if group_name is not None:
             if group_name in f:
                 g = f[group_name]
@@ -1011,7 +1011,7 @@ class YTArray(np.ndarray):
         if dataset_name is None:
             dataset_name = 'array_data'
 
-        f = h5py.File(filename)
+        f = h5py.File(filename, "r")
         if group_name is not None:
             g = f[group_name]
         else:

--- a/yt/utilities/answer_testing/answer_tests.py
+++ b/yt/utilities/answer_testing/answer_tests.py
@@ -283,7 +283,7 @@ def light_cone_projection(parameter_file, simulation_type):
     lc.project_light_cone(
         (600.0, "arcmin"), (60.0, "arcsec"), "density",
         weight_field=None, save_stack=True)
-    fh = h5py.File("LC/LightCone.h5")
+    fh = h5py.File("LC/LightCone.h5", "r")
     data = fh["density_None"].value
     units = fh["density_None"].attrs["units"]
     assert units == "g/cm**2"


### PR DESCRIPTION
## PR Summary

h5py is changing to require the mode (`'r'`, `'w'`, etc) specified when `h5py.File` is used.  The Debian version of h5py has already applied the upstream commits making this mandatory, which require this patch.

For reference: This was [Debian#960573](https://bugs.debian.org/960573), and we [fixed this locally in release 3.6.0-3](https://salsa.debian.org/debian-astro-team/yt/-/blob/6cf4a4d9ee190913b3648cd2291738f4cb601cf7/debian/patches/Add-mode-argument-to-h5py.File.patch).


## PR Checklist

- [x] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
