### PR TITLE
ci: bump flake8 linter version, fix newly detected errors (YTEP0037 2/6)

### DIFF
--- a/tests/lint_requirements.txt
+++ b/tests/lint_requirements.txt
@@ -1,6 +1,6 @@
-flake8==3.6.0
+flake8==3.8.1
 mccabe==0.6.1
-pycodestyle==2.4.0
-pyflakes==2.0.0
+pycodestyle==2.6.0
+pyflakes==2.2.0
 isort==4.3
 black==19.10b0

--- a/yt/data_objects/tests/test_fluxes.py
+++ b/yt/data_objects/tests/test_fluxes.py
@@ -69,15 +69,16 @@ class ExporterTests(TestCase):
         rhos = [0.5, 0.25]
         trans = [0.5, 1.0]
         for i, r in enumerate(rhos):
+            basename = "my_galaxy_color_%d" % i
             surf = ds.surface(sp,'density',r)
-            surf.export_obj("my_galaxy_color".format(i),
+            surf.export_obj(basename,
                             transparency=trans[i],
                             color_field='temperature', dist_fac=1.0,
                             plot_index=i, color_field_max=ma,
                             color_field_min=mi)
 
-        assert os.path.exists('my_galaxy_color.obj')
-        assert os.path.exists('my_galaxy_color.mtl')
+            assert os.path.exists('%s.obj' % basename)
+            assert os.path.exists('%s.mtl' % basename)
 
         def _Emissivity(field, data):
             return (data['density']*data['density'] *
@@ -85,15 +86,16 @@ class ExporterTests(TestCase):
         ds.add_field("emissivity", sampling_type='cell', function=_Emissivity,
                      units=r"g**2*sqrt(K)/cm**6")
         for i, r in enumerate(rhos):
+            basename = "my_galaxy_emis_%d" % i
             surf = ds.surface(sp,'density',r)
-            surf.export_obj("my_galaxy_emis".format(i),
+            surf.export_obj(basename,
                             transparency=trans[i],
                             color_field='temperature',
                             emit_field='emissivity',
                             dist_fac=1.0, plot_index=i)
 
-        assert os.path.exists('my_galaxy_emis.obj')
-        assert os.path.exists('my_galaxy_emis.mtl')
+            assert os.path.exists('%s.obj' % basename)
+            assert os.path.exists('%s.mtl' % basename)
 
 def test_correct_output_unit_fake_ds():
     # see issue #1368

--- a/yt/data_objects/tests/test_fluxes.py
+++ b/yt/data_objects/tests/test_fluxes.py
@@ -77,6 +77,8 @@ class ExporterTests(TestCase):
                             plot_index=i, color_field_max=ma,
                             color_field_min=mi)
 
+        for i, _ in enumerate(rhos):
+            basename = "my_galaxy_color_%d" % i
             assert os.path.exists('%s.obj' % basename)
             assert os.path.exists('%s.mtl' % basename)
 
@@ -94,6 +96,8 @@ class ExporterTests(TestCase):
                             emit_field='emissivity',
                             dist_fac=1.0, plot_index=i)
 
+        for i, _ in enumerate(rhos):
+            basename = "my_galaxy_emis_%d" % i
             assert os.path.exists('%s.obj' % basename)
             assert os.path.exists('%s.mtl' % basename)
 

--- a/yt/data_objects/tests/test_fluxes.py
+++ b/yt/data_objects/tests/test_fluxes.py
@@ -69,7 +69,7 @@ class ExporterTests(TestCase):
         rhos = [0.5, 0.25]
         trans = [0.5, 1.0]
         for i, r in enumerate(rhos):
-            basename = "my_galaxy_color_%d" % i
+            basename = "my_galaxy_color"
             surf = ds.surface(sp,'density',r)
             surf.export_obj(basename,
                             transparency=trans[i],
@@ -77,8 +77,6 @@ class ExporterTests(TestCase):
                             plot_index=i, color_field_max=ma,
                             color_field_min=mi)
 
-        for i, _ in enumerate(rhos):
-            basename = "my_galaxy_color_%d" % i
             assert os.path.exists('%s.obj' % basename)
             assert os.path.exists('%s.mtl' % basename)
 
@@ -88,7 +86,7 @@ class ExporterTests(TestCase):
         ds.add_field("emissivity", sampling_type='cell', function=_Emissivity,
                      units=r"g**2*sqrt(K)/cm**6")
         for i, r in enumerate(rhos):
-            basename = "my_galaxy_emis_%d" % i
+            basename = "my_galaxy_emis"
             surf = ds.surface(sp,'density',r)
             surf.export_obj(basename,
                             transparency=trans[i],
@@ -96,8 +94,7 @@ class ExporterTests(TestCase):
                             emit_field='emissivity',
                             dist_fac=1.0, plot_index=i)
 
-        for i, _ in enumerate(rhos):
-            basename = "my_galaxy_emis_%d" % i
+            basename = "my_galaxy_emis"
             assert os.path.exists('%s.obj' % basename)
             assert os.path.exists('%s.mtl' % basename)
 

--- a/yt/frontends/tipsy/data_structures.py
+++ b/yt/frontends/tipsy/data_structures.py
@@ -72,7 +72,7 @@ class TipsyDataset(SPHDataset):
         success, self.endian = self._validate_header(filename)
         if not success:
             print("SOMETHING HAS GONE WRONG.  NBODIES != SUM PARTICLES.")
-            print("%s != (%s == %s + %s + %s)" % (
+            print("%s != (sum == %s + %s + %s)" % (
                 self.parameters['nbodies'],
                 self.parameters['nsph'],
                 self.parameters['ndark'],

--- a/yt/geometry/tests/test_particle_octree.py
+++ b/yt/geometry/tests/test_particle_octree.py
@@ -591,13 +591,13 @@ def fake_decomp(decomp, npart, nfiles, ifile, DLE, DRE,
         if distrib == 'uniform':
             pos = fake_decomp_random(npart, nfiles, ifile, DLE, DRE, **kws)
         else:
-            raise ValueError("Unsupported value for input parameter 'distrib'".format(distrib))
+            raise ValueError("Unsupported value {} for input parameter 'distrib'".format(distrib))
     # Each file contains a slab (part of x domain, all of y/z domain)
     elif decomp == 'sliced':
         if distrib == 'uniform':
             pos = fake_decomp_sliced(npart, nfiles, ifile, DLE, DRE, **kws)
         else:
-            raise ValueError("Unsupported value for input parameter 'distrib'".format(distrib))
+            raise ValueError("Unsupported value {} for input parameter 'distrib'".format(distrib))
     # Particles are assigned to files based on their location on a
     # Peano-Hilbert curve of order 6
     elif decomp.startswith('hilbert'):
@@ -613,7 +613,7 @@ def fake_decomp(decomp, npart, nfiles, ifile, DLE, DRE,
             pos = fake_decomp(decomp, npart, nfiles, ifile, DLE, DRE,
                               distrib=distrib, fname=fname, **kws)
         else:
-            raise ValueError("Unsupported value for input parameter 'distrib'".format(distrib))
+            raise ValueError("Unsupported value {} for input parameter 'distrib'".format(distrib))
     # Particles are assigned to files based on their location on a
     # Morton ordered Z-curve of order 6
     elif decomp.startswith('morton'):
@@ -624,7 +624,7 @@ def fake_decomp(decomp, npart, nfiles, ifile, DLE, DRE,
         if distrib == 'uniform':
             pos = fake_decomp_morton(npart, nfiles, ifile, DLE, DRE, **kws)
         else:
-            raise ValueError("Unsupported value for input parameter 'distrib'".format(distrib))
+            raise ValueError("Unsupported value {} for input parameter 'distrib'".format(distrib))
     else:
         raise ValueError("Unsupported value {} for input parameter 'decomp'".format(decomp))
     # Save


### PR DESCRIPTION
We currently run flake8 3.6 on travis. A more recent release (3.8) catches precedently undetected errors.

Important note: there are _more_ errors than the ones I patch here.
This PR is specifically targeted at errors that can't be solved automatically with black.
Namely, these are almost exclusively string formatting errors, with either too many or not enough substitutions declared, as compared with the number of placeholders.