### PR TITLE
cleanup: wrapped exceptions

### DIFF
--- a/doc/extensions/pythonscript_sphinxext.py
+++ b/doc/extensions/pythonscript_sphinxext.py
@@ -101,4 +101,3 @@ def thread_safe_mkdir(dirname):
     except OSError as e:
         if e.errno != errno.EEXIST:
             raise
-        pass

--- a/setupext.py
+++ b/setupext.py
@@ -263,7 +263,7 @@ def get_cpu_count():
         raise ValueError(
             "MAX_BUILD_CORES must be set to an integer. "
             + "See above for original error."
-        ).with_traceback(e.__traceback__)
+        ) from e
     max_cores = min(cpu_count, user_max_cores)
     return max_cores
 
@@ -307,12 +307,12 @@ def create_build_ext(lib_exts, cythonize_aliases):
             try:
                 import cython
                 import numpy
-            except ImportError:
+            except ImportError as e:
                 raise ImportError(
                     """Could not import cython or numpy. Building yt from source requires
     cython and numpy to be installed. Please install these packages using
     the appropriate package manager for your python environment."""
-                )
+                ) from e
             if LooseVersion(cython.__version__) < LooseVersion("0.26.1"):
                 raise RuntimeError(
                     """Building yt from source requires Cython 0.26.1 or newer but

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -789,13 +789,13 @@ class YTCoveringGrid(YTSelectionContainer3D):
             return
         try:
             fill, gen, part, alias = self._split_fields(fields_to_get)
-        except NeedsGridType:
+        except NeedsGridType as e:
             if self._num_ghost_zones == 0:
                 raise RuntimeError(
                     "Attempting to access a field that needs ghost zones, but "
                     "num_ghost_zones = %s. You should create the covering grid "
                     "with nonzero num_ghost_zones." % self._num_ghost_zones
-                )
+                ) from e
             else:
                 raise
 

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -385,7 +385,7 @@ class YTDataContainer:
             finfo.check_available(gen_obj)
         except NeedsGridType as ngt_exception:
             if ngt_exception.ghost_zones != 0:
-                raise NotImplementedError
+                raise NotImplementedError from ngt_exception
             size = self._count_particles(ftype)
             rv = self.ds.arr(np.empty(size, dtype="float64"), finfo.units)
             ind = 0
@@ -802,13 +802,13 @@ class YTDataContainer:
         try:
             from firefly_api.particlegroup import ParticleGroup
             from firefly_api.reader import Reader
-        except ImportError:
+        except ImportError as e:
             raise ImportError(
                 "Can't find firefly_api, ensure it"
-                + "is in your python path or install it with"
-                + "'$ pip install firefly_api'. It is also available"
-                + "on github at github.com/agurvich/firefly_api"
-            )
+                "is in your python path or install it with"
+                "'$ pip install firefly_api'. It is also available"
+                "on github at github.com/agurvich/firefly_api"
+            ) from e
 
         ## handle default arguments
         fields_to_include = [] if fields_to_include is None else fields_to_include
@@ -1746,17 +1746,17 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface):
                         )
                     try:
                         fd.convert_to_units(fi.units)
-                    except AttributeError:
+                    except AttributeError as e:
                         # If the field returns an ndarray, coerce to a
                         # dimensionless YTArray and verify that field is
                         # supposed to be unitless
                         fd = self.ds.arr(fd, "")
                         if fi.units != "":
-                            raise YTFieldUnitError(fi, fd.units)
-                    except UnitConversionError:
-                        raise YTFieldUnitError(fi, fd.units)
-                    except UnitParseError:
-                        raise YTFieldUnitParseError(fi)
+                            raise YTFieldUnitError(fi, fd.units) from e
+                    except UnitConversionError as e:
+                        raise YTFieldUnitError(fi, fd.units) from e
+                    except UnitParseError as e:
+                        raise YTFieldUnitParseError(fi) from e
                     self.field_data[field] = fd
                 except GenerationInProgress as gip:
                     for f in gip.fields:

--- a/yt/data_objects/particle_trajectories.py
+++ b/yt/data_objects/particle_trajectories.py
@@ -124,10 +124,10 @@ class ParticleTrajectories:
                     # duplicate. This is due to the fact that the rhs
                     # would then have a different shape as the lhs
                     output_field[indices, i] = pfields[field]
-                except ValueError:
+                except ValueError as e:
                     raise YTIllDefinedParticleData(
                         "This dataset contains duplicate particle indices!"
-                    )
+                    ) from e
             self.field_data[field] = array_like_field(
                 dd_first, output_field.copy(), fds[field]
             )

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -1368,7 +1368,7 @@ def create_profile(
             bf_units = data_source.ds.field_info[bin_field].output_units
             try:
                 field_ex = list(extrema[bin_field[-1]])
-            except KeyError:
+            except KeyError as e:
                 try:
                     field_ex = list(extrema[bin_field])
                 except KeyError:
@@ -1376,7 +1376,7 @@ def create_profile(
                         "Could not find field {0} or {1} in extrema".format(
                             bin_field[-1], bin_field
                         )
-                    )
+                    ) from e
 
             if isinstance(field_ex[0], tuple):
                 field_ex = [data_source.ds.quan(*f) for f in field_ex]

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -167,8 +167,8 @@ class DatasetSeries:
         ret = super(DatasetSeries, cls).__new__(cls)
         try:
             ret._pre_outputs = outputs[:]
-        except TypeError:
-            raise YTOutputNotIdentified(outputs)
+        except TypeError as e:
+            raise YTOutputNotIdentified(outputs) from e
         return ret
 
     def __init__(

--- a/yt/frontends/enzo/data_structures.py
+++ b/yt/frontends/enzo/data_structures.py
@@ -413,8 +413,8 @@ class EnzoHierarchy(GridIndex):
                     continue
                 try:
                     gf = self.io._read_field_names(grid)
-                except self.io._read_exception:
-                    raise IOError("Grid %s is a bit funky?", grid.id)
+                except self.io._read_exception as e:
+                    raise IOError("Grid %s is a bit funky?", grid.id) from e
                 mylog.debug("Grid %s has: %s", grid.id, gf)
                 field_list = field_list.union(gf)
             if "AppendActiveParticleType" in self.dataset.parameters:

--- a/yt/frontends/enzo_p/io.py
+++ b/yt/frontends/enzo_p/io.py
@@ -26,12 +26,12 @@ class EnzoPIOHandler(BaseIOHandler):
         f = h5py.File(grid.filename, mode="r")
         try:
             group = f[grid.block_name]
-        except KeyError:
+        except KeyError as e:
             raise YTException(
                 message="Grid %s is missing from data file %s."
                 % (grid.block_name, grid.filename),
                 ds=self.ds,
-            )
+            ) from e
         fields = []
         ptypes = set()
         dtypes = set()

--- a/yt/frontends/exodus_ii/data_structures.py
+++ b/yt/frontends/exodus_ii/data_structures.py
@@ -227,10 +227,10 @@ class ExodusIIDataset(Dataset):
         with self._handle.open_ds() as ds:
             try:
                 return ds.variables["time_whole"][self.step]
-            except IndexError:
+            except IndexError as e:
                 raise RuntimeError(
                     "Invalid step number, max is %d" % (self.num_steps - 1)
-                )
+                ) from e
             except (KeyError, TypeError):
                 return 0.0
 

--- a/yt/frontends/flash/data_structures.py
+++ b/yt/frontends/flash/data_structures.py
@@ -193,14 +193,12 @@ class FLASHDataset(Dataset):
                 mylog.info(
                     "Particle file found: %s", self.particle_filename.split("/")[-1]
                 )
-            except IOError:
+            except OSError:
                 self._particle_handle = self._handle
         else:
             # particle_filename is specified by user
-            try:
-                self._particle_handle = HDF5FileHandler(self.particle_filename)
-            except Exception:
-                raise IOError(self.particle_filename)
+            self._particle_handle = HDF5FileHandler(self.particle_filename)
+
         # Check if the particle file has the same time
         if self._particle_handle != self._handle:
             part_time = self._particle_handle.handle.get("real scalars")[0][1]

--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -233,10 +233,7 @@ class GAMERDataset(Dataset):
         if self.particle_filename is None:
             self._particle_handle = self._handle
         else:
-            try:
-                self._particle_handle = HDF5FileHandler(self.particle_filename)
-            except Exception:
-                raise IOError(self.particle_filename)
+            self._particle_handle = HDF5FileHandler(self.particle_filename)
 
         # currently GAMER only supports refinement by a factor of 2
         self.refine_by = 2

--- a/yt/frontends/gdf/data_structures.py
+++ b/yt/frontends/gdf/data_structures.py
@@ -245,8 +245,8 @@ class GDFDataset(Dataset):
             geometry = just_one(sp.get("geometry", 0))
             try:
                 self.geometry = GEOMETRY_TRANS[geometry]
-            except KeyError:
-                raise YTGDFUnknownGeometry(geometry)
+            except KeyError as e:
+                raise YTGDFUnknownGeometry(geometry) from e
         self.parameters.update(sp)
         self.domain_left_edge = sp["domain_left_edge"][:]
         self.domain_right_edge = sp["domain_right_edge"][:]

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -363,7 +363,6 @@ class StreamDictFieldHandler(dict):
         fields = list(set(fields))
         return fields
 
-
 class StreamParticleIndex(SPHParticleIndex):
     def __init__(self, ds, dataset_type=None):
         self.stream_handler = ds.stream_handler

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -363,6 +363,7 @@ class StreamDictFieldHandler(dict):
         fields = list(set(fields))
         return fields
 
+
 class StreamParticleIndex(SPHParticleIndex):
     def __init__(self, ds, dataset_type=None):
         self.stream_handler = ds.stream_handler

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -41,7 +41,7 @@ def iterable(obj):
     """
     try:
         len(obj)
-    except Exception:
+    except TypeError:
         return False
     return True
 
@@ -1187,7 +1187,7 @@ def get_hash(infile, algorithm="md5", BLOCKSIZE=65536):
 
     try:
         hasher = getattr(hashlib, algorithm)()
-    except Exception:
+    except AttributeError as e:
         raise NotImplementedError(
             f"'{algorithm}' not available!  Available algorithms: {hashlib.algorithms}"
         )

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -1190,7 +1190,7 @@ def get_hash(infile, algorithm="md5", BLOCKSIZE=65536):
     except AttributeError as e:
         raise NotImplementedError(
             f"'{algorithm}' not available!  Available algorithms: {hashlib.algorithms}"
-        )
+        ) from e
 
     filesize = os.path.getsize(infile)
     iterations = int(float(filesize) / float(BLOCKSIZE))

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -133,8 +133,8 @@ def load_simulation(fn, simulation_type, find_outputs=False):
 
     try:
         cls = simulation_time_series_registry[simulation_type]
