### PR TITLE
fix: log error instead of crashing in smoothed grid computation if ghost-zones can't be reconstructed

### DIFF
--- a/yt/fields/field_exceptions.py
+++ b/yt/fields/field_exceptions.py
@@ -8,7 +8,8 @@ class NeedsGridType(ValidationException):
         self.fields = fields
 
     def __str__(self):
-        return f"({self.ghost_zones}, {self.fields})"
+        s = "s" if self.ghost_zones != 1 else ""
+        return f"fields {self.fields} require {self.ghost_zones} ghost zone{s}."
 
 
 class NeedsOriginalGrid(NeedsGridType):

--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -999,14 +999,16 @@ cdef class RegionSelector(SelectorObject):
             else:
                 if LE[i] < DLE[i] or RE[i] > DRE[i]:
                     raise RuntimeError(
-                        "Error: yt attempted to read outside the boundaries of "
+                        "yt attempted to read outside the boundaries of "
                         "a non-periodic domain along dimension %s.\n"
                         "Region left edge = %s, Region right edge = %s\n"
                         "Dataset left edge = %s, Dataset right edge = %s\n\n"
                         "This commonly happens when trying to compute ghost cells "
                         "up to the domain boundary. Two possible solutions are to "
-                        "load a smaller region that does not border the edge or "
-                        "override the periodicity for this dataset." % \
+                        "select a smaller region that does not border domain edge "
+                        "(see https://yt-project.org/docs/analyzing/objects.html?highlight=region)\n"
+                        "or override the periodicity with e.g\n"
+                        "ds.periodicity = 3*[True]" % \
                         (i, dobj.left_edge[i], dobj.right_edge[i],
                          dobj.ds.domain_left_edge[i], dobj.ds.domain_right_edge[i])
                     )


### PR DESCRIPTION
## PR Summary

A semi-fix to #2710 
The core issue in #2710 is that we don't have ghost-zone reconstruction in the AMRVAC frontend.
With this change, instead of crashing, yt logs an error message pointing to the defective class for lacking ghost-on support.
Results are obviously buggy (see below) but it's still better than nothing and at least the user gets a better idea what's wrong.