### PR TITLE
Support for Gadget HDF5-like datasets without smoothing lengths included

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -162,6 +162,5 @@ other_tests:
   unittests:
      - '--exclude=test_mesh_slices'  # disable randomly failing test
      - '--exclude=test_load_from_path'  # py2
-     - '--exclude=test_Snipshot'  # until PR 2645 is merged
   cookbook:
      - 'doc/source/cookbook/tests/test_cookbook.py'

--- a/yt/frontends/arepo/fields.py
+++ b/yt/frontends/arepo/fields.py
@@ -7,24 +7,22 @@ metal_elements = ["He", "C", "N", "O", "Ne", "Mg", "Si", "Fe"]
 
 
 class ArepoFieldInfo(GadgetFieldInfo):
-    known_particle_fields = GadgetFieldInfo.known_particle_fields + (
-        ("smoothing_length", ("code_length", [], None)),
-        ("MagneticField", ("code_magnetic", ["particle_magnetic_field"], None)),
-        (
-            "MagneticFieldDivergence",
-            ("code_magnetic/code_length", ["magnetic_field_divergence"], None),
-        ),
-        ("GFM_Metallicity", ("", ["metallicity"], None)),
-        ("GFM_Metals_00", ("", ["H_fraction"], None)),
-        ("GFM_Metals_01", ("", ["He_fraction"], None)),
-        ("GFM_Metals_02", ("", ["C_fraction"], None)),
-        ("GFM_Metals_03", ("", ["N_fraction"], None)),
-        ("GFM_Metals_04", ("", ["O_fraction"], None)),
-        ("GFM_Metals_05", ("", ["Ne_fraction"], None)),
-        ("GFM_Metals_06", ("", ["Mg_fraction"], None)),
-        ("GFM_Metals_07", ("", ["Si_fraction"], None)),
-        ("GFM_Metals_08", ("", ["Fe_fraction"], None)),
-    )
+    known_particle_fields = GadgetFieldInfo.known_particle_fields + \
+                            (("MagneticField",
+                              ("code_magnetic", ["particle_magnetic_field"], None)),
+                             ("MagneticFieldDivergence",
+                              ("code_magnetic/code_length", ["magnetic_field_divergence"], None)),
+                             ("GFM_Metallicity", ("", ["metallicity"], None)),
+                             ("GFM_Metals_00", ("", ["H_fraction"], None)),
+                             ("GFM_Metals_01", ("", ["He_fraction"], None)),
+                             ("GFM_Metals_02", ("", ["C_fraction"], None)),
+                             ("GFM_Metals_03", ("", ["N_fraction"], None)),
+                             ("GFM_Metals_04", ("", ["O_fraction"], None)),
+                             ("GFM_Metals_05", ("", ["Ne_fraction"], None)),
+                             ("GFM_Metals_06", ("", ["Mg_fraction"], None)),
+                             ("GFM_Metals_07", ("", ["Si_fraction"], None)),
+                             ("GFM_Metals_08", ("", ["Fe_fraction"], None)),
+                             )
 
     def __init__(self, ds, field_list, slice_info=None):
         if ds.cosmological_simulation:

--- a/yt/frontends/arepo/fields.py
+++ b/yt/frontends/arepo/fields.py
@@ -7,7 +7,6 @@ metal_elements = ["He", "C", "N", "O", "Ne", "Mg", "Si", "Fe"]
 
 
 class ArepoFieldInfo(GadgetFieldInfo):
-
     def __init__(self, ds, field_list, slice_info=None):
         if ds.cosmological_simulation:
             GFM_SFT_units = "dimensionless"
