### PR TITLE
Remove all occurences of VR.render() called right before VR.save()

### DIFF
--- a/doc/source/cookbook/amrkdtree_downsampling.py
+++ b/doc/source/cookbook/amrkdtree_downsampling.py
@@ -39,7 +39,6 @@ print(kd_low_res.count_cells())
 
 render_source.set_volume(kd_low_res)
 render_source.set_field("density")
-sc.render()
 sc.save("v1.png", sigma_clip=6.0)
 
 # This operation was substantially faster.  Now lets modify the low resolution
@@ -54,13 +53,11 @@ tf.add_layers(
     alpha=np.ones(4, dtype="float64"),
     colormap="RdBu_r",
 )
-sc.render()
 sc.save("v2.png", sigma_clip=6.0)
 
 # This looks better.  Now let's try turning on opacity.
 
 tf.grey_opacity = True
-sc.render()
 sc.save("v3.png", sigma_clip=6.0)
 #
 ## That seemed to pick out som interesting structures.  Now let's bump up the
@@ -74,13 +71,13 @@ tf.add_layers(
     alpha=10.0 * np.ones(4, dtype="float64"),
     colormap="RdBu_r",
 )
-sc.render()
+tf.add_layers(4, 0.01, col_bounds=[-27.5, -25.5],
+              alpha=10.0 * np.ones(4, dtype='float64'), colormap='RdBu_r')
 sc.save("v4.png", sigma_clip=6.0)
 #
 ## This looks pretty good, now lets go back to the full resolution AMRKDTree
 #
 render_source.set_volume(kd)
-sc.render()
 sc.save("v5.png", sigma_clip=6.0)
 
 # This looks great!

--- a/doc/source/cookbook/camera_movement.py
+++ b/doc/source/cookbook/camera_movement.py
@@ -12,19 +12,16 @@ frame += 1
 
 # Zoom out by a factor of 2 over 5 frames
 for _ in cam.iter_zoom(0.5, 5):
-    sc.render()
     sc.save("camera_movement_%04i.png" % frame)
     frame += 1
 
 # Move to the position [-10.0, 10.0, -10.0] over 5 frames
 pos = ds.arr([-10.0, 10.0, -10.0], "code_length")
 for _ in cam.iter_move(pos, 5):
-    sc.render()
     sc.save("camera_movement_%04i.png" % frame)
     frame += 1
 
 # Rotate by 180 degrees over 5 frames
 for _ in cam.iter_rotate(np.pi, 5):
-    sc.render()
     sc.save("camera_movement_%04i.png" % frame)
     frame += 1

--- a/doc/source/cookbook/opaque_rendering.py
+++ b/doc/source/cookbook/opaque_rendering.py
@@ -13,7 +13,6 @@ tf.clear()
 tf.add_layers(
     4, 0.01, col_bounds=[-27.5, -25.5], alpha=np.logspace(-3, 0, 4), colormap="RdBu_r"
 )
-sc.render()
 sc.save("v1.png", sigma_clip=6.0)
 
 # In this case, the default alphas used (np.logspace(-3,0,Nbins)) does not
@@ -25,14 +24,12 @@ tf.clear()
 tf.add_layers(
     4, 0.01, col_bounds=[-27.5, -25.5], alpha=np.logspace(0, 0, 4), colormap="RdBu_r"
 )
-sc.render()
 sc.save("v2.png", sigma_clip=6.0)
 
 # Now let's set the grey_opacity to True.  This should make the inner portions
 # start to be obscured
 
 tf.grey_opacity = True
-sc.render()
 sc.save("v3.png", sigma_clip=6.0)
 
 # That looks pretty good, but let's start bumping up the opacity.
@@ -45,7 +42,6 @@ tf.add_layers(
     alpha=10.0 * np.ones(4, dtype="float64"),
     colormap="RdBu_r",
 )
-sc.render()
 sc.save("v4.png", sigma_clip=6.0)
 
 # Let's bump up again to see if we can obscure the inner contour.
@@ -58,7 +54,6 @@ tf.add_layers(
     alpha=30.0 * np.ones(4, dtype="float64"),
     colormap="RdBu_r",
 )
-sc.render()
 sc.save("v5.png", sigma_clip=6.0)
 
 # Now we are losing sight of everything.  Let's see if we can obscure the next
@@ -72,14 +67,12 @@ tf.add_layers(
     alpha=100.0 * np.ones(4, dtype="float64"),
     colormap="RdBu_r",
 )
-sc.render()
 sc.save("v6.png", sigma_clip=6.0)
 
 # That is very opaque!  Now lets go back and see what it would look like with
 # grey_opacity = False
 
 tf.grey_opacity = False
-sc.render()
 sc.save("v7.png", sigma_clip=6.0)
 
 # That looks pretty different, but the main thing is that you can see that the

--- a/doc/source/cookbook/sigma_clip.py
+++ b/doc/source/cookbook/sigma_clip.py
@@ -10,7 +10,6 @@ ds = yt.load("enzo_tiny_cosmology/RD0009/RD0009")
 # Sigma clipping removes the highest intensity pixels in a volume render,
 # which affects the overall contrast of the image.
 sc = yt.create_scene(ds, field=("gas", "density"))
-sc.render()
 sc.save("clip_0.png")
 sc.save("clip_2.png", sigma_clip=2)
 sc.save("clip_4.png", sigma_clip=4)

