### PR TITLE
update pre-commit hooks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,9 +20,9 @@ detail.  Why is this change required?  What problem does it solve?-->
 
 <!-- Note that some of these check boxes may not apply to all pull requests -->
 
-- [ ] pass `flake8 yt/`
-- [ ] pass `isort . --check --diff`
 - [ ] pass `black --check yt/`
+- [ ] pass `isort . --check --diff`
+- [ ] pass `flake8 yt/`
 - [ ] New features are documented, with docstrings and narrative docs
 - [ ] Adds a test for any bugs fixed. Adds tests for new features.
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
     - id: black
       language_version: python3.7
 -   repo: https://github.com/timothycrosley/isort
-    rev: '5.1.4'  # keep in sync with tests/lint_requirements.txt
+    rev: '5.2.0'  # keep in sync with tests/lint_requirements.txt
     hooks:
     -   id: isort
 -   repo: https://gitlab.com/pycqa/flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
--   repo: https://gitlab.com/pycqa/flake8
-    rev: ''
-    hooks:
-    -   id: flake8
--   repo: https://github.com/timothycrosley/isort
-    rev: ''
-    hooks:
-    -   id: isort
 -   repo: https://github.com/ambv/black
     rev: 19.10b0
     hooks:
     - id: black
       language_version: python3.7
+-   repo: https://github.com/timothycrosley/isort
+    rev: ''
+    hooks:
+    -   id: isort
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: ''
+    hooks:
+    -   id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
     - id: black
       language_version: python3.7
 -   repo: https://github.com/timothycrosley/isort
-    rev: '5.2.0'  # keep in sync with tests/lint_requirements.txt
+    rev: '5.2.1'  # keep in sync with tests/lint_requirements.txt
     hooks:
     -   id: isort
 -   repo: https://gitlab.com/pycqa/flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,10 +4,10 @@
     - id: black
       language_version: python3.7
 -   repo: https://github.com/timothycrosley/isort
-    rev: ''
+    rev: '5.1.4'  # keep in sync with tests/lint_requirements.txt
     hooks:
     -   id: isort
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: ''
+    rev: '3.8.1'  # keep in sync with tests/lint_requirements.txt
     hooks:
     -   id: flake8

--- a/tests/lint_requirements.txt
+++ b/tests/lint_requirements.txt
@@ -1,7 +1,7 @@
-flake8==3.8.1
+flake8==3.8.1  # keep in sync with .pre-commit-config.yaml
 mccabe==0.6.1
 pycodestyle==2.6.0
 pyflakes==2.2.0
-isort~=5.1
+isort==5.1.4  # keep in sync with .pre-commit-config.yaml
 black==19.10b0
 flake8-bugbear

--- a/tests/lint_requirements.txt
+++ b/tests/lint_requirements.txt
@@ -2,6 +2,6 @@ flake8==3.8.1  # keep in sync with .pre-commit-config.yaml
 mccabe==0.6.1
 pycodestyle==2.6.0
 pyflakes==2.2.0
-isort==5.2.0   # keep in sync with .pre-commit-config.yaml
+isort==5.2.1   # keep in sync with .pre-commit-config.yaml
 black==19.10b0
 flake8-bugbear

--- a/tests/lint_requirements.txt
+++ b/tests/lint_requirements.txt
@@ -2,6 +2,6 @@ flake8==3.8.1  # keep in sync with .pre-commit-config.yaml
 mccabe==0.6.1
 pycodestyle==2.6.0
 pyflakes==2.2.0
-isort==5.1.4  # keep in sync with .pre-commit-config.yaml
+isort==5.2.0   # keep in sync with .pre-commit-config.yaml
 black==19.10b0
 flake8-bugbear


### PR DESCRIPTION
## PR Summary

Something I did not consider when I added the pre-commit hooks is the order in which they trigger :
sometimes `flake8` errors are automatically fixed by `black` or `isort` so it's cleaner to run the `flake8` check last.

Note to early adopters: once this goes in, you won't need to reinstall the hooks to take advantage of this change :)

I'm also changing the PR template to reflect this order (may save a few minutes of work to contributors if they don't realise most of there flake8 errors can be solved automatically).

## PR Checklist

- [x] pass `flake8 yt/`
- [x] pass `isort . --check --diff`
- [x] pass `black --check yt/`