### PR TITLE
CI: optimize testing time for AMRVAC

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -1,6 +1,6 @@
 answer_tests:
 
-  local_amrvac_004:
+  local_amrvac_005:
     - yt/frontends/amrvac/tests/test_outputs.py
     
   local_arepo_005:

--- a/yt/frontends/amrvac/tests/test_outputs.py
+++ b/yt/frontends/amrvac/tests/test_outputs.py
@@ -28,6 +28,9 @@ def _get_fields_to_check(ds):
         fields.append("magnetic_energy_density")
     if "e" in raw_fields_labels:
         fields.append("energy_density")
+    if "rhod1" in raw_fields_labels:
+        fields.append("total_dust_density")
+        # note : not hitting dust velocity fields
     return fields
 
 @requires_file(khi_cartesian_2D)
@@ -115,6 +118,13 @@ def test_riemann_cartesian_175D():
         test_riemann_cartesian_175D.__name__ = test.description
         yield test
 
+@requires_ds(rmi_cartesian_dust_2D)
+def test_rmi_cartesian_dust_2D():
+    # dataset with dust fields
+    ds = data_dir_load(rmi_cartesian_dust_2D)
+    for test in small_patch_amr(ds, _get_fields_to_check(ds.field_list)):
+        test_rmi_cartesian_dust_2D.__name__ = test.description
+        yield test
 
 
 # Tests for units: verify that overriding certain units yields the correct derived units.
@@ -208,19 +218,3 @@ def test_normalisations_vel_and_length():
                      temperature_unit=temperature_unit)
     with assert_raises(ValueError):
         data_dir_load(khi_cartesian_2D, kwargs={'units_override': overrides})
-
-@requires_file(rmi_cartesian_dust_2D)
-def test_dust_fields():
-    # Check all dust fields are correctly setup and can be retrieved
-    ds = data_dir_load(rmi_cartesian_dust_2D)
-    fields = ["total_dust_density", "dust_to_gas_ratio"]
-    for idust in range(1, 5):
-        fields.append("dust%d_density" % idust)
-        for idir, alias in enumerate("xy", start=1):
-            fields += ["dust%d_velocity_%d" % (idust, idir),
-                       "dust%d_velocity_%s" % (idust, alias)]
-
-    ad = ds.all_data()
-    for fieldname in fields:
-        assert ("gas", fieldname) in ds.derived_field_list
-        ad[fieldname]

--- a/yt/frontends/amrvac/tests/test_outputs.py
+++ b/yt/frontends/amrvac/tests/test_outputs.py
@@ -65,42 +65,42 @@ def test_grid_attributes():
 @requires_ds(blastwave_polar_2D)
 def test_bw_polar_2d():
     ds = data_dir_load(blastwave_polar_2D)
-    for test in small_patch_amr(ds, _get_fields_to_check(ds.field_list)):
+    for test in small_patch_amr(ds, _get_fields_to_check(ds)):
         test_bw_polar_2d.__name__ = test.description
         yield test
 
 @requires_ds(blastwave_cartesian_3D)
 def test_blastwave_cartesian_3D():
     ds = data_dir_load(blastwave_cartesian_3D)
-    for test in small_patch_amr(ds, _get_fields_to_check(ds.field_list)):
+    for test in small_patch_amr(ds, _get_fields_to_check(ds)):
         test_blastwave_cartesian_3D.__name__ = test.description
         yield test
 
 @requires_ds(blastwave_spherical_2D)
 def test_blastwave_spherical_2D():
     ds = data_dir_load(blastwave_spherical_2D)
-    for test in small_patch_amr(ds, _get_fields_to_check(ds.field_list)):
+    for test in small_patch_amr(ds, _get_fields_to_check(ds)):
         test_blastwave_spherical_2D.__name__ = test.description
         yield test
 
 @requires_ds(blastwave_cylindrical_3D)
 def test_blastwave_cylindrical_3D():
     ds = data_dir_load(blastwave_cylindrical_3D)
-    for test in small_patch_amr(ds, _get_fields_to_check(ds.field_list)):
+    for test in small_patch_amr(ds, _get_fields_to_check(ds)):
         test_blastwave_cylindrical_3D.__name__ = test.description
         yield test
 
 @requires_ds(khi_cartesian_2D)
 def test_khi_cartesian_2D():
     ds = data_dir_load(khi_cartesian_2D)
-    for test in small_patch_amr(ds, _get_fields_to_check(ds.field_list)):
+    for test in small_patch_amr(ds, _get_fields_to_check(ds)):
         test_khi_cartesian_2D.__name__ = test.description
         yield test
 
 @requires_ds(khi_cartesian_3D)
 def test_khi_cartesian_3D():
     ds = data_dir_load(khi_cartesian_3D)
-    for test in small_patch_amr(ds, _get_fields_to_check(ds.field_list)):
+    for test in small_patch_amr(ds, _get_fields_to_check(ds)):
         test_khi_cartesian_3D.__name__ = test.description
         yield test
 