--- a/doc/source/cookbook/various_lens.py
+++ b/doc/source/cookbook/various_lens.py
@@ -32,7 +32,6 @@ cam.switch_orientation(normal_vector=normal_vector, north_vector=north_vector)
 # height of final projection, while width[2] in plane-parallel lens is not used.
 cam.set_width(ds.domain_width * 0.5)
 sc.add_source(vol)
-sc.render()
 sc.save("lens_plane-parallel.png", sigma_clip=6.0)
 
 # Perspective lens
@@ -47,7 +46,6 @@ cam.switch_orientation(normal_vector=normal_vector, north_vector=north_vector)
 # camera and the final image.
 cam.set_width(ds.domain_width * 0.5)
 sc.add_source(vol)
-sc.render()
 sc.save("lens_perspective.png", sigma_clip=6.0)
 
 # Stereo-perspective lens
@@ -61,7 +59,6 @@ cam.set_width(ds.domain_width * 0.5)
 # Set the distance between left-eye and right-eye.
 cam.lens.disparity = ds.domain_width[0] * 1.0e-3
 sc.add_source(vol)
-sc.render()
 sc.save("lens_stereo-perspective.png", sigma_clip=6.0)
 
 # Fisheye lens
@@ -74,7 +71,6 @@ cam.switch_orientation(normal_vector=normal_vector, north_vector=north_vector)
 cam.set_width(ds.domain_width)
 cam.lens.fov = 360.0
 sc.add_source(vol)
-sc.render()
 sc.save("lens_fisheye.png", sigma_clip=6.0)
 
 # Spherical lens
@@ -90,7 +86,6 @@ cam.switch_orientation(normal_vector=normal_vector, north_vector=north_vector)
 # In (stereo)spherical camera, camera width is not used since the entire volume
 # will be rendered
 sc.add_source(vol)
-sc.render()
 sc.save("lens_spherical.png", sigma_clip=6.0)
 
 # Stereo-spherical lens
@@ -107,5 +102,4 @@ cam.switch_orientation(normal_vector=normal_vector, north_vector=north_vector)
 # Set the distance between left-eye and right-eye.
 cam.lens.disparity = ds.domain_width[0] * 1.0e-3
 sc.add_source(vol)
-sc.render()
 sc.save("lens_stereo-spherical.png", sigma_clip=6.0)

--- a/yt/utilities/answer_testing/answer_tests.py
+++ b/yt/utilities/answer_testing/answer_tests.py
@@ -304,7 +304,6 @@ def extract_connected_sets(ds_fn, data_source, field, num_levels, min_val, max_v
 def VR_image_comparison(scene):
     tmpfd, tmpname = tempfile.mkstemp(suffix=".png")
     os.close(tmpfd)
-    scene.render()
     scene.save(tmpname, sigma_clip=1.0)
     image = mpimg.imread(tmpname)
     os.remove(tmpname)

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -820,7 +820,6 @@ class VRImageComparisonTest(AnswerTestingTest):
     def run(self):
         tmpfd, tmpname = tempfile.mkstemp(suffix=".png")
         os.close(tmpfd)
-        self.scene.render()
         self.scene.save(tmpname, sigma_clip=1.0)
         image = mpimg.imread(tmpname)
         os.remove(tmpname)

--- a/yt/visualization/volume_rendering/tests/test_lenses.py
+++ b/yt/visualization/volume_rendering/tests/test_lenses.py
@@ -46,7 +46,6 @@ class LensTest(TestCase):
         tf = vol.transfer_function
         tf.grey_opacity = True
         sc.add_source(vol)
-        sc.render()
         sc.save("test_perspective_%s.png" % self.field[1], sigma_clip=6.0)
 
     def test_stereoperspective_lens(self):
@@ -58,7 +57,6 @@ class LensTest(TestCase):
         tf = vol.transfer_function
         tf.grey_opacity = True
         sc.add_source(vol)
-        sc.render()
         sc.save("test_stereoperspective_%s.png" % self.field[1], sigma_clip=6.0)
 
     def test_fisheye_lens(self):
@@ -73,7 +71,6 @@ class LensTest(TestCase):
         tf = vol.transfer_function
         tf.grey_opacity = True
         sc.add_source(vol)
-        sc.render()
         sc.save("test_fisheye_%s.png" % self.field[1], sigma_clip=6.0)
 
     def test_plane_lens(self):
@@ -86,7 +83,6 @@ class LensTest(TestCase):
         tf = vol.transfer_function
         tf.grey_opacity = True
         sc.add_source(vol)
-        sc.render()
         sc.save("test_plane_%s.png" % self.field[1], sigma_clip=6.0)
 
     def test_spherical_lens(self):
@@ -98,7 +94,6 @@ class LensTest(TestCase):
         tf = vol.transfer_function
         tf.grey_opacity = True
         sc.add_source(vol)
-        sc.render()
         sc.save("test_spherical_%s.png" % self.field[1], sigma_clip=6.0)
 
     def test_stereospherical_lens(self):
@@ -112,5 +107,4 @@ class LensTest(TestCase):
         tf = vol.transfer_function
         tf.grey_opacity = True
         sc.add_source(vol)
-        sc.render()
         sc.save("test_stereospherical_%s.png" % self.field[1], sigma_clip=6.0)


### PR DESCRIPTION
This PR removes unnecessary and very costly `.render()` call, since `Scene.save()` explicitly calls `Scene.render()`.