### PR TITLE
Support vertex centred data

### DIFF
--- a/yt/data_objects/octree_subset.py
+++ b/yt/data_objects/octree_subset.py
@@ -104,7 +104,7 @@ class OctreeSubset(YTSelectionContainer):
 
     def select_blocks(self, selector):
         mask = self.oct_handler.mask(selector, domain_id=self.domain_id)
-        slicer = OctreeSubsetBlockSlice(self)
+        slicer = OctreeSubsetBlockSlice(self, self.ds)
         for i, sl in slicer:
             yield sl, np.atleast_3d(mask[i, ...])
 
@@ -528,6 +528,7 @@ class OctreeSubsetBlockSlicePosition:
         self.block_slice = block_slice
         nz = self.block_slice.octree_subset.nz
         self.ActiveDimensions = np.array([nz, nz, nz], dtype="int64")
+        self.ds = block_slice.ds
 
     def __getitem__(self, key):
         bs = self.block_slice
@@ -572,8 +573,10 @@ class OctreeSubsetBlockSlicePosition:
     def clear_data(self):
         pass
 
-    def get_vertex_centered_data(self, *args, **kwargs):
-        raise NotImplementedError
+    def get_vertex_centered_data(self, fields, smoothed=False, no_ghost=False):
+        field = fields[0]
+        new_field = self.block_slice.get_vertex_centered_data(fields)[field]
+        return {field: new_field[..., self.ind]}
 
     @contextmanager
     def _field_parameter_state(self, field_parameters):
@@ -581,12 +584,55 @@ class OctreeSubsetBlockSlicePosition:
 
 
 class OctreeSubsetBlockSlice:
-    def __init__(self, octree_subset):
+    def __init__(self, octree_subset, ds):
         self.octree_subset = octree_subset
+        self.ds = ds
+        self._vertex_centered_data = {}
         # Cache some attributes
         for attr in ["ires", "icoords", "fcoords", "fwidth"]:
             v = getattr(octree_subset, attr)
             setattr(self, f"_{attr}", octree_subset._reshape_vals(v))
+
+    @property
+    def octree_subset_with_gz(self):
+        subset_with_gz = getattr(self, "_octree_subset_with_gz", None)
+        if not subset_with_gz:
+            self._octree_subset_with_gz = self.octree_subset.retrieve_ghost_zones(1, [])
+        return self._octree_subset_with_gz
+
+    def get_vertex_centered_data(self, fields, smoothed=False, no_ghost=False):
+        if no_ghost is True:
+            raise NotImplementedError(
+                "get_vertex_centered_data without ghost zones for oct-based datasets has not been implemented."
+            )
+
+        # Make sure the field list has only unique entries
+        fields = list(set(fields))
+        new_fields = {}
+        cg = self.octree_subset_with_gz
+        for field in fields:
+            if field in self._vertex_centered_data:
+                new_fields[field] = self._vertex_centered_data[field]
+            else:
+                finfo = self.ds._get_field_info(field)
+                orig_field = cg[field]
+                nocts = orig_field.shape[-1]
+                new_field = np.zeros((3, 3, 3, nocts), order="F")
+                new_field += orig_field[1:, 1:, 1:]
+                new_field += orig_field[:-1, 1:, 1:]
+                new_field += orig_field[1:, :-1, 1:]
+                new_field += orig_field[1:, 1:, :-1]
+                new_field += orig_field[:-1, 1:, :-1]
+                new_field += orig_field[1:, :-1, :-1]
+                new_field += orig_field[:-1, :-1, 1:]
+                new_field += orig_field[:-1, :-1, :-1]
+                new_field *= 0.125
+
+                new_fields[field] = self.ds.arr(new_field, finfo.output_units)
+
+                self._vertex_centered_data[field] = new_fields[field]
+
+        return new_fields
 
     def __iter__(self):
         for i in range(self._ires.shape[-1]):

