### PR TITLE
Make sure we include IDs as a particle type in Gadget FOF

### DIFF
--- a/yt/frontends/gadget_fof/io.py
+++ b/yt/frontends/gadget_fof/io.py
@@ -149,8 +149,7 @@ class IOHandlerGadgetFOFHDF5(BaseIOHandler):
         si, ei = data_file.start, data_file.end
         pcount = \
           {"Group": data_file.header["Ngroups_ThisFile"],
-           "Subhalo": data_file.header["Nsubgroups_ThisFile"],
-           "IDs": data_file.header["Nids_ThisFile"]}
+           "Subhalo": data_file.header["Nsubgroups_ThisFile"]}
         if None not in (si, ei):
             for ptype in pcount:
                 pcount[ptype] = np.clip(pcount[ptype]-si, 0, ei-si)

--- a/yt/frontends/gadget_fof/io.py
+++ b/yt/frontends/gadget_fof/io.py
@@ -149,7 +149,8 @@ class IOHandlerGadgetFOFHDF5(BaseIOHandler):
         si, ei = data_file.start, data_file.end
         pcount = \
           {"Group": data_file.header["Ngroups_ThisFile"],
-           "Subhalo": data_file.header["Nsubgroups_ThisFile"]}
+           "Subhalo": data_file.header["Nsubgroups_ThisFile"],
+           "IDs": data_file.header["Nids_ThisFile"]}
         if None not in (si, ei):
             for ptype in pcount:
                 pcount[ptype] = np.clip(pcount[ptype]-si, 0, ei-si)

--- a/yt/frontends/gadget_fof/tests/test_outputs.py
+++ b/yt/frontends/gadget_fof/tests/test_outputs.py
@@ -87,8 +87,9 @@ g56 = "gadget_halos/data/groups_056/fof_subhalo_tab_056.0.hdf5"
 def test_unbalanced_dataset():
     ds = data_dir_load(g56)
     halo = ds.halo("Group", 0)
-    halo["member_ids"]
-    assert True
+    assert_equal(len(halo["member_ids"]), 33)
+    assert_equal(halo["member_ids"].min().d, 723254.0)
+    assert_equal(halo["member_ids"].max().d, 772662.0)
 
 # fof/subhalo catalog with no member ids in first file
 g76 = "gadget_halos/data/groups_076/fof_subhalo_tab_076.0.hdf5"


### PR DESCRIPTION
This adds the IDs particle type to the list of particle types to check
in the Gadget FOF frontend.  It should eliminate the error seen in the
test suite on Fido.