### PR TITLE
Add mode kwarg to h5py.File calls

### DIFF
--- a/doc/source/analyzing/analysis_modules/absorption_spectrum.rst
+++ b/doc/source/analyzing/analysis_modules/absorption_spectrum.rst
@@ -195,7 +195,7 @@ errors produced in saving to a ascii file will negatively impact fit quality.
 
 .. code-block:: python
 
-    f = h5py.File('spectrum.h5', 'r')
+    f = h5py.File('spectrum.h5', mode='r')
     wavelength = f["wavelength"][:]
     flux = f['flux'][:]
     f.close()

--- a/doc/source/analyzing/ionization_cube.py
+++ b/doc/source/analyzing/ionization_cube.py
@@ -36,5 +36,5 @@ t2 = time.time()
 print("Completed.  %0.3e" % (t2-t1))
 
 if comm.rank == 0:
-    f = h5py.File("IonizationCube.h5", "w")
+    f = h5py.File("IonizationCube.h5", mode="w")
     f.create_dataset("/z", data=ionized_z)

--- a/doc/source/cookbook/extract_fixed_resolution_data.py
+++ b/doc/source/cookbook/extract_fixed_resolution_data.py
@@ -20,7 +20,7 @@ cube = ds.covering_grid(level,
 
 # Now we open our output file using h5py
 # Note that we open with 'w' (write), which will overwrite existing files!
-f = h5py.File("my_data.h5", "w")
+f = h5py.File("my_data.h5", mode="w")
 
 # We create a dataset at the root, calling it "density"
 f.create_dataset("/density", data=cube["density"])
@@ -29,5 +29,5 @@ f.create_dataset("/density", data=cube["density"])
 f.close()
 
 # If we want to then access this datacube in the h5 file, we can now...
-f = h5py.File("my_data.h5", "r")
+f = h5py.File("my_data.h5", mode="r")
 print(f["density"][()])

--- a/doc/source/developing/external_analysis.rst
+++ b/doc/source/developing/external_analysis.rst
@@ -395,7 +395,7 @@ import, and then save things out into a file.
 .. code-block:: python
 
    import h5py
-   f = h5py.File("some_file.h5", "w")
+   f = h5py.File("some_file.h5", mode="w")
    f.create_dataset("/data", data=some_data)
 
 This will create ``some_file.h5`` if necessary and add a new dataset

--- a/doc/source/visualizing/callbacks.rst
+++ b/doc/source/visualizing/callbacks.rst
@@ -760,7 +760,7 @@ Annotate Triangle Facets Callback
    #setup file path for yt test directory
    filename = os.path.join(yt.config.ytcfg.get("yt", "test_data_dir"),
                            "MoabTest/mcnp_n_impr_fluka.h5m")
-   f = h5py.File(filename, "r")
+   f = h5py.File(filename, mode="r")
    coords = f["/tstt/nodes/coordinates"][:]
    conn = f["/tstt/elements/Tri3/connectivity"][:]
    points = coords[conn-1]

--- a/yt/analysis_modules/absorption_spectrum/absorption_spectrum.py
+++ b/yt/analysis_modules/absorption_spectrum/absorption_spectrum.py
@@ -635,7 +635,7 @@ class AbsorptionSpectrum(object):
 
         """
         mylog.info("Writing spectrum to hdf5 file: %s.", filename)
-        output = h5py.File(filename, 'w')
+        output = h5py.File(filename, mode='w')
         output.create_dataset('wavelength', data=self.lambda_field)
         output.create_dataset('tau', data=self.tau_field)
         output.create_dataset('flux', data=self.flux_field)

--- a/yt/analysis_modules/absorption_spectrum/absorption_spectrum_fit.py
+++ b/yt/analysis_modules/absorption_spectrum/absorption_spectrum_fit.py
@@ -1008,7 +1008,7 @@ def _output_fit(lineDic, file_name = 'spectrum_fit.h5'):
         Name of the file to output fit to. Default = 'spectrum_fit.h5'
 
     """
-    f = h5py.File(file_name, 'w')
+    f = h5py.File(file_name, mode='w')
     for ion, params in lineDic.items():
         f.create_dataset("{0}/N".format(ion),data=params['N'])
         f.create_dataset("{0}/b".format(ion),data=params['b'])

--- a/yt/analysis_modules/cosmological_observation/light_cone/light_cone.py
+++ b/yt/analysis_modules/cosmological_observation/light_cone/light_cone.py
@@ -438,7 +438,7 @@ class LightCone(CosmologySplice):
 
         mylog.info("Writing light cone data to %s." % filename)
 
-        fh = h5py.File(filename, "a")
+        fh = h5py.File(filename, mode="a")
 
         if field_node in fh:
             del fh[field_node]

--- a/yt/analysis_modules/cosmological_observation/light_cone/tests/test_light_cone.py
+++ b/yt/analysis_modules/cosmological_observation/light_cone/tests/test_light_cone.py
@@ -60,7 +60,7 @@ class LightConeProjectionTest(AnswerTestingTest):
             (600.0, "arcmin"), (60.0, "arcsec"), "density",
             weight_field=None, save_stack=True)
 
-        fh = h5py.File("LC/LightCone.h5", "r")
+        fh = h5py.File("LC/LightCone.h5", mode="r")
         data = fh["density_None"].value
         units = fh["density_None"].attrs["units"]
         assert units == "g/cm**2"

