### PR TITLE
[bugfix] ewah_bool_wrap needs C++11 on some Linux machines

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -230,7 +230,7 @@ cython_extensions = [
               ["yt/utilities/lib/ewah_bool_wrap.pyx"],
               include_dirs=["yt/utilities/lib/",
                             "yt/utilities/lib/ewahboolarray"],
-              language="c++"),
+              language="c++", extra_compile_args=["-std=c++11"]),
     Extension("yt.utilities.lib.image_samplers",
               ["yt/utilities/lib/image_samplers.pyx",
                "yt/utilities/lib/fixed_interpolator.c"],


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

I was not able to get yt to compile on NASA's Pleiades machine because of errors when compiling `ewah_bool_wrap.pxd`. Setting the C++11 flag fixes it. 

Fixes issue #2685.