@@ -16,8 +15,10 @@ class ArepoFieldInfo(GadgetFieldInfo):
         self.known_particle_fields += (
             ("GFM_StellarFormationTime", (GFM_SFT_units, ["stellar_age"], None)),
             ("MagneticField", ("code_magnetic", ["particle_magnetic_field"], None)),
-            ("MagneticFieldDivergence",
-                ("code_magnetic/code_length", ["magnetic_field_divergence"], None)),
+            (
+                "MagneticFieldDivergence",
+                ("code_magnetic/code_length", ["magnetic_field_divergence"], None),
+            ),
             ("GFM_Metallicity", ("", ["metallicity"], None)),
             ("GFM_Metals_00", ("", ["H_fraction"], None)),
             ("GFM_Metals_01", ("", ["He_fraction"], None)),

--- a/yt/frontends/arepo/fields.py
+++ b/yt/frontends/arepo/fields.py
@@ -15,10 +15,23 @@ class ArepoFieldInfo(GadgetFieldInfo):
             GFM_SFT_units = "code_length/code_velocity"
         self.known_particle_fields += (
             ("GFM_StellarFormationTime", (GFM_SFT_units, ["stellar_age"], None)),
+            ("MagneticField", ("code_magnetic", ["particle_magnetic_field"], None)),
+            ("MagneticFieldDivergence",
+                ("code_magnetic/code_length", ["magnetic_field_divergence"], None)),
+            ("GFM_Metallicity", ("", ["metallicity"], None)),
+            ("GFM_Metals_00", ("", ["H_fraction"], None)),
+            ("GFM_Metals_01", ("", ["He_fraction"], None)),
+            ("GFM_Metals_02", ("", ["C_fraction"], None)),
+            ("GFM_Metals_03", ("", ["N_fraction"], None)),
+            ("GFM_Metals_04", ("", ["O_fraction"], None)),
+            ("GFM_Metals_05", ("", ["Ne_fraction"], None)),
+            ("GFM_Metals_06", ("", ["Mg_fraction"], None)),
+            ("GFM_Metals_07", ("", ["Si_fraction"], None)),
+            ("GFM_Metals_08", ("", ["Fe_fraction"], None)),
         )
         super(ArepoFieldInfo, self).__init__(ds, field_list, slice_info=slice_info)
 
-    def setup_particle_fields(self, ptype):
+    def setup_particle_fields(self, ptype, *args, **kwargs):
         FieldInfoContainer.setup_particle_fields(self, ptype)
         if ptype == "PartType0":
             self.setup_gas_particle_fields(ptype)

--- a/yt/frontends/arepo/fields.py
+++ b/yt/frontends/arepo/fields.py
@@ -7,22 +7,6 @@ metal_elements = ["He", "C", "N", "O", "Ne", "Mg", "Si", "Fe"]
 
 
 class ArepoFieldInfo(GadgetFieldInfo):
-    known_particle_fields = GadgetFieldInfo.known_particle_fields + \
-                            (("MagneticField",
-                              ("code_magnetic", ["particle_magnetic_field"], None)),
-                             ("MagneticFieldDivergence",
-                              ("code_magnetic/code_length", ["magnetic_field_divergence"], None)),
-                             ("GFM_Metallicity", ("", ["metallicity"], None)),
-                             ("GFM_Metals_00", ("", ["H_fraction"], None)),
-                             ("GFM_Metals_01", ("", ["He_fraction"], None)),
-                             ("GFM_Metals_02", ("", ["C_fraction"], None)),
-                             ("GFM_Metals_03", ("", ["N_fraction"], None)),
-                             ("GFM_Metals_04", ("", ["O_fraction"], None)),
-                             ("GFM_Metals_05", ("", ["Ne_fraction"], None)),
-                             ("GFM_Metals_06", ("", ["Mg_fraction"], None)),
-                             ("GFM_Metals_07", ("", ["Si_fraction"], None)),
-                             ("GFM_Metals_08", ("", ["Fe_fraction"], None)),
-                             )
 
     def __init__(self, ds, field_list, slice_info=None):
         if ds.cosmological_simulation:

--- a/yt/frontends/arepo/io.py
+++ b/yt/frontends/arepo/io.py
@@ -1,6 +1,8 @@
-from yt.frontends.gadget.api import IOHandlerGadgetHDF5
 import numpy as np
+
+from yt.frontends.gadget.api import IOHandlerGadgetHDF5
 from yt.utilities.on_demand_imports import _h5py as h5py
+
 
 class IOHandlerArepoHDF5(IOHandlerGadgetHDF5):
     _dataset_type = "arepo_hdf5"
@@ -20,12 +22,11 @@ class IOHandlerArepoHDF5(IOHandlerGadgetHDF5):
             # we compute one here by finding the radius of the sphere
             # corresponding to the volume of the Voroni cell and multiplying
             # by a user-configurable smoothing factor.
-            hsml = f[ptype]["Masses"][si:ei,...]/f[ptype]["Density"][si:ei,...]
-            hsml *= 3.0/(4.0*np.pi)
-            hsml **= (1./3.)
+            hsml = f[ptype]["Masses"][si:ei, ...] / f[ptype]["Density"][si:ei, ...]
+            hsml *= 3.0 / (4.0 * np.pi)
+            hsml **= 1.0 / 3.0
             hsml *= self.ds.smoothing_factor
-            dt = hsml.dtype.newbyteorder("N") # Native
+            dt = hsml.dtype.newbyteorder("N")  # Native
             if position_dtype is not None and dt < position_dtype:
                 dt = position_dtype
             return hsml.astype(dt)
-

--- a/yt/frontends/arepo/io.py
+++ b/yt/frontends/arepo/io.py
@@ -1,11 +1,13 @@
-import numpy as np
-
 from yt.frontends.gadget.api import IOHandlerGadgetHDF5
+import numpy as np
 from yt.utilities.on_demand_imports import _h5py as h5py
-
 
 class IOHandlerArepoHDF5(IOHandlerGadgetHDF5):
     _dataset_type = "arepo_hdf5"
+
+    def _generate_smoothing_length(self, data_files, kdtree):
+        # This is handled below in _get_smoothing_length
+        return
 
     def _get_smoothing_length(self, data_file, position_dtype, position_shape):
         ptype = self.ds._sph_ptypes[0]
@@ -18,16 +20,12 @@ class IOHandlerArepoHDF5(IOHandlerGadgetHDF5):
             # we compute one here by finding the radius of the sphere
             # corresponding to the volume of the Voroni cell and multiplying
             # by a user-configurable smoothing factor.
-            hsml = f[ptype]["Masses"][si:ei, ...] / f[ptype]["Density"][si:ei, ...]
-            hsml *= 3.0 / (4.0 * np.pi)
-            hsml **= 1.0 / 3.0
+            hsml = f[ptype]["Masses"][si:ei,...]/f[ptype]["Density"][si:ei,...]
+            hsml *= 3.0/(4.0*np.pi)
+            hsml **= (1./3.)
             hsml *= self.ds.smoothing_factor
-            dt = hsml.dtype.newbyteorder("N")  # Native
+            dt = hsml.dtype.newbyteorder("N") # Native
             if position_dtype is not None and dt < position_dtype:
                 dt = position_dtype
             return hsml.astype(dt)
 
-    def _identify_fields(self, data_file):
-        fields, _units = super(IOHandlerArepoHDF5, self)._identify_fields(data_file)
-        fields.append(("PartType0", "smoothing_length"))
-        return fields, _units

--- a/yt/frontends/eagle/fields.py
+++ b/yt/frontends/eagle/fields.py
@@ -128,7 +128,7 @@ class EagleNetworkFieldInfo(OWLSFieldInfo):
     )
 
     def __init__(self, ds, field_list, slice_info=None):
