### PR TITLE
[BUGFIX] Art: fix dm_only frontend

### DIFF
--- a/yt/frontends/art/data_structures.py
+++ b/yt/frontends/art/data_structures.py
@@ -508,7 +508,7 @@ class DarkMatterARTDataset(ARTDataset):
         with open(self._file_particle_header, "rb") as fh:
             seek = 4
             fh.seek(seek)
-            headerstr = np.fromfile(fh, count=1, dtype=(str,45))
+            headerstr = fh.read(45).decode('ascii')
             aexpn = np.fromfile(fh, count=1, dtype='>f4')
             aexp0 = np.fromfile(fh, count=1, dtype='>f4')
             amplt = np.fromfile(fh, count=1, dtype='>f4')
@@ -534,7 +534,7 @@ class DarkMatterARTDataset(ARTDataset):
             lspecies = np.fromfile(fh, count=10, dtype='>i4')
             extras = np.fromfile(fh, count=79, dtype='>f4')
             boxsize = np.fromfile(fh, count=1, dtype='>f4')
-        n = nspecs
+        n = nspecs[0]
         particle_header_vals = {}
         tmp = np.array([headerstr, aexpn, aexp0, amplt, astep, istep,
             partw, tintg, ekin, ekin1, ekin2, au0, aeu0, nrowc, ngridc,
@@ -577,10 +577,11 @@ class DarkMatterARTDataset(ARTDataset):
                         dtype='int64')*2 # NOT ng
 
         # setup standard simulation params yt expects to see
-        self.current_redshift = self.parameters["aexpn"]**-1.0 - 1.0
-        self.omega_lambda = particle_header_vals['Oml0']
-        self.omega_matter = particle_header_vals['Om0']
-        self.hubble_constant = particle_header_vals['hubble']
+        # Convert to float to please unyt
+        self.current_redshift = float(self.parameters["aexpn"]**-1.0 - 1.0)
+        self.omega_lambda = float(particle_header_vals['Oml0'])
+        self.omega_matter = float(particle_header_vals['Om0'])
+        self.hubble_constant = float(particle_header_vals['hubble'])
         self.min_level = 0
         self.max_level = 0
 #        self.min_level = particle_header_vals['min_level']
@@ -631,7 +632,7 @@ class DarkMatterARTDataset(ARTDataset):
             try:
                 seek = 4
                 fh.seek(seek)
-                headerstr = np.fromfile(fh, count=1, dtype=(str,45))  # NOQA
+                headerstr = fh.read(45).decode('ascii')  # NOQA
                 aexpn = np.fromfile(fh, count=1, dtype='>f4')  # NOQA
                 aexp0 = np.fromfile(fh, count=1, dtype='>f4')  # NOQA
                 amplt = np.fromfile(fh, count=1, dtype='>f4')  # NOQA

--- a/yt/frontends/art/data_structures.py
+++ b/yt/frontends/art/data_structures.py
@@ -385,12 +385,12 @@ class ARTDataset(Dataset):
         return False
 
 class ARTParticleFile(ParticleFile):
-    def __init__(self, ds, io, filename, file_id):
-        super(ARTParticleFile, self).__init__(ds, io, filename, file_id)
+    def __init__(self, ds, io, filename, file_id, range):
         self.total_particles = {}
         for ptype, count in zip(ds.particle_types_raw, 
                                 ds.parameters['total_particles']):
             self.total_particles[ptype] = count
+        super(ARTParticleFile, self).__init__(ds, io, filename, file_id, range)
         with open(filename, "rb") as f:
             f.seek(0, os.SEEK_END)
             self._file_size = f.tell()
@@ -632,7 +632,7 @@ class DarkMatterARTDataset(ARTDataset):
             try:
                 seek = 4
                 fh.seek(seek)
-                headerstr = fh.read(45).decode('ascii')  # NOQA
+                headerstr = np.fromfile(fh, count=1, dtype=(str,45))  # NOQA
                 aexpn = np.fromfile(fh, count=1, dtype='>f4')  # NOQA
                 aexp0 = np.fromfile(fh, count=1, dtype='>f4')  # NOQA
                 amplt = np.fromfile(fh, count=1, dtype='>f4')  # NOQA

--- a/yt/frontends/art/data_structures.py
+++ b/yt/frontends/art/data_structures.py
@@ -386,11 +386,11 @@ class ARTDataset(Dataset):
 
 class ARTParticleFile(ParticleFile):
     def __init__(self, ds, io, filename, file_id):
+        super(ARTParticleFile, self).__init__(ds, io, filename, file_id, range=None)
         self.total_particles = {}
         for ptype, count in zip(ds.particle_types_raw, 
                                 ds.parameters['total_particles']):
             self.total_particles[ptype] = count
-        super(ARTParticleFile, self).__init__(ds, io, filename, file_id, range=None)
         with open(filename, "rb") as f:
             f.seek(0, os.SEEK_END)
             self._file_size = f.tell()

--- a/yt/frontends/art/io.py
+++ b/yt/frontends/art/io.py
@@ -206,7 +206,7 @@ class IOHandlerDarkMatterART(IOHandlerART):
                 field_list.append(pfn)
         return field_list, {}
 
-    def _get_field(self,  field):
+    def _get_field(self, field):
         if field in self.cache.keys() and self.caching:
             mylog.debug("Cached %s", str(field))
             return self.cache[field]
@@ -262,6 +262,13 @@ class IOHandlerDarkMatterART(IOHandlerART):
         else:
             return tr[field]
 
+    def _yield_coordinates(self, data_file):
+        for ptype in self.ds.particle_types_raw:
+            x = self._get_field((ptype, 'particle_position_x'))
+            y = self._get_field((ptype, 'particle_position_y'))
+            z = self._get_field((ptype, 'particle_position_z'))
+
+            yield ptype, np.stack((x, y, z), axis=-1)
 
 def _determine_field_size(pf, field, lspecies, ptmax):
     pbool = np.zeros(len(lspecies), dtype="bool")

--- a/yt/frontends/art/io.py
+++ b/yt/frontends/art/io.py
@@ -178,7 +178,8 @@ class IOHandlerART(BaseIOHandler):
 class IOHandlerDarkMatterART(IOHandlerART):
     _dataset_type = "dm_art"
     def _count_particles(self, data_file):
-        return self.ds.parameters['lspecies'][-1]
+        return {k: self.ds.parameters['lspecies'][i] 
+                for i, k in enumerate(self.ds.particle_types_raw)}
 
     def _initialize_index(self, data_file, regions):
         totcount = 4096**2 #file is always this size

--- a/yt/frontends/art/tests/test_outputs.py
+++ b/yt/frontends/art/tests/test_outputs.py
@@ -21,7 +21,7 @@ _fields = (
 )
 
 d9p = "D9p_500/10MpcBox_HartGal_csf_a0.500.d"
-dmonly = "DMonly/PMcrd.0100.DAT"
+dmonly = "DMonly/PMcrs0.0100.DAT"
 
 @requires_ds(d9p, big_data=True)
 def test_d9p():

--- a/yt/frontends/art/tests/test_outputs.py
+++ b/yt/frontends/art/tests/test_outputs.py
@@ -21,6 +21,7 @@ _fields = (
 )
 
 d9p = "D9p_500/10MpcBox_HartGal_csf_a0.500.d"
+dmonly = "DMonly/PMcrd.0100.DAT"
 
 @requires_ds(d9p, big_data=True)
 def test_d9p():
@@ -103,3 +104,8 @@ def test_ARTDataset():
 def test_units_override():
     units_override_check(d9p)
 
+@requires_file(dmonly)
+def test_particle_selection():
+    ds = data_dir_load(dmonly)
+    psc = ParticleSelectionComparison(ds)
+    psc.run_defaults()

--- a/yt/frontends/art/tests/test_outputs.py
+++ b/yt/frontends/art/tests/test_outputs.py
@@ -103,8 +103,3 @@ def test_ARTDataset():
 def test_units_override():
     units_override_check(d9p)
 
-@requires_file(d9p)
-def test_particle_selection():
-    ds = data_dir_load(d9p)
-    psc = ParticleSelectionComparison(ds)
-    psc.run_defaults()


### PR DESCRIPTION
## PR Summary

Removes tests that are intended for particle datasets. They were incorrectly run on ART, an octree dataset.
