### PR TITLE
boxlib/amrex parameter parsing: periodicity

### DIFF
--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -1650,13 +1650,10 @@ class WarpXDataset(BoxlibDataset):
                     self.parameters[l[0].strip()] = l[1].strip()
 
         # set the periodicity based on the integer BC runtime parameters
-        is_periodic = []
+        self.periodicity[:] = False
         if "geometry.is_periodic" in self.parameters:
             is_periodic = self.parameters["geometry.is_periodic"].split()
-        periodicity = [bool(val) for val in is_periodic]
-        for _ in range(self.dimensionality, 3):
-            periodicity += [False]  # pad to 3D
-        self.periodicity = ensure_tuple(periodicity)
+            self.periodicity[: len(is_periodic)] = [val == "1" for val in is_periodic]
 
         particle_types = glob.glob(self.output_dir + "/*/Header")
         particle_types = [cpt.split(os.sep)[-2] for cpt in particle_types]

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -1650,7 +1650,7 @@ class WarpXDataset(BoxlibDataset):
                     self.parameters[l[0].strip()] = l[1].strip()
 
         # set the periodicity based on the integer BC runtime parameters
-        self.periodicity[:] = False
+        self.periodicity = (False, False, False)
         if "geometry.is_periodic" in self.parameters:
             is_periodic = self.parameters["geometry.is_periodic"].split()
             self.periodicity[: len(is_periodic)] = [val == "1" for val in is_periodic]

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -1650,10 +1650,14 @@ class WarpXDataset(BoxlibDataset):
                     self.parameters[l[0].strip()] = l[1].strip()
 
         # set the periodicity based on the integer BC runtime parameters
-        self.periodicity = (False, False, False)
-        if "geometry.is_periodic" in self.parameters:
-            is_periodic = self.parameters["geometry.is_periodic"].split()
-            self.periodicity[: len(is_periodic)] = [val == "1" for val in is_periodic]
+        self.periodicity = [True, True, True]
+        #    note: non-periodicity currently cause problems in volume rendering
+        # self.periodicity = [False, False, False]  # AMReX default
+        # if "geometry.is_periodic" in self.parameters:
+        #     is_periodic = self.parameters["geometry.is_periodic"].split()
+        #     self.periodicity[: len(is_periodic)] = [
+        #         val == "1" for val in is_periodic]
+        self.periodicity = ensure_tuple(self.periodicity)
 
         particle_types = glob.glob(self.output_dir + "/*/Header")
         particle_types = [cpt.split(os.sep)[-2] for cpt in particle_types]

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -1650,10 +1650,12 @@ class WarpXDataset(BoxlibDataset):
                     self.parameters[l[0].strip()] = l[1].strip()
 
         # set the periodicity based on the integer BC runtime parameters
-        is_periodic = self.parameters["geometry.is_periodic"].split()
+        is_periodic = []
+        if 'geometry.is_periodic' is self.parameters:
+            is_periodic = self.parameters["geometry.is_periodic"].split()
         periodicity = [bool(val) for val in is_periodic]
         for _ in range(self.dimensionality, 3):
-            periodicity += [True]  # pad to 3D
+            periodicity += [False]  # pad to 3D
         self.periodicity = ensure_tuple(periodicity)
 
         particle_types = glob.glob(self.output_dir + "/*/Header")

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -1651,7 +1651,7 @@ class WarpXDataset(BoxlibDataset):
 
         # set the periodicity based on the integer BC runtime parameters
         is_periodic = []
-        if 'geometry.is_periodic' is self.parameters:
+        if "geometry.is_periodic" in self.parameters:
             is_periodic = self.parameters["geometry.is_periodic"].split()
         periodicity = [bool(val) for val in is_periodic]
         for _ in range(self.dimensionality, 3):


### PR DESCRIPTION
AMReX' `geometry.is_periodic` is an optional input parameter that defaults to `False` per direction.

This fixes a crash that makes this parameter non-optional in post-processing with `yt`:
```
File .local/lib/python3.6/site-packages/yt/frontends/boxlib/data_structures.py", line 1571, in _parse_parameter_file
    is_periodic = self.parameters['geometry.is_periodic'].split()
KeyError: 'geometry.is_periodic'
```

~~This also changes the default padding to `False` as is the meaning in AMReX.~~

CC @atmyers for potential review :)

Refs.:
- https://amrex-codes.github.io/amrex/docs_html/InputsProblemDefinition.html
- https://travis-ci.com/github/ECP-WarpX/WarpX/jobs/364923589

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] pass `flake8 yt/`
- [x] pass `isort . --check --diff`
- [x] pass `black --check yt/`
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
