### PR TITLE
Internally import from unyt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
     hooks:
     -   id: flake8
 -   repo: https://github.com/timothycrosley/isort
-    rev: ''
+    rev: '5.1.4'
     hooks:
     -   id: isort
 -   repo: https://github.com/ambv/black

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,6 @@ combine_as_imports=True
 line_length=88
 # isort can't be applied to yt/__init__.py because it creates circular imports
 skip = venv, doc, benchmarks, yt/__init__.py, yt/extern
-known_third_party = IPython, nose, numpy, sympy, matplotlib, unyt, git, yaml, dateutil, requests, coverage, pytest, pyx
+known_third_party = IPython, nose, numpy, sympy, matplotlib, unyt, git, yaml, dateutil, requests, coverage, pytest, pyx, OpenGL
 known_first_party = yt
 sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -7,6 +7,8 @@ from collections import defaultdict
 from contextlib import contextmanager
 
 import numpy as np
+from unyt import dimensions as ytdims, unyt_array, unyt_quantity
+from unyt.array import uconcatenate
 from unyt.exceptions import UnitConversionError, UnitParseError
 
 import yt.geometry.selection_routines
@@ -24,8 +26,6 @@ from yt.funcs import (
     validate_width_tuple,
 )
 from yt.geometry.selection_routines import compose_selector
-from yt.units import dimensions as ytdims
-from yt.units.yt_array import YTArray, YTQuantity, uconcatenate
 from yt.utilities.amr_kdtree.api import AMRKDTree
 from yt.utilities.exceptions import (
     YTBooleanObjectError,
@@ -187,11 +187,11 @@ class YTDataContainer(metaclass=RegisteredDataContainer):
         if center is None:
             self.center = None
             return
-        elif isinstance(center, YTArray):
+        elif isinstance(center, unyt_array):
             self.center = self.ds.arr(center.astype("float64"))
             self.center.convert_to_units("code_length")
         elif isinstance(center, (list, tuple, np.ndarray)):
-            if isinstance(center[0], YTQuantity):
+            if isinstance(center[0], unyt_quantity):
                 self.center = self.ds.arr([c.copy() for c in center], dtype="float64")
                 self.center.convert_to_units("code_length")
             else:
@@ -1747,7 +1747,7 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface):
                         fd.convert_to_units(fi.units)
                     except AttributeError:
                         # If the field returns an ndarray, coerce to a
-                        # dimensionless YTArray and verify that field is
+                        # dimensionless unyt_array and verify that field is
                         # supposed to be unitless
                         fd = self.ds.arr(fd, "")
                         if fi.units != "":
@@ -2069,7 +2069,7 @@ class YTSelectionContainer2D(YTSelectionContainer):
             center = self.center
             if center is None:
                 center = (self.ds.domain_right_edge + self.ds.domain_left_edge) / 2.0
-        elif iterable(center) and not isinstance(center, YTArray):
+        elif iterable(center) and not isinstance(center, unyt_array):
             center = self.ds.arr(center, "code_length")
         if iterable(width):
             w, u = width
@@ -2077,14 +2077,14 @@ class YTSelectionContainer2D(YTSelectionContainer):
                 height = u
                 w, u = w
             width = self.ds.quan(w, units=u)
-        elif not isinstance(width, YTArray):
+        elif not isinstance(width, unyt_array):
             width = self.ds.quan(width, "code_length")
         if height is None:
             height = width
         elif iterable(height):
             h, u = height
             height = self.ds.quan(h, units=u)
-        elif not isinstance(height, YTArray):
+        elif not isinstance(height, unyt_array):
             height = self.ds.quan(height, "code_length")
         if not iterable(resolution):
             resolution = (resolution, resolution)

--- a/yt/data_objects/derived_quantities.py
+++ b/yt/data_objects/derived_quantities.py
@@ -1,7 +1,6 @@
 import numpy as np
 
