### PR TITLE
[BUGFIX] Prevent RAMSES fail with recent versions of `f90nml`

### DIFF
--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -573,7 +573,7 @@ class RAMSESDataset(Dataset):
                     nml = f90nml.read(f)
             except ImportError as e:
                 nml = "An error occurred when reading the namelist: %s" % str(e)
-            except ValueError as e:
+            except (ValueError, StopIteration) as e:
                 mylog.warn("Could not parse `namelist.txt` file as it was malformed: %s" % str(e))
                 return
 


### PR DESCRIPTION
Recent versions of f90nml (>=1.2.0), which is used to read the parameter file RAMSES uses, fail with a `StopIteration` instead of `ValueError`. This PR adapts to capture this new exception.