### PR TITLE
promote log message from warning to error in add_field methods

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1254,7 +1254,7 @@ class Dataset(metaclass = RegisteredDataset):
                                "derived fields, not on-disk fields.")
         # Handle the case where the field has already been added.
         if not override and name in self.field_info:
-            mylog.warning("Field %s already exists. To override use " +
+            mylog.error("Field %s already exists. To override use " +
                           "force_override=True.", name)
         if kwargs.setdefault('particle_type', False):
             if sampling_type is not None and sampling_type != "particle":

--- a/yt/fields/local_fields.py
+++ b/yt/fields/local_fields.py
@@ -19,7 +19,7 @@ class LocalFieldInfoContainer(FieldInfoContainer):
         override = kwargs.get("force_override", False)
         # Handle the case where the field has already been added.
         if not override and name in self:
-            mylog.warning("Field %s already exists. To override use " +
+            mylog.error("Field %s already exists. To override use " +
                           "force_override=True.", name)
         if kwargs.setdefault('particle_type', False):
             if sampling_type is not None and sampling_type != "particle":


### PR DESCRIPTION
## PR Summary

Very quick PR to promote a warning message to error since it "warns" on code doing nothing.
(as a user I personally set logger to error level and this feels like something even I should be informed of)

I'm noting that there's a lot of code duplication in those functions, I'll try to address that in a separate PR.