### PR TITLE
Parallelize pixelize_sph_kernel_projection. Fixes #2682

### DIFF
--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -1039,7 +1039,7 @@ def pixelize_sph_kernel_projection(
         #   1) use multiple cores to process individual particles (the outer loop)
         #   2) use multiple cores to process individual pixels for a given particle
         #      (the inner loops)
-        # Depending on the ratio of particles' "sphere of influnce" (a.k.a. the smoothing
+        # Depending on the ratio of particles' "sphere of influence" (a.k.a. the smoothing
         # length) to the physical width of the pixels, different parallelization
         # strategies may yield different speed-ups. Strategy #1 works better in the case
         # of lots of itty bitty particles. Strategy #2 works well when we have a


### PR DESCRIPTION
### PR Summary

This PR parallelizes sph kernel projection using OpenMP. On my laptop the speed up is modarate (<0.5 for 4 cores), but it yields a significant improvement on testing infra:

```
$ time python doc/source/cookbook/image_resolution.py   # without this patch

real	16m6.577s
user	16m5.294s
sys	0m4.467s

$ time python doc/source/cookbook/image_resolution.py # with this patch, all cores (40)
real	3m11.529s
user	23m2.800s
sys	0m14.970s

$ export OMP_NUM_THREADS=8  # the default setting we use during a test suite build
$ time python doc/source/cookbook/image_resolution.py 

real	4m9.637s
user	14m26.263s
sys	0m2.226s
```
