### PR TITLE
fix: Improved typing flexibility and type checking for Dataset units_override

### DIFF
--- a/yt/data_objects/tests/test_units_override.py
+++ b/yt/data_objects/tests/test_units_override.py
@@ -1,0 +1,70 @@
+from functools import partial
+
+from yt.data_objects.static_output import Dataset
+from yt.testing import assert_raises
+from yt.units import YTQuantity
+from yt.units.unit_registry import UnitRegistry
+
+mock_quan = partial(YTQuantity, registry=UnitRegistry())
+
+
+def test_schema_validation():
+
+    valid_schemas = [
+        {"length_unit": 1.0},
+        {"length_unit": [1.0]},
+        {"length_unit": (1.0,)},
+        {"length_unit": int(1.0)},
+        {"length_unit": (1.0, "m")},
+        {"length_unit": [1.0, "m"]},
+        {"length_unit": YTQuantity(1.0, "m")},
+    ]
+
+    for schema in valid_schemas:
+        uo = Dataset._sanitize_units_override(schema)
+        for k, v in uo.items():
+            q = mock_quan(v)  # check that no error (TypeError) is raised
+            q.to("pc")  # check that q is a length
+
+
+def test_invalid_schema_detection():
+    invalid_key_schemas = [
+        {"len_unit": 1.0},  # plain invalid key
+        {"lenght_unit": 1.0},  # typo
+    ]
+    for invalid_schema in invalid_key_schemas:
+        assert_raises(ValueError, Dataset._sanitize_units_override, invalid_schema)
+
+    invalid_val_schemas = [
+        {"length_unit": [1, 1, 1]},  # len(val) > 2
+        {"length_unit": [1, 1, 1, 1, 1]},  # "data type not understood" in unyt
+    ]
+
+    for invalid_schema in invalid_val_schemas:
+        assert_raises(TypeError, Dataset._sanitize_units_override, invalid_schema)
+
+    # 0 shouldn't make sense
+    invalid_number_schemas = [
+        {"length_unit": 0},
+        {"length_unit": [0]},
+        {"length_unit": (0,)},
+        {"length_unit": (0, "cm")},
+    ]
+    for invalid_schema in invalid_number_schemas:
+        assert_raises(ValueError, Dataset._sanitize_units_override, invalid_schema)
+
+
+def test_typing_error_detection():
+    invalid_schema = {"length_unit": "1m"}
+
+    # this is the error that is raised by unyt on bad input
+    assert_raises(RuntimeError, mock_quan, invalid_schema["length_unit"])
+
+    # check that the sanitizer function is able to catch the
+    # type issue before passing down to unyt
+    assert_raises(TypeError, Dataset._sanitize_units_override, invalid_schema)
+
+
+def test_dimensionality_error_detection():
+    invalid_schema = {"length_unit": YTQuantity(1.0, "s")}
+    assert_raises(ValueError, Dataset._sanitize_units_override, invalid_schema)

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -863,7 +863,7 @@ def units_override_check(fn):
         unit_attr = getattr(ds1, "%s_unit" % u, None)
         if unit_attr is not None:
             attrs1.append(unit_attr)
-            units_override["%s_unit" % u] = (unit_attr.v, str(unit_attr.units))
+            units_override["%s_unit" % u] = (unit_attr.v, unit_attr.units)
     del ds1
     ds2 = load(fn, units_override=units_override)
     assert len(ds2.units_override) > 0


### PR DESCRIPTION
## PR Summary

This improves error handling for `Dataset(units_override=data)` when ill formatted data is passed by checking and crashing early.
This adds flexibility (fixes #2702) and improves the sanitizing step by checking that overrides are dimensionally consistent, and checks for unrecognised keys as well (previously those where silently passed and had no effect).

**old VS new behaviour** against spurious parameter values

```python
import yt
fn = "IsolatedGalaxy/galaxy0030/galaxy0030"

# inconsistent unit/dim
yt.load(fn, units_override={"length_unit": (1, "K")})
old >> IllDefinedUnitSystem: Cannot create unit system with inconsistent mapping from dimensions to units. Received:
OrderedDict([((length), code_length), ((mass), code_mass), ((time), code_time), ((temperature), code_temperature), ((angle), rad), ((current_mks), None), ((luminous_intensity), cd), ((logarithmic), Np)])
# the above error is raised from unyt and it may be hard to understand what is wrong from the user perspective
new >> ValueError: Inconsistent dimensionality in units_override. Received length_unit = 1 K

# typos or unknown "unit" keys:
yt.load(fn, units_override={"len_unit": (1, "cm")})
old >> # loads silently
new >> ValueError: units_override contains invalid keys: {'len_unit'}

# flexible typing input (this was reported in #2702 and fixed here)
yt.load(fn, units_override={"length_unit": [1, "cm"]}) 
old >> RuntimeError: unyt_quantity values must be numeric
new >> # loads correctly

# invalid "0" value
yt.load(fn, units_override={"length_unit": 0})
old >>
.../unyt/unyt/array.py:1753: RuntimeWarning: divide by zero encountered in true_divide
  out_arr = func(
.../unyt/unyt/array.py:1753: RuntimeWarning: invalid value encountered in multiply
  out_arr = func(
# the above still loads, only RuntimeWarnings are thrown
new >> ValueError: Invalid 0 normalisation factor in units_override for length_unit.
```