### PR TITLE
Add precommit hooks for flake8, isort and black (YTEP0037 5/6)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: ''
+    hooks:
+    -   id: flake8
+-   repo: https://github.com/timothycrosley/isort
+    rev: ''
+    hooks:
+    -   id: isort
+-   repo: https://github.com/ambv/black
+    rev: 19.10b0
+    hooks:
+    - id: black
+      language_version: python3.7


### PR DESCRIPTION
## PR Summary

As support to #2592 and #2596, add a precommit hook configuration file to allow devs to install  isort, black and flake8 as hooks locally.