### PR TITLE
cleanup: replace AssertionError raise statements where undue

### DIFF
--- a/yt/geometry/grid_geometry_handler.py
+++ b/yt/geometry/grid_geometry_handler.py
@@ -297,7 +297,7 @@ class GridIndex(Index, abc.ABC):
         y = ensure_numpy_array(y)
         z = ensure_numpy_array(z)
         if not len(x) == len(y) == len(z):
-            raise AssertionError("Arrays of indices must be of the same size")
+            raise ValueError("Arrays of indices must be of the same size")
 
         grid_tree = self._get_grid_tree()
         pts = MatchPointsToGrids(grid_tree, len(x), x, y, z)

--- a/yt/geometry/tests/test_grid_container.py
+++ b/yt/geometry/tests/test_grid_container.py
@@ -133,7 +133,7 @@ def test_find_points():
     assert_equal(point_grid_inds, grid_inds[ind])
 
     # Test if find_points fails properly for non equal indices' array sizes
-    assert_raises(AssertionError, test_ds.index._find_points, [0], 1.0, [2, 3])
+    assert_raises(ValueError, test_ds.index._find_points, [0], 1.0, [2, 3])
 
 
 def test_grid_arrays_view():

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -2352,17 +2352,23 @@ def SlicePlot(ds, normal=None, fields=None, axis=None, *args, **kwargs):
     ...                 north_vector=[0.2,-0.3,0.1])
 
     """
-    # Make sure we are passed a normal
-    # we check the axis keyword for backwards compatibility
-    if normal is None:
+    if axis is not None:
+        issue_deprecation_warning(
+            "SlicePlot's argument 'axis' is a deprecated alias for 'normal', it "
+            "will be removed in a future version of yt."
+        )
+        if normal is not None:
+            raise TypeError(
+                "SlicePlot() received incompatible arguments 'axis' and 'normal'"
+            )
         normal = axis
-    if normal is None:
-        raise AssertionError("Must pass a normal vector to the slice!")
 
-    # to keep positional ordering we had to make fields a keyword; make sure
-    # it is present
+    # to keep positional ordering we had to make 'normal' and 'fields' keywords
+    if normal is None:
+        raise TypeError("Missing argument in SlicePlot(): 'normal'")
+
     if fields is None:
-        raise AssertionError("Must pass field(s) to plot!")
+        raise TypeError("Missing argument in SlicePlot(): 'fields'")
 
     # use an AxisAlignedSlicePlot where possible, e.g.:
     # maybe someone passed normal=[0,0,0.2] when they should have just used "z"


### PR DESCRIPTION
## PR Summary

quoting [Python's official documentation](https://docs.python.org/3/library/exceptions.html#AssertionError)
> exception AssertionError
Raised when an assert statement fails.

This PR replaces a handful of `raise AssertionError` found in the code base with more appropriate errors (namely `TypeError` and `ValueError`). It also adds a deprecation warning for `SlicePlot`'s argument `axis`.

Note that I purposely left untouched a few `raise AssertionError` found in tests/testing framework because I _think_ it may be ok to use it there.

## PR Checklist

- [x] pass `flake8 yt/`
- [x] pass `isort -rc . --check-only`
- [x] pass `black --check yt/`
