### PR TITLE
Fields autocompletion for data objects

### DIFF
--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -267,7 +267,11 @@ class YTDataContainer(metaclass = RegisteredDataContainer):
             rv = self.ds.arr(self.field_data[key], fi.units)
         return rv
 
-
+    def _ipython_key_completions_(self):
+        keys = self.ds.field_list + self.ds.derived_field_list
+        types = list(set(k[0] for k in keys))
+        labels = list(set(k[1] for k in keys))
+        return types + labels
 
     def __setitem__(self, key, val):
         """

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -257,14 +257,17 @@ class YTDataContainer(metaclass = RegisteredDataContainer):
         # hanging off the dataset to define this unit object.
         # Note that this is less succinct so that we can account for the case
         # when there are, for example, no elements in the object.
-        rv = self.field_data.get(f, None)
-        if rv is None:
+        try:
+            rv = self.field_data[f]
+        except KeyError:
             if isinstance(f, tuple):
                 fi = self.ds._get_field_info(*f)
             elif isinstance(f, bytes):
                 fi = self.ds._get_field_info("unknown", f)
             rv = self.ds.arr(self.field_data[key], fi.units)
         return rv
+
+
 
     def __setitem__(self, key, val):
         """

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1,5 +1,6 @@
 import itertools
 import uuid
+from distutils.version import LooseVersion
 
 import numpy as np
 import weakref
@@ -269,10 +270,14 @@ class YTDataContainer(metaclass = RegisteredDataContainer):
 
     def _ipython_key_completions_(self):
         # to keep in sync with yt.data_objects.region_expression.RegionExpression
+        from IPython import __version__ as IPY_VERSION
+
         keys = self.ds.field_list + self.ds.derived_field_list
-        ftypes = list(set(k[0] for k in keys))
+        if LooseVersion(IPY_VERSION) >= LooseVersion("8.0.0"):
+            return keys
+
         fnames = list(set(k[1] for k in keys))
-        return ftypes + fnames
+        return fnames
 
     def __setitem__(self, key, val):
         """

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -269,9 +269,9 @@ class YTDataContainer(metaclass = RegisteredDataContainer):
 
     def _ipython_key_completions_(self):
         keys = self.ds.field_list + self.ds.derived_field_list
-        types = list(set(k[0] for k in keys))
-        labels = list(set(k[1] for k in keys))
-        return types + labels
+        ftypes = list(set(k[0] for k in keys))
+        fnames = list(set(k[1] for k in keys))
+        return ftypes + fnames
 
     def __setitem__(self, key, val):
         """

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1,6 +1,5 @@
 import itertools
 import uuid
-from distutils.version import LooseVersion
 
 import numpy as np
 import weakref
@@ -74,6 +73,14 @@ def sanitize_weight_field(ds, field, weight):
     else:
         weight_field = weight
     return weight_field
+
+def _get_ipython_key_completion(ds):
+    # tuple-completion (ftype, fname) was added in IPython 8.0.0
+    # with earlier versions, completion works with fname only
+    # this implementation should work transparently with all IPython versions
+    tuple_keys = ds.field_list + ds.derived_field_list
+    fnames = list(set(k[1] for k in tuple_keys))
+    return tuple_keys + fnames
 
 class RegisteredDataContainer(type):
     def __init__(cls, name, b, d):
@@ -269,15 +276,7 @@ class YTDataContainer(metaclass = RegisteredDataContainer):
         return rv
 
     def _ipython_key_completions_(self):
-        # to keep in sync with yt.data_objects.region_expression.RegionExpression
-        from IPython import __version__ as IPY_VERSION
-
-        keys = self.ds.field_list + self.ds.derived_field_list
-        if LooseVersion(IPY_VERSION) >= LooseVersion("8.0.0"):
-            return keys
-
-        fnames = list(set(k[1] for k in keys))
-        return fnames
+        return _get_ipython_key_completion(self.ds)
 
     def __setitem__(self, key, val):
         """

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -268,6 +268,7 @@ class YTDataContainer(metaclass = RegisteredDataContainer):
         return rv
 
     def _ipython_key_completions_(self):
+        # to keep in sync with yt.data_objects.region_expression.RegionExpression
         keys = self.ds.field_list + self.ds.derived_field_list
         ftypes = list(set(k[0] for k in keys))
         fnames = list(set(k[1] for k in keys))

--- a/yt/data_objects/region_expression.py
+++ b/yt/data_objects/region_expression.py
@@ -63,6 +63,13 @@ class RegionExpression(object):
                 return self.all_data
             return self._create_region(item)
 
+    def _ipython_key_completions_(self):
+        # to keep in sync with yt.data_objects.data_containers.YTDataContainer
+        keys = self.ds.field_list + self.ds.derived_field_list
+        ftypes = list(set(k[0] for k in keys))
+        fnames = list(set(k[1] for k in keys))
+        return ftypes + fnames
+
     def _spec_to_value(self, input):
         if isinstance(input, tuple):
             v = self.ds.quan(input[0], input[1]).to("code_length")

--- a/yt/data_objects/region_expression.py
+++ b/yt/data_objects/region_expression.py
@@ -1,10 +1,10 @@
-from distutils.version import LooseVersion
 import weakref
 
 from yt.funcs import obj_length
 from yt.units.yt_array import YTQuantity
 from yt.utilities.exceptions import YTDimensionalityError
 from yt.visualization.line_plot import LineBuffer
+from .data_containers import _get_ipython_key_completion
 
 class RegionExpression(object):
     _all_data = None
@@ -65,15 +65,7 @@ class RegionExpression(object):
             return self._create_region(item)
 
     def _ipython_key_completions_(self):
-        # to keep in sync with yt.data_objects.data_containers.YTDataContainer
-        from IPython import __version__ as IPY_VERSION
-
-        keys = self.ds.field_list + self.ds.derived_field_list        
-        if LooseVersion(IPY_VERSION) >= LooseVersion("8.0.0"):
-            return keys
-
-        fnames = list(set(k[1] for k in keys))
-        return fnames
+        return _get_ipython_key_completion(self.ds)
 
     def _spec_to_value(self, input):
         if isinstance(input, tuple):

--- a/yt/data_objects/region_expression.py
+++ b/yt/data_objects/region_expression.py
@@ -1,3 +1,4 @@
+from distutils.version import LooseVersion
 import weakref
 
 from yt.funcs import obj_length
@@ -65,10 +66,14 @@ class RegionExpression(object):
 
     def _ipython_key_completions_(self):
         # to keep in sync with yt.data_objects.data_containers.YTDataContainer
-        keys = self.ds.field_list + self.ds.derived_field_list
-        ftypes = list(set(k[0] for k in keys))
+        from IPython import __version__ as IPY_VERSION
+
+        keys = self.ds.field_list + self.ds.derived_field_list        
+        if LooseVersion(IPY_VERSION) >= LooseVersion("8.0.0"):
+            return keys
+
         fnames = list(set(k[1] for k in keys))
-        return ftypes + fnames
+        return fnames
 
     def _spec_to_value(self, input):
         if isinstance(input, tuple):


### PR DESCRIPTION
## PR Summary

fix #2397
This is a simple implementation of the `_ipython_key_completion_` method for data objects.

**example**

![Screenshot 2020-06-12 at 20 22 09](https://user-images.githubusercontent.com/14075922/84534600-844a2d80-acea-11ea-9f77-3eed0ad29db1.png)

**limitation**
I couldn't find how to make it work with the double key syntax yet, e.g

```python
ad = ds.all_data()
ad["gas", "<TAB>
```