-    except KeyError:
-        raise YTSimulationNotIdentified(simulation_type)
+    except KeyError as e:
+        raise YTSimulationNotIdentified(simulation_type) from e
 
     return cls(fn, find_outputs=find_outputs)
 

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -1133,11 +1133,11 @@ def assert_allclose_units(actual, desired, rtol=1e-7, atol=0, **kwargs):
 
     try:
         des = des.in_units(act.units)
-    except UnitOperationError:
+    except UnitOperationError as e:
         raise AssertionError(
             "Units of actual (%s) and desired (%s) do not have "
             "equivalent dimensions" % (act.units, des.units)
-        )
+        ) from e
 
     rt = YTArray(rtol)
     if not rt.units.is_dimensionless:
@@ -1148,11 +1148,11 @@ def assert_allclose_units(actual, desired, rtol=1e-7, atol=0, **kwargs):
 
     try:
         at = at.in_units(act.units)
-    except UnitOperationError:
+    except UnitOperationError as e:
         raise AssertionError(
             "Units of atol (%s) and actual (%s) do not have "
             "equivalent dimensions" % (at.units, act.units)
-        )
+        ) from e
 
     # units have been validated, so we strip units before calling numpy
     # to avoid spurious errors

--- a/yt/utilities/answer_testing/utils.py
+++ b/yt/utilities/answer_testing/utils.py
@@ -186,7 +186,7 @@ def generate_hash(data):
         if isinstance(data, dict):
             hd = _hash_dict(data)
         else:
