### PR TITLE
Cleanup some old python 2 idioms

### DIFF
--- a/yt/config.py
+++ b/yt/config.py
@@ -109,7 +109,7 @@ if not os.path.exists(CURRENT_CONFIG_FILE):
     except IOError:
         warnings.warn("unable to write new config file")
 
-class YTConfigParser(configparser.ConfigParser, object):
+class YTConfigParser(configparser.ConfigParser):
     def __setitem__(self, key, val):
         self.set(key[0], key[1], val)
 

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -1073,7 +1073,7 @@ class YTArbitraryGrid(YTCoveringGrid):
 
         return bounds, size
 
-class LevelState(object):
+class LevelState:
     current_dx = None
     current_dims = None
     current_level = None

--- a/yt/data_objects/derived_quantities.py
+++ b/yt/data_objects/derived_quantities.py
@@ -72,7 +72,7 @@ class DerivedQuantity(ParallelAnalysisInterface, metaclass = RegisteredDerivedQu
     def reduce_intermediate(self, values):
         raise NotImplementedError
 
-class DerivedQuantityCollection(object):
+class DerivedQuantityCollection:
     def __new__(cls, data_source, *args, **kwargs):
         inst = object.__new__(cls)
         inst.data_source = data_source

--- a/yt/data_objects/level_sets/clump_info_items.py
+++ b/yt/data_objects/level_sets/clump_info_items.py
@@ -8,7 +8,7 @@ clump_info_registry = OperatorRegistry()
 def add_clump_info(name, function):
     clump_info_registry[name] = ClumpInfoCallback(name, function)
 
-class ClumpInfoCallback(object):
+class ClumpInfoCallback:
     r"""
     A ClumpInfoCallback is a function that takes a clump, computes a 
     quantity, and returns a string to be printed out for writing clump info.

--- a/yt/data_objects/level_sets/clump_validators.py
+++ b/yt/data_objects/level_sets/clump_validators.py
@@ -12,7 +12,7 @@ clump_validator_registry = OperatorRegistry()
 def add_validator(name, function):
     clump_validator_registry[name] = ClumpValidator(function)
 
-class ClumpValidator(object):
+class ClumpValidator:
     r"""
     A ClumpValidator is a function that takes a clump and returns 
     True or False as to whether the clump is valid and shall be kept.

--- a/yt/data_objects/octree_subset.py
+++ b/yt/data_objects/octree_subset.py
@@ -446,7 +446,7 @@ class OctreeSubset(YTSelectionContainer):
         mask = selector.select_points(x,y,z, 0.0)
         return mask
 
-class OctreeSubsetBlockSlicePosition(object):
+class OctreeSubsetBlockSlicePosition:
     def __init__(self, ind, block_slice):
         self.ind = ind
         self.block_slice = block_slice
@@ -497,7 +497,7 @@ class OctreeSubsetBlockSlicePosition(object):
         yield self.block_slice.octree_subset._field_parameter_state(
                 field_parameters)
 
-class OctreeSubsetBlockSlice(object):
+class OctreeSubsetBlockSlice:
     def __init__(self, octree_subset):
         self.octree_subset = octree_subset
         # Cache some attributes

--- a/yt/data_objects/particle_filters.py
+++ b/yt/data_objects/particle_filters.py
@@ -9,13 +9,13 @@ from yt.utilities.exceptions import YTIllDefinedFilter
 # One to one mapping
 filter_registry = {}
 
-class DummyFieldInfo(object):
+class DummyFieldInfo:
     particle_type = True
     sampling_type = 'particle'
 
 dfi = DummyFieldInfo()
 
-class ParticleFilter(object):
+class ParticleFilter:
     def __init__(self, name, function, requires, filtered_type):
         self.name = name
         self.function = function

--- a/yt/data_objects/particle_trajectories.py
+++ b/yt/data_objects/particle_trajectories.py
@@ -11,7 +11,7 @@ from collections import OrderedDict
 import numpy as np
 from yt.utilities.on_demand_imports import _h5py as h5py
 
-class ParticleTrajectories(object):
+class ParticleTrajectories:
     r"""A collection of particle trajectories in time over a series of
     datasets.
 

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -61,7 +61,7 @@ def preserve_source_parameters(func):
         return tr
     return save_state
 
-class ProfileFieldAccumulator(object):
+class ProfileFieldAccumulator:
     def __init__(self, n_fields, size):
         shape = size + (n_fields,)
         self.values = np.zeros(shape, dtype="float64")

--- a/yt/data_objects/region_expression.py
+++ b/yt/data_objects/region_expression.py
@@ -5,7 +5,7 @@ from yt.units.yt_array import YTQuantity
 from yt.utilities.exceptions import YTDimensionalityError
 from yt.visualization.line_plot import LineBuffer
 
-class RegionExpression(object):
+class RegionExpression:
     _all_data = None
     def __init__(self, ds):
         self.ds = weakref.proxy(ds)

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -89,7 +89,7 @@ class RegisteredDataset(type):
         output_type_registry[name] = cls
         mylog.debug("Registering: %s as %s", name, cls)
 
-class IndexProxy(object):
+class IndexProxy:
     # This is a simple proxy for Index objects.  It enables backwards
     # compatibility so that operations like .h.sphere, .h.print_stats and
     # .h.grid_left_edge will correctly pass through to the various dataset or
@@ -107,7 +107,7 @@ class IndexProxy(object):
             return getattr(self.ds.index, name)
         raise AttributeError
 
-class MutableAttribute(object):
+class MutableAttribute:
     """A descriptor for mutable data"""
     def __init__(self, display_array = False):
         self.data = weakref.WeakKeyDictionary()
@@ -1522,7 +1522,7 @@ def _reconstruct_ds(*args, **kwargs):
     return ds
 
 @functools.total_ordering
-class ParticleFile(object):
+class ParticleFile:
     def __init__(self, ds, io, filename, file_id, range = None):
         self.ds = ds
         self.io = weakref.proxy(io)

--- a/yt/data_objects/tests/test_derived_quantities.py
+++ b/yt/data_objects/tests/test_derived_quantities.py
@@ -1,4 +1,4 @@
-from __future__ import division
+
 
 import numpy as np
 import yt

--- a/yt/data_objects/tests/test_octree.py
+++ b/yt/data_objects/tests/test_octree.py
@@ -12,7 +12,7 @@ def test_building_tree():
     '''
     ds = fake_sph_grid_ds()
     octree = ds.octree(n_ref=1)
-    assert(type(octree) == YTOctree)
+    assert(type(octree) is YTOctree)
     assert(octree[('index', 'x')].shape[0] == 456)
 
 def test_saving_loading():

--- a/yt/data_objects/tests/test_particle_filter.py
+++ b/yt/data_objects/tests/test_particle_filter.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 
 import numpy as np
 import os

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -31,7 +31,7 @@ from yt.utilities.parallel_tools.parallel_analysis_interface \
 from yt.utilities.parameter_file_storage import \
     simulation_time_series_registry
      
-class AnalysisTaskProxy(object):
+class AnalysisTaskProxy:
     def __init__(self, time_series):
         self.time_series = time_series
 
@@ -75,7 +75,7 @@ attrs = ("refine_by", "dimensionality", "current_time",
          "omega_matter", "omega_lambda", "omega_radiation",
          "hubble_constant")
 
-class TimeSeriesParametersContainer(object):
+class TimeSeriesParametersContainer:
     def __init__(self, data_object):
         self.data_object = data_object
 
@@ -84,7 +84,7 @@ class TimeSeriesParametersContainer(object):
             return self.data_object.eval(get_ds_prop(attr)())
         raise AttributeError(attr)
 
-class DatasetSeries(object):
+class DatasetSeries:
     r"""The DatasetSeries object is a container of multiple datasets,
     allowing easy iteration and computation on them.
 
@@ -449,7 +449,7 @@ class DatasetSeries(object):
         return ParticleTrajectories(self, indices, fields=fields, suppress_logging=suppress_logging,
                                     ptype=ptype)
 
-class TimeSeriesQuantitiesContainer(object):
+class TimeSeriesQuantitiesContainer:
     def __init__(self, data_object, quantities):
         self.data_object = data_object
         self.quantities = quantities
@@ -465,7 +465,7 @@ class TimeSeriesQuantitiesContainer(object):
             return run_quantity
         return run_quantity_wrapper(q, key)
 
-class DatasetSeriesObject(object):
+class DatasetSeriesObject:
     def __init__(self, time_series, data_object_name, *args, **kwargs):
         self.time_series = weakref.proxy(time_series)
         self.data_object_name = data_object_name

--- a/yt/data_objects/unions.py
+++ b/yt/data_objects/unions.py
@@ -1,6 +1,6 @@
 from yt.funcs import ensure_list
 
-class Union(object):
+class Union:
     _union_type = ""
     def __init__(self, name, sub_types):
         self.name = name

--- a/yt/exthook.py
+++ b/yt/exthook.py
@@ -24,7 +24,7 @@ import sys
 import os
 
 
-class ExtensionImporter(object):
+class ExtensionImporter:
     """This importer redirects imports from this submodule to other locations.
     This makes it possible to transition from the old flaskext.name to the
     newer flask_name without people having a hard time.

--- a/yt/fields/derived_field.py
+++ b/yt/fields/derived_field.py
@@ -32,7 +32,7 @@ def TranslationFunc(field_name):
 def NullFunc(field, data):
     raise YTFieldNotFound(field.name)
 
-class DerivedField(object):
+class DerivedField:
     """
     This is the base class used to describe a cell-by-cell derived field.
 
@@ -412,7 +412,7 @@ class DerivedField(object):
         return label
 
 
-class FieldValidator(object):
+class FieldValidator:
     pass
 
 class ValidateParameter(FieldValidator):

--- a/yt/fields/domain_context.py
+++ b/yt/fields/domain_context.py
@@ -1,6 +1,6 @@
 domain_context_registry = {}
 
-class DomainContext(object):
+class DomainContext:
     class __metaclass__(type):
         def __init__(cls, name, b, d):
             type.__init__(cls, name, b, d)

--- a/yt/fields/field_detector.py
+++ b/yt/fields/field_detector.py
@@ -58,8 +58,8 @@ class FieldDetector(defaultdict):
             ds.periodicity = (True, True, True)
         self.ds = ds
 
-        class fake_index(object):
-            class fake_io(object):
+        class fake_index:
+            class fake_io:
                 def _read_data_set(io_self, data, field):
                     return self._read_data(field)
                 _read_exception = RuntimeError

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -401,7 +401,7 @@ class FieldInfoContainer(dict):
             except Exception as e:
                 if field in self._show_field_errors:
                     raise
-                if type(e) != YTFieldNotFound:
+                if not isinstance(e, YTFieldNotFound):
                     # if we're doing field tests, raise an error
                     # see yt.fields.tests.test_fields
                     if hasattr(self.ds, '_field_test_dataset'):

--- a/yt/fields/tests/test_fields.py
+++ b/yt/fields/tests/test_fields.py
@@ -61,7 +61,7 @@ def _strip_ftype(field):
     return field[1]
 
 
-class TestFieldAccess(object):
+class TestFieldAccess:
     description = None
 
     def __init__(self, field_name, ds, nprocs):

--- a/yt/fields/tests/test_fields.py
+++ b/yt/fields/tests/test_fields.py
@@ -405,19 +405,19 @@ def test_ion_field_labels():
     ds = fake_random_ds(16, fields=fields, units=units)
 
     # by default labels should use roman numerals
-    default_labels = {"O_p1_number_density":u"$\\rm{O\ II\ Number\ Density}$",
-                      "O2_p1_number_density":u"$\\rm{O_{2}\ II\ Number\ Density}$",
-                      "CO2_p1_number_density":u"$\\rm{CO_{2}\ II\ Number\ Density}$",
-                      "Co_p1_number_density":u"$\\rm{Co\ II\ Number\ Density}$",
-                      "O2_p2_number_density":u"$\\rm{O_{2}\ III\ Number\ Density}$",
-                      "H2O_p1_number_density":u"$\\rm{H_{2}O\ II\ Number\ Density}$"}
+    default_labels = {"O_p1_number_density":"$\\rm{O\ II\ Number\ Density}$",
+                      "O2_p1_number_density":"$\\rm{O_{2}\ II\ Number\ Density}$",
+                      "CO2_p1_number_density":"$\\rm{CO_{2}\ II\ Number\ Density}$",
+                      "Co_p1_number_density":"$\\rm{Co\ II\ Number\ Density}$",
+                      "O2_p2_number_density":"$\\rm{O_{2}\ III\ Number\ Density}$",
+                      "H2O_p1_number_density":"$\\rm{H_{2}O\ II\ Number\ Density}$"}
 
-    pm_labels = {"O_p1_number_density":u"$\\rm{{O}^{+}\ Number\ Density}$",
-                 "O2_p1_number_density":u"$\\rm{{O_{2}}^{+}\ Number\ Density}$",
-                 "CO2_p1_number_density":u"$\\rm{{CO_{2}}^{+}\ Number\ Density}$",
-                 "Co_p1_number_density":u"$\\rm{{Co}^{+}\ Number\ Density}$",
-                 "O2_p2_number_density":u"$\\rm{{O_{2}}^{++}\ Number\ Density}$",
-                 "H2O_p1_number_density":u"$\\rm{{H_{2}O}^{+}\ Number\ Density}$"}
+    pm_labels = {"O_p1_number_density":"$\\rm{{O}^{+}\ Number\ Density}$",
+                 "O2_p1_number_density":"$\\rm{{O_{2}}^{+}\ Number\ Density}$",
+                 "CO2_p1_number_density":"$\\rm{{CO_{2}}^{+}\ Number\ Density}$",
+                 "Co_p1_number_density":"$\\rm{{Co}^{+}\ Number\ Density}$",
+                 "O2_p2_number_density":"$\\rm{{O_{2}}^{++}\ Number\ Density}$",
+                 "H2O_p1_number_density":"$\\rm{{H_{2}O}^{+}\ Number\ Density}$"}
 
     fobj = ds.fields.stream
 

--- a/yt/fields/xray_emission_fields.py
+++ b/yt/fields/xray_emission_fields.py
@@ -55,7 +55,7 @@ class ObsoleteDataException(YTException):
         return self.msg
 
 
-class XrayEmissivityIntegrator(object):
+class XrayEmissivityIntegrator:
     r"""Class for making X-ray emissivity fields. Uses hdf5 data tables
     generated from Cloudy and AtomDB/APEC.
 

--- a/yt/frontends/art/data_structures.py
+++ b/yt/frontends/art/data_structures.py
@@ -719,7 +719,7 @@ class ARTDomainSubset(OctreeSubset):
                 source)
         return tr
 
-class ARTDomainFile(object):
+class ARTDomainFile:
     """
     Read in the AMR, left/right edges, fill out the octhandler
     """

--- a/yt/frontends/art/io.py
+++ b/yt/frontends/art/io.py
@@ -308,7 +308,7 @@ def _read_art_level_info(f, level_oct_offsets, level, coarse_grid=128,
     fl = np.ones((nLevel, 6), dtype='int64')
     iocts = np.zeros(nLevel+1, dtype='int64')
     idxa, idxb = 0, 0
-    chunk = long(1e6)  # this is ~111MB for 15 dimensional 64 bit arrays
+    chunk = int(1e6)  # this is ~111MB for 15 dimensional 64 bit arrays
     left = nLevel
     while left > 0:
         this_chunk = min(chunk, left)
@@ -472,7 +472,7 @@ def _read_child_mask_level(f, level_child_offsets, level, nLevel, nhydro_vars):
     ioctch = np.zeros(nLevel, dtype='uint8')
     idc = np.zeros(nLevel, dtype='int32')
 
-    chunk = long(1e6)
+    chunk = int(1e6)
     left = nLevel
     width = nhydro_vars+6
     a, b = 0, 0

--- a/yt/frontends/artio/definitions.py
+++ b/yt/frontends/artio/definitions.py
@@ -30,7 +30,7 @@ yt_to_art = {
 art_to_yt = dict(zip(yt_to_art.values(), yt_to_art.keys()))
 
 
-class ARTIOconstants():
+class ARTIOconstants:
     def __init__(self):
         self.yr = 365.25*86400
         self.Myr = 1.0e6*self.yr

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -123,7 +123,7 @@ class BoxlibGrid(AMRGridPatch):
              startIndex[2]:endIndex[2]] = tofill
 
 
-class BoxLibParticleHeader(object):
+class BoxLibParticleHeader:
 
     def __init__(self, ds, directory_name, is_checkpoint, 
                  extra_field_names=None):
@@ -220,7 +220,7 @@ class BoxLibParticleHeader(object):
                                             for t in self.known_real_fields])
 
 
-class AMReXParticleHeader(object):
+class AMReXParticleHeader:
 
     def __init__(self, ds, directory_name, is_checkpoint, 
                  extra_field_names=None):
@@ -1405,7 +1405,7 @@ def _read_header(raw_file, field):
     return nghost, all_boxes, all_file_names, all_offsets
 
 
-class WarpXHeader(object):
+class WarpXHeader:
     def __init__(self, header_fn):
         self.data = {}
         with open(header_fn, "r") as f:

--- a/yt/frontends/chombo/io.py
+++ b/yt/frontends/chombo/io.py
@@ -33,7 +33,7 @@ class IOHandlerChomboHDF5(BaseIOHandler):
         self._offsets = {}
         num_comp = self._handle.attrs['num_components']
         level = 0
-        while 1:
+        while True:
             lname = 'level_%i' % level
             if lname not in self._handle: break
             boxes = self._handle['level_0']['boxes'][()]

--- a/yt/frontends/enzo/answer_testing_support.py
+++ b/yt/frontends/enzo/answer_testing_support.py
@@ -15,7 +15,7 @@ from yt.utilities.answer_testing.framework import \
     temp_cwd
 
 
-class AssertWrapper(object):
+class AssertWrapper:
     """
     Used to wrap a numpy testing assertion, in order to provide a useful name
     for a given assertion test.
@@ -67,7 +67,7 @@ def standard_small_simulation(ds_fn, fields):
             yield FieldValuesTest(
                     ds_fn, field, dobj_name, decimals=tolerance)
                     
-class ShockTubeTest(object):
+class ShockTubeTest:
     def __init__(self, data_file, solution_file, fields, 
                  left_edges, right_edges, rtol, atol):
         self.solution_file = solution_file

--- a/yt/frontends/enzo/data_structures.py
+++ b/yt/frontends/enzo/data_structures.py
@@ -1,5 +1,3 @@
-
-
 from yt.utilities.on_demand_imports import _h5py as h5py
 import io
 import weakref

--- a/yt/frontends/enzo/data_structures.py
+++ b/yt/frontends/enzo/data_structures.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 from yt.utilities.on_demand_imports import _h5py as h5py
 import io

--- a/yt/frontends/enzo_p/data_structures.py
+++ b/yt/frontends/enzo_p/data_structures.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 from yt.utilities.on_demand_imports import \
     _h5py as h5py

--- a/yt/frontends/enzo_p/data_structures.py
+++ b/yt/frontends/enzo_p/data_structures.py
@@ -1,5 +1,3 @@
-
-
 from yt.utilities.on_demand_imports import \
     _h5py as h5py
 from yt.utilities.on_demand_imports import \

--- a/yt/frontends/fits/misc.py
+++ b/yt/frontends/fits/misc.py
@@ -179,7 +179,7 @@ def ds9_region(ds, reg, obj=None, field_parameters=None):
             obj.set_field_parameter(k,v)
     return obj.cut_region(["obj['%s'] > 0" % (reg_name)])
 
-class PlotWindowWCS(object):
+class PlotWindowWCS:
     r"""
     Use AstroPy's WCSAxes class to plot celestial coordinates on the axes of a
     on-axis PlotWindow plot. See 

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -35,7 +35,7 @@ def _byte_swap_32(x):
     return struct.unpack('>I', struct.pack('<I', x))[0]
 
 
-class GadgetBinaryHeader(object):
+class GadgetBinaryHeader:
     """A convenient interface to Gadget binary header.
     
     This is a helper class to facilitate the main dataset and IO classes.

--- a/yt/frontends/open_pmd/data_structures.py
+++ b/yt/frontends/open_pmd/data_structures.py
@@ -197,7 +197,7 @@ class OpenPMDHierarchy(GridIndex):
             meshes = f[bp + mp]
             for mname in meshes.keys():
                 mesh = meshes[mname]
-                if type(mesh) is h5.Group:
+                if isinstance(mesh, h5.Group):
                     shape = mesh[list(mesh.keys())[0]].shape
                 else:
                     shape = mesh.shape
@@ -495,7 +495,7 @@ class OpenPMDDataset(Dataset):
             meshes = f[bp + mp]
             for mname in meshes.keys():
                 mesh = meshes[mname]
-                if type(mesh) is h5.Group:
+                if isinstance(mesh, h5.Group):
                     shape = np.asarray(mesh[list(mesh.keys())[0]].shape)
                 else:
                     shape = np.asarray(mesh.shape)

--- a/yt/frontends/open_pmd/fields.py
+++ b/yt/frontends/open_pmd/fields.py
@@ -128,7 +128,7 @@ class OpenPMDFieldInfo(FieldInfoContainer):
             fields = f[bp + mp]
             for fname in fields.keys():
                 field = fields[fname]
-                if type(field) is h5.Dataset or is_const_component(field):
+                if isinstance(field, h5.Dataset) or is_const_component(field):
                     # Don't consider axes. This appears to be a vector field of single dimensionality
                     ytname = str("_".join([fname.replace("_", "-")]))
                     parsed = parse_unit_dimension(np.asarray(field.attrs["unitDimension"], dtype=np.int))
@@ -169,7 +169,7 @@ class OpenPMDFieldInfo(FieldInfoContainer):
                             # Symbolically rename position to preserve yt's interpretation of the pfield
                             # particle_position is later derived in setup_absolute_positions in the way yt expects it
                             ytattrib = "positionCoarse"
-                        if type(record) is h5.Dataset or is_const_component(record):
+                        if isinstance(record, h5.Dataset) or is_const_component(record):
                             name = ["particle", ytattrib]
                             self.known_particle_fields += ((str("_".join(name)), (unit, [], None)),)
                         else:

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -36,7 +36,7 @@ from yt.utilities.lib.cosmology_time import \
 
 from .io_utils import read_amr, fill_hydro
 
-class RAMSESDomainFile(object):
+class RAMSESDomainFile:
     _last_mask = None
     _last_selector_id = None
 

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -106,7 +106,7 @@ class StreamGrid(AMRGridPatch):
         return [self.index.grids[cid - self._id_offset]
                 for cid in self._children_ids]
 
-class StreamHandler(object):
+class StreamHandler:
     def __init__(self, left_edges, right_edges, dimensions,
                  levels, parent_ids, particle_count, processor_ids,
                  fields, field_units, code_units, io = None,

--- a/yt/frontends/swift/tests/test_outputs.py
+++ b/yt/frontends/swift/tests/test_outputs.py
@@ -15,7 +15,7 @@ EAGLE_6 = "EAGLE_6/eagle_0005.hdf5"
 @requires_file(keplerian_ring)
 def test_non_cosmo_dataset():
     ds = load(keplerian_ring)
-    assert(type(ds) == SwiftDataset)
+    assert(type(ds) is SwiftDataset)
 
     field = ('gas', 'density')
     ad = ds.all_data()

--- a/yt/frontends/tipsy/data_structures.py
+++ b/yt/frontends/tipsy/data_structures.py
@@ -148,7 +148,7 @@ class TipsyDataset(SPHDataset):
                 param, val = (i.strip() for i in line.split('=', 1))
                 val = val.split('#')[0]
                 if param.startswith('n') or param.startswith('i'):
-                    val = long(val)
+                    val = int(val)
                 elif param.startswith('d'):
                     val = float(val)
                 elif param.startswith('b'):

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -314,7 +314,7 @@ def insert_ipython(num_up=1):
 # Our progress bar types and how to get one
 #
 
-class TqdmProgressBar(object):
+class TqdmProgressBar:
     # This is a drop in replacement for pbar
     # called tqdm
     def __init__(self,title, maxval):
@@ -329,7 +329,7 @@ class TqdmProgressBar(object):
     def finish(self):
         self._pbar.close()
 
-class DummyProgressBar(object):
+class DummyProgressBar:
     # This progressbar gets handed if we don't
     # want ANY output
     def __init__(self, *args, **kwargs):
@@ -339,7 +339,7 @@ class DummyProgressBar(object):
     def finish(self, *args, **kwargs):
         return
 
-class ParallelProgressBar(object):
+class ParallelProgressBar:
     # This is just a simple progress bar
     # that prints on start/stop
     def __init__(self, title, maxval):
@@ -350,7 +350,7 @@ class ParallelProgressBar(object):
     def finish(self):
         mylog.info("Finishing '%s'", self.title)
 
-class GUIProgressBar(object):
+class GUIProgressBar:
     def __init__(self, title, maxval):
         import wx
         self.maxval = maxval
@@ -486,7 +486,7 @@ def _rdbeta(key):
 class NoCUDAException(Exception):
     pass
 
-class YTEmptyClass(object):
+class YTEmptyClass:
     pass
 
 def update_hg_or_git(path):

--- a/yt/geometry/coordinates/coordinate_handler.py
+++ b/yt/geometry/coordinates/coordinate_handler.py
@@ -53,7 +53,7 @@ def validate_iterable_width(width, ds, unit=None):
             return (ds.quan(width[0], fix_unitary(width[1])),
                     ds.quan(width[0], fix_unitary(width[1])))
 
-class CoordinateHandler(object):
+class CoordinateHandler:
     name = None
 
     def __init__(self, ds, ordering):

--- a/yt/geometry/coordinates/spherical_coordinates.py
+++ b/yt/geometry/coordinates/spherical_coordinates.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 import numpy as np
 from .coordinate_handler import \
     CoordinateHandler, \

--- a/yt/geometry/coordinates/spherical_coordinates.py
+++ b/yt/geometry/coordinates/spherical_coordinates.py
@@ -1,4 +1,3 @@
-
 import numpy as np
 from .coordinate_handler import \
     CoordinateHandler, \

--- a/yt/geometry/coordinates/tests/test_cartesian_coordinates.py
+++ b/yt/geometry/coordinates/tests/test_cartesian_coordinates.py
@@ -13,8 +13,7 @@ def test_cartesian_coordinates():
     # We're going to load up a simple AMR grid and check its volume
     # calculations and path length calculations.
     ds = fake_amr_ds()
-    axes = list(set(ds.coordinates.axis_name.values()))
-    axes.sort()
+    axes = sorted(set(ds.coordinates.axis_name.values()))
     for i, axis in enumerate(axes):
         dd = ds.all_data()
         fi = ("index", axis)

--- a/yt/geometry/geometry_handler.py
+++ b/yt/geometry/geometry_handler.py
@@ -413,9 +413,6 @@ class ChunkDataCache:
         return self
 
     def __next__(self):
-        return self.next()
-
-    def next(self):
         if len(self.queue) == 0:
             for i in range(self.max_length):
                 try:

--- a/yt/geometry/geometry_handler.py
+++ b/yt/geometry/geometry_handler.py
@@ -258,7 +258,7 @@ def cached_property(func):
         return tr
     return property(cached_func)
 
-class YTDataChunk(object):
+class YTDataChunk:
 
     def __init__(self, dobj, chunk_type, objs, data_size = None,
                  field_type = None, cache = False, fast_index = None):
@@ -395,7 +395,7 @@ class YTDataChunk(object):
         return ci
 
 
-class ChunkDataCache(object):
+class ChunkDataCache:
     def __init__(self, base_iter, preload_fields, geometry_handler,
                  max_length = 256):
         # At some point, max_length should instead become a heuristic function,

--- a/yt/geometry/object_finding_mixin.py
+++ b/yt/geometry/object_finding_mixin.py
@@ -13,7 +13,7 @@ from yt.utilities.physical_ratios import \
     HUGE
 from yt.utilities.exceptions import YTTooParallel
 
-class ObjectFindingMixin(object) :
+class ObjectFindingMixin :
 
     def find_ray_grids(self, coord, axis):
         """

--- a/yt/geometry/object_finding_mixin.py
+++ b/yt/geometry/object_finding_mixin.py
@@ -50,7 +50,7 @@ class ObjectFindingMixin :
             # search is smaller than the number of processors being applied to
             # the task, by 
             nproc = ytcfg.getint("yt", "__topcomm_parallel_size")
-            while 1:
+            while True:
                 gi = (self.grid_levels >= self.max_level - finest_levels).ravel()
                 if gi.sum() >= nproc:
                     break

--- a/yt/geometry/particle_geometry_handler.py
+++ b/yt/geometry/particle_geometry_handler.py
@@ -55,7 +55,7 @@ class ParticleIndex(Index):
         for i in range(int(ndoms)):
             start = 0
             end = start + CHUNKSIZE
-            while 1:
+            while True:
                 df = cls(self.dataset, self.io, template % {'num':i}, fi, (start, end))
                 if max(df.total_particles.values()) == 0:
                     break

--- a/yt/geometry/tests/fake_octree.py
+++ b/yt/geometry/tests/fake_octree.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 from yt.geometry.fake_octree import create_fake_octree
 from yt.geometry.oct_container import RAMSESOctreeContainer, ParticleOctreeContainer
 import numpy as np

--- a/yt/geometry/tests/fake_octree.py
+++ b/yt/geometry/tests/fake_octree.py
@@ -1,4 +1,3 @@
-
 from yt.geometry.fake_octree import create_fake_octree
 from yt.geometry.oct_container import RAMSESOctreeContainer, ParticleOctreeContainer
 import numpy as np

--- a/yt/mods.py
+++ b/yt/mods.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 #
 # ALL IMPORTS GO HERE

--- a/yt/mods.py
+++ b/yt/mods.py
@@ -1,5 +1,3 @@
-
-
 #
 # ALL IMPORTS GO HERE
 #

--- a/yt/pmods.py
+++ b/yt/pmods.py
@@ -191,7 +191,7 @@ Some implementation details
   treat it as if it were -1 (try relative and absolute imports). For
   more information about the level parameter, run ``help(__import__)``.
 """
-from __future__ import print_function
+
 
 import sys
 import imp

--- a/yt/pmods.py
+++ b/yt/pmods.py
@@ -175,7 +175,7 @@ Some implementation details
   be replaced with the following wrapper::
 
     from mpi4py import MPI
-    class mpi(object):
+    class mpi:
         rank = MPI.COMM_WORLD.Get_rank()
         @staticmethod
         def bcast(obj=None,root=0):
@@ -200,13 +200,13 @@ import builtins
 from mpi4py import MPI
 
 
-class mpi(object):
+class mpi:
     rank = MPI.COMM_WORLD.Get_rank()
     @staticmethod
     def bcast(obj=None,root=0):
         return MPI.COMM_WORLD.bcast(obj,root)
 
-class mpi_import(object):
+class mpi_import:
     def __enter__(self):
         imp.acquire_lock()
         __import_hook__.mpi_import = self

--- a/yt/units/__init__.py
+++ b/yt/units/__init__.py
@@ -27,7 +27,7 @@ YTQuantity = unyt_quantity
 from yt.units.unit_symbols import _SymbolContainer
 from yt.units.physical_constants import _ConstantContainer
 
-class UnitContainer(object):
+class UnitContainer:
     """A container for units and constants to associate with a dataset
 
     This object is usually accessed on a Dataset instance via ``ds.units``.

--- a/yt/units/physical_constants.py
+++ b/yt/units/physical_constants.py
@@ -4,7 +4,7 @@ from unyt.unit_systems import add_constants
 
 add_constants(globals(), registry=default_unit_registry)
 
-class _ConstantContainer(object):
+class _ConstantContainer:
     """A container for physical constants to associate with a dataset.
 
     This object is usually accessed on a Dataset instance via

--- a/yt/units/unit_symbols.py
+++ b/yt/units/unit_symbols.py
@@ -4,7 +4,7 @@ from unyt.unit_systems import add_symbols
 
 add_symbols(globals(), registry=default_unit_registry)
 
-class _SymbolContainer(object):
+class _SymbolContainer:
     """A container for units to associate with a dataset.
 
     This object is usually accessed on a Dataset instance via

--- a/yt/utilities/amr_kdtree/amr_kdtree.py
+++ b/yt/utilities/amr_kdtree/amr_kdtree.py
@@ -39,7 +39,7 @@ def _apply_log(data, log_changed, log_new):
     else:
         np.power(10.0, data, data)
 
-class Tree(object):
+class Tree:
     def __init__(self, ds, comm_rank=0, comm_size=1, left=None, right=None,
         min_level=None, max_level=None, data_source=None):
 

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -164,7 +164,7 @@ class AnswerTesting(Plugin):
     def help(self):
         return "yt answer testing support"
 
-class AnswerTestStorage(object):
+class AnswerTestStorage:
     def __init__(self, reference_name=None, answer_name=None):
         self.reference_name = reference_name
         self.answer_name = answer_name
@@ -323,7 +323,7 @@ def sim_dir_load(sim_fn, path = None, sim_type = "Enzo",
     return simulation(os.path.join(path, sim_fn), sim_type,
                       find_outputs=find_outputs)
 
-class AnswerTestingTest(object):
+class AnswerTestingTest:
     reference_storage = None
     result_storage = None
     prefix = ""

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -518,7 +518,7 @@ class YTBugreportCmd(YTCommand):
             print("(okay, type now)")
             print()
             lines = []
-            while 1:
+            while True:
                 line = input()
                 if line.strip() == "---": break
                 lines.append(line)
@@ -601,7 +601,7 @@ class YTHubRegisterCmd(YTCommand):
         print()
         print("Please choose a password:")
         print()
-        while 1:
+        while True:
             password1 = getpass.getpass("Password? ")
             password2 = getpass.getpass("Confirm? ")
             if len(password1) == 0: continue

--- a/yt/utilities/cosmology.py
+++ b/yt/utilities/cosmology.py
@@ -16,7 +16,7 @@ from yt.utilities.physical_constants import \
      gravitational_constant_cgs as G, \
      speed_of_light_cgs
 
-class Cosmology(object):
+class Cosmology:
     r"""
     Create a cosmology calculator to compute cosmological distances and times.
 
@@ -624,7 +624,7 @@ def trapezoid_cumulative_integral(f, x):
     fy = f(x)
     return (0.5 * (fy[:-1] + fy[1:]) * np.diff(x)).cumsum()
 
-class InterpTable(object):
+class InterpTable:
     """
     Generate a function to linearly interpolate from provided arrays.
     """

--- a/yt/utilities/decompose.py
+++ b/yt/utilities/decompose.py
@@ -1,4 +1,4 @@
-from __future__ import division
+
 
 import numpy as np
 

--- a/yt/utilities/decompose.py
+++ b/yt/utilities/decompose.py
@@ -1,5 +1,3 @@
-
-
 import numpy as np
 
 SIEVE_PRIMES = \

--- a/yt/utilities/file_handler.py
+++ b/yt/utilities/file_handler.py
@@ -20,7 +20,7 @@ def warn_h5py(fn):
                            "but h5py is not installed.")
 
 
-class HDF5FileHandler(object):
+class HDF5FileHandler:
     handle = None
 
     def __init__(self, filename):
@@ -98,7 +98,7 @@ def warn_netcdf(fn):
                            "python bindings for netCDF4 are not installed.")
 
 
