### PR TITLE
Modified artio frontend fields to ytep 0003 conv: Issue/2608/artio

### DIFF
--- a/yt/fields/field_aliases.py
+++ b/yt/fields/field_aliases.py
@@ -137,7 +137,6 @@ _field_name_aliases = [
     ("HeI density",                      "He_density"),
     ("HeII density",                     "He_p1_density"),
     ("HeIII density",                    "He_p2_density"),
-#    ("H2 density",                       "H2_density"),
 ]
 
 _field_units_aliases = [

--- a/yt/fields/field_aliases.py
+++ b/yt/fields/field_aliases.py
@@ -132,7 +132,12 @@ _field_name_aliases = [
     ("VorticityRPGrowthTimescale",       "vorticity_radiation_pressure_growth_timescale"),
     ("DiskAngle",                        "theta"),
     ("Height",                           "height"),
+    ("HI density",                       "H_density"),
+    ("HII density",                      "H_p1_density"),
+    ("HeI density",                      "He_density"),
+    ("HeII density",                     "He_p1_density"),
     ("HeIII density",                    "He_p2_density"),
+#    ("H2 density",                       "H2_density"),
 ]
 
 _field_units_aliases = [

--- a/yt/fields/field_aliases.py
+++ b/yt/fields/field_aliases.py
@@ -132,6 +132,7 @@ _field_name_aliases = [
     ("VorticityRPGrowthTimescale",       "vorticity_radiation_pressure_growth_timescale"),
     ("DiskAngle",                        "theta"),
     ("Height",                           "height"),
+    ("HeIII density",                    "He_p2_density"),
 ]
 
 _field_units_aliases = [

--- a/yt/frontends/artio/fields.py
+++ b/yt/frontends/artio/fields.py
@@ -50,7 +50,7 @@ class ARTIOFieldInfo(FieldInfoContainer):
         ("RT_HVAR_HII", (rho_units, ["HII density"], None)),
         ("RT_HVAR_HeI", (rho_units, ["HeI density"], None)),
         ("RT_HVAR_HeII", (rho_units, ["HeII density"], None)),
-        ("RT_HVAR_HeIII", (rho_units, ["HeIII density"], None)),
+        ("RT_HVAR_HeIII", (rho_units, ["He_p2_density"], None)),
     )
 
     known_particle_fields = (

--- a/yt/frontends/artio/fields.py
+++ b/yt/frontends/artio/fields.py
@@ -46,11 +46,12 @@ class ARTIOFieldInfo(FieldInfoContainer):
         ("HVAR_METAL_DENSITY_II", (rho_units, ["metal_ii_density"], None)),
         ("VAR_POTENTIAL", ("", ["potential"], None)),
         ("VAR_POTENTIAL_HYDRO", ("", ["gas_potential"], None)),
-        ("RT_HVAR_HI", (rho_units, ["HI density"], None)),
-        ("RT_HVAR_HII", (rho_units, ["HII density"], None)),
-        ("RT_HVAR_HeI", (rho_units, ["HeI density"], None)),
-        ("RT_HVAR_HeII", (rho_units, ["HeII density"], None)),
+        ("RT_HVAR_HI", (rho_units, ["H_density"], None)),
+        ("RT_HVAR_HII", (rho_units, ["H_p1_density"], None)),
+        ("RT_HVAR_HeI", (rho_units, ["He_density"], None)),
+        ("RT_HVAR_HeII", (rho_units, ["He_p1_density"], None)),
         ("RT_HVAR_HeIII", (rho_units, ["He_p2_density"], None)),
+        ("RT_HVAR_H2", (rho_units, ["H2_density"], None)),
     )
 
     known_particle_fields = (

--- a/yt/frontends/artio/fields.py
+++ b/yt/frontends/artio/fields.py
@@ -48,10 +48,10 @@ class ARTIOFieldInfo(FieldInfoContainer):
         ("VAR_POTENTIAL_HYDRO", ("", ["gas_potential"], None)),
         ("RT_HVAR_HI", (rho_units, ["H_density"], None)),
         ("RT_HVAR_HII", (rho_units, ["H_p1_density"], None)),
+        ("RT_HVAR_H2", (rho_units, ["H2_density"], None)),
         ("RT_HVAR_HeI", (rho_units, ["He_density"], None)),
         ("RT_HVAR_HeII", (rho_units, ["He_p1_density"], None)),
         ("RT_HVAR_HeIII", (rho_units, ["He_p2_density"], None)),
-        ("RT_HVAR_H2", (rho_units, ["H2_density"], None)),
     )
 
     known_particle_fields = (


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Modified ARTIO variable names to YTEP-0003 conventions for Issue #2608 

- [x] modify fields such as HeIII density -> He_p2_density in line 53 of yt/frontends/artio/fields.py
- [x] add old field names to yt/fields/field_aliases.py to allow for backwards compatibility using ds._setup_deprecated_fields()

Question:  @provider10 and I would like to make sure that folks using the other field names can easily use (and know to use) the back-compatibility functionality. We are open to any thoughts or suggestions for putting in a specific error message for ARTIO users to let them know that they are missing the if the ds._setup_deprecated_fields() if the user has not added it, which we can add before this PR is merged.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->
Addresses: Issue #2608


## PR Checklist

<!-- Note that some of these check boxIssue #2608es may not apply to all pull requests -->

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
