### PR TITLE
[AMRVAC] fix: improve read_amrvac_namelist api 

### DIFF
--- a/doc/source/reference/api/api.rst
+++ b/doc/source/reference/api/api.rst
@@ -189,7 +189,7 @@ AMRVAC
    ~yt.frontends.amrvac.data_structures.AMRVACDataset
    ~yt.frontends.amrvac.fields.AMRVACFieldInfo
    ~yt.frontends.amrvac.io.AMRVACIOHandler
-   ~yt.frontends.amrvac.read_amrvac_namelist
+   ~yt.frontends.amrvac.io.read_amrvac_namelist
 
 ARTIO
 ^^^^^

--- a/yt/frontends/amrvac/__init__.py
+++ b/yt/frontends/amrvac/__init__.py
@@ -1,6 +1,7 @@
 import os
-from yt.utilities.on_demand_imports import _f90nml as f90nml
+
 from yt.funcs import ensure_list
+from yt.utilities.on_demand_imports import _f90nml as f90nml
 
 
 def read_amrvac_namelist(parfiles):

--- a/yt/frontends/amrvac/__init__.py
+++ b/yt/frontends/amrvac/__init__.py
@@ -1,39 +1,5 @@
 import os
 
 from yt.funcs import ensure_list
-from yt.utilities.on_demand_imports import _f90nml as f90nml
 
-
-def read_amrvac_namelist(parfiles):
-    """Read one or more parfiles, and return a unified f90nml.Namelist object.
-
-    This function replicates the patching logic of MPI-AMRVAC where redundant parameters
-    only retain last-in-line values EXCEPT `&filelist:base_filename`, which is accumulated.
-    When passed a single file, this function acts as a mere wrapper of f90nml.read().
-
-    Parameters
-    ----------
-    parfiles : str or list
-        A file path, or a list of file paths to MPI-AMRVAC configuration parfiles.
-
-    Returns
-    -------
-    unified_namelist : f90nml.Namelist
-        A single namelist object. The class inherits from ordereddict.
-
-    """
-    parfiles = [os.path.expanduser(pf) for pf in ensure_list(parfiles)]
-
-    # first merge the namelists
-    namelists = [f90nml.read(parfile) for parfile in parfiles]
-    unified_namelist = f90nml.Namelist()
-    for nml in namelists:
-        unified_namelist.patch(nml)
-
-    # accumulate `&filelist:base_filename`
-    base_filename = "".join(
-        [nml.get("filelist", {}).get("base_filename", "") for nml in namelists]
-    )
-    unified_namelist["filelist"]["base_filename"] = base_filename
-
-    return unified_namelist
+from .io import read_amrvac_namelist

--- a/yt/frontends/amrvac/__init__.py
+++ b/yt/frontends/amrvac/__init__.py
@@ -1,12 +1,6 @@
-"""
-API for yt.frontends.amrvac
-
-
-
-"""
-
-
+import os
 from yt.utilities.on_demand_imports import _f90nml as f90nml
+from yt.funcs import ensure_list
 
 
 def read_amrvac_namelist(parfiles):
@@ -27,10 +21,7 @@ def read_amrvac_namelist(parfiles):
         A single namelist object. The class inherits from ordereddict.
 
     """
-    # typechecking
-    if isinstance(parfiles, str):
-        parfiles = [parfiles]
-    assert all([isinstance(pf, str) for pf in parfiles])
+    parfiles = [os.path.expanduser(pf) for pf in ensure_list(parfiles)]
 
     # first merge the namelists
     namelists = [f90nml.read(parfile) for parfile in parfiles]

--- a/yt/frontends/amrvac/api.py
+++ b/yt/frontends/amrvac/api.py
@@ -1,11 +1,7 @@
 """
-API for yt.frontends.amrvac
-
-
-
+frontend API: a submodule that exposes user-facing defs and classes
 """
-
 
 from .data_structures import AMRVACDataset, AMRVACGrid, AMRVACHierarchy
 from .fields import AMRVACFieldInfo
-from .io import AMRVACIOHandler
+from .io import AMRVACIOHandler, read_amrvac_namelist

--- a/yt/frontends/amrvac/io.py
+++ b/yt/frontends/amrvac/io.py
@@ -4,13 +4,51 @@ AMRVAC-specific IO functions
 
 
 """
+import os
 
 import numpy as np
 
+from yt.funcs import ensure_list
 from yt.geometry.selection_routines import GridSelector
 from yt.utilities.io_handler import BaseIOHandler
+from yt.utilities.on_demand_imports import _f90nml as f90nml
 
 from .datfile_utils import get_single_block_field_data