-            raise TypeError
+            raise
     return hd
 
 

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -134,8 +134,8 @@ def _print_installation_information(path):
 def _get_girder_client():
     try:
         import girder_client
-    except ImportError:
-        raise YTCommandRequiresModule("girder_client")
+    except ImportError as e:
+        raise YTCommandRequiresModule("girder_client") from e
     if not ytcfg.get("yt", "hub_api_key"):
         print("Before you can access the yt Hub you need an API key")
         print("In order to obtain one, either register by typing:")
@@ -797,8 +797,8 @@ class YTHubRegisterCmd(YTCommand):
     def __call__(self, args):
         try:
             import requests
-        except ImportError:
-            raise YTCommandRequiresModule("requests")
+        except ImportError as e:
+            raise YTCommandRequiresModule("requests") from e
         if ytcfg.get("yt", "hub_api_key") != "":
             print("You seem to already have an API key for the hub in")
             print(f"{CURRENT_CONFIG_FILE} . Delete this if you want to force a")
@@ -1045,12 +1045,12 @@ class YTMapserverCmd(YTCommand):
         PannableMapServer(p.data_source, args.field, args.takelog, args.cmap)
         try:
             import bottle
-        except ImportError:
+        except ImportError as e:
             raise ImportError(
                 "The mapserver functionality requires the bottle "
                 "package to be installed. Please install using `pip "
                 "install bottle`."
-            )
+            ) from e
         bottle.debug(True)
         if args.host is not None:
             colonpl = args.host.find(":")
