### PR TITLE
cleanup: remove version checks for python 3

### DIFF
--- a/doc/source/cookbook/tests/test_cookbook.py
+++ b/doc/source/cookbook/tests/test_cookbook.py
@@ -11,8 +11,8 @@ Example:
 """
 import glob
 import os
-import sys
 import subprocess
+import sys
 
 
 def run_with_capture(*args, **kwargs):
@@ -35,10 +35,12 @@ def run_with_capture(*args, **kwargs):
 
 
 PARALLEL_TEST = {"rockstar_nest.py": "3"}
-BLACKLIST = ["opengl_ipython.py", "opengl_vr.py", "matplotlib-animation.py"]
-
-if sys.version_info >= (3, 0, 0):
-    BLACKLIST.append("rockstar_nest.py")
+BLACKLIST = [
+    "opengl_ipython.py",
+    "opengl_vr.py",
+    "matplotlib-animation.py",
+    "rockstar_nest.py",
+]
 
 
 def test_recipe():

--- a/setup.py
+++ b/setup.py
@@ -13,11 +13,6 @@ from setupext import (
     install_ccompiler,
 )
 
-if sys.version_info < (3, 5):
-    print("yt currently supports versions newer than Python 3.5")
-    print("certain features may fail unexpectedly and silently with older " "versions.")
-    sys.exit(1)
-
 install_ccompiler()
 
 try:

--- a/setupext.py
+++ b/setupext.py
@@ -61,13 +61,9 @@ def stdchannel_redirected(stdchannel, dest_filename):
 def check_for_openmp():
     """Returns True if local setup supports OpenMP, False otherwise
 
-    Code adapted from astropy_helpers, originally written by Tom 
+    Code adapted from astropy_helpers, originally written by Tom
     Robitaille and Curtis McCully.
     """
-
-    # See https://bugs.python.org/issue25150
-    if sys.version_info[:3] == (3, 5, 0):
-        return False
 
     # Create a temporary directory
     ccompiler = new_compiler()

--- a/tests/nose_runner.py
+++ b/tests/nose_runner.py
@@ -78,16 +78,12 @@ class NoseTask(object):
 
 def generate_tasks_input():
     pyver = "py{}{}".format(sys.version_info.major, sys.version_info.minor)
-    if sys.version_info < (3, 0, 0):
-        DROP_TAG = "py3"
-    else:
-        DROP_TAG = "py2"
 
     test_dir = ytcfg.get("yt", "test_data_dir")
     answers_dir = os.path.join(test_dir, "answers")
     with open("tests/tests.yaml", "r") as obj:
         lines = obj.read()
-    data = "\n".join([line for line in lines.split("\n") if DROP_TAG not in line])
+    data = "\n".join([line for line in lines.split("\n") if "py2" not in line])
     tests = yaml.load(data, Loader=yaml.FullLoader)
 
     base_argv = ["-s", "--nologcapture", "--with-xunit"]

--- a/yt/frontends/art/io.py
+++ b/yt/frontends/art/io.py
@@ -1,6 +1,5 @@
 import os
 import os.path
-import sys
 from collections import defaultdict
 
 import numpy as np
@@ -16,9 +15,6 @@ from yt.utilities.fortran_utils import read_vector, skip
 from yt.utilities.io_handler import BaseIOHandler
 from yt.utilities.lib.geometry_utils import compute_morton
 from yt.utilities.logger import ytLogger as mylog
-
-if sys.version_info >= (3, 0, 0):
-    long = int
 
 
 class IOHandlerART(BaseIOHandler):

--- a/yt/utilities/lodgeit.py
+++ b/yt/utilities/lodgeit.py
@@ -26,7 +26,6 @@
               2006 Matt Good <matt@matt-good.net>,
               2005 Raphael Slinckx <raphael@slinckx.net>
 """
-
 import os
 import sys
 from optparse import OptionParser
@@ -204,10 +203,7 @@ def download_paste(uid):
     paste = xmlrpc.pastes.getPaste(uid)
     if not paste:
         fail('Paste "%s" does not exist.' % uid, 5)
-    if sys.version_info >= (3, 0, 0):
-        code = paste["code"]
-    else:
-        code = paste["code"].encode("utf-8")
+    code = paste["code"]
     print(code)
 
 
@@ -323,9 +319,7 @@ def main(
         fail("Aborted, no content to paste.", 4)
 
     # create paste
-    code = make_utf8(data, encoding)
-    if sys.version_info >= (3, 0, 0):
-        code = code.decode("utf-8")
+    code = make_utf8(data, encoding).decode("utf-8")
     pid = create_paste(code, language, filename, mimetype, private)
     url = "%sshow/%s/" % (SERVICE_URL, pid)
     print(url)


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

Apparently I missed stuff in https://github.com/yt-project/yt/pull/2641, so here's a follow up

## PR Checklist

- [x] pass `flake8 yt/`
- [x] pass `isort -rc . --check-only`
- [x] pass `black --check yt/`
