### PR TITLE
Fix khi_cartesian_2D filename

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -1,6 +1,6 @@
 answer_tests:
 
-  local_amrvac_005:
+  local_amrvac_006:
     - yt/frontends/amrvac/tests/test_outputs.py:test_domain_size
     - yt/frontends/amrvac/tests/test_outputs.py:test_bw_polar_2d
     - yt/frontends/amrvac/tests/test_outputs.py:test_blastwave_cartesian_3D

--- a/yt/frontends/amrvac/tests/test_outputs.py
+++ b/yt/frontends/amrvac/tests/test_outputs.py
@@ -107,7 +107,7 @@ def test_khi_cartesian_3D():
 @requires_ds(jet_cylindrical_25D)
 def test_jet_cylindrical_25D():
    ds = data_dir_load(jet_cylindrical_25D)
-   for test in small_patch_amr(ds, ds.field_list):
+   for test in small_patch_amr(ds, _get_fields_to_check(ds)):
        test_jet_cylindrical_25D.__name__ = test.description
        yield test
 

--- a/yt/frontends/amrvac/tests/test_outputs.py
+++ b/yt/frontends/amrvac/tests/test_outputs.py
@@ -11,7 +11,7 @@ from yt.frontends.amrvac.api import AMRVACDataset, AMRVACGrid
 from yt.units import YTQuantity
 
 blastwave_spherical_2D = "amrvac/bw_2d0000.dat"
-khi_cartesian_2D = "amrvac/kh_2D0000.dat"
+khi_cartesian_2D = "amrvac/kh_2d0000.dat"
 khi_cartesian_3D = "amrvac/kh_3D0000.dat"
 jet_cylindrical_25D = "amrvac/Jet0003.dat"
 riemann_cartesian_175D = "amrvac/R_1d0005.dat"


### PR DESCRIPTION
## PR Summary

This fixes the filename used in tests to match what we have on disk.
Note: I also noticed that `Richtmyer_Meshkov_dust_2D` was missing on the testing box, so this PR should yield a lot of NoOldAnswer. I'll bump answer store, once I see that's the case.

