### PR TITLE
[bugfix] ensure correct axis units when unit_system=code

### DIFF
--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1347,7 +1347,7 @@ class YTDataContainer:
                     i,
                     getattr(self, i).in_base(unit_system=self.ds.unit_system),
                 )
-            except (AttributeError, KeyError):
+            except AttributeError:
                 s += ", %s=%s" % (i, getattr(self, i))
         return s
 

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1347,8 +1347,8 @@ class YTDataContainer:
                     i,
                     getattr(self, i).in_base(unit_system=self.ds.unit_system),
                 )
-            except AttributeError:
-                s += f", {i}={getattr(self, i)}"
+            except (AttributeError, KeyError):
+                s += ", %s=%s" % (i, getattr(self, i))
         return s
 
     @contextmanager

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1348,7 +1348,7 @@ class YTDataContainer:
                     getattr(self, i).in_base(unit_system=self.ds.unit_system),
                 )
             except AttributeError:
-                s += ", %s=%s" % (i, getattr(self, i))
+                s += f", {i}={getattr(self, i)}"
         return s
 
     @contextmanager

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1108,8 +1108,6 @@ class Dataset(abc.ABC):
         us = create_code_unit_system(
             self.unit_registry, current_mks_unit=current_mks_unit
         )
-        keyname = str(unit_system).lower()
-
         if unit_system != "code":
             us = unit_system_registry[str(unit_system).lower()]
 

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1112,8 +1112,9 @@ class Dataset(abc.ABC):
 
         if unit_system == "code":
             us.name = keyname  # replace an otherwise random label
+
         else:
-            us = unit_system_registry[keyname]
+            us = unit_system_registry[str(unit_system).lower()]
 
         self.unit_system = us
         self.unit_registry.unit_system = self.unit_system

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1108,8 +1108,10 @@ class Dataset(abc.ABC):
         us = create_code_unit_system(
             self.unit_registry, current_mks_unit=current_mks_unit
         )
+        keyname = str(unit_system).lower()
         if unit_system != "code":
-            us = unit_system_registry[str(unit_system).lower()]
+            us = unit_system_registry[keyname]
+        us.name = keyname
         self.unit_system = us
         self.unit_registry.unit_system = self.unit_system
 

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1110,11 +1110,10 @@ class Dataset(abc.ABC):
         )
         keyname = str(unit_system).lower()
 
-        if unit_system == "code":
-            us.name = keyname  # replace an otherwise random label
-
-        else:
+        if unit_system != "code":
             us = unit_system_registry[str(unit_system).lower()]
+
+        us._code_flag = unit_system == "code"
 
         self.unit_system = us
         self.unit_registry.unit_system = self.unit_system

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1109,9 +1109,12 @@ class Dataset(abc.ABC):
             self.unit_registry, current_mks_unit=current_mks_unit
         )
         keyname = str(unit_system).lower()
-        if unit_system != "code":
+
+        if unit_system == "code":
+            us.name = keyname  # replace an otherwise random label
+        else:
             us = unit_system_registry[keyname]
-        us.name = keyname
+
         self.unit_system = us
         self.unit_registry.unit_system = self.unit_system
 

--- a/yt/units/unit_systems.py
+++ b/yt/units/unit_systems.py
@@ -3,7 +3,7 @@ from unyt.unit_systems import *
 
 def create_code_unit_system(unit_registry, current_mks_unit=None):
     code_unit_system = UnitSystem(
-        name="code_{}".format(unit_registry.unit_system_id),
+        name=unit_registry.unit_system_id,
         length_unit="code_length",
         mass_unit="code_mass",
         time_unit="code_time",

--- a/yt/units/unit_systems.py
+++ b/yt/units/unit_systems.py
@@ -3,11 +3,11 @@ from unyt.unit_systems import *
 
 def create_code_unit_system(unit_registry, current_mks_unit=None):
     code_unit_system = UnitSystem(
-        unit_registry.unit_system_id,
-        "code_length",
-        "code_mass",
-        "code_time",
-        "code_temperature",
+        name="code_{}".format(unit_registry.unit_system_id),
+        length_unit="code_length",
+        mass_unit="code_mass",
+        time_unit="code_time",
+        temperature_unit="code_temperature",
         current_mks_unit=current_mks_unit,
         registry=unit_registry,
     )

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -2471,7 +2471,7 @@ class TimestampCallback(PlotCallback):
         if self.time:
             # If no time_units are set, then identify a best fit time unit
             if self.time_unit is None:
-                if plot.ds.unit_system.name == "code":
+                if plot.ds.unit_system.name.startswith("code"):
                     # if the unit system is in code units
                     # we should not convert to seconds for the plot.
                     self.time_unit = plot.ds.unit_system.base_units[dimensions.time]

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -2471,7 +2471,7 @@ class TimestampCallback(PlotCallback):
         if self.time:
             # If no time_units are set, then identify a best fit time unit
             if self.time_unit is None:
-                if plot.ds.unit_system.name.startswith("code"):
+                if plot.ds.unit_system._code_flag:
                     # if the unit system is in code units
                     # we should not convert to seconds for the plot.
                     self.time_unit = plot.ds.unit_system.base_units[dimensions.time]

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -2491,16 +2491,16 @@ class TimestampCallback(PlotCallback):
                         "'time_offset' must be a float, tuple, or" "YTQuantity!"
                     )
                 t -= toffset.in_units(self.time_unit)
