### PR TITLE
[BUGFIX] Call function wrapped with requires_file

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -1,55 +1,90 @@
 answer_tests:
 
   local_amrvac_005:
-    - yt/frontends/amrvac/tests/test_outputs.py
+    - yt/frontends/amrvac/tests/test_outputs.py:test_domain_size
+    - yt/frontends/amrvac/tests/test_outputs.py:test_bw_polar_2d
+    - yt/frontends/amrvac/tests/test_outputs.py:test_blastwave_cartesian_3D
+    - yt/frontends/amrvac/tests/test_outputs.py:test_blastwave_spherical_2D
+    - yt/frontends/amrvac/tests/test_outputs.py:test_blastwave_cylindrical_3D
+    - yt/frontends/amrvac/tests/test_outputs.py:test_khi_cartesian_2D
+    - yt/frontends/amrvac/tests/test_outputs.py:test_khi_cartesian_3D
+    - yt/frontends/amrvac/tests/test_outputs.py:test_jet_cylindrical_25D
+    - yt/frontends/amrvac/tests/test_outputs.py:test_riemann_cartesian_175D
+    - yt/frontends/amrvac/tests/test_outputs.py:test_rmi_cartesian_dust_2D
     
   local_arepo_005:
-    - yt/frontends/arepo/tests/test_outputs.py
+    - yt/frontends/arepo/tests/test_outputs.py:test_arepo_bullet
+    - yt/frontends/arepo/tests/test_outputs.py:test_arepo_tng59
+    - yt/frontends/arepo/tests/test_outputs.py:test_index_override
 
   local_artio_003:
-    - yt/frontends/artio/tests/test_outputs.py
+    - yt/frontends/artio/tests/test_outputs.py:test_sizmbhloz
 
   local_athena_007:
-    - yt/frontends/athena
+    - yt/frontends/athena/tests/test_outputs.py:test_cloud
+    - yt/frontends/athena/tests/test_outputs.py:test_blast
+    - yt/frontends/athena/tests/test_outputs.py:test_stripping
 
   local_athena_pp_003:
-    - yt/frontends/athena_pp
+    - yt/frontends/athena_pp/tests/test_outputs.py:test_disk
+    - yt/frontends/athena_pp/tests/test_outputs.py:test_AM06
 
   local_chombo_004:
-    - yt/frontends/chombo/tests/test_outputs.py
+    - yt/frontends/chombo/tests/test_outputs.py:test_gc
+    - yt/frontends/chombo/tests/test_outputs.py:test_tb
+    - yt/frontends/chombo/tests/test_outputs.py:test_iso
+    - yt/frontends/chombo/tests/test_outputs.py:test_zp
+    - yt/frontends/chombo/tests/test_outputs.py:test_kho
 
   local_enzo_006:
-    - yt/frontends/enzo
+    - yt/frontends/enzo/tests/test_outputs.py:test_moving7
+    - yt/frontends/enzo/tests/test_outputs.py:test_galaxy0030
+    - yt/frontends/enzo/tests/test_outputs.py:test_toro1d
+    - yt/frontends/enzo/tests/test_outputs.py:test_kh2d
+    - yt/frontends/enzo/tests/test_outputs.py:test_ecp
+    - yt/frontends/enzo/tests/test_outputs.py:test_nuclei_density_fields
 
   local_enzo_p_007:
-    - yt/frontends/enzo_p/tests/test_outputs.py
+    - yt/frontends/enzo_p/tests/test_outputs.py:test_hello_world
+    - yt/frontends/enzo_p/tests/test_outputs.py:test_particle_fields
 
   local_fits_003:
-    - yt/frontends/fits/tests/test_outputs.py
+    - yt/frontends/fits/tests/test_outputs.py:test_grs
+    - yt/frontends/fits/tests/test_outputs.py:test_velocity_field
+    - yt/frontends/fits/tests/test_outputs.py:test_acis
+    - yt/frontends/fits/tests/test_outputs.py:test_A2052
 
   local_flash_012:
-    - yt/frontends/flash/tests/test_outputs.py
+    - yt/frontends/flash/tests/test_outputs.py:test_sloshing
+    - yt/frontends/flash/tests/test_outputs.py:test_wind_tunnel
+    - yt/frontends/flash/tests/test_outputs.py:test_fid_1to3_b1
 
   local_gadget_003:
-    - yt/frontends/gadget/tests/test_outputs.py
+    - yt/frontends/gadget/tests/test_outputs.py:test_iso_collapse
+    - yt/frontends/gadget/tests/test_outputs.py:test_pid_uniqueness
+    - yt/frontends/gadget/tests/test_outputs.py:test_bigendian_field_access
 
   local_gamer_007:
