### PR TITLE
fix: automatic slice->region expansion support for 1D and 2D datasets

### DIFF
--- a/yt/data_objects/region_expression.py
+++ b/yt/data_objects/region_expression.py
@@ -41,8 +41,8 @@ class RegionExpression:
                 # possible use case of this would be where we supply something
                 # like ds.r[::256j] .  This would be expanded, implicitly into
                 # ds.r[::256j, ::256j, ::256j].  Other cases would be if we do
-                # ds.r[0.1:0.9] where it will be expanded along three dimensions.
-                item = (item, item, item)
+                # ds.r[0.1:0.9] where it will be expanded along all dimensions.
+                item = tuple(item for _ in range(self.ds.dimensionality))
         if len(item) != self.ds.dimensionality:
             # Not the right specification, and we don't want to do anything
             # implicitly.  Note that this happens *after* the implicit expansion

--- a/yt/data_objects/region_expression.py
+++ b/yt/data_objects/region_expression.py
@@ -2,7 +2,7 @@ import weakref
 
 from yt.funcs import obj_length
 from yt.units.yt_array import YTQuantity
-from yt.utilities.exceptions import YTDimensionalityError
+from yt.utilities.exceptions import YTDimensionalityError, YTFieldNotParseable
 from yt.visualization.line_plot import LineBuffer
 
 from .data_containers import _get_ipython_key_completion
@@ -24,12 +24,11 @@ class RegionExpression:
         # At first, we will only implement this as accepting a slice that is
         # (optionally) unitful corresponding to a specific set of coordinates
         # that result in a rectangular prism or a slice.
-        if isinstance(item, str):
-            # This is some field; we will instead pass this back to the
-            # all_data object.
+        try:
             return self.all_data[item]
-        if isinstance(item, tuple) and isinstance(item[1], str):
-            return self.all_data[item]
+        except (TypeError, YTFieldNotParseable):
+            pass
+
         if isinstance(item, slice):
             if obj_length(item.start) == 3 and obj_length(item.stop) == 3:
                 # This is for a ray that is not orthogonal to an axis.


### PR DESCRIPTION
## PR Summary

Very simple refactor for `RegionExpression.__getitem__` :
- simplify existing code with try block
- add flexibility for single-slice expansion (previously only expanded to 3D)

```python
ds = yt.load("amrvac/bw_2d0000.dat")
ds.r[1:2]
old >> YTDimensionalityError: Dimensionality specified was 3 but we need 2
new >> YTSlice (bw_2d0000.dat): , axis=2, coord=0.5 cm
```