### PR TITLE
Time series enhancements

### DIFF
--- a/yt/convenience.py
+++ b/yt/convenience.py
@@ -52,7 +52,7 @@ def load(*args ,**kwargs):
     if not any(valid_file):
         try:
             from yt.data_objects.time_series import DatasetSeries
-            ts = DatasetSeries.from_filenames(*args, **kwargs)
+            ts = DatasetSeries(*args, **kwargs)
             return ts
         except (TypeError, YTOutputNotIdentified):
             pass

--- a/yt/convenience.py
+++ b/yt/convenience.py
@@ -54,7 +54,7 @@ def load(*args ,**kwargs):
             from yt.data_objects.time_series import DatasetSeries
             ts = DatasetSeries(*args, **kwargs)
             return ts
-        except (TypeError, FileNotFoundError, YTOutputNotIdentified):
+        except (TypeError, OSError, YTOutputNotIdentified):
             pass
         # We check if either the first argument is a dict or list, in which
         # case we try identifying candidates.

--- a/yt/convenience.py
+++ b/yt/convenience.py
@@ -54,7 +54,7 @@ def load(*args ,**kwargs):
             from yt.data_objects.time_series import DatasetSeries
             ts = DatasetSeries(*args, **kwargs)
             return ts
-        except (TypeError, YTOutputNotIdentified):
+        except (TypeError, FileNotFoundError, YTOutputNotIdentified):
             pass
         # We check if either the first argument is a dict or list, in which
         # case we try identifying candidates.

--- a/yt/data_objects/tests/test_time_series.py
+++ b/yt/data_objects/tests/test_time_series.py
@@ -1,0 +1,25 @@
+from yt.data_objects.time_series import get_filenames_from_glob_pattern
+
+from pathlib import Path
+import os
+import tempfile
+from yt.testing import assert_raises
+
+def test_pattern_expansion():
+    file_list = ["fake_data_file_{}".format(str(i).zfill(4)) for i in range(10)]
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for file in file_list:
+            (Path(tmpdir) / file).touch()
+
+        pattern = os.path.join(tmpdir, "fake_data_file_*")
+        found = get_filenames_from_glob_pattern(pattern)
+        assert found == [os.path.join(tmpdir, file) for file in file_list]
+
+        found2 = get_filenames_from_glob_pattern(Path(pattern))
+        assert found2 == found
+
+def test_no_match_pattern():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        pattern = os.path.join(tmpdir, "fake_data_file_*")
+        assert_raises(OSError, get_filenames_from_glob_pattern, pattern)

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -56,16 +56,12 @@ def get_ds_prop(propname):
                 dict(eval = _eval, _params = tuple()))
     return cls
 
-def get_filenames_from_glob_pattern(filenames):
-    file_list = glob.glob(filenames)
-    if len(file_list) == 0:
-        data_dir = ytcfg.get("yt", "test_data_dir")
-        pattern = os.path.join(data_dir, filenames)
-        td_filenames = glob.glob(pattern)
-        if len(td_filenames) > 0:
-            file_list = td_filenames
-        else:
-            raise YTOutputNotIdentified(filenames, {})
+def get_filenames_from_glob_pattern(pattern):
+    epattern = os.path.expanduser(pattern)
+    data_dir = ytcfg.get("yt", "test_data_dir")
+    file_list = glob.glob(epattern) or glob.glob(os.path.join(data_dir, epattern))
+    if not file_list:
+        raise FileNotFoundError("No file matched this pattern '%s'" % pattern)
     return sorted(file_list)
 
 attrs = ("refine_by", "dimensionality", "current_time",

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -4,7 +4,6 @@ import glob
 import numpy as np
 import os
 import weakref
-import warnings
 
 from functools import wraps
 
@@ -23,7 +22,7 @@ from yt.funcs import \
     iterable, \
     ensure_list, \
     mylog, \
-    VisibleDeprecationWarning
+    issue_deprecation_warning
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.exceptions import \
     YTException, \
@@ -366,10 +365,10 @@ class DatasetSeries(object):
         ...     SlicePlot(ds, "x", "Density").save()
 
         """
-        warnings.warn(
-            VisibleDeprecationWarning(
-                "DatasetSeries.from_filenames() is deprecated and will be removed in a future version of yt. Use DatasetSeries() directly."
-            ))
+        issue_deprecation_warning(
+                "DatasetSeries.from_filenames() is deprecated and will be removed "
+                "in a future version of yt. Use DatasetSeries() directly."
+        )
         obj = cls(filenames, parallel=parallel, setup_function=setup_function, **kwargs)
         return obj
 

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -60,7 +60,9 @@ def get_ds_prop(propname):
 def get_filenames_from_glob_pattern(pattern):
     epattern = os.path.expanduser(pattern)
     data_dir = ytcfg.get("yt", "test_data_dir")
-    file_list = glob.glob(epattern) or glob.glob(os.path.join(data_dir, epattern))
+    # if not match if found from the current work dir,
+    # we try to match the pattern from the test data dir
+    file_list = glob.glob(epattern) or glob.glob(os.path.join(data_dir, pattern))
     if not file_list:
         raise FileNotFoundError("No file matched this pattern '%s'" % pattern)
     return sorted(file_list)

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -64,7 +64,7 @@ def get_filenames_from_glob_pattern(pattern):
     # we try to match the pattern from the test data dir
     file_list = glob.glob(epattern) or glob.glob(os.path.join(data_dir, pattern))
     if not file_list:
-        raise FileNotFoundError("No file matched this pattern '%s'" % pattern)
+        raise FileNotFoundError("No file matched this pattern or pattern(s) {}".format(pattern))
     return sorted(file_list)
 
 attrs = ("refine_by", "dimensionality", "current_time",

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -62,7 +62,7 @@ def get_filenames_from_glob_pattern(pattern):
     data_dir = ytcfg.get("yt", "test_data_dir")
     # if not match if found from the current work dir,
     # we try to match the pattern from the test data dir
-    file_list = glob.glob(epattern) or glob.glob(os.path.join(data_dir, pattern))
+    file_list = glob.glob(epattern) or glob.glob(os.path.join(data_dir, epattern))
     if not file_list:
         raise OSError("No match found for pattern : {}".format(pattern))
     return sorted(file_list)

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -95,7 +95,7 @@ class DatasetSeries(object):
 
     Parameters
     ----------
-    filenames : list or pattern
+    outputs : list or pattern
         This can either be a list of filenames (such as ["DD0001/DD0001",
         "DD0002/DD0002"]) or a pattern to match, such as
         "DD*/DD*.index").  If it's the former, they will be loaded in

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -64,7 +64,7 @@ def get_filenames_from_glob_pattern(pattern):
     # we try to match the pattern from the test data dir
     file_list = glob.glob(epattern) or glob.glob(os.path.join(data_dir, pattern))
     if not file_list:
-        raise FileNotFoundError("No file matched this pattern or pattern(s) {}".format(pattern))
+        raise OSError("No match found for pattern : {}".format(pattern))
     return sorted(file_list)
 
 attrs = ("refine_by", "dimensionality", "current_time",
@@ -490,7 +490,7 @@ class SimulationTimeSeries(DatasetSeries, metaclass = RegisteredSimulationTimeSe
         """
 
         if not os.path.exists(parameter_filename):
-            raise IOError(parameter_filename)
+            raise OSError(parameter_filename)
         self.parameter_filename = parameter_filename
         self.basename = os.path.basename(parameter_filename)
         self.directory = os.path.dirname(parameter_filename)

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -92,6 +92,10 @@ class DatasetSeries(object):
     primarily expressed through iteration, but can also be constructed via
     analysis tasks (see :ref:`time-series-analysis`).
 
+    Note that contained datasets are lazily loaded and weakly referenced. This means
+    that in order to perform follow-up operations on data it's best to define handles on
+    these datasets during iteration.
+
     Parameters
     ----------
     outputs : list or pattern

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -57,7 +57,12 @@ def get_ds_prop(propname):
                 dict(eval = _eval, _params = tuple()))
     return cls
 