@@ -1607,8 +1607,8 @@ class YTUploadFileCmd(YTCommand):
     def __call__(self, args):
         try:
             import requests
-        except ImportError:
-            raise YTCommandRequiresModule("requests")
+        except ImportError as e:
+            raise YTCommandRequiresModule("requests") from e
 
         fs = iter(FileStreamer(open(args.file, "rb")))
         upload_url = ytcfg.get("yt", "curldrop_upload_url")

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -598,7 +598,7 @@ class YTPlotCallbackError(Exception):
         self.callback = "annotate_" + callback
 
     def __str__(self):
-        return "%s callback failed" % self.callback
+        return f"{self.callback} callback failed"
 
 
 class YTPixelizeError(YTException):

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -594,13 +594,11 @@ class YTInvalidUnitEquivalence(Exception):
 
 
 class YTPlotCallbackError(Exception):
-    def __init__(self, callback, error):
+    def __init__(self, callback):
         self.callback = "annotate_" + callback
-        self.error = error
 
     def __str__(self):
-        msg = "%s callback failed with the following error: %s"
-        return msg % (self.callback, self.error)
+        return "%s callback failed" % self.callback
 
 
 class YTPixelizeError(YTException):

--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -1555,6 +1555,7 @@ def pixelize_sph_kernel_arbitrary_grid(np.float64_t[:, :, :] buff,
             
                                     buff[xi, yi, zi] += prefactor_j * kernel_func(q_ij)
 
+
 def pixelize_element_mesh_line(np.ndarray[np.float64_t, ndim=2] coords,
                                np.ndarray[np.int64_t, ndim=2] conn,
                                np.ndarray[np.float64_t, ndim=1] start_point,

--- a/yt/utilities/particle_generator.py
+++ b/yt/utilities/particle_generator.py
@@ -33,11 +33,11 @@ class ParticleGenerator:
             self.posx_index = self.field_list.index(self.default_fields[0])
             self.posy_index = self.field_list.index(self.default_fields[1])
             self.posz_index = self.field_list.index(self.default_fields[2])
-        except Exception:
+        except Exception as e:
             raise KeyError(
                 "You must specify position fields: "
                 + " ".join(["particle_position_%s" % ax for ax in "xyz"])
-            )
+            ) from e
         self.index_index = self.field_list.index((ptype, "particle_index"))
 
         self.num_grids = self.ds.index.num_grids

--- a/yt/visualization/color_maps.py
+++ b/yt/visualization/color_maps.py
@@ -589,12 +589,12 @@ def show_colormaps(subset="all", filename=None):
             maps = [m for m in plt.colormaps() if m in subset]
             if len(maps) == 0:
                 raise AttributeError
-        except AttributeError:
+        except AttributeError as e:
             raise AttributeError(
                 "show_colormaps requires subset attribute "
                 "to be 'all', 'yt_native', or a list of "
                 "valid colormap names."
-            )
+            ) from e
     maps = sorted(set(maps))
     # scale the image size by the number of cmaps
     plt.figure(figsize=(2.0 * len(maps) / 10.0, 6))

