### PR TITLE
Allow throttling of number of cores for build.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,12 @@ import pkg_resources
 def _get_cpu_count():
     if platform.system() != "Windows":
         cpu_count = os.cpu_count()
-        max_cores = min(cpu_count, int(os.getenv('MAX_BUILD_CORES', cpu_count)))
+        try:
+            user_max_cores = int(os.getenv('MAX_BUILD_CORES'), cpu_count)
+        except ValueError as e:
+            # print useful error message
+            raise e
+        max_cores = min(cpu_count, user_max_cores)
         return max_cores
     return 0
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def _get_cpu_count():
         try:
             user_max_cores = int(os.getenv('MAX_BUILD_CORES', cpu_count))
         except ValueError as e:
-            # print useful error message
+            print ("MAX_BUILD_CORES needs to be set to an integer.")
             raise e
         max_cores = min(cpu_count, user_max_cores)
         return max_cores

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def _get_cpu_count():
     if platform.system() != "Windows":
         cpu_count = os.cpu_count()
         try:
-            user_max_cores = int(os.getenv('MAX_BUILD_CORES'), cpu_count)
+            user_max_cores = int(os.getenv('MAX_BUILD_CORES', cpu_count))
         except ValueError as e:
             # print useful error message
             raise e

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,9 @@ import pkg_resources
 
 def _get_cpu_count():
     if platform.system() != "Windows":
-        return os.cpu_count()
+        cpu_count = os.cpu_count()
+        max_cores = min(cpu_count, int(os.getenv('MAX_BUILD_CORES', cpu_count)))
+        return max_cores
     return 0
 
 

--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,10 @@ def _get_cpu_count():
     cpu_count = os.cpu_count()
     try:
         user_max_cores = int(os.getenv('MAX_BUILD_CORES', cpu_count))
-    except ValueError:
+    except ValueError as e:
         raise ValueError(
             "MAX_BUILD_CORES must be set to an integer. " +
-            "See above for original error.")
+            "See above for original error.").with_traceback(e.__traceback__)
     max_cores = min(cpu_count, user_max_cores)
     return max_cores
 

--- a/setup.py
+++ b/setup.py
@@ -19,17 +19,18 @@ import pkg_resources
 
 
 def _get_cpu_count():
-    if platform.system() != "Windows":
-        cpu_count = os.cpu_count()
-        try:
-            user_max_cores = int(os.getenv('MAX_BUILD_CORES', cpu_count))
-        except ValueError as e:
-            print ("MAX_BUILD_CORES needs to be set to an integer.")
-            raise e
-        max_cores = min(cpu_count, user_max_cores)
-        return max_cores
-    return 0
+    if platform.system() == "Windows":
+        return 0
 
+    cpu_count = os.cpu_count()
+    try:
+        user_max_cores = int(os.getenv('MAX_BUILD_CORES', cpu_count))
+    except ValueError:
+        raise ValueError(
+            "MAX_BUILD_CORES must be set to an integer. " +
+            "See above for original error.")
+    max_cores = min(cpu_count, user_max_cores)
+    return max_cores
 
 def _compile(
     self, sources, output_dir=None, macros=None, include_dirs=None,


### PR DESCRIPTION
This allows the user to set a maximum number of cores to use for the build. This is helpful on shared systems where jobs using all available cores get terminated.