### PR TITLE
Bump unyt to 2.7.2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ install:
     # Install specified version of numpy and dependencies
     - "conda install --yes -c conda-forge numpy scipy nose pytest setuptools ipython git
     Cython sympy fastcache h5py matplotlib=3.1.3 mock pandas cartopy conda-build pooch pyyaml"
-    - "pip install git+https://github.com/yt-project/unyt@de443dff7671f1e68557306d77582cd117cc94f8#egg=unyt"
+    - "pip install unyt"
     # install yt
     - "pip install -e ."
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,9 +30,8 @@ install:
     - "python --version"
 
     # Install specified version of numpy and dependencies
-    - "conda install --yes -c conda-forge numpy scipy nose pytest setuptools ipython git
+    - "conda install --yes -c conda-forge numpy scipy nose pytest setuptools ipython git unyt
     Cython sympy fastcache h5py matplotlib=3.1.3 mock pandas cartopy conda-build pooch pyyaml"
-    - "pip install unyt"
     # install yt
     - "pip install -e ."
 

--- a/setup.py
+++ b/setup.py
@@ -437,7 +437,7 @@ if __name__ == "__main__":
             'sympy>=1.2',
             'numpy>=1.10.4',
             'IPython>=1.0',
-            'unyt>=2.2.2',
+            'unyt>=2.7.2',
         ],
         extras_require = {
             'hub':  ["girder_client"],

--- a/tests/test_minimal_requirements.txt
+++ b/tests/test_minimal_requirements.txt
@@ -8,4 +8,4 @@ pytest~=4.6; python_version < '3.0'
 pyyaml>=4.2b1
 coverage==4.5.1
 codecov==2.0.15
-git+https://github.com/yt-project/unyt@de443dff7671f1e68557306d77582cd117cc94f8#egg=unyt
+unyt==2.7.2

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -21,7 +21,7 @@ libconf==1.0.1
 cartopy==0.17.0
 pyaml==17.10.0
 mpi4py==3.0.3
-git+https://github.com/yt-project/unyt@de443dff7671f1e68557306d77582cd117cc94f8#egg=unyt
+unyt==2.7.2
 pyyaml>=4.2b1
 xarray==0.12.3
 firefly_api>=0.0.2


### PR DESCRIPTION
We had been installing unyt from git, but this bumps the requirement to
the newly-released 2.7.2.