### PR TITLE
ignore flake8-bugbear B008 errors (YTEP0037 6/6 part 3)

### DIFF
--- a/yt/testing.py
+++ b/yt/testing.py
@@ -574,7 +574,7 @@ def fake_sph_grid_ds(hsml_factor=1.0):
     return load_particles(data=data, length_unit=1.0, bbox=bbox)
 
 
-def construct_octree_mask(prng=RandomState(0x1D3D3D3), refined=None):
+def construct_octree_mask(prng=RandomState(0x1D3D3D3), refined=None):  # noqa B008
     # Implementation taken from url:
     # http://docs.hyperion-rt.org/en/stable/advanced/indepth_oct.html
 
@@ -600,7 +600,7 @@ def construct_octree_mask(prng=RandomState(0x1D3D3D3), refined=None):
 
 
 def fake_octree_ds(
-    prng=RandomState(0x1D3D3D3),
+    prng=RandomState(0x1D3D3D3),  # noqa B008
     refined=None,
     quantities=None,
     bbox=None,

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -600,7 +600,7 @@ def construct_octree_mask(prng=RandomState(0x1D3D3D3), refined=None):  # noqa B0
 
 
 def fake_octree_ds(
-    prng=RandomState(0x1D3D3D3),  # noqa B008
+    prng=RandomState(0x4D3D3D3),  # noqa B008
     refined=None,
     quantities=None,
     bbox=None,


### PR DESCRIPTION
## PR Summary

This addresses part of #2666, namely B008 "Do not perform function calls in argument defaults". The solution here is simply to ignore this error locally since it's only triggered in lines where calling a function in default attrs is the intended behaviour (in test functions).