### PR TITLE
add progress bar display for yt.load_sample() (requires tqdm)

### DIFF
--- a/yt/utilities/load_sample.py
+++ b/yt/utilities/load_sample.py
@@ -48,11 +48,14 @@ def load_sample(name=None, specific_file=None, pbar=True):
     base_path = fido.fido.path
     fileext, name, extension = _validate_sampledata_name(name)
 
+    downloader = None
     if pbar:
-        from pooch import HTTPDownloader
-        downloader = HTTPDownloader(progressbar=True)
-    else:
-        downloader = None
+        try:
+            import tqdm
+            from pooch import HTTPDownloader
+            downloader = HTTPDownloader(progressbar=True)
+        except ImportError:
+            mylog.warning("tqdm is not installed, progress bar can not be displayed.")
 
     if extension == "h5":
         fname = fetch_noncompressed_file(fileext, fido, downloader=downloader)

--- a/yt/utilities/load_sample.py
+++ b/yt/utilities/load_sample.py
@@ -52,8 +52,7 @@ def load_sample(name=None, specific_file=None, pbar=True):
     if pbar:
         try:
             import tqdm  # noqa: F401
-            from pch import HTTPDownloader
-            downloader = HTTPDownloader(progressbar=True)
+            downloader = pch.pooch.HTTPDownloader(progressbar=True)
         except ImportError:
             mylog.warning("tqdm is not installed, progress bar can not be displayed.")
 
@@ -152,4 +151,3 @@ def fetch_noncompressed_file(name, fido, downloader=None):
     """
     fname = fido.fido.fetch(name, downloader=downloader)
     return fname
-

--- a/yt/utilities/load_sample.py
+++ b/yt/utilities/load_sample.py
@@ -52,7 +52,7 @@ def load_sample(name=None, specific_file=None, pbar=True):
     if pbar:
         try:
             import tqdm  # noqa: F401
-            from pooch import HTTPDownloader
+            from pch import HTTPDownloader
             downloader = HTTPDownloader(progressbar=True)
         except ImportError:
             mylog.warning("tqdm is not installed, progress bar can not be displayed.")

--- a/yt/utilities/load_sample.py
+++ b/yt/utilities/load_sample.py
@@ -150,6 +150,6 @@ def fetch_noncompressed_file(name, fido, downloader=None):
     """
     Load an uncompressed file from the data registry
     """
-    fname = fido.fido.fetch(name, downloader)
+    fname = fido.fido.fetch(name, downloader=downloader)
     return fname
 

--- a/yt/utilities/load_sample.py
+++ b/yt/utilities/load_sample.py
@@ -51,7 +51,7 @@ def load_sample(name=None, specific_file=None, pbar=True):
     downloader = None
     if pbar:
         try:
-            import tqdm
+            import tqdm  # noqa: F401
             from pooch import HTTPDownloader
             downloader = HTTPDownloader(progressbar=True)
         except ImportError:


### PR DESCRIPTION
# PR Summary
building on top of #2417, use progress bar already offered by pooch.
I chose to set `pbar=True` by default. Also this capability requires tqdm to be installed.