-        super(EagleNetworkFieldInfo,self).__init__(ds, field_list, slice_info=slice_info)
+        super(EagleNetworkFieldInfo, self).__init__(ds, field_list, slice_info=slice_info)
 
     def _create_ion_density_func(self, ftype, ion):
         """ returns a function that calculates the ion density of a particle. 

--- a/yt/frontends/eagle/fields.py
+++ b/yt/frontends/eagle/fields.py
@@ -127,13 +127,12 @@ class EagleNetworkFieldInfo(OWLSFieldInfo):
         "Fe27",
     )
 
-    def __init__(self, *args, **kwargs):
-
-        super(EagleNetworkFieldInfo, self).__init__(*args, **kwargs)
+    def __init__(self, ds, field_list, slice_info=None):
+        super(EagleNetworkFieldInfo,self).__init__(ds, field_list, slice_info=slice_info)
 
     def _create_ion_density_func(self, ftype, ion):
-        """ returns a function that calculates the ion density of a particle.
-        """
+        """ returns a function that calculates the ion density of a particle. 
+        """ 
 
         def _ion_density(field, data):
 

--- a/yt/frontends/eagle/fields.py
+++ b/yt/frontends/eagle/fields.py
@@ -128,11 +128,13 @@ class EagleNetworkFieldInfo(OWLSFieldInfo):
     )
 
     def __init__(self, ds, field_list, slice_info=None):
-        super(EagleNetworkFieldInfo, self).__init__(ds, field_list, slice_info=slice_info)
+        super(EagleNetworkFieldInfo, self).__init__(
+            ds, field_list, slice_info=slice_info
+        )
 
     def _create_ion_density_func(self, ftype, ion):
-        """ returns a function that calculates the ion density of a particle. 
-        """ 
+        """ returns a function that calculates the ion density of a particle.
+        """
 
         def _ion_density(field, data):
 

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -335,6 +335,7 @@ class GadgetDataset(SPHDataset):
         return os.path.basename(self.parameter_filename).split(".")[0]
 
     def _get_hvals(self):
+        self.gen_hsmls = False
         return self._header.value
 
     def _parse_parameter_file(self):
@@ -578,7 +579,6 @@ class GadgetHDF5Dataset(GadgetDataset):
             bounding_box=bounding_box,
             unit_system=unit_system,
         )
-        self._check_hsml()
 
     def _get_hvals(self):
         handle = h5py.File(self.parameter_filename, mode="r")
@@ -587,6 +587,7 @@ class GadgetHDF5Dataset(GadgetDataset):
         # Compat reasons.
         hvals["NumFiles"] = hvals["NumFilesPerSnapshot"]
         hvals["Massarr"] = hvals["MassTable"]
+        self.gen_hsmls = "SmoothingLength" not in handle[self._sph_ptypes[0]]
         handle.close()
         return hvals
 
@@ -596,11 +597,6 @@ class GadgetHDF5Dataset(GadgetDataset):
         uvals.update((str(k), v) for k, v in handle["/Units"].attrs.items())
         handle.close()
         return uvals
-
-    def _check_hsml(self):
-        handle = h5py.File(self.parameter_filename, mode="r")
-        self.gen_hsmls = "SmoothingLength" not in handle[self._sph_ptypes[0]]
-        handle.close()
 
     def _set_owls_eagle(self):
 

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -578,6 +578,7 @@ class GadgetHDF5Dataset(GadgetDataset):
             bounding_box=bounding_box,
             unit_system=unit_system,
         )
+        self._check_hsml()
 
     def _get_hvals(self):
         handle = h5py.File(self.parameter_filename, mode="r")
@@ -595,6 +596,11 @@ class GadgetHDF5Dataset(GadgetDataset):
         uvals.update((str(k), v) for k, v in handle["/Units"].attrs.items())
         handle.close()
         return uvals
+
+    def _check_hsml(self):
+        handle = h5py.File(self.parameter_filename, mode="r")
+        self.gen_hsmls = "SmoothingLength" not in handle[self._sph_ptypes[0]]
+        handle.close()
 
     def _set_owls_eagle(self):
 

--- a/yt/frontends/gadget/fields.py
+++ b/yt/frontends/gadget/fields.py
@@ -4,6 +4,13 @@ from yt.utilities.physical_ratios import _primordial_mass_fraction
 
 
 class GadgetFieldInfo(SPHFieldInfo):
+    def __init__(self, ds, field_list, slice_info=None):
+        if ds.gen_hsmls:
+            hsml = (("smoothing_length", ("code_length", [], None)),)
+            self.known_particle_fields += hsml
+        super(GadgetFieldInfo, self).__init__(ds, field_list,
+                                              slice_info=slice_info)
+
     def setup_particle_fields(self, ptype, *args, **kwargs):
 
         # setup some special fields that only make sense for SPH particles

--- a/yt/frontends/gadget/fields.py
+++ b/yt/frontends/gadget/fields.py
@@ -8,8 +8,7 @@ class GadgetFieldInfo(SPHFieldInfo):
         if ds.gen_hsmls:
             hsml = (("smoothing_length", ("code_length", [], None)),)
             self.known_particle_fields += hsml
-        super(GadgetFieldInfo, self).__init__(ds, field_list,
-                                              slice_info=slice_info)
+        super(GadgetFieldInfo, self).__init__(ds, field_list, slice_info=slice_info)
 
     def setup_particle_fields(self, ptype, *args, **kwargs):
 

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -139,7 +139,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
         ptype = self.ds._sph_ptypes[0]
         si, ei = data_file.start, data_file.end
         if self.ds.gen_hsmls:
-            fn = data_file.filename+".hsml"
+            fn = data_file.filename.replace(".hdf5", ".hsml.hdf5")
         else:
             fn = data_file.filename
         with h5py.File(fn, mode="r") as f:

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -107,13 +107,13 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
                     data_file, needed_ptype=self.ds._sph_ptypes[0]):
                 counts[data_file.filename] += ppos.shape[0]
                 positions.append(ppos)
-        if len(positions) == 0:
+        if not positions:
             return
         offsets = {}
         offset = 0
-        for fn in counts:
+        for fn, count in counts.items():
             offsets[fn] = offset
-            offset += counts[fn]
+            offset += count
         positions = np.concatenate(positions)[kdtree.idx]
         hsml = generate_smoothing_length(
             positions, kdtree, self.ds._num_neighbors)
@@ -280,10 +280,11 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
                         self._vector_fields[kk] = g[kk].shape[1]
                     fields.append((ptype, str(kk)))
 
+        f.close()
+
         if self.ds.gen_hsmls:
             fields.append(("PartType0", "smoothing_length"))
 
-        f.close()
         return fields, {}
 
 

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -5,8 +5,7 @@ import numpy as np
 
 from yt.frontends.sph.io import IOHandlerSPH
 from yt.units.yt_array import uconcatenate
-from yt.utilities.lib.particle_kdtree_tools import \
-    generate_smoothing_length
+from yt.utilities.lib.particle_kdtree_tools import generate_smoothing_length
 from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.on_demand_imports import _h5py as h5py
 
@@ -106,7 +105,8 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
         counts = defaultdict(int)
         for data_file in data_files:
             for _, ppos in self._yield_coordinates(
-                    data_file, needed_ptype=self.ds._sph_ptypes[0]):
+                data_file, needed_ptype=self.ds._sph_ptypes[0]
+            ):
                 counts[data_file.filename] += ppos.shape[0]
                 positions.append(ppos)
         if not positions:
@@ -117,8 +117,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
             offsets[fn] = offset
             offset += count
         positions = uconcatenate(positions)[kdtree.idx]
-        hsml = generate_smoothing_length(
-            positions, kdtree, self.ds._num_neighbors)
+        hsml = generate_smoothing_length(positions, kdtree, self.ds._num_neighbors)
         dtype = positions.dtype
         hsml = hsml[np.argsort(kdtree.idx)].astype(dtype)
         mylog.warning("Writing smoothing lengths to hsml files.")
@@ -126,13 +125,15 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
             si, ei = data_file.start, data_file.end
             fn = data_file.filename
             hsml_fn = data_file.filename.replace(".hdf5", ".hsml.hdf5")
-            with h5py.File(hsml_fn, mode='a') as f:
-                if i == 0: f.attrs['q'] = self.ds._file_hash
+            with h5py.File(hsml_fn, mode="a") as f:
+                if i == 0:
+                    f.attrs["q"] = self.ds._file_hash
                 g = f.require_group(self.ds._sph_ptypes[0])
-                d = g.require_dataset("SmoothingLength", dtype=dtype,
-                                      shape=(counts[fn],))
-                begin = si+offsets[fn]
-                end = min(ei, d.size)+offsets[fn]
+                d = g.require_dataset(
+                    "SmoothingLength", dtype=dtype, shape=(counts[fn],)
+                )
+                begin = si + offsets[fn]
+                end = min(ei, d.size) + offsets[fn]
                 d[si:ei] = hsml[begin:end]
 
     def _get_smoothing_length(self, data_file, position_dtype, position_shape):

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 import numpy as np
 
 from yt.frontends.sph.io import IOHandlerSPH
+from yt.units.yt_array import uconcatenate
 from yt.utilities.lib.particle_kdtree_tools import \
     generate_smoothing_length
 from yt.utilities.logger import ytLogger as mylog
@@ -114,7 +115,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
         for fn, count in counts.items():
             offsets[fn] = offset
             offset += count
-        positions = np.concatenate(positions)[kdtree.idx]
+        positions = uconcatenate(positions)[kdtree.idx]
         hsml = generate_smoothing_length(
             positions, kdtree, self.ds._num_neighbors)
         dtype = positions.dtype

--- a/yt/frontends/owls/fields.py
+++ b/yt/frontends/owls/fields.py
@@ -104,7 +104,7 @@ class OWLSFieldInfo(SPHFieldInfo):
 
         self.known_particle_fields += new_particle_fields
 
-        super(OWLSFieldInfo,self).__init__(ds, field_list, slice_info=slice_info)
+        super(OWLSFieldInfo, self).__init__(ds, field_list, slice_info=slice_info)
 
         # This enables the machinery in yt.fields.species_fields
         self.species_names += list(self._elements)

--- a/yt/frontends/owls/fields.py
+++ b/yt/frontends/owls/fields.py
@@ -85,7 +85,7 @@ class OWLSFieldInfo(SPHFieldInfo):
 
     _add_ions = "PartType0"
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, ds, field_list, slice_info=None):
 
         new_particle_fields = (
             ("Hydrogen", ("", ["H_fraction"], None)),
@@ -99,9 +99,12 @@ class OWLSFieldInfo(SPHFieldInfo):
             ("Iron", ("", ["Fe_fraction"], None)),
         )
 
+        if ds.gen_hsmls:
+            new_particle_fields += (("smoothing_length", ("code_length", [], None)),)
+
         self.known_particle_fields += new_particle_fields
 
-        super(OWLSFieldInfo, self).__init__(*args, **kwargs)
+        super(OWLSFieldInfo,self).__init__(ds, field_list, slice_info=slice_info)
 
         # This enables the machinery in yt.fields.species_fields
         self.species_names += list(self._elements)


### PR DESCRIPTION
# PR Summary

A number of frontends are derived from the `GadgetHDF5Dataset` class (and its associated field info and index classes). Most of the time, the `SmoothingLength` field is included in the dataset, but if not, it needs to be generated. This PR provides the code needed to generate the smoothing length in the event it does not exist. 

If a dataset does not have the `SmoothingLength` field, this PR generates a set of smoothing lengths for the SPH particles which are stored to auxiliary file(s), the number of such files depending on the number of files in the dataset itself. Then the smoothing lengths are read from these files.

I had to touch a lot more files than I would have liked in order to make sure all the parts worked together. This also has side-effects on Arepo datasets (which also do not have smoothing lengths but take care of them in other ways) which I had to fix.

## PR Checklist

This is not ready for merge yet. It needs:

- [x] Logic to prevent the `hsml` files from being overwritten if they already exist and are consistent with the dataset
- [ ] Tests, especially since the logic to go from `data_files` (based on chunking) to the `hsml` filenames is a bit odd and I'm not 100% sure I did it right. 

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