-class NetCDF4FileHandler(object):
+class NetCDF4FileHandler:
     def __init__(self, filename):
         self.filename = filename
 

--- a/yt/utilities/flagging_methods.py
+++ b/yt/utilities/flagging_methods.py
@@ -21,7 +21,7 @@ class OverDensity(FlaggingMethod):
         rho = grid["density"] / (grid.ds.refine_by**grid.Level)
         return (rho > self.over_density)
 
-class FlaggingGrid(object):
+class FlaggingGrid:
     def __init__(self, grid, methods):
         self.grid = grid
         flagged = np.zeros(grid.ActiveDimensions, dtype="bool")
@@ -60,7 +60,7 @@ class FlaggingGrid(object):
 
 
 # Much or most of this is directly translated from Enzo
-class ProtoSubgrid(object):
+class ProtoSubgrid:
 
     def __init__(self, flagged_base, left_index, dimensions, offset = (0,0,0)):
         self.left_index = left_index.copy()

--- a/yt/utilities/fortran_utils.py
+++ b/yt/utilities/fortran_utils.py
@@ -60,7 +60,7 @@ def read_attrs(f, attrs,endian='='):
     for a, n, t in attrs:
         for end in '@=<>':
             t = t.replace(end,'')
-        if type(a) == tuple:
+        if isinstance(a, tuple):
             n = len(a)
         s1 = vals.pop(0)
         v = [vals.pop(0) for i in range(n)]
