### PR TITLE
Slash commands

### DIFF
--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -14,4 +14,4 @@ jobs:
             help
             format
             rebase
-          repository: matthewturk/slash-command-processor
+          repository: yt-project/slash-command-processor

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -14,4 +14,6 @@ jobs:
             help
             format
             rebase
+            isort
+            black
           repository: yt-project/slash-command-processor

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -10,5 +10,8 @@ jobs:
         uses: peter-evans/slash-command-dispatch@v2
         with:
           token: ${{ secrets.PAT }}
-          commands: example
+          commands: |
+            example
+            black
+            rebase
           repository: matthewturk/slash-command-processor

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           token: ${{ secrets.PAT }}
           commands: |
-            example
-            black
+            help
+            format
             rebase
           repository: matthewturk/slash-command-processor


### PR DESCRIPTION
This PR implements three chatops style commands: `example` (which we can later disable), `rebase` and `black`.

It does not yet work, and will need both the repository for the slash commands transferred over to `yt-project` (it's currently at https://github.com/matthewturk/slash-command-processor ) and the personal access token set correctly.

I also think there's a possibility we want to change some of the parameters, maybe even add `isort`, and set @yt-fido to be the user in charge.  I am planning to issue a PR to YTEP-0037 as well.
