### PR TITLE
[bugfix] update art frontend to be compatible with numpy 1.18

### DIFF
--- a/yt/frontends/art/io.py
+++ b/yt/frontends/art/io.py
@@ -582,7 +582,7 @@ def find_root(f, a, b, tol=1e-6):
 
 
 def quad(fintegrand, xmin, xmax, n=1e4):
-    spacings = np.logspace(np.log10(xmin), np.log10(xmax), n)
+    spacings = np.logspace(np.log10(xmin), np.log10(xmax), num=int(n))
     integrand_arr = fintegrand(spacings)
     val = np.trapz(integrand_arr, dx=np.diff(spacings))
     return val
@@ -612,7 +612,7 @@ def a2t(at, Om0=0.27, Oml0=0.73, h=0.700):
     integrand = lambda x: 1./(x*sqrt(Oml0+Om0*x**-3.0))
     # current_time,err = si.quad(integrand,0.0,at,epsabs=1e-6,epsrel=1e-6)
     current_time = quad(integrand, 1e-4, at)
-    # spacings = np.logspace(-5,np.log10(at),1e5)
+    # spacings = np.logspace(-5,np.log10(at),num=int(1e5))
     # integrand_arr = integrand(spacings)
     # current_time = np.trapz(integrand_arr,dx=np.diff(spacings))
     current_time *= 9.779/h


### PR DESCRIPTION
## PR Summary

This is a bugfix to resolve yt-project/yt#2646 . 

A similar fix was implemented in yt-project/yt#2448. Here I've made the last argument in logspace explicitly labeled with the `num` kwarg, so it's consistent with updated numpy docs. I also call `int` on the variable so we don't get the error reported in the issue. 

I also updated an inline comment to be consistent with this change in the code. 

Note: this is a quick bugfix for the art frontend. I'll probably submit a later PR to address similar ambiguities in the codebase. 

@claytonstrawn I can load art frontend files with this fix applied. 

## PR Checklist

- [x] Code passes flake8 checker
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.