### PR TITLE
[bugfix] Pass center kwarg on to reloaded projection dataset.

### DIFF
--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1480,6 +1480,7 @@ class ProjectionPlot(PWViewerMPL):
                 proj.weight_field = proj._determine_fields(weight_field)[0]
             else:
                 proj.weight_field = weight_field
+            proj.center = center
         else:
             proj = ds.proj(fields, axis, weight_field=weight_field,
                            center=center, data_source=data_source,


### PR DESCRIPTION
This fixes the issue reported on the mailing list where the center keyword was having no effect on projections made after using `save_as_dataset`.