--- a/yt/visualization/image_writer.py
+++ b/yt/visualization/image_writer.py
@@ -254,7 +254,7 @@ def apply_colormap(image, color_bounds=None, cmap_name=None, func=lambda x: x):
 def map_to_colors(buff, cmap_name):
     try:
         lut = cmd.color_map_luts[cmap_name]
-    except KeyError:
+    except KeyError as e:
         try:
             # if cmap is tuple, then we're using palettable or brewer2mpl cmaps
             if isinstance(cmap_name, tuple):
@@ -267,7 +267,7 @@ def map_to_colors(buff, cmap_name):
             raise KeyError(
                 "Your color map (%s) was not found in either the extracted"
                 " colormap file or matplotlib colormaps" % cmap_name
-            )
+            ) from e
 
     if isinstance(cmap_name, tuple):
         # If we are using the colorbrewer maps, don't interpolate

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -951,13 +951,13 @@ class StreamlineCallback(PlotCallback):
                 try:
                     linewidth *= mask
                     self.plot_args["linewidth"] = linewidth
-                except ValueError:
+                except ValueError as e:
                     err_msg = (
                         "Error applying display threshold: linewidth"
                         + "must have shape ({}, {}) or be scalar"
                     )
                     err_msg = err_msg.format(nx, ny)
-                    raise ValueError(err_msg)
+                    raise ValueError(err_msg) from e
 
         else:
             field_colors = None

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -2732,12 +2732,12 @@ class ScaleCallback(PlotCallback):
             setter_func = "set_" + key
             try:
                 getattr(fontproperties, setter_func)(val)
-            except AttributeError:
+            except AttributeError as e:
                 raise AttributeError(
                     "Cannot set text_args keyword "
                     "to include '%s' because MPL's fontproperties object does "
                     "not contain function '%s'." % (key, setter_func)
-                )
+                ) from e
 
         # this "anchors" the size bar to a box centered on self.pos in axis
         # coordinates

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1276,8 +1276,7 @@ class PWViewerMPL(PlotWindow):
                 except YTDataTypeUnsupported as e:
                     raise e
                 except Exception as e:
-                    new_exc = YTPlotCallbackError(callback._type_name, e)
-                    raise new_exc.with_traceback(sys.exc_info()[2])
+                    raise YTPlotCallbackError(callback._type_name) from e
             for key in self.frb.keys():
                 if key not in keys:
                     del self.frb[key]

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1,4 +1,3 @@
-import sys
 import types
 from collections import defaultdict
 from distutils.version import LooseVersion

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -768,8 +768,8 @@ class PlotWindow(ImagePlotContainer):
             for un in unit_name:
                 try:
                     self.ds.length_unit.in_units(un)
-                except (UnitConversionError, UnitParseError):
-                    raise YTUnitNotRecognized(un)
+                except (UnitConversionError, UnitParseError) as e:
+                    raise YTUnitNotRecognized(un) from e
         self._axes_unit_names = unit_name
         return self
 

--- a/yt/visualization/volume_rendering/interactive_vr_helpers.py
+++ b/yt/visualization/volume_rendering/interactive_vr_helpers.py
@@ -44,11 +44,11 @@ def _render_opengl(
     try:
         import cyglfw3  # NOQA
         import OpenGL.GL  # NOQA
-    except ImportError:
+    except ImportError as e:
         raise ImportError(
             "This functionality requires the cyglfw3 and PyOpenGL "
             "packages to be installed."
-        )
+        ) from e
 
     from .interactive_loop import RenderingContext
     from .interactive_vr import (


### PR DESCRIPTION
## PR Summary

Pylint is now able to detect places from `raise Exception from parent_exception` pattern would be meaningful, namely when exception are wrapped into more friendly ones.

Here is the difference between the two patterns:
```python
try:
    assert(False)
except AssertionError:
    raise FriendlyError
# error in handling >> During handling of the above exception, another exception occurred:

try:
    assert(False)
except AssertionError as e:
    raise FriendlyError from e
# The above exception was the direct cause of the following exception:
```
The second indicates more clearly what's actually going on and reflects the developer's intention best in almost every cases.


Generating the report
```bash
pip install git+https://github.com/PyCQA/pylint
pylint yt | grep W707
```

Additionally pylint detects "too broad exceptions" (W703), notably where we simply use `except Exception`, which in most cases is an overkill. Not going to fix all of them here, only the ones that also fall in W707