### PR TITLE
Remove some redundancy in VR tests

### DIFF
--- a/yt/visualization/volume_rendering/tests/test_lenses.py
+++ b/yt/visualization/volume_rendering/tests/test_lenses.py
@@ -51,7 +51,7 @@ class LensTest(TestCase):
     def test_stereoperspective_lens(self):
         sc = Scene()
         cam = sc.add_camera(self.ds, lens_type="stereo-perspective")
-        cam.resolution = [1024, 512]
+        cam.resolution = [256, 128]
         cam.position = self.ds.arr(np.array([0.7, 0.7, 0.7]), "code_length")
         vol = VolumeSource(self.ds, field=self.field)
         tf = vol.transfer_function
@@ -88,7 +88,7 @@ class LensTest(TestCase):
     def test_spherical_lens(self):
         sc = Scene()
         cam = sc.add_camera(self.ds, lens_type="spherical")
-        cam.resolution = [512, 256]
+        cam.resolution = [256, 128]
         cam.position = self.ds.arr(np.array([0.6, 0.5, 0.5]), "code_length")
         vol = VolumeSource(self.ds, field=self.field)
         tf = vol.transfer_function
@@ -101,7 +101,7 @@ class LensTest(TestCase):
         w = self.ds.arr(w, "code_length")
         sc = Scene()
         cam = sc.add_camera(self.ds, lens_type="stereo-spherical")
-        cam.resolution = [512, 512]
+        cam.resolution = [256, 256]
         cam.position = self.ds.arr(np.array([0.6, 0.5, 0.5]), "code_length")
         vol = VolumeSource(self.ds, field=self.field)
         tf = vol.transfer_function

--- a/yt/visualization/volume_rendering/tests/test_scene.py
+++ b/yt/visualization/volume_rendering/tests/test_scene.py
@@ -69,17 +69,14 @@ class RotationTest(TestCase):
         mi_bound = ((ma - mi) * (0.10)) + mi
         ma_bound = ((ma - mi) * (0.90)) + mi
         tf.map_to_colormap(mi_bound, ma_bound, scale=0.01, colormap="Reds_r")
-        sc.render()
-        for suffix in ["png", "eps", "ps", "pdf"]:
-            fname = "test_scene.{}".format(suffix)
-            sc.save(fname, sigma_clip=6.0)
-            assert_fname(fname)
+        fname = "test_scene.pdf"
+        sc.save(fname, sigma_clip=6.0)
+        assert_fname(fname)
 
-        nrot = 2
-        for i in range(nrot):
-            sc.camera.pitch(2 * np.pi / nrot)
-            sc.render()
-            sc.save("test_rot_%04i.png" % i, sigma_clip=6.0)
+        fname = "test_rot.png"
+        sc.camera.pitch(np.pi)
+        sc.save(fname, sigma_clip=6.0)
+        assert_fname(fname)
 
 
 def test_annotations():

--- a/yt/visualization/volume_rendering/tests/test_sigma_clip.py
+++ b/yt/visualization/volume_rendering/tests/test_sigma_clip.py
@@ -35,8 +35,4 @@ class SigmaClipTest(TestCase):
     def test_sigma_clip(self):
         ds = fake_random_ds(32)
         sc = yt.create_scene(ds)
-        im = sc.render()
-        sc.save("raw.png")
         sc.save("clip_2.png", sigma_clip=2)
-        sc.save("clip_4.png", sigma_clip=4.0)
-        return im, sc

--- a/yt/visualization/volume_rendering/tests/test_varia.py
+++ b/yt/visualization/volume_rendering/tests/test_varia.py
@@ -63,11 +63,8 @@ class VariousVRTests(TestCase):
     def test_rotation_volume_rendering(self):
         im, sc = yt.volume_render(self.ds)
 
-        angle = 2 * np.pi
-        frames = 4
-        for _ in range(frames):
-            sc.camera.yaw(angle / frames)
-            sc.render()
+        sc.camera.yaw(np.pi)
+        sc.render()
 
     def test_simple_volume_rendering(self):
         im, sc = yt.volume_render(self.ds, sigma_clip=4.0)


### PR DESCRIPTION
## PR Summary

This PR modifies the tests to avoid situation where code paths are tested more than once, e.g. it's sufficient to rotate vr scene once instead of 5 times to check if it works. Same goes for rendering the same scene over and over again for each possible image suffix...