### PR TITLE
Fix conda_env embree checks

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -143,17 +143,13 @@ def check_for_pyembree(std_libs):
     embree_libs = []
     embree_aliases = {}
     try:
-        fn = resource_filename("pyembree", "rtcore.pxd")
+        _ = resource_filename("pyembree", "rtcore.pxd")
     except ImportError:
         return embree_libs, embree_aliases
 
     embree_prefix = os.path.abspath(read_embree_location())
     embree_inc_dir = os.path.join(embree_prefix, "include")
     embree_lib_dir = os.path.join(embree_prefix, "lib")
-    if in_conda_env():
-        conda_basedir = os.path.dirname(os.path.dirname(sys.executable))
-        embree_inc_dir.append(os.path.join(conda_basedir, "include"))
-        embree_lib_dir.append(os.path.join(conda_basedir, "lib"))
 
     if _platform == "darwin":
         embree_lib_name = "embree.2"
@@ -164,6 +160,12 @@ def check_for_pyembree(std_libs):
     embree_aliases["EMBREE_LIB_DIR"] = [embree_lib_dir]
     embree_aliases["EMBREE_LIBS"] = std_libs + [embree_lib_name]
     embree_libs += ["yt/utilities/lib/embree_mesh/*.pyx"]
+
+    if in_conda_env():
+        conda_basedir = os.path.dirname(os.path.dirname(sys.executable))
+        embree_aliases["EMBREE_INC_DIR"].append(os.path.join(conda_basedir, "include"))
+        embree_aliases["EMBREE_LIB_DIR"].append(os.path.join(conda_basedir, "lib"))
+
     return embree_libs, embree_aliases
 
 


### PR DESCRIPTION
Turns out, you can't append to a string.  I don't know quite why this happened the way that it did for me, but some combination of environmental variables did it.  This fixes the build on my system.