### PR TITLE
Fix Rockstar PSC tests with a nulp check

### DIFF
--- a/yt/testing.py
+++ b/yt/testing.py
@@ -1326,7 +1326,11 @@ class ParticleSelectionComparison:
                 obj_results = np.concatenate(obj_results, axis = 0)
             else:
                 obj_results = np.empty((0, 3))
-            assert_equal(sel_pos, obj_results)
+            # Sometimes we get unitary scaling or other floating point noise. 5
+            # NULP should be OK.  This is mostly for stuff like Rockstar, where
+            # the f32->f64 casting happens at different places depending on
+            # which code path we use.
+            assert_array_almost_equal_nulp(sel_pos, obj_results, 5)
 
     def run_defaults(self):
         """


### PR DESCRIPTION
As noted in #2677, we're getting errors with Rockstar.  The arrays differ by about 1e-14, which is likely due to roundtripping unit conversions in different precisions.  This allows for wiggle room in the comparison of 5 units in the last place of the floating point values.