--- a/yt/data_objects/octree_subset.py
+++ b/yt/data_objects/octree_subset.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from itertools import product, repeat
 
 import numpy as np
 
@@ -618,14 +619,11 @@ class OctreeSubsetBlockSlice:
                 orig_field = cg[field]
                 nocts = orig_field.shape[-1]
                 new_field = np.zeros((3, 3, 3, nocts), order="F")
-                new_field += orig_field[1:, 1:, 1:]
-                new_field += orig_field[:-1, 1:, 1:]
-                new_field += orig_field[1:, :-1, 1:]
-                new_field += orig_field[1:, 1:, :-1]
-                new_field += orig_field[:-1, 1:, :-1]
-                new_field += orig_field[1:, :-1, :-1]
-                new_field += orig_field[:-1, :-1, 1:]
-                new_field += orig_field[:-1, :-1, :-1]
+
+                # Compute vertex-centred data as mean of 8 neighbours cell data
+                slices = (slice(1, None), slice(None, -1))
+                for slx, sly, slz in product(*repeat(slices, 3)):
+                    new_field += orig_field[slx, sly, slz]
                 new_field *= 0.125
 
                 new_fields[field] = self.ds.arr(new_field, finfo.output_units)

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -357,12 +357,23 @@ class RAMSESDomainSubset(OctreeSubset):
             )
             smoothed = False
 
-        new_subset = RAMSESDomainSubset(
-            self.base_region, self.domain, self.ds, num_ghost_zones=ngz, base_grid=self
-        )
+        try:
+            new_subset = self._subset_with_gz
+            mylog.debug(
+                "Reusing previous subset with ghost zone for domain %s", self.domain_id
+            )
+        except AttributeError:
+            new_subset = RAMSESDomainSubset(
+                self.base_region,
+                self.domain,
+                self.ds,
+                num_ghost_zones=ngz,
+                base_grid=self,
+            )
+            self._subset_with_gz = new_subset
 
-        # Cache the fields
-        new_subset.get_data(fields)
+            # Cache the fields
+            new_subset.get_data(fields)
 
         return new_subset
 

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -349,9 +349,15 @@ class RAMSESDomainSubset(OctreeSubset):
             )
 
     def retrieve_ghost_zones(self, ngz, fields, smoothed=False):
+        if smoothed:
+            raise NotImplementedError
+
         new_subset = RAMSESDomainSubset(
             self.base_region, self.domain, self.ds, num_ghost_zones=ngz, base_grid=self
         )
+
+        # Cache the fields
+        new_subset.get_data(fields)
 
         return new_subset
 

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -350,7 +350,12 @@ class RAMSESDomainSubset(OctreeSubset):
 
     def retrieve_ghost_zones(self, ngz, fields, smoothed=False):
         if smoothed:
-            raise NotImplementedError
+            mylog.warning(
+                f"{self}.retrieve_ghost_zones was called with the "
+                f"`smoothed` argument set to True. This is not supported, "
+                "ignoring it."
+            )
+            smoothed = False
 
         new_subset = RAMSESDomainSubset(
             self.base_region, self.domain, self.ds, num_ghost_zones=ngz, base_grid=self


### PR DESCRIPTION
Adds support for vertex centred data. This has the effect of making isocontours possible on octree datasets using the same API as for the rest of yt.

This should be merged after #2425 has been merged. I marked it as draft to prevent people from reviewing it, since many files have been modified in the aforementioned PRs.

This allows for example to export a dataset to [sketchfab](https://skfb.ly/6SXyJ).

Note that in its current form, the isosurface algorithm does work. However, it is very slow as it performs the marching cube algorithm on each _individual oct_. It also returns a non-connected set of points (that represent the isosurface), since the output of the marching cube algorithms aren't stitched together. Note that a quick hack would be to merge vertices of the isosurface if they are very close one from another. A better solution however would be to feed sets of connected octs that live at the same level to the marching cube algorithms, but this is well beyond the scope of the current PR. 