### PR TITLE
[BUGFIX] Update con_args parsing for current h5py

### DIFF
--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -21,7 +21,7 @@ libconf==1.0.1
 cartopy==0.17.0
 pyaml==17.10.0
 mpi4py==3.0.3
-unyt==2.7.2
+git+https://github.com/yt-project/unyt@e02254e3ecc11a84854a22109354fe3f47bd8985#egg=unyt
 pyyaml>=4.2b1
 xarray==0.12.3
 firefly_api>=0.0.2

--- a/yt/frontends/ytdata/data_structures.py
+++ b/yt/frontends/ytdata/data_structures.py
@@ -72,6 +72,11 @@ class SavedDataset(Dataset):
                     except ValueError:
                         # support older ytdata outputs
                         v = v.astype('str')
+                    except NameError:
+                        # This is the most common error we expect, and it
+                        # results from having the eval do a concatenated decoded
+                        # set of the values.
+                        v = [_.decode('utf8') for _ in v]
                 self.parameters[key] = v
             self._with_parameter_file_open(f)
 

--- a/yt/frontends/ytdata/tests/test_old_outputs.py
+++ b/yt/frontends/ytdata/tests/test_old_outputs.py
@@ -27,17 +27,12 @@ from yt.frontends.ytdata.tests.test_outputs import \
 from yt.testing import \
     assert_allclose_units, \
     assert_array_equal, \
-    assert_fname, \
-    requires_file, \
-    requires_module
+    requires_file
 from yt.utilities.answer_testing.framework import \
     requires_ds, \
     data_dir_load
 from yt.units.yt_array import \
     YTArray
-from yt.visualization.plot_window import \
-    SlicePlot, \
-    ProjectionPlot
 from yt.visualization.profile_plotter import \
     ProfilePlot, \
     PhasePlot
@@ -184,36 +179,3 @@ def test_old_nonspatial_data():
     new_ds = data_dir_load(full_fn)
     assert isinstance(new_ds, YTNonspatialDataset)
     yield YTDataFieldTest(full_fn, "density", geometric=False)
-
-@requires_module('h5py')
-@requires_file(os.path.join(ytdata_dir, "slice.h5"))
-@requires_file(os.path.join(ytdata_dir, "proj.h5"))
-@requires_file(os.path.join(ytdata_dir, "oas.h5"))
-def test_old_plot_data():
-    tmpdir = tempfile.mkdtemp()
-    curdir = os.getcwd()
-    os.chdir(tmpdir)
-
-    fn = "slice.h5"
-    full_fn = os.path.join(ytdata_dir, fn)
-    ds_slice = data_dir_load(full_fn)
-    p = SlicePlot(ds_slice, 'z', 'density')
-    fn = p.save()
-    assert_fname(fn[0])
-
-    fn = "proj.h5"
-    full_fn = os.path.join(ytdata_dir, fn)
-    ds_proj = data_dir_load(full_fn)
-    p = ProjectionPlot(ds_proj, 'z', 'density')
-    fn = p.save()
-    assert_fname(fn[0])
-
-    fn = "oas.h5"
-    full_fn = os.path.join(ytdata_dir, fn)
-    ds_oas = data_dir_load(full_fn)
-    p = SlicePlot(ds_oas, [1, 1, 1], 'density')
-    fn = p.save()
-    assert_fname(fn[0])
-
-    os.chdir(curdir)
-    shutil.rmtree(tmpdir)

--- a/yt/frontends/ytdata/tests/test_outputs.py
+++ b/yt/frontends/ytdata/tests/test_outputs.py
@@ -12,10 +12,7 @@ from yt.frontends.ytdata.api import \
 from yt.testing import \
     assert_array_equal, \
     assert_allclose_units, \
-    assert_equal, \
-    assert_fname, \
-    fake_random_ds, \
-    requires_module
+    assert_equal
 from yt.utilities.answer_testing.framework import \
     requires_ds, \
     data_dir_load, \
@@ -23,9 +20,6 @@ from yt.utilities.answer_testing.framework import \
 from yt.units.yt_array import \
     YTArray, \
     YTQuantity
-from yt.visualization.plot_window import \
-    SlicePlot, \
-    ProjectionPlot
 from yt.visualization.profile_plotter import \
     ProfilePlot, \
     PhasePlot
@@ -243,38 +237,6 @@ def test_nonspatial_data():
     new_ds = load(full_fn)
     assert isinstance(new_ds, YTNonspatialDataset)
     yield YTDataFieldTest(full_fn, "density", geometric=False)
