### PR TITLE
Use 'a' mode for saving arrays to hdf. Fixes #2642

### DIFF
--- a/yt/units/yt_array.py
+++ b/yt/units/yt_array.py
@@ -962,7 +962,7 @@ class YTArray(np.ndarray):
         if dataset_name is None:
             dataset_name = 'array_data'
 
-        f = h5py.File(filename, "w")
+        f = h5py.File(filename, mode="a")
         if group_name is not None:
             if group_name in f:
                 g = f[group_name]


### PR DESCRIPTION
## PR Summary

When saving an array to hdf5 file open the file read/write if it exists, create it otherwise.

#### Note
Without this PR documentation build is failing.