-            if isinstance(self.time_unit, Unit):
+            try:
                 # here the time unit will be in brackets on the annotation.
-                # This will most likely be in "code_time".
                 un = self.time_unit.latex_representation()
                 time_unit = r"$\ \ (" + un + r")$"
-            else:
-                # the 'smallest_appropriate_unit' function will return a
-                # string, so we shouldn't need to format it further.
-                time_unit = self.time_unit
-            self.text += self.time_format.format(time=float(t), units=time_unit)
+            except AttributeError:
+                # this should only happen if self.time_unit is "code_time"
+                # in which case we drop the "_" in the time stamp
+                time_unit = str(self.time_unit).replace("_", " ")
+            self.text += self.time_format.format(time=float(t),
+                                                 units=time_unit)
 
         # If time and redshift both shown, do one on top of the other
         if self.time and self.redshift:

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -2471,7 +2471,7 @@ class TimestampCallback(PlotCallback):
         if self.time:
             # If no time_units are set, then identify a best fit time unit
             if self.time_unit is None:
-                if plot.ds.unit_system.name not in ('cgs', 'mks'):
+                if plot.ds.unit_system.name == "code":
                     # if the unit system is in code units
                     # we should not convert to seconds for the plot.
                     self.time_unit = plot.ds.unit_system.base_units[dimensions.time]

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -2471,10 +2471,9 @@ class TimestampCallback(PlotCallback):
         if self.time:
             # If no time_units are set, then identify a best fit time unit
             if self.time_unit is None:
-                if plot.ds.unit_system.name.startswith("us"):
-                    # if the unit system name startswith "us", that means it is
-                    # in code units and we should not convert to seconds for
-                    # the plot.
+                if plot.ds.unit_system.name not in ('cgs', 'mks'):
+                    # if the unit system is in code units
+                    # we should not convert to seconds for the plot.
                     self.time_unit = plot.ds.unit_system.base_units[dimensions.time]
                 else:
                     # in the case of non- code units then we

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -2494,9 +2494,11 @@ class TimestampCallback(PlotCallback):
                 # here the time unit will be in brackets on the annotation.
                 un = self.time_unit.latex_representation()
                 time_unit = r"$\ \ (" + un + r")$"
-            except AttributeError:
-                # this should only happen if self.time_unit is "code_time"
-                # in which case we drop the "_" in the time stamp
+            except AttributeError as err:
+                if plot.ds.unit_system._code_flag == "code":
+                    raise RuntimeError(
+                        "The time unit str repr didn't match expectations, something is wrong."
+                    ) from err
                 time_unit = str(self.time_unit).replace("_", " ")
             self.text += self.time_format.format(time=float(t), units=time_unit)
 

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -15,7 +15,6 @@ from yt.funcs import is_sequence, mylog, validate_width_tuple
 from yt.geometry.geometry_handler import is_curvilinear
 from yt.geometry.unstructured_mesh_handler import UnstructuredIndex
 from yt.units import dimensions
-from yt.units.unit_object import Unit
 from yt.units.yt_array import YTArray, YTQuantity, uhstack
 from yt.utilities.exceptions import YTDataTypeUnsupported
 from yt.utilities.lib.geometry_utils import triangle_plane_intersect
@@ -2499,8 +2498,7 @@ class TimestampCallback(PlotCallback):
                 # this should only happen if self.time_unit is "code_time"
                 # in which case we drop the "_" in the time stamp
                 time_unit = str(self.time_unit).replace("_", " ")
-            self.text += self.time_format.format(time=float(t),
-                                                 units=time_unit)
+            self.text += self.time_format.format(time=float(t), units=time_unit)
 
         # If time and redshift both shown, do one on top of the other
         if self.time and self.redshift:

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -903,7 +903,7 @@ class PWViewerMPL(PlotWindow):
             axis_index = self.data_source.axis
 
             xc, yc = self._setup_origin()
