### PR TITLE
ci: bump unyt version to latest release in test_requirements

### DIFF
--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -21,7 +21,7 @@ libconf==1.0.1
 cartopy==0.17.0
 pyaml==17.10.0
 mpi4py==3.0.3
-git+https://github.com/yt-project/unyt@e02254e3ecc11a84854a22109354fe3f47bd8985#egg=unyt
+unyt==2.7.2
 pyyaml>=4.2b1
 xarray==0.12.3
 firefly_api>=0.0.2


### PR DESCRIPTION
## PR Summary

since unyt 2.7.2 was released we don't need to pin a git version anymore.