### PR TITLE
[yt-4.0] added domain_overrride to fix bbox

### DIFF
--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -271,6 +271,8 @@ class GadgetDataset(SPHDataset):
             unit_base['cmcm'] = 1.0 / unit_base["UnitLength_in_cm"]
         self._unit_base = unit_base
         if bounding_box is not None:
+            # This ensures that we know a bounding box has been applied
+            self.domain_override = True
             bbox = np.array(bounding_box, dtype="float64")
             if bbox.shape == (2, 3):
                 bbox = bbox.transpose()

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -272,7 +272,7 @@ class GadgetDataset(SPHDataset):
         self._unit_base = unit_base
         if bounding_box is not None:
             # This ensures that we know a bounding box has been applied
-            self.domain_override = True
+            self._domain_override = True
             bbox = np.array(bounding_box, dtype="float64")
             if bbox.shape == (2, 3):
                 bbox = bbox.transpose()

--- a/yt/frontends/sdf/data_structures.py
+++ b/yt/frontends/sdf/data_structures.py
@@ -63,7 +63,7 @@ class SDFDataset(ParticleDataset):
                  unit_system="cgs"):
         if bounding_box is not None:
             # This ensures that we know a bounding box has been applied
-            self.domain_override = True
+            self._domain_override = True
             self._subspace = True
             bbox = np.array(bounding_box, dtype="float64")
             if bbox.shape == (2, 3):

--- a/yt/frontends/sdf/data_structures.py
+++ b/yt/frontends/sdf/data_structures.py
@@ -62,6 +62,8 @@ class SDFDataset(ParticleDataset):
                  units_override=None,
                  unit_system="cgs"):
         if bounding_box is not None:
+            # This ensures that we know a bounding box has been applied
+            self.domain_override = True
             self._subspace = True
             bbox = np.array(bounding_box, dtype="float64")
             if bbox.shape == (2, 3):

--- a/yt/frontends/tipsy/data_structures.py
+++ b/yt/frontends/tipsy/data_structures.py
@@ -175,7 +175,7 @@ class TipsyDataset(SPHDataset):
                 self.domain_right_edge = None
         else:
             # This ensures that we know a bounding box has been applied
-            self.domain_override = True
+            self._domain_override = True
             bbox = np.array(self.bounding_box, dtype="float64")
             if bbox.shape == (2, 3):
                 bbox = bbox.transpose()

--- a/yt/frontends/tipsy/data_structures.py
+++ b/yt/frontends/tipsy/data_structures.py
@@ -174,6 +174,8 @@ class TipsyDataset(SPHDataset):
                 self.domain_left_edge = None
                 self.domain_right_edge = None
         else:
+            # This ensures that we know a bounding box has been applied
+            self.domain_override = True
             bbox = np.array(self.bounding_box, dtype="float64")
             if bbox.shape == (2, 3):
                 bbox = bbox.transpose()

--- a/yt/geometry/particle_geometry_handler.py
+++ b/yt/geometry/particle_geometry_handler.py
@@ -108,7 +108,7 @@ class ParticleIndex(Index):
 
         # If we have applied a bounding box then we can't cache the
         # ParticleBitmap because it is doman dependent
-        if getattr(ds, "domain_override", False):
+        if getattr(ds, "_domain_override", False):
             dont_cache = True
 
         if not hasattr(self.ds, '_file_hash'):

--- a/yt/geometry/particle_geometry_handler.py
+++ b/yt/geometry/particle_geometry_handler.py
@@ -92,7 +92,7 @@ class ParticleIndex(Index):
             ds.domain_left_edge = ds.arr(1.05*min_ppos, 'code_length')
             ds.domain_right_edge = ds.arr(1.05*max_ppos, 'code_length')
             ds.domain_width = ds.domain_right_edge - ds.domain_left_edge
-            
+
         # use a trivial morton index for datasets containing a single chunk
         if len(self.data_files) == 1:
             order1 = 1
@@ -105,6 +105,11 @@ class ParticleIndex(Index):
             dont_cache = True
         else:
             dont_cache = False
+
+        # If we have applied a bounding box then we can't cache the
+        # ParticleBitmap because it is doman dependent
+        if getattr(ds, "domain_override", False):
+            dont_cache = True
 
         if not hasattr(self.ds, '_file_hash'):
             self.ds._file_hash = self._generate_hash()


### PR DESCRIPTION
## PR Summary

Added a `ds.domain_override` when a `bbox` is applied to a dataset. This prevents the particle index from caching which ensures the particle selection is correct. Fixes #2612 

## PR Checklist

- [x] Code passes flake8 checker
- *NA* New features are documented, with docstrings and narrative docs
- *NA* Adds a test for any bugs fixed. Adds tests for new features.