--- a/yt/analysis_modules/halo_analysis/halo_callbacks.py
+++ b/yt/analysis_modules/halo_analysis/halo_callbacks.py
@@ -295,7 +295,7 @@ def save_profiles(halo, storage="profiles", filename=None,
     mylog.info("Saving halo %d profile data to %s." %
                (halo.quantities["particle_identifier"], output_file))
 
-    fh = h5py.File(output_file, "w")
+    fh = h5py.File(output_file, mode="w")
     my_profile = getattr(halo, storage)
     profile_group = fh.create_group("profiles")
     for field in my_profile:
@@ -353,7 +353,7 @@ def load_profiles(halo, storage="profiles", fields=None,
     mylog.info("Loading halo %d profile data from %s." %
                (halo.quantities["particle_identifier"], output_file))
 
-    fh = h5py.File(output_file, "r")
+    fh = h5py.File(output_file, mode="r")
     if fields is None:
         profile_fields = fh["profiles"].keys()
     else:

--- a/yt/analysis_modules/halo_finding/halo_objects.py
+++ b/yt/analysis_modules/halo_finding/halo_objects.py
@@ -660,7 +660,7 @@ class LoadedHalo(Halo):
         # First get the list of fields from the first file. Not all fields
         # are saved all the time (e.g. creation_time, particle_type).
         mylog.info("Getting field %s from hdf5 halo particle files." % field)
-        f = h5py.File(fnames[0], 'r')
+        f = h5py.File(fnames[0], mode='r')
         fields = f["Halo%08d" % halo].keys()
         # If we dont have this field, we can give up right now.
         if field not in fields:
@@ -677,7 +677,7 @@ class LoadedHalo(Halo):
         del f
         offset = 0
         for fname in fnames:
-            f = h5py.File(fname, 'r')
+            f = h5py.File(fname, mode='r')
             this = f["Halo%08d" % halo][field][:]
             s = this.size
             field_data[offset:offset + s] = this
@@ -1368,7 +1368,7 @@ class GenericHaloFinder(HaloList, ParallelAnalysisInterface):
         """
         ensure_dir_exists(prefix)
         fn = "%s.h5" % self.comm.get_filename(prefix)
-        f = h5py.File(fn, "w")
+        f = h5py.File(fn, mode="w")
         for halo in self._groups:
             if not self.comm.is_mine(halo): continue
             halo.write_particle_list(f)

--- a/yt/analysis_modules/photon_simulator/photon_simulator.py
+++ b/yt/analysis_modules/photon_simulator/photon_simulator.py
@@ -132,7 +132,7 @@ class PhotonList(object):
         photons = {}
         parameters = {}
 
-        f = h5py.File(filename, "r")
+        f = h5py.File(filename, mode="r")
 
         p = f["/parameters"]
         parameters["FiducialExposureTime"] = YTQuantity(p["fid_exp_time"].value, "s")
@@ -445,7 +445,7 @@ class PhotonList(object):
 
         if comm.rank == 0:
 
-            f = h5py.File(photonfile, "w")
+            f = h5py.File(photonfile, mode="w")
 
             # Parameters
 
@@ -921,7 +921,7 @@ class EventList(object):
         events = {}
         parameters = {}
 
-        f = h5py.File(h5file, "r")
+        f = h5py.File(h5file, mode="r")
 
         p = f["/parameters"]
         parameters["ExposureTime"] = YTQuantity(p["exp_time"].value, "s")
@@ -1222,7 +1222,7 @@ class EventList(object):
         """
         Write an EventList to the HDF5 file given by *h5file*.
         """
-        f = h5py.File(h5file, "w")
+        f = h5py.File(h5file, mode="w")
 
         p = f.create_group("parameters")
         p.create_dataset("exp_time", data=float(self.parameters["ExposureTime"]))
@@ -1473,8 +1473,8 @@ def merge_files(input_files, output_file, clobber=False,
         raise IOError("Cannot overwrite existing file %s. " % output_file +
                       "If you want to do this, set clobber=True.")
 
-    f_in = h5py.File(input_files[0], "r")
-    f_out = h5py.File(output_file, "w")
+    f_in = h5py.File(input_files[0], mode="r")
+    f_out = h5py.File(output_file, mode="w")
 
     exp_time_key = ""
     p_out = f_out.create_group("parameters")
@@ -1486,7 +1486,7 @@ def merge_files(input_files, output_file, clobber=False,
 
     skip = [exp_time_key] if add_exposure_times else []
     for fn in input_files[1:]:
-        f = h5py.File(fn, "r")
+        f = h5py.File(fn, mode="r")
         validate_parameters(f_in["parameters"], f["parameters"], skip=skip)
         f.close()
 
@@ -1496,7 +1496,7 @@ def merge_files(input_files, output_file, clobber=False,
     tot_exp_time = 0.0
 
     for i, fn in enumerate(input_files):
-        f = h5py.File(fn, "r")
+        f = h5py.File(fn, mode="r")
         if add_exposure_times:
             tot_exp_time += f["/parameters"][exp_time_key].value
         elif i == 0:
@@ -1537,7 +1537,7 @@ def convert_old_file(input_file, output_file, clobber=False):
         raise IOError("Cannot overwrite existing file %s. " % output_file +
                       "If you want to do this, set clobber=True.")
 
-    f_in = h5py.File(input_file, "r")
+    f_in = h5py.File(input_file, mode="r")
 
     if "num_photons" in f_in:
         params = ["fid_exp_time", "fid_area", "fid_d_a", "fid_redshift",
@@ -1550,7 +1550,7 @@ def convert_old_file(input_file, output_file, clobber=False):
                   "instrument", "sky_center", "pix_center", "dtheta"]
         data = ["xsky", "ysky", "xpix", "ypix", "eobs", "pi", "pha"]
 
-    f_out = h5py.File(output_file, "w")
+    f_out = h5py.File(output_file, mode="w")
 
     p = f_out.create_group("parameters")
     d = f_out.create_group("data")

--- a/yt/analysis_modules/photon_simulator/spectral_models.py
+++ b/yt/analysis_modules/photon_simulator/spectral_models.py
@@ -333,7 +333,7 @@ class TableAbsorbModel(SpectralModel):
         if not os.path.exists(filename):
             raise IOError("File does not exist: %s." % filename)
         self.filename = filename
-        f = h5py.File(self.filename,"r")
+        f = h5py.File(self.filename, mode="r")
         emin = f["energy"][:].min()
         emax = f["energy"][:].max()
         self.sigma = YTArray(f["cross_section"][:], "cm**2")

--- a/yt/analysis_modules/star_analysis/sfr_spectrum.py
+++ b/yt/analysis_modules/star_analysis/sfr_spectrum.py
@@ -339,7 +339,7 @@ class SpectrumBuilder(object):
         self.flux = {}
         for file in self.model:
             fname = self.bcdir + "/" + self.model[file]
-            fp = h5py.File(fname, 'r')
+            fp = h5py.File(fname, mode='r')
             self.age = YTArray(fp["agebins"][:], 'yr')  # 1D floats
             self.wavelength = fp["wavebins"][:]  # 1D floats
             self.flux[file] = fp["flam"][:, :]  # 2D floats, [agebin, wavebin]

--- a/yt/analysis_modules/two_point_functions/two_point_functions.py
+++ b/yt/analysis_modules/two_point_functions/two_point_functions.py
@@ -649,7 +649,7 @@ class TwoPointFunctions(ParallelAnalysisInterface):
         """
         if self.mine == 0:
             for fset in self._fsets:
-                f = h5py.File(fn % fset.function.__name__, "w")
+                f = h5py.File(fn % fset.function.__name__, mode="w")
                 bin_names = []
                 prob_names = []
                 bin_counts = []

--- a/yt/data_objects/particle_trajectories.py
+++ b/yt/data_objects/particle_trajectories.py
@@ -378,7 +378,7 @@ class ParticleTrajectories(object):
         >>> trajs = ParticleTrajectories(my_fns, indices)
         >>> trajs.write_out_h5("orbit_trajectories")
         """
-        fid = h5py.File(filename, "w")
+        fid = h5py.File(filename, mode="w")
         fid.create_dataset("particle_indices", dtype=np.int64,
                            data=self.indices)
         fid.close()

--- a/yt/fields/xray_emission_fields.py
+++ b/yt/fields/xray_emission_fields.py
@@ -97,7 +97,7 @@ class XrayEmissivityIntegrator(object):
 
         filename = _get_data_file(table_type, data_dir=data_dir)
         only_on_root(mylog.info, "Loading emissivity data from %s." % filename)
-        in_file = h5py.File(filename, "r")
+        in_file = h5py.File(filename, mode="r")
         if "info" in in_file.attrs:
             only_on_root(mylog.info, parse_h5_attr(in_file, "info"))
         if parse_h5_attr(in_file, "version") != data_version[table_type]:

--- a/yt/frontends/chombo/data_structures.py
+++ b/yt/frontends/chombo/data_structures.py
@@ -48,7 +48,7 @@ from .fields import ChomboFieldInfo, Orion2FieldInfo, \
 
 def is_chombo_hdf5(fn):
     try:
-        with h5py.File(fn, 'r') as fileh:
+        with h5py.File(fn, mode='r') as fileh:
             valid = "Chombo_global" in fileh["/"]
     except (KeyError, IOError, ImportError):
         return False
@@ -383,7 +383,7 @@ class ChomboDataset(Dataset):
 
         if not (pluto_ini_file_exists or orion2_ini_file_exists):
             try:
-                fileh = h5py.File(args[0],'r')
+                fileh = h5py.File(args[0], mode='r')
                 valid = "Chombo_global" in fileh["/"]
                 # ORION2 simulations should always have this:
                 valid = valid and not ('CeilVA_mass' in fileh.attrs.keys())
@@ -691,7 +691,7 @@ class Orion2Dataset(ChomboDataset):
 
         if not pluto_ini_file_exists:
             try:
-                fileh = h5py.File(args[0],'r')
+                fileh = h5py.File(args[0], mode='r')
                 valid = 'CeilVA_mass' in fileh.attrs.keys()
                 valid = "Chombo_global" in fileh["/"] and "Charm_global" not in fileh["/"]
                 valid = valid and 'CeilVA_mass' in fileh.attrs.keys()
@@ -751,7 +751,7 @@ class ChomboPICDataset(ChomboDataset):
             return False
 
         try:
-            fileh = h5py.File(args[0],'r')
+            fileh = h5py.File(args[0], mode='r')
             valid = "Charm_global" in fileh["/"]
             fileh.close()
             return valid

--- a/yt/frontends/enzo/data_structures.py
+++ b/yt/frontends/enzo/data_structures.py
@@ -384,7 +384,7 @@ class EnzoHierarchy(GridIndex):
                 continue
             gs = self.grids[select_grids > 0]
             g = gs[0]
-            handle = h5py.File(g.filename, "r")
+            handle = h5py.File(g.filename, mode="r")
             node = handle["/Grid%08i/Particles/" % g.id]
             for ptype in (str(p) for p in node):
                 if ptype not in _fields: continue

--- a/yt/frontends/enzo/io.py
+++ b/yt/frontends/enzo/io.py
@@ -34,7 +34,7 @@ class IOHandlerPackedHDF5(BaseIOHandler):
 
     def _read_field_names(self, grid):
         if grid.filename is None: return []
-        f = h5py.File(grid.filename, "r")
+        f = h5py.File(grid.filename, mode="r")
         try:
             group = f["/Grid%08i" % grid.id]
         except KeyError:
@@ -84,7 +84,7 @@ class IOHandlerPackedHDF5(BaseIOHandler):
                 if g.filename is None: continue
                 if f is None:
                     #print "Opening (read) %s" % g.filename
-                    f = h5py.File(g.filename, "r")
+                    f = h5py.File(g.filename, mode="r")
                 nap = sum(g.NumberOfActiveParticles.values())
                 if g.NumberOfParticles == 0 and nap == 0:
                     continue
@@ -285,7 +285,7 @@ class IOHandlerPacked2D(IOHandlerPackedHDF5):
     _particle_reader = False
 
     def _read_data_set(self, grid, field):
-        f = h5py.File(grid.filename, "r")
+        f = h5py.File(grid.filename, mode="r")
         ds = f["/Grid%08i/%s" % (grid.id, field)][:]
         f.close()
         return ds.transpose()[:,:,None]
@@ -301,7 +301,7 @@ class IOHandlerPacked2D(IOHandlerPackedHDF5):
             if not (len(chunks) == len(chunks[0].objs) == 1):
                 raise RuntimeError
             g = chunks[0].objs[0]
-            f = h5py.File(g.filename, 'r')
+            f = h5py.File(g.filename, mode='r')
             gds = f.get("/Grid%08i" % g.id)
             for ftype, fname in fields:
                 rv[(ftype, fname)] = np.atleast_3d(
@@ -324,7 +324,7 @@ class IOHandlerPacked2D(IOHandlerPackedHDF5):
             for g in chunk.objs:
                 if f is None:
                     #print "Opening (count) %s" % g.filename
-                    f = h5py.File(g.filename, "r")
+                    f = h5py.File(g.filename, mode="r")
                 gds = f.get("/Grid%08i" % g.id)
                 if gds is None:
                     gds = f
@@ -342,7 +342,7 @@ class IOHandlerPacked1D(IOHandlerPackedHDF5):
     _particle_reader = False
 
     def _read_data_set(self, grid, field):
-        f = h5py.File(grid.filename, "r")
+        f = h5py.File(grid.filename, mode="r")
         ds = f["/Grid%08i/%s" % (grid.id, field)][:]
         f.close()
         return ds.transpose()[:,None,None]

--- a/yt/frontends/enzo_p/data_structures.py
+++ b/yt/frontends/enzo_p/data_structures.py
@@ -115,7 +115,7 @@ class EnzoPGrid(AMRGridPatch):
     @property
     def particle_count(self):
         if self._particle_count is None:
-            with h5py.File(self.filename, "r") as f:
+            with h5py.File(self.filename, mode="r") as f:
                 fnstr = "%s/%s" % \
                   (self.block_name,
                    self.ds.index.io._sep.join(["particle", "%s", "%s"]))

--- a/yt/frontends/enzo_p/io.py
+++ b/yt/frontends/enzo_p/io.py
@@ -38,7 +38,7 @@ class EnzoPIOHandler(BaseIOHandler):
 
     def _read_field_names(self, grid):
         if grid.filename is None: return []
-        f = h5py.File(grid.filename, "r")
+        f = h5py.File(grid.filename, mode="r")
         try:
             group = f[grid.block_name]
         except KeyError:
@@ -92,7 +92,7 @@ class EnzoPIOHandler(BaseIOHandler):
                 if g.filename is None:
                     continue
                 if f is None:
-                    f = h5py.File(g.filename, "r")
+                    f = h5py.File(g.filename, mode="r")
                 if g.particle_count is None:
                     fnstr = "%s/%s" % \
                       (g.block_name, self._sep.join(["particle", "%s", "%s"]))

--- a/yt/frontends/enzo_p/tests/test_outputs.py
+++ b/yt/frontends/enzo_p/tests/test_outputs.py
@@ -80,7 +80,7 @@ def test_particle_fields():
 def test_hierarchy():
     ds = data_dir_load(hello_world)
 
-    fh = h5py.File(ds.index.grids[0].filename, "r")
+    fh = h5py.File(ds.index.grids[0].filename, mode="r")
     for grid in ds.index.grids:
         assert_array_equal(
             grid.LeftEdge.d, fh[grid.block_name].attrs["enzo_GridLeftEdge"])

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -60,7 +60,7 @@ class IOHandlerGadgetHDF5(BaseIOHandler):
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
         for data_file in sorted(data_files, key=lambda x: x.filename):
-            f = h5py.File(data_file.filename, "r")
+            f = h5py.File(data_file.filename, mode="r")
             # This double-reads
             for ptype, field_list in sorted(ptf.items()):
                 if data_file.total_particles[ptype] == 0:
@@ -78,7 +78,7 @@ class IOHandlerGadgetHDF5(BaseIOHandler):
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
         for data_file in sorted(data_files, key=lambda x: x.filename):
-            f = h5py.File(data_file.filename, "r")
+            f = h5py.File(data_file.filename, mode="r")
             for ptype, field_list in sorted(ptf.items()):
                 if data_file.total_particles[ptype] == 0:
                     continue
@@ -114,7 +114,7 @@ class IOHandlerGadgetHDF5(BaseIOHandler):
 
     def _initialize_index(self, data_file, regions):
         index_ptype = self.index_ptype
-        f = h5py.File(data_file.filename, "r")
+        f = h5py.File(data_file.filename, mode="r")
         if index_ptype == "all":
             pcount = f["/Header"].attrs["NumPart_ThisFile"][:].sum()
             keys = f.keys()
@@ -145,14 +145,14 @@ class IOHandlerGadgetHDF5(BaseIOHandler):
         return morton
 
     def _count_particles(self, data_file):
-        f = h5py.File(data_file.filename, "r")
+        f = h5py.File(data_file.filename, mode="r")
         pcount = f["/Header"].attrs["NumPart_ThisFile"][:]
         f.close()
         npart = dict(("PartType%s" % (i), v) for i, v in enumerate(pcount))
         return npart
 
     def _identify_fields(self, data_file):
-        f = h5py.File(data_file.filename, "r")
+        f = h5py.File(data_file.filename, mode="r")
         fields = []
         cname = self.ds._particle_coordinates_name  # Coordinates
         mname = self.ds._particle_mass_name  # Mass

--- a/yt/frontends/gadget_fof/data_structures.py
+++ b/yt/frontends/gadget_fof/data_structures.py
@@ -118,7 +118,7 @@ class GadgetFOFParticleIndex(ParticleIndex):
 
 class GadgetFOFHDF5File(HaloCatalogFile):
     def __init__(self, ds, io, filename, file_id):
-        with h5py.File(filename, "r") as f:
+        with h5py.File(filename, mode="r") as f:
             self.header = \
               dict((str(field), val)
                    for field, val in f["Header"].attrs.items())
@@ -140,7 +140,7 @@ class GadgetFOFHDF5File(HaloCatalogFile):
 
         if f is None:
             close = True
-            f = h5py.File(self.filename, "r")
+            f = h5py.File(self.filename, mode="r")
         else:
             close = False
 
@@ -198,7 +198,7 @@ class GadgetFOFDataset(Dataset):
         self.halo = partial(GagdetFOFHaloContainer, ds=self._halos_ds)
 
     def _parse_parameter_file(self):
-        with h5py.File(self.parameter_filename,"r") as f:
+        with h5py.File(self.parameter_filename, mode="r") as f:
             self.parameters = \
               dict((str(field), val)
                    for field, val in f["Header"].attrs.items())
@@ -427,7 +427,7 @@ class GadgetFOFHaloParticleIndex(GadgetFOFParticleIndex):
 
             # only open file if it's not already open
             my_f = f if self.data_files[i_scalar].filename == filename \
-              else h5py.File(self.data_files[i_scalar].filename, "r")
+              else h5py.File(self.data_files[i_scalar].filename, mode="r")
 
             for field in fields:
                 data[field][target] = \
@@ -644,7 +644,7 @@ class GagdetFOFHaloContainer(YTSelectionContainer):
         all_id_start = self.index._group_length_sum[:g_scalar].sum(dtype=np.int64)
 
         # Now add the halos in this file that come before.
-        with h5py.File(self.index.data_files[g_scalar].filename, "r") as f:
+        with h5py.File(self.index.data_files[g_scalar].filename, mode="r") as f:
             all_id_start += f["Group"]["GroupLen"][:group_index].sum(dtype=np.int64)
 
         # Add the subhalo offset.

--- a/yt/frontends/gadget_fof/io.py
+++ b/yt/frontends/gadget_fof/io.py
@@ -44,7 +44,7 @@ class IOHandlerGadgetFOFHDF5(BaseIOHandler):
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
         for data_file in sorted(data_files):
-            with h5py.File(data_file.filename, "r") as f:
+            with h5py.File(data_file.filename, mode="r") as f:
                 for ptype, field_list in sorted(ptf.items()):
                     coords = data_file._get_particle_positions(ptype, f=f)
                     if coords is None:
@@ -62,7 +62,7 @@ class IOHandlerGadgetFOFHDF5(BaseIOHandler):
             if fh.filename == offset_file.filename:
                 ofh = fh
             else:
-                ofh = h5py.File(offset_file.filename, "r")
+                ofh = h5py.File(offset_file.filename, mode="r")
             subindex = np.arange(offset_file.total_offset) + offset_file.offset_start
             substart = max(fofindex[0] - subindex[0], 0)
             subend = min(fofindex[-1] - subindex[0], subindex.size - 1)
@@ -79,7 +79,7 @@ class IOHandlerGadgetFOFHDF5(BaseIOHandler):
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
         for data_file in sorted(data_files):
-            with h5py.File(data_file.filename, "r") as f:
+            with h5py.File(data_file.filename, mode="r") as f:
                 for ptype, field_list in sorted(ptf.items()):
                     pcount = data_file.total_particles[ptype]
                     if pcount == 0:
@@ -125,7 +125,7 @@ class IOHandlerGadgetFOFHDF5(BaseIOHandler):
         mylog.debug("Initializing index % 5i (% 7i particles)",
                     data_file.file_id, pcount)
         ind = 0
-        with h5py.File(data_file.filename, "r") as f:
+        with h5py.File(data_file.filename, mode="r") as f:
             if not f.keys(): return None
             dx = np.finfo(f["Group"]["GroupPos"].dtype).eps
             dx = 2.0*self.ds.quan(dx, "code_length")
@@ -157,7 +157,7 @@ class IOHandlerGadgetFOFHDF5(BaseIOHandler):
         fields = []
         pcount = data_file.total_particles
         if sum(pcount.values()) == 0: return fields, {}
-        with h5py.File(data_file.filename, "r") as f:
+        with h5py.File(data_file.filename, mode="r") as f:
             for ptype in self.ds.particle_types_raw:
                 if data_file.total_particles[ptype] == 0: continue
                 fields.append((ptype, "particle_identifier"))
@@ -230,7 +230,7 @@ class IOHandlerGadgetFOFHaloHDF5(IOHandlerGadgetFOFHDF5):
         all_data = {}
         if not scalar_fields: return all_data
         pcount = 1
-        with h5py.File(dobj.scalar_data_file.filename, "r") as f:
+        with h5py.File(dobj.scalar_data_file.filename, mode="r") as f:
             for ptype, field_list in sorted(scalar_fields.items()):
                 for field in field_list:
                     if field == "particle_identifier":
@@ -261,7 +261,7 @@ class IOHandlerGadgetFOFHaloHDF5(IOHandlerGadgetFOFHDF5):
             pcount = end_index - start_index
             if pcount == 0: continue
             field_end = field_start + end_index - start_index
-            with h5py.File(data_file.filename, "r") as f:
+            with h5py.File(data_file.filename, mode="r") as f:
                 for ptype, field_list in sorted(member_fields.items()):
                     for field in field_list:
                         field_data = all_data[(ptype, field)]
@@ -301,7 +301,7 @@ class IOHandlerGadgetFOFHaloHDF5(IOHandlerGadgetFOFHDF5):
         fields = []
         scalar_fields = []
         id_fields = {}
-        with h5py.File(data_file.filename, "r") as f:
+        with h5py.File(data_file.filename, mode="r") as f:
             for ptype in self.ds.particle_types_raw:
                 fields.append((ptype, "particle_identifier"))
                 scalar_fields.append((ptype, "particle_identifier"))

--- a/yt/frontends/gdf/data_structures.py
+++ b/yt/frontends/gdf/data_structures.py
@@ -90,24 +90,24 @@ class GDFHierarchy(GridIndex):
     def __init__(self, ds, dataset_type='grid_data_format'):
         self.dataset = weakref.proxy(ds)
         self.index_filename = self.dataset.parameter_filename
-        h5f = h5py.File(self.index_filename, 'r')
+        h5f = h5py.File(self.index_filename, mode='r')
         self.dataset_type = dataset_type
         GridIndex.__init__(self, ds, dataset_type)
         self.directory = os.path.dirname(self.index_filename)
         h5f.close()
 
     def _detect_output_fields(self):
-        h5f = h5py.File(self.index_filename, 'r')
+        h5f = h5py.File(self.index_filename, mode='r')
         self.field_list = [("gdf", str(f)) for f in h5f['field_types'].keys()]
         h5f.close()
 
     def _count_grids(self):
-        h5f = h5py.File(self.index_filename, 'r')
+        h5f = h5py.File(self.index_filename, mode='r')
         self.num_grids = h5f['/grid_parent_id'].shape[0]
         h5f.close()
 
     def _parse_index(self):
-        h5f = h5py.File(self.index_filename, 'r')
+        h5f = h5py.File(self.index_filename, mode='r')
         dxs = []
         self.grids = np.empty(self.num_grids, dtype='object')
         levels = (h5f['grid_level'][:]).copy()
@@ -196,7 +196,7 @@ class GDFDataset(Dataset):
         """
 
         # This should be improved.
-        h5f = h5py.File(self.parameter_filename, "r")
+        h5f = h5py.File(self.parameter_filename, mode="r")
         for field_name in h5f["/field_types"]:
             current_field = h5f["/field_types/%s" % field_name]
             if 'field_to_cgs' in current_field.attrs:
@@ -245,7 +245,7 @@ class GDFDataset(Dataset):
         h5f.close()
 
     def _parse_parameter_file(self):
-        self._handle = h5py.File(self.parameter_filename, "r")
+        self._handle = h5py.File(self.parameter_filename, mode="r")
         if 'data_software' in self._handle['gridded_data_format'].attrs:
             self.data_software = \
                 self._handle['gridded_data_format'].attrs['data_software']
@@ -294,7 +294,7 @@ class GDFDataset(Dataset):
     @classmethod
     def _is_valid(self, *args, **kwargs):
         try:
-            fileh = h5py.File(args[0], 'r')
+            fileh = h5py.File(args[0], mode='r')
             if "gridded_data_format" in fileh:
                 fileh.close()
                 return True

--- a/yt/frontends/gdf/io.py
+++ b/yt/frontends/gdf/io.py
@@ -45,7 +45,7 @@ class IOHandlerGDFHDF5(BaseIOHandler):
             if not (len(chunks) == len(chunks[0].objs) == 1):
                 raise RuntimeError
             grid = chunks[0].objs[0]
-            h5f = h5py.File(grid.filename, 'r')
+            h5f = h5py.File(grid.filename, mode='r')
             gds = h5f.get(_grid_dname(grid.id))
             for ftype, fname in fields:
                 if self.ds.field_ordering == 1:

--- a/yt/frontends/halo_catalog/data_structures.py
+++ b/yt/frontends/halo_catalog/data_structures.py
@@ -69,7 +69,7 @@ class HaloCatalogFile(ParticleFile):
 
 class HaloCatalogHDF5File(HaloCatalogFile):
     def __init__(self, ds, io, filename, file_id):
-        with h5py.File(filename, "r") as f:
+        with h5py.File(filename, mode="r") as f:
             self.header = dict((field, parse_h5_attr(f, field)) \
                                for field in f.attrs.keys())
         super(HaloCatalogHDF5File, self).__init__(
@@ -82,7 +82,7 @@ class HaloCatalogHDF5File(HaloCatalogFile):
 
         if f is None:
             close = True
-            f = h5py.File(self.filename, "r")
+            f = h5py.File(self.filename, mode="r")
         else:
             close = False
 
@@ -131,7 +131,7 @@ class HaloCatalogDataset(SavedDataset):
     @classmethod
     def _is_valid(self, *args, **kwargs):
         if not args[0].endswith(".h5"): return False
-        with h5py.File(args[0], "r") as f:
+        with h5py.File(args[0], mode="r") as f:
             if "data_type" in f.attrs and \
               parse_h5_attr(f, "data_type") == "halo_catalog":
                 return True

--- a/yt/frontends/halo_catalog/io.py
+++ b/yt/frontends/halo_catalog/io.py
@@ -47,7 +47,7 @@ class IOHandlerHaloCatalogHDF5(BaseIOHandler):
                 data_files.update(obj.data_files)
         pn = "particle_position_%s"
         for data_file in sorted(data_files):
-            with h5py.File(data_file.filename, "r") as f:
+            with h5py.File(data_file.filename, mode="r") as f:
                 units = parse_h5_attr(f[pn % "x"], "units")
                 pos = data_file._get_particle_positions(ptype, f=f)
                 x, y, z = (self.ds.arr(pos[:, i], units)
@@ -66,7 +66,7 @@ class IOHandlerHaloCatalogHDF5(BaseIOHandler):
                 data_files.update(obj.data_files)
         pn = "particle_position_%s"
         for data_file in sorted(data_files):
-            with h5py.File(data_file.filename, "r") as f:
+            with h5py.File(data_file.filename, mode="r") as f:
                 for ptype, field_list in sorted(ptf.items()):
                     units = parse_h5_attr(f[pn % "x"], "units")
                     pos = data_file._get_particle_positions(ptype, f=f)
@@ -87,7 +87,7 @@ class IOHandlerHaloCatalogHDF5(BaseIOHandler):
         ind = 0
         if pcount == 0: return None
         ptype = 'halos'
-        with h5py.File(data_file.filename, "r") as f:
+        with h5py.File(data_file.filename, mode="r") as f:
             if not f.keys(): return None
             units = parse_h5_attr(f["particle_position_x"], "units")
             pos = data_file._get_particle_positions(ptype, f=f)
@@ -108,7 +108,7 @@ class IOHandlerHaloCatalogHDF5(BaseIOHandler):
         return {'halos': data_file.header['num_halos']}
 
     def _identify_fields(self, data_file):
-        with h5py.File(data_file.filename, "r") as f:
+        with h5py.File(data_file.filename, mode="r") as f:
             fields = [("halos", field) for field in f]
             units = dict([(("halos", field),
                            parse_h5_attr(f[field], "units"))

--- a/yt/frontends/moab/data_structures.py
+++ b/yt/frontends/moab/data_structures.py
@@ -40,7 +40,7 @@ class MoabHex8Hierarchy(UnstructuredIndex):
         self.dataset_type = dataset_type
         self.index_filename = self.dataset.parameter_filename
         self.directory = os.path.dirname(self.index_filename)
-        self._fhandle = h5py.File(self.index_filename,'r')
+        self._fhandle = h5py.File(self.index_filename, mode='r')
 
         UnstructuredIndex.__init__(self, ds, dataset_type)
 
@@ -85,7 +85,7 @@ class MoabHex8Dataset(Dataset):
         setdefaultattr(self, 'mass_unit', self.quan(1.0, "g"))
 
     def _parse_parameter_file(self):
-        self._handle = h5py.File(self.parameter_filename, "r")
+        self._handle = h5py.File(self.parameter_filename, mode="r")
         coords = self._handle["/tstt/nodes/coordinates"]
         self.domain_left_edge = coords[0]
         self.domain_right_edge = coords[-1]

--- a/yt/frontends/owls_subfind/data_structures.py
+++ b/yt/frontends/owls_subfind/data_structures.py
@@ -97,7 +97,7 @@ class OWLSSubfindParticleIndex(ParticleIndex):
 class OWLSSubfindHDF5File(ParticleFile):
     def __init__(self, ds, io, filename, file_id):
         super(OWLSSubfindHDF5File, self).__init__(ds, io, filename, file_id)
-        with h5py.File(filename, "r") as f:
+        with h5py.File(filename, mode="r") as f:
             self.header = dict((field, f.attrs[field]) \
                                for field in f.attrs.keys())
     

--- a/yt/frontends/owls_subfind/io.py
+++ b/yt/frontends/owls_subfind/io.py
@@ -43,7 +43,7 @@ class IOHandlerOWLSSubfindHDF5(BaseIOHandler):
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
         for data_file in sorted(data_files, key=lambda f: f.filename):
-            with h5py.File(data_file.filename, "r") as f:
+            with h5py.File(data_file.filename, mode="r") as f:
                 for ptype, field_list in sorted(ptf.items()):
                     pcount = data_file.total_particles[ptype]
                     coords = f[ptype]["CenterOfMass"][()].astype("float64")
@@ -60,7 +60,7 @@ class IOHandlerOWLSSubfindHDF5(BaseIOHandler):
             if fh.filename == offset_file.filename:
                 ofh = fh
             else:
-                ofh = h5py.File(offset_file.filename, "r")
+                ofh = h5py.File(offset_file.filename, mode="r")
             subindex = np.arange(offset_file.total_offset) + offset_file.offset_start
             substart = max(fofindex[0] - subindex[0], 0)
             subend = min(fofindex[-1] - subindex[0], subindex.size - 1)
@@ -77,7 +77,7 @@ class IOHandlerOWLSSubfindHDF5(BaseIOHandler):
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
         for data_file in sorted(data_files, key=lambda f: f.filename):
-            with h5py.File(data_file.filename, "r") as f:
+            with h5py.File(data_file.filename, mode="r") as f:
                 for ptype, field_list in sorted(ptf.items()):
                     pcount = data_file.total_particles[ptype]
                     if pcount == 0: continue
@@ -118,7 +118,7 @@ class IOHandlerOWLSSubfindHDF5(BaseIOHandler):
         mylog.debug("Initializing index % 5i (% 7i particles)",
                     data_file.file_id, pcount)
         ind = 0
-        with h5py.File(data_file.filename, "r") as f:
+        with h5py.File(data_file.filename, mode="r") as f:
             if not f.keys(): return None
             dx = np.finfo(f["FOF"]['CenterOfMass'].dtype).eps
             dx = 2.0*self.ds.quan(dx, "code_length")
@@ -149,7 +149,7 @@ class IOHandlerOWLSSubfindHDF5(BaseIOHandler):
         return morton
 
     def _count_particles(self, data_file):
-        with h5py.File(data_file.filename, "r") as f:
+        with h5py.File(data_file.filename, mode="r") as f:
             pcount = {"FOF": f["FOF"].attrs["Number_of_groups"]}
             if "SUBFIND" in f:
                 # We need this to figure out where the offset fields are stored.
@@ -164,7 +164,7 @@ class IOHandlerOWLSSubfindHDF5(BaseIOHandler):
         fields = []
         pcount = data_file.total_particles
         if sum(pcount.values()) == 0: return fields, {}
-        with h5py.File(data_file.filename, "r") as f:
+        with h5py.File(data_file.filename, mode="r") as f:
             for ptype in self.ds.particle_types_raw:
                 if data_file.total_particles[ptype] == 0: continue
                 fields.append((ptype, "particle_identifier"))

--- a/yt/frontends/ytdata/data_structures.py
+++ b/yt/frontends/ytdata/data_structures.py
@@ -81,7 +81,7 @@ class SavedDataset(Dataset):
 
     def _parse_parameter_file(self):
         self.refine_by = 2
-        with h5py.File(self.parameter_filename, "r") as f:
+        with h5py.File(self.parameter_filename, mode="r") as f:
             for key in f.attrs.keys():
                 v = parse_h5_attr(f, key)
                 if key == "con_args":
@@ -221,7 +221,7 @@ class YTDataset(SavedDataset):
 
 class YTDataHDF5File(ParticleFile):
     def __init__(self, ds, io, filename, file_id):
-        with h5py.File(filename, "r") as f:
+        with h5py.File(filename, mode="r") as f:
             self.header = dict((field, parse_h5_attr(f, field)) \
                                for field in f.attrs.keys())
 
@@ -290,7 +290,7 @@ class YTDataContainerDataset(YTDataset):
     @classmethod
     def _is_valid(self, *args, **kwargs):
         if not args[0].endswith(".h5"): return False
-        with h5py.File(args[0], "r") as f:
+        with h5py.File(args[0], mode="r") as f:
             data_type = parse_h5_attr(f, "data_type")
             cont_type = parse_h5_attr(f, "container_type")
             if data_type is None:
@@ -334,7 +334,7 @@ class YTDataLightRayDataset(YTDataContainerDataset):
     @classmethod
     def _is_valid(self, *args, **kwargs):
         if not args[0].endswith(".h5"): return False
-        with h5py.File(args[0], "r") as f:
+        with h5py.File(args[0], mode="r") as f:
             data_type = parse_h5_attr(f, "data_type")
             if data_type in ["yt_light_ray"]:
                 return True
@@ -361,7 +361,7 @@ class YTSpatialPlotDataset(YTDataContainerDataset):
     @classmethod
     def _is_valid(self, *args, **kwargs):
         if not args[0].endswith(".h5"): return False
-        with h5py.File(args[0], "r") as f:
+        with h5py.File(args[0], mode="r") as f:
             data_type = parse_h5_attr(f, "data_type")
             cont_type = parse_h5_attr(f, "container_type")
             if data_type == "yt_data_container" and \
@@ -432,7 +432,7 @@ class YTDataHierarchy(GridIndex):
     def _detect_output_fields(self):
         self.field_list = []
         self.ds.field_units = self.ds.field_units or {}
-        with h5py.File(self.ds.parameter_filename, "r") as f:
+        with h5py.File(self.ds.parameter_filename, mode="r") as f:
             for group in f:
                 for field in f[group]:
                     field_name = (str(group), str(field))
@@ -519,7 +519,7 @@ class YTGridDataset(YTDataset):
     @classmethod
     def _is_valid(self, *args, **kwargs):
         if not args[0].endswith(".h5"): return False
-        with h5py.File(args[0], "r") as f:
+        with h5py.File(args[0], mode="r") as f:
             data_type = parse_h5_attr(f, "data_type")
             cont_type = parse_h5_attr(f, "container_type")
             if data_type == "yt_frb":
@@ -724,7 +724,7 @@ class YTNonspatialDataset(YTGridDataset):
     @classmethod
     def _is_valid(self, *args, **kwargs):
         if not args[0].endswith(".h5"): return False
-        with h5py.File(args[0], "r") as f:
+        with h5py.File(args[0], mode="r") as f:
             data_type = parse_h5_attr(f, "data_type")
             if data_type == "yt_array_data":
                 return True
@@ -830,7 +830,7 @@ class YTProfileDataset(YTNonspatialDataset):
     @classmethod
     def _is_valid(self, *args, **kwargs):
         if not args[0].endswith(".h5"): return False
-        with h5py.File(args[0], "r") as f:
+        with h5py.File(args[0], mode="r") as f:
             data_type = parse_h5_attr(f, "data_type")
             if data_type == "yt_profile":
                 return True
@@ -903,7 +903,7 @@ class YTClumpTreeDataset(YTNonspatialDataset):
     @classmethod
     def _is_valid(self, *args, **kwargs):
         if not args[0].endswith(".h5"): return False
-        with h5py.File(args[0], "r") as f:
+        with h5py.File(args[0], mode="r") as f:
             data_type = parse_h5_attr(f, "data_type")
             if data_type is None:
                 return False

--- a/yt/frontends/ytdata/io.py
+++ b/yt/frontends/ytdata/io.py
@@ -44,7 +44,7 @@ class IOHandlerYTNonspatialhdf5(BaseIOHandler):
                 gf = self._cached_fields[g.id]
                 rv.update(gf)
             if len(rv) == len(fields): return rv
-            f = h5py.File(u(g.filename), "r")
+            f = h5py.File(u(g.filename), mode="r")
             for field in fields:
                 if field in rv:
                     self._hits += 1
@@ -79,7 +79,7 @@ class IOHandlerYTGridHDF5(BaseIOHandler):
                 gf = self._cached_fields[g.id]
                 rv.update(gf)
             if len(rv) == len(fields): return rv
-            f = h5py.File(u(g.filename), "r")
+            f = h5py.File(u(g.filename), mode="r")
             gds = f[self.ds.default_fluid_type]
             for field in fields:
                 if field in rv:
@@ -110,7 +110,7 @@ class IOHandlerYTGridHDF5(BaseIOHandler):
             for g in chunk.objs:
                 if g.filename is None: continue
                 if f is None:
-                    f = h5py.File(g.filename, "r")
+                    f = h5py.File(g.filename, mode="r")
                 gf = self._cached_fields.get(g.id, {})
                 nd = 0
                 for field in fields:
@@ -140,7 +140,7 @@ class IOHandlerYTGridHDF5(BaseIOHandler):
             for g in chunk.objs:
                 if g.filename is None: continue
                 if f is None:
-                    f = h5py.File(g.filename, "r")
+                    f = h5py.File(g.filename, mode="r")
                 if g.NumberOfParticles == 0:
                     continue
                 for ptype, field_list in sorted(ptf.items()):
@@ -162,7 +162,7 @@ class IOHandlerYTGridHDF5(BaseIOHandler):
             for g in chunk.objs:
                 if g.filename is None: continue
                 if f is None:
-                    f = h5py.File(g.filename, "r")
+                    f = h5py.File(g.filename, mode="r")
                 if g.NumberOfParticles == 0:
                     continue
                 for ptype, field_list in sorted(ptf.items()):
@@ -191,7 +191,7 @@ class IOHandlerYTDataContainerHDF5(BaseIOHandler):
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
         for data_file in sorted(data_files):
-            with h5py.File(data_file.filename, "r") as f:
+            with h5py.File(data_file.filename, mode="r") as f:
                 for ptype, field_list in sorted(ptf.items()):
                     pcount = data_file.total_particles[ptype]
                     if pcount == 0: continue
@@ -209,7 +209,7 @@ class IOHandlerYTDataContainerHDF5(BaseIOHandler):
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
         for data_file in sorted(data_files):
-            with h5py.File(data_file.filename, "r") as f:
+            with h5py.File(data_file.filename, mode="r") as f:
                 for ptype, field_list in sorted(ptf.items()):
                     units = _get_position_array_units(ptype, f, "x")
                     x, y, z = \
@@ -229,7 +229,7 @@ class IOHandlerYTDataContainerHDF5(BaseIOHandler):
         mylog.debug("Initializing index % 5i (% 7i particles)",
                     data_file.file_id, pcount)
         ind = 0
-        with h5py.File(data_file.filename, "r") as f:
+        with h5py.File(data_file.filename, mode="r") as f:
             for ptype in all_count:
                 if ptype not in f or all_count[ptype] == 0: continue
                 pos = np.empty((all_count[ptype], 3), dtype="float64")
@@ -269,7 +269,7 @@ class IOHandlerYTDataContainerHDF5(BaseIOHandler):
     def _identify_fields(self, data_file):
         fields = []
         units = {}
-        with h5py.File(data_file.filename, "r") as f:
+        with h5py.File(data_file.filename, mode="r") as f:
             for ptype in f:
                 fields.extend([(ptype, str(field)) for field in f[ptype]])
                 units.update(dict([((ptype, str(field)), 
@@ -288,7 +288,7 @@ class IOHandlerYTSpatialPlotHDF5(IOHandlerYTDataContainerHDF5):
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
         for data_file in sorted(data_files):
-            with h5py.File(data_file.filename, "r") as f:
+            with h5py.File(data_file.filename, mode="r") as f:
                 for ptype, field_list in sorted(ptf.items()):
                     pcount = data_file.total_particles[ptype]
                     if pcount == 0: continue
@@ -307,7 +307,7 @@ class IOHandlerYTSpatialPlotHDF5(IOHandlerYTDataContainerHDF5):
                 data_files.update(obj.data_files)
         for data_file in sorted(data_files):
             all_count = self._count_particles(data_file)
-            with h5py.File(data_file.filename, "r") as f:
+            with h5py.File(data_file.filename, mode="r") as f:
                 for ptype, field_list in sorted(ptf.items()):
                     x = _get_position_array(ptype, f, "px")
                     y = _get_position_array(ptype, f, "py")
@@ -327,7 +327,7 @@ class IOHandlerYTSpatialPlotHDF5(IOHandlerYTDataContainerHDF5):
         mylog.debug("Initializing index % 5i (% 7i particles)",
                     data_file.file_id, pcount)
         ind = 0
-        with h5py.File(data_file.filename, "r") as f:
+        with h5py.File(data_file.filename, mode="r") as f:
             for ptype in all_count:
                 if ptype not in f or all_count[ptype] == 0: continue
                 pos = np.empty((all_count[ptype], 3), dtype="float64")

--- a/yt/frontends/ytdata/utilities.py
+++ b/yt/frontends/ytdata/utilities.py
@@ -99,7 +99,7 @@ def save_as_dataset(ds, filename, data, field_types=None,
                    "length_unit", "mass_unit", "time_unit",
                    "velocity_unit", "magnetic_unit"]
 
-    fh = h5py.File(filename, "w")
+    fh = h5py.File(filename, mode="w")
     if ds is None: ds = {}
 
     if hasattr(ds, "parameters") and isinstance(ds.parameters, dict):

--- a/yt/geometry/geometry_handler.py
+++ b/yt/geometry/geometry_handler.py
@@ -106,7 +106,7 @@ class Index(ParallelAnalysisInterface):
     def __create_data_file(self, fn):
         # Note that this used to be parallel_root_only; it no longer is,
         # because we have better logic to decide who owns the file.
-        f = h5py.File(fn, 'a')
+        f = h5py.File(fn, mode='a')
         f.close()
 
     def _setup_data_io(self):

--- a/yt/geometry/grid_geometry_handler.py
+++ b/yt/geometry/grid_geometry_handler.py
@@ -75,7 +75,7 @@ class GridIndex(Index):
         return
         try:
             backup_filename = self.dataset.backup_filename
-            f = h5py.File(backup_filename, 'r')
+            f = h5py.File(backup_filename, mode='r')
             g = f["data"]
             grid = self.grids[0] # simply check one of the grids
             grid_group = g["grid_%010i" % (grid.id - grid._id_offset)]

--- a/yt/units/yt_array.py
+++ b/yt/units/yt_array.py
@@ -1011,7 +1011,7 @@ class YTArray(np.ndarray):
         if dataset_name is None:
             dataset_name = 'array_data'
 
-        f = h5py.File(filename, "r")
+        f = h5py.File(filename, mode="r")
         if group_name is not None:
             g = f[group_name]
         else:

--- a/yt/utilities/amr_kdtree/amr_kdtree.py
+++ b/yt/utilities/amr_kdtree/amr_kdtree.py
@@ -438,7 +438,7 @@ class AMRKDTree(ParallelAnalysisInterface):
             fn = '%s_kd_bricks.h5'%self.ds
         if self.comm.rank != 0:
             self.comm.recv_array(self.comm.rank-1, tag=self.comm.rank-1)
-        f = h5py.File(fn,'w')
+        f = h5py.File(fn, mode='w')
         for node in self.tree.depth_traverse():
             i = node.node_id
             if node.data is not None:
@@ -458,7 +458,7 @@ class AMRKDTree(ParallelAnalysisInterface):
         if self.comm.rank != 0:
             self.comm.recv_array(self.comm.rank-1, tag=self.comm.rank-1)
         try:
-            f = h5py.File(fn,"a")
+            f = h5py.File(fn, mode="a")
             for node in self.tree.depth_traverse():
                 i = node.node_id
                 if node.grid != -1:

--- a/yt/utilities/answer_testing/answer_tests.py
+++ b/yt/utilities/answer_testing/answer_tests.py
@@ -283,7 +283,7 @@ def light_cone_projection(parameter_file, simulation_type):
     lc.project_light_cone(
         (600.0, "arcmin"), (60.0, "arcsec"), "density",
         weight_field=None, save_stack=True)
-    fh = h5py.File("LC/LightCone.h5", "r")
+    fh = h5py.File("LC/LightCone.h5", mode="r")
     data = fh["density_None"].value
     units = fh["density_None"].attrs["units"]
     assert units == "g/cm**2"

--- a/yt/utilities/file_handler.py
+++ b/yt/utilities/file_handler.py
@@ -39,7 +39,7 @@ class HDF5FileHandler(object):
     handle = None
 
     def __init__(self, filename):
-        self.handle = h5py.File(filename, 'r')
+        self.handle = h5py.File(filename, mode='r')
 
     def __getitem__(self, key):
         return self.handle[key]

--- a/yt/utilities/grid_data_format/writer.py
+++ b/yt/utilities/grid_data_format/writer.py
@@ -224,10 +224,10 @@ def _get_backup_file(ds):
         if communication_system.communicators[-1].size > 1 and \
                 h5py.get_config().mpi:
             mpi4py_communicator = communication_system.communicators[-1].comm
-            f = h5py.File(backup_filename, "r+", driver='mpio', 
+            f = h5py.File(backup_filename, mode="r+", driver='mpio', 
                           comm=mpi4py_communicator)
         else:
-            f = h5py.File(backup_filename, "r+")
+            f = h5py.File(backup_filename, mode="r+")
         yield f
         f.close()
     else:
@@ -266,10 +266,10 @@ def _create_new_gdf(ds, gdf_path, data_author=None, data_comment=None,
     if communication_system.communicators[-1].size > 1 and \
             h5py.get_config().mpi:
         mpi4py_communicator = communication_system.communicators[-1].comm
-        f = h5py.File(gdf_path, "w", driver='mpio', 
+        f = h5py.File(gdf_path, mode="w", driver='mpio', 
                       comm=mpi4py_communicator)
     else:
-        f = h5py.File(gdf_path, "w")
+        f = h5py.File(gdf_path, mode="w")
 
     ###
     # "gridded_data_format" group

--- a/yt/utilities/io_handler.py
+++ b/yt/utilities/io_handler.py
@@ -88,7 +88,7 @@ class BaseIOHandler(object):
 
     def _field_in_backup(self, grid, backup_file, field_name):
         if os.path.exists(backup_file):
-            fhandle = h5py.File(backup_file, 'r')
+            fhandle = h5py.File(backup_file, mode='r')
             g = fhandle["data"]
             grid_group = g["grid_%010i" % (grid.id - grid._id_offset)]
             if field_name in grid_group:
@@ -107,7 +107,7 @@ class BaseIOHandler(object):
         if not grid.ds.read_from_backup:
             return self._read_data(grid, field)
         elif self._field_in_backup(grid, backup_filename, field):
-            fhandle = h5py.File(backup_filename, 'r')
+            fhandle = h5py.File(backup_filename, mode='r')
             g = fhandle["data"]
             grid_group = g["grid_%010i" % (grid.id - grid._id_offset)]
             data = grid_group[field][:]

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -291,7 +291,7 @@ class FixedResolutionBuffer(object):
             These fields will be pixelized and output.
         """
         if fields is None: fields = list(self.data.keys())
-        output = h5py.File(filename, "a")
+        output = h5py.File(filename, mode="a")
         for field in fields:
             output.create_dataset(field,data=self[field])
         output.close()

--- a/yt/visualization/volume_rendering/image_handling.py
+++ b/yt/visualization/volume_rendering/image_handling.py
@@ -26,7 +26,7 @@ def export_rgba(image, fn, h5=True, fits=False, ):
     if (not h5 and not fits) or (h5 and fits):
         raise ValueError("Choose either HDF5 or FITS format!")
     if h5:
-        f = h5py.File('%s.h5'%fn, "w")
+        f = h5py.File('%s.h5'%fn, mode="w")
         f.create_dataset("R", data=image[:,:,0])
         f.create_dataset("G", data=image[:,:,1])
         f.create_dataset("B", data=image[:,:,2])
@@ -49,7 +49,7 @@ def import_rgba(name, h5=True):
     in.
     """
     if h5:
-        f = h5py.File(name, "r")
+        f = h5py.File(name, mode="r")
         r = f['R'].value
         g = f['G'].value
         b = f['B'].value


### PR DESCRIPTION
## PR Summary

This is built on top of #2594 as per suggested there.

for reference this change was performed automatically with the following script:
```python
import re
from pathlib import Path

yt_dir = Path(__file__).parent.parent

exp = re.compile("""h5py\.File\([^,]+,\s*['"]""")

def repl_exp(matchobj):
    core = matchobj.group(0)[:-1].rstrip()
    sep = matchobj.group(0)[-1]
    return f"{core} mode={sep}"

for file in yt_dir.glob("**/*.py"):
    with open(file, mode="r") as fileobj:
        text = fileobj.read()

    if (new_text := exp.sub(repl_exp, text)) == text:
        continue

    with open(file, mode="w") as fileobj:
        fileobj.write(new_text)
```