### PR TITLE
hotfix: support matplotlib 3.3.0

### DIFF
--- a/yt/utilities/png_writer.py
+++ b/yt/utilities/png_writer.py
@@ -13,8 +13,7 @@ def call_png_write_png(buffer, fileobj, dpi):
     try:
         _png.write_png(buffer, fileobj, dpi)
     except NameError:
-        # I don't get how not to pass the dpi argument atm
-        Image.fromarray(buffer).save(fileobj)
+        Image.fromarray(buffer).save(fileobj, dpi=(dpi, dpi))
 
 
 def write_png(buffer, filename, dpi=100):

--- a/yt/utilities/png_writer.py
+++ b/yt/utilities/png_writer.py
@@ -8,6 +8,7 @@ try:
 except ImportError:
     from PIL import Image
 
+
 def call_png_write_png(buffer, fileobj, dpi):
     try:
         _png.write_png(buffer, fileobj, dpi)
@@ -19,6 +20,7 @@ def call_png_write_png(buffer, fileobj, dpi):
 def write_png(buffer, filename, dpi=100):
     with open(filename, "wb") as fileobj:
         call_png_write_png(buffer, fileobj, dpi)
+
 
 def write_png_to_string(buffer, dpi=100):
     fileobj = BytesIO()

--- a/yt/utilities/png_writer.py
+++ b/yt/utilities/png_writer.py
@@ -1,24 +1,28 @@
 from io import BytesIO
 
-import matplotlib._png as _png
+try:
+    # matplotlib switched from an internal submodule _png to using pillow (PIL)
+    # between v3.1.0 and v3.3.0
+    # So PIL should be available on any system where matplotlib._png doesn't exist
+    import matplotlib._png as _png
+except ImportError:
+    from PIL import Image
 
-
-def call_png_write_png(buffer, width, height, fileobj, dpi):
-    _png.write_png(buffer, fileobj, dpi)
+def call_png_write_png(buffer, fileobj, dpi):
+    try:
+        _png.write_png(buffer, fileobj, dpi)
+    except NameError:
+        # I don't get how not to pass the dpi argument atm
+        Image.fromarray(buffer).save(fileobj)
 
 
 def write_png(buffer, filename, dpi=100):
-    width = buffer.shape[1]
-    height = buffer.shape[0]
     with open(filename, "wb") as fileobj:
-        call_png_write_png(buffer, width, height, fileobj, dpi)
+        call_png_write_png(buffer, fileobj, dpi)
 
-
-def write_png_to_string(buffer, dpi=100, gray=0):
-    width = buffer.shape[1]
-    height = buffer.shape[0]
+def write_png_to_string(buffer, dpi=100):
     fileobj = BytesIO()
-    call_png_write_png(buffer, width, height, fileobj, dpi)
+    call_png_write_png(buffer, fileobj, dpi)
     png_str = fileobj.getvalue()
     fileobj.close()
     return png_str


### PR DESCRIPTION
## PR Summary

fix #2752
I also simplified `call_png_write_png` since it had two required positional arguments that were actually not used.