### PR TITLE
Hotfix broken raise statement

### DIFF
--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -428,8 +428,6 @@ class FieldInfoContainer(dict):
         unavailable = []
         fields_to_check = fields_to_check or list(self.keys())
         for field in fields_to_check:
-            if field not in self:
-                raise YTFieldNotFound(str(field))
             fi = self[field]
             try:
                 fd = fi.get_dependencies(ds=self.ds)


### PR DESCRIPTION
## PR Summary

fix a broken raise statement (missing positional argument in `YTFieldNotFound` init).
While I'm at it, I'm changing the pattern to EAFP.

edit:
Wait. This error is actually encapsulating another one that's pretty much identical

```python
KeyError: 'No field named blblblb'
During handling of the above exception, another exception occurred:

YTFieldNotFound 
YTFieldNotFound: Could not find field 'blblblb' in MYFILE.
```

So I think the best course of action is simply to get rid of this redundant error-chaining.

But there's worse: I'm getting this while I'm trying to *add* a field to a dataset, so none of these errors makes much sense to me.
-> this is a different problem and is actually fixed with #2638