-def get_filenames_from_glob_pattern(pattern):
+def get_filenames_from_glob_pattern(outputs):
+    """
+    Helper function to DatasetSeries.__new__
+    handle a special case where "outputs" is assumed to be really a pattern string
+    """
+    pattern = outputs
     epattern = os.path.expanduser(pattern)
     data_dir = ytcfg.get("yt", "test_data_dir")
     # if not match if found from the current work dir,

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -4,6 +4,7 @@ import glob
 import numpy as np
 import os
 import weakref
+import warnings
 
 from functools import wraps
 
@@ -21,7 +22,8 @@ from yt.data_objects.particle_trajectories import \
 from yt.funcs import \
     iterable, \
     ensure_list, \
-    mylog
+    mylog, \
+    VisibleDeprecationWarning
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.exceptions import \
     YTException, \
@@ -364,19 +366,11 @@ class DatasetSeries(object):
         ...     SlicePlot(ds, "x", "Density").save()
 
         """
-        
-        if isinstance(filenames, str):
-            filenames = get_filenames_from_glob_pattern(filenames)
-
-        # This will crash with a less informative error if filenames is not
-        # iterable, but the plural keyword should give users a clue...
-        for fn in filenames:
-            if not isinstance(fn, str):
-                raise YTOutputNotIdentified("DataSeries accepts a list of "
-                                            "strings, but "
-                                            "received {0}".format(fn))
-        obj = cls(filenames[:], parallel = parallel,
-                  setup_function = setup_function, **kwargs)
+        warnings.warn(
+            VisibleDeprecationWarning(
+                "DatasetSeries.from_filenames() is deprecated and will be removed in a future version of yt. Use DatasetSeries() directly."
+            ))
+        obj = cls(filenames, parallel=parallel, setup_function=setup_function, **kwargs)
         return obj
 
     @classmethod

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -95,11 +95,9 @@ class DatasetSeries(object):
     Parameters
     ----------
     outputs : list or pattern
-        This can either be a list of filenames (such as ["DD0001/DD0001",
-        "DD0002/DD0002"]) or a pattern to match, such as
-        "DD*/DD*.index").  If it's the former, they will be loaded in
-        order.  The latter will be identified with the glob module and then
-        sorted.
+        A list of filenames, for instance ["DD0001/DD0001", "DD0002/DD0002"],
+        or a glob pattern (i.e. containing wildcards '[]?!*') such as "DD*/DD*.index".
+        In the latter case, results are sorted automatically.
     parallel : True, False or int
         This parameter governs the behavior when .piter() is called on the
         resultant DatasetSeries object.  If this is set to False, the time


### PR DESCRIPTION
## PR Summary
This is part of an effort to harmonise and simplify the data loading api.

This PR includes the following improvements to `DatasetSeries`:
- deprecate `DatasetSeries.from_filenames()` because it's redundant since `DatasetSeries.__new__` was added, and I suspect it is not used
- fix a docstring inconsistency
- add tests for pattern detection
- refactor the pattern parsing function (simplify + add `'~'` token expansion, to improve consistency between `DatasetSeries()` and `yt.load()`)

⚠️ **minor backward incompatibility**
I changed the error raised in the pattern parsing function to `FileNotFoundError` to better reflect the issue, this could potentially break downstream code that relies on this function throwing `YTOutputNotIdentified`, though it seems very unlikely.

## PR Checklist

- [x] Code passes flake8 checker
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.
