### PR TITLE
[yt-4.0] check for bbox before reverting to all_data

### DIFF
--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -953,7 +953,7 @@ cdef class RegionSelector(SelectorObject):
         re_all = (np.array(RE) == _ensure_code(dobj.ds.domain_right_edge)).all()
         # If we have a bounding box, then we should *not* revert to all data
         domain_override = getattr(dobj.ds, '_domain_override', False)
-        if le_all and re_all and not dobj.ds._domain_override:
+        if le_all and re_all and not domain_override:
             self.is_all_data = True
         else:
             self.is_all_data = False

--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -951,7 +951,9 @@ cdef class RegionSelector(SelectorObject):
         cdef np.float64_t[:] DRE = _ensure_code(dobj.ds.domain_right_edge)
         le_all = (np.array(LE) == _ensure_code(dobj.ds.domain_left_edge)).all()
         re_all = (np.array(RE) == _ensure_code(dobj.ds.domain_right_edge)).all()
-        if le_all and re_all:
+        # If we have a bounding box, then we should *not* revert to all data
+        domain_override = getattr(dobj.ds, '_domain_override', False)
+        if le_all and re_all and not dobj.ds._domain_override:
             self.is_all_data = True
         else:
             self.is_all_data = False


### PR DESCRIPTION
## PR Summary

Prior to this PR the code says if the edges of the selected region are equal to the domain edges then we need to return **every** particle stored on disk.

This is **not true** if a bounding box has been applied. I've added a check for a `_domain_override`

This fixes the example I posted in #2612

## PR Checklist

- [ ] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.