### PR TITLE
added H2 density in artio frontend

### DIFF
--- a/yt/frontends/artio/fields.py
+++ b/yt/frontends/artio/fields.py
@@ -51,6 +51,7 @@ class ARTIOFieldInfo(FieldInfoContainer):
         ("RT_HVAR_HeI", (rho_units, ["HeI density"], None)),
         ("RT_HVAR_HeII", (rho_units, ["HeII density"], None)),
         ("RT_HVAR_HeIII", (rho_units, ["HeIII density"], None)),
+        ("RT_HVAR_H2", (rho_units, ["H2 density"], None)),
     )
 
     known_particle_fields = (


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

General Summary: Adds one line in yt/frontends/artio/fields.py to include H2 Density for analysis on ARTIO data. 

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->
H2 was a missing field that previously had no assigned units. 

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
