### PR TITLE
Add pyproject.toml (YTEP0037 3/6)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+# See https://github.com/scipy/scipy/pull/10431 for the AIX issue.
+requires = [
+  "setuptools>=19.6",
+  "wheel",
+
+  # keep in sync with travis.yml "minimal" specs (Cython and numpy for py36)
+  "Cython>=0.26.1",
+  "numpy==1.13.3; python_version=='3.6' and platform_system!='AIX'",
+  "numpy==1.18.1; python_version=='3.7' and platform_system!='AIX'",
+  "numpy==1.18.4; python_version=='3.8' and platform_system!='AIX'",
+]


### PR DESCRIPTION
## PR Summary

In my work on #2596, I had to tweak the newly added `pyproject.toml` file (required by black for configuration) to make installation of yt with `pip install -e` work properly across python versions (>=3.6).

In order to validate it, I'm opening this separate PR to introduce the file to the repo without all black-related changes.

This file may introduce redundancy with `.travis.yml`, `setup.py`. Sadly, it won't be mergeable with `setup.cfg`, which we use to configure flake8 (currently not supporting pyproject.toml).
