### PR TITLE
add support for region selection with numpy-like ellipsis syntax

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,6 @@ combine_as_imports=True
 line_length=88
 # isort can't be applied to yt/__init__.py because it creates circular imports
 skip = venv, doc, benchmarks, yt/__init__.py, yt/extern
-known_third_party = IPython, nose, numpy, sympy, matplotlib, unyt, git, yaml, dateutil, requests, coverage, pytest, pyx
+known_third_party = IPython, nose, numpy, sympy, matplotlib, unyt, git, yaml, dateutil, requests, coverage, pytest, pyx, glue
 known_first_party = yt
 sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER

--- a/yt/data_objects/region_expression.py
+++ b/yt/data_objects/region_expression.py
@@ -2,11 +2,7 @@ import weakref
 
 from yt.funcs import obj_length
 from yt.units.yt_array import YTQuantity
-from yt.utilities.exceptions import (
-    YTDimensionalityError,
-    YTFieldNotFound,
-    YTFieldNotParseable,
-)
+from yt.utilities.exceptions import YTDimensionalityError, YTFieldNotParseable
 from yt.visualization.line_plot import LineBuffer
 
 from .data_containers import _get_ipython_key_completion
@@ -30,7 +26,7 @@ class RegionExpression:
         # that result in a rectangular prism or a slice.
         try:
             return self.all_data[item]
-        except (TypeError, YTFieldNotFound, YTFieldNotParseable):
+        except (TypeError, YTFieldNotParseable):
             pass
 
         if isinstance(item, slice):

--- a/yt/data_objects/tests/test_regions.py
+++ b/yt/data_objects/tests/test_regions.py
@@ -1,4 +1,4 @@
-from yt.testing import assert_array_equal, fake_amr_ds, fake_random_ds
+from yt.testing import assert_array_equal, assert_raises, fake_amr_ds, fake_random_ds
 from yt.units import cm
 
 
@@ -28,3 +28,24 @@ def test_max_level_min_level_semantics():
     assert ad["grid_level"].min() == 2
     ad.min_level = 0
     assert ad["grid_level"].min() == 0
+
+
+def test_ellipsis_selection():
+    ds = fake_amr_ds()
+    reg = ds.r[:, :, :]
+    ereg = ds.r[...]
+    assert_array_equal(reg.fwidth, ereg.fwidth)
+
+    reg = ds.r[(0.5, "cm"), :, :]
+    ereg = ds.r[(0.5, "cm"), ...]
+    assert_array_equal(reg.fwidth, ereg.fwidth)
+
+    reg = ds.r[:, :, (0.5, "cm")]
+    ereg = ds.r[..., (0.5, "cm")]
+    assert_array_equal(reg.fwidth, ereg.fwidth)
+
+    reg = ds.r[:, :, (0.5, "cm")]
+    ereg = ds.r[..., (0.5, "cm")]
+    assert_array_equal(reg.fwidth, ereg.fwidth)
+
+    assert_raises(IndexError, ds.r.__getitem__, (..., (0.5, "cm"), ...))


### PR DESCRIPTION
## PR Summary

Region selection mostly feels like array slicing with magic, though there's one way to write array slicing that is currently not supported in yt : ellipsis `...` !
This PR adds support for this by expanding an ellipsis into the required number of `slice` instances.

For reference here's yt's current behaviour:
```python
ds = yt.testing.fake_amr_ds()

reg1 = ds.r[...]  # is equivalent to ds.r[:,:,:]
old >> TypeError: object of type 'ellipsis' has no len()

reg2 = ds.r[(1, "cm"), ...]  # is equivalent to ds.r[(1, "cm"),:,:]
old >> YTDimensionalityError: Dimensionality specified was 2 but we need 3

# though this might be considered equivalent to ds.r[:, (1, "cm"), :]
# it's regarded as ambiguous in the general case in numpy so we won't support this
# but throw a relevant error instead, in numpy's fashion
reg3 = ds.r[..., (1, "cm"), ...]  
old >> RuntimeError: unyt_quantity values must be numeric
new >> IndexError: an index can only have a single ellipsis ('...')
```

Note: I'm not currently aware of any other place in the code base where it would be useful, though this pattern should be trivial to isolate as a helper function if needed.

## PR Checklist

- [x] Code passes flake8 checker
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.
