### PR TITLE
[AMRVAC] units override check (follow up #2703)

### DIFF
--- a/yt/data_objects/tests/test_units_override.py
+++ b/yt/data_objects/tests/test_units_override.py
@@ -1,0 +1,70 @@
+from functools import partial
+
+from yt.data_objects.static_output import Dataset
+from yt.testing import assert_raises
+from yt.units import YTQuantity
+from yt.units.unit_registry import UnitRegistry
+
+mock_quan = partial(YTQuantity, registry=UnitRegistry())
+
+
+def test_schema_validation():
+
+    valid_schemas = [
+        {"length_unit": 1.0},
+        {"length_unit": [1.0]},
+        {"length_unit": (1.0,)},
+        {"length_unit": int(1.0)},
+        {"length_unit": (1.0, "m")},
+        {"length_unit": [1.0, "m"]},
+        {"length_unit": YTQuantity(1.0, "m")},
+    ]
+
+    for schema in valid_schemas:
+        uo = Dataset._sanitize_units_override(schema)
+        for k, v in uo.items():
+            q = mock_quan(v)  # check that no error (TypeError) is raised
+            q.to("pc")  # check that q is a length
+
+
+def test_invalid_schema_detection():
+    invalid_key_schemas = [
+        {"len_unit": 1.0},  # plain invalid key
+        {"lenght_unit": 1.0},  # typo
+    ]
+    for invalid_schema in invalid_key_schemas:
+        assert_raises(ValueError, Dataset._sanitize_units_override, invalid_schema)
+
+    invalid_val_schemas = [
+        {"length_unit": [1, 1, 1]},  # len(val) > 2
+        {"length_unit": [1, 1, 1, 1, 1]},  # "data type not understood" in unyt
+    ]
+
+    for invalid_schema in invalid_val_schemas:
+        assert_raises(TypeError, Dataset._sanitize_units_override, invalid_schema)
+
+    # 0 shouldn't make sense
+    invalid_number_schemas = [
+        {"length_unit": 0},
+        {"length_unit": [0]},
+        {"length_unit": (0,)},
+        {"length_unit": (0, "cm")},
+    ]
+    for invalid_schema in invalid_number_schemas:
+        assert_raises(ValueError, Dataset._sanitize_units_override, invalid_schema)
+
+
+def test_typing_error_detection():
+    invalid_schema = {"length_unit": "1m"}
+
+    # this is the error that is raised by unyt on bad input
+    assert_raises(RuntimeError, mock_quan, invalid_schema["length_unit"])
+
+    # check that the sanitizer function is able to catch the
+    # type issue before passing down to unyt
+    assert_raises(TypeError, Dataset._sanitize_units_override, invalid_schema)
+
+
+def test_dimensionality_error_detection():
+    invalid_schema = {"length_unit": YTQuantity(1.0, "s")}
+    assert_raises(ValueError, Dataset._sanitize_units_override, invalid_schema)

--- a/yt/frontends/amrvac/tests/test_outputs.py
+++ b/yt/frontends/amrvac/tests/test_outputs.py
@@ -3,7 +3,7 @@ import numpy as np  # NOQA
 import yt  # NOQA
 from yt.frontends.amrvac.api import AMRVACDataset, AMRVACGrid
 from yt.testing import assert_allclose_units, assert_raises, requires_file
-from yt.units import YTQuantity
+from yt.units import YTArray, YTQuantity
 from yt.utilities.answer_testing.framework import (
     data_dir_load,
     requires_ds,
@@ -59,8 +59,8 @@ def test_grid_attributes():
     assert ds.index.max_level == 2
     for g in grids:
         assert isinstance(g, AMRVACGrid)
-        assert isinstance(g.LeftEdge, yt.units.yt_array.YTArray)
-        assert isinstance(g.RightEdge, yt.units.yt_array.YTArray)
+        assert isinstance(g.LeftEdge, YTArray)
+        assert isinstance(g.RightEdge, YTArray)
         assert isinstance(g.ActiveDimensions, np.ndarray)
         assert isinstance(g.Level, (np.int32, np.int64, int))
 

--- a/yt/frontends/amrvac/tests/test_units_override.py
+++ b/yt/frontends/amrvac/tests/test_units_override.py
@@ -1,0 +1,97 @@
+from yt.testing import assert_allclose_units, assert_raises, requires_file
+from yt.units import YTQuantity
+from yt.utilities.answer_testing.framework import data_dir_load
+
+khi_cartesian_2D = "amrvac/kh_2d0000.dat"
+
+# Tests for units: verify that overriding certain units yields the correct derived units.
+# The following are correct normalisations based on length, numberdensity and temperature
+length_unit = (1e9, 'cm')
+numberdensity_unit = (1e9, 'cm**-3')
+temperature_unit = (1e6, 'K')
+density_unit = (2.341670657200000e-15, 'g*cm**-3')
+mass_unit = (2.341670657200000e+12, 'g')
+velocity_unit = (1.164508387441102e+07, 'cm*s**-1')
+pressure_unit = (3.175492240000000e-01, 'dyn*cm**-2')
+time_unit = (8.587314705370271e+01, 's')
+magnetic_unit = (1.997608879907716, 'gauss')
+
+def _assert_normalisations_equal(ds):
+    assert_allclose_units(ds.length_unit, YTQuantity(*length_unit))
+    assert_allclose_units(ds.numberdensity_unit, YTQuantity(*numberdensity_unit))
+    assert_allclose_units(ds.temperature_unit, YTQuantity(*temperature_unit))
+    assert_allclose_units(ds.density_unit, YTQuantity(*density_unit))
+    assert_allclose_units(ds.mass_unit, YTQuantity(*mass_unit))
+    assert_allclose_units(ds.velocity_unit, YTQuantity(*velocity_unit))
+    assert_allclose_units(ds.pressure_unit, YTQuantity(*pressure_unit))
+    assert_allclose_units(ds.time_unit, YTQuantity(*time_unit))
+    assert_allclose_units(ds.magnetic_unit, YTQuantity(*magnetic_unit))
+
+@requires_file(khi_cartesian_2D)
+def test_normalisations_length_temp_nb():
+    # overriding length, temperature, numberdensity
+    overrides = dict(length_unit=length_unit, temperature_unit=temperature_unit,
+                     numberdensity_unit=numberdensity_unit)
+    ds = data_dir_load(khi_cartesian_2D, kwargs={'units_override': overrides})
+    _assert_normalisations_equal(ds)
+
+@requires_file(khi_cartesian_2D)
+def test_normalisations_length_temp_mass():
+    # overriding length, temperature, mass
+    overrides = dict(length_unit=length_unit, temperature_unit=temperature_unit,
+                     mass_unit=mass_unit)
+    ds = data_dir_load(khi_cartesian_2D, kwargs={'units_override': overrides})
+    _assert_normalisations_equal(ds)
+
+@requires_file(khi_cartesian_2D)
+def test_normalisations_length_time_mass():
+    # overriding length, time, mass
+    overrides = dict(length_unit=length_unit, time_unit=time_unit, mass_unit=mass_unit)
+    ds = data_dir_load(khi_cartesian_2D, kwargs={'units_override': overrides})
+    _assert_normalisations_equal(ds)
+
+@requires_file(khi_cartesian_2D)
+def test_normalisations_length_vel_nb():
+    # overriding length, velocity, numberdensity
+    overrides = dict(length_unit=length_unit, velocity_unit=velocity_unit,
+                     numberdensity_unit=numberdensity_unit)
+    ds = data_dir_load(khi_cartesian_2D, kwargs={'units_override': overrides})
+    _assert_normalisations_equal(ds)
+
+@requires_file(khi_cartesian_2D)
+def test_normalisations_length_vel_mass():
+    # overriding length, velocity, mass
+    overrides = dict(length_unit=length_unit, velocity_unit=velocity_unit,
+                     mass_unit=mass_unit)
+    ds = data_dir_load(khi_cartesian_2D, kwargs={'units_override': overrides})
+    _assert_normalisations_equal(ds)
+
+@requires_file(khi_cartesian_2D)
+def test_normalisations_default():
+    # test default normalisations, without overrides
+    ds = data_dir_load(khi_cartesian_2D)
+    assert_allclose_units(ds.length_unit, YTQuantity(1, 'cm'))
+    assert_allclose_units(ds.numberdensity_unit, YTQuantity(1, 'cm**-3'))
+    assert_allclose_units(ds.temperature_unit, YTQuantity(1, 'K'))
+    assert_allclose_units(ds.density_unit, YTQuantity(2.341670657200000e-24, 'g*cm**-3'))
+    assert_allclose_units(ds.mass_unit, YTQuantity(2.341670657200000e-24, 'g'))
+    assert_allclose_units(ds.velocity_unit, YTQuantity(1.164508387441102e+04, 'cm*s**-1'))
+    assert_allclose_units(ds.pressure_unit, YTQuantity(3.175492240000000e-16, 'dyn*cm**-2'))
+    assert_allclose_units(ds.time_unit, YTQuantity(8.587314705370271e-05, 's'))
+    assert_allclose_units(ds.magnetic_unit, YTQuantity(6.316993934686148e-08, 'gauss'))
+
+@requires_file(khi_cartesian_2D)
+def test_normalisations_too_many_args():
+    # test forbidden case: too many arguments (max 3 are allowed)
+    overrides = dict(length_unit=length_unit, numberdensity_unit=numberdensity_unit,
+                     temperature_unit=temperature_unit, time_unit=time_unit)
+    with assert_raises(ValueError):
+        data_dir_load(khi_cartesian_2D, kwargs={'units_override': overrides})
+
+@requires_file(khi_cartesian_2D)
+def test_normalisations_vel_and_length():
+    # test forbidden case: both velocity and temperature are specified as overrides
+    overrides = dict(length_unit=length_unit, velocity_unit=velocity_unit,
+                     temperature_unit=temperature_unit)
+    with assert_raises(ValueError):
+        data_dir_load(khi_cartesian_2D, kwargs={'units_override': overrides})

--- a/yt/frontends/amrvac/tests/test_units_override.py
+++ b/yt/frontends/amrvac/tests/test_units_override.py
@@ -6,15 +6,16 @@ khi_cartesian_2D = "amrvac/kh_2d0000.dat"
 
 # Tests for units: verify that overriding certain units yields the correct derived units.
 # The following are correct normalisations based on length, numberdensity and temperature
-length_unit = (1e9, 'cm')
-numberdensity_unit = (1e9, 'cm**-3')
-temperature_unit = (1e6, 'K')
-density_unit = (2.341670657200000e-15, 'g*cm**-3')
-mass_unit = (2.341670657200000e+12, 'g')
-velocity_unit = (1.164508387441102e+07, 'cm*s**-1')
-pressure_unit = (3.175492240000000e-01, 'dyn*cm**-2')
-time_unit = (8.587314705370271e+01, 's')
-magnetic_unit = (1.997608879907716, 'gauss')
+length_unit = (1e9, "cm")
+numberdensity_unit = (1e9, "cm**-3")
+temperature_unit = (1e6, "K")
+density_unit = (2.341670657200000e-15, "g*cm**-3")
+mass_unit = (2.341670657200000e12, "g")
+velocity_unit = (1.164508387441102e07, "cm*s**-1")
+pressure_unit = (3.175492240000000e-01, "dyn*cm**-2")
+time_unit = (8.587314705370271e01, "s")
+magnetic_unit = (1.997608879907716, "gauss")
+
 
 def _assert_normalisations_equal(ds):
     assert_allclose_units(ds.length_unit, YTQuantity(*length_unit))
@@ -27,71 +28,100 @@ def _assert_normalisations_equal(ds):
     assert_allclose_units(ds.time_unit, YTQuantity(*time_unit))
     assert_allclose_units(ds.magnetic_unit, YTQuantity(*magnetic_unit))
 
+
 @requires_file(khi_cartesian_2D)
 def test_normalisations_length_temp_nb():
     # overriding length, temperature, numberdensity
-    overrides = dict(length_unit=length_unit, temperature_unit=temperature_unit,
-                     numberdensity_unit=numberdensity_unit)
-    ds = data_dir_load(khi_cartesian_2D, kwargs={'units_override': overrides})
+    overrides = dict(
+        length_unit=length_unit,
+        temperature_unit=temperature_unit,
+        numberdensity_unit=numberdensity_unit,
+    )
+    ds = data_dir_load(khi_cartesian_2D, kwargs={"units_override": overrides})
     _assert_normalisations_equal(ds)
+
 
 @requires_file(khi_cartesian_2D)
 def test_normalisations_length_temp_mass():
     # overriding length, temperature, mass
-    overrides = dict(length_unit=length_unit, temperature_unit=temperature_unit,
-                     mass_unit=mass_unit)
-    ds = data_dir_load(khi_cartesian_2D, kwargs={'units_override': overrides})
+    overrides = dict(
+        length_unit=length_unit, temperature_unit=temperature_unit, mass_unit=mass_unit
+    )
+    ds = data_dir_load(khi_cartesian_2D, kwargs={"units_override": overrides})
     _assert_normalisations_equal(ds)
+
 
 @requires_file(khi_cartesian_2D)
 def test_normalisations_length_time_mass():
     # overriding length, time, mass
     overrides = dict(length_unit=length_unit, time_unit=time_unit, mass_unit=mass_unit)
-    ds = data_dir_load(khi_cartesian_2D, kwargs={'units_override': overrides})
+    ds = data_dir_load(khi_cartesian_2D, kwargs={"units_override": overrides})
     _assert_normalisations_equal(ds)
+
 
 @requires_file(khi_cartesian_2D)
 def test_normalisations_length_vel_nb():
     # overriding length, velocity, numberdensity
-    overrides = dict(length_unit=length_unit, velocity_unit=velocity_unit,
-                     numberdensity_unit=numberdensity_unit)
-    ds = data_dir_load(khi_cartesian_2D, kwargs={'units_override': overrides})
+    overrides = dict(
+        length_unit=length_unit,
+        velocity_unit=velocity_unit,
+        numberdensity_unit=numberdensity_unit,
+    )
+    ds = data_dir_load(khi_cartesian_2D, kwargs={"units_override": overrides})
     _assert_normalisations_equal(ds)
+
 
 @requires_file(khi_cartesian_2D)
 def test_normalisations_length_vel_mass():
     # overriding length, velocity, mass
-    overrides = dict(length_unit=length_unit, velocity_unit=velocity_unit,
-                     mass_unit=mass_unit)
-    ds = data_dir_load(khi_cartesian_2D, kwargs={'units_override': overrides})
+    overrides = dict(
+        length_unit=length_unit, velocity_unit=velocity_unit, mass_unit=mass_unit
+    )
+    ds = data_dir_load(khi_cartesian_2D, kwargs={"units_override": overrides})
     _assert_normalisations_equal(ds)
+
 
 @requires_file(khi_cartesian_2D)
 def test_normalisations_default():
     # test default normalisations, without overrides
     ds = data_dir_load(khi_cartesian_2D)
-    assert_allclose_units(ds.length_unit, YTQuantity(1, 'cm'))
-    assert_allclose_units(ds.numberdensity_unit, YTQuantity(1, 'cm**-3'))
-    assert_allclose_units(ds.temperature_unit, YTQuantity(1, 'K'))
-    assert_allclose_units(ds.density_unit, YTQuantity(2.341670657200000e-24, 'g*cm**-3'))
-    assert_allclose_units(ds.mass_unit, YTQuantity(2.341670657200000e-24, 'g'))
-    assert_allclose_units(ds.velocity_unit, YTQuantity(1.164508387441102e+04, 'cm*s**-1'))
-    assert_allclose_units(ds.pressure_unit, YTQuantity(3.175492240000000e-16, 'dyn*cm**-2'))
-    assert_allclose_units(ds.time_unit, YTQuantity(8.587314705370271e-05, 's'))
-    assert_allclose_units(ds.magnetic_unit, YTQuantity(6.316993934686148e-08, 'gauss'))
+    assert_allclose_units(ds.length_unit, YTQuantity(1, "cm"))
+    assert_allclose_units(ds.numberdensity_unit, YTQuantity(1, "cm**-3"))
+    assert_allclose_units(ds.temperature_unit, YTQuantity(1, "K"))
+    assert_allclose_units(
+        ds.density_unit, YTQuantity(2.341670657200000e-24, "g*cm**-3")
+    )
+    assert_allclose_units(ds.mass_unit, YTQuantity(2.341670657200000e-24, "g"))
+    assert_allclose_units(
+        ds.velocity_unit, YTQuantity(1.164508387441102e04, "cm*s**-1")
+    )
+    assert_allclose_units(
+        ds.pressure_unit, YTQuantity(3.175492240000000e-16, "dyn*cm**-2")
+    )
+    assert_allclose_units(ds.time_unit, YTQuantity(8.587314705370271e-05, "s"))
+    assert_allclose_units(ds.magnetic_unit, YTQuantity(6.316993934686148e-08, "gauss"))
+
 
 @requires_file(khi_cartesian_2D)
 def test_normalisations_too_many_args():
     # test forbidden case: too many arguments (max 3 are allowed)
-    overrides = dict(length_unit=length_unit, numberdensity_unit=numberdensity_unit,
-                     temperature_unit=temperature_unit, time_unit=time_unit)
+    overrides = dict(
+        length_unit=length_unit,
+        numberdensity_unit=numberdensity_unit,
+        temperature_unit=temperature_unit,
+        time_unit=time_unit,
+    )
     with assert_raises(ValueError):
-        data_dir_load(khi_cartesian_2D, kwargs={'units_override': overrides})
+        data_dir_load(khi_cartesian_2D, kwargs={"units_override": overrides})
+
 
 @requires_file(khi_cartesian_2D)
 def test_normalisations_vel_and_length():
     # test forbidden case: both velocity and temperature are specified as overrides
-    overrides = dict(length_unit=length_unit, velocity_unit=velocity_unit,
-                     temperature_unit=temperature_unit)
+    overrides = dict(
+        length_unit=length_unit,
+        velocity_unit=velocity_unit,
+        temperature_unit=temperature_unit,
+    )
     with assert_raises(ValueError):
-        data_dir_load(khi_cartesian_2D, kwargs={'units_override': overrides})
+        data_dir_load(khi_cartesian_2D, kwargs={"units_override": overrides})


### PR DESCRIPTION
## PR Summary
This is a follow up to #2703 (only the last commit is unique to this PR)
Given that the AMRVAC frontend already had a mechanism to check `units_override`, this unifies the existing mechanism with the sanitizing function introduced by the previous PR.

Edit:  #2703 helped revealing a bug in AMRVAC's frontend where the special key "number_density" in units_override is not handled anywhere. Passing it now raises :
```python
ValueError: units_override contains invalid keys: {'numberdensity_unit'}
```
Thanks to @n-claes , we already had some tests for sanity checks in units_override, but now they fail (which is expected).