### PR TITLE
add ignore list for git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# transition to isort
+7edfcee093cca277307aabdb180e0ffc69768291
+
+# transisiton to black
+ebadee629414aed2c7b6526e22a419205329ec38
+
+# automated trailing whitespace removal
+3ee548b04a41dfbc009921c492fba6a0682651ca


### PR DESCRIPTION
## PR Summary

I thought I added this already in #2749 but apparently I messed up.
This adds a `.git-blame-ignore-revs` file to mark automated commits as ignorable to git blame, see https://github.com/psf/black#migrating-your-code-style-without-ruining-git-blame