### PR TITLE
fix: min/max detection consistency

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -933,11 +933,20 @@ class Dataset(metaclass=RegisteredDataset):
         mylog.info("%s value is %0.5e at %0.16f %0.16f %0.16f", ext, val, *coords)
         if to_array:
             if any(x.units.is_dimensionless for x in coords):
-                raise ValueError(
-                    "Can not convert dimensionless coordinates to spatial."
-                    "For non cartesian geometries, please use 'to_array=False'"
+                mylog.warning(
+                    f"dataset {self} has angular coordinates. "
+                    "Use 'to_array=False' to preserve "
+                    "dimensionality in each coordinate."
                 )
-            coords = self.arr(coords, dtype="float64").to("code_length")
+
+            # force conversion to length
+            alt_coords = []
+            for x in coords:
+                alt_coords.append(
+                    self.quan(x.v, "code_length") if x.units.is_dimensionless else x
+                )
+
+            coords = self.arr(alt_coords, dtype="float64").to("code_length")
         return val, coords
 
     def find_max(self, field, source=None, to_array=True):


### PR DESCRIPTION
## PR Summary

This fix inconsistencies between `Dataset.find_min` and `Dataset.find_max` methods by making special cases of a new, more general class method `Dataset._find_extremum`.

## Fix

For non-cartesian datasets, `find_min` didn't contain the "hack" from `find_max` to handle dimensionless coords
```python
import yt
ds = yt.load("amrvac/bw_2d0000.dat") # polar dataset
ds.find_max("density")
>> (unyt_quantity(6.9545098e-24, 'g/cm**3'), unyt_array([1.5703125 , 1.71756761, 0.5       ], 'code_length'))

# inconsistency for find_min
ds.find_min("density")
old >> IterableUnitCoercionError: Received a list or tuple of quantities with nonuniform units: [unyt_quantity(0.9921875, 'cm'), unyt_quantity(3.16613635, '(dimensionless)'), unyt_quantity(0.5, 'cm')]
new >> (unyt_quantity(2.82470365e-25, 'g/cm**3'), unyt_array([2.0078125 , 1.55950623, 0.5       ], 'code_length'))
```

## new feature

I expose two new arguments to the user for the following reasons
- maybe the user does *not* want a `unyt_array` typed output, especially with non-cartesian datasets.
- the "source" (object) in which the search is performed could be anything, it doesn't have to be `ds.all_data()`
```python
# don't convert to "code_lenght"
ds.find_max("density", to_array=False)
>> (unyt_quantity(6.9545098e-24, 'g/cm**3'),
 [unyt_quantity(1.5703125, 'cm'),
  unyt_quantity(1.71756761, '(dimensionless)'),
  unyt_quantity(0.5, '(dimensionless)')])

# region selection
region = ds.r[1:1.2, :]
ds.find_max("density", source=region, to_array=True)
>> (unyt_quantity(2.51770532e-24, 'g/cm**3'), unyt_array([1.0234375, 0.159534 , 0.5      ], 'code_length'))
```

## PR Checklist

- [x] Code passes flake8 checker
- [x] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