-    - yt/frontends/gamer/tests/test_outputs.py
+    - yt/frontends/gamer/tests/test_outputs.py:test_jet
+    - yt/frontends/gamer/tests/test_outputs.py:test_psiDM
+    - yt/frontends/gamer/tests/test_outputs.py:test_plummer
+    - yt/frontends/gamer/tests/test_outputs.py:test_mhdvortex
 
   local_gdf_001:
-    - yt/frontends/gdf/tests/test_outputs.py
+    - yt/frontends/gdf/tests/test_outputs.py:test_sedov_tunnel
 
   local_gizmo_004:
-    - yt/frontends/gizmo/tests/test_outputs.py
+    - yt/frontends/gizmo/tests/test_outputs.py:test_gizmo_64
 
   local_halos_009:
-    - yt/frontends/ahf/tests/test_outputs.py
+    - yt/frontends/ahf/tests/test_outputs.py:test_fields_ahf_halos
     # - yt/frontends/owls_subfind/tests/test_outputs.py
     - yt/frontends/gadget_fof/tests/test_outputs.py:test_fields_g5
     - yt/frontends/gadget_fof/tests/test_outputs.py:test_fields_g42
 
   local_owls_004:
-    - yt/frontends/owls/tests/test_outputs.py
+    - yt/frontends/owls/tests/test_outputs.py:test_snapshot_033
+    - yt/frontends/owls/tests/test_outputs.py:test_OWLS_particlefilter
 
   local_pw_029:
     - yt/visualization/tests/test_plotwindow.py:test_attributes
@@ -60,7 +95,9 @@ answer_tests:
     - yt/visualization/tests/test_raw_field_slices.py:test_raw_field_slices
 
   local_tipsy_005:
-    - yt/frontends/tipsy/tests/test_outputs.py
+    - yt/frontends/tipsy/tests/test_outputs.py:test_pkdgrav
+    - yt/frontends/tipsy/tests/test_outputs.py:test_gasoline_dmonly
+    - yt/frontends/tipsy/tests/test_outputs.py:test_tipsy_galaxy
 
   local_varia_015:
     - yt/frontends/moab/tests/test_c5.py
@@ -106,7 +143,7 @@ answer_tests:
     - yt/frontends/boxlib/tests/test_outputs.py:test_WarpXDataset
 
   local_ramses_002:
-    - yt/frontends/ramses/tests/test_outputs.py
+    - yt/frontends/ramses/tests/test_outputs.py:test_output_00080
 
   local_ytdata_007:
     - yt/frontends/ytdata/tests/test_outputs.py

--- a/yt/frontends/arepo/tests/test_outputs.py
+++ b/yt/frontends/arepo/tests/test_outputs.py
@@ -14,13 +14,10 @@ _tng59_bbox = [[45135.0, 51343.0], [51844.0, 56184.0], [60555.0, 63451.0]]
 
 
 @requires_file(bullet_h5)
-def test_arepo_hdf5():
-    assert isinstance(data_dir_load(bullet_h5),
-                      ArepoHDF5Dataset)
-
-@requires_file(bullet_h5)
 def test_arepo_hdf5_selection():
     ds = data_dir_load(bullet_h5)
+    assert isinstance(data_dir_load(bullet_h5),
+                      ArepoHDF5Dataset)
     psc = ParticleSelectionComparison(ds)
     psc.run_defaults()
 
@@ -43,11 +40,6 @@ def test_arepo_bullet():
         test_arepo_bullet.__name__ = test.description
         yield test
 
