### PR TITLE
Cleanup copyright blurb

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -790,7 +790,6 @@ Source code style guide
 
  * In general, follow PEP-8 guidelines.
    https://www.python.org/dev/peps/pep-0008/
- * We no longer have a copyright blurb in every source file.
  * Classes are ``ConjoinedCapitals``, methods and functions are
    ``lowercase_with_underscores``.
  * Use 4 spaces, not tabs, to represent indentation.

--- a/COPYING.txt
+++ b/COPYING.txt
@@ -68,14 +68,3 @@ Development Team.  If individual contributors want to maintain a record of what
 changes/contributions they have specific copyright on, they should indicate
 their copyright in the commit message of the change, when they commit the
 change to one of the yt repositories.
-
-With this in mind, the following banner should be used in any source code file
-to indicate the copyright and license terms:
-
-#-----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------

--- a/yt/frontends/adaptahop/__init__.py
+++ b/yt/frontends/adaptahop/__init__.py
@@ -5,11 +5,3 @@ API for AdaptaHOP frontend.
 
 
 """
-
-# -----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-# -----------------------------------------------------------------------------

--- a/yt/frontends/adaptahop/data_structures.py
+++ b/yt/frontends/adaptahop/data_structures.py
@@ -6,13 +6,6 @@ Data structures for AdaptaHOP frontend.
 
 """
 
-# -----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-# -----------------------------------------------------------------------------
 
 import os
 import re

--- a/yt/frontends/adaptahop/definitions.py
+++ b/yt/frontends/adaptahop/definitions.py
@@ -5,14 +5,6 @@ Data structures for AdaptaHOP
 
 """
 
-# -----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-# -----------------------------------------------------------------------------
-
 
 HEADER_ATTRIBUTES = (
     ("npart", 1, "i"),

--- a/yt/frontends/adaptahop/fields.py
+++ b/yt/frontends/adaptahop/fields.py
@@ -6,13 +6,6 @@ AdaptaHOP-specific fields
 
 """
 
-# -----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-# -----------------------------------------------------------------------------
 
 from yt.fields.field_info_container import FieldInfoContainer
 

--- a/yt/frontends/adaptahop/io.py
+++ b/yt/frontends/adaptahop/io.py
@@ -6,13 +6,6 @@ AdaptaHOP data-file handling function
 
 """
 
-# -----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-# -----------------------------------------------------------------------------
 
 from operator import attrgetter
 

--- a/yt/frontends/amrvac/__init__.py
+++ b/yt/frontends/amrvac/__init__.py
@@ -5,13 +5,6 @@ API for yt.frontends.amrvac
 
 """
 
-# -----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-# -----------------------------------------------------------------------------
 
 from yt.utilities.on_demand_imports import _f90nml as f90nml
 

--- a/yt/frontends/amrvac/api.py
+++ b/yt/frontends/amrvac/api.py
@@ -5,13 +5,6 @@ API for yt.frontends.amrvac
 
 """
 
-# -----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-# -----------------------------------------------------------------------------
 
 from .data_structures import AMRVACDataset, AMRVACGrid, AMRVACHierarchy
 from .fields import AMRVACFieldInfo

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -5,13 +5,6 @@ AMRVAC data structures
 
 """
 
-# -----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-# -----------------------------------------------------------------------------
 
 import os
 import stat

--- a/yt/frontends/amrvac/fields.py
+++ b/yt/frontends/amrvac/fields.py
@@ -3,13 +3,6 @@ AMRVAC-specific fields
 
 """
 
-# -----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-# -----------------------------------------------------------------------------
 
 import functools
 

--- a/yt/frontends/amrvac/io.py
+++ b/yt/frontends/amrvac/io.py
@@ -5,13 +5,6 @@ AMRVAC-specific IO functions
 
 """
 
-# -----------------------------------------------------------------------------
-# Copyright (c) 2013, yt Development Team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file COPYING.txt, distributed with this software.
-# -----------------------------------------------------------------------------
 import numpy as np
 
 from yt.geometry.selection_routines import GridSelector


### PR DESCRIPTION
## PR Summary

Quoting `CONTRIBUTING.rst`
>Source code style guide
>-----------------------
>...
> * We no longer have a copyright blurb in every source file.

This PR removes the surviving occurrences of the copyright header in two frontends and removes the above line from the contributing guide.