+
+
+def read_amrvac_namelist(parfiles):
+    """Read one or more parfiles, and return a unified f90nml.Namelist object.
+
+    This function replicates the patching logic of MPI-AMRVAC where redundant parameters
+    only retain last-in-line values EXCEPT `&filelist:base_filename`, which is accumulated.
+    When passed a single file, this function acts as a mere wrapper of f90nml.read().
+
+    Parameters
+    ----------
+    parfiles : str or list
+        A file path, or a list of file paths to MPI-AMRVAC configuration parfiles.
+
+    Returns
+    -------
+    unified_namelist : f90nml.Namelist
+        A single namelist object. The class inherits from ordereddict.
+
+    """
+    parfiles = [os.path.expanduser(pf) for pf in ensure_list(parfiles)]
+
+    # first merge the namelists
+    namelists = [f90nml.read(parfile) for parfile in parfiles]
+    unified_namelist = f90nml.Namelist()
+    for nml in namelists:
+        unified_namelist.patch(nml)
+
+    # accumulate `&filelist:base_filename`
+    base_filename = "".join(
+        [nml.get("filelist", {}).get("base_filename", "") for nml in namelists]
+    )
+    unified_namelist["filelist"]["base_filename"] = base_filename
+
+    return unified_namelist
 
 
 class AMRVACIOHandler(BaseIOHandler):

--- a/yt/frontends/amrvac/io.py
+++ b/yt/frontends/amrvac/io.py
@@ -20,12 +20,13 @@ def read_amrvac_namelist(parfiles):
     """Read one or more parfiles, and return a unified f90nml.Namelist object.
 
     This function replicates the patching logic of MPI-AMRVAC where redundant parameters
-    only retain last-in-line values EXCEPT `&filelist:base_filename`, which is accumulated.
-    When passed a single file, this function acts as a mere wrapper of f90nml.read().
+    only retain last-in-line values, with the exception of `&filelist:base_filename`,
+    which is accumulated. When passed a single file, this function acts as a mere
+    wrapper of f90nml.read().
 
     Parameters
     ----------
-    parfiles : str or list
+    parfiles : str, os.Pathlike, byte, or an iterable returning those types
         A file path, or a list of file paths to MPI-AMRVAC configuration parfiles.
 
     Returns

--- a/yt/frontends/amrvac/tests/test_read_amrvac_namelist.py
+++ b/yt/frontends/amrvac/tests/test_read_amrvac_namelist.py
@@ -1,14 +1,14 @@
+import os
 from copy import deepcopy
-from os import path
 from pathlib import Path
 
 from yt.frontends.amrvac import read_amrvac_namelist
 from yt.testing import requires_module
 from yt.utilities.on_demand_imports import _f90nml as f90nml
 
-test_dir = path.dirname(path.abspath(__file__))
-blast_wave_parfile = path.join(test_dir, "sample_parfiles", "bw_3d.par")
-modifier_parfile = path.join(test_dir, "sample_parfiles", "tvdlf_scheme.par")
+test_dir = os.path.dirname(os.path.abspath(__file__))
+blast_wave_parfile = os.path.join(test_dir, "sample_parfiles", "bw_3d.par")
+modifier_parfile = os.path.join(test_dir, "sample_parfiles", "tvdlf_scheme.par")
 
 
 @requires_module("f90nml")

--- a/yt/frontends/amrvac/tests/test_read_amrvac_namelist.py
+++ b/yt/frontends/amrvac/tests/test_read_amrvac_namelist.py
@@ -1,20 +1,20 @@
-from os import path
-from pathlib import Path
 from copy import deepcopy
 from os import path
+from pathlib import Path
 
 from yt.frontends.amrvac import read_amrvac_namelist
 from yt.testing import requires_module
 from yt.utilities.on_demand_imports import _f90nml as f90nml
 
 test_dir = path.dirname(path.abspath(__file__))
-blast_wave_parfile = path.join(test_dir, "sample_parfiles/bw_3d.par")
-modifier_parfile = path.join(test_dir, "sample_parfiles/tvdlf_scheme.par")
+blast_wave_parfile = path.join(test_dir, "sample_parfiles", "bw_3d.par")
+modifier_parfile = path.join(test_dir, "sample_parfiles", "tvdlf_scheme.par")
 
 
 @requires_module("f90nml")
 def test_read_pathlike():
     read_amrvac_namelist(Path(blast_wave_parfile))
+
 
 @requires_module("f90nml")
 def test_read_one_file():

--- a/yt/frontends/amrvac/tests/test_read_amrvac_namelist.py
+++ b/yt/frontends/amrvac/tests/test_read_amrvac_namelist.py
@@ -1,3 +1,5 @@
+from os import path
+from pathlib import Path
 from copy import deepcopy
 from os import path
 
@@ -9,6 +11,10 @@ test_dir = path.dirname(path.abspath(__file__))
 blast_wave_parfile = path.join(test_dir, "sample_parfiles/bw_3d.par")
 modifier_parfile = path.join(test_dir, "sample_parfiles/tvdlf_scheme.par")
 
+
+@requires_module("f90nml")
+def test_read_pathlike():
+    read_amrvac_namelist(Path(blast_wave_parfile))
 
 @requires_module("f90nml")
 def test_read_one_file():


### PR DESCRIPTION
## PR Summary

automatically expand '~' token… and natively support pathlike objects

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes flake8 checker
- [x] Adds a test for any bugs fixed. Adds tests for new features.

