### PR TITLE
Random tests optimization (take 2)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,8 @@ install:
 
     # Install specified version of numpy and dependencies
     - "conda install --yes -c conda-forge numpy scipy nose pytest setuptools ipython git unyt
-    Cython sympy fastcache h5py matplotlib=3.1.3 mock pandas cartopy conda-build pooch pyyaml"
+    Cython sympy fastcache h5py matplotlib=3.1.3 mock pandas cartopy conda-build pooch pyyaml
+    nose-timer pykdtree"
     # install yt
     - "pip install -e ."
 
@@ -39,7 +40,7 @@ install:
 build: false
 
 test_script:
-    - "nosetests --nologcapture -sv --traverse-namespace yt"
+    - "nosetests --with-timer --timer-top-n=20 --nologcapture --with-xunit -sv --traverse-namespace yt"
 
 # Enable this to be able to login to the build worker. You can use the
 # `remmina` program in Ubuntu, use the login information that the line below

--- a/tests/test_minimal_requirements.txt
+++ b/tests/test_minimal_requirements.txt
@@ -9,3 +9,4 @@ pyyaml>=4.2b1
 coverage==4.5.1
 codecov==2.0.15
 unyt==2.7.2
+mock

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -28,3 +28,4 @@ firefly_api>=0.0.2
 f90nml>=1.1.2
 MiniballCpp>=0.2.1
 pooch>=0.7.0
+pykdtree==1.3.1

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -6,7 +6,7 @@ glueviz==0.13.3
 h5py==2.10.0
 ipython==7.1.1
 matplotlib==3.3.0
-mock==2.0.0; python_version < '3.0'
+mock
 nose-timer==1.0.0
 nose==1.3.7
 pandas==0.25.3

--- a/yt/data_objects/tests/test_projection.py
+++ b/yt/data_objects/tests/test_projection.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 
+import mock
 import numpy as np
 
 from yt.testing import assert_equal, assert_rel_equal, fake_amr_ds, fake_random_ds
@@ -23,7 +24,8 @@ def teardown_func(fns):
             pass
 
 
-def test_projection():
+@mock.patch("yt.visualization._mpl_imports.FigureCanvasAgg.print_figure")
+def test_projection(pf):
     fns = []
     for nprocs in [8, 1]:
         # We want to test both 1 proc and 8 procs, to make sure that

--- a/yt/data_objects/tests/test_slice.py
+++ b/yt/data_objects/tests/test_slice.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 
+import mock
 import numpy as np
 
 from yt.testing import assert_equal, fake_random_ds
@@ -21,7 +22,8 @@ def teardown_func(fns):
             pass
 
 
-def test_slice():
+@mock.patch("yt.visualization._mpl_imports.FigureCanvasAgg.print_figure")
+def test_slice(pf):
     fns = []
     grid_eps = np.finfo(np.float64).eps
     for nprocs in [8, 1]:

--- a/yt/visualization/tests/test_particle_plot.py
+++ b/yt/visualization/tests/test_particle_plot.py
@@ -3,6 +3,7 @@ import shutil
 import tempfile
 import unittest
 
+import mock
 import numpy as np
 
 from yt.convenience import load
@@ -11,7 +12,6 @@ from yt.data_objects.profiles import create_profile
 from yt.testing import (
     assert_allclose,
     assert_array_almost_equal,
-    assert_fname,
     fake_particle_ds,
     requires_file,
 )
@@ -69,11 +69,7 @@ CENTER_SPECS = (
     YTArray([0.3, 0.4, 0.7], "cm"),
 )
 
