### PR TITLE
Allow in_conda_env to look for conda-forge

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -132,7 +132,7 @@ def check_for_pyembree():
     return os.path.dirname(fn)
 
 def in_conda_env():
-    return any(s in sys.version for s in ("Anaconda", "Continuum"))
+    return any(s in sys.version for s in ("Anaconda", "Continuum", "conda-forge"))
 
 def read_embree_location():
     '''


### PR DESCRIPTION
I had to make this change to ensure that conda-forge-built environments
were detected by the `in_conda_env` function.