### PR TITLE
fix: add support to init from pathlike objects for time series

### DIFF
--- a/yt/data_objects/tests/test_time_series.py
+++ b/yt/data_objects/tests/test_time_series.py
@@ -2,8 +2,9 @@ import os
 import tempfile
 from pathlib import Path
 
-from yt.data_objects.time_series import get_filenames_from_glob_pattern
+from yt.data_objects.time_series import DatasetSeries, get_filenames_from_glob_pattern
 from yt.testing import assert_raises
+from yt.utilities.exceptions import YTOutputNotIdentified
 
 
 def test_pattern_expansion():
@@ -25,3 +26,36 @@ def test_no_match_pattern():
     with tempfile.TemporaryDirectory() as tmpdir:
         pattern = os.path.join(tmpdir, "fake_data_file_*")
         assert_raises(OSError, get_filenames_from_glob_pattern, pattern)
+
+def test_init_fake_dataseries():
+
+    file_list = ["fake_data_file_{}".format(str(i).zfill(4)) for i in range(10)]
+    with tempfile.TemporaryDirectory() as tmpdir:
+        pfile_list = [Path(tmpdir) / file for file in file_list]
+        sfile_list = [os.path.join(tmpdir, f) for f in file_list]
+        for file in pfile_list:
+            file.touch()
+        pattern = os.path.join(tmpdir, "fake_data_file_*")
+
+        # init from str pattern
+        ts = DatasetSeries(pattern)
+        assert ts._pre_outputs == sfile_list
+
+        # init from Path pattern
+        ppattern = Path(pattern)
+        ts = DatasetSeries(ppattern)
+        assert ts._pre_outputs == sfile_list
+
+        # init form str list
+        ts = DatasetSeries(sfile_list)
+        assert ts._pre_outputs == sfile_list
+
+        # init form Path list
+        ts = DatasetSeries(pfile_list)
+        assert ts._pre_outputs == pfile_list
+
+        # rejected input type (str repr of a list) "[file1, file2, ...]"
+        assert_raises(OSError, DatasetSeries, str(file_list))
+
+        # finally, check that ts[0] fails to actually load
+        assert_raises(YTOutputNotIdentified, ts.__getitem__, 0)

--- a/yt/data_objects/tests/test_time_series.py
+++ b/yt/data_objects/tests/test_time_series.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from yt.data_objects.time_series import DatasetSeries
 from yt.testing import assert_raises
-from yt.utilities.exceptions import YTOutputNotIdentified
+from yt.utilities.exceptions import YTUnidentifiedDataType
 
 
 def test_pattern_expansion():
@@ -61,4 +61,4 @@ def test_init_fake_dataseries():
         assert_raises(FileNotFoundError, DatasetSeries, str(file_list))
 
         # finally, check that ts[0] fails to actually load
-        assert_raises(YTOutputNotIdentified, ts.__getitem__, 0)
+        assert_raises(YTUnidentifiedDataType, ts.__getitem__, 0)

--- a/yt/data_objects/tests/test_time_series.py
+++ b/yt/data_objects/tests/test_time_series.py
@@ -32,7 +32,7 @@ def test_no_match_pattern():
 
 def test_init_fake_dataseries():
 
-    file_list = ["fake_data_file_{}".format(str(i).zfill(4)) for i in range(10)]
+    file_list = [f"fake_data_file_{str(i).zfill(4)}" for i in range(10)]
     with tempfile.TemporaryDirectory() as tmpdir:
         pfile_list = [Path(tmpdir) / file for file in file_list]
         sfile_list = [os.path.join(tmpdir, f) for f in file_list]

--- a/yt/data_objects/tests/test_time_series.py
+++ b/yt/data_objects/tests/test_time_series.py
@@ -25,7 +25,9 @@ def test_pattern_expansion():
 def test_no_match_pattern():
     with tempfile.TemporaryDirectory() as tmpdir:
         pattern = os.path.join(tmpdir, "fake_data_file_*")
-        assert_raises(OSError, DatasetSeries._get_filenames_from_glob_pattern, pattern)
+        assert_raises(
+            FileNotFoundError, DatasetSeries._get_filenames_from_glob_pattern, pattern
+        )
 
 
 def test_init_fake_dataseries():
@@ -56,7 +58,7 @@ def test_init_fake_dataseries():
         assert ts._pre_outputs == pfile_list
 
         # rejected input type (str repr of a list) "[file1, file2, ...]"
-        assert_raises(OSError, DatasetSeries, str(file_list))
+        assert_raises(FileNotFoundError, DatasetSeries, str(file_list))
 
         # finally, check that ts[0] fails to actually load
         assert_raises(YTOutputNotIdentified, ts.__getitem__, 0)

--- a/yt/data_objects/tests/test_time_series.py
+++ b/yt/data_objects/tests/test_time_series.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 from pathlib import Path
 
-from yt.data_objects.time_series import DatasetSeries, get_filenames_from_glob_pattern
+from yt.data_objects.time_series import DatasetSeries
 from yt.testing import assert_raises
 from yt.utilities.exceptions import YTOutputNotIdentified
 
