### PR TITLE
fix an unintuitive behaviour in ProfilePlot

### DIFF
--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -181,9 +181,9 @@ class ProfilePlot(object):
         arguments.  For example, dict(color="red", linestyle=":").
         Default: None.
     x_log : bool
-        If not None, whether the x_axis should be plotted with a logarithmic
-        scaling.
-        Default: None
+        Whether the x_axis should be plotted with a logarithmic
+        scaling (True), or linear scaling (False).
+        Default: True.
     y_log : dict
         A dictionary containing field:boolean pairs, setting the logarithmic
         property for that field. May be overridden after instantiation using 
@@ -237,14 +237,11 @@ class ProfilePlot(object):
                  weight_field="cell_mass", n_bins=64,
                  accumulation=False, fractional=False,
                  label=None, plot_spec=None,
-                 x_log=None, y_log=None):
+                 x_log=True, y_log=None):
 
         data_source = data_object_or_all_data(data_source)
 
-        if x_log is None:
-            logs = None
-        else:
-            logs = {x_field:x_log}
+        logs = {x_field: bool(x_log)}
 
         if isinstance(data_source.ds, YTProfileDataset):
             profiles = [data_source.ds.profile]

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -417,7 +417,7 @@ class ProfilePlot(object):
         obj._font_color = None
         obj.profiles = ensure_list(profiles)
         obj.x_log = None
-        obj.y_log = sanitize_field_tuple_keys(y_log, obj.profiles[0].data_source)
+        obj.y_log = sanitize_field_tuple_keys(y_log, obj.profiles[0].data_source) or {}
         obj.y_title = {}
         obj.x_title = None
         obj.label = sanitize_label(labels, len(obj.profiles))

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -701,7 +701,7 @@ class ProfilePlot(object):
 
     def _get_field_log(self, field_y, profile):
         yfi = profile.field_info[field_y]
-        x_log = self.x_log or profile.x_log
+        x_log = self.x_log if self.x_log is not None else profile.x_log
         y_log = self.y_log.get(field_y, yfi.take_log)
         scales = {True: 'log', False: 'linear'}
         return scales[x_log], scales[y_log]

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -188,7 +188,7 @@ class ProfilePlot(object):
         A dictionary containing field:boolean pairs, setting the logarithmic
         property for that field. May be overridden after instantiation using 
         set_log
-        A single boolean can be passed to signifies all fields should use
+        A single boolean can be passed to signify all fields should use
         logarithmic (True) or linear scaling (False).
         Default: True.
 

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -701,14 +701,8 @@ class ProfilePlot(object):
 
     def _get_field_log(self, field_y, profile):
         yfi = profile.field_info[field_y]
-        if self.x_log is None:
-            x_log = profile.x_log
-        else:
-            x_log = self.x_log
-        if field_y in self.y_log:
-            y_log = self.y_log[field_y]
-        else:
-            y_log = yfi.take_log
+        x_log = self.x_log or profile.x_log
+        y_log = self.y_log.get(field_y, yfi.take_log)
         scales = {True: 'log', False: 'linear'}
         return scales[x_log], scales[y_log]
 

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -701,7 +701,10 @@ class ProfilePlot(object):
 
     def _get_field_log(self, field_y, profile):
         yfi = profile.field_info[field_y]
-        x_log = self.x_log if self.x_log is not None else profile.x_log
+        if self.x_log is None:
+            x_log = profile.x_log
+        else:
+            x_log = self.x_log
         y_log = self.y_log.get(field_y, yfi.take_log)
         scales = {True: 'log', False: 'linear'}
         return scales[x_log], scales[y_log]


### PR DESCRIPTION
## PR Summary

Because of the way it's currently implemented, `ProfilePlot` produces unintuitive results when passed `x_log=None`, which is effectively, equivalent has passing `x_log=True` despite the fact that `bool(None)==False`.

with this change, the following produce the same result
```python
import yt
ds = yt.testing.fake_random_ds(128)
yt.ProfilePlot(ds, 'y', ['density', "velocity_magnitude"], n_bins=500, x_log=None)
yt.ProfilePlot(ds, 'y', ['density', "velocity_magnitude"], n_bins=500, x_log=0)
yt.ProfilePlot(ds, 'y', ['density', "velocity_magnitude"], n_bins=500, x_log=False)
```

This issue was reported on slack by Jack Jenkins.
I'm opening this as a draft since there may be other appropriate changes to ProfilePlot.__init__() that could go with it.