### PR TITLE
Ignore .kdtree file while detecting format. Fixes #2778

### DIFF
--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -248,7 +248,12 @@ class GadgetDataset(SPHDataset):
             # came through _is_valid in load()
             for f in os.listdir(filename):
                 fname = os.path.join(filename, f)
-                if (".0" in f) and (".ewah" not in f) and os.path.isfile(fname):
+                fext = os.path.splitext(fname)[-1]
+                if (
+                    (".0" in f)
+                    and (fext not in {".ewah", ".kdtree"})
+                    and os.path.isfile(fname)
+                ):
                     filename = os.path.join(filename, f)
                     break
         self._header = GadgetBinaryHeader(filename, header_spec)

--- a/yt/frontends/gizmo/data_structures.py
+++ b/yt/frontends/gizmo/data_structures.py
@@ -20,7 +20,12 @@ class GizmoDataset(GadgetHDF5Dataset):
             valid_files = []
             for f in os.listdir(args[0]):
                 fname = os.path.join(args[0], f)
-                if (".0" in f) and (".ewah" not in f) and os.path.isfile(fname):
+                fext = os.path.splitext(fname)[-1]
+                if (
+                    (".0" in f)
+                    and (fext not in {".ewah", ".kdtree"})
+                    and os.path.isfile(fname)
+                ):
                     valid_files.append(fname)
             if len(valid_files) == 0:
                 valid = False

--- a/yt/frontends/owls/data_structures.py
+++ b/yt/frontends/owls/data_structures.py
@@ -48,7 +48,12 @@ class OWLSDataset(GadgetHDF5Dataset):
             valid_files = []
             for f in os.listdir(args[0]):
                 fname = os.path.join(args[0], f)
-                if (".0" in f) and (".ewah" not in f) and os.path.isfile(fname):
+                fext = os.path.splitext(fname)[-1]
+                if (
+                    (".0" in f)
+                    and (fext not in {".ewah", ".kdtree"})
+                    and os.path.isfile(fname)
+                ):
                     valid_files.append(fname)
             if len(valid_files) == 0:
                 valid = False


### PR DESCRIPTION
## PR Summary

This PR updates the file detection logic to take .kdtree files into account.
