### PR TITLE
hotfix: support time series loading from load_sample

### DIFF
--- a/yt/utilities/load_sample.py
+++ b/yt/utilities/load_sample.py
@@ -72,7 +72,7 @@ def load_sample(name=None, specific_file=None, pbar=True):
 
     # Location of the file to load automatically, registered in the Fido class
     info = fido[fileext]
-    file_lookup = info['load_name']
+    file_lookup = info['load_name'] or "*"
     optional_args = info['load_kwargs']
 
     if specific_file is None:


### PR DESCRIPTION
## PR Summary

This is a quick (and dirty ?) fix for #2699 
It works for the one sample @munkm reported on, but I'm not sure that it generalises well to other data samples with "null" `load_name`.

edit: it already doesn't work with armvac samples (not time series), because they untar into a nested folder, whose outer layer isn't a valid argument for yt.load, so this is definitely not sufficient.

Now I'm not sure that there exists a universal fix for this other than filling the currently undefined `load_name` parameters