-from yt.funcs import camelcase_to_underscore, ensure_list
-from yt.units.yt_array import array_like_field
+from yt.funcs import array_like_field, camelcase_to_underscore, ensure_list
 from yt.utilities.exceptions import YTParticleTypeNotFound
 from yt.utilities.parallel_tools.parallel_analysis_interface import (
     ParallelAnalysisInterface,
@@ -61,7 +60,7 @@ class DerivedQuantity(ParallelAnalysisInterface, metaclass=RegisteredDerivedQuan
         for key in sorted(storage):
             for i in range(self.num_vals):
                 values[i].append(storage[key][i])
-        # These will be YTArrays
+        # These will be unyt_arrays
         values = [self.data_source.ds.arr(values[i]) for i in range(self.num_vals)]
         values = self.reduce_intermediate(values)
         return values
@@ -96,8 +95,8 @@ class WeightedAverageQuantity(DerivedQuantity):
     r"""
     Calculates the weight average of a field or fields.
 
-    Returns a YTQuantity for each field requested; if one,
-    it returns a single YTQuantity, if many, it returns a list of YTQuantities
+    Returns a unyt_quantity for each field requested; if one,
+    it returns a single unyt_quantity, if many, it returns a list of YTQuantities
     in order of the listed fields.
 
     Where f is the field and w is the weight, the weighted average is
@@ -182,7 +181,7 @@ class TotalQuantity(DerivedQuantity):
 
 class TotalMass(TotalQuantity):
     r"""
-    Calculates the total mass of the object. Returns a YTArray where the
+    Calculates the total mass of the object. Returns a unyt_array where the
     first element is total gas mass and the second element is total particle
     mass.
 
@@ -284,7 +283,7 @@ class CenterOfMass(DerivedQuantity):
         w = values.pop(0).sum(dtype=np.float64)
         if len(values) > 0:
             # Note that this could be shorter if we pre-initialized our x,y,z,w
-            # values as YTQuantity objects.
+            # values as unyt_quantity objects.
             x += values.pop(0).sum(dtype=np.float64)
             y += values.pop(0).sum(dtype=np.float64)
             z += values.pop(0).sum(dtype=np.float64)
@@ -365,7 +364,7 @@ class BulkVelocity(DerivedQuantity):
         w = values.pop(0).sum(dtype=np.float64)
         if len(values) > 0:
             # Note that this could be shorter if we pre-initialized our x,y,z,w
-            # values as YTQuantity objects.
+            # values as unyt_quantity objects.
             x += values.pop(0).sum(dtype=np.float64)
             y += values.pop(0).sum(dtype=np.float64)
             z += values.pop(0).sum(dtype=np.float64)
@@ -376,9 +375,9 @@ class BulkVelocity(DerivedQuantity):
 class WeightedVariance(DerivedQuantity):
     r"""
     Calculates the weighted variance and weighted mean for a field
-    or list of fields. Returns a YTArray for each field requested; if one,
-    it returns a single YTArray, if many, it returns a list of YTArrays
-    in order of the listed fields.  The first element of each YTArray is
+    or list of fields. Returns a unyt_array for each field requested; if one,
+    it returns a single unyt_array, if many, it returns a list of unyt_arrays
+    in order of the listed fields.  The first element of each unyt_array is
     the weighted variance, and the second element is the weighted mean.
 
     Where f is the field, w is the weight, and <f_w> is the weighted mean,
@@ -460,7 +459,7 @@ class AngularMomentumVector(DerivedQuantity):
     Calculates the angular momentum vector, using gas (grid-based) and/or particles.
 
     The angular momentum vector is the mass-weighted mean specific angular momentum.
-    Returns a YTArray of the vector.
+    Returns a unyt_array of the vector.
 
     Parameters
     ----------
@@ -561,9 +560,9 @@ class AngularMomentumVector(DerivedQuantity):
 class Extrema(DerivedQuantity):
     r"""
     Calculates the min and max value of a field or list of fields.
-    Returns a YTArray for each field requested.  If one, a single YTArray
-    is returned, if many, a list of YTArrays in order of field list is
-    returned.  The first element of each YTArray is the minimum of the
+    Returns a unyt_array for each field requested.  If one, a single unyt_array
+    is returned, if many, a list of unyt_arrays in order of field list is
+    returned.  The first element of each unyt_array is the minimum of the
     field and the second is the maximum of the field.
 
     Parameters

--- a/yt/data_objects/grid_patch.py
+++ b/yt/data_objects/grid_patch.py
@@ -2,13 +2,13 @@ import warnings
 import weakref
 
 import numpy as np
+from unyt import unyt_array
 
-import yt.geometry.particle_deposit as particle_deposit
 from yt.config import ytcfg
 from yt.data_objects.data_containers import YTSelectionContainer
 from yt.funcs import iterable
+from yt.geometry import particle_deposit as particle_deposit
 from yt.geometry.selection_routines import convert_mask_to_indices
-from yt.units.yt_array import YTArray
 from yt.utilities.exceptions import (
     YTFieldTypeNotFound,
     YTParticleDepositionNotImplemented,
@@ -137,7 +137,7 @@ class AMRGridPatch(YTSelectionContainer):
             self.dds[2] = ds.domain_right_edge[2] - ds.domain_left_edge[2]
         elif self.ds.dimensionality < 2:
             self.dds[1] = ds.domain_right_edge[1] - ds.domain_left_edge[1]
-        self.dds = self.dds.view(YTArray)
+        self.dds = self.dds.view(unyt_array)
         self.dds.units = self.index.grid_left_edge.units
 
     def __repr__(self):

--- a/yt/data_objects/image_array.py
+++ b/yt/data_objects/image_array.py
@@ -1,13 +1,13 @@
 import warnings
 
 import numpy as np
+from unyt import unyt_array
 
 from yt.config import ytcfg
-from yt.units.yt_array import YTArray
 from yt.visualization.image_writer import write_bitmap, write_image
 
 
-class ImageArray(YTArray):
+class ImageArray(unyt_array):
     r"""A custom Numpy ndarray used for images.
 
     This differs from ndarray in that you can optionally specify an

--- a/yt/data_objects/octree_subset.py
+++ b/yt/data_objects/octree_subset.py
@@ -1,14 +1,16 @@
 from contextlib import contextmanager
 
 import numpy as np
+from unyt import unyt_array
+from unyt.dimensions import length
 
-import yt.geometry.particle_deposit as particle_deposit
-import yt.geometry.particle_smooth as particle_smooth
 from yt.data_objects.data_containers import YTSelectionContainer
 from yt.funcs import mylog
+from yt.geometry import (
+    particle_deposit as particle_deposit,
+    particle_smooth as particle_smooth,
+)
 from yt.geometry.particle_oct_container import ParticleOctreeContainer
-from yt.units.dimensions import length
-from yt.units.yt_array import YTArray
 from yt.utilities.exceptions import (
     YTFieldTypeNotFound,
     YTInvalidPositionArray,
@@ -593,7 +595,7 @@ class OctreeSubsetBlockSlice:
             yield i, OctreeSubsetBlockSlicePosition(i, self)
 
 
-class YTPositionArray(YTArray):
+class YTPositionArray(unyt_array):
     @property
     def morton(self):
         self.validate()

--- a/yt/data_objects/particle_trajectories.py
+++ b/yt/data_objects/particle_trajectories.py
@@ -4,8 +4,7 @@ import numpy as np
 
 from yt.config import ytcfg
 from yt.data_objects.field_data import YTFieldData
-from yt.funcs import get_pbar, mylog
-from yt.units.yt_array import array_like_field
+from yt.funcs import array_like_field, get_pbar, mylog
 from yt.utilities.exceptions import YTIllDefinedParticleData
 from yt.utilities.lib.particle_mesh_operations import CICSample_3
 from yt.utilities.on_demand_imports import _h5py as h5py

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -1,17 +1,18 @@
 import numpy as np
+from unyt import unyt_quantity
+from unyt.unit_object import Unit
 
 from yt.data_objects.field_data import YTFieldData
 from yt.fields.derived_field import DerivedField
 from yt.frontends.ytdata.utilities import save_as_dataset
 from yt.funcs import (
+    array_like_field,
     ensure_list,
     get_output_filename,
     issue_deprecation_warning,
     iterable,
     mylog,
 )
-from yt.units.unit_object import Unit
-from yt.units.yt_array import YTQuantity, array_like_field
 from yt.utilities.exceptions import (
     YTIllDefinedBounds,
     YTIllDefinedProfile,
@@ -35,12 +36,12 @@ def _sanitize_min_max_units(amin, amax, finfo, registry):
     umax = getattr(amax, "units", None)
     if umin is None:
         umin = Unit(finfo.output_units, registry=registry)
-        rmin = YTQuantity(amin, umin)
+        rmin = unyt_quantity(amin, umin)
     else:
         rmin = amin.in_units(finfo.output_units)
     if umax is None:
         umax = Unit(finfo.output_units, registry=registry)
-        rmax = YTQuantity(amax, umax)
+        rmax = unyt_quantity(amax, umax)
     else:
         rmax = amax.in_units(finfo.output_units)
     return rmin, rmax

--- a/yt/data_objects/region_expression.py
+++ b/yt/data_objects/region_expression.py
@@ -1,7 +1,8 @@
 import weakref
 
+from unyt import unyt_quantity
+
 from yt.funcs import obj_length
-from yt.units.yt_array import YTQuantity
 from yt.utilities.exceptions import YTDimensionalityError, YTFieldNotParseable
 from yt.visualization.line_plot import LineBuffer
 
@@ -69,7 +70,7 @@ class RegionExpression:
     def _spec_to_value(self, input):
         if isinstance(input, tuple):
             v = self.ds.quan(input[0], input[1]).to("code_length")
-        elif isinstance(input, YTQuantity):
+        elif isinstance(input, unyt_quantity):
             v = self.ds.quan(input).to("code_length")
         else:
             v = self.ds.quan(input, "code_length")

--- a/yt/data_objects/selection_data_containers.py
+++ b/yt/data_objects/selection_data_containers.py
@@ -1,4 +1,6 @@
 import numpy as np
+from unyt import unyt_array, unyt_quantity
+from unyt.array import udot, unorm
 
 from yt.data_objects.data_containers import (
     YTSelectionContainer,
@@ -24,7 +26,6 @@ from yt.funcs import (
     validate_width_tuple,
 )
 from yt.geometry.selection_routines import points_in_cells
-from yt.units.yt_array import YTArray, YTQuantity, udot, unorm
 from yt.utilities.exceptions import (
     YTEllipsoidOrdering,
     YTException,
@@ -76,7 +77,7 @@ class YTPoint(YTSelectionContainer0D):
         validate_object(field_parameters, dict)
         validate_object(data_source, YTSelectionContainer)
         super(YTPoint, self).__init__(ds, field_parameters, data_source)
-        if isinstance(p, YTArray):
+        if isinstance(p, unyt_array):
             # we pass p through ds.arr to ensure code units are attached
             self.p = self.ds.arr(p)
         else:
@@ -153,11 +154,11 @@ class YTOrthoRay(YTSelectionContainer1D):
         self.px_dx = "d%s" % ("xyz"[self.px_ax])
         self.py_dx = "d%s" % ("xyz"[self.py_ax])
         # Convert coordinates to code length.
-        if isinstance(coords[0], YTQuantity):
+        if isinstance(coords[0], unyt_quantity):
             self.px = self.ds.quan(coords[0]).to("code_length")
         else:
             self.px = self.ds.quan(coords[0], "code_length")
-        if isinstance(coords[1], YTQuantity):
+        if isinstance(coords[1], unyt_quantity):
             self.py = self.ds.quan(coords[1]).to("code_length")
         else:
             self.py = self.ds.quan(coords[1], "code_length")
@@ -228,11 +229,11 @@ class YTRay(YTSelectionContainer1D):
         validate_object(field_parameters, dict)
         validate_object(data_source, YTSelectionContainer)
         super(YTRay, self).__init__(ds, field_parameters, data_source)
-        if isinstance(start_point, YTArray):
+        if isinstance(start_point, unyt_array):
             self.start_point = self.ds.arr(start_point).to("code_length")
         else:
             self.start_point = self.ds.arr(start_point, "code_length", dtype="float64")
-        if isinstance(end_point, YTArray):
+        if isinstance(end_point, unyt_array):
             self.end_point = self.ds.arr(end_point).to("code_length")
         else:
             self.end_point = self.ds.arr(end_point, "code_length", dtype="float64")
@@ -761,15 +762,15 @@ class YTRegion(YTSelectionContainer3D):
         validate_object(field_parameters, dict)
         validate_object(data_source, YTSelectionContainer)
         YTSelectionContainer3D.__init__(self, center, ds, field_parameters, data_source)
-        if not isinstance(left_edge, YTArray):
+        if not isinstance(left_edge, unyt_array):
             self.left_edge = self.ds.arr(left_edge, "code_length", dtype="float64")
         else:
-            # need to assign this dataset's unit registry to the YTArray
+            # need to assign this dataset's unit registry to the unyt_array
             self.left_edge = self.ds.arr(left_edge.copy(), dtype="float64")
-        if not isinstance(right_edge, YTArray):
+        if not isinstance(right_edge, unyt_array):
             self.right_edge = self.ds.arr(right_edge, "code_length", dtype="float64")
         else:
-            # need to assign this dataset's unit registry to the YTArray
+            # need to assign this dataset's unit registry to the unyt_array
             self.right_edge = self.ds.arr(right_edge.copy(), dtype="float64")
 
     def _get_bbox(self):
@@ -810,10 +811,10 @@ class YTSphere(YTSelectionContainer3D):
     ----------
     center : array_like
         The center of the sphere.
-    radius : float, width specifier, or YTQuantity
+    radius : float, width specifier, or unyt_quantity
         The radius of the sphere. If passed a float,
         that will be interpreted in code units. Also
-        accepts a (radius, unit) tuple or YTQuantity
+        accepts a (radius, unit) tuple or unyt_quantity
         instance with units attached.
 
     Examples
@@ -862,7 +863,7 @@ class YTMinimalSphere(YTSelectionContainer3D):
 
     Parameters
     ----------
-    points : YTArray
+    points : unyt_array
         The points that the sphere will contain.
 
     Examples
@@ -882,7 +883,7 @@ class YTMinimalSphere(YTSelectionContainer3D):
         validate_object(ds, Dataset)
         validate_object(field_parameters, dict)
         validate_object(data_source, YTSelectionContainer)
-        validate_object(points, YTArray)
+        validate_object(points, unyt_array)
 
         points = fix_length(points, ds)
         if len(points) < 2:

--- a/yt/data_objects/tests/test_chunking.py
+++ b/yt/data_objects/tests/test_chunking.py
@@ -1,5 +1,6 @@
+from unyt import uconcatenate
+
 from yt.testing import assert_equal, assert_true, fake_random_ds
-from yt.units.yt_array import uconcatenate
 
 
 def _get_dobjs(c):

--- a/yt/data_objects/tests/test_compose.py
+++ b/yt/data_objects/tests/test_compose.py
@@ -1,7 +1,7 @@
 import numpy as np
+from unyt import uintersect1d, unyt_array
 
 from yt.testing import assert_array_equal, fake_amr_ds, fake_random_ds
-from yt.units.yt_array import YTArray, uintersect1d
 
 
 def setup():
@@ -14,7 +14,7 @@ def setup():
 # each cell from cell positions
 def _IDFIELD(field, data):
     width = data.ds.domain_right_edge - data.ds.domain_left_edge
-    min_dx = YTArray(1.0 / 8192, units="code_length", registry=data.ds.unit_registry)
+    min_dx = unyt_array(1.0 / 8192, units="code_length", registry=data.ds.unit_registry)
     delta = width / min_dx
     x = data["x"] - min_dx / 2.0
     y = data["y"] - min_dx / 2.0

--- a/yt/data_objects/tests/test_covering_grid.py
+++ b/yt/data_objects/tests/test_covering_grid.py
@@ -1,4 +1,5 @@
 import numpy as np
+from unyt import kpc
 
 from yt.convenience import load
 from yt.fields.derived_field import ValidateParameter
@@ -12,7 +13,6 @@ from yt.testing import (
     requires_file,
     requires_module,
 )
-from yt.units import kpc
 
 # cylindrical data for covering_grid test
 cyl_2d = "WDMerger_hdf5_chk_1000/WDMerger_hdf5_chk_1000.hdf5"
@@ -269,11 +269,11 @@ def test_arbitrary_field_parameters():
 def test_arbitrary_grid_edge():
     # Tests bug fix for issue #2087
     # Regardless of how left_edge and right_edge are passed, the result should be
-    # a YTArray with a unit registry that matches that of the dataset.
+    # a unyt_array with a unit registry that matches that of the dataset.
     dims = [32, 32, 32]
     ds = fake_random_ds(dims)
-    # Test when edge is a list, numpy array, YTArray with dataset units, and
-    # YTArray with non-dataset units
+    # Test when edge is a list, numpy array, unyt_array with dataset units, and
+    # unyt_array with non-dataset units
     ledge = [
         [0.0, 0.0, 0.0],
         np.array([0.0, 0.0, 0.0]),

--- a/yt/data_objects/tests/test_cutting_plane.py
+++ b/yt/data_objects/tests/test_cutting_plane.py
@@ -1,8 +1,9 @@
 import os
 import tempfile
 
+from unyt import Unit
+
 from yt.testing import assert_equal, fake_random_ds
-from yt.units.unit_object import Unit
 
 
 def setup():

--- a/yt/data_objects/tests/test_data_containers.py
+++ b/yt/data_objects/tests/test_data_containers.py
@@ -107,7 +107,7 @@ class TestDataContainers(unittest.TestCase):
 
     @requires_module("astropy")
     def test_to_astropy_table(self):
-        from yt.units.yt_array import YTArray
+        from unyt import unyt_array
 
         fields = ["density", "velocity_z"]
         ds = fake_random_ds(6)
@@ -115,8 +115,8 @@ class TestDataContainers(unittest.TestCase):
         at1 = dd.to_astropy_table(fields)
         assert_array_equal(dd[fields[0]].d, at1[fields[0]].value)
         assert_array_equal(dd[fields[1]].d, at1[fields[1]].value)
-        assert dd[fields[0]].units == YTArray.from_astropy(at1[fields[0]]).units
-        assert dd[fields[1]].units == YTArray.from_astropy(at1[fields[1]]).units
+        assert dd[fields[0]].units == unyt_array.from_astropy(at1[fields[0]]).units
+        assert dd[fields[1]].units == unyt_array.from_astropy(at1[fields[1]]).units
 
     def test_std(self):
         ds = fake_random_ds(3)

--- a/yt/data_objects/tests/test_disks.py
+++ b/yt/data_objects/tests/test_disks.py
@@ -1,7 +1,7 @@
 from nose.tools import assert_raises
 from numpy.testing import assert_equal
+from unyt import unyt_quantity
 
-from yt import YTQuantity
 from yt.testing import fake_random_ds
 
 
@@ -40,7 +40,7 @@ def test_bad_disk_input():
             [0, 0, 1],
             (10, "kpc"),
             (20, "kpc"),
-            fields=YTQuantity(1, "kpc"),
+            fields=unyt_quantity(1, "kpc"),
         )
     desired = "Expected an iterable object, received" " 'unyt.array.unyt_quantity'"
     assert_equal(str(ex.exception), desired)

--- a/yt/data_objects/tests/test_profiles.py
+++ b/yt/data_objects/tests/test_profiles.py
@@ -4,6 +4,7 @@ import tempfile
 import unittest
 
 import numpy as np
+from unyt import unyt_array, unyt_quantity
 
 import yt
 from yt.data_objects.particle_filters import add_particle_filter
@@ -544,7 +545,7 @@ class TestBadProfiles(unittest.TestCase):
             "temperature": temperature,
             "cell_mass": cell_mass,
         }
-        fake_ds_med = {"current_time": yt.YTQuantity(10, "Myr")}
+        fake_ds_med = {"current_time": unyt_quantity(10, "Myr")}
         yt.save_as_dataset(fake_ds_med, "mydata.h5", my_data)
 
         ds = yt.load("mydata.h5")
@@ -569,7 +570,7 @@ class TestBadProfiles(unittest.TestCase):
             "temperature": temperature,
             "cell_mass": cell_mass,
         }
-        fake_ds_med = {"current_time": yt.YTQuantity(10, "Myr")}
+        fake_ds_med = {"current_time": unyt_quantity(10, "Myr")}
         yt.save_as_dataset(fake_ds_med, "mydata.h5", my_data)
 
         ds = yt.load("mydata.h5")
@@ -603,7 +604,6 @@ def test_index_field_units():
 
 @requires_module("astropy")
 def test_export_astropy():
-    from yt.units.yt_array import YTArray
 
     ds = fake_random_ds(64)
     ad = ds.all_data()
@@ -621,9 +621,9 @@ def test_export_astropy():
     assert_equal(prof.x.d, at1["radius"].value)
     assert_equal(prof["density"].d, at1["density"].value)
     assert_equal(prof["velocity_x"].d, at1["velocity_x"].value)
-    assert prof.x.units == YTArray.from_astropy(at1["radius"]).units
-    assert prof["density"].units == YTArray.from_astropy(at1["density"]).units
-    assert prof["velocity_x"].units == YTArray.from_astropy(at1["velocity_x"]).units
+    assert prof.x.units == unyt_array.from_astropy(at1["radius"]).units
+    assert prof["density"].units == unyt_array.from_astropy(at1["density"]).units
+    assert prof["velocity_x"].units == unyt_array.from_astropy(at1["velocity_x"]).units
     assert np.all(at1.mask["density"] == prof.used)
     at2 = prof.to_astropy_table(fields="density", only_used=True)
     assert "radius" in at2.colnames

--- a/yt/data_objects/tests/test_projection.py
+++ b/yt/data_objects/tests/test_projection.py
@@ -3,9 +3,9 @@ import tempfile
 
 import mock
 import numpy as np
+from unyt import Unit
 
 from yt.testing import assert_equal, assert_rel_equal, fake_amr_ds, fake_random_ds
-from yt.units.unit_object import Unit
 
 LENGTH_UNIT = 2.0
 

--- a/yt/data_objects/tests/test_rays.py
+++ b/yt/data_objects/tests/test_rays.py
@@ -1,8 +1,8 @@
 import numpy as np
+from unyt import uconcatenate
 
 from yt import load
 from yt.testing import assert_equal, assert_rel_equal, fake_random_ds, requires_file
-from yt.units.yt_array import uconcatenate
 
 
 def test_ray():

--- a/yt/data_objects/tests/test_regions.py
+++ b/yt/data_objects/tests/test_regions.py
@@ -1,5 +1,6 @@
+from unyt import cm
+
 from yt.testing import assert_array_equal, fake_amr_ds, fake_random_ds
-from yt.units import cm
 
 
 def test_box_creation():

--- a/yt/data_objects/tests/test_slice.py
+++ b/yt/data_objects/tests/test_slice.py
@@ -3,9 +3,9 @@ import tempfile
 
 import mock
 import numpy as np
+from unyt import Unit
 
 from yt.testing import assert_equal, fake_random_ds
-from yt.units.unit_object import Unit
 
 
 def setup():

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -6,6 +6,7 @@ import weakref
 from functools import wraps
 
 import numpy as np
+from unyt import unyt_array, unyt_quantity
 
 from yt.config import ytcfg
 from yt.convenience import load
@@ -18,7 +19,6 @@ from yt.data_objects.data_containers import data_object_registry
 from yt.data_objects.derived_quantities import derived_quantity_registry
 from yt.data_objects.particle_trajectories import ParticleTrajectories
 from yt.funcs import ensure_list, issue_deprecation_warning, iterable, mylog
-from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.exceptions import YTException, YTOutputNotIdentified
 from yt.utilities.parallel_tools.parallel_analysis_interface import (
     communication_system,
@@ -581,7 +581,7 @@ class SimulationTimeSeries(DatasetSeries, metaclass=RegisteredSimulationTimeSeri
     def arr(self):
         if self._arr is not None:
             return self._arr
-        self._arr = functools.partial(YTArray, registry=self.unit_registry)
+        self._arr = functools.partial(unyt_array, registry=self.unit_registry)
         return self._arr
 
     _quan = None
@@ -590,7 +590,7 @@ class SimulationTimeSeries(DatasetSeries, metaclass=RegisteredSimulationTimeSeri
     def quan(self):
         if self._quan is not None:
             return self._quan
-        self._quan = functools.partial(YTQuantity, registry=self.unit_registry)
+        self._quan = functools.partial(unyt_quantity, registry=self.unit_registry)
         return self._quan
 
     @parallel_root_only
@@ -655,7 +655,7 @@ class SimulationTimeSeries(DatasetSeries, metaclass=RegisteredSimulationTimeSeri
 
         """
 
-        if not isinstance(values, YTArray):
+        if not isinstance(values, unyt_array):
             if isinstance(values, tuple) and len(values) == 2:
                 values = self.arr(*values)
             else:

--- a/yt/fields/derived_field.py
+++ b/yt/fields/derived_field.py
@@ -3,9 +3,10 @@ import inspect
 import re
 import warnings
 
+from unyt.unit_object import Unit
+
 import yt.units.dimensions as ytdims
 from yt.funcs import VisibleDeprecationWarning, ensure_list
-from yt.units.unit_object import Unit
 from yt.utilities.exceptions import YTFieldNotFound
 
 from .field_detector import FieldDetector
@@ -74,7 +75,7 @@ class DerivedField:
        For fields that exist on disk, which we may want to convert to other
        fields or that get aliased to themselves, we can specify a different
        desired output unit than the unit found on disk.
-    dimensions : str or object from yt.units.dimensions
+    dimensions : str or object from unyt.dimensions
        The dimensions of the field, only needed if units="auto" and only used
        for error checking.
     nodal_flag : array-like with three components

--- a/yt/fields/field_detector.py
+++ b/yt/fields/field_detector.py
@@ -1,8 +1,7 @@
 from collections import defaultdict
 
 import numpy as np
-
-from yt.units.yt_array import YTArray
+from unyt import unyt_array
 
 from .field_exceptions import NeedsGridType
 
@@ -155,20 +154,20 @@ class FieldDetector(defaultdict):
                 or "MagneticField" in (item, item[1])
             ):
                 # A vector
-                self[item] = YTArray(
+                self[item] = unyt_array(
                     np.ones((self.NumberOfParticles, 3)),
                     finfo.units,
                     registry=self.ds.unit_registry,
                 )
             elif "FourMetalFractions" in (item, item[1]):
-                self[item] = YTArray(
+                self[item] = unyt_array(
                     np.ones((self.NumberOfParticles, 4)),
                     finfo.units,
                     registry=self.ds.unit_registry,
                 )
             else:
                 # Not a vector
-                self[item] = YTArray(
+                self[item] = unyt_array(
                     np.ones(self.NumberOfParticles),
                     finfo.units,
                     registry=self.ds.unit_registry,
@@ -219,7 +218,7 @@ class FieldDetector(defaultdict):
         if finfo.sampling_type == "particle":
             self.requested.append(field_name)
             return np.ones(self.NumberOfParticles)
-        return YTArray(
+        return unyt_array(
             defaultdict.__missing__(self, field_name),
             units=finfo.units,
             registry=self.ds.unit_registry,
@@ -249,7 +248,7 @@ class FieldDetector(defaultdict):
             return rv
         elif param.endswith("_hat"):
             ax = param[0]
-            rv = YTArray((0.0, 0.0, 0.0), fp_units[param])
+            rv = unyt_array((0.0, 0.0, 0.0), fp_units[param])
             rv["xyz".index(ax)] = 1.0
             return rv
         elif param == "fof_groups":

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -2,11 +2,11 @@ import warnings
 from numbers import Number as numeric_type
 
 import numpy as np
+from unyt.dimensions import dimensionless
+from unyt.unit_object import Unit
 
 from yt.funcs import mylog, only_on_root
 from yt.geometry.geometry_handler import is_curvilinear
-from yt.units.dimensions import dimensionless
-from yt.units.unit_object import Unit
 from yt.utilities.exceptions import YTFieldNotFound
 
 from .derived_field import DerivedField, NullFunc, TranslationFunc

--- a/yt/fields/fluid_fields.py
+++ b/yt/fields/fluid_fields.py
@@ -1,8 +1,8 @@
 import numpy as np
+from unyt.unit_object import Unit
 
 from yt.funcs import mylog
 from yt.geometry.geometry_handler import is_curvilinear
-from yt.units.unit_object import Unit
 from yt.utilities.chemical_formulas import default_mu
 from yt.utilities.lib.misc_utilities import obtain_relative_velocity_vector
 

--- a/yt/fields/magnetic_field.py
+++ b/yt/fields/magnetic_field.py
@@ -1,8 +1,8 @@
 import numpy as np
+from unyt import dimensions
+from unyt.array import ustack
 
 from yt.fields.derived_field import ValidateParameter
-from yt.units import dimensions
-from yt.units.yt_array import ustack
 from yt.utilities.math_utils import get_sph_phi_component, get_sph_theta_component
 
 from .field_plugin_registry import register_field_plugin

--- a/yt/fields/particle_fields.py
+++ b/yt/fields/particle_fields.py
@@ -1,9 +1,9 @@
 import numpy as np
+from unyt.array import uconcatenate, ucross
 
 from yt.fields.derived_field import ValidateParameter, ValidateSpatial
 from yt.fields.field_detector import FieldDetector
 from yt.funcs import issue_deprecation_warning
-from yt.units.yt_array import uconcatenate, ucross
 from yt.utilities.lib.misc_utilities import (
     obtain_position_vector,
     obtain_relative_velocity_vector,

--- a/yt/fields/tests/test_fields.py
+++ b/yt/fields/tests/test_fields.py
@@ -1,4 +1,5 @@
 import numpy as np
+from unyt import unyt_array, unyt_quantity
 
 from yt import load
 from yt.frontends.stream.fields import StreamFieldInfo
@@ -14,7 +15,7 @@ from yt.testing import (
     fake_random_ds,
     requires_file,
 )
-from yt.units.yt_array import YTArray, YTQuantity, array_like_field
+from yt.units.yt_array import array_like_field
 from yt.utilities.cosmology import Cosmology
 from yt.utilities.exceptions import (
     YTDimensionalityError,
@@ -26,17 +27,17 @@ from yt.utilities.exceptions import (
 def get_params(ds):
     return dict(
         axis=0,
-        center=YTArray((0.0, 0.0, 0.0), "cm", registry=ds.unit_registry),
-        bulk_velocity=YTArray((0.0, 0.0, 0.0), "cm/s", registry=ds.unit_registry),
-        bulk_magnetic_field=YTArray((0.0, 0.0, 0.0), "G", registry=ds.unit_registry),
-        normal=YTArray((0.0, 0.0, 1.0), "", registry=ds.unit_registry),
-        cp_x_vec=YTArray((1.0, 0.0, 0.0), "", registry=ds.unit_registry),
-        cp_y_vec=YTArray((0.0, 1.0, 0.0), "", registry=ds.unit_registry),
-        cp_z_vec=YTArray((0.0, 0.0, 1.0), "", registry=ds.unit_registry),
+        center=unyt_array((0.0, 0.0, 0.0), "cm", registry=ds.unit_registry),
+        bulk_velocity=unyt_array((0.0, 0.0, 0.0), "cm/s", registry=ds.unit_registry),
+        bulk_magnetic_field=unyt_array((0.0, 0.0, 0.0), "G", registry=ds.unit_registry),
+        normal=unyt_array((0.0, 0.0, 1.0), "", registry=ds.unit_registry),
+        cp_x_vec=unyt_array((1.0, 0.0, 0.0), "", registry=ds.unit_registry),
+        cp_y_vec=unyt_array((0.0, 1.0, 0.0), "", registry=ds.unit_registry),
+        cp_z_vec=unyt_array((0.0, 0.0, 1.0), "", registry=ds.unit_registry),
         omega_baryon=0.04,
         observer_redshift=0.0,
         source_redshift=3.0,
-        virial_radius=YTQuantity(1.0, "cm"),
+        virial_radius=unyt_quantity(1.0, "cm"),
     )
 
 

--- a/yt/fields/tests/test_vector_fields.py
+++ b/yt/fields/tests/test_vector_fields.py
@@ -1,7 +1,7 @@
 import numpy as np
+from unyt import cm, s
 
 from yt.testing import assert_allclose_units, fake_random_ds, requires_file
-from yt.units import cm, s
 from yt.utilities.answer_testing.framework import data_dir_load
 
 

--- a/yt/fields/vector_operations.py
+++ b/yt/fields/vector_operations.py
@@ -152,7 +152,7 @@ def create_squared_field(
 
 
 def create_vector_fields(registry, basename, field_units, ftype="gas", slice_info=None):
-    from yt.units.unit_object import Unit
+    from unyt.unit_object import Unit
 
     # slice_info would be the left, the right, and the factor.
     # For example, with the old Enzo-ZEUS fields, this would be:

--- a/yt/frontends/_skeleton/data_structures.py
+++ b/yt/frontends/_skeleton/data_structures.py
@@ -114,7 +114,7 @@ class SkeletonDataset(Dataset):
     def _parse_parameter_file(self):
         # This needs to set up the following items.  Note that these are all
         # assumed to be in code units; domain_left_edge and domain_right_edge
-        # will be converted to YTArray automatically at a later time.
+        # will be converted to unyt_array automatically at a later time.
         # This includes the cosmological parameters.
         #
         #   self.unique_identifier      <= unique identifier for the dataset

--- a/yt/frontends/adaptahop/data_structures.py
+++ b/yt/frontends/adaptahop/data_structures.py
@@ -12,6 +12,7 @@ import re
 import stat
 
 import numpy as np
+from unyt import Mpc
 
 from yt.data_objects.data_containers import YTSelectionContainer
 from yt.data_objects.static_output import Dataset
@@ -20,7 +21,6 @@ from yt.frontends.halo_catalog.data_structures import (
     HaloCatalogParticleIndex,
 )
 from yt.funcs import setdefaultattr
-from yt.units import Mpc
 from yt.utilities.cython_fortran_utils import FortranFile
 
 from .definitions import HEADER_ATTRIBUTES

--- a/yt/frontends/amrvac/fields.py
+++ b/yt/frontends/amrvac/fields.py
@@ -7,11 +7,11 @@ AMRVAC-specific fields
 import functools
 
 import numpy as np
+from unyt import dimensions
 
 from yt import mylog
 from yt.fields.field_info_container import FieldInfoContainer
 from yt.fields.magnetic_field import setup_magnetic_field_aliases
-from yt.units import dimensions
 
 # We need to specify which fields we might have in our dataset.  The field info
 # container subclass here will define which fields it knows about.  There are

--- a/yt/frontends/amrvac/tests/test_outputs.py
+++ b/yt/frontends/amrvac/tests/test_outputs.py
@@ -1,9 +1,9 @@
 import numpy as np  # NOQA
+from unyt import unyt_quantity
 
 import yt  # NOQA
 from yt.frontends.amrvac.api import AMRVACDataset, AMRVACGrid
 from yt.testing import assert_allclose_units, assert_raises, requires_file
-from yt.units import YTQuantity
 from yt.utilities.answer_testing.framework import (
     data_dir_load,
     requires_ds,
@@ -59,8 +59,8 @@ def test_grid_attributes():
     assert ds.index.max_level == 2
     for g in grids:
         assert isinstance(g, AMRVACGrid)
-        assert isinstance(g.LeftEdge, yt.units.yt_array.YTArray)
-        assert isinstance(g.RightEdge, yt.units.yt_array.YTArray)
+        assert isinstance(g.LeftEdge, yt.units.yt_array.unyt_array)
+        assert isinstance(g.RightEdge, yt.units.yt_array.unyt_array)
         assert isinstance(g.ActiveDimensions, np.ndarray)
         assert isinstance(g.Level, (np.int32, np.int64, int))
 
@@ -152,15 +152,15 @@ magnetic_unit = (1.997608879907716, "gauss")
 
 
 def _assert_normalisations_equal(ds):
-    assert_allclose_units(ds.length_unit, YTQuantity(*length_unit))
-    assert_allclose_units(ds.numberdensity_unit, YTQuantity(*numberdensity_unit))
-    assert_allclose_units(ds.temperature_unit, YTQuantity(*temperature_unit))
-    assert_allclose_units(ds.density_unit, YTQuantity(*density_unit))
-    assert_allclose_units(ds.mass_unit, YTQuantity(*mass_unit))
-    assert_allclose_units(ds.velocity_unit, YTQuantity(*velocity_unit))
-    assert_allclose_units(ds.pressure_unit, YTQuantity(*pressure_unit))
-    assert_allclose_units(ds.time_unit, YTQuantity(*time_unit))
-    assert_allclose_units(ds.magnetic_unit, YTQuantity(*magnetic_unit))
+    assert_allclose_units(ds.length_unit, unyt_quantity(*length_unit))
+    assert_allclose_units(ds.numberdensity_unit, unyt_quantity(*numberdensity_unit))
+    assert_allclose_units(ds.temperature_unit, unyt_quantity(*temperature_unit))
+    assert_allclose_units(ds.density_unit, unyt_quantity(*density_unit))
+    assert_allclose_units(ds.mass_unit, unyt_quantity(*mass_unit))
+    assert_allclose_units(ds.velocity_unit, unyt_quantity(*velocity_unit))
+    assert_allclose_units(ds.pressure_unit, unyt_quantity(*pressure_unit))
+    assert_allclose_units(ds.time_unit, unyt_quantity(*time_unit))
+    assert_allclose_units(ds.magnetic_unit, unyt_quantity(*magnetic_unit))
 
 
 @requires_file(khi_cartesian_2D)
@@ -219,21 +219,23 @@ def test_normalisations_length_vel_mass():
 def test_normalisations_default():
     # test default normalisations, without overrides
     ds = data_dir_load(khi_cartesian_2D)
-    assert_allclose_units(ds.length_unit, YTQuantity(1, "cm"))
-    assert_allclose_units(ds.numberdensity_unit, YTQuantity(1, "cm**-3"))
-    assert_allclose_units(ds.temperature_unit, YTQuantity(1, "K"))
+    assert_allclose_units(ds.length_unit, unyt_quantity(1, "cm"))
+    assert_allclose_units(ds.numberdensity_unit, unyt_quantity(1, "cm**-3"))
+    assert_allclose_units(ds.temperature_unit, unyt_quantity(1, "K"))
     assert_allclose_units(
-        ds.density_unit, YTQuantity(2.341670657200000e-24, "g*cm**-3")
+        ds.density_unit, unyt_quantity(2.341670657200000e-24, "g*cm**-3")
     )
-    assert_allclose_units(ds.mass_unit, YTQuantity(2.341670657200000e-24, "g"))
+    assert_allclose_units(ds.mass_unit, unyt_quantity(2.341670657200000e-24, "g"))
     assert_allclose_units(
-        ds.velocity_unit, YTQuantity(1.164508387441102e04, "cm*s**-1")
+        ds.velocity_unit, unyt_quantity(1.164508387441102e04, "cm*s**-1")
     )
     assert_allclose_units(
-        ds.pressure_unit, YTQuantity(3.175492240000000e-16, "dyn*cm**-2")
+        ds.pressure_unit, unyt_quantity(3.175492240000000e-16, "dyn*cm**-2")
     )
-    assert_allclose_units(ds.time_unit, YTQuantity(8.587314705370271e-05, "s"))
-    assert_allclose_units(ds.magnetic_unit, YTQuantity(6.316993934686148e-08, "gauss"))
+    assert_allclose_units(ds.time_unit, unyt_quantity(8.587314705370271e-05, "s"))
+    assert_allclose_units(
+        ds.magnetic_unit, unyt_quantity(6.316993934686148e-08, "gauss")
+    )
 
 
 @requires_file(khi_cartesian_2D)

--- a/yt/frontends/art/io.py
+++ b/yt/frontends/art/io.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from functools import partial
 
 import numpy as np
+from unyt import unyt_array, unyt_quantity
 
 from yt.frontends.art.definitions import (
     hydro_struct,
@@ -11,7 +12,6 @@ from yt.frontends.art.definitions import (
     particle_star_fields,
     star_struct,
 )
-from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.fortran_utils import read_vector, skip
 from yt.utilities.io_handler import BaseIOHandler
 from yt.utilities.lib.geometry_utils import compute_morton
@@ -298,13 +298,13 @@ def interpolate_ages(
         t_stars, a_stars = read_star_field(file_stars, field="t_stars")
         # timestamp of file should match amr timestamp
         if current_time:
-            tdiff = YTQuantity(b2t(t_stars), "Gyr") - current_time.in_units("Gyr")
+            tdiff = unyt_quantity(b2t(t_stars), "Gyr") - current_time.in_units("Gyr")
             if np.abs(tdiff) > 1e-4:
                 mylog.info("Timestamp mismatch in star " + "particle header: %s", tdiff)
         mylog.info("Interpolating ages")
         interp_tb, interp_ages = b2t(data)
-        interp_tb = YTArray(interp_tb, "Gyr")
-        interp_ages = YTArray(interp_ages, "Gyr")
+        interp_tb = unyt_array(interp_tb, "Gyr")
+        interp_ages = unyt_array(interp_ages, "Gyr")
     temp = np.interp(data, interp_tb, interp_ages)
     return interp_tb, interp_ages, temp
 

--- a/yt/frontends/art/tests/test_outputs.py
+++ b/yt/frontends/art/tests/test_outputs.py
@@ -1,3 +1,5 @@
+from unyt import unyt_quantity
+
 from yt.frontends.art.api import ARTDataset
 from yt.testing import (
     ParticleSelectionComparison,
@@ -6,7 +8,6 @@ from yt.testing import (
     requires_file,
     units_override_check,
 )
-from yt.units.yt_array import YTQuantity
 from yt.utilities.answer_testing.framework import (
     FieldValuesTest,
     PixelizedProjectionValuesTest,
@@ -70,8 +71,8 @@ def test_d9p():
             npart_read += 1
         assert_equal(npart_read, npart_header)
 
-    AnaBoxSize = YTQuantity(7.1442196564, "Mpc")
-    AnaVolume = YTQuantity(364.640074656, "Mpc**3")
+    AnaBoxSize = unyt_quantity(7.1442196564, "Mpc")
+    AnaVolume = unyt_quantity(364.640074656, "Mpc**3")
     Volume = 1
     for i in ds.domain_width.in_units("Mpc"):
         assert_almost_equal(i, AnaBoxSize)
@@ -81,26 +82,26 @@ def test_d9p():
     AnaNCells = 4087490
     assert_equal(len(ad[("index", "cell_volume")]), AnaNCells)
 
-    AnaTotDMMass = YTQuantity(1.01191786808255e14, "Msun")
+    AnaTotDMMass = unyt_quantity(1.01191786808255e14, "Msun")
     assert_almost_equal(
         ad[("darkmatter", "particle_mass")].sum().in_units("Msun"), AnaTotDMMass
     )
 
-    AnaTotStarMass = YTQuantity(1776701.3990607238, "Msun")
+    AnaTotStarMass = unyt_quantity(1776701.3990607238, "Msun")
     assert_almost_equal(
         ad[("stars", "particle_mass")].sum().in_units("Msun"), AnaTotStarMass
     )
 
-    AnaTotStarMassInitial = YTQuantity(2423468.2801332865, "Msun")
+    AnaTotStarMassInitial = unyt_quantity(2423468.2801332865, "Msun")
     assert_almost_equal(
         ad[("stars", "particle_mass_initial")].sum().in_units("Msun"),
         AnaTotStarMassInitial,
     )
 
-    AnaTotGasMass = YTQuantity(1.7826982029216785e13, "Msun")
+    AnaTotGasMass = unyt_quantity(1.7826982029216785e13, "Msun")
     assert_almost_equal(ad[("gas", "cell_mass")].sum().in_units("Msun"), AnaTotGasMass)
 
-    AnaTotTemp = YTQuantity(150219844793.39072, "K")  # just leaves
+    AnaTotTemp = unyt_quantity(150219844793.39072, "K")  # just leaves
     assert_equal(ad[("gas", "temperature")].sum(), AnaTotTemp)
 
 

--- a/yt/frontends/artio/fields.py
+++ b/yt/frontends/artio/fields.py
@@ -1,7 +1,7 @@
 import numpy as np
+from unyt import unyt_array
 
 from yt.fields.field_info_container import FieldInfoContainer
-from yt.units.yt_array import YTArray
 from yt.utilities.physical_constants import amu_cgs, boltzmann_constant_cgs
 
 b_units = "code_magnetic"
@@ -133,7 +133,7 @@ class ARTIOFieldInfo(FieldInfoContainer):
         if ptype == "STAR":
 
             def _creation_time(field, data):
-                return YTArray(
+                return unyt_array(
                     data.ds._handle.tphys_from_tcode_array(data["STAR", "BIRTH_TIME"]),
                     "yr",
                 )

--- a/yt/frontends/boxlib/fields.py
+++ b/yt/frontends/boxlib/fields.py
@@ -2,9 +2,9 @@ import re
 import string
 
 import numpy as np
+from unyt import unyt_quantity
 
 from yt.fields.field_info_container import FieldInfoContainer
-from yt.units import YTQuantity
 from yt.utilities.physical_constants import amu_cgs, boltzmann_constant_cgs, c
 
 rho_units = "code_mass / code_length**3"
@@ -93,7 +93,7 @@ class WarpXFieldInfo(FieldInfoContainer):
     def setup_particle_fields(self, ptype):
         def get_mass(field, data):
             species_mass = data.ds.index.parameters[ptype + "_mass"]
-            return data["particle_weight"] * YTQuantity(species_mass, "kg")
+            return data["particle_weight"] * unyt_quantity(species_mass, "kg")
 
         self.add_field(
             (ptype, "particle_mass"),
@@ -104,7 +104,7 @@ class WarpXFieldInfo(FieldInfoContainer):
 
         def get_charge(field, data):
             species_charge = data.ds.index.parameters[ptype + "_charge"]
-            return data["particle_weight"] * YTQuantity(species_charge, "C")
+            return data["particle_weight"] * unyt_quantity(species_charge, "C")
 
         self.add_field(
             (ptype, "particle_charge"),

--- a/yt/frontends/chombo/fields.py
+++ b/yt/frontends/chombo/fields.py
@@ -1,4 +1,5 @@
 import numpy as np
+from unyt.unit_object import Unit
 
 from yt.fields.field_info_container import (
     FieldInfoContainer,
@@ -6,7 +7,6 @@ from yt.fields.field_info_container import (
     particle_vector_functions,
     standard_particle_fields,
 )
-from yt.units.unit_object import Unit
 from yt.utilities.exceptions import YTFieldNotFound
 
 rho_units = "code_mass / code_length**3"

--- a/yt/frontends/eagle/fields.py
+++ b/yt/frontends/eagle/fields.py
@@ -1,6 +1,7 @@
+from unyt import unyt_quantity
+
 from yt.frontends.eagle.definitions import eaglenetwork_ion_lookup
 from yt.frontends.owls.fields import OWLSFieldInfo
-from yt.units.yt_array import YTQuantity
 from yt.utilities.periodic_table import periodic_table
 
 
@@ -149,7 +150,9 @@ class EagleNetworkFieldInfo(OWLSFieldInfo):
                 symbol = ion[0:2].capitalize()
             else:
                 symbol = ion[0:1].capitalize()
-            m_ion = YTQuantity(periodic_table.elements_by_symbol[symbol].weight, "amu")
+            m_ion = unyt_quantity(
+                periodic_table.elements_by_symbol[symbol].weight, "amu"
+            )
 
             # hydrogen number density
             n_H = data["PartType0", "H_number_density"]

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -7,6 +7,9 @@ from collections import defaultdict
 
 import numpy as np
 import numpy.core.defchararray as np_char
+from unyt import dimensions, unyt_quantity
+from unyt._unit_lookup_table import default_unit_symbol_lut, unit_prefixes
+from unyt.unit_object import UnitParseError
 
 from yt.config import ytcfg
 from yt.data_objects.grid_patch import AMRGridPatch
@@ -14,10 +17,6 @@ from yt.data_objects.static_output import Dataset
 from yt.funcs import ensure_list, issue_deprecation_warning, mylog, setdefaultattr
 from yt.geometry.geometry_handler import YTDataChunk
 from yt.geometry.grid_geometry_handler import GridIndex
-from yt.units import dimensions
-from yt.units.unit_lookup_table import default_unit_symbol_lut, unit_prefixes
-from yt.units.unit_object import UnitParseError
-from yt.units.yt_array import YTQuantity
 from yt.utilities.decompose import decompose_array, get_psize
 from yt.utilities.file_handler import FITSFileHandler
 from yt.utilities.io_handler import io_registry
@@ -83,7 +82,7 @@ class FITSHierarchy(GridIndex):
             try:
                 # First let AstroPy attempt to figure the unit out
                 u = 1.0 * _astropy.units.Unit(bunit, format="fits")
-                u = YTQuantity.from_astropy(u).units
+                u = unyt_quantity.from_astropy(u).units
             except ValueError:
                 try:
                     # Let yt try it by itself

--- a/yt/frontends/fits/misc.py
+++ b/yt/frontends/fits/misc.py
@@ -3,10 +3,10 @@ import os
 from io import BytesIO
 
 import numpy as np
+from unyt import unyt_array, unyt_quantity
 
 from yt.fields.derived_field import ValidateSpatial
 from yt.funcs import issue_deprecation_warning, mylog
-from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.on_demand_imports import _astropy
 
 
@@ -86,7 +86,7 @@ def create_spectral_slabs(filename, slab_centers, slab_width, **kwargs):
         The centers of the slabs, where the keys are the names
         of the new fields and the values are (float, string) tuples or
         YTQuantities, specifying a value for each center and its unit.
-    slab_width : YTQuantity or (float, string) tuple
+    slab_width : unyt_quantity or (float, string) tuple
         The width of the slab along the spectral axis.
 
     Examples
@@ -105,13 +105,13 @@ def create_spectral_slabs(filename, slab_centers, slab_width, **kwargs):
     from yt.visualization.fits_image import FITSImageData
 
     cube = SpectralCube.read(filename)
-    if not isinstance(slab_width, YTQuantity):
-        slab_width = YTQuantity(slab_width[0], slab_width[1])
+    if not isinstance(slab_width, unyt_quantity):
+        slab_width = unyt_quantity(slab_width[0], slab_width[1])
     slab_data = {}
     field_units = cube.header.get("bunit", "dimensionless")
     for k, v in slab_centers.items():
-        if not isinstance(v, YTQuantity):
-            slab_center = YTQuantity(v[0], v[1])
+        if not isinstance(v, unyt_quantity):
+            slab_center = unyt_quantity(v[0], v[1])
         else:
             slab_center = v
         mylog.info(
@@ -120,7 +120,7 @@ def create_spectral_slabs(filename, slab_centers, slab_width, **kwargs):
         slab_lo = (slab_center - 0.5 * slab_width).to_astropy()
         slab_hi = (slab_center + 0.5 * slab_width).to_astropy()
         subcube = cube.spectral_slab(slab_lo, slab_hi)
-        slab_data[k] = YTArray(subcube.filled_data[:, :, :], field_units)
+        slab_data[k] = unyt_array(subcube.filled_data[:, :, :], field_units)
     width = subcube.header["naxis3"] * cube.header["cdelt3"]
     w = subcube.wcs.copy()
     w.wcs.crpix[-1] = 0.5

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -2,9 +2,9 @@ import os
 from collections import defaultdict
 
 import numpy as np
+from unyt import uconcatenate
 
 from yt.frontends.sph.io import IOHandlerSPH
-from yt.units.yt_array import uconcatenate
 from yt.utilities.lib.particle_kdtree_tools import generate_smoothing_length
 from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.on_demand_imports import _h5py as h5py

--- a/yt/frontends/gdf/data_structures.py
+++ b/yt/frontends/gdf/data_structures.py
@@ -2,13 +2,13 @@ import os
 import weakref
 
 import numpy as np
+from unyt.dimensions import dimensionless as sympy_one
+from unyt.unit_object import Unit
 
 from yt.data_objects.grid_patch import AMRGridPatch
 from yt.data_objects.static_output import Dataset
 from yt.funcs import ensure_tuple, just_one, setdefaultattr
 from yt.geometry.grid_geometry_handler import GridIndex
-from yt.units.dimensions import dimensionless as sympy_one
-from yt.units.unit_object import Unit
 from yt.units.unit_systems import unit_system_registry
 from yt.utilities.exceptions import YTGDFUnknownGeometry
 from yt.utilities.lib.misc_utilities import get_box_grids_level

--- a/yt/frontends/halo_catalog/io.py
+++ b/yt/frontends/halo_catalog/io.py
@@ -1,7 +1,7 @@
 import numpy as np
+from unyt.array import uvstack
 
 from yt.funcs import mylog, parse_h5_attr
-from yt.units.yt_array import uvstack
 from yt.utilities.exceptions import YTDomainOverflow
 from yt.utilities.io_handler import BaseIOHandler
 from yt.utilities.lib.geometry_utils import compute_morton

--- a/yt/frontends/halo_catalog/tests/test_outputs.py
+++ b/yt/frontends/halo_catalog/tests/test_outputs.py
@@ -1,10 +1,10 @@
 import numpy as np
+from unyt import unyt_array, unyt_quantity
 
 from yt.convenience import load as yt_load
 from yt.frontends.halo_catalog.data_structures import HaloCatalogDataset
 from yt.frontends.ytdata.utilities import save_as_dataset
 from yt.testing import TempDirTest, assert_array_equal, requires_module
-from yt.units.yt_array import YTArray, YTQuantity
 
 
 def fake_halo_catalog(data):
@@ -19,9 +19,9 @@ def fake_halo_catalog(data):
         "omega_matter": 0.3,
         "hubble_constant": 0.7,
         "current_redshift": 0,
-        "current_time": YTQuantity(1, "yr"),
-        "domain_left_edge": YTArray(np.zeros(3), "cm"),
-        "domain_right_edge": YTArray(np.ones(3), "cm"),
+        "current_time": unyt_quantity(1, "yr"),
+        "domain_left_edge": unyt_array(np.zeros(3), "cm"),
+        "domain_right_edge": unyt_array(np.ones(3), "cm"),
     }
     save_as_dataset(ds, filename, data, field_types=ftypes, extra_attrs=extra_attrs)
     return filename
@@ -38,7 +38,7 @@ class HaloCatalogTest(TempDirTest):
         ]
         units = ["g"] + ["cm"] * 3
         data = dict(
-            (field, YTArray(rs.random_sample(n_halos), unit))
+            (field, unyt_array(rs.random_sample(n_halos), unit))
             for field, unit in zip(fields, units)
         )
 
@@ -64,7 +64,7 @@ class HaloCatalogTest(TempDirTest):
         ]
         units = ["g"] + ["cm"] * 3
         data = dict(
-            (field, YTArray(rs.random_sample(n_halos), unit))
+            (field, unyt_array(rs.random_sample(n_halos), unit))
             for field, unit in zip(fields, units)
         )
 

--- a/yt/frontends/open_pmd/fields.py
+++ b/yt/frontends/open_pmd/fields.py
@@ -1,9 +1,9 @@
 import numpy as np
+from unyt import unyt_quantity
 
 from yt.fields.field_info_container import FieldInfoContainer
 from yt.fields.magnetic_field import setup_magnetic_field_aliases
 from yt.frontends.open_pmd.misc import is_const_component, parse_unit_dimension
-from yt.units.yt_array import YTQuantity
 from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.on_demand_imports import _h5py as h5
 from yt.utilities.physical_constants import mu_0, speed_of_light
@@ -157,7 +157,7 @@ class OpenPMDFieldInfo(FieldInfoContainer):
                     parsed = parse_unit_dimension(
                         np.asarray(field.attrs["unitDimension"], dtype=np.int)
                     )
-                    unit = str(YTQuantity(1, parsed).units)
+                    unit = str(unyt_quantity(1, parsed).units)
                     aliases = []
                     # Save a list of magnetic fields for aliasing later on
                     # We can not reasonably infer field type/unit by name in openPMD
@@ -170,7 +170,7 @@ class OpenPMDFieldInfo(FieldInfoContainer):
                         parsed = parse_unit_dimension(
                             np.asarray(field.attrs["unitDimension"], dtype=np.int)
                         )
-                        unit = str(YTQuantity(1, parsed).units)
+                        unit = str(unyt_quantity(1, parsed).units)
                         aliases = []
                         # Save a list of magnetic fields for aliasing later on
                         # We can not reasonably infer field type by name in openPMD
@@ -190,7 +190,7 @@ class OpenPMDFieldInfo(FieldInfoContainer):
                     try:
                         record = species[recname]
                         parsed = parse_unit_dimension(record.attrs["unitDimension"])
-                        unit = str(YTQuantity(1, parsed).units)
+                        unit = str(unyt_quantity(1, parsed).units)
                         ytattrib = str(recname).replace("_", "-")
                         if ytattrib == "position":
                             # Symbolically rename position to preserve yt's

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -7,6 +7,8 @@ from itertools import chain, product, repeat
 from numbers import Number as numeric_type
 
 import numpy as np
+from unyt import unyt_quantity
+from unyt.array import uconcatenate
 
 from yt.data_objects.field_data import YTFieldData
 from yt.data_objects.grid_patch import AMRGridPatch
@@ -24,7 +26,6 @@ from yt.geometry.grid_geometry_handler import GridIndex
 from yt.geometry.oct_container import OctreeContainer
 from yt.geometry.oct_geometry_handler import OctreeIndex
 from yt.geometry.unstructured_mesh_handler import UnstructuredIndex
-from yt.units.yt_array import YTQuantity, uconcatenate
 from yt.utilities.decompose import decompose_array, get_psize
 from yt.utilities.exceptions import (
     YTIllDefinedAMR,
@@ -337,7 +338,7 @@ class StreamDataset(Dataset):
                 uq = self.quan(1.0, unit)
             elif isinstance(unit, numeric_type):
                 uq = self.quan(unit, cgs_unit)
-            elif isinstance(unit, YTQuantity):
+            elif isinstance(unit, unyt_quantity):
                 uq = unit
             elif isinstance(unit, tuple):
                 uq = self.quan(unit[0], unit[1])
@@ -511,7 +512,7 @@ def process_data(data, grid_dims=None):
     for field, val in data.items():
         # val is a data array
         if isinstance(val, np.ndarray):
-            # val is a YTArray
+            # val is a unyt_array
             if hasattr(val, "units"):
                 field_units[field] = val.units
                 new_data[field] = val.copy().d
@@ -675,7 +676,7 @@ def load_uniform_grid(
     ...                        bbox=bbox, nprocs=12)
     >>> dd = ds.all_data()
     >>> dd['density']
-    YTArray([ 0.87568064,  0.33686453,  0.70467189, ...,  0.70439916,
+    unyt_array([ 0.87568064,  0.33686453,  0.70467189, ...,  0.70439916,
             0.97506269,  0.03047113]) g/cm**3
     """
 

--- a/yt/frontends/tipsy/data_structures.py
+++ b/yt/frontends/tipsy/data_structures.py
@@ -246,7 +246,7 @@ class TipsyDataset(SPHDataset):
                 self.hubble_constant *= np.sqrt(G * density_unit)
                 # Finally, we scale the hubble constant by 100 km/s/Mpc
                 self.hubble_constant /= self.quan(100, "km/s/Mpc")
-                # If we leave it as a YTQuantity, the cosmology object
+                # If we leave it as a unyt_quantity, the cosmology object
                 # used below will add units back on.
                 self.hubble_constant = self.hubble_constant.to_value("")
         else:

--- a/yt/frontends/ytdata/data_structures.py
+++ b/yt/frontends/ytdata/data_structures.py
@@ -4,6 +4,8 @@ from collections import defaultdict
 from numbers import Number as numeric_type
 
 import numpy as np
+from unyt import UnitRegistry, dimensions, unyt_quantity
+from unyt.array import uconcatenate
 
 from yt.data_objects.data_containers import GenerationInProgress
 from yt.data_objects.grid_patch import AMRGridPatch
@@ -18,9 +20,6 @@ from yt.fields.field_exceptions import NeedsGridType
 from yt.funcs import is_root, parse_h5_attr
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.geometry.particle_geometry_handler import ParticleIndex
-from yt.units import dimensions
-from yt.units.unit_registry import UnitRegistry
-from yt.units.yt_array import YTQuantity, uconcatenate
 from yt.utilities.exceptions import YTFieldTypeNotFound
 from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.on_demand_imports import _h5py as h5py
@@ -130,7 +129,7 @@ class SavedDataset(Dataset):
         base_units = np.ones(len(attrs))
         for unit, attr, cgs_unit in zip(base_units, attrs, cgs_units):
             if attr in self.parameters and isinstance(
-                self.parameters[attr], YTQuantity
+                self.parameters[attr], unyt_quantity
             ):
                 uq = self.parameters[attr]
             elif attr in self.parameters and "%s_units" % attr in self.parameters:
@@ -143,7 +142,7 @@ class SavedDataset(Dataset):
                 uq = self.quan(1.0, unit)
             elif isinstance(unit, numeric_type):
                 uq = self.quan(unit, cgs_unit)
-            elif isinstance(unit, YTQuantity):
+            elif isinstance(unit, unyt_quantity):
                 uq = unit
             elif isinstance(unit, tuple):
                 uq = self.quan(unit[0], unit[1])

--- a/yt/frontends/ytdata/io.py
+++ b/yt/frontends/ytdata/io.py
@@ -1,8 +1,8 @@
 import numpy as np
+from unyt.array import uvstack
 
 from yt.funcs import mylog, parse_h5_attr
 from yt.geometry.selection_routines import GridSelector
-from yt.units.yt_array import uvstack
 from yt.utilities.exceptions import YTDomainOverflow
 from yt.utilities.io_handler import BaseIOHandler
 from yt.utilities.lib.geometry_utils import compute_morton

--- a/yt/frontends/ytdata/tests/test_old_outputs.py
+++ b/yt/frontends/ytdata/tests/test_old_outputs.py
@@ -18,6 +18,7 @@ import shutil
 import tempfile
 
 import numpy as np
+from unyt import unyt_array
 
 from yt.data_objects.api import create_profile
 from yt.frontends.ytdata.api import (
@@ -32,7 +33,6 @@ from yt.frontends.ytdata.tests.test_outputs import (
     compare_unit_attributes,
 )
 from yt.testing import assert_allclose_units, assert_array_equal, requires_file
-from yt.units.yt_array import YTArray
 from yt.utilities.answer_testing.framework import data_dir_load, requires_ds
 from yt.visualization.profile_plotter import PhasePlot, ProfilePlot
 
@@ -175,7 +175,7 @@ def test_old_nonspatial_data():
     yield YTDataFieldTest(full_fn, "region_density", geometric=False)
     yield YTDataFieldTest(full_fn, "sphere_density", geometric=False)
 
-    my_data = {"density": YTArray(np.linspace(1.0, 20.0, 10), "g/cm**3")}
+    my_data = {"density": unyt_array(np.linspace(1.0, 20.0, 10), "g/cm**3")}
     fn = "random_data.h5"
     full_fn = os.path.join(ytdata_dir, fn)
     new_ds = data_dir_load(full_fn)

--- a/yt/frontends/ytdata/tests/test_outputs.py
+++ b/yt/frontends/ytdata/tests/test_outputs.py
@@ -3,6 +3,7 @@ import shutil
 import tempfile
 
 import numpy as np
+from unyt import unyt_array, unyt_quantity
 
 from yt.convenience import load
 from yt.data_objects.api import create_profile
@@ -15,7 +16,6 @@ from yt.frontends.ytdata.api import (
     save_as_dataset,
 )
 from yt.testing import assert_allclose_units, assert_array_equal, assert_equal
-from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.answer_testing.framework import (
     AnswerTestingTest,
     data_dir_load,
@@ -240,8 +240,8 @@ def test_nonspatial_data():
     yield YTDataFieldTest(full_fn, "region_density", geometric=False)
     yield YTDataFieldTest(full_fn, "sphere_density", geometric=False)
 
-    my_data = {"density": YTArray(np.linspace(1.0, 20.0, 10), "g/cm**3")}
-    fake_ds = {"current_time": YTQuantity(10, "Myr")}
+    my_data = {"density": unyt_array(np.linspace(1.0, 20.0, 10), "g/cm**3")}
+    fake_ds = {"current_time": unyt_quantity(10, "Myr")}
     fn = "random_data.h5"
     save_as_dataset(fake_ds, fn, my_data)
     full_fn = os.path.join(tmpdir, fn)

--- a/yt/frontends/ytdata/utilities.py
+++ b/yt/frontends/ytdata/utilities.py
@@ -1,4 +1,5 @@
-from yt.units.yt_array import YTArray
+from unyt import unyt_array
+
 from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.on_demand_imports import _h5py as h5py
 
@@ -57,7 +58,7 @@ def save_as_dataset(ds, filename, data, field_types=None, extra_attrs=None):
        3.57339907e-30   2.83150720e-30] g/cm**3
     >>> data = {"density": yt.YTArray(1e-24 * np.ones(10), "g/cm**3"),
     ...         "temperature": yt.YTArray(1000. * np.ones(10), "K")}
-    >>> ds_data = {"current_time": yt.YTQuantity(10, "Myr")}
+    >>> ds_data = {"current_time": yt.YTArray(10, "Myr")}
     >>> yt.save_as_dataset(ds_data, "random_data.h5", data)
     >>> new_ds = yt.load("random_data.h5")
     >>> print (new_ds.data["temperature"])
@@ -141,7 +142,7 @@ def save_as_dataset(ds, filename, data, field_types=None, extra_attrs=None):
 
 
 def _hdf5_yt_array(fh, field, ds=None):
-    r"""Load an hdf5 dataset as a YTArray.
+    r"""Load an hdf5 dataset as a unyt_array.
 
     Reads in a dataset from an open hdf5 file or group and uses the
     "units" attribute, if it exists, to apply units.
@@ -158,12 +159,12 @@ def _hdf5_yt_array(fh, field, ds=None):
 
     Returns
     -------
-    A YTArray of the requested field.
+    A unyt_array of the requested field.
 
     """
 
     if ds is None:
-        new_arr = YTArray
+        new_arr = unyt_array
     else:
         new_arr = ds.arr
     units = ""
@@ -175,9 +176,9 @@ def _hdf5_yt_array(fh, field, ds=None):
 
 
 def _yt_array_hdf5(fh, field, data):
-    r"""Save a YTArray to an open hdf5 file or group.
+    r"""Save a unyt_array to an open hdf5 file or group.
 
-    Save a YTArray to an open hdf5 file or group, and save the
+    Save a unyt_array to an open hdf5 file or group, and save the
     units to a "units" attribute.
 
     Parameters
@@ -186,7 +187,7 @@ def _yt_array_hdf5(fh, field, data):
         The hdf5 file or group to which the data will be written.
     field : str
         The name of the field to be saved.
-    data : YTArray
+    data : unyt_array
         The data array to be saved.
 
     Returns
@@ -198,14 +199,14 @@ def _yt_array_hdf5(fh, field, data):
 
     dataset = fh.create_dataset(str(field), data=data)
     units = ""
-    if isinstance(data, YTArray):
+    if isinstance(data, unyt_array):
         units = str(data.units)
     dataset.attrs["units"] = units
     return dataset
 
 
 def _yt_array_hdf5_attr(fh, attr, val):
-    r"""Save a YTArray or YTQuantity as an hdf5 attribute.
+    r"""Save a unyt_array or unyt_quantity as an hdf5 attribute.
 
     Save an hdf5 attribute.  If it has units, save an
     additional attribute with the units.

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -25,9 +25,9 @@ from numbers import Number as numeric_type
 
 import matplotlib
 import numpy as np
+from unyt import unyt_array, unyt_quantity
 
 from yt.extern.tqdm import tqdm
-from yt.units import YTArray, YTQuantity
 from yt.utilities.exceptions import YTInvalidWidthError
 from yt.utilities.logger import ytLogger as mylog
 
@@ -100,8 +100,8 @@ def read_struct(f, fmt):
 def just_one(obj):
     # If we have an iterable, sometimes we only want one item
     if hasattr(obj, "flat"):
-        if isinstance(obj, YTArray):
-            return YTQuantity(obj.flat[0], obj.units, registry=obj.units.registry)
+        if isinstance(obj, unyt_array):
+            return unyt_quantity(obj.flat[0], obj.units, registry=obj.units.registry)
         return obj.flat[0]
     elif iterable(obj):
         return obj[0]
@@ -856,19 +856,19 @@ def get_yt_supp():
 
 def fix_length(length, ds):
     registry = ds.unit_registry
-    if isinstance(length, YTArray):
+    if isinstance(length, unyt_array):
         if registry is not None:
             length.units.registry = registry
         return length.in_units("code_length")
     if isinstance(length, numeric_type):
-        return YTArray(length, "code_length", registry=registry)
+        return unyt_array(length, "code_length", registry=registry)
     length_valid_tuple = isinstance(length, (list, tuple)) and len(length) == 2
     unit_is_string = isinstance(length[1], str)
     length_is_number = isinstance(length[0], numeric_type) and not isinstance(
-        length[0], YTArray
+        length[0], unyt_array
     )
     if length_valid_tuple and unit_is_string and length_is_number:
-        return YTArray(*length, registry=registry)
+        return unyt_array(*length, registry=registry)
     else:
         raise RuntimeError("Length %s is invalid" % str(length))
 
@@ -1006,7 +1006,7 @@ def validate_width_tuple(width):
     if not iterable(width) or len(width) != 2:
         raise YTInvalidWidthError("width (%s) is not a two element tuple" % width)
     is_numeric = isinstance(width[0], numeric_type)
-    length_has_units = isinstance(width[0], YTArray)
+    length_has_units = isinstance(width[0], unyt_array)
     unit_is_string = isinstance(width[1], str)
     if not is_numeric or length_has_units and unit_is_string:
         msg = "width (%s) is invalid. " % str(width)
@@ -1354,7 +1354,7 @@ def array_like_field(data, x, field):
         units = finfo.output_units
     else:
         units = finfo.units
-    if isinstance(x, YTArray):
+    if isinstance(x, unyt_array):
         arr = copy.deepcopy(x)
         arr.convert_to_units(units)
         return arr
@@ -1376,7 +1376,7 @@ def validate_float(obj):
     """Validates if the passed argument is a float value.
 
     Raises an exception if `obj` is a single float value
-    or a YTQuantity of size 1.
+    or a unyt_quantity of size 1.
 
     Parameters
     ----------
@@ -1392,14 +1392,14 @@ def validate_float(obj):
     --------
     >>> validate_float(1)
     >>> validate_float(1.50)
-    >>> validate_float(YTQuantity(1,"cm"))
+    >>> validate_float(unyt_quantity(1,"cm"))
     >>> validate_float((1,"cm"))
     >>> validate_float([1, 1, 1])
     Traceback (most recent call last):
     ...
     TypeError: Expected a numeric value (or size-1 array), received 'list' of length 3
 
-    >>> validate_float([YTQuantity(1, "cm"), YTQuantity(2,"cm")])
+    >>> validate_float([unyt_quantity(1, "cm"), unyt_quantity(2,"cm")])
     Traceback (most recent call last):
     ...
     TypeError: Expected a numeric value (or size-1 array), received 'list' of length 2
@@ -1465,10 +1465,10 @@ def validate_center(center):
                 "'m', 'max', 'min'] or the prefix to be "
                 "'max_'/'min_', received '%s'." % center
             )
-    elif not isinstance(center, (numeric_type, YTQuantity)) and not iterable(center):
+    elif not isinstance(center, (numeric_type, unyt_quantity)) and not iterable(center):
         raise TypeError(
             "Expected 'center' to be a numeric object of type "
-            "list/tuple/np.ndarray/YTArray/YTQuantity, "
+            "list/tuple/np.ndarray/unyt_array/unyt_quantity, "
             "received '%s'." % str(type(center)).split("'")[1]
         )
 

--- a/yt/geometry/coordinates/cartesian_coordinates.py
+++ b/yt/geometry/coordinates/cartesian_coordinates.py
@@ -1,8 +1,9 @@
 import numpy as np
+from unyt import unyt_array
+from unyt.array import uconcatenate, uvstack
 
 from yt.data_objects.unstructured_mesh import SemiStructuredMesh
 from yt.funcs import mylog
-from yt.units.yt_array import YTArray, uconcatenate, uvstack
 from yt.utilities.lib.pixelization_routines import (
     interpolate_sph_grid_gather,
     normalization_2d_utility,
@@ -271,8 +272,8 @@ class CartesianCoordinateHandler(CoordinateHandler):
                 field_data,
                 index_offset=offset,
             )
-            arc_length = YTArray(arc_length, start_point.units)
-            plot_values = YTArray(plot_values, field_data.units)
+            arc_length = unyt_array(arc_length, start_point.units)
+            plot_values = unyt_array(plot_values, field_data.units)
         else:
             ray = self.ds.ray(start_point, end_point)
             arc_length, plot_values = _sample_ray(ray, npoints, field)

--- a/yt/geometry/coordinates/coordinate_handler.py
+++ b/yt/geometry/coordinates/coordinate_handler.py
@@ -2,9 +2,9 @@ import weakref
 from numbers import Number
 
 import numpy as np
+from unyt import unyt_array, unyt_quantity
 
 from yt.funcs import fix_unitary, iterable, validate_width_tuple
-from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.exceptions import YTCoordinateNotImplemented, YTInvalidWidthError
 
 
@@ -42,7 +42,7 @@ def validate_iterable_width(width, ds, unit=None):
         )
     elif isinstance(width[0], Number) and isinstance(width[1], Number):
         return (ds.quan(width[0], "code_length"), ds.quan(width[1], "code_length"))
-    elif isinstance(width[0], YTQuantity) and isinstance(width[1], YTQuantity):
+    elif isinstance(width[0], unyt_quantity) and isinstance(width[1], unyt_quantity):
         return (ds.quan(width[0]), ds.quan(width[1]))
     else:
         validate_width_tuple(width)
@@ -205,7 +205,7 @@ class CoordinateHandler:
             depth = (
                 self.ds.quan(depth, "code_length", registry=self.ds.unit_registry),
             )
-        elif isinstance(depth, YTQuantity):
+        elif isinstance(depth, unyt_quantity):
             depth = (depth,)
         else:
             raise YTInvalidWidthError(depth)
@@ -228,7 +228,7 @@ class CoordinateHandler:
             width = (w[0], w[1])
         elif iterable(width):
             width = validate_iterable_width(width, self.ds)
-        elif isinstance(width, YTQuantity):
+        elif isinstance(width, unyt_quantity):
             width = (width, width)
         elif isinstance(width, Number):
             width = (
@@ -254,7 +254,7 @@ class CoordinateHandler:
                 center = (self.ds.domain_left_edge + self.ds.domain_right_edge) / 2
             else:
                 raise RuntimeError('center keyword "%s" not recognized' % center)
-        elif isinstance(center, YTArray):
+        elif isinstance(center, unyt_array):
             return self.ds.arr(center), self.convert_to_cartesian(center)
         elif iterable(center):
             if isinstance(center[0], str) and isinstance(center[1], str):
@@ -286,7 +286,7 @@ class CoordinateHandler:
 
 def cartesian_to_cylindrical(coord, center=(0, 0, 0)):
     c2 = np.zeros_like(coord)
-    if not isinstance(center, YTArray):
+    if not isinstance(center, unyt_array):
         center = center * coord.uq
     c2[..., 0] = (
         (coord[..., 0] - center[0]) ** 2.0 + (coord[..., 1] - center[1]) ** 2.0
@@ -298,7 +298,7 @@ def cartesian_to_cylindrical(coord, center=(0, 0, 0)):
 
 def cylindrical_to_cartesian(coord, center=(0, 0, 0)):
     c2 = np.zeros_like(coord)
-    if not isinstance(center, YTArray):
+    if not isinstance(center, unyt_array):
         center = center * coord.uq
     c2[..., 0] = np.cos(coord[..., 0]) * coord[..., 1] + center[0]
     c2[..., 1] = np.sin(coord[..., 0]) * coord[..., 1] + center[1]

--- a/yt/geometry/geometry_handler.py
+++ b/yt/geometry/geometry_handler.py
@@ -4,10 +4,11 @@ import pickle
 import weakref
 
 import numpy as np
+from unyt import unyt_array
+from unyt.array import uconcatenate
 
 from yt.config import ytcfg
 from yt.funcs import iterable
-from yt.units.yt_array import YTArray, uconcatenate
 from yt.utilities.exceptions import YTFieldNotFound
 from yt.utilities.io_handler import io_registry
 from yt.utilities.logger import ytLogger as mylog
@@ -325,10 +326,12 @@ class YTDataChunk:
     def fcoords(self):
         if self._fast_index is not None:
             ci = self._fast_index.select_fcoords(self.dobj.selector, self.data_size)
-            ci = YTArray(ci, units="code_length", registry=self.dobj.ds.unit_registry)
+            ci = unyt_array(
+                ci, units="code_length", registry=self.dobj.ds.unit_registry
+            )
             return ci
         ci = np.empty((self.data_size, 3), dtype="float64")
-        ci = YTArray(ci, units="code_length", registry=self.dobj.ds.unit_registry)
+        ci = unyt_array(ci, units="code_length", registry=self.dobj.ds.unit_registry)
         if self.data_size == 0:
             return ci
         ind = 0
@@ -361,10 +364,12 @@ class YTDataChunk:
     def fwidth(self):
         if self._fast_index is not None:
             ci = self._fast_index.select_fwidth(self.dobj.selector, self.data_size)
-            ci = YTArray(ci, units="code_length", registry=self.dobj.ds.unit_registry)
+            ci = unyt_array(
+                ci, units="code_length", registry=self.dobj.ds.unit_registry
+            )
             return ci
         ci = np.empty((self.data_size, 3), dtype="float64")
-        ci = YTArray(ci, units="code_length", registry=self.dobj.ds.unit_registry)
+        ci = unyt_array(ci, units="code_length", registry=self.dobj.ds.unit_registry)
         if self.data_size == 0:
             return ci
         ind = 0
@@ -420,7 +425,7 @@ class YTDataChunk:
         nodes_per_elem = self.dobj.index.meshes[0].connectivity_indices.shape[1]
         dim = self.dobj.ds.dimensionality
         ci = np.empty((self.data_size, nodes_per_elem, dim), dtype="float64")
-        ci = YTArray(ci, units="code_length", registry=self.dobj.ds.unit_registry)
+        ci = unyt_array(ci, units="code_length", registry=self.dobj.ds.unit_registry)
         if self.data_size == 0:
             return ci
         ind = 0

--- a/yt/geometry/tests/test_particle_octree.py
+++ b/yt/geometry/tests/test_particle_octree.py
@@ -1,14 +1,12 @@
 import os
 
 import numpy as np
+from unyt import UnitRegistry, dimensions, unyt_array
 
-import yt.units.dimensions as dimensions
 from yt.geometry.oct_container import _ORDER_MAX
 from yt.geometry.particle_oct_container import ParticleBitmap, ParticleOctreeContainer
 from yt.geometry.selection_routines import RegionSelector
 from yt.testing import assert_array_equal, assert_equal, assert_true
-from yt.units.unit_registry import UnitRegistry
-from yt.units.yt_array import YTArray
 from yt.utilities.lib.geometry_utils import (
     get_hilbert_indices,
     get_hilbert_points,
@@ -64,10 +62,10 @@ class FakeDS:
 class FakeRegion:
     def __init__(self, nfiles, periodic=False):
         self.ds = FakeDS()
-        self.ds.domain_left_edge = YTArray(
+        self.ds.domain_left_edge = unyt_array(
             [0.0, 0.0, 0.0], "code_length", registry=self.ds.unit_registry
         )
-        self.ds.domain_right_edge = YTArray(
+        self.ds.domain_right_edge = unyt_array(
             [nfiles, nfiles, nfiles],
             "code_length",
             registry=self.ds.unit_registry,
@@ -78,10 +76,10 @@ class FakeRegion:
         self.nfiles = nfiles
 
     def set_edges(self, file_id, dx=0.1):
-        self.left_edge = YTArray(
+        self.left_edge = unyt_array(
             [file_id + dx, 0.0, 0.0], "code_length", registry=self.ds.unit_registry
         )
-        self.right_edge = YTArray(
+        self.right_edge = unyt_array(
             [file_id + 1 - dx, self.nfiles, self.nfiles],
             "code_length",
             registry=self.ds.unit_registry,
@@ -91,10 +89,10 @@ class FakeRegion:
 class FakeBoxRegion:
     def __init__(self, nfiles, left_edge, right_edge):
         self.ds = FakeDS()
-        self.ds.domain_left_edge = YTArray(
+        self.ds.domain_left_edge = unyt_array(
             left_edge, "code_length", registry=self.ds.unit_registry
         )
-        self.ds.domain_right_edge = YTArray(
+        self.ds.domain_right_edge = unyt_array(
             right_edge, "code_length", registry=self.ds.unit_registry
         )
         self.ds.domain_width = self.ds.domain_right_edge - self.ds.domain_left_edge

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -11,13 +11,13 @@ import unittest
 import matplotlib
 import numpy as np
 from numpy.random import RandomState
+from unyt import unyt_array, unyt_quantity
 from unyt.exceptions import UnitOperationError
 
 import yt
 from yt.config import ytcfg
 from yt.convenience import load
 from yt.funcs import iterable
-from yt.units.yt_array import YTArray, YTQuantity
 
 # we import this in a weird way from numpy.testing to avoid triggering
 # flake8 errors from the unused imports. These test functions are imported
@@ -1134,8 +1134,8 @@ def assert_allclose_units(actual, desired, rtol=1e-7, atol=0, **kwargs):
 
     """
     # Create a copy to ensure this function does not alter input arrays
-    act = YTArray(actual)
-    des = YTArray(desired)
+    act = unyt_array(actual)
+    des = unyt_array(desired)
 
     try:
         des = des.in_units(act.units)
@@ -1145,12 +1145,12 @@ def assert_allclose_units(actual, desired, rtol=1e-7, atol=0, **kwargs):
             "equivalent dimensions" % (act.units, des.units)
         )
 
-    rt = YTArray(rtol)
+    rt = unyt_array(rtol)
     if not rt.units.is_dimensionless:
         raise AssertionError("Units of rtol (%s) are not " "dimensionless" % rt.units)
 
-    if not isinstance(atol, YTArray):
-        at = YTQuantity(atol, des.units)
+    if not isinstance(atol, unyt_array):
+        at = unyt_quantity(atol, des.units)
 
     try:
         at = at.in_units(act.units)

--- a/yt/tests/test_funcs.py
+++ b/yt/tests/test_funcs.py
@@ -1,6 +1,6 @@
 from nose.tools import assert_raises
+from unyt import unyt_quantity
 
-from yt import YTQuantity
 from yt.funcs import validate_axis, validate_center
 from yt.testing import assert_equal, fake_amr_ds
 
@@ -35,7 +35,7 @@ def test_validate_center():
     )
     assert_equal(str(ex.exception), desired)
 
-    validate_center(YTQuantity(0.25, "cm"))
+    validate_center(unyt_quantity(0.25, "cm"))
     validate_center([0.25, 0.25, 0.25])
 
     class CustomCenter:
@@ -46,7 +46,7 @@ def test_validate_center():
         validate_center(CustomCenter(10))
     desired = (
         "Expected 'center' to be a numeric object of type "
-        "list/tuple/np.ndarray/YTArray/YTQuantity, received "
+        "list/tuple/np.ndarray/unyt_array/unyt_quantity, received "
         "'yt.tests.test_funcs.test_validate_center.<locals>."
         "CustomCenter'."
     )

--- a/yt/units/__init__.py
+++ b/yt/units/__init__.py
@@ -1,3 +1,4 @@
+"""This module is a wrapper around unyt"""
 from unyt.array import (
     loadtxt,
     savetxt,
@@ -21,11 +22,11 @@ from yt.units.physical_constants import *
 from yt.units.physical_constants import _ConstantContainer
 from yt.units.unit_symbols import *
 from yt.units.unit_symbols import _SymbolContainer
-from yt.utilities.exceptions import YTArrayTooLargeToDisplay
-
-YTArray = unyt_array
-
-YTQuantity = unyt_quantity
+from yt.units.yt_array import (  # aliases kept for backward compatibility
+    YTArray,
+    YTQuantity,
+)
+from yt.utilities.exceptions import unyt_arrayTooLargeToDisplay
 
 
 class UnitContainer:
@@ -73,14 +74,14 @@ class UnitContainer:
 
 def display_ytarray(arr):
     r"""
-    Display a YTArray in a Jupyter widget that enables unit switching.
+    Display a unyt_array in a Jupyter widget that enables unit switching.
 
     The array returned by this function is read-only, and only works with
     arrays of size 3 or lower.
 
     Parameters
     ----------
-    arr : YTArray
+    arr : unyt_array
         The Array to display; must be of size 3 or lower.
 
     Examples
@@ -89,7 +90,7 @@ def display_ytarray(arr):
     >>> display_ytarray(ds.domain_width)
     """
     if arr.size > 3:
-        raise YTArrayTooLargeToDisplay(arr.size, 3)
+        raise unyt_arrayTooLargeToDisplay(arr.size, 3)
     import ipywidgets
 
     unit_registry = arr.units.registry

--- a/yt/units/yt_array.py
+++ b/yt/units/yt_array.py
@@ -1,19 +1,19 @@
+from unyt import unyt_array as YTArray, unyt_quantity as YTQuantity
 from unyt.array import *
 
 from yt.funcs import array_like_field
-from yt.units import YTArray, YTQuantity
 
 
 def display_ytarray(arr):
     r"""
-    Display a YTArray in a Jupyter widget that enables unit switching.
+    Display a unyt_array in a Jupyter widget that enables unit switching.
 
     The array returned by this function is read-only, and only works with
     arrays of size 3 or lower.
 
     Parameters
     ----------
-    arr : YTArray
+    arr : unyt_array
         The Array to display; must be of size 3 or lower.
 
     Examples
@@ -22,7 +22,7 @@ def display_ytarray(arr):
     >>> display_ytarray(ds.domain_width)
     """
     if arr.size > 3:
-        raise YTArrayTooLargeToDisplay(arr.size, 3)
+        raise unyt_arrayTooLargeToDisplay(arr.size, 3)
     import ipywidgets
 
     unit_registry = arr.units.registry

--- a/yt/utilities/answer_testing/utils.py
+++ b/yt/utilities/answer_testing/utils.py
@@ -11,17 +11,19 @@ import os
 import numpy as np
 import pytest
 import yaml
+from unyt import unyt_array, unyt_quantity
 
-import yt.visualization.particle_plots as particle_plots
-import yt.visualization.plot_window as pw
-import yt.visualization.profile_plotter as profile_plotter
 from yt.config import ytcfg
 from yt.convenience import load, simulation
 from yt.data_objects.selection_data_containers import YTRegion
 from yt.data_objects.static_output import Dataset
 from yt.frontends.ytdata.api import save_as_dataset
-from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.exceptions import YTOutputNotIdentified
+from yt.visualization import (
+    particle_plots as particle_plots,
+    plot_window as pw,
+    profile_plotter as profile_plotter,
+)
 from yt.visualization.volume_rendering.scene import Scene
 
 
@@ -438,9 +440,9 @@ def fake_halo_catalog(data):
         "omega_matter": 0.3,
         "hubble_constant": 0.7,
         "current_redshift": 0,
-        "current_time": YTQuantity(1, "yr"),
-        "domain_left_edge": YTArray(np.zeros(3), "cm"),
-        "domain_right_edge": YTArray(np.ones(3), "cm"),
+        "current_time": unyt_quantity(1, "yr"),
+        "domain_left_edge": unyt_array(np.zeros(3), "cm"),
+        "domain_right_edge": unyt_array(np.ones(3), "cm"),
     }
     save_as_dataset(ds, filename, data, field_types=ftypes, extra_attrs=extra_attrs)
     return filename

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -41,6 +41,7 @@ from yt.visualization.plot_window import ProjectionPlot, SlicePlot
 # isort: off
 # This needs to be set before importing startup_tasks
 ytcfg["yt", "__command_line"] = "True"  # isort: skip
+
 from yt.startup_tasks import parser, subparsers  # isort: skip # noqa: E402
 
 # isort: on

--- a/yt/utilities/cosmology.py
+++ b/yt/utilities/cosmology.py
@@ -1,12 +1,10 @@
 import functools
 
 import numpy as np
+from unyt import UnitRegistry, dimensions, unyt_array, unyt_quantity
+from unyt.unit_object import Unit
 
 from yt.funcs import issue_deprecation_warning
-from yt.units import dimensions
-from yt.units.unit_object import Unit
-from yt.units.unit_registry import UnitRegistry
-from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.physical_constants import (
     gravitational_constant_cgs as G,
     speed_of_light_cgs,
@@ -541,7 +539,7 @@ class Cosmology:
 
         Parameters
         ----------
-        t : YTQuantity or float
+        t : unyt_quantity or float
             Time since the Big Bang.  If a float is given, units are
             assumed to be seconds.
 
@@ -554,7 +552,7 @@ class Cosmology:
 
         """
 
-        if not isinstance(t, YTArray):
+        if not isinstance(t, unyt_array):
             t = self.arr(t, "s")
         lt = np.log10((t * self.hubble_constant).to(""))
 
@@ -602,7 +600,7 @@ class Cosmology:
 
         Parameters
         ----------
-        t : YTQuantity or float
+        t : unyt_quantity or float
             Time since the Big Bang.  If a float is given, units are
             assumed to be seconds.
 
@@ -650,7 +648,7 @@ class Cosmology:
     def arr(self):
         if self._arr is not None:
             return self._arr
-        self._arr = functools.partial(YTArray, registry=self.unit_registry)
+        self._arr = functools.partial(unyt_array, registry=self.unit_registry)
         return self._arr
 
     _quan = None
@@ -659,7 +657,7 @@ class Cosmology:
     def quan(self):
         if self._quan is not None:
             return self._quan
-        self._quan = functools.partial(YTQuantity, registry=self.unit_registry)
+        self._quan = functools.partial(unyt_quantity, registry=self.unit_registry)
         return self._quan
 
 

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -840,7 +840,7 @@ class YTModuleRemoved(Exception):
         Exception.__init__(self, message)
 
 
-class YTArrayTooLargeToDisplay(YTException):
+class unyt_arrayTooLargeToDisplay(YTException):
     def __init__(self, size, max_size):
         self.size = size
         self.max_size = max_size

--- a/yt/utilities/lib/marching_cubes.pyx
+++ b/yt/utilities/lib/marching_cubes.pyx
@@ -25,7 +25,7 @@ from libc.stdlib cimport abs, free, malloc
 
 from yt.utilities.lib.fp_utils cimport fclip, fmax, fmin, iclip, imax, imin
 
-from yt.units.yt_array import YTArray
+from unyt import unyt_array
 
 
 cdef extern from "marching_cubes.h":
@@ -269,7 +269,7 @@ def march_cubes_grid(np.float64_t isovalue,
     FillTriangleValues(sampled, triangles.first, nskip)
     FillAndWipeTriangles(vertices, triangles.first)
     if hasattr(obj_sample, 'units'):
-        sampled = YTArray(sampled, obj_sample.units)
+        sampled = unyt_array(sampled, obj_sample.units)
     return vertices, sampled
 
 @cython.boundscheck(False)

--- a/yt/utilities/lib/mesh_utilities.pyx
+++ b/yt/utilities/lib/mesh_utilities.pyx
@@ -13,10 +13,9 @@ import numpy as np
 cimport cython
 cimport numpy as np
 from libc.stdlib cimport abs, free, malloc
+from unyt import unyt_array
 
 from yt.utilities.lib.fp_utils cimport fclip, fmax, fmin, i64clip, iclip, imax, imin
-
-from yt.units.yt_array import YTArray
 
 
 cdef extern from "platform_dep.h":

--- a/yt/utilities/lib/misc_utilities.pyx
+++ b/yt/utilities/lib/misc_utilities.pyx
@@ -10,9 +10,9 @@ Simple utilities that don't fit anywhere else
 
 
 import numpy as np
+from unyt import unyt_array
 
 from yt.funcs import get_pbar
-from yt.units.yt_array import YTArray
 
 cimport cython
 cimport libc.math as math
@@ -589,7 +589,7 @@ def obtain_position_vector(
         xf = data[field_names[0]]
         yf = data[field_names[1]]
         zf = data[field_names[2]]
-        rf = YTArray(np.empty((3, xf.shape[0]), 'float64'), xf.units)
+        rf = unyt_array(np.empty((3, xf.shape[0]), 'float64'), xf.units)
         for i in range(xf.shape[0]):
             rf[0, i] = xf[i] - c[0]
             rf[1, i] = yf[i] - c[1]
@@ -601,8 +601,8 @@ def obtain_position_vector(
         yg = data[field_names[1]]
         zg = data[field_names[2]]
         shape = (3, xg.shape[0], xg.shape[1], xg.shape[2])
-        rg = YTArray(np.empty(shape, 'float64'), xg.units)
-        #rg = YTArray(rg, xg.units)
+        rg = unyt_array(np.empty(shape, 'float64'), xg.units)
+        #rg = unyt_array(rg, xg.units)
         for i in range(xg.shape[0]):
             for j in range(xg.shape[1]):
                 for k in range(xg.shape[2]):
@@ -639,7 +639,7 @@ def obtain_relative_velocity_vector(
         vzf = data[field_names[2]].astype("float64")
         vyf.convert_to_units(vxf.units)
         vzf.convert_to_units(vxf.units)
-        rvf = YTArray(np.empty((3, vxf.shape[0]), 'float64'), vxf.units)
+        rvf = unyt_array(np.empty((3, vxf.shape[0]), 'float64'), vxf.units)
         if bulk_vector is None:
             bv[0] = bv[1] = bv[2] = 0.0
         else:
@@ -660,7 +660,7 @@ def obtain_relative_velocity_vector(
         vyg.convert_to_units(vxg.units)
         vzg.convert_to_units(vxg.units)
         shape = (3, vxg.shape[0], vxg.shape[1], vxg.shape[2])
-        rvg = YTArray(np.empty(shape, 'float64'), vxg.units)
+        rvg = unyt_array(np.empty(shape, 'float64'), vxg.units)
         if bulk_vector is None:
             bv[0] = bv[1] = bv[2] = 0.0
         else:

--- a/yt/utilities/math_utils.py
+++ b/yt/utilities/math_utils.py
@@ -1,8 +1,7 @@
 import math
 
 import numpy as np
-
-from yt.units.yt_array import YTArray
+from unyt import unyt_array
 
 prec_accum = {
     np.int: np.int64,
@@ -136,8 +135,8 @@ def periodic_ray(start, end, left=None, right=None):
     periodic_ray(start, end, left=None, right=None)
 
     Break up periodic ray into non-periodic segments.
-    Accepts start and end points of periodic ray as YTArrays.
-    Accepts optional left and right edges of periodic volume as YTArrays.
+    Accepts start and end points of periodic ray as unyt_arrays.
+    Accepts optional left and right edges of periodic volume as unyt_arrays.
     Returns a list of lists of coordinates, where each element of the
     top-most list is a 2-list of start coords and end coords of the
     non-periodic ray:
@@ -165,8 +164,8 @@ def periodic_ray(start, end, left=None, right=None):
     >>> start = yt.YTArray([0.5, 0.5, 0.5])
     >>> end = yt.YTArray([1.25, 1.25, 1.25])
     >>> periodic_ray(start, end)
-    [[YTArray([0.5, 0.5, 0.5]) (dimensionless), YTArray([1., 1., 1.]) (dimensionless)],
-     [YTArray([0., 0., 0.]) (dimensionless), YTArray([0.25, 0.25, 0.25]) (dimensionless)]]
+    [[unyt_array([0.5, 0.5, 0.5]) (dimensionless), unyt_array([1., 1., 1.]) (dimensionless)],
+     [unyt_array([0., 0., 0.]) (dimensionless), unyt_array([0.25, 0.25, 0.25]) (dimensionless)]]
 
     """
 
@@ -1482,7 +1481,7 @@ def get_sph_r_component(vectors, theta, phi, normal):
     tile_shape = [1] + list(vectors.shape)[1:]
 
     Jx, Jy, Jz = (
-        YTArray(np.tile(rprime, tile_shape), "")
+        unyt_array(np.tile(rprime, tile_shape), "")
         for rprime in (res_xprime, res_yprime, res_zprime)
     )
 
@@ -1504,8 +1503,8 @@ def get_sph_phi_component(vectors, phi, normal):
     res_yprime = resize_vector(yprime, vectors)
 
     tile_shape = [1] + list(vectors.shape)[1:]
-    Jx = YTArray(np.tile(res_xprime, tile_shape), "")
-    Jy = YTArray(np.tile(res_yprime, tile_shape), "")
+    Jx = unyt_array(np.tile(res_xprime, tile_shape), "")
+    Jy = unyt_array(np.tile(res_yprime, tile_shape), "")
 
     phihat = -Jx * np.sin(phi) + Jy * np.cos(phi)
 
@@ -1523,7 +1522,7 @@ def get_sph_theta_component(vectors, theta, phi, normal):
 
     tile_shape = [1] + list(vectors.shape)[1:]
     Jx, Jy, Jz = (
-        YTArray(np.tile(rprime, tile_shape), "")
+        unyt_array(np.tile(rprime, tile_shape), "")
         for rprime in (res_xprime, res_yprime, res_zprime)
     )
 

--- a/yt/utilities/minimal_representation.py
+++ b/yt/utilities/minimal_representation.py
@@ -8,10 +8,10 @@ from tempfile import TemporaryFile
 from uuid import uuid4
 
 import numpy as np
+from unyt import unyt_array, unyt_quantity
 
 from yt.config import ytcfg
 from yt.funcs import compare_dicts, get_pbar, iterable
-from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.exceptions import YTHubRegisterError
 from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.on_demand_imports import _h5py as h5
@@ -41,7 +41,7 @@ def _sanitize_list(flist):
 
 def _serialize_to_h5(g, cdict):
     for item in cdict:
-        if isinstance(cdict[item], (YTQuantity, YTArray)):
+        if isinstance(cdict[item], (unyt_quantity, unyt_array)):
             g[item] = cdict[item].d
             g[item].attrs["units"] = str(cdict[item].units)
         elif isinstance(cdict[item], dict):
@@ -155,7 +155,7 @@ class MinimalRepresentation(metaclass=abc.ABCMeta):
                     if isinstance(fname, (tuple, list)):
                         fname = "*".join(fname)
 
-                    if isinstance(fdata, (YTQuantity, YTArray)):
+                    if isinstance(fdata, (unyt_quantity, unyt_array)):
                         g.create_dataset(fname, data=fdata.d, compression="lzf")
                         g[fname].attrs["units"] = str(fdata.units)
                     else:

--- a/yt/utilities/orientation.py
+++ b/yt/utilities/orientation.py
@@ -1,7 +1,7 @@
 import numpy as np
+from unyt import unyt_array
 
 from yt.funcs import mylog
-from yt.units.yt_array import YTArray
 from yt.utilities.exceptions import YTException
 
 
@@ -14,9 +14,9 @@ def _validate_unit_vectors(normal_vector, north_vector):
 
     # Make sure vectors are unitless
     if north_vector is not None:
-        north_vector = YTArray(north_vector, "", dtype="float64")
+        north_vector = unyt_array(north_vector, "", dtype="float64")
     if normal_vector is not None:
-        normal_vector = YTArray(normal_vector, "", dtype="float64")
+        normal_vector = unyt_array(normal_vector, "", dtype="float64")
 
     if not np.dot(normal_vector, normal_vector) > 0:
         raise YTException("normal_vector cannot be the zero vector.")
@@ -85,5 +85,5 @@ class Orientation:
         east_vector /= np.sqrt(np.dot(east_vector, east_vector))
         self.normal_vector = normal_vector
         self.north_vector = north_vector
-        self.unit_vectors = YTArray([east_vector, north_vector, normal_vector], "")
+        self.unit_vectors = unyt_array([east_vector, north_vector, normal_vector], "")
         self.inv_mat = np.linalg.pinv(self.unit_vectors)

--- a/yt/utilities/particle_generator.py
+++ b/yt/utilities/particle_generator.py
@@ -1,7 +1,7 @@
 import numpy as np
+from unyt.array import uconcatenate
 
 from yt.funcs import get_pbar, issue_deprecation_warning
-from yt.units.yt_array import uconcatenate
 from yt.utilities.lib.particle_mesh_operations import CICSample_3
 
 

--- a/yt/utilities/physical_constants.py
+++ b/yt/utilities/physical_constants.py
@@ -1,6 +1,7 @@
 from math import pi
 
-from yt.units.yt_array import YTQuantity
+from unyt import unyt_quantity
+
 from yt.utilities.physical_ratios import (
     amu_grams,
     boltzmann_constant_erg_per_K,
@@ -27,62 +28,62 @@ from yt.utilities.physical_ratios import (
     standard_gravity_cm_per_s2,
 )
 
-mass_electron_cgs = YTQuantity(mass_electron_grams, "g")
+mass_electron_cgs = unyt_quantity(mass_electron_grams, "g")
 mass_electron = mass_electron_cgs
 me = mass_electron_cgs
 
-amu_cgs = YTQuantity(amu_grams, "g")
+amu_cgs = unyt_quantity(amu_grams, "g")
 amu = amu_cgs
 Na = 1 / amu_cgs
 
-mass_hydrogen_cgs = YTQuantity(mass_hydrogen_grams, "g")
+mass_hydrogen_cgs = unyt_quantity(mass_hydrogen_grams, "g")
 mass_hydrogen = mass_hydrogen_cgs
 mp = mass_hydrogen_cgs
 mh = mp
 
 # Velocities
-speed_of_light_cgs = YTQuantity(speed_of_light_cm_per_s, "cm/s")
+speed_of_light_cgs = unyt_quantity(speed_of_light_cm_per_s, "cm/s")
 speed_of_light = speed_of_light_cgs
 clight = speed_of_light_cgs
 c = speed_of_light_cgs
 
 # Cross Sections
 # 8*pi/3 (alpha*hbar*c/(2*pi))**2
-cross_section_thompson_cgs = YTQuantity(6.65245854533e-25, "cm**2")
+cross_section_thompson_cgs = unyt_quantity(6.65245854533e-25, "cm**2")
 cross_section_thompson = cross_section_thompson_cgs
 thompson_cross_section = cross_section_thompson_cgs
 sigma_thompson = cross_section_thompson_cgs
 
 # Charge
-charge_proton_cgs = YTQuantity(4.8032056e-10, "esu")
+charge_proton_cgs = unyt_quantity(4.8032056e-10, "esu")
 charge_proton = charge_proton_cgs
 proton_charge = charge_proton_cgs
 elementary_charge = charge_proton_cgs
 qp = charge_proton_cgs
 
 # Physical Constants
-boltzmann_constant_cgs = YTQuantity(boltzmann_constant_erg_per_K, "erg/K")
+boltzmann_constant_cgs = unyt_quantity(boltzmann_constant_erg_per_K, "erg/K")
 boltzmann_constant = boltzmann_constant_cgs
 kboltz = boltzmann_constant_cgs
 kb = kboltz
 
-gravitational_constant_cgs = YTQuantity(newton_cgs, "cm**3/g/s**2")
+gravitational_constant_cgs = unyt_quantity(newton_cgs, "cm**3/g/s**2")
 gravitational_constant = gravitational_constant_cgs
 G = gravitational_constant_cgs
 
-planck_constant_cgs = YTQuantity(planck_cgs, "erg*s")
+planck_constant_cgs = unyt_quantity(planck_cgs, "erg*s")
 planck_constant = planck_constant_cgs
 hcgs = planck_constant_cgs
 hbar = 0.5 * hcgs / pi
 
-stefan_boltzmann_constant_cgs = YTQuantity(5.670373e-5, "erg/cm**2/s**1/K**4")
+stefan_boltzmann_constant_cgs = unyt_quantity(5.670373e-5, "erg/cm**2/s**1/K**4")
 stefan_boltzmann_constant = stefan_boltzmann_constant_cgs
 
-Tcmb = YTQuantity(2.726, "K")  # Current CMB temperature
+Tcmb = unyt_quantity(2.726, "K")  # Current CMB temperature
 CMB_temperature = Tcmb
 
 # Solar System
-mass_sun_cgs = YTQuantity(mass_sun_grams, "g")
+mass_sun_cgs = unyt_quantity(mass_sun_grams, "g")
 mass_sun = mass_sun_cgs
 solar_mass = mass_sun_cgs
 msun = mass_sun_cgs
@@ -90,51 +91,51 @@ msun = mass_sun_cgs
 # in Highlights of Astronomy (I. Appenzeller, ed.), Table 1,
 # Kluwer Academic Publishers, Dordrecht.
 # REMARK: following masses include whole systems (planet + moons)
-mass_jupiter_cgs = YTQuantity(mass_jupiter_grams, "g")
+mass_jupiter_cgs = unyt_quantity(mass_jupiter_grams, "g")
 mass_jupiter = mass_jupiter_cgs
 jupiter_mas = mass_jupiter_cgs
 
-mass_mercury_cgs = YTQuantity(mass_mercury_grams, "g")
+mass_mercury_cgs = unyt_quantity(mass_mercury_grams, "g")
 mass_mercury = mass_mercury_cgs
 mercury_mass = mass_mercury_cgs
 
-mass_venus_cgs = YTQuantity(mass_venus_grams, "g")
+mass_venus_cgs = unyt_quantity(mass_venus_grams, "g")
 mass_venus = mass_venus_cgs
 venus_mass = mass_venus_cgs
 
-mass_earth_cgs = YTQuantity(mass_earth_grams, "g")
+mass_earth_cgs = unyt_quantity(mass_earth_grams, "g")
 mass_earth = mass_earth_cgs
 earth_mass = mass_earth_cgs
 mearth = mass_earth_cgs
 
-mass_mars_cgs = YTQuantity(mass_mars_grams, "g")
+mass_mars_cgs = unyt_quantity(mass_mars_grams, "g")
 mass_mars = mass_mars_cgs
 mars_mass = mass_mars_cgs
 
-mass_saturn_cgs = YTQuantity(mass_saturn_grams, "g")
+mass_saturn_cgs = unyt_quantity(mass_saturn_grams, "g")
 mass_saturn = mass_saturn_cgs
 saturn_mass = mass_saturn_cgs
 
-mass_uranus_cgs = YTQuantity(mass_uranus_grams, "g")
+mass_uranus_cgs = unyt_quantity(mass_uranus_grams, "g")
 mass_uranus = mass_uranus_cgs
 uranus_mass = mass_uranus_cgs
 
-mass_neptune_cgs = YTQuantity(mass_neptune_grams, "g")
+mass_neptune_cgs = unyt_quantity(mass_neptune_grams, "g")
 mass_neptune = mass_neptune_cgs
 neptune_mass = mass_neptune_cgs
 
 # Planck units
-m_pl = planck_mass = YTQuantity(planck_mass_grams, "g")
-l_pl = planck_length = YTQuantity(planck_length_cm, "cm")
-t_pl = planck_time = YTQuantity(planck_time_s, "s")
-E_pl = planck_energy = YTQuantity(planck_energy_erg, "erg")
-q_pl = planck_charge = YTQuantity(planck_charge_esu, "esu")
-T_pl = planck_temperature = YTQuantity(planck_temperature_K, "K")
+m_pl = planck_mass = unyt_quantity(planck_mass_grams, "g")
+l_pl = planck_length = unyt_quantity(planck_length_cm, "cm")
+t_pl = planck_time = unyt_quantity(planck_time_s, "s")
+E_pl = planck_energy = unyt_quantity(planck_energy_erg, "erg")
+q_pl = planck_charge = unyt_quantity(planck_charge_esu, "esu")
+T_pl = planck_temperature = unyt_quantity(planck_temperature_K, "K")
 
 # MKS E&M units
-mu_0 = YTQuantity(4.0e-7 * pi, "N/A**2")
+mu_0 = unyt_quantity(4.0e-7 * pi, "N/A**2")
 eps_0 = (1.0 / (clight ** 2 * mu_0)).in_units("C**2/N/m**2")
 
 # Misc
-standard_gravity_cgs = YTQuantity(standard_gravity_cm_per_s2, "cm/s**2")
+standard_gravity_cgs = unyt_quantity(standard_gravity_cm_per_s2, "cm/s**2")
 standard_gravity = standard_gravity_cgs

--- a/yt/utilities/tests/test_cosmology.py
+++ b/yt/utilities/tests/test_cosmology.py
@@ -1,6 +1,7 @@
 import os
 
 import numpy as np
+from unyt import unyt_array, unyt_quantity
 
 from yt.testing import (
     assert_almost_equal,
@@ -9,7 +10,6 @@ from yt.testing import (
     requires_file,
     requires_module,
 )
-from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.answer_testing.framework import data_dir_load
 from yt.utilities.cosmology import Cosmology
 from yt.utilities.on_demand_imports import _yaml as yaml
@@ -24,7 +24,7 @@ def z_from_t_analytic(my_time, hubble_constant=0.7, omega_matter=0.3, omega_lamb
     units.
     """
 
-    hubble_constant = YTQuantity(hubble_constant, "100*km/s/Mpc")
+    hubble_constant = unyt_quantity(hubble_constant, "100*km/s/Mpc")
     omega_curvature = 1.0 - omega_matter - omega_lambda
 
     OMEGA_TOLERANCE = 1e-5
@@ -32,8 +32,8 @@ def z_from_t_analytic(my_time, hubble_constant=0.7, omega_matter=0.3, omega_lamb
 
     # Convert the time to Time * H0.
 
-    if not isinstance(my_time, YTArray):
-        my_time = YTArray(my_time, "s")
+    if not isinstance(my_time, unyt_array):
+        my_time = unyt_array(my_time, "s")
 
     t0 = (my_time.in_units("s") * hubble_constant.in_units("1/s")).to_ndarray()
 
@@ -94,7 +94,7 @@ def t_from_z_analytic(z, hubble_constant=0.7, omega_matter=0.3, omega_lambda=0.7
     CosmologyComputeTimeFromRedshift.C, but altered to use physical units.
     """
 
-    hubble_constant = YTQuantity(hubble_constant, "100*km/s/Mpc")
+    hubble_constant = unyt_quantity(hubble_constant, "100*km/s/Mpc")
     omega_curvature = 1.0 - omega_matter - omega_lambda
 
     # For a flat universe with omega_matter = 1, things are easy.

--- a/yt/utilities/tests/test_particle_generator.py
+++ b/yt/utilities/tests/test_particle_generator.py
@@ -1,10 +1,10 @@
 import numpy as np
+from unyt import uconcatenate
 
 import yt.utilities.flagging_methods as fm
 import yt.utilities.initial_conditions as ic
 from yt.frontends.stream.api import load_uniform_grid, refine_amr
 from yt.testing import assert_almost_equal, assert_equal
-from yt.units.yt_array import uconcatenate
 from yt.utilities.particle_generator import (
     FromListParticleGenerator,
     LatticeParticleGenerator,

--- a/yt/visualization/eps_writer.py
+++ b/yt/visualization/eps_writer.py
@@ -1,11 +1,10 @@
 import numpy as np
 import pyx
 from matplotlib import cm, pyplot as plt
+from unyt import Unit, unyt_quantity
 
 from yt.config import ytcfg
 from yt.funcs import issue_deprecation_warning
-from yt.units.unit_object import Unit
-from yt.units.yt_array import YTQuantity
 from yt.utilities.logger import ytLogger as mylog
 
 from .plot_window import PlotWindow
@@ -141,9 +140,9 @@ class DualEPS:
         >>> d.save_fig()
         """
 
-        if isinstance(xrange[0], YTQuantity):
+        if isinstance(xrange[0], unyt_quantity):
             xrange = (xrange[0].value, xrange[1].value)
-        if isinstance(yrange[0], YTQuantity):
+        if isinstance(yrange[0], unyt_quantity):
             yrange = (yrange[0].value, yrange[1].value)
         if tickcolor is None:
             c1 = pyx.graph.axis.painter.regular(tickattrs=[pyx.color.cmyk.black])
@@ -434,16 +433,16 @@ class DualEPS:
             # limits for axes
             xlimits = subplot.get_xlim()
             _xrange = (
-                YTQuantity(xlimits[0], "m"),
-                YTQuantity(xlimits[1], "m"),
+                unyt_quantity(xlimits[0], "m"),
+                unyt_quantity(xlimits[1], "m"),
             )  # unit hardcoded but afaik it is not used anywhere so it doesn't matter
             if list(plot.axes.ylim.viewvalues())[0][0] is None:
                 ylimits = subplot.get_ylim()
             else:
                 ylimits = list(plot.axes.ylim.viewvalues())[0]
             _yrange = (
-                YTQuantity(ylimits[0], "m"),
-                YTQuantity(ylimits[1], "m"),
+                unyt_quantity(ylimits[0], "m"),
+                unyt_quantity(ylimits[1], "m"),
             )  # unit hardcoded but afaik it is not used anywhere so it doesn't matter
             # axis labels
             xaxis = subplot.xaxis

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -294,7 +294,7 @@ class FixedResolutionBuffer:
                 unit, equivalency, **equivalency_kwargs
             )
             # equiv_array isn't necessarily an ImageArray. This is an issue
-            # inherent to the way the unit system handles YTArray
+            # inherent to the way the unit system handles unyt_array
             # subclasses and I don't see how to modify the unit system to
             # fix this. Instead, we paper over this issue and hard code
             # that equiv_array is an ImageArray

--- a/yt/visualization/image_writer.py
+++ b/yt/visualization/image_writer.py
@@ -1,10 +1,10 @@
 import builtins
 
 import numpy as np
+from unyt import unyt_quantity
 
 from yt.config import ytcfg
 from yt.funcs import get_brewer_cmap, get_image_suffix, mylog
-from yt.units.yt_array import YTQuantity
 from yt.utilities import png_writer as pw
 from yt.utilities.exceptions import YTNotInsideNotebook
 from yt.utilities.lib import image_utilities as au
@@ -242,7 +242,7 @@ def apply_colormap(image, color_bounds=None, cmap_name=None, func=lambda x: x):
         ma = np.nanmax(image[~np.isinf(image)]) * image.uq
         color_bounds = mi, ma
     else:
-        color_bounds = [YTQuantity(func(c), image.units) for c in color_bounds]
+        color_bounds = [unyt_quantity(func(c), image.units) for c in color_bounds]
     image = (image - color_bounds[0]) / (color_bounds[1] - color_bounds[0])
     to_plot = map_to_colors(image, cmap_name)
     to_plot = np.clip(to_plot, 0, 255)

--- a/yt/visualization/line_plot.py
+++ b/yt/visualization/line_plot.py
@@ -1,10 +1,10 @@
 from collections import defaultdict
 
 import numpy as np
+from unyt import unyt_array
+from unyt.unit_object import Unit
 
 from yt.funcs import iterable, mylog
-from yt.units.unit_object import Unit
-from yt.units.yt_array import YTArray
 from yt.visualization.base_plot_types import PlotMPL
 from yt.visualization.plot_container import (
     PlotContainer,
@@ -22,17 +22,17 @@ class LineBuffer:
     This takes a data source and implements a protocol for generating a
     'pixelized', fixed-resolution line buffer. In other words, LineBuffer
     takes a starting point, ending point, and number of sampling points and
-    can subsequently generate YTArrays of field values along the sample points.
+    can subsequently generate unyt_arrays of field values along the sample points.
 
     Parameters
     ----------
     ds : :class:`yt.data_objects.static_output.Dataset`
         This is the dataset object holding the data that can be sampled by the
         LineBuffer
-    start_point : n-element list, tuple, ndarray, or YTArray
+    start_point : n-element list, tuple, ndarray, or unyt_array
         Contains the coordinates of the first point for constructing the LineBuffer.
         Must contain n elements where n is the dimensionality of the dataset.
-    end_point : n-element list, tuple, ndarray, or YTArray
+    end_point : n-element list, tuple, ndarray, or unyt_array
         Contains the coordinates of the first point for constructing the LineBuffer.
         Must contain n elements where n is the dimensionality of the dataset.
     npoints : int
@@ -117,10 +117,10 @@ class LinePlot(PlotContainer):
         simulation output to be plotted.
     fields : string / tuple, or list of strings / tuples
         The name(s) of the field(s) to be plotted.
-    start_point : n-element list, tuple, ndarray, or YTArray
+    start_point : n-element list, tuple, ndarray, or unyt_array
         Contains the coordinates of the first point for constructing the line.
         Must contain n elements where n is the dimensionality of the dataset.
-    end_point : n-element list, tuple, ndarray, or YTArray
+    end_point : n-element list, tuple, ndarray, or unyt_array
         Contains the coordinates of the first point for constructing the line.
         Must contain n elements where n is the dimensionality of the dataset.
     npoints : int
@@ -433,7 +433,7 @@ class LinePlot(PlotContainer):
 def _validate_point(point, ds, start=False):
     if not iterable(point):
         raise RuntimeError("Input point must be array-like")
-    if not isinstance(point, YTArray):
+    if not isinstance(point, unyt_array):
         point = ds.arr(point, "code_length")
     if len(point.shape) != 1:
         raise RuntimeError("Input point must be a 1D array")

--- a/yt/visualization/particle_plots.py
+++ b/yt/visualization/particle_plots.py
@@ -1,8 +1,8 @@
 import numpy as np
+from unyt import unyt_array
 
 from yt.data_objects.profiles import create_profile
 from yt.funcs import ensure_list, fix_axis
-from yt.units.yt_array import YTArray
 from yt.visualization.fixed_resolution import ParticleImageBuffer
 from yt.visualization.profile_plotter import PhasePlot
 
@@ -38,8 +38,8 @@ class ParticleAxisAlignedDummyDataSource:
         else:
             self.field_parameters = field_parameters
 
-        LE = center - 0.5 * YTArray(width)
-        RE = center + 0.5 * YTArray(width)
+        LE = center - 0.5 * unyt_array(width)
+        RE = center + 0.5 * unyt_array(width)
         for ax in range(3):
             if not ds.periodicity[ax]:
                 LE[ax] = max(LE[ax], ds.domain_left_edge[ax])
@@ -107,7 +107,7 @@ class ParticleProjectionPlot(PWViewerMPL):
          field is supported by providing a tuple such as ("min","temperature") or
          ("max","dark_matter_density"). Units can be specified by passing in *center*
          as a tuple containing a coordinate and string unit name or by passing
-         in a YTArray. If a list or unitless array is supplied, code units are
+         in a unyt_array. If a list or unitless array is supplied, code units are
          assumed.
     width : tuple or a float.
          Width can have four different formats to support windows with variable
@@ -446,7 +446,7 @@ def ParticlePlot(ds, x_field, y_field, z_fields=None, color="b", *args, **kwargs
          field is supported by providing a tuple such as ("min","temperature") or
          ("max","dark_matter_density"). Units can be specified by passing in *center*
          as a tuple containing a coordinate and string unit name or by passing
-         in a YTArray. If a list or unitless array is supplied, code units are
+         in a unyt_array. If a list or unitless array is supplied, code units are
          assumed. This argument is only accepted by ``ParticleProjectionPlot``.
     width : tuple or a float.
          Width can have four different formats to support windows with variable

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -6,6 +6,8 @@ from functools import wraps
 
 import matplotlib
 import numpy as np
+from unyt import unyt_quantity
+from unyt.unit_object import Unit
 
 from yt.config import ytcfg
 from yt.data_objects.time_series import DatasetSeries
@@ -17,8 +19,6 @@ from yt.funcs import (
     iterable,
     mylog,
 )
-from yt.units import YTQuantity
-from yt.units.unit_object import Unit
 from yt.utilities.definitions import formatted_length_unit_names
 from yt.utilities.exceptions import YTNotInsideNotebook
 from yt.visualization.color_maps import yt_colormaps
@@ -882,10 +882,10 @@ class ImagePlotContainer(PlotContainer):
         field : string
             the field to set a colormap scale
             if field == 'all', applies to all plots.
-        zmin : float, tuple, YTQuantity or str
+        zmin : float, tuple, unyt_quantity or str
             the new minimum of the colormap scale. If 'min', will
             set to the minimum value in the current view.
-        zmax : float, tuple, YTQuantity or str
+        zmax : float, tuple, unyt_quantity or str
             the new maximum of the colormap scale. If 'max', will
             set to the maximum value in the current view.
 
@@ -904,14 +904,14 @@ class ImagePlotContainer(PlotContainer):
             # convert dimensionful inputs to float
             if isinstance(z, tuple):
                 z = self.ds.quan(*z)
-            if isinstance(z, YTQuantity):
+            if isinstance(z, unyt_quantity):
                 try:
                     plot_units = self.frb[_field].units
                     z = z.to(plot_units).value
                 except AttributeError:
                     # only certain subclasses have a frb attribute they can rely on for inspecting units
                     mylog.warning(
-                        "%s class doesn't support zmin/zmax set as tuples or YTQuantity"
+                        "%s class doesn't support zmin/zmax set as tuples or unyt_quantity"
                         % self.__class__.__name__
                     )
                     z = z.value

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -5,6 +5,9 @@ from numbers import Number
 
 import matplotlib
 import numpy as np
+from unyt import dimensions, unyt_array, unyt_quantity
+from unyt.array import uhstack
+from unyt.unit_object import Unit
 
 from yt.data_objects.data_containers import YTDataContainer
 from yt.data_objects.level_sets.clump_handling import Clump
@@ -14,9 +17,6 @@ from yt.frontends.ytdata.data_structures import YTClumpContainer
 from yt.funcs import iterable, mylog, validate_width_tuple
 from yt.geometry.geometry_handler import is_curvilinear
 from yt.geometry.unstructured_mesh_handler import UnstructuredIndex
-from yt.units import dimensions
-from yt.units.unit_object import Unit
-from yt.units.yt_array import YTArray, YTQuantity, uhstack
 from yt.utilities.exceptions import YTDataTypeUnsupported
 from yt.utilities.lib.geometry_utils import triangle_plane_intersect
 from yt.utilities.lib.line_integral_convolution import line_integral_convolution_2d
@@ -74,12 +74,12 @@ class PlotCallback(metaclass=RegisteredCallback):
         """
         Convert coordinates from simulation data coordinates to projected
         data coordinates.  Simulation data coordinates are three dimensional,
-        and can either be specified as a YTArray or as a list or array in
+        and can either be specified as a unyt_array or as a list or array in
         code_length units.  Projected data units are 2D versions of the
         simulation data units relative to the axes of the final plot.
         """
         if len(coord) == 3:
-            if not isinstance(coord, YTArray):
+            if not isinstance(coord, unyt_array):
                 coord = plot.data.ds.arr(coord, "code_length")
             coord.convert_to_units("code_length")
             ax = plot.data.axis
@@ -200,7 +200,7 @@ class PlotCallback(metaclass=RegisteredCallback):
                 2D coordinates within figure object from (0,0) in lower left
                 to (1,1) in upper right.  Same as matplotlib figure coords.
         """
-        # Assure coords are either a YTArray or numpy array
+        # Assure coords are either a unyt_array or numpy array
         coord = np.asanyarray(coord, dtype="float64")
         # if in data coords, project them to plot coords
         if coord_system == "data":
@@ -1519,7 +1519,7 @@ class SphereCallback(PlotCallback):
     center : 2- or 3-element tuple, list, or array
         These are the coordinates where the circle will be overplotted
 
-    radius : YTArray, float, or (1, ('kpc')) style tuple
+    radius : unyt_array, float, or (1, ('kpc')) style tuple
         The radius of the circle in code coordinates
 
     circle_args : dict, optional
@@ -1593,8 +1593,8 @@ class SphereCallback(PlotCallback):
         if iterable(self.radius):
             self.radius = plot.data.ds.quan(self.radius[0], self.radius[1])
             self.radius = np.float64(self.radius.in_units(plot.xlim[0].units))
-        if isinstance(self.radius, YTQuantity):
-            if isinstance(self.center, YTArray):
+        if isinstance(self.radius, unyt_quantity):
+            if isinstance(self.center, unyt_array):
                 units = self.center.units
             else:
                 units = "code_length"
@@ -2046,7 +2046,7 @@ class ParticleCallback(PlotCallback):
         if iterable(self.width):
             validate_width_tuple(self.width)
             self.width = plot.data.ds.quan(self.width[0], self.width[1])
-        elif isinstance(self.width, YTQuantity):
+        elif isinstance(self.width, unyt_quantity):
             self.width = plot.data.ds.quan(self.width.value, self.width.units)
         else:
             self.width = plot.data.ds.quan(self.width, "code_length")
@@ -2359,7 +2359,7 @@ class TimestampCallback(PlotCallback):
 
             "figure" -- the MPL figure coordinates: (0,0) is lower left, (1,1) is upper right
 
-    time_offset : float, (value, unit) tuple, or YTQuantity, optional
+    time_offset : float, (value, unit) tuple, or unyt_quantity, optional
         Apply an offset to the time shown in the annotation from the
         value of the current time. If a scalar value with no units is
         passed in, the value of the *time_unit* kwarg is used for the
@@ -2491,9 +2491,9 @@ class TimestampCallback(PlotCallback):
                     toffset = plot.ds.quan(self.time_offset[0], self.time_offset[1])
                 elif isinstance(self.time_offset, Number):
                     toffset = plot.ds.quan(self.time_offset, self.time_unit)
-                elif not isinstance(self.time_offset, YTQuantity):
+                elif not isinstance(self.time_offset, unyt_quantity):
                     raise RuntimeError(
-                        "'time_offset' must be a float, tuple, or" "YTQuantity!"
+                        "'time_offset' must be a float, tuple, or" "unyt_quantity!"
                     )
                 t -= toffset.in_units(self.time_unit)
             if isinstance(self.time_unit, Unit):

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -6,7 +6,9 @@ from numbers import Number
 
 import matplotlib
 import numpy as np
-from unyt.exceptions import UnitConversionError
+from unyt import unyt_array, unyt_quantity
+from unyt.exceptions import UnitConversionError, UnitParseError
+from unyt.unit_object import Unit
 
 from yt.data_objects.image_array import ImageArray
 from yt.frontends.ytdata.data_structures import YTSpatialPlotDataset
@@ -19,9 +21,6 @@ from yt.funcs import (
     mylog,
     obj_length,
 )
-from yt.units.unit_object import Unit
-from yt.units.unit_registry import UnitParseError
-from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.exceptions import (
     YTCannotParseUnitDisplayName,
     YTDataTypeUnsupported,
@@ -104,12 +103,12 @@ def get_axes_unit(width, ds):
             axes_unit = (width[1], width[1])
         elif iterable(width[1]):
             axes_unit = (width[0][1], width[1][1])
-        elif isinstance(width[0], YTArray):
+        elif isinstance(width[0], unyt_array):
             axes_unit = (str(width[0].units), str(width[1].units))
         else:
             axes_unit = None
     else:
-        if isinstance(width, YTArray):
+        if isinstance(width, unyt_array):
             axes_unit = (str(width.units), str(width.units))
         else:
             axes_unit = None
@@ -370,7 +369,9 @@ class PlotWindow(ImagePlotContainer):
                 self.ds.quan(deltas[0][0], deltas[0][1]),
                 self.ds.quan(deltas[1][0], deltas[1][1]),
             )
-        elif isinstance(deltas[0], YTQuantity) and isinstance(deltas[1], YTQuantity):
+        elif isinstance(deltas[0], unyt_quantity) and isinstance(
+            deltas[1], unyt_quantity
+        ):
             pass
         else:
             raise RuntimeError(
@@ -670,7 +671,7 @@ class PlotWindow(ImagePlotContainer):
 
         unit : string
             The name of the unit new_center is given in.  If new_center is a
-            YTArray or tuple of YTQuantities, this keyword is ignored.
+            unyt_array or tuple of YTQuantities, this keyword is ignored.
 
         """
         error = RuntimeError(
@@ -685,7 +686,7 @@ class PlotWindow(ImagePlotContainer):
             if len(new_center) != 2:
                 raise error
             for el in new_center:
-                if not isinstance(el, Number) and not isinstance(el, YTQuantity):
+                if not isinstance(el, Number) and not isinstance(el, unyt_quantity):
                     raise error
             if isinstance(new_center[0], Number):
                 new_center = [self.ds.quan(c, unit) for c in new_center]
@@ -1308,7 +1309,7 @@ class AxisAlignedSlicePlot(PWViewerMPL):
          field is supported by providing a tuple such as ("min","temperature") or
          ("max","dark_matter_density"). Units can be specified by passing in *center*
          as a tuple containing a coordinate and string unit name or by passing
-         in a YTArray. If a list or unitless array is supplied, code units are
+         in a unyt_array. If a list or unitless array is supplied, code units are
          assumed.
     width : tuple or a float.
          Width can have four different formats to support windows with variable
@@ -1493,7 +1494,7 @@ class ProjectionPlot(PWViewerMPL):
          field is supported by providing a tuple such as ("min","temperature") or
          ("max","dark_matter_density"). Units can be specified by passing in *center*
          as a tuple containing a coordinate and string unit name or by passing
-         in a YTArray. If a list or unitless array is supplied, code units are
+         in a unyt_array. If a list or unitless array is supplied, code units are
          assumed.
     width : tuple or a float.
          Width can have four different formats to support windows with variable
@@ -1730,7 +1731,7 @@ class OffAxisSlicePlot(PWViewerMPL):
          field is supported by providing a tuple such as ("min","temperature") or
          ("max","dark_matter_density"). Units can be specified by passing in *center*
          as a tuple containing a coordinate and string unit name or by passing
-         in a YTArray. If a list or unitless array is supplied, code units are
+         in a unyt_array. If a list or unitless array is supplied, code units are
          assumed.
     width : tuple or a float.
          Width can have four different formats to support windows with variable
@@ -1909,7 +1910,7 @@ class OffAxisProjectionPlot(PWViewerMPL):
          field is supported by providing a tuple such as ("min","temperature") or
          ("max","dark_matter_density"). Units can be specified by passing in *center*
          as a tuple containing a coordinate and string unit name or by passing
-         in a YTArray. If a list or unitless array is supplied, code units are
+         in a unyt_array. If a list or unitless array is supplied, code units are
          assumed.
     width : tuple or a float.
          Width can have four different formats to support windows with variable
@@ -2175,7 +2176,7 @@ def SlicePlot(ds, normal=None, fields=None, axis=None, *args, **kwargs):
          field is supported by providing a tuple such as ("min","temperature") or
          ("max","dark_matter_density"). Units can be specified by passing in *center*
          as a tuple containing a coordinate and string unit name or by passing
-         in a YTArray. If a list or unitless array is supplied, code units are
+         in a unyt_array. If a list or unitless array is supplied, code units are
          assumed.
     width : tuple or a float.
          Width can have four different formats to support windows with variable
@@ -2350,7 +2351,7 @@ def plot_2d(
          field is supported by providing a tuple such as ("min","temperature") or
          ("max","dark_matter_density"). Units can be specified by passing in *center*
          as a tuple containing a coordinate and string unit name or by passing
-         in a YTArray. If a list or unitless array is supplied, code units are
+         in a unyt_array. If a list or unitless array is supplied, code units are
          assumed. For plot_2d, this keyword accepts a coordinate in two dimensions.
     width : tuple or a float.
          Width can have four different formats to support windows with variable
@@ -2441,7 +2442,7 @@ def plot_2d(
         if not c0_string and not c1_string:
             if obj_length(center[0]) == 2 and c1_string:
                 center = ds.arr(center[0], center[1])
-            elif not isinstance(center, YTArray):
+            elif not isinstance(center, unyt_array):
                 center = ds.arr(center, "code_length")
             center.convert_to_units("code_length")
         center = ds.arr([center[0], center[1], ds.domain_center[2]])

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -814,7 +814,7 @@ class ProfilePlot:
           Dictionary of text keyword arguments to be passed to matplotlib
 
         >>>  import yt
-        >>>  from yt.units import kpc
+        >>>  from unyt import kpc
         >>>  ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
         >>>  my_galaxy = ds.disk(ds.domain_center, [0.0, 0.0, 1.0], 10*kpc, 3*kpc)
         >>>  plot = yt.ProfilePlot(my_galaxy, "density", ["temperature"])

--- a/yt/visualization/streamlines.py
+++ b/yt/visualization/streamlines.py
@@ -1,8 +1,8 @@
 import numpy as np
+from unyt import unyt_array
 
 from yt.data_objects.construction_data_containers import YTStreamline
 from yt.funcs import get_pbar
-from yt.units.yt_array import YTArray
 from yt.utilities.amr_kdtree.api import AMRKDTree
 from yt.utilities.parallel_tools.parallel_analysis_interface import (
     ParallelAnalysisInterface,
@@ -13,7 +13,7 @@ from yt.utilities.parallel_tools.parallel_analysis_interface import (
 def sanitize_length(length, ds):
     # Ensure that lengths passed in with units are returned as code_length
     # magnitudes without units
-    if isinstance(length, YTArray):
+    if isinstance(length, unyt_array):
         return ds.arr(length).in_units("code_length").d
     else:
         return length

--- a/yt/visualization/tests/test_particle_plot.py
+++ b/yt/visualization/tests/test_particle_plot.py
@@ -5,6 +5,7 @@ import unittest
 
 import mock
 import numpy as np
+from unyt import unyt_array
 
 from yt.convenience import load
 from yt.data_objects.particle_filters import add_particle_filter
@@ -15,7 +16,6 @@ from yt.testing import (
     fake_particle_ds,
     requires_file,
 )
-from yt.units.yt_array import YTArray
 from yt.utilities.answer_testing.framework import (
     PhasePlotAttributeTest,
     PlotWindowAttributeTest,
@@ -66,7 +66,7 @@ CENTER_SPECS = (
     "Center",
     [0.5, 0.5, 0.5],
     [[0.2, 0.3, 0.4], "cm"],
-    YTArray([0.3, 0.4, 0.7], "cm"),
+    unyt_array([0.3, 0.4, 0.7], "cm"),
 )
 
 WEIGHT_FIELDS = (None, "particle_ones", ("all", "particle_mass"))

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -10,6 +10,7 @@ from distutils.version import LooseVersion
 import matplotlib
 import numpy as np
 from nose.tools import assert_true
+from unyt import kboltz, unyt_array, unyt_quantity
 
 from yt.frontends.stream.api import load_uniform_grid
 from yt.testing import (
@@ -22,8 +23,6 @@ from yt.testing import (
     fake_random_ds,
     requires_file,
 )
-from yt.units import kboltz
-from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.answer_testing.framework import (
     PlotWindowAttributeTest,
     data_dir_load,
@@ -87,7 +86,7 @@ CENTER_SPECS = (
     "Center",
     [0.5, 0.5, 0.5],
     [[0.2, 0.3, 0.4], "cm"],
-    YTArray([0.3, 0.4, 0.7], "cm"),
+    unyt_array([0.3, 0.4, 0.7], "cm"),
 )
 
 WIDTH_SPECS = {
@@ -270,9 +269,9 @@ class TestSetWidth(unittest.TestCase):
         assert_array_equal(
             [self.slc.xlim, self.slc.ylim, self.slc.width],
             [
-                (YTQuantity(0.25, "cm"), YTQuantity(0.75, "cm")),
-                (YTQuantity(0.25, "cm"), YTQuantity(0.75, "cm")),
-                (YTQuantity(0.5, "cm"), YTQuantity(0.5, "cm")),
+                (unyt_quantity(0.25, "cm"), unyt_quantity(0.75, "cm")),
+                (unyt_quantity(0.25, "cm"), unyt_quantity(0.75, "cm")),
+                (unyt_quantity(0.5, "cm"), unyt_quantity(0.5, "cm")),
             ],
         )
 
@@ -280,9 +279,9 @@ class TestSetWidth(unittest.TestCase):
         assert_array_equal(
             [self.slc.xlim, self.slc.ylim, self.slc.width],
             [
-                (YTQuantity(0.25, "cm"), YTQuantity(0.75, "cm")),
-                (YTQuantity(0.125, "cm"), YTQuantity(0.875, "cm")),
-                (YTQuantity(0.5, "cm"), YTQuantity(0.75, "cm")),
+                (unyt_quantity(0.25, "cm"), unyt_quantity(0.75, "cm")),
+                (unyt_quantity(0.125, "cm"), unyt_quantity(0.875, "cm")),
+                (unyt_quantity(0.5, "cm"), unyt_quantity(0.75, "cm")),
             ],
         )
 

--- a/yt/visualization/volume_rendering/camera.py
+++ b/yt/visualization/volume_rendering/camera.py
@@ -2,9 +2,9 @@ import weakref
 from numbers import Number as numeric_type
 
 import numpy as np
+from unyt import unyt_array, unyt_quantity
 
 from yt.funcs import ensure_numpy_array, iterable
-from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.math_utils import get_rotation_matrix
 from yt.utilities.orientation import Orientation
 
@@ -16,7 +16,7 @@ def _sanitize_camera_property_units(value, scene):
     if iterable(value):
         if len(value) == 1:
             return _sanitize_camera_property_units(value[0], scene)
-        elif isinstance(value, YTArray) and len(value) == 3:
+        elif isinstance(value, unyt_array) and len(value) == 3:
             return scene.arr(value).in_units("unitary")
         elif (
             len(value) == 2
@@ -39,7 +39,7 @@ def _sanitize_camera_property_units(value, scene):
                     )
             return scene.arr(value, "unitary")
     else:
-        if isinstance(value, (YTQuantity, YTArray)):
+        if isinstance(value, (unyt_quantity, unyt_array)):
             return scene.arr([value.d] * 3, value.units).in_units("unitary")
         elif isinstance(value, numeric_type):
             return scene.arr([value] * 3, "unitary")
@@ -158,7 +158,7 @@ class Camera(Orientation):
         Parameters
         ----------
 
-        position : number, YTQuantity, :obj:`!iterable`, or 3 element YTArray
+        position : number, unyt_quantity, :obj:`!iterable`, or 3 element unyt_array
             If a scalar, assumes that the position is the same in all three
             coordinates. If an iterable, must contain only scalars or
             (length, unit) tuples.
@@ -192,7 +192,7 @@ class Camera(Orientation):
         Parameters
         ----------
 
-        width : number, YTQuantity, :obj:`!iterable`, or 3 element YTArray
+        width : number, unyt_quantity, :obj:`!iterable`, or 3 element unyt_array
             The width of the volume rendering in the horizontal, vertical, and
             depth directions. If a scalar, assumes that the width is the same in
             all three directions. If an iterable, must contain only scalars or
@@ -222,7 +222,7 @@ class Camera(Orientation):
         Parameters
         ----------
 
-        focus : number, YTQuantity, :obj:`!iterable`, or 3 element YTArray
+        focus : number, unyt_quantity, :obj:`!iterable`, or 3 element unyt_array
             The width of the volume rendering in the horizontal, vertical, and
             depth directions. If a scalar, assumes that the width is the same in
             all three directions. If an iterable, must contain only scalars or
@@ -340,9 +340,9 @@ class Camera(Orientation):
         if not iterable(width):
             width = data_source.ds.arr([width, width, width], units="code_length")
             # left/right, top/bottom, front/back
-        if not isinstance(width, YTArray):
+        if not isinstance(width, unyt_array):
             width = data_source.ds.arr(width, units="code_length")
-        if not isinstance(focus, YTArray):
+        if not isinstance(focus, unyt_array):
             focus = data_source.ds.arr(focus, units="code_length")
 
         # We can't use the property setters yet, since they rely on attributes
@@ -365,7 +365,7 @@ class Camera(Orientation):
         Parameters
         ----------
 
-        width : number, YTQuantity, :obj:`!iterable`, or 3 element YTArray
+        width : number, unyt_quantity, :obj:`!iterable`, or 3 element unyt_array
             The width of the volume rendering in the horizontal, vertical, and
             depth directions. If a scalar, assumes that the width is the same in
             all three directions. If an iterable, must contain only scalars or
@@ -384,7 +384,7 @@ class Camera(Orientation):
         Parameters
         ----------
 
-        width : number, YTQuantity, :obj:`!iterable`, or 3 element YTArray
+        width : number, unyt_quantity, :obj:`!iterable`, or 3 element unyt_array
             If a scalar, assumes that the position is the same in all three
             coordinates. If an iterable, must contain only scalars or
             (length, unit) tuples.
@@ -408,7 +408,7 @@ class Camera(Orientation):
         Parameters
         ----------
 
-        focus : number, YTQuantity, :obj:`!iterable`, or 3 element YTArray
+        focus : number, unyt_quantity, :obj:`!iterable`, or 3 element unyt_array
             If a scalar, assumes that the focus is the same is all three
             coordinates. If an iterable, must contain only scalars or
             (length, unit) tuples.
@@ -658,7 +658,7 @@ class Camera(Orientation):
 
         Parameters
         ----------
-        final : YTArray
+        final : unyt_array
             The final center to move to after `n_steps`
         n_steps : int
             The number of snapshots to make.
@@ -681,7 +681,7 @@ class Camera(Orientation):
         ...     sc.save("move_%04i.png" % i)
 
         """
-        assert isinstance(final, YTArray)
+        assert isinstance(final, unyt_array)
         if exponential:
             position_diff = (final / self.position) * 1.0
             dx = position_diff ** (1.0 / n_steps)

--- a/yt/visualization/volume_rendering/interactive_vr_helpers.py
+++ b/yt/visualization/volume_rendering/interactive_vr_helpers.py
@@ -25,10 +25,10 @@ def _render_opengl(
         The width and the height of the Interactive Data Visualization window.
         For performance reasons it is recommended to use values that are natural
         powers of 2.
-    cam_position : 3 element YTArray, optional
+    cam_position : 3 element unyt_array, optional
         The camera position in physical coordinates. If unspecified,
         data_source's domain right edge will be used.
-    cam_focus: 3 element YTArray, optional
+    cam_focus: 3 element unyt_array, optional
         The focus defines the point the camera is pointed at. If unspecified,
         data_source's domain center will be used.
 

--- a/yt/visualization/volume_rendering/lens.py
+++ b/yt/visualization/volume_rendering/lens.py
@@ -1,8 +1,8 @@
 import numpy as np
+from unyt.array import uhstack, unorm, uvstack
 
 from yt.data_objects.image_array import ImageArray
 from yt.funcs import mylog
-from yt.units.yt_array import uhstack, unorm, uvstack
 from yt.utilities.lib.grid_traversal import arr_fisheye_vectors
 from yt.utilities.math_utils import get_rotation_matrix
 from yt.utilities.parallel_tools.parallel_analysis_interface import (

--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -1,8 +1,8 @@
 import numpy as np
+from unyt.unit_object import Unit
 
 from yt.data_objects.api import ImageArray
 from yt.funcs import iterable, mylog
-from yt.units.unit_object import Unit
 from yt.utilities.lib.partitioned_grid import PartitionedGrid
 from yt.utilities.lib.pixelization_routines import (
     normalization_2d_utility,

--- a/yt/visualization/volume_rendering/old_camera.py
+++ b/yt/visualization/volume_rendering/old_camera.py
@@ -2,12 +2,12 @@ import builtins
 from copy import deepcopy
 
 import numpy as np
+from unyt import unyt_array
 
 from yt.config import ytcfg
 from yt.data_objects.api import ImageArray
 from yt.data_objects.data_containers import data_object_registry
 from yt.funcs import ensure_numpy_array, get_num_threads, get_pbar, iterable, mylog
-from yt.units.yt_array import YTArray
 from yt.utilities.amr_kdtree.api import AMRKDTree
 from yt.utilities.exceptions import YTNotInsideNotebook
 from yt.utilities.lib.grid_traversal import (
@@ -183,9 +183,9 @@ class Camera(ParallelAnalysisInterface):
             width = width.in_units("code_length").value
         if not iterable(width):
             width = (width, width, width)  # left/right, top/bottom, front/back
-        if not isinstance(width, YTArray):
+        if not isinstance(width, unyt_array):
             width = self.ds.arr(width, units="code_length")
-        if not isinstance(center, YTArray):
+        if not isinstance(center, unyt_array):
             center = self.ds.arr(center, units="code_length")
         # Ensure that width and center are in the same units
         # Cf. https://bitbucket.org/yt_analysis/yt/issue/1080
@@ -234,14 +234,14 @@ class Camera(ParallelAnalysisInterface):
     def _setup_box_properties(self, width, center, unit_vectors):
         self.width = width
         self.center = center
-        self.box_vectors = YTArray(
+        self.box_vectors = unyt_array(
             [
                 unit_vectors[0] * width[0],
                 unit_vectors[1] * width[1],
                 unit_vectors[2] * width[2],
             ]
         )
-        self.origin = center - 0.5 * width.dot(YTArray(unit_vectors, ""))
+        self.origin = center - 0.5 * width.dot(unyt_array(unit_vectors, ""))
         self.back_center = center - 0.5 * width[2] * unit_vectors[2]
         self.front_center = center + 0.5 * width[2] * unit_vectors[2]
 
@@ -431,10 +431,10 @@ class Camera(ParallelAnalysisInterface):
         im : ImageArray or 2D ndarray
             Existing image that has the same resolution as the Camera,
             which will be painted by grid lines.
-        x0 : YTArray or ndarray
+        x0 : unyt_array or ndarray
             Starting coordinate.  If passed in as an ndarray,
             assumed to be in code units.
-        x1 : YTArray or ndarray
+        x1 : unyt_array or ndarray
             Ending coordinate, in simulation coordinates.  If passed in as
             an ndarray, assumed to be in code units.
         color : array like, optional
@@ -1007,13 +1007,13 @@ class Camera(ParallelAnalysisInterface):
         ...     iw.write_bitmap(snapshot, "move_%04i.png" % i)
         """
         dW = None
-        if not isinstance(final, YTArray):
+        if not isinstance(final, unyt_array):
             final = self.ds.arr(final, units="code_length")
         if exponential:
             if final_width is not None:
                 if not iterable(final_width):
                     final_width = [final_width, final_width, final_width]
-                if not isinstance(final_width, YTArray):
+                if not isinstance(final_width, unyt_array):
                     final_width = self.ds.arr(final_width, units="code_length")
                     # left/right, top/bottom, front/back
                 if (self.center == 0.0).all():
@@ -1028,7 +1028,7 @@ class Camera(ParallelAnalysisInterface):
             if final_width is not None:
                 if not iterable(final_width):
                     final_width = [final_width, final_width, final_width]
-                if not isinstance(final_width, YTArray):
+                if not isinstance(final_width, unyt_array):
                     final_width = self.ds.arr(final_width, units="code_length")
                     # left/right, top/bottom, front/back
                 dW = (1.0 * final_width - self.width) / n_steps

--- a/yt/visualization/volume_rendering/render_source.py
+++ b/yt/visualization/volume_rendering/render_source.py
@@ -831,7 +831,7 @@ class PointSource(OpaqueSource):
     >>> import yt
     >>> import numpy as np
     >>> from yt.visualization.volume_rendering.api import PointSource
-    >>> from yt.units import kpc
+    >>> from unyt import kpc
     >>> ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
 
     >>> im, sc = yt.volume_render(ds)
@@ -954,7 +954,7 @@ class LineSource(OpaqueSource):
     >>> import yt
     >>> import numpy as np
     >>> from yt.visualization.volume_rendering.api import LineSource
-    >>> from yt.units import kpc
+    >>> from unyt import kpc
     >>> ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
 
     >>> im, sc = yt.volume_render(ds)

--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -3,12 +3,11 @@ import functools
 from collections import OrderedDict
 
 import numpy as np
+from unyt import UnitRegistry, unyt_array, unyt_quantity
+from unyt.dimensions import length
 
 from yt.config import ytcfg
 from yt.funcs import get_image_suffix, mylog
-from yt.units.dimensions import length
-from yt.units.unit_registry import UnitRegistry
-from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.exceptions import YTNotInsideNotebook
 
 from .camera import Camera
@@ -147,7 +146,7 @@ class Scene:
                 )
 
         if isinstance(render_source, (LineSource, PointSource)):
-            if isinstance(render_source.positions, YTArray):
+            if isinstance(render_source.positions, unyt_array):
                 render_source.positions = (
                     self.arr(render_source.positions).in_units("code_length").d
                 )
@@ -688,13 +687,13 @@ class Scene:
         def fset(self, value):
             self._unit_registry = value
             if self.camera is not None:
-                self.camera.width = YTArray(
+                self.camera.width = unyt_array(
                     self.camera.width.in_units("unitary"), registry=value
                 )
-                self.camera.focus = YTArray(
+                self.camera.focus = unyt_array(
                     self.camera.focus.in_units("unitary"), registry=value
                 )
-                self.camera.position = YTArray(
+                self.camera.position = unyt_array(
                     self.camera.position.in_units("unitary"), registry=value
                 )
 
@@ -888,9 +887,9 @@ class Scene:
 
     @property
     def arr(self):
-        """Converts an array into a :class:`yt.units.yt_array.YTArray`
+        """Converts an array into a :class:`yt.units.yt_array.unyt_array`
 
-        The returned YTArray will be dimensionless by default, but can be
+        The returned unyt_array will be dimensionless by default, but can be
         cast to arbitrary units using the ``units`` keyword argument.
 
         Parameters
@@ -912,30 +911,30 @@ class Scene:
         >>> a = sc.arr([1, 2, 3], 'cm')
         >>> b = sc.arr([4, 5, 6], 'm')
         >>> a + b
-        YTArray([ 401.,  502.,  603.]) cm
+        unyt_array([ 401.,  502.,  603.]) cm
         >>> b + a
-        YTArray([ 4.01,  5.02,  6.03]) m
+        unyt_array([ 4.01,  5.02,  6.03]) m
 
         Arrays returned by this function know about the scene's unit system
 
         >>> a = sc.arr(np.ones(5), 'unitary')
         >>> a.in_units('Mpc')
-        YTArray([ 1.00010449,  1.00010449,  1.00010449,  1.00010449,
+        unyt_array([ 1.00010449,  1.00010449,  1.00010449,  1.00010449,
                  1.00010449]) Mpc
 
         """
         if self._arr is not None:
             return self._arr
-        self._arr = functools.partial(YTArray, registry=self.unit_registry)
+        self._arr = functools.partial(unyt_array, registry=self.unit_registry)
         return self._arr
 
     _quan = None
 
     @property
     def quan(self):
-        """Converts an scalar into a :class:`yt.units.yt_array.YTQuantity`
+        """Converts an scalar into a :class:`yt.units.yt_array.unyt_quantity`
 
-        The returned YTQuantity will be dimensionless by default, but can be
+        The returned unyt_quantity will be dimensionless by default, but can be
         cast to arbitrary units using the ``units`` keyword argument.
 
         Parameters
@@ -971,7 +970,7 @@ class Scene:
         """
         if self._quan is not None:
             return self._quan
-        self._quan = functools.partial(YTQuantity, registry=self.unit_registry)
+        self._quan = functools.partial(unyt_quantity, registry=self.unit_registry)
         return self._quan
 
     def _repr_png_(self):

--- a/yt/visualization/volume_rendering/shader_objects.py
+++ b/yt/visualization/volume_rendering/shader_objects.py
@@ -4,8 +4,8 @@ import os
 from collections import OrderedDict
 
 from OpenGL import GL as GL
+from unyt import unyt_quantity
 
-from yt.units.yt_array import YTQuantity
 from yt.utilities.exceptions import (
     YTInvalidShaderType,
     YTUnknownUniformKind,
@@ -74,7 +74,7 @@ class ShaderProgram:
         # but we will not be using that here.
         if isinstance(value, int):
             return GL.glUniform1i
-        elif isinstance(value, (YTQuantity, float)):
+        elif isinstance(value, (unyt_quantity, float)):
             return GL.glUniform1f
         else:
             kind = value.dtype.kind


### PR DESCRIPTION
## PR Summary

Quoting `CONTRIBUTING.rst`
> * Internally, only import from source files directly -- instead of:
     ``from yt.visualization.api import ProjectionPlot``
   do:
     ``from yt.visualization.plot_window import ProjectionPlot``

I think this principle could and should be applied to `unyt`, which we currently wrap under `yt.units`.
Directly importing from `unyt` instead of the wrapper would reduce the overhead of this wrapper: it's easier to learn the origin of a function/class if we avoid layered import. This should reduce the maintenance burden of the wrapper as well, though the primary goal is to make definitions easier to discover from everywhere else in `yt/`

**highlight points**
- This should not remove anything from namespaces `yt.units` (and its children) in any way, so as not to break any downstream code.
- Documentation (website + docstrings) remains unchanged, this is not about telling users not to use the wrapper, but only a matter of clarifying the code base.