-            if self.ds.unit_system.name.startswith("code") or self.ds.no_cgs_equiv_length:
+            if self.ds.unit_system._code_flag or self.ds.no_cgs_equiv_length:
                 # this should happen only if the dataset was initialized with
                 # argument unit_system="code" or if it's set to have no CGS
                 # equivalent.  This only needs to happen here in the specific

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -903,7 +903,7 @@ class PWViewerMPL(PlotWindow):
             axis_index = self.data_source.axis
 
             xc, yc = self._setup_origin()
-            if self.ds.unit_system.name.startswith("us") or self.ds.no_cgs_equiv_length:
+            if self.ds.unit_system.name not in ('cgs', 'mks') or self.ds.no_cgs_equiv_length:
                 # this should happen only if the dataset was initialized with
                 # argument unit_system="code" or if it's set to have no CGS
                 # equivalent.  This only needs to happen here in the specific

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -903,7 +903,7 @@ class PWViewerMPL(PlotWindow):
             axis_index = self.data_source.axis
 
             xc, yc = self._setup_origin()
-            if self.ds.unit_system.name not in ('cgs', 'mks') or self.ds.no_cgs_equiv_length:
+            if self.ds.unit_system.name == "code" or self.ds.no_cgs_equiv_length:
                 # this should happen only if the dataset was initialized with
                 # argument unit_system="code" or if it's set to have no CGS
                 # equivalent.  This only needs to happen here in the specific

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -903,7 +903,7 @@ class PWViewerMPL(PlotWindow):
             axis_index = self.data_source.axis
 
             xc, yc = self._setup_origin()
-            if self.ds.unit_system.name == "code" or self.ds.no_cgs_equiv_length:
+            if self.ds.unit_system.name.startswith("code") or self.ds.no_cgs_equiv_length:
                 # this should happen only if the dataset was initialized with
                 # argument unit_system="code" or if it's set to have no CGS
                 # equivalent.  This only needs to happen here in the specific

--- a/yt/visualization/tests/test_plot_modifications.py
+++ b/yt/visualization/tests/test_plot_modifications.py
@@ -1,0 +1,13 @@
+from yt.testing import requires_file
+from yt.utilities.answer_testing.framework import data_dir_load
+from yt.visualization.plot_window import SlicePlot
+
+
+@requires_file("amrvac/bw_3d0000.dat")
+def test_code_units_xy_labels():
+    ds = data_dir_load("amrvac/bw_3d0000.dat", kwargs=dict(unit_system="code"))
+    p = SlicePlot(ds, "x", "density")
+
+    ax = p.plots["density"].axes
+    assert "code length" in ax.get_xlabel().replace("\\", "")
+    assert "code length" in ax.get_ylabel().replace("\\", "")

--- a/yt/visualization/tests/test_plot_modifications.py
+++ b/yt/visualization/tests/test_plot_modifications.py
@@ -6,8 +6,8 @@ from yt.visualization.plot_window import SlicePlot
 @requires_file("amrvac/bw_3d0000.dat")
 def test_code_units_xy_labels():
     ds = data_dir_load("amrvac/bw_3d0000.dat", kwargs=dict(unit_system="code"))
-    p = SlicePlot(ds, "x", "density")
+    p = SlicePlot(ds, "x", ("gas", "density"))
 
-    ax = p.plots["density"].axes
+    ax = p.plots[("gas", "density")].axes
     assert "code length" in ax.get_xlabel().replace("\\", "")
     assert "code length" in ax.get_ylabel().replace("\\", "")


### PR DESCRIPTION
This (again) fixes the issue that axis units are not displaying `code_length` for datasets loaded with `unit_system='code'` (issue: #2353, PR: #2354). This also extends to `annotate_timestamp` not displaying the units correctly (issue: #2432, PR: #2435). I assume that merging yt 4.0 undid these.

As far as I could see the unit systems no longer have 'us' in their name, but are simply 'cgs' or 'mks'. The code unit system however has the name 'e0ff37ce2df3cfe508167372302fd83d' (at least in my case) and I'm not sure where this comes from...

The fix is easy, but I don't know if this is going to break other stuff. If it's fine I'll add a test so this doesn't happen again.

```python
    ds = yt.load('amrvac/bw_3d0000.dat', unit_system='code')
    p = yt.SlicePlot(ds, 'x', 'density')
    p.annotate_timestamp()
```

## Before
<img width="640" alt="code_units_before" src="https://user-images.githubusercontent.com/43474374/86540441-9a23ca80-bf05-11ea-84b8-a3483e744547.png">

## After
<img width="640" alt="code_units_after" src="https://user-images.githubusercontent.com/43474374/86540451-a3ad3280-bf05-11ea-8f09-bd537f9d5997.png">