@@ -114,7 +114,7 @@ def test_jet_cylindrical_25D():
 @requires_ds(riemann_cartesian_175D)
 def test_riemann_cartesian_175D():
     ds = data_dir_load(riemann_cartesian_175D)
-    for test in small_patch_amr(ds, _get_fields_to_check(ds.field_list)):
+    for test in small_patch_amr(ds, _get_fields_to_check(ds)):
         test_riemann_cartesian_175D.__name__ = test.description
         yield test
 
@@ -122,7 +122,7 @@ def test_riemann_cartesian_175D():
 def test_rmi_cartesian_dust_2D():
     # dataset with dust fields
     ds = data_dir_load(rmi_cartesian_dust_2D)
-    for test in small_patch_amr(ds, _get_fields_to_check(ds.field_list)):
+    for test in small_patch_amr(ds, _get_fields_to_check(ds)):
         test_rmi_cartesian_dust_2D.__name__ = test.description
         yield test
 

--- a/yt/frontends/amrvac/tests/test_outputs.py
+++ b/yt/frontends/amrvac/tests/test_outputs.py
@@ -20,6 +20,16 @@ blastwave_polar_2D = "amrvac/bw_polar_2D0000.dat"
 blastwave_cylindrical_3D = "amrvac/bw_cylindrical_3D0000.dat"
 rmi_cartesian_dust_2D = "amrvac/Richtmyer_Meshkov_dust_2D/RM2D_dust_Kwok0000.dat"
 
+
+def _get_fields_to_check(ds):
+    fields = ["density", "velocity_magnitude"]
+    raw_fields_labels = [fname for ftype, fname in ds.field_list]
+    if "b1" in raw_fields_labels:
+        fields.append("magnetic_energy_density")
+    if "e" in raw_fields_labels:
+        fields.append("energy_density")
+    return fields
+
 @requires_file(khi_cartesian_2D)
 def test_AMRVACDataset():
     assert isinstance(data_dir_load(khi_cartesian_2D), AMRVACDataset)
@@ -52,42 +62,42 @@ def test_grid_attributes():
 @requires_ds(blastwave_polar_2D)
 def test_bw_polar_2d():
     ds = data_dir_load(blastwave_polar_2D)
-    for test in small_patch_amr(ds, ds.field_list):
+    for test in small_patch_amr(ds, _get_fields_to_check(ds.field_list)):
         test_bw_polar_2d.__name__ = test.description
         yield test
 
 @requires_ds(blastwave_cartesian_3D)
 def test_blastwave_cartesian_3D():
     ds = data_dir_load(blastwave_cartesian_3D)
-    for test in small_patch_amr(ds, ds.field_list):
+    for test in small_patch_amr(ds, _get_fields_to_check(ds.field_list)):
         test_blastwave_cartesian_3D.__name__ = test.description
         yield test
 
 @requires_ds(blastwave_spherical_2D)
 def test_blastwave_spherical_2D():
     ds = data_dir_load(blastwave_spherical_2D)
-    for test in small_patch_amr(ds, ds.field_list):
+    for test in small_patch_amr(ds, _get_fields_to_check(ds.field_list)):
         test_blastwave_spherical_2D.__name__ = test.description
         yield test
 
 @requires_ds(blastwave_cylindrical_3D)
 def test_blastwave_cylindrical_3D():
     ds = data_dir_load(blastwave_cylindrical_3D)
-    for test in small_patch_amr(ds, ds.field_list):
+    for test in small_patch_amr(ds, _get_fields_to_check(ds.field_list)):
         test_blastwave_cylindrical_3D.__name__ = test.description
         yield test
 
 @requires_ds(khi_cartesian_2D)
 def test_khi_cartesian_2D():
     ds = data_dir_load(khi_cartesian_2D)
-    for test in small_patch_amr(ds, ds.field_list):
+    for test in small_patch_amr(ds, _get_fields_to_check(ds.field_list)):
         test_khi_cartesian_2D.__name__ = test.description
         yield test
 
 @requires_ds(khi_cartesian_3D)
 def test_khi_cartesian_3D():
     ds = data_dir_load(khi_cartesian_3D)
-    for test in small_patch_amr(ds, ds.field_list):
+    for test in small_patch_amr(ds, _get_fields_to_check(ds.field_list)):
         test_khi_cartesian_3D.__name__ = test.description
         yield test
 
@@ -101,7 +111,7 @@ def test_jet_cylindrical_25D():
 @requires_ds(riemann_cartesian_175D)
 def test_riemann_cartesian_175D():
     ds = data_dir_load(riemann_cartesian_175D)
-    for test in small_patch_amr(ds, ds.field_list):
+    for test in small_patch_amr(ds, _get_fields_to_check(ds.field_list)):
         test_riemann_cartesian_175D.__name__ = test.description
         yield test
 


### PR DESCRIPTION
@Xarthisius  brought up on Slack that answer testing time is currently dominated by AMRVAC's tests because of the shear number of fields tested against.

This is an attempt at reducing this testing time by checking a reduced number of derived field that should still hit every on-disk fields.