### PR TITLE
[AMRVAC] hotfix for ghost-zones dependent fields computations

### DIFF
--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -9,6 +9,7 @@ AMRVAC data structures
 import os
 import stat
 import struct
+import warnings
 import weakref
 
 import numpy as np
@@ -57,6 +58,18 @@ class AMRVACGrid(AMRGridPatch):
         start_index = (self.LeftEdge - self.ds.domain_left_edge) / self.dds
         self.start_index = np.rint(start_index).astype("int64").ravel()
         return self.start_index
+
+    def retrieve_ghost_zones(self, n_zones, fields, all_levels=False, smoothed=False):
+        if smoothed:
+            warnings.warn(
+                "ghost-zones interpolation/smoothing is not "
+                "currently supported for AMRVAC data.",
+                category=RuntimeWarning,
+            )
+            smoothed = False
+        return super(AMRVACGrid, self).retrieve_ghost_zones(
+            n_zones, fields, all_levels=all_levels, smoothed=smoothed
+        )
 
 
 class AMRVACHierarchy(GridIndex):


### PR DESCRIPTION
## PR Summary

follow up to #2715 and fix #2710
Renouncing interpolation/smoothing allows to generate _a_ plot. It has artefacts but it's clearly better than just throwing an error imo.

This is a _hotfix_, it's clean but it doesn't address the root problem which is that we don't have proper ghost-zone reconstruction yet in the frontend.

```python
import yt
ds = yt.load("amrvac/jk20200500.dat")
ds.periodicity = 3*[True]
plot = yt.plot_2d(ds, "vorticity_magnitude")

plot.save("/tmp/jake2")
plot.annotate_grids()
plot.save("/tmp/jake2_grid")

>> RuntimeWarning: ghost-zones interpolation/smoothing is not currently supported for AMRVAC data.
```
![jake2_Slice_z_vorticity_magnitude](https://user-images.githubusercontent.com/14075922/87478486-229f1b00-c62a-11ea-8d0e-e5f219ace053.png)
![jake2_grid_Slice_z_vorticity_magnitude](https://user-images.githubusercontent.com/14075922/87478494-25017500-c62a-11ea-8ead-e5b3f47f37c8.png)