### PR TITLE
Adds render option to scene.save to avoid re-rendering

### DIFF
--- a/doc/source/visualizing/Volume_Rendering_Tutorial.ipynb
+++ b/doc/source/visualizing/Volume_Rendering_Tutorial.ipynb
@@ -4,14 +4,31 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook shows how to use the new (in version 3.3) Scene interface to create custom volume renderings. To begin, we load up a dataset and use the yt.create_scene method to set up a basic Scene. We store the Scene in a variable called 'sc' and render the default ('gas', 'density') field."
+    "# Volume Rendering Tutorial \n",
+    "\n",
+    "This notebook shows how to use the new (in version 3.3) Scene interface to create custom volume renderings. The tutorial proceeds in the following steps: \n",
+    "\n",
+    "1. [Creating the Scene](#1.-Creating-the-Scene)\n",
+    "2. [Displaying the Scene](#2.-Displaying-the-Scene)\n",
+    "3. [Adjusting Transfer Functions](#3.-Adjusting-Transfer-Functions)\n",
+    "4. [Saving an Image](#4.-Saving-an-Image)\n",
+    "5. [Adding Annotations](#5.-Adding-Annotations)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Creating the Scene \n",
+    "\n",
+    "To begin, we load up a dataset and use the `yt.create_scene` method to set up a basic Scene. We store the Scene in a variable called `sc` and render the default `('gas', 'density')` field."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "scrolled": true
    },
    "outputs": [],
    "source": [
@@ -28,15 +45,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Note that to render a different field, we would use pass the field name to `yt.create_scene` using the `field` argument. \n",
+    "\n",
     "Now we can look at some information about the Scene we just created using the python print keyword:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print (sc)"
@@ -52,9 +69,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print (sc.get_source())"
@@ -64,15 +79,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can see that the yt.create_source has created a VolumeSource with default values for the center, bounds, and transfer function. Now, let's see what this Scene looks like. In the notebook, we can do this by calling sc.show(). "
+    "## 2. Displaying the Scene \n",
+    "\n",
+    "We can see that the `yt.create_source` method has created a `VolumeSource` with default values for the center, bounds, and transfer function. Now, let's see what this Scene looks like. In the notebook, we can do this by calling `sc.show()`. "
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sc.show()"
@@ -88,9 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sc.camera.zoom(3.0)"
@@ -106,9 +119,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "print (sc)"
@@ -118,15 +129,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To see what this looks like, we re-render the image and display the scene again. Note that we don't actually have to call sc.show() here - we can just have Ipython evaluate the Scene and that will display it automatically."
+    "To see what this looks like, we re-render the image and display the scene again. Note that we don't actually have to call `sc.show()` here - we can just have Ipython evaluate the Scene and that will display it automatically."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sc.render()\n",
@@ -137,15 +146,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "That's better! The image looks a little washed-out though, so we use the sigma_clip argument to sc.show() to improve the contrast:"
+    "That's better! The image looks a little washed-out though, so we use the `sigma_clip` argument to `sc.show()` to improve the contrast:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sc.show(sigma_clip=4.0)"
@@ -155,15 +162,65 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, we demonstrate how to change the mapping between the field values and the colors in the image. We use the TransferFunctionHelper to create a new transfer function using the \"gist_rainbow\" colormap, and then re-create the image as follows:"
+    "Applying different values of `sigma_clip` with `sc.show()` is a relatively fast process because `sc.show()` will pull the most recently rendered image and apply the contrast adjustment without rendering the scene again. While this is useful for quickly testing the affect of different values of `sigma_clip`, it can lead to confusion if we don't remember to render after making changes to the camera. For example, if we zoom in again and simply call `sc.show()`, then we get the same image as before:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sc.camera.zoom(3.0)\n",
+    "sc.show(sigma_clip=4.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For the change to the camera to take affect, we have to explictly render again: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sc.render()\n",
+    "sc.show(sigma_clip=4.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As a general rule, any changes to the scene itself such as adjusting the camera or changing transfer functions requires rendering again. Before moving on, let's undo the last zoom:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sc.camera.zoom(1./3.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Adjusting Transfer Functions\n",
+    "\n",
+    "Next, we demonstrate how to change the mapping between the field values and the colors in the image. We use the TransferFunctionHelper to create a new transfer function using the `gist_rainbow` colormap, and then re-create the image as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Set up a custom transfer function using the TransferFunctionHelper. \n",
@@ -194,9 +251,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "cam = sc.add_camera(ds, lens_type='perspective')\n",
@@ -226,9 +281,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sc.render()\n",
@@ -239,15 +292,51 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## 4. Saving an Image\n",
+    "\n",
+    "To save a volume rendering to an image file at any point, we can use `sc.save` as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sc.save('volume_render.png',render=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Including the keyword argument `render=False` indicates that the most recently rendered image will be saved (otherwise, `sc.save()` will trigger a call to `sc.render()`). This behavior differs from `sc.show()`, which always uses the most recently rendered image. \n",
+    "\n",
+    "An additional caveat is that if we used `sigma_clip` in our call to `sc.show()`, then we must **also** pass it to `sc.save()` as sigma clipping is applied on top of a rendered image array. In that case, we would do the following: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sc.save('volume_render_clip4.png',sigma_clip=4.0,render=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Adding Annotations\n",
+    "\n",
     "Finally, the next cell restores the lens and the transfer function to the defaults, moves the camera, and adds an opaque source  that shows the axes of the simulation coordinate system."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# set the lens type back to plane-parallel\n",
@@ -263,6 +352,13 @@
     "sc.render()\n",
     "sc.show(sigma_clip=4.0)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -281,9 +377,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/doc/source/visualizing/volume_rendering.rst
+++ b/doc/source/visualizing/volume_rendering.rst
@@ -873,8 +873,7 @@ scene and volumes, you can simply call
 calling :meth:`~yt.visualization.volume_rendering.scene.Scene.render`. If you
 wish to save the most recently rendered image without rendering again, set
 ``render=False`` in the call to
-:meth:`~yt.visualization.volume_rendering.scene.Scene.save` and the most
-recently rendered image array will be used.  Cases where you
+:meth:`~yt.visualization.volume_rendering.scene.Scene.save`.  Cases where you
 may wish to use ``render=False`` include saving images at different
 ``sigma_clip`` values (see :ref:`cookbook-sigma_clip`) or when saving an image
 that has already been rendered in a Jupyter notebook using

--- a/doc/source/visualizing/volume_rendering.rst
+++ b/doc/source/visualizing/volume_rendering.rst
@@ -80,7 +80,7 @@ The scene's most important functions are
 :meth:`~yt.visualization.volume_rendering.scene.Scene.render` for
 casting rays through the scene and
 :meth:`~yt.visualization.volume_rendering.scene.Scene.save` for saving the
-resulting rendered image to disk.
+resulting rendered image to disk (see note on :ref:`when_to_render`).
 
 The easiest way to create a scene with sensible defaults is to use the
 functions:
@@ -329,7 +329,7 @@ To add a single gaussian layer with a color determined by a colormap value, use
    source.tfh.plot('transfer_function.png', profile_field='density')
 
    sc.save('rendering.png', sigma_clip=6)
-   
+
 
 add_gaussian
 """"""""""""
@@ -400,7 +400,7 @@ the volume rendering.
    def linramp(vals, minval, maxval):
        return (vals - vals.min())/(vals.max() - vals.min())
 
-   tf.map_to_colormap(np.log10(3e-31), np.log10(5e-27), colormap='arbre', 
+   tf.map_to_colormap(np.log10(3e-31), np.log10(5e-27), colormap='arbre',
                       scale_func=linramp)
 
    source.tfh.tf = tf
@@ -408,7 +408,7 @@ the volume rendering.
 
    source.tfh.plot('transfer_function.png', profile_field='density')
 
-   sc.save('rendering.png', sigma_clip=6)   
+   sc.save('rendering.png', sigma_clip=6)
 
 Projection Transfer Function
 ++++++++++++++++++++++++++++
@@ -522,10 +522,10 @@ adjusts for an opening view angle, so that the scene will have an
 element of perspective to it.
 :class:`~yt.visualization.volume_rendering.lens.StereoPerspectiveLens`
 is identical to PerspectiveLens, but it produces two images from nearby
-camera positions for use in 3D viewing. How 3D the image appears at viewing 
-will depend upon the value of 
-:attr:`~yt.visualization.volume_rendering.lens.StereoPerspectiveLens.disparity`, 
-which is half the maximum distance between two corresponding points in the left 
+camera positions for use in 3D viewing. How 3D the image appears at viewing
+will depend upon the value of
+:attr:`~yt.visualization.volume_rendering.lens.StereoPerspectiveLens.disparity`,
+which is half the maximum distance between two corresponding points in the left
 and right images. By default, it is set to 3 pixels.
 
 
@@ -556,11 +556,11 @@ see `the YouTube help: Upload virtual reality videos
 <https://support.google.com/youtube/answer/6316263?hl=en>`_).
 `This virtual reality video
 <https://youtu.be/ZYWY53X7UQE>`_ on YouTube is an example produced with
-:class:`~yt.visualization.volume_rendering.lens.StereoSphericalLens`. As in 
-the case of  
-:class:`~yt.visualization.volume_rendering.lens.StereoPerspectiveLens`, the 
-difference between the two images can be controlled by changing the value of 
-:attr:`~yt.visualization.volume_rendering.lens.StereoSphericalLens.disparity` 
+:class:`~yt.visualization.volume_rendering.lens.StereoSphericalLens`. As in
+the case of
+:class:`~yt.visualization.volume_rendering.lens.StereoPerspectiveLens`, the
+difference between the two images can be controlled by changing the value of
+:attr:`~yt.visualization.volume_rendering.lens.StereoSphericalLens.disparity`
 (See above).
 
 .. _annotated-vr-example:
@@ -573,7 +573,7 @@ Annotated Examples
              information can be hard.  We've provided information about best
              practices and tried to make the interface easy to develop nice
              visualizations, but getting them *just right* is often
-             time-consuming.  It's usually best to start out simple and expand 
+             time-consuming.  It's usually best to start out simple and expand
              and tweak as needed.
 
 The scene interface provides a modular interface for creating renderings
@@ -653,7 +653,7 @@ function. Example:
 
     import numpy as np
     import yt
-  
+
 
     ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
     sc = yt.create_scene(ds, 'density')
@@ -856,3 +856,28 @@ dark.  ``sigma_clip = N`` can address this by removing values that are more
 than ``N`` standard deviations brighter than the mean of your image.
 Typically, a choice of 4 to 6 will help dramatically with your resulting image.
 See the cookbook recipe :ref:`cookbook-sigma_clip` for a demonstration.
+
+.. _when_to_render:
+
+When to Render
+^^^^^^^^^^^^^^
+
+The rendering of a scene is the most computationally demanding step in
+creating a final image and there are a number of ways to control at which point
+a scene is actually rendered. The default behavior of the
+:meth:`~yt.visualization.volume_rendering.scene.Scene.save` function includes
+a call to :meth:`~yt.visualization.volume_rendering.scene.Scene.render`. This
+means that in most cases (including the above examples), after you set up your
+scene and volumes, you can simply call
+:meth:`~yt.visualization.volume_rendering.scene.Scene.save` without first
+calling :meth:`~yt.visualization.volume_rendering.scene.Scene.render`. If you
+wish to save the most recently rendered image without rendering again, set
+``render=False`` in the call to
+:meth:`~yt.visualization.volume_rendering.scene.Scene.save` and the most
+recently rendered image array will be used.  Cases where you
+may wish to use ``render=False`` include saving images at different
+``sigma_clip`` values (see :ref:`cookbook-sigma_clip`) or when saving an image
+that has already been rendered in a Jupyter notebook using
+:meth:`~yt.visualization.volume_rendering.scene.Scene.show`. Changes to the
+scene including adding sources, modifying transfer functions or adjusting camera
+settings generally require rendering again.

--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -226,9 +226,9 @@ class Scene:
         self._last_render = bmp
         return bmp
 
-    def _check_render(self, fname, render=True):    
-        # checks for existing render before saving,  in most cases we want to 
-        # render every time, but in some cases pulling the previous render is 
+    def _check_render(self, fname, render=True):
+        # checks for existing render before saving,  in most cases we want to
+        # render every time, but in some cases pulling the previous render is
         # desirable (e.g., if only changing sigma_clip or
         # saving after a call to sc.show()).
         if self._last_render is None:
@@ -236,13 +236,12 @@ class Scene:
             render = True
         elif render:
             mylog.info("Overwriting previous rendered image with new rendering, saving to %s", fname)
-        else:            
-            mylog.info("Saving most recently rendered image to %s.",fname)            
-            
-            
-        if render:    
+        else:
+            mylog.info("Saving most recently rendered image to %s.",fname)
+
+        if render:
             self.render()
-            
+
     def save(self, fname=None, sigma_clip=None, render=True):
         r"""Saves a rendered image of the Scene to disk.
 
@@ -319,8 +318,8 @@ class Scene:
             suffix = ".png"
             fname = "%s%s" % (fname, suffix)
 
-        self._check_render(fname, render) 
-    
+        self._check_render(fname, render)
+
         # We can render pngs natively but for other formats we defer to
         # matplotlib.
         if suffix == ".png":

--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -207,7 +207,7 @@ class Scene:
         >>> sc.save(sigma_clip=4.0,render=False)
 
         Altneratively, if you do not need the image array, you can just call
-        save as follows.
+        ``save`` as follows.
 
         >>> import yt
         >>> ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')

--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -232,12 +232,18 @@ class Scene:
         # desirable (e.g., if only changing sigma_clip or
         # saving after a call to sc.show()).
         if self._last_render is None:
-            mylog.warning("No previous rendered image found, rendering now and saving to %s", fname)
+            mylog.warning(
+                "No previous rendered image found, rendering now and saving to %s",
+                fname,
+            )
             render = True
         elif render:
-            mylog.info("Overwriting previous rendered image with new rendering, saving to %s", fname)
+            mylog.info(
+                "Overwriting previous rendered image with new rendering, saving to %s",
+                fname,
+            )
         else:
-            mylog.info("Saving most recently rendered image to %s.",fname)
+            mylog.info("Saving most recently rendered image to %s.", fname)
 
         if render:
             self.render()
@@ -350,9 +356,15 @@ class Scene:
             ax.imshow(np.rot90(out), origin="lower")
             canvas.print_figure(fname, dpi=100)
 
-    def save_annotated(self, fname=None, label_fmt=None,
-                       text_annotate=None, dpi=100, sigma_clip=None,
-                       render=True):
+    def save_annotated(
+        self,
+        fname=None,
+        label_fmt=None,
+        text_annotate=None,
+        dpi=100,
+        sigma_clip=None,
+        render=True,
+    ):
         r"""Saves the most recently rendered image of the Scene to disk,
         including an image of the transfer function and and user-defined
         text.

--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -226,8 +226,25 @@ class Scene:
         self._last_render = bmp
         return bmp
 
+    def _check_render(self, fname, render=True):    
+        # checks for existing render before saving,  in most cases we want to 
+        # render every time, but in some cases pulling the previous render is 
+        # desirable (e.g., if only changing sigma_clip or
+        # saving after a call to sc.show()).
+        if self._last_render is None:
+            mylog.warning("No previous rendered image found, rendering now and saving to %s", fname)
+            render = True
+        elif render:
+            mylog.info("Overwriting previous rendered image with new rendering, saving to %s", fname)
+        else:            
+            mylog.info("Saving most recently rendered image to %s.",fname)            
+            
+            
+        if render:    
+            self.render()
+            
     def save(self, fname=None, sigma_clip=None, render=True):
-        r"""Saves the most recently rendered image of the Scene to disk.
+        r"""Saves a rendered image of the Scene to disk.
 
         Once you have created a scene, this saves an image array to disk with
         an optional filename. This function calls render() to generate an
@@ -302,13 +319,8 @@ class Scene:
             suffix = ".png"
             fname = "%s%s" % (fname, suffix)
 
-        # in most cases we want to render every time, but in some cases pulling
-        # the previous render is desirable (e.g., if only changing sigma_clip or
-        # saving after a call to sc.show()).
-        if render or hasattr(self,'_last_render') is False:
-            self.render()
-
-        mylog.info("Saving render %s", fname)
+        self._check_render(fname, render) 
+    
         # We can render pngs natively but for other formats we defer to
         # matplotlib.
         if suffix == ".png":
@@ -429,8 +441,7 @@ class Scene:
             suffix = ".png"
             fname = "%s%s" % (fname, suffix)
 
-        if render or hasattr(self,'_last_render') is False:
-            self.render()
+        self._check_render(fname, render)
 
         # which transfer function?
         rs = rensources[0]

--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -207,7 +207,7 @@ class Scene:
         >>> sc.save(sigma_clip=4.0,render=False)
 
         Altneratively, if you do not need the image array, you can just call
-        save as follows. 
+        save as follows.
 
         >>> import yt
         >>> ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
@@ -229,7 +229,7 @@ class Scene:
     def save(self, fname=None, sigma_clip=None, render=True):
         r"""Saves the most recently rendered image of the Scene to disk.
 
-        Once you have created a scene, this saves that image array to disk with
+        Once you have created a scene, this saves an image array to disk with
         an optional filename. This function calls render() to generate an
         image array, unless the render parameter is set to False, in which case
         the most recently rendered scene is used if it exists.

--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -226,24 +226,18 @@ class Scene:
         self._last_render = bmp
         return bmp
 
-    def _check_render(self, fname, render=True):
-        # checks for existing render before saving,  in most cases we want to
+    def _render_if_missing(self, render=True):
+        # checks for existing render before saving, in most cases we want to
         # render every time, but in some cases pulling the previous render is
         # desirable (e.g., if only changing sigma_clip or
         # saving after a call to sc.show()).
         if self._last_render is None:
-            mylog.warning(
-                "No previous rendered image found, rendering now and saving to %s",
-                fname,
-            )
+            mylog.warning("No previous rendered image found, rendering now.")
             render = True
         elif render:
-            mylog.info(
-                "Overwriting previous rendered image with new rendering, saving to %s",
-                fname,
-            )
+            mylog.info("Overwriting previous rendered image with new rendering.")
         else:
-            mylog.info("Saving most recently rendered image to %s.", fname)
+            mylog.info("Found previous rendered image to save.")
 
         if render:
             self.render()
@@ -324,7 +318,8 @@ class Scene:
             suffix = ".png"
             fname = "%s%s" % (fname, suffix)
 
-        self._check_render(fname, render)
+        self._render_if_missing(render)
+        mylog.info("Saving rendered image to %s", fname)
 
         # We can render pngs natively but for other formats we defer to
         # matplotlib.
@@ -452,7 +447,8 @@ class Scene:
             suffix = ".png"
             fname = "%s%s" % (fname, suffix)
 
-        self._check_render(fname, render)
+        self._render_if_missing(fname, render)
+        mylog.info("Saving rendered image to %s", fname)
 
         # which transfer function?
         rs = rensources[0]

--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -277,7 +277,7 @@ class Scene:
         >>>
         >>> sc = yt.create_scene(ds)
         >>> # save with different sigma clipping values
-        >>> sc.save('raw.png')
+        >>> sc.save('raw.png')  # The initial render call happens here
         >>> sc.save('clipped_2.png', sigma_clip=2, render=False)
         >>> sc.save('clipped_4.png', sigma_clip=4, render=False)
 

--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -269,7 +269,7 @@ class Scene:
         >>> sc.save('test.png', sigma_clip=4)
 
         When saving multiple images without modifying the scene (camera,
-        sources,etc.), render=False can be used to avoid re-rendering.
+        sources,etc.), render=False can be used to avoid re-rendering when a scene is saved.
         This is useful for generating images at a range of sigma_clip values:
 
         >>> import yt

--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -380,7 +380,7 @@ class Scene:
 
            Each item in the main list is a separate string to write.
         render: boolean, optional
-            If True, will always render the scene before saving.
+            If True, will render the scene before saving.
             If False, will use results of previous render if it exists.
             Default: True
 

--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -226,7 +226,7 @@ class Scene:
         self._last_render = bmp
         return bmp
 
-    def _sanitize_render(self, render=True):
+    def _sanitize_render(self, render):
         # checks for existing render before saving, in most cases we want to
         # render every time, but in some cases pulling the previous render is
         # desirable (e.g., if only changing sigma_clip or

--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -226,21 +226,23 @@ class Scene:
         self._last_render = bmp
         return bmp
 
-    def _render_if_missing(self, render=True):
+    def _sanitize_render(self, render=True):
         # checks for existing render before saving, in most cases we want to
         # render every time, but in some cases pulling the previous render is
         # desirable (e.g., if only changing sigma_clip or
         # saving after a call to sc.show()).
         if self._last_render is None:
-            mylog.warning("No previous rendered image found, rendering now.")
+            mylog.warning("No previously rendered image found, rendering now.")
             render = True
         elif render:
-            mylog.info("Overwriting previous rendered image with new rendering.")
+            mylog.warning(
+                "Previously rendered image exists, but rendering anyway. "
+                "Supply 'render=False' to save previously rendered image directly."
+            )
         else:
-            mylog.info("Found previous rendered image to save.")
+            mylog.info("Found previously rendered image to save.")
 
-        if render:
-            self.render()
+        return render
 
     def save(self, fname=None, sigma_clip=None, render=True):
         r"""Saves a rendered image of the Scene to disk.
@@ -318,7 +320,9 @@ class Scene:
             suffix = ".png"
             fname = "%s%s" % (fname, suffix)
 
-        self._render_if_missing(render)
+        render = self._sanitize_render(render)
+        if render:
+            self.render()
         mylog.info("Saving rendered image to %s", fname)
 
         # We can render pngs natively but for other formats we defer to
@@ -447,7 +451,9 @@ class Scene:
             suffix = ".png"
             fname = "%s%s" % (fname, suffix)
 
-        self._render_if_missing(fname, render)
+        render = self._sanitize_render(render)
+        if render:
+            self.render()
         mylog.info("Saving rendered image to %s", fname)
 
         # which transfer function?

--- a/yt/visualization/volume_rendering/tests/test_save_render.py
+++ b/yt/visualization/volume_rendering/tests/test_save_render.py
@@ -5,16 +5,18 @@ import yt
 from yt.testing import fake_random_ds
 from unittest import TestCase
 
+
 def setup():
     """Test specific setup."""
     from yt.config import ytcfg
+
     ytcfg["yt", "__withintesting"] = "True"
 
 
 class SaveRenderTest(TestCase):
     # This toggles using a temporary directory. Turn off to examine images.
     use_tmpdir = True
-    tmpdir = './'
+    tmpdir = "./"
 
     def setUp(self):
         if self.use_tmpdir:
@@ -30,13 +32,11 @@ class SaveRenderTest(TestCase):
         sc = yt.create_scene(ds)
 
         # make sure it renders if nothing exists, even if render = False
-        sc.save(os.path.join(self.tmpdir,'raw.png'), render=False)
+        sc.save(os.path.join(self.tmpdir, "raw.png"), render=False)
         # make sure it re-renders
-        sc.save(os.path.join(self.tmpdir,'raw_2.png'), render=True)
+        sc.save(os.path.join(self.tmpdir, "raw_2.png"), render=True)
         # make sure sigma clip does not re-render
-        sc.save(os.path.join(self.tmpdir,'clip_2.png'), sigma_clip=2.,
-                render=False)
-        sc.save(os.path.join(self.tmpdir,'clip_4.png'), sigma_clip=4.,
-                render=False)
+        sc.save(os.path.join(self.tmpdir, "clip_2.png"), sigma_clip=2.0, render=False)
+        sc.save(os.path.join(self.tmpdir, "clip_4.png"), sigma_clip=4.0, render=False)
 
         return sc

--- a/yt/visualization/volume_rendering/tests/test_save_render.py
+++ b/yt/visualization/volume_rendering/tests/test_save_render.py
@@ -14,26 +14,29 @@ def setup():
 class SaveRenderTest(TestCase):
     # This toggles using a temporary directory. Turn off to examine images.
     use_tmpdir = True
+    tmpdir = './'
 
     def setUp(self):
         if self.use_tmpdir:
-            self.curdir = os.getcwd()
-            # Perform I/O in safe place instead of yt main dir
+            tempfile.mkdtemp()
             self.tmpdir = tempfile.mkdtemp()
-            os.chdir(self.tmpdir)
-        else:
-            self.curdir, self.tmpdir = None, None
 
     def tearDown(self):
         if self.use_tmpdir:
-            os.chdir(self.curdir)
             shutil.rmtree(self.tmpdir)
 
     def test_save_render(self):
         ds = fake_random_ds(ndims=32)
         sc = yt.create_scene(ds)
-        sc.save('raw.png') # will use render = True by default
-        sc.save('clip_2.png', sigma_clip=2, render=False) # will pull render
-        sc.save('clip_4.png', sigma_clip=4.0, render=False)
+
+        # make sure it renders if nothing exists, even if render = False 
+        sc.save(os.path.join(self.tmpdir,'raw.png'), render = False) 
+        # make sure it re-renders 
+        sc.save(os.path.join(self.tmpdir,'raw_2.png'), render = True)
+        # make sure sigma clip does not re-render 
+        sc.save(os.path.join(self.tmpdir,'clip_2.png'), sigma_clip=2., 
+            render=False)
+        sc.save(os.path.join(self.tmpdir,'clip_4.png'), sigma_clip=4., 
+            render=False)
 
         return sc

--- a/yt/visualization/volume_rendering/tests/test_save_render.py
+++ b/yt/visualization/volume_rendering/tests/test_save_render.py
@@ -1,9 +1,10 @@
 import os
-import tempfile
 import shutil
+import tempfile
+from unittest import TestCase
+
 import yt
 from yt.testing import fake_random_ds
-from unittest import TestCase
 
 
 def setup():

--- a/yt/visualization/volume_rendering/tests/test_save_render.py
+++ b/yt/visualization/volume_rendering/tests/test_save_render.py
@@ -1,0 +1,39 @@
+import os
+import tempfile
+import shutil
+import yt
+from yt.testing import fake_random_ds
+from unittest import TestCase
+
+def setup():
+    """Test specific setup."""
+    from yt.config import ytcfg
+    ytcfg["yt", "__withintesting"] = "True"
+
+
+class SaveRenderTest(TestCase):
+    # This toggles using a temporary directory. Turn off to examine images.
+    use_tmpdir = True
+
+    def setUp(self):
+        if self.use_tmpdir:
+            self.curdir = os.getcwd()
+            # Perform I/O in safe place instead of yt main dir
+            self.tmpdir = tempfile.mkdtemp()
+            os.chdir(self.tmpdir)
+        else:
+            self.curdir, self.tmpdir = None, None
+
+    def tearDown(self):
+        if self.use_tmpdir:
+            os.chdir(self.curdir)
+            shutil.rmtree(self.tmpdir)
+
+    def test_save_render(self):
+        ds = fake_random_ds(32)
+        sc = yt.create_scene(ds)
+        sc.save('raw.png') # will use render = True by default
+        sc.save('clip_2.png', sigma_clip=2, render=False) # will pull render
+        sc.save('clip_4.png', sigma_clip=4.0, render=False)
+
+        return sc

--- a/yt/visualization/volume_rendering/tests/test_save_render.py
+++ b/yt/visualization/volume_rendering/tests/test_save_render.py
@@ -30,7 +30,7 @@ class SaveRenderTest(TestCase):
             shutil.rmtree(self.tmpdir)
 
     def test_save_render(self):
-        ds = fake_random_ds(32)
+        ds = fake_random_ds(ndims=32)
         sc = yt.create_scene(ds)
         sc.save('raw.png') # will use render = True by default
         sc.save('clip_2.png', sigma_clip=2, render=False) # will pull render

--- a/yt/visualization/volume_rendering/tests/test_save_render.py
+++ b/yt/visualization/volume_rendering/tests/test_save_render.py
@@ -29,14 +29,14 @@ class SaveRenderTest(TestCase):
         ds = fake_random_ds(ndims=32)
         sc = yt.create_scene(ds)
 
-        # make sure it renders if nothing exists, even if render = False 
-        sc.save(os.path.join(self.tmpdir,'raw.png'), render = False) 
-        # make sure it re-renders 
-        sc.save(os.path.join(self.tmpdir,'raw_2.png'), render = True)
-        # make sure sigma clip does not re-render 
-        sc.save(os.path.join(self.tmpdir,'clip_2.png'), sigma_clip=2., 
-            render=False)
-        sc.save(os.path.join(self.tmpdir,'clip_4.png'), sigma_clip=4., 
-            render=False)
+        # make sure it renders if nothing exists, even if render = False
+        sc.save(os.path.join(self.tmpdir,'raw.png'), render=False)
+        # make sure it re-renders
+        sc.save(os.path.join(self.tmpdir,'raw_2.png'), render=True)
+        # make sure sigma clip does not re-render
+        sc.save(os.path.join(self.tmpdir,'clip_2.png'), sigma_clip=2.,
+                render=False)
+        sc.save(os.path.join(self.tmpdir,'clip_4.png'), sigma_clip=4.,
+                render=False)
 
         return sc

--- a/yt/visualization/volume_rendering/volume_rendering.py
+++ b/yt/visualization/volume_rendering/volume_rendering.py
@@ -124,5 +124,5 @@ def volume_render(
     """
     sc = create_scene(data_source, field=field)
     im = sc.render()
-    sc.save(fname=fname, sigma_clip=sigma_clip)
+    sc.save(fname=fname, sigma_clip=sigma_clip, render=False)
     return im, sc


### PR DESCRIPTION
## PR Summary

Adds an optional `render` boolean argument to `scene.save()`. Default behavior is `render=True` in which case `scene.save()` will call `scene.render()` prior to saving the image array. If `render=False`, will write the most recently rendered image array if it exists. Useful for avoiding unnecessary calls to `scene.render()` when saving at a range of `sigma_clip` values or when saving an image from a notebook after calling `sc.show()`. 

Includes updates to relevant docstrings. 

Addresses #2733 

## PR Checklist

- [x] Code passes flake8 checker
- [x] New features are documented, with docstrings and narrative docs
- [x] Added  tests for new features: yt/visualization/volume_rendering/tests/test_save_render.py 

