### PR TITLE
[BOXLIB] consistent parsing for periodicity parameters

### DIFF
--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -756,8 +756,9 @@ class BoxlibDataset(Dataset):
                 vals = self.refine_by = int(vals[0])
             elif param == "Prob.lo_bc":
                 vals = tuple(p == "1" for p in vals.split())
-                periodicity = [False, False, False]
-                periodicity[: len(vals)] = vals
+                assert len(vals) == self.dimensionality
+                periodicity = [False, False, False]  # default to non periodic
+                periodicity[: self.dimensionality] = vals  # fill in ndim parsed values
                 self.periodicity = tuple(periodicity)
             elif param == "castro.use_comoving":
                 vals = self.cosmological_simulation = int(vals)

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -1143,7 +1143,7 @@ class CastroDataset(BoxlibDataset):
         periodicity = [False, False, False]
         for i, axis in enumerate("xyz"):
             try:
-                periodicity[i] = self.parameters["-%s" % axis] == "interior"
+                periodicity[i] = self.parameters[f"-{axis}"] == "interior"
             except KeyError:
                 break
 

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -629,7 +629,7 @@ class BoxlibDataset(Dataset):
     _output_prefix = None
 
     # THIS SHOULD BE FIXED:
-    periodicity = (True, True, True)
+    periodicity = (False, False, False)
 
     def __init__(
         self,

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -917,7 +917,7 @@ class BoxlibDataset(Dataset):
         self.domain_dimensions = np.array(tmp)
         self.periodicity = list(self.periodicity)
         self.periodicity[1:] = False
-        self.periodicity = ensure_tuple(tmp)
+        self.periodicity = ensure_tuple(self.periodicity)
 
     def _setup2d(self):
         self.domain_left_edge = np.concatenate([self.domain_left_edge, [0.0]])
@@ -1594,7 +1594,7 @@ class WarpXDataset(BoxlibDataset):
                     self.parameters[l[0].strip()] = l[1].strip()
 
         # set the periodicity based on the integer BC runtime parameters
-        self.periodicity = [True] * 3
+        self.periodicity = [False] * 3
         try:
             is_periodic = self.parameters["geometry.is_periodic"].split()
             self.periodicity[: len(is_periodic)] = [p == "1" for p in is_periodic]

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -1159,7 +1159,8 @@ class CastroDataset(BoxlibDataset):
         self.parameters["HydroMethod"] = "Castro"
 
         # set the periodicity based on the runtime parameters
-        self.periodicity = [True, True, True]
+        # https://amrex-astro.github.io/Castro/docs/inputs.html?highlight=periodicity
+        self.periodicity = [False] * 3
         for i, axis in enumerate("xyz"):
             try:
                 self.periodicity[i] = self.parameters["-%s" % axis] == "interior"
@@ -1594,6 +1595,7 @@ class WarpXDataset(BoxlibDataset):
                     self.parameters[l[0].strip()] = l[1].strip()
 
         # set the periodicity based on the integer BC runtime parameters
+        # https://amrex-codes.github.io/amrex/docs_html/InputsProblemDefinition.html
         self.periodicity = [False] * 3
         try:
             is_periodic = self.parameters["geometry.is_periodic"].split()

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -831,17 +831,13 @@ class BoxlibDataset(Dataset):
         # This is traditionally a index attribute, so we will set it, but
         # in a slightly hidden variable.
         self._max_level = int(header_file.readline())
-        dle = np.zeros(3, dtype="float64")
-        dle[: self.dimensionality] = np.array(
-            header_file.readline().split(), dtype="float64"
-        )
-        self.domain_left_edge = dle
-        dre = np.ones(3, dtype="float64")
-        dre[: self.dimensionality] = np.array(
-            header_file.readline().split(), dtype="float64"
-        )
-        self.domain_right_edge = dre
-        ref_factors = np.array([int(i) for i in header_file.readline().split()])
+
+        for side, init in zip(["left", "right"], [np.zeros, np.ones]):
+            domain_edge = init(3, dtype="float64")
+            domain_edge[: self.dimensionality] = header_file.readline().split()
+            setattr(self, f"domain_{side}_edge", domain_edge)
+
+        ref_factors = np.array(header_file.readline().split(), dtype="int64")
         if ref_factors.size == 0:
             # We use a default of two, as Nyx doesn't always output this value
             ref_factors = [2] * (self._max_level + 1)

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -755,7 +755,10 @@ class BoxlibDataset(Dataset):
             elif param == "amr.ref_ratio":
                 vals = self.refine_by = int(vals[0])
             elif param == "Prob.lo_bc":
-                vals = self.periodicity = tuple(p == "1" for p in vals.split())
+                vals = tuple(p == "1" for p in vals.split())
+                periodicity = [False, False, False]
+                periodicity[: len(vals)] = vals
+                self.periodicity = tuple(periodicity)
             elif param == "castro.use_comoving":
                 vals = self.cosmological_simulation = int(vals)
             else:
@@ -828,12 +831,16 @@ class BoxlibDataset(Dataset):
         # This is traditionally a index attribute, so we will set it, but
         # in a slightly hidden variable.
         self._max_level = int(header_file.readline())
-        self.domain_left_edge = np.array(
+        dle = np.zeros(3, dtype="float64")
+        dle[: self.dimensionality] = np.array(
             header_file.readline().split(), dtype="float64"
         )
-        self.domain_right_edge = np.array(
+        self.domain_left_edge = dle
+        dre = np.ones(3, dtype="float64")
+        dre[: self.dimensionality] = np.array(
             header_file.readline().split(), dtype="float64"
         )
+        self.domain_right_edge = dre
         ref_factors = np.array([int(i) for i in header_file.readline().split()])
         if ref_factors.size == 0:
             # We use a default of two, as Nyx doesn't always output this value
@@ -872,7 +879,10 @@ class BoxlibDataset(Dataset):
         root_space = index_space.replace("(", "").replace(")", "").split()[:2]
         start = np.array(root_space[0].split(","), dtype="int64")
         stop = np.array(root_space[1].split(","), dtype="int64")
-        self.domain_dimensions = stop - start + 1
+        dd = np.ones(3, dtype="int64")
+        dd[: self.dimensionality] = stop - start + 1
+        self.domain_dimensions = dd
+
         # Skip timesteps per level
         header_file.readline()
         self._header_mesh_start = header_file.tell()
@@ -885,52 +895,23 @@ class BoxlibDataset(Dataset):
             coordinate_type = int(next_line)
         else:
             coordinate_type = 0
-        if coordinate_type == 0:
-            self.geometry = "cartesian"
-        elif coordinate_type == 1:
-            self.geometry = "cylindrical"
-        elif coordinate_type == 2:
-            self.geometry = "spherical"
-        else:
-            raise RuntimeError("Unknown BoxLib coord_type")
 
-        # overrides for 1/2-dimensional data
-        if self.dimensionality == 1:
-            self._setup1d()
-        elif self.dimensionality == 2:
-            self._setup2d()
+        known_types = {0: "cartesian", 1: "cylindrical", 2: "spherical"}
+        try:
+            self.geometry = known_types[coordinate_type]
+        except KeyError as err:
+            raise ValueError(f"Unknown BoxLib coord_type `{coordinate_type}`.") from err
+
+        if self.geometry == "cylindrical":
+            dre = self.domain_right_edge
+            dre[2] = 2.0 * np.pi
+            self.domain_right_edge = dre
 
     def _set_code_unit_attributes(self):
         setdefaultattr(self, "length_unit", self.quan(1.0, "cm"))
         setdefaultattr(self, "mass_unit", self.quan(1.0, "g"))
         setdefaultattr(self, "time_unit", self.quan(1.0, "s"))
         setdefaultattr(self, "velocity_unit", self.quan(1.0, "cm/s"))
-
-    def _setup1d(self):
-        # self._index_class = BoxlibHierarchy1D
-        # self._fieldinfo_fallback = Orion1DFieldInfo
-        self.domain_left_edge = np.concatenate([self.domain_left_edge, [0.0, 0.0]])
-        self.domain_right_edge = np.concatenate([self.domain_right_edge, [1.0, 1.0]])
-        tmp = self.domain_dimensions.tolist()
-        tmp.extend((1, 1))
-        self.domain_dimensions = np.array(tmp)
-        periodicity = list(self.periodicity)
-        periodicity[1:] = False
-        self.periodicity = tuple(periodicity)
-
-    def _setup2d(self):
-        self.domain_left_edge = np.concatenate([self.domain_left_edge, [0.0]])
-        self.domain_right_edge = np.concatenate([self.domain_right_edge, [1.0]])
-        if self.geometry == "cylindrical":
-            dre = self.domain_right_edge
-            dre[2] = 2.0 * np.pi
-            self.domain_right_edge = dre
-        tmp = self.domain_dimensions.tolist()
-        tmp.append(1)
-        self.domain_dimensions = np.array(tmp)
-        periodicity = list(self.periodicity)
-        periodicity[2] = False
-        self.periodicity = tuple(tmp)
 
     @parallel_root_only
     def print_key_parameters(self):


### PR DESCRIPTION
## PR Summary

This supersedes #2787 and adresses the issue at the frontend level. Turns out there is actually more than one place where periodicity is incorrectly or inconsistently parsed.

## PR Checklist

- [x] pass `flake8 yt/`
- [x] pass `isort . --check --diff`
- [x] pass `black --check yt/`