@@ -73,7 +73,7 @@ def read_attrs(f, attrs,endian='='):
                 'end of the record: %s %s', s1, s2)
         if n == 1:
             v = v[0]
-        if type(a)==tuple:
+        if isinstance(a, tuple):
             if len(a) != len(v):
                 raise IOError(
                     'An error occured while reading a Fortran '
@@ -132,11 +132,11 @@ def read_cattrs(f, attrs, endian='='):
     for a, n, t in attrs:
         for end in '@=<>':
             t = t.replace(end,'')
-        if type(a)==tuple:
+        if isinstance(a, tuple):
             n = len(a)
         v = [vals.pop(0) for i in range(n)]
         if n == 1: v = v[0]
-        if type(a)==tuple:
+        if isinstance(a, tuple):
             if len(a) != len(v):
                 raise IOError(
                     'An error occured while reading a Fortran '

--- a/yt/utilities/grid_data_format/__init__.py
+++ b/yt/utilities/grid_data_format/__init__.py
@@ -1,3 +1,3 @@
-from __future__ import absolute_import
+
 from .conversion import *
 

--- a/yt/utilities/grid_data_format/__init__.py
+++ b/yt/utilities/grid_data_format/__init__.py
@@ -1,3 +1,1 @@
-
 from .conversion import *
-

--- a/yt/utilities/grid_data_format/conversion/__init__.py
+++ b/yt/utilities/grid_data_format/conversion/__init__.py
@@ -1,4 +1,2 @@
-
 from .conversion_abc import Converter
 from .conversion_athena import AthenaDistributedConverter, AthenaConverter
-

--- a/yt/utilities/grid_data_format/conversion/__init__.py
+++ b/yt/utilities/grid_data_format/conversion/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 from .conversion_abc import Converter
 from .conversion_athena import AthenaDistributedConverter, AthenaConverter
 

--- a/yt/utilities/grid_data_format/conversion/conversion_abc.py
+++ b/yt/utilities/grid_data_format/conversion/conversion_abc.py
@@ -1,5 +1,5 @@
 
-class Converter(object):
+class Converter:
     def __init__(self, basename, outname=None):
         self.basename = basename
         self.outname = outname

--- a/yt/utilities/grid_data_format/conversion/conversion_athena.py
+++ b/yt/utilities/grid_data_format/conversion/conversion_athena.py
@@ -1,5 +1,3 @@
-
-
 import numpy as np
 from yt.utilities.grid_data_format.conversion.conversion_abc import Converter
 from yt.utilities.on_demand_imports import _h5py as h5

--- a/yt/utilities/grid_data_format/conversion/conversion_athena.py
+++ b/yt/utilities/grid_data_format/conversion/conversion_athena.py
@@ -1,5 +1,5 @@
-from __future__ import print_function
-from __future__ import absolute_import
+
+
 import numpy as np
 from yt.utilities.grid_data_format.conversion.conversion_abc import Converter
 from yt.utilities.on_demand_imports import _h5py as h5

--- a/yt/utilities/initial_conditions.py
+++ b/yt/utilities/initial_conditions.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-class FluidOperator(object):
+class FluidOperator:
     def apply(self, ds):
         for g in ds.index.grids: self(g)
 

--- a/yt/utilities/io_handler.py
+++ b/yt/utilities/io_handler.py
@@ -34,8 +34,6 @@ class BaseIOHandler(metaclass = RegisteredIOHandler):
     _misses = 0
     _hits = 0
 
-    __metaclass__ = RegisteredIOHandler
-
     def __init__(self, ds):
         self.queue = defaultdict(dict)
         self.ds = ds

--- a/yt/utilities/lib/cykdtree/tests/test_utils.py
+++ b/yt/utilities/lib/cykdtree/tests/test_utils.py
@@ -1,5 +1,3 @@
-
-
 import numpy as np
 from nose.tools import assert_equal
 from yt.utilities.lib.cykdtree.tests import parametrize, assert_less_equal

--- a/yt/utilities/lib/cykdtree/tests/test_utils.py
+++ b/yt/utilities/lib/cykdtree/tests/test_utils.py
@@ -1,4 +1,4 @@
-from __future__ import division
+
 
 import numpy as np
 from nose.tools import assert_equal

--- a/yt/utilities/lodgeit.py
+++ b/yt/utilities/lodgeit.py
@@ -26,7 +26,7 @@
               2006 Matt Good <matt@matt-good.net>,
               2005 Raphael Slinckx <raphael@slinckx.net>
 """
-from __future__ import print_function
+
 import os
 import sys
 from optparse import OptionParser

--- a/yt/utilities/math_utils.py
+++ b/yt/utilities/math_utils.py
@@ -819,31 +819,30 @@ def quartiles(a, axis=None, out=None, overwrite_input=False):
     """
     if overwrite_input:
         if axis is None:
-            sorted = a.ravel()
-            sorted.sort()
+            a_sorted = sorted(a.ravel())
         else:
             a.sort(axis=axis)
-            sorted = a
+            a_sorted = a
     else:
-        sorted = np.sort(a, axis=axis)
+        a_sorted = np.sort(a, axis=axis)
     if axis is None:
         axis = 0
-    indexer = [slice(None)] * sorted.ndim
-    indices = [int(sorted.shape[axis]/4), int(sorted.shape[axis]*.75)]
+    indexer = [slice(None)] * a_sorted.ndim
+    indices = [int(a_sorted.shape[axis]/4), int(a_sorted.shape[axis]*.75)]
     result = []
     for index in indices:
-        if sorted.shape[axis] % 2 == 1:
+        if a_sorted.shape[axis] % 2 == 1:
             # index with slice to allow mean (below) to work
             indexer[axis] = slice(index, index+1)
         else:
             indexer[axis] = slice(index-1, index+1)
         # special cases for small arrays
-        if sorted.shape[axis] == 2:
+        if a_sorted.shape[axis] == 2:
             # index with slice to allow mean (below) to work
             indexer[axis] = slice(index, index+1)
         # Use mean in odd and even case to coerce data type
         # and check, use out array.
-        result.append(np.mean(sorted[tuple(indexer)], axis=axis, out=out))
+        result.append(np.mean(a_sorted[tuple(indexer)], axis=axis, out=out))
     return np.array(result)
 
 def get_perspective_matrix(fovy, aspect, z_near, z_far):

--- a/yt/utilities/minimal_representation.py
+++ b/yt/utilities/minimal_representation.py
@@ -82,7 +82,7 @@ def _deserialize_from_h5(g, ds):
     return result
 
 
-class UploaderBar(object):
+class UploaderBar:
     pbar = None
 
     def __init__(self, my_name=""):
@@ -96,7 +96,7 @@ class UploaderBar(object):
             self.pbar.finish()
 
 
-class ContainerClass(object):
+class ContainerClass:
     pass
 
 
@@ -357,7 +357,7 @@ class MinimalNotebook(MinimalRepresentation):
         return (metadata, ("chunks", chunks))
 
 
-class ImageCollection(object):
+class ImageCollection:
 
     def __init__(self, ds, name):
         self.ds = ds

--- a/yt/utilities/on_demand_imports.py
+++ b/yt/utilities/on_demand_imports.py
@@ -1,7 +1,7 @@
 from pkg_resources import parse_version
 import sys
 
-class NotAModule(object):
+class NotAModule:
     """
     A class to implement an informative error message that will be outputted if
     someone tries to use an on-demand import without having the requisite
@@ -44,7 +44,7 @@ class NotCartopy(NotAModule):
                 "For further instruction please refer to the "
                 "yt documentation." % self.pkg_name)
 
-class netCDF4_imports(object):
+class netCDF4_imports:
     _name = "netCDF4"
     _Dataset = None
     @property
@@ -61,7 +61,7 @@ class netCDF4_imports(object):
 _netCDF4 = netCDF4_imports()
 
 
-class astropy_imports(object):
+class astropy_imports:
     _name = "astropy"
     _pyfits = None
     @property
@@ -162,7 +162,7 @@ class astropy_imports(object):
 
 _astropy = astropy_imports()
 
-class cartopy_imports(object):
+class cartopy_imports:
     _name = "cartopy"
 
     _crs = None
@@ -190,7 +190,7 @@ class cartopy_imports(object):
 
 _cartopy = cartopy_imports()
 
-class pooch_imports(object):
+class pooch_imports:
     _name = "pooch"
 
     _pooch = None
@@ -206,7 +206,7 @@ class pooch_imports(object):
 
 _pooch = pooch_imports()
 
-class scipy_imports(object):
+class scipy_imports:
     _name = "scipy"
     _integrate = None
     @property
@@ -298,7 +298,7 @@ class scipy_imports(object):
 
 _scipy = scipy_imports()
 
-class h5py_imports(object):
+class h5py_imports:
     _name = "h5py"
     _err = None
 
@@ -446,7 +446,7 @@ class h5py_imports(object):
 
 _h5py = h5py_imports()
 
-class nose_imports(object):
+class nose_imports:
     _name = "nose"
     _run = None
     @property
@@ -461,7 +461,7 @@ class nose_imports(object):
 
 _nose = nose_imports()
 
-class libconf_imports(object):
+class libconf_imports:
     _name = "libconf"
     _load = None
     @property
@@ -476,7 +476,7 @@ class libconf_imports(object):
 
 _libconf = libconf_imports()
 
-class yaml_imports(object):
+class yaml_imports:
     _name = "yaml"
     _load = None
     _FullLoader = None
@@ -512,7 +512,7 @@ class NotMiniball(NotAModule):
                "install via `pip install MiniballCpp`.")
         self.error = ImportError(str % self.pkg_name)
 
-class miniball_imports(object):
+class miniball_imports:
     _name = 'miniball'
     _Miniball = None
 

--- a/yt/utilities/orientation.py
+++ b/yt/utilities/orientation.py
@@ -25,7 +25,7 @@ def _validate_unit_vectors(normal_vector, north_vector):
     return normal_vector, north_vector
 
 
-class Orientation(object):
+class Orientation:
     def __init__(self, normal_vector, north_vector=None, steady_north=False):
         r"""An object that returns a set of basis vectors for orienting
         cameras a data containers.

--- a/yt/utilities/parallel_tools/controller_system.py
+++ b/yt/utilities/parallel_tools/controller_system.py
@@ -2,7 +2,7 @@ from .parallel_analysis_interface import \
     ProcessorPool
 from abc import abstractmethod
 
-class WorkSplitter(object):
+class WorkSplitter:
     def __init__(self, controller, group1, group2):
         self.group1 = group1
         self.group2 = group2

--- a/yt/utilities/parallel_tools/io_runner.py
+++ b/yt/utilities/parallel_tools/io_runner.py
@@ -76,7 +76,7 @@ class IOCommunicator(BaseIOHandler):
 
     def wait(self):
         status = MPI.Status()
-        while 1:
+        while True:
             if self.comm.comm.Iprobe(MPI.ANY_SOURCE,
                                 YT_TAG_MESSAGE,
                                 status = status):

--- a/yt/utilities/parallel_tools/parallel_analysis_interface.py
+++ b/yt/utilities/parallel_tools/parallel_analysis_interface.py
@@ -154,7 +154,7 @@ def get_mpi_type(dtype):
     for dt, val in dtype_names.items():
         if dt == dtype: return val
 
-class ObjectIterator(object):
+class ObjectIterator:
     """
     This is a generalized class that accepts a list of objects and then
     attempts to intelligently iterate over them.
@@ -317,14 +317,14 @@ def parallel_root_only(func):
         return rv
     return root_only
 
-class Workgroup(object):
+class Workgroup:
     def __init__(self, size, ranks, comm, name):
         self.size = size
         self.ranks = ranks
         self.comm = comm
         self.name = name
 
-class ProcessorPool(object):
+class ProcessorPool:
     comm = None
     size = None
     ranks = None
@@ -391,7 +391,7 @@ class ProcessorPool(object):
             if wg.name == key: return wg
         raise KeyError(key)
 
-class ResultsStorage(object):
+class ResultsStorage:
     slots = ['result', 'result_id']
     result = None
     result_id = None
@@ -616,7 +616,7 @@ def parallel_ring(objects, generator_func, mutable = False):
         my_comm.mpi_Request_Waitall(tags)
         del odata
 
-class CommunicationSystem(object):
+class CommunicationSystem:
     communicators = []
 
     def __init__(self):
@@ -648,7 +648,7 @@ class CommunicationSystem(object):
 def _reconstruct_communicator():
     return communication_system.communicators[-1]
 
-class Communicator(object):
+class Communicator:
     comm = None
     _grids = None
     _distributed = None
@@ -1069,7 +1069,7 @@ class Communicator(object):
 
 communication_system = CommunicationSystem()
 
-class ParallelAnalysisInterface(object):
+class ParallelAnalysisInterface:
     comm = None
     _grids = None
     _distributed = None

--- a/yt/utilities/parallel_tools/parallel_analysis_interface.py
+++ b/yt/utilities/parallel_tools/parallel_analysis_interface.py
@@ -710,8 +710,7 @@ class Communicator:
             data = self.comm.bcast(data, root=0)
             return data
         elif datatype == "dict" and op == "cat":
-            field_keys = data.keys()
-            field_keys.sort()
+            field_keys = sorted(data.keys())
             size = data[field_keys[0]].shape[-1]
             sizes = np.zeros(self.comm.size, dtype='int64')
             outsize = np.array(size, dtype='int64')
@@ -1058,7 +1057,7 @@ class Communicator:
         return recv
 
     def probe_loop(self, tag, callback):
-        while 1:
+        while True:
             st = MPI.Status()
             self.comm.Probe(MPI.ANY_SOURCE, tag = tag, status = st)
             try:

--- a/yt/utilities/parallel_tools/task_queue.py
+++ b/yt/utilities/parallel_tools/task_queue.py
@@ -14,7 +14,7 @@ messages = dict(
     end = dict(msg = 'no_more_tasks'),
 )
 
-class TaskQueueNonRoot(object):
+class TaskQueueNonRoot:
     def __init__(self, tasks, comm, subcomm):
         self.tasks = tasks
         self.results = {}

--- a/yt/utilities/parameter_file_storage.py
+++ b/yt/utilities/parameter_file_storage.py
@@ -25,7 +25,7 @@ class UnknownDatasetType(Exception):
     def __repr__(self):
         return "%s" % self.name
 
-class ParameterFileStore(object):
+class ParameterFileStore:
     """
     This class is designed to be a semi-persistent storage for parameter
     files.  By identifying each dataset with a unique hash, objects
@@ -188,10 +188,10 @@ class ParameterFileStore(object):
             else: v['last_seen'] = float(v['last_seen'])
         return db
 
-class ObjectStorage(object):
+class ObjectStorage:
     pass
 
-class EnzoRunDatabase(object):
+class EnzoRunDatabase:
     conn = None
 
     def __init__(self, path = None):

--- a/yt/utilities/particle_generator.py
+++ b/yt/utilities/particle_generator.py
@@ -4,7 +4,7 @@ from yt.utilities.lib.particle_mesh_operations import \
 from yt.funcs import get_pbar, issue_deprecation_warning
 from yt.units.yt_array import uconcatenate
 
-class ParticleGenerator(object):
+class ParticleGenerator:
 
     def __init__(self, ds, num_particles, field_list, ptype="io"):
         """

--- a/yt/utilities/performance_counters.py
+++ b/yt/utilities/performance_counters.py
@@ -9,7 +9,7 @@ from functools import wraps
 from yt.config import ytcfg
 from yt.funcs import mylog
 
-class PerformanceCounters(object):
+class PerformanceCounters:
     _shared_state = {}
     def __new__(cls, *args, **kwargs):
         self = object.__new__(cls, *args, **kwargs)
@@ -81,7 +81,7 @@ yt_counters = PerformanceCounters()
 time_function = yt_counters.call_func
 
 
-class ProfilingController(object):
+class ProfilingController:
     def __init__(self):
         self.profilers = {}
 

--- a/yt/utilities/poster/__init__.py
+++ b/yt/utilities/poster/__init__.py
@@ -25,7 +25,7 @@ Support for streaming HTTP uploads, and multipart/form-data encoding
 New releases of poster will always have a version number that compares greater
 than an older version of poster.
 New in version 0.6."""
-from __future__ import absolute_import
+
 
 from . import streaminghttp
 from . import encode

--- a/yt/utilities/poster/encode.py
+++ b/yt/utilities/poster/encode.py
@@ -48,7 +48,7 @@ def _strify(s):
         return s.encode("utf-8")
     return str(s)
 
-class MultipartParam(object):
+class MultipartParam:
     """Represents a single parameter in a multipart/form-data request
 
     ``name`` is the name of this parameter.

--- a/yt/utilities/poster/encode.py
+++ b/yt/utilities/poster/encode.py
@@ -327,7 +327,7 @@ class multipart_yielder:
     def __iter__(self):
         return self
 
-    def next(self):
+    def __next__(self):
         """generator function to yield multipart/form-data representation
         of parameters"""
         if self.param_iter is not None:

--- a/yt/utilities/poster/encode.py
+++ b/yt/utilities/poster/encode.py
@@ -35,7 +35,7 @@ def encode_and_quote(data):
     if data is None:
         return None
 
-    if isinstance(data, unicode):
+    if isinstance(data, str):
         data = data.encode("utf-8")
     return urllib.quote_plus(data)
 
@@ -44,7 +44,7 @@ def _strify(s):
     otherwise return str(s), or None if s is None"""
     if s is None:
         return None
-    if isinstance(s, unicode):
+    if isinstance(s, str):
         return s.encode("utf-8")
     return str(s)
 
@@ -87,7 +87,7 @@ class MultipartParam:
         if filename is None:
             self.filename = None
         else:
-            if isinstance(filename, unicode):
+            if isinstance(filename, str):
                 # Encode with XML entities
                 self.filename = filename.encode("ascii", "xmlcharrefreplace")
             else:

--- a/yt/utilities/poster/streaminghttp.py
+++ b/yt/utilities/poster/streaminghttp.py
@@ -25,7 +25,7 @@ Example usage:
 >>> req = urllib2.Request("http://localhost:5000", f,
 ...                       {'Content-Length': str(len(s))})
 """
-from __future__ import print_function
+
 
 import http.client as http_client
 import urllib

--- a/yt/utilities/rpdb.py
+++ b/yt/utilities/rpdb.py
@@ -53,7 +53,7 @@ def rpdb_excepthook(exc_type, exc, tb):
         # let this get out of hand.
         MPI.COMM_WORLD.Barrier()
 
-class pdb_handler(object):
+class pdb_handler:
     def __init__(self, tb):
         self.cin = StringIO()
         sys.stdin = self.cin

--- a/yt/utilities/sdf.py
+++ b/yt/utilities/sdf.py
@@ -139,7 +139,7 @@ def get_keyv(iarr, level):
     np.bitwise_or(i1, i3, i1)
     return i1
 
-class DataStruct(object):
+class DataStruct:
     """docstring for DataStruct"""
 
     _offset = 0
@@ -203,7 +203,7 @@ class DataStruct(object):
         else:
             return arr[mask]
 
-class RedirectArray(object):
+class RedirectArray:
     """docstring for RedirectArray"""
     def __init__(self, http_array, key):
         self.http_array = http_array
@@ -539,7 +539,7 @@ def _shift_periodic(pos, left, right, domain_width):
     return
 
 
-class SDFIndex(object):
+class SDFIndex:
 
     """docstring for SDFIndex
 

--- a/yt/utilities/sdf.py
+++ b/yt/utilities/sdf.py
@@ -178,13 +178,12 @@ class DataStruct:
 
     def __getitem__(self, key):
         mask = None
-        kt = type(key)
-        if kt == int or kt == np.int64 or kt == np.int32 or kt == np.int:
+        if isinstance(key, (int, np.int, np.integer)):
             if key == -1:
                 key = slice(-1, None)
             else:
                 key = slice(key, key+1)
-        elif type(key) == np.ndarray:
+        elif isinstance(key, np.ndarray):
             mask = key
             key = slice(None, None)
         if not isinstance(key, slice):

--- a/yt/utilities/sdf.py
+++ b/yt/utilities/sdf.py
@@ -1,4 +1,3 @@
-
 from io import StringIO
 import os
 import numpy as np
@@ -1342,4 +1341,3 @@ class SDFIndex:
         pbox[0, 1] = pbox[0, 0] + pad[0]
         for k in self.get_bbox(pbox[:,0], pbox[:,1]):
             yield k
-

--- a/yt/utilities/sdf.py
+++ b/yt/utilities/sdf.py
@@ -1,4 +1,4 @@
-from __future__ import print_function
+
 from io import StringIO
 import os
 import numpy as np

--- a/yt/utilities/tests/test_hierarchy_inspection.py
+++ b/yt/utilities/tests/test_hierarchy_inspection.py
@@ -7,10 +7,10 @@ Created on Wed Feb 18 18:24:09 2015
 
 from .. hierarchy_inspection import find_lowest_subclasses
 
-class level1(object):
+class level1:
     pass
 
-class level1a(object):
+class level1a:
     pass
 
 class level2(level1):

--- a/yt/utilities/tree_container.py
+++ b/yt/utilities/tree_container.py
@@ -1,4 +1,4 @@
-class TreeContainer(object):
+class TreeContainer:
     r"""A recursive data container for things like merger trees and
     clump-finder trees.
 

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -35,7 +35,7 @@ backend_dict = {'GTK': ['backend_gtk', 'FigureCanvasGTK',
 
 _AGG_FORMATS = (".png", ".jpg", ".jpeg", ".raw", ".rgba", ".tif", ".tiff")
 
-class CallbackWrapper(object):
+class CallbackWrapper:
     def __init__(self, viewer, window_plot, frb, field, font_properties,
                  font_color):
         self.frb = frb
@@ -62,7 +62,7 @@ class CallbackWrapper(object):
         self.field = field
 
 
-class PlotMPL(object):
+class PlotMPL:
     """A base class for all yt plots made using matplotlib, that is backend independent.
 
     """

--- a/yt/visualization/color_maps.py
+++ b/yt/visualization/color_maps.py
@@ -389,8 +389,7 @@ def show_colormaps(subset="all", filename=None):
             raise AttributeError("show_colormaps requires subset attribute "
                                  "to be 'all', 'yt_native', or a list of "
                                  "valid colormap names.")
-    maps = list(set(maps))
-    maps.sort()
+    maps = sorted(set(maps))
     # scale the image size by the number of cmaps
     plt.figure(figsize=(2.*len(maps)/10.,6))
     plt.subplots_adjust(top=0.7,bottom=0.05,left=0.01,right=0.99)

--- a/yt/visualization/eps_writer.py
+++ b/yt/visualization/eps_writer.py
@@ -42,7 +42,7 @@ def pyxize_label(string):
     return result
 
 
-class DualEPS(object):
+class DualEPS:
     def __init__(self, figsize=(12,12)):
         r"""Initializes the DualEPS class to which we can progressively add layers
         of vector graphics and compressed bitmaps.

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -19,7 +19,7 @@ import sys
 from numbers import Number as numeric_type
 
 
-class UnitfulHDU(object):
+class UnitfulHDU:
     def __init__(self, hdu):
         self.hdu = hdu
         self.header = self.hdu.header
@@ -36,7 +36,7 @@ class UnitfulHDU(object):
         return "FITSImage: %s (%s, %s)" % (self.name, im_shape, self.units)
 
 
-class FITSImageData(object):
+class FITSImageData:
 
     def __init__(self, data, fields=None, length_unit=None, width=None,
                  img_ctr=None, wcs=None, current_time=None, time_unit=None,

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -19,7 +19,7 @@ import numpy as np
 import weakref
 import types
 
-class FixedResolutionBuffer(object):
+class FixedResolutionBuffer:
     r"""
     FixedResolutionBuffer(data_source, bounds, buff_size, antialias = True)
 

--- a/yt/visualization/line_plot.py
+++ b/yt/visualization/line_plot.py
@@ -17,7 +17,7 @@ from yt.visualization.plot_container import \
     linear_transform, \
     invalidate_plot
 
-class LineBuffer(object):
+class LineBuffer:
     r"""
     LineBuffer(ds, start_point, end_point, npoints, label = None)
 

--- a/yt/visualization/mapserver/pannable_map.py
+++ b/yt/visualization/mapserver/pannable_map.py
@@ -24,7 +24,7 @@ def exc_writeout(f):
             raise
     return func
 
-class PannableMapServer(object):
+class PannableMapServer:
     _widget_name = "pannable_map"
     def __init__(self, data, field, takelog, cmap, route_prefix = ""):
         self.data = data

--- a/yt/visualization/particle_plots.py
+++ b/yt/visualization/particle_plots.py
@@ -16,7 +16,7 @@ from yt.visualization.profile_plotter import \
     PhasePlot
 
 
-class ParticleAxisAlignedDummyDataSource(object):
+class ParticleAxisAlignedDummyDataSource:
     _type_name = 'Particle'
     _dimensionality = 2
     _con_args = ('center', 'axis', 'width', 'fields', 'weight_field')

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -160,7 +160,7 @@ def get_symlog_minorticks(linthresh, vmin, vmax):
 field_transforms = {}
 
 
-class FieldTransform(object):
+class FieldTransform:
     def __init__(self, name, func):
         self.name = name
         self.func = func
@@ -190,7 +190,7 @@ class PlotDictionary(defaultdict):
         self.data_source = data_source
         return defaultdict.__init__(self, default_factory)
 
-class PlotContainer(object):
+class PlotContainer:
     """A container for generic plots"""
     _plot_type = None
     _plot_valid = False

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+
 
 import warnings
 

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -1765,7 +1765,7 @@ class ParticleCallback(PlotCallback):
         # we construct a rectangular prism
         x0, x1, y0, y1 = self._physical_bounds(plot)
         xx0, xx1, yy0, yy1 = self._plot_bounds(plot)
-        if type(self.data_source)==YTCutRegion:
+        if isinstance(self.data_source, YTCutRegion):
             mylog.warning("Parameter 'width' is ignored in annotate_particles if the "
                           "data_source is a cut_region. "
                           "See https://github.com/yt-project/yt/issues/1933 for further details.")

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1644,7 +1644,7 @@ class OffAxisSlicePlot(PWViewerMPL):
             axes_unit = get_axes_unit(width, ds)
         self.set_axes_unit(axes_unit)
 
-class OffAxisProjectionDummyDataSource(object):
+class OffAxisProjectionDummyDataSource:
     _type_name = 'proj'
     _key_fields = []
     def __init__(self, center, ds, normal_vector, width, fields,

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -116,7 +116,7 @@ def data_object_or_all_data(data_source):
 
     return data_source
 
-class ProfilePlot(object):
+class ProfilePlot:
     r"""
     Create a 1d profile plot from a data source or from a list 
     of profile objects.

--- a/yt/visualization/volume_rendering/camera_path.py
+++ b/yt/visualization/volume_rendering/camera_path.py
@@ -2,7 +2,7 @@ import random
 import numpy as np
 from yt.visualization.volume_rendering.create_spline import create_spline
 
-class Keyframes(object):
+class Keyframes:
     def __init__(self, x, y, z=None, north_vectors=None, up_vectors=None,
                  times=None, niter=50000, init_temp=10.0, alpha=0.999,
                  fixed_start=False):

--- a/yt/visualization/volume_rendering/glfw_inputhook.py
+++ b/yt/visualization/volume_rendering/glfw_inputhook.py
@@ -66,7 +66,7 @@ def create_inputhook_glfw(mgr, render_loop):
         try:
             t = glfw.GetTime()
             while not stdin_ready():
-                render_loop.next()
+                next(render_loop)
 
                 used_time = glfw.GetTime() - t
                 if used_time > 10.0:

--- a/yt/visualization/volume_rendering/input_events.py
+++ b/yt/visualization/volume_rendering/input_events.py
@@ -15,7 +15,7 @@ event_registry = {}
 GLFWEvent = namedtuple("GLFWEvent", ['window', 'key', 'scancode', 'action',
                        'mods', 'width', 'height'])
 
-class EventCollection(object):
+class EventCollection:
     '''Class handling mouse and keyboard events occurring in IDV
     
     Parameters
@@ -335,7 +335,7 @@ def nplane_further(event_coll, event):
     event_coll.camera.near_plane *= 2.0
     return True
 
-class MouseRotation(object):
+class MouseRotation:
     '''Class translating mouse movements to positions in OpenGL scene's coordinates'''
     def __init__(self):
         self.start = None
@@ -378,7 +378,7 @@ class MouseRotation(object):
         self.start = new_end
         return True
 
-class BlendFuncs(object):
+class BlendFuncs:
     '''Class allowing to switch between different GL blending functions'''
     possibilities = (
         "GL_ZERO", "GL_ONE", "GL_SRC_COLOR", "GL_ONE_MINUS_SRC_COLOR",

--- a/yt/visualization/volume_rendering/interactive_loop.py
+++ b/yt/visualization/volume_rendering/interactive_loop.py
@@ -9,7 +9,7 @@ from .input_events import EventCollection, MouseRotation
 
 from yt import write_bitmap
 
-class EGLRenderingContext(object):
+class EGLRenderingContext:
     '''Rendering context using EGL (experimental)
 
     Parameters
@@ -85,7 +85,7 @@ class EGLRenderingContext(object):
         arr = scene._retrieve_framebuffer()
         write_bitmap(arr, "test.png")
 
-class RenderingContext(object):
+class RenderingContext:
     '''Basic rendering context for IDV using GLFW3, that handles the main window even loop
     
     Parameters

--- a/yt/visualization/volume_rendering/interactive_vr.py
+++ b/yt/visualization/volume_rendering/interactive_vr.py
@@ -66,7 +66,7 @@ FULLSCREEN_QUAD = np.array(
      +1.0, +1.0, 0.0], dtype=np.float32
 )
 
-class IDVCamera(object):
+class IDVCamera:
     '''Camera object used in the Interactive Data Visualization
 
     Parameters
@@ -243,7 +243,7 @@ class TrackballCamera(IDVCamera):
                                                 self.far_plane)
 
 
-class SceneComponent(object):
+class SceneComponent:
     """A class that defines basic OpenGL object
 
     This class contains the largest common set of features that every object in

--- a/yt/visualization/volume_rendering/lens.py
+++ b/yt/visualization/volume_rendering/lens.py
@@ -1,4 +1,3 @@
-
 from yt.funcs import mylog
 from yt.utilities.parallel_tools.parallel_analysis_interface import \
     ParallelAnalysisInterface

--- a/yt/visualization/volume_rendering/lens.py
+++ b/yt/visualization/volume_rendering/lens.py
@@ -1,4 +1,4 @@
-from __future__ import division
+
 from yt.funcs import mylog
 from yt.utilities.parallel_tools.parallel_analysis_interface import \
     ParallelAnalysisInterface

--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -27,7 +27,7 @@ from .zbuffer_array import ZBuffer
 import builtins
 from yt.utilities.exceptions import YTNotInsideNotebook
 
-class Scene(object):
+class Scene:
 
     """A virtual landscape for a volume rendering.
 

--- a/yt/visualization/volume_rendering/shader_objects.py
+++ b/yt/visualization/volume_rendering/shader_objects.py
@@ -12,7 +12,7 @@ from yt.units.yt_array import YTQuantity
 
 known_shaders = {}
 
-class ShaderProgram(object):
+class ShaderProgram:
     '''
     Wrapper class that compiles and links vertex and fragment shaders
     into a shader program.

--- a/yt/visualization/volume_rendering/transfer_function_helper.py
+++ b/yt/visualization/volume_rendering/transfer_function_helper.py
@@ -10,7 +10,7 @@ from yt.visualization.volume_rendering.transfer_functions import \
 from io import BytesIO
 
 
-class TransferFunctionHelper(object):
+class TransferFunctionHelper:
     r"""A transfer function helper.
 
     This attempts to help set up a good transfer function by finding

--- a/yt/visualization/volume_rendering/transfer_functions.py
+++ b/yt/visualization/volume_rendering/transfer_functions.py
@@ -7,7 +7,7 @@ from yt.funcs import \
 from yt.utilities.physical_constants import \
     clight, hcgs, kboltz
 
-class TransferFunction(object):
+class TransferFunction:
     r"""A transfer function governs the transmission of emission and
     absorption through a volume.
 
@@ -221,7 +221,7 @@ class TransferFunction(object):
                 (self.x_bounds[0], self.x_bounds[1], self.nbins, self.features)
         return disp
 
-class MultiVariateTransferFunction(object):
+class MultiVariateTransferFunction:
     r"""This object constructs a set of field tables that allow for
     multiple field variables to control the integration through a volume.
 

--- a/yt/visualization/volume_rendering/zbuffer_array.py
+++ b/yt/visualization/volume_rendering/zbuffer_array.py
@@ -2,7 +2,7 @@
 import numpy as np
 
 
-class ZBuffer(object):
+class ZBuffer:
     """A container object for z-buffer arrays
 
     A zbuffer is a companion array for an image that allows the volume rendering


### PR DESCRIPTION
- Inheritance from `object` class is implicit in python 3 so there's no need to keep enforcing it after we dropped support for python 2.

The following were done semi-automatically through `2to3` + manual validation, since in many cases this tool will produce incorrect results (e.g. with sorting numpy arrays)
- cleanup metaclass declarations
- remove future imports
- cleanup rare reliquary occurrences of `long` (-> `int`) and `unicode` (-> `str`)
- ⚠️ two classes were implementing a `next` method instead of `__next__`, this change could break some downstream code if the deprecated syntax `self.next()` was used (should be a niche case and is easily fixed)
- use builtin `a = sorted(data)` instead of `a=list(data); a.sort()` where relevant (i.e. where it doesn't cause performance hits by adding a copy step)
- consistently use `while True` instead of `while 1`
- cleanup type comparisons: use builtin `isinstance(a, mytype)` instead of `type(a) is mytype`.  Within tests I conservatively assumed it's preferable to leave the more strict type comparison but replaced some `==` comparisons with `is` (I don't know if it's even possible to build case where they are not equivalent but the later is definetely correct).