### PR TITLE
make YTOutputNotIdentified subclass FileNotFoundError

### DIFF
--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -11,7 +11,7 @@ class YTException(Exception):
 
 # Data access exceptions:
 
-class YTOutputNotIdentified(YTException):
+class YTOutputNotIdentified(YTException, FileNotFoundError):
     def __init__(self, args, kwargs):
         self.args = args
         self.kwargs = kwargs


### PR DESCRIPTION
## PR Summary

This is part of a larger effort to harmonise and simplify the data loading api.
This change makes catching `YTOutputNotIdentified` and the builtin `FileNotFoundError` redundant. The idea is that it makes it easier to handle loading errors on the user side since it doesn't require the additional import from `yt.utilities.exceptions`.

It makes this user script relevant
```python
import yt
try:
    yt.load("nothing")
except FileNotFoundError:
    print("gotcha")
```
While not breaking downstream code that would specifically catch `YTOutputNotIdentified`.