-    os.chdir(curdir)
-    if tmpdir != '.':
-        shutil.rmtree(tmpdir)
-
-@requires_module('h5py')
-def test_plot_data():
-    tmpdir = make_tempdir()
-    curdir = os.getcwd()
-    os.chdir(tmpdir)
-    ds = fake_random_ds(16)
-
-    plot = SlicePlot(ds, 'z', 'density')
-    fn = plot.data_source.save_as_dataset('slice.h5')
-    ds_slice = load(fn)
-    p = SlicePlot(ds_slice, 'z', 'density')
-    fn = p.save()
-    assert_fname(fn[0])
-
-    plot = ProjectionPlot(ds, 'z', 'density')
-    fn = plot.data_source.save_as_dataset('proj.h5')
-    ds_proj = load(fn)
-    p = ProjectionPlot(ds_proj, 'z', 'density')
-    fn = p.save()
-    assert_fname(fn[0])
-
-    plot = SlicePlot(ds, [1, 1, 1], 'density')
-    fn = plot.data_source.save_as_dataset('oas.h5')
-    ds_oas = load(fn)
-    p = SlicePlot(ds_oas, [1, 1, 1], 'density')
-    fn = p.save()
-    assert_fname(fn[0])
-
     os.chdir(curdir)
     if tmpdir != '.':
         shutil.rmtree(tmpdir)

--- a/yt/frontends/ytdata/tests/test_unit.py
+++ b/yt/frontends/ytdata/tests/test_unit.py
@@ -1,0 +1,77 @@
+from yt.convenience import load
+from yt.testing import assert_fname, fake_random_ds, requires_module, requires_file
+from yt.utilities.answer_testing.framework import data_dir_load
+from yt.visualization.plot_window import SlicePlot, ProjectionPlot
+import tempfile
+import os
+import shutil
+
+
+ytdata_dir = "ytdata_test"
+
+
+@requires_module("h5py")
+@requires_file(os.path.join(ytdata_dir, "slice.h5"))
+@requires_file(os.path.join(ytdata_dir, "proj.h5"))
+@requires_file(os.path.join(ytdata_dir, "oas.h5"))
+def test_old_plot_data():
+    tmpdir = tempfile.mkdtemp()
+    curdir = os.getcwd()
+    os.chdir(tmpdir)
+
+    fn = "slice.h5"
+    full_fn = os.path.join(ytdata_dir, fn)
+    ds_slice = data_dir_load(full_fn)
+    p = SlicePlot(ds_slice, "z", "density")
+    fn = p.save()
+    assert_fname(fn[0])
+
+    fn = "proj.h5"
+    full_fn = os.path.join(ytdata_dir, fn)
+    ds_proj = data_dir_load(full_fn)
+    p = ProjectionPlot(ds_proj, "z", "density")
+    fn = p.save()
+    assert_fname(fn[0])
+
+    fn = "oas.h5"
+    full_fn = os.path.join(ytdata_dir, fn)
+    ds_oas = data_dir_load(full_fn)
+    p = SlicePlot(ds_oas, [1, 1, 1], "density")
+    fn = p.save()
+    assert_fname(fn[0])
+
+    os.chdir(curdir)
+    shutil.rmtree(tmpdir)
+
+
+@requires_module("h5py")
+def test_plot_data():
+    tmpdir = tempfile.mkdtemp()
+    curdir = os.getcwd()
+    os.chdir(tmpdir)
+    ds = fake_random_ds(16)
+
+    plot = SlicePlot(ds, "z", "density")
+    fn = plot.data_source.save_as_dataset("slice.h5")
+    ds_slice = load(fn)
+    p = SlicePlot(ds_slice, "z", "density")
+    fn = p.save()
+    assert_fname(fn[0])
+
+    plot = ProjectionPlot(ds, "z", "density")
+    fn = plot.data_source.save_as_dataset("proj.h5")
+    ds_proj = load(fn)
+    p = ProjectionPlot(ds_proj, "z", "density")
+    fn = p.save()
+    assert_fname(fn[0])
+
+    plot = SlicePlot(ds, [1, 1, 1], "density")
+    fn = plot.data_source.save_as_dataset("oas.h5")
+    ds_oas = load(fn)
+    p = SlicePlot(ds_oas, [1, 1, 1], "density")
+    fn = p.save()
+    assert_fname(fn[0])
+
+    os.chdir(curdir)
+    if tmpdir != ".":
+        shutil.rmtree(tmpdir)


### PR DESCRIPTION
This fixes the ytdata tests for me.  What was happening:

```
f.attrs.get("con_args")
```

was returning

```
array([b'axis', b'coord'], dtype='|S5')
```

So when this was getting `eval`'d, it was trying to eval `axiscoord` (or
`normalcenter`) which didn't exist.  So instead let's pull the
individual values, decode them, and assign them.