-
-@requires_file(tng59_h5)
-def test_tng_hdf5():
-    assert isinstance(data_dir_load(tng59_h5),
-                      ArepoHDF5Dataset)
 
 tng59_fields = OrderedDict(
     [
@@ -80,6 +72,8 @@ def test_index_override():
     os.close(tmpfd)
     ds = data_dir_load(tng59_h5, kwargs = {'index_filename': tmpname,
                                            'bounding_box': _tng59_bbox})
+    assert isinstance(data_dir_load(tng59_h5),
+                      ArepoHDF5Dataset)
     ds.index
     assert len(open(tmpname, "r").read()) == 0
 

--- a/yt/frontends/owls_subfind/tests/test_outputs.py
+++ b/yt/frontends/owls_subfind/tests/test_outputs.py
@@ -1,12 +1,11 @@
 import os.path
 from yt.testing import \
-    assert_equal, \
-    requires_file
+    assert_equal
 from yt.utilities.answer_testing.framework import \
     FieldValuesTest, \
     requires_ds, \
     data_dir_load
-from yt.frontends.owls_subfind.api import OWLSSubfindDataset
+# from yt.frontends.owls_subfind.api import OWLSSubfindDataset
 
 _fields = ("particle_position_x", "particle_position_y",
            "particle_position_z", "particle_mass")
@@ -31,6 +30,6 @@ def test_fields_g1():
     for field in _fields:
         yield FieldValuesTest(g1, field, particle_type=True)
 
-#@requires_file(g1)
-#def test_OWLSSubfindDataset():
-#    assert isinstance(data_dir_load(g1), OWLSSubfindDataset)
+# @requires_file(g1)
+# def test_OWLSSubfindDataset():
+#     assert isinstance(data_dir_load(g1), OWLSSubfindDataset)

--- a/yt/frontends/owls_subfind/tests/test_outputs.py
+++ b/yt/frontends/owls_subfind/tests/test_outputs.py
@@ -31,6 +31,6 @@ def test_fields_g1():
     for field in _fields:
         yield FieldValuesTest(g1, field, particle_type=True)
 
-@requires_file(g1)
-def test_OWLSSubfindDataset():
-    assert isinstance(data_dir_load(g1), OWLSSubfindDataset)
+#@requires_file(g1)
+#def test_OWLSSubfindDataset():
+#    assert isinstance(data_dir_load(g1), OWLSSubfindDataset)

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -424,7 +424,7 @@ def test_ramses_empty_record():
     # Access some field
     ds.r[('gas', 'density')]
 
-@requires_ds(ramses_new_format)
+@requires_file(ramses_new_format)
 @requires_module('f90nml')
 def test_namelist_reading():
     ds = data_dir_load(ramses_new_format)
@@ -436,8 +436,8 @@ def test_namelist_reading():
 
     assert nml == ref
 
-@requires_ds(ramses_empty_record)
-@requires_ds(output_00080)
+@requires_file(ramses_empty_record)
+@requires_file(output_00080)
 @requires_module('f90nml')
 def test_namelist_reading_should_not_fail():
 

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -730,7 +730,7 @@ def requires_file(req_file):
     def ftrue(func):
         @functools.wraps(func)
         def true_wrapper(*args, **kwargs):
-            return func
+            return func(*args, **kwargs)
         return true_wrapper
     if os.path.exists(req_file):
         return ftrue

--- a/yt/utilities/tests/test_minimal_representation.py
+++ b/yt/utilities/tests/test_minimal_representation.py
@@ -1,6 +1,5 @@
 import numpy as np
 import os.path
-from unyt.exceptions import UnitOperationError
 import yt
 from yt.config import ytcfg
 from yt.testing import \

--- a/yt/utilities/tests/test_minimal_representation.py
+++ b/yt/utilities/tests/test_minimal_representation.py
@@ -1,5 +1,6 @@
 import numpy as np
 import os.path
+from unyt.exceptions import UnitOperationError
 import yt
 from yt.config import ytcfg
 from yt.testing import \
@@ -37,11 +38,13 @@ def test_store():
 
     def fail_for_different_method():
         proj2_c = ds.proj(field, "z", data_source=sp, method="mip")
-        return np.equal(proj2[field], proj2_c[field]).all()
-    assert_raises(YTUnitOperationError, fail_for_different_method)
+        assert_equal(proj2[field], proj2_c[field])
+    # A note here: a unyt.exceptions.UnitOperationError is raised
+    # and caught by numpy, which reraises a ValueError
+    assert_raises(ValueError, fail_for_different_method)
 
     def fail_for_different_source():
         sp = ds.sphere(ds.domain_center, (2, 'kpc'))
         proj2_c = ds.proj(field, "z", data_source=sp, method="integrate")
-        return assert_equal(proj2_c[field], proj2[field])
+        assert_equal(proj2_c[field], proj2[field])
     assert_raises(AssertionError, fail_for_different_source)

--- a/yt/utilities/tests/test_minimal_representation.py
+++ b/yt/utilities/tests/test_minimal_representation.py
@@ -1,10 +1,8 @@
-import numpy as np
 import os.path
 import yt
 from yt.config import ytcfg
 from yt.testing import \
     assert_equal, requires_file, assert_raises
-from yt.utilities.exceptions import YTUnitOperationError
 
 G30 = "IsolatedGalaxy/galaxy0030/galaxy0030"
 


### PR DESCRIPTION
WIthout this, *any* test wrapped with `requires_file` isn't run and is marked as ok by the testing suite.

A quick grep through the code indicates that this affects 200 tests :(.