### PR TITLE
[BUGFIX] ValueError with mesh deposition mechanism

### DIFF
--- a/yt/data_objects/octree_subset.py
+++ b/yt/data_objects/octree_subset.py
@@ -214,8 +214,7 @@ class OctreeSubset(YTSelectionContainer):
         op.initialize(npart)
         mylog.debug("Depositing %s Octs onto %s (%s^3) particles",
                     nocts, positions.shape[0], positions.shape[0]**0.3333333)
-        pos = np.asarray(positions.convert_to_units("code_length"),
-                         dtype="float64")
+        pos = positions.to("code_length").value.astype("float64")
 
         op.process_octree(self.oct_handler, self.domain_ind, pos, None,
             self.domain_id, self._domain_offset, lvlmax=lvlmax)

--- a/yt/geometry/tests/test_particle_deposit.py
+++ b/yt/geometry/tests/test_particle_deposit.py
@@ -36,7 +36,7 @@ def test_one_zone_octree_deposit():
 @requires_file(RAMSES)
 @requires_file(ISOGAL)
 def test_mesh_sampling():
-    for fn in [RAMSES, ISOGAL]:
+    for fn in (RAMSES, ISOGAL):
         ds = yt.load(fn)
         ds.add_mesh_sampling_particle_field(('index', 'x'), ptype='all')
         ds.add_mesh_sampling_particle_field(('index', 'dx'), ptype='all')
@@ -53,8 +53,8 @@ def test_mesh_sampling():
 @requires_file(RAMSES)
 @requires_file(ISOGAL)
 def test_mesh_sampling_for_filtered_particles():
-    for fn in [RAMSES, ISOGAL]:
-        ds = yt.load(RAMSES)
+    for fn in (RAMSES, ISOGAL):
+        ds = yt.load(fn)
 
         @yt.particle_filter(requires=['particle_position_x'], filtered_type='io')
         def left(pfilter, data):


### PR DESCRIPTION
## PR Summary

Fixes mesh sampling functions. This was due to "convert_to_units" being an in-place operation, so that there were no positions passed to the mesh deposition mechanism.