### PR TITLE
cleanup: remove a class that was only used in python 2

### DIFF
--- a/yt/utilities/poster/streaminghttp.py
+++ b/yt/utilities/poster/streaminghttp.py
@@ -49,7 +49,6 @@ def request_get_data(req):
 
 __all__ = [
     "StreamingHTTPConnection",
-    "StreamingHTTPRedirectHandler",
     "StreamingHTTPHandler",
     "register_openers",
 ]
@@ -116,57 +115,6 @@ class StreamingHTTPConnection(_StreamingHTTPMixin, http_client.HTTPConnection):
     pass
 
 
-class StreamingHTTPRedirectHandler(urllib.request.HTTPRedirectHandler):
-    """Subclass of `urllib2.HTTPRedirectHandler` that overrides the
-    `redirect_request` method to properly handle redirected POST requests
-
-    This class is required because python 2.5's HTTPRedirectHandler does
-    not remove the Content-Type or Content-Length headers when requesting
-    the new resource, but the body of the original request is not preserved.
-    """
-
-    handler_order = urllib.request.HTTPRedirectHandler.handler_order - 1
-
-    # From python2.6 urllib2's HTTPRedirectHandler
-    def redirect_request(self, req, fp, code, msg, headers, newurl):
-        """Return a Request or None in response to a redirect.
-
-        This is called by the http_error_30x methods when a
-        redirection response is received.  If a redirection should
-        take place, return a new Request to allow http_error_30x to
-        perform the redirect.  Otherwise, raise HTTPError if no-one
-        else should try to handle this url.  Return None if you can't
-        but another Handler might.
-        """
-        m = req.get_method()
-        if (
-            code in (301, 302, 303, 307)
-            and m in ("GET", "HEAD")
-            or code in (301, 302, 303)
-            and m == "POST"
-        ):
-            # Strictly (according to RFC 2616), 301 or 302 in response
-            # to a POST MUST NOT cause a redirection without confirmation
-            # from the user (of urllib2, in this case).  In practice,
-            # essentially all clients do redirect in this case, so we
-            # do the same.
-            # be conciliant with URIs containing a space
-            newurl = newurl.replace(" ", "%20")
-            newheaders = dict(
-                (k, v)
-                for k, v in list(req.headers.items())
-                if k.lower() not in ("content-length", "content-type")
-            )
-            return urllib.request.Request(
-                newurl,
-                headers=newheaders,
-                origin_req_host=req.get_origin_req_host(),
-                unverifiable=True,
-            )
-        else:
-            raise urllib.error.HTTPError(req.get_full_url(), code, msg, headers, fp)
-
-
 class StreamingHTTPHandler(urllib.request.HTTPHandler):
     """Subclass of `urllib2.HTTPHandler` that uses
     StreamingHTTPConnection as its http connection class."""
@@ -219,7 +167,7 @@ if hasattr(http_client, "HTTPS"):
 
 
 def get_handlers():
-    handlers = [StreamingHTTPHandler, StreamingHTTPRedirectHandler]
+    handlers = [StreamingHTTPHandler]
     if hasattr(http_client, "HTTPS"):
         handlers.append(StreamingHTTPSHandler)
     return handlers


### PR DESCRIPTION
## PR Summary
Unless I'm misreading its docstring, this class isn't required anymore.