-WEIGHT_FIELDS = (
-    None,
-    "particle_ones",
-    ("all", "particle_mass"),
-)
+WEIGHT_FIELDS = (None, "particle_ones", ("all", "particle_mass"))
 
 PHASE_FIELDS = [
     ("particle_velocity_x", "particle_position_z", "particle_mass"),
@@ -231,9 +227,17 @@ class TestParticlePhasePlotSave(unittest.TestCase):
 
                 particle_phases.append(ParticlePhasePlot.from_profile(pp))
         particle_phases[0]._repr_html_()
-        for p in particle_phases:
-            for fname in TEST_FLNMS:
-                assert_fname(p.save(fname)[0])
+
+        with mock.patch(
+            "yt.visualization._mpl_imports.FigureCanvasAgg.print_figure"
+        ), mock.patch(
+            "yt.visualization._mpl_imports.FigureCanvasPdf.print_figure"
+        ), mock.patch(
+            "yt.visualization._mpl_imports.FigureCanvasPS.print_figure"
+        ):
+            for p in particle_phases:
+                for fname in TEST_FLNMS:
+                    p.save(fname)
 
 
 tgal = "TipsyGalaxy/galaxy.00300"
@@ -331,8 +335,15 @@ class TestParticleProjectionPlotSave(unittest.TestCase):
         test_ds = fake_particle_ds()
         for dim in range(3):
             pplot = ParticleProjectionPlot(test_ds, dim, "particle_mass")
-            for fname in TEST_FLNMS:
-                assert_fname(pplot.save(fname)[0])
+            with mock.patch(
+                "yt.visualization._mpl_imports.FigureCanvasAgg.print_figure"
+            ), mock.patch(
+                "yt.visualization._mpl_imports.FigureCanvasPdf.print_figure"
+            ), mock.patch(
+                "yt.visualization._mpl_imports.FigureCanvasPS.print_figure"
+            ):
+                for fname in TEST_FLNMS:
+                    pplot.save(fname)[0]
 
     def test_particle_plot_ds(self):
         test_ds = fake_particle_ds()
@@ -341,7 +352,10 @@ class TestParticleProjectionPlotSave(unittest.TestCase):
             pplot_ds = ParticleProjectionPlot(
                 test_ds, dim, "particle_mass", data_source=ds_region
             )
-            pplot_ds.save()
+            with mock.patch(
+                "yt.visualization._mpl_imports.FigureCanvasAgg.print_figure"
+            ):
+                pplot_ds.save()
 
     def test_particle_plot_c(self):
         test_ds = fake_particle_ds()
@@ -350,7 +364,10 @@ class TestParticleProjectionPlotSave(unittest.TestCase):
                 pplot_c = ParticleProjectionPlot(
                     test_ds, dim, "particle_mass", center=center
                 )
-                pplot_c.save()
+                with mock.patch(
+                    "yt.visualization._mpl_imports.FigureCanvasAgg.print_figure"
+                ):
+                    pplot_c.save()
 
     def test_particle_plot_wf(self):
         test_ds = fake_particle_ds()
@@ -359,7 +376,10 @@ class TestParticleProjectionPlotSave(unittest.TestCase):
                 pplot_wf = ParticleProjectionPlot(
                     test_ds, dim, "particle_mass", weight_field=weight_field
                 )
-                pplot_wf.save()
+                with mock.patch(
+                    "yt.visualization._mpl_imports.FigureCanvasAgg.print_figure"
+                ):
+                    pplot_wf.save()
 
     def test_creation_with_width(self):
         test_ds = fake_particle_ds()


### PR DESCRIPTION
Currently 10 unit tests account for **25%** of build time on Travis (and I assume appveyor):

```
[success] 5.40% yt.data_objects.tests.test_projection.test_projection: 82.3893s
[success] 4.90% yt.visualization.tests.test_particle_plot.TestParticlePhasePlotSave.test_particle_phase_plot: 74.7280s
[success] 3.55% yt.visualization.tests.test_geo_projections.TestGeoProjections.test_geo_projections: 54.0847s
[success] 2.49% yt.frontends.gadget.tests.test_outputs.test_gadget_binary: 37.9936s
[success] 2.21% yt.visualization.tests.test_particle_plot.TestParticleProjectionPlotSave.test_particle_plot_c: 33.6426s
[success] 1.80% yt.data_objects.tests.test_slice.test_slice: 27.3991s
[success] 1.62% yt.visualization.volume_rendering.tests.test_scene.RotationTest.test_rotation: 24.6765s
[success] 1.14% yt.frontends.stream.tests.test_stream_particles.test_stream_particles: 17.4531s
[success] 1.10% yt.visualization.tests.test_callbacks.test_mesh_lines_callback: 16.7762s
[success] 1.08% yt.visualization.tests.test_plotwindow.TestPlotWindowSave.test_projection_plot_c: 16.3965s
```

This PR addresses some of them by:
 1) mocking MPL's `print_figure` method, as we're not actually analyzing images in any way
 2) using `pykdtree` instead of `scipy.kdtree` for `Cartopy`. On my laptop it yields 3x speed up for *test_geo_projections*