@@ -15,17 +15,18 @@ def test_pattern_expansion():
             (Path(tmpdir) / file).touch()
 
         pattern = os.path.join(tmpdir, "fake_data_file_*")
-        found = get_filenames_from_glob_pattern(pattern)
+        found = DatasetSeries._get_filenames_from_glob_pattern(pattern)
         assert found == [os.path.join(tmpdir, file) for file in file_list]
 
-        found2 = get_filenames_from_glob_pattern(Path(pattern))
+        found2 = DatasetSeries._get_filenames_from_glob_pattern(Path(pattern))
         assert found2 == found
 
 
 def test_no_match_pattern():
     with tempfile.TemporaryDirectory() as tmpdir:
         pattern = os.path.join(tmpdir, "fake_data_file_*")
-        assert_raises(OSError, get_filenames_from_glob_pattern, pattern)
+        assert_raises(OSError, DatasetSeries._get_filenames_from_glob_pattern, pattern)
+
 
 def test_init_fake_dataseries():
 

--- a/yt/data_objects/tests/test_time_series.py
+++ b/yt/data_objects/tests/test_time_series.py
@@ -1,4 +1,3 @@
-import os
 import tempfile
 from pathlib import Path
 
@@ -11,20 +10,22 @@ def test_pattern_expansion():
     file_list = [f"fake_data_file_{str(i).zfill(4)}" for i in range(10)]
 
     with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = Path(tmpdir)
         for file in file_list:
-            (Path(tmpdir) / file).touch()
+            (tmp_path / file).touch()
 
-        pattern = os.path.join(tmpdir, "fake_data_file_*")
+        pattern = tmp_path / "fake_data_file_*"
+        expected = [str(tmp_path / file) for file in file_list]
         found = DatasetSeries._get_filenames_from_glob_pattern(pattern)
-        assert found == [os.path.join(tmpdir, file) for file in file_list]
+        assert found == expected
 
         found2 = DatasetSeries._get_filenames_from_glob_pattern(Path(pattern))
-        assert found2 == found
+        assert found2 == expected
 
 
 def test_no_match_pattern():
     with tempfile.TemporaryDirectory() as tmpdir:
-        pattern = os.path.join(tmpdir, "fake_data_file_*")
+        pattern = Path(tmpdir).joinpath("fake_data_file_*")
         assert_raises(
             FileNotFoundError, DatasetSeries._get_filenames_from_glob_pattern, pattern
         )
@@ -35,10 +36,10 @@ def test_init_fake_dataseries():
     file_list = [f"fake_data_file_{str(i).zfill(4)}" for i in range(10)]
     with tempfile.TemporaryDirectory() as tmpdir:
         pfile_list = [Path(tmpdir) / file for file in file_list]
-        sfile_list = [os.path.join(tmpdir, f) for f in file_list]
+        sfile_list = [str(file) for file in pfile_list]
         for file in pfile_list:
             file.touch()
-        pattern = os.path.join(tmpdir, "fake_data_file_*")
+        pattern = Path(tmpdir) / "fake_data_file_*"
 
         # init from str pattern
         ts = DatasetSeries(pattern)

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -152,10 +152,7 @@ class DatasetSeries:
         except TypeError:
             pass
         ret = super(DatasetSeries, cls).__new__(cls)
-        try:
-            ret._pre_outputs = outputs[:]
-        except TypeError as e:
-            raise YTUnidentifiedDataType(outputs, *args, **kwargs) from e
+        ret._pre_outputs = outputs[:]
         return ret
 
     def __init__(

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -196,7 +196,7 @@ class DatasetSeries:
         # we try to match the pattern from the test data dir
         file_list = glob.glob(epattern) or glob.glob(os.path.join(data_dir, epattern))
         if not file_list:
-            raise OSError(f"No match found for pattern : {pattern}")
+            raise FileNotFoundError(f"No match found for pattern : {pattern}")
         return sorted(file_list)
 
     def __iter__(self):

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -101,7 +101,7 @@ class DatasetSeries:
         A list of filenames, for instance ["DD0001/DD0001", "DD0002/DD0002"],
         or a glob pattern (i.e. containing wildcards '[]?!*') such as "DD*/DD*.index".
         In the latter case, results are sorted automatically.
-        Filenames and patterns can be of type str, os.Patlike or bytes.
+        Filenames and patterns can be of type str, os.Pathlike or bytes.
     parallel : True, False or int
         This parameter governs the behavior when .piter() is called on the
         resultant DatasetSeries object.  If this is set to False, the time

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -537,7 +537,7 @@ class SimulationTimeSeries(DatasetSeries):
         """
 
         if not os.path.exists(parameter_filename):
-            raise OSError(parameter_filename)
+            raise FileNotFoundError(parameter_filename)
         self.parameter_filename = parameter_filename
         self.basename = os.path.basename(parameter_filename)
         self.directory = os.path.dirname(parameter_filename)

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -113,10 +113,11 @@ class DatasetSeries:
 
     Parameters
     ----------
-    outputs : list or pattern
+    outputs : list of filenames, or pattern
         A list of filenames, for instance ["DD0001/DD0001", "DD0002/DD0002"],
         or a glob pattern (i.e. containing wildcards '[]?!*') such as "DD*/DD*.index".
         In the latter case, results are sorted automatically.
+        Filenames and patterns can be of type str, os.Patlike or bytes.
     parallel : True, False or int
         This parameter governs the behavior when .piter() is called on the
         resultant DatasetSeries object.  If this is set to False, the time

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -162,8 +162,10 @@ class DatasetSeries:
             mylog.debug("Registering simulation: %s as %s", code_name, cls)
 
     def __new__(cls, outputs, *args, **kwargs):
-        if isinstance(outputs, str):
+        try:
             outputs = get_filenames_from_glob_pattern(outputs)
+        except TypeError:
+            pass
         ret = super(DatasetSeries, cls).__new__(cls)
         try:
             ret._pre_outputs = outputs[:]
@@ -202,11 +204,11 @@ class DatasetSeries:
     def __iter__(self):
         # We can make this fancier, but this works
         for o in self._pre_outputs:
-            if isinstance(o, str):
+            try:
                 ds = self._load(o, **self.kwargs)
                 self._setup_function(ds)
                 yield ds
-            else:
+            except TypeError:
                 yield o
 
     def __getitem__(self, key):
@@ -218,9 +220,11 @@ class DatasetSeries:
                 self._pre_outputs[key], parallel=self.parallel, **self.kwargs
             )
         o = self._pre_outputs[key]
-        if isinstance(o, str):
+        try:
             o = self._load(o, **self.kwargs)
             self._setup_function(o)
+        except TypeError:
+            pass
         return o
 
     def __len__(self):

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -12,7 +12,7 @@ from yt.data_objects.analyzer_objects import AnalysisTask, create_quantity_proxy
 from yt.data_objects.particle_trajectories import ParticleTrajectories
 from yt.funcs import ensure_list, issue_deprecation_warning, iterable, mylog
 from yt.units.yt_array import YTArray, YTQuantity
-from yt.utilities.exceptions import YTException, YTUnidentifiedDataType
+from yt.utilities.exceptions import YTException
 from yt.utilities.object_registries import (
     analysis_task_registry,
     data_object_registry,

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -55,22 +55,6 @@ def get_ds_prop(propname):
     return cls
 
 
-def get_filenames_from_glob_pattern(outputs):
-    """
-    Helper function to DatasetSeries.__new__
-    handle a special case where "outputs" is assumed to be really a pattern string
-    """
-    pattern = outputs
-    epattern = os.path.expanduser(pattern)
-    data_dir = ytcfg.get("yt", "test_data_dir")
-    # if not match if found from the current work dir,
-    # we try to match the pattern from the test data dir
-    file_list = glob.glob(epattern) or glob.glob(os.path.join(data_dir, epattern))
-    if not file_list:
-        raise OSError(f"No match found for pattern : {pattern}")
-    return sorted(file_list)
-
-
 attrs = (
     "refine_by",
     "dimensionality",
@@ -164,7 +148,7 @@ class DatasetSeries:
 
     def __new__(cls, outputs, *args, **kwargs):
         try:
-            outputs = get_filenames_from_glob_pattern(outputs)
+            outputs = cls._get_filenames_from_glob_pattern(outputs)
         except TypeError:
             pass
         ret = super(DatasetSeries, cls).__new__(cls)
@@ -201,6 +185,22 @@ class DatasetSeries:
             )
         self.parallel = parallel
         self.kwargs = kwargs
+
+    @staticmethod
+    def _get_filenames_from_glob_pattern(outputs):
+        """
+        Helper function to DatasetSeries.__new__
+        handle a special case where "outputs" is assumed to be really a pattern string
+        """
+        pattern = outputs
+        epattern = os.path.expanduser(pattern)
+        data_dir = ytcfg.get("yt", "test_data_dir")
+        # if not match if found from the current work dir,
+        # we try to match the pattern from the test data dir
+        file_list = glob.glob(epattern) or glob.glob(os.path.join(data_dir, epattern))
+        if not file_list:
+            raise OSError(f"No match found for pattern : {pattern}")
+        return sorted(file_list)
 
     def __iter__(self):
         # We can make this fancier, but this works


### PR DESCRIPTION
#  PR Summary

fix #2633 

This is a very light change, but the branch is based on top of #2695 (merged ! 🎉 )
Reason: in order to avoid type checking with `isinstance(output, str)` and allow allow pathlike types to be treated equally, I use this pattern to determine if an output represents loaded or loadable data
```python
try:
    return load(output) # loadable data ?
except TypeError:
    return output # assumed loaded data
```
... and this pattern is only relevant if `load` is able to throw `TypeError`. To a certain extent, this proves the point I made in #2695 : it makes for a more maintainable code base.
Based on master, I would need to catch `YTOutputNotIdentified`, which would not be specific enough and could cause very weird behaviour downstream.

## PR Checklist

- [x] Code passes flake8 checker
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.
