### PR TITLE
ci: merge linting steps into a single job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,14 +78,12 @@ install:
 
 jobs:
   include:
-    - stage: Lint
-      python: 3.6
-      script: flake8 yt/
 
     - stage: Lint
       python: 3.6
-      script: isort --check-only -rc yt/
+      script: flake8 yt/
       script: black --check yt/
+      script: isort --check-only -rc yt/
 
     - stage: tests
       name: "Python: 3.6 Minimal Dependency Unit Tests"


### PR DESCRIPTION
## PR Summary
Only run one job on travis to combine black, flake8 and isort checks