### PR TITLE
fix some ignored Flake8 errors

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,6 @@ ignore = E203, # Whitespace before ':' (black compatibility)
          E741, # Do not use variables named 'I', 'O', or 'l'
          W503, # Line break occurred before a binary operator (black compatibility)
          W605, # Invalid escape sequence 'x'
-         B005, # "Using .strip() with multi-character strings is misleading the reader."
          B302, # this is a python 3 compatibility warning, not relevant since don't support python 2 anymore
 
 jobs=8

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,6 @@ ignore = E203, # Whitespace before ':' (black compatibility)
          E266, # Too many leading '#' for block comment
          E302, # Expected 2 blank lines, found 0
          E306, # Expected 1 blank line before a nested definition
-         E501, # Line too long (black compatibility)
          E741, # Do not use variables named 'I', 'O', or 'l'
          W503, # Line break occurred before a binary operator (black compatibility)
          W605, # Invalid escape sequence 'x'

--- a/yt/convenience.py
+++ b/yt/convenience.py
@@ -56,7 +56,8 @@ def load(fn, *args, **kwargs):
 
         return DatasetSeries(fn, *args, **kwargs)
 
-    # Unless the dataset starts with http, look for it using the path or relative to the data dir (in this order).
+    # Unless the dataset starts with http,
+    # look for it using the path or relative to the data dir (in this order).
     if not (os.path.exists(fn) or fn.startswith("http")):
         data_dir = ytcfg.get("yt", "test_data_dir")
         alt_fn = os.path.join(data_dir, fn)

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -99,15 +99,17 @@ class YTDataContainer:
         sets its initial set of fields, and the remainder of the arguments
         are passed as field_parameters.
         """
-        # ds is typically set in the new object type created in Dataset._add_object_class
-        # but it can also be passed as a parameter to the constructor, in which case it will
-        # override the default. This code ensures it is never not set.
+        # ds is typically set in the new object type created in
+        # Dataset._add_object_class but it can also be passed as a parameter to the
+        # constructor, in which case it will override the default.
+        # This code ensures it is never not set.
         if ds is not None:
             self.ds = ds
         else:
             if not hasattr(self, "ds"):
                 raise RuntimeError(
-                    "Error: ds must be set either through class type or parameter to the constructor"
+                    "Error: ds must be set either through class type "
+                    "or parameter to the constructor"
                 )
 
         self._current_particle_type = "all"

--- a/yt/data_objects/image_array.py
+++ b/yt/data_objects/image_array.py
@@ -107,9 +107,15 @@ class ImageArray(YTArray):
         ...     for k in range(im.shape[2]):
         ...         im[i,:,k] = np.linspace(0.,0.3*k, im.shape[1])
 
-        >>> myinfo = {'field':'dinosaurs', 'east_vector':np.array([1.,0.,0.]),
-        ...     'north_vector':np.array([0.,0.,1.]), 'normal_vector':np.array([0.,1.,0.]),
-        ...     'width':0.245, 'units':'cm', 'type':'rendering'}
+        >>> myinfo = {
+        ...    'field':'dinosaurs',
+        ...    'east_vector':np.array([1.,0.,0.]),
+        ...    'north_vector':np.array([0.,0.,1.]),
+        ...    'normal_vector':np.array([0.,1.,0.]),
+        ...    'width':0.245,
+        ...    'units':'cm',
+        ...    'type':'rendering'
+        ... }
 
         >>> im_arr = ImageArray(im, info=myinfo)
         >>> im_arr.write_hdf5('test_ImageArray.h5')
@@ -361,9 +367,15 @@ class ImageArray(YTArray):
         >>> for i in range(im.shape[0]):
         ...     im[i,:] = np.linspace(0.,0.3*i, im.shape[1])
 
-        >>> myinfo = {'field':'dinosaurs', 'east_vector':np.array([1.,0.,0.]),
-        ...     'north_vector':np.array([0.,0.,1.]), 'normal_vector':np.array([0.,1.,0.]),
-        ...     'width':0.245, 'units':'cm', 'type':'rendering'}
+        >>> myinfo = {
+        ...    'field':'dinosaurs',
+        ...    'east_vector':np.array([1.,0.,0.]),
+        ...    'north_vector':np.array([0.,0.,1.]),
+        ...    'normal_vector':np.array([0.,1.,0.]),
+        ...    'width':0.245,
+        ...    'units':'cm',
+        ...    'type':'rendering'
+        ... }
 
         >>> im_arr = ImageArray(im, info=myinfo)
         >>> im_arr.write_image('test_ImageArray.png')

--- a/yt/data_objects/level_sets/clump_tools.py
+++ b/yt/data_objects/level_sets/clump_tools.py
@@ -40,8 +40,10 @@ def return_all_clumps(clump):
 
 
 def return_bottom_clumps(clump, dbg=0):
-    """Recursively return clumps at the bottom of the index.
-    This gives a list of clumps similar to what one would get from a CLUMPFIND routine"""
+    """
+    Recursively return clumps at the bottom of the index.
+    This gives a list of clumps similar to what one would get from a CLUMPFIND routine
+    """
     global counter
     counter = 0
     list = []

--- a/yt/data_objects/selection_data_containers.py
+++ b/yt/data_objects/selection_data_containers.py
@@ -1121,7 +1121,7 @@ class YTCutRegion(YTSelectionContainer3D):
         locals = self.locals.copy()
         if "obj" in locals:
             raise RuntimeError(
-                "'obj' has been defined in the 'locals' ;"
+                "'obj' has been defined in the 'locals' ; "
                 "this is not supported, please rename the variable."
             )
         locals["obj"] = obj

--- a/yt/data_objects/selection_data_containers.py
+++ b/yt/data_objects/selection_data_containers.py
@@ -1121,7 +1121,8 @@ class YTCutRegion(YTSelectionContainer3D):
         locals = self.locals.copy()
         if "obj" in locals:
             raise RuntimeError(
-                '"obj" has been defined in the "locals" ; this is not supported, please rename the variable.'
+                "'obj' has been defined in the 'locals' ;"
+                "this is not supported, please rename the variable."
             )
         locals["obj"] = obj
         with obj._field_parameter_state(self.field_parameters):

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -284,13 +284,15 @@ class Dataset:
     @abc.abstractmethod
     def _parse_parameter_file(self):
         # set up various attributes from self.parameter_filename
-        # see yt.frontends._skeleton.SkeletonDataset for a full description of what is required here
+        # for a full description of what is required here see
+        # yt.frontends._skeleton.SkeletonDataset
         pass
 
     @abc.abstractmethod
     def _set_code_unit_attributes(self):
         # set up code-units to physical units normalization factors
-        # see yt.frontends._skeleton.SkeletonDataset for a full description of what is required here
+        # for a full description of what is required here see
+        # yt.frontends._skeleton.SkeletonDataset
         pass
 
     def _set_derived_attrs(self):
@@ -1579,8 +1581,9 @@ class Dataset:
          ('gas', 'temperature_gradient_z'),
          ('gas', 'temperature_gradient_magnitude')]
 
-        Note that the above example assumes ds.geometry == 'cartesian'. In general, the function
-        will create gradients components along the axes of the dataset coordinate system.
+        Note that the above example assumes ds.geometry == 'cartesian'. In general,
+        the function will create gradients components along the axes of the dataset
+        coordinate system.
         For instance, with cylindrical data, one gets 'temperature_gradient_<r,theta,z>'
         """
         self.index

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -473,8 +473,8 @@ class DatasetSeries:
 
         Note
         ----
-        This function will fail if there are duplicate particle ids or if some of the particle
-        disappear.
+        This function will fail if there are duplicate particle ids or if some of the
+        particle disappear.
         """
         return ParticleTrajectories(
             self, indices, fields=fields, suppress_logging=suppress_logging, ptype=ptype

--- a/yt/fields/fluid_fields.py
+++ b/yt/fields/fluid_fields.py
@@ -221,7 +221,8 @@ def setup_gradient_fields(registry, grad_field, field_units, slice_info=None):
     geom = registry.ds.geometry
     if is_curvilinear(geom):
         mylog.warning(
-            "In %s geometry, gradient fields may contain artifacts near cartesian axes.",
+            "In %s geometry, gradient fields may contain "
+            "artifacts near cartesian axes.",
             geom,
         )
 

--- a/yt/fields/interpolated_fields.py
+++ b/yt/fields/interpolated_fields.py
@@ -31,7 +31,8 @@ def add_interpolated_field(
 
     if len(axes_fields) != len(axes_data) or len(axes_fields) != len(table_data.shape):
         raise RuntimeError(
-            "Data dimension mismatch: data is %d, %d axes data provided, and %d axes fields provided."
+            "Data dimension mismatch: data is %d, "
+            "%d axes data provided, and %d axes fields provided."
             % (len(table_data.shape), len(axes_data), len(axes_fields))
         )
 

--- a/yt/frontends/_skeleton/data_structures.py
+++ b/yt/frontends/_skeleton/data_structures.py
@@ -140,7 +140,9 @@ class SkeletonDataset(Dataset):
         #   self.unique_identifier      <= unique identifier for the dataset
         #                                  being read (e.g., UUID or ST_CTIME) (int)
         #
-        #   self.geometry (defaults to 'cartesian') <= a lower case string ("cartesian", "polar", "cylindrical"...)
+        #   self.geometry  <= a lower case string
+        #                     ("cartesian", "polar", "cylindrical"...)
+        #                     (defaults to 'cartesian')
         pass
 
     @classmethod

--- a/yt/frontends/_skeleton/io.py
+++ b/yt/frontends/_skeleton/io.py
@@ -34,8 +34,9 @@ class SkeletonIOHandler(BaseIOHandler):
         # transpose is required (e.g., using np_array.transpose() or
         # np_array.swapaxes(0,2)).
 
-        # Note this method is not abstract, and has a default implementation in the base class.
-        # However, the default implementation requires that the method io_iter be defined
+        # This method is not abstract, and has a default implementation
+        # in the base class.However, the default implementation requires that the method
+        # io_iter be defined
         pass
 
     def _read_chunk_data(self, chunk, fields):

--- a/yt/frontends/adaptahop/data_structures.py
+++ b/yt/frontends/adaptahop/data_structures.py
@@ -49,7 +49,8 @@ class AdaptaHOPDataset(Dataset):
         self.over_refine_factor = over_refine_factor
         if parent_ds is None:
             raise RuntimeError(
-                "The AdaptaHOP frontend requires a parent dataset to be passed as `parent_ds`."
+                "The AdaptaHOP frontend requires a parent dataset "
+                "to be passed as `parent_ds`."
             )
         self.parent_ds = parent_ds
 
@@ -178,8 +179,10 @@ class AdaptaHOPHaloContainer(YTSelectionContainer):
     --------
 
     >>> import yt
-    >>> ds = yt.load('output_00080_halos/tree_bricks080', parent_ds=yt.load('output_00080/info_00080.txt'))
-    >>>
+    >>> ds = yt.load(
+    ...      'output_00080_halos/tree_bricks080',
+    ...       parent_ds=yt.load('output_00080/info_00080.txt')
+    ... )
     >>> ds.halo(1, ptype='io')
     >>> print(halo.mass)
     119.22804260253906 100000000000.0*Msun

--- a/yt/frontends/adaptahop/io.py
+++ b/yt/frontends/adaptahop/io.py
@@ -209,7 +209,7 @@ class IOHandlerAdaptaHOPBinary(BaseIOHandler):
         # Make sure halos are loaded in increasing halo_id order
         assert np.all(np.diff(offset_map[:, 0]) > 0)
 
-        # Cache particle positions as one do not expect a (very) large number of halos anyway
+        # Cache particle positions as one do not expect a large number of halos anyway
         self._particle_positions = data
         self._offsets = offset_map
         return data

--- a/yt/frontends/amrvac/datfile_utils.py
+++ b/yt/frontends/amrvac/datfile_utils.py
@@ -105,8 +105,8 @@ def get_header(istream):
 
 def get_tree_info(istream):
     """
-    Read levels, morton-curve indices, and byte offsets for each block as stored in the datfile
-    istream is an open datfile buffer with 'rb' mode
+    Read levels, morton-curve indices, and byte offsets for each block as stored in the
+    datfile istream is an open datfile buffer with 'rb' mode
     This can be used as the "first pass" data reading required by YT's interface.
     """
     istream.seek(0)

--- a/yt/frontends/amrvac/fields.py
+++ b/yt/frontends/amrvac/fields.py
@@ -41,8 +41,9 @@ def _velocity(field, data, idir, prefix=None):
     mask1 = rho == 0
     if mask1.any():
         mylog.info(
-            "zeros found in %sdensity, patching them to compute corresponding velocity field.",
-            prefix,
+            "zeros found in %sdensity, "
+            "patching them to compute corresponding velocity field.",
+            prefix
         )
         mask2 = moment == 0
         if not ((mask1 & mask2) == mask1).all():
@@ -55,42 +56,34 @@ code_density = "code_mass / code_length**3"
 code_moment = "code_mass / code_length**2 / code_time"
 code_pressure = "code_mass / code_length / code_time**2"
 
-# for now, define a finite family of dust fields (up to 100 species, should be enough)
-MAXN_DUST_SPECIES = 100
-known_dust_fields = [
-    ("rhod%d" % idust, (code_density, ["dust%d_density" % idust], None))
-    for idust in range(1, MAXN_DUST_SPECIES + 1)
-]
-for idir in (1, 2, 3):
-    known_dust_fields += [
+
+class AMRVACFieldInfo(FieldInfoContainer):
+    # for now, define a finite family of dust fields (up to 100 species)
+    MAXN_DUST_SPECIES = 100
+    known_dust_fields = [
+        ("rhod%d" % idust, (code_density, ["dust%d_density" % idust], None))
+        for idust in range(1, MAXN_DUST_SPECIES + 1)
+    ] + [
         (
             "m%dd%d" % (idir, idust),
             (code_moment, ["dust%d_moment_%d" % (idust, idir)], None),
         )
         for idust in range(1, MAXN_DUST_SPECIES + 1)
+        for idir in (1, 2, 3)
     ]
-
-
-class AMRVACFieldInfo(FieldInfoContainer):
-
     # format: (native(?) field, (units, [aliases], display_name))
-    # note: aliases will correspond to "gas" typed fields, whereas the native ones are "amrvac" typed
-    known_other_fields = tuple(
-        list(
-            (
-                ("rho", (code_density, ["density"], None)),
-                ("m1", (code_moment, ["moment_1"], None)),
-                ("m2", (code_moment, ["moment_2"], None)),
-                ("m3", (code_moment, ["moment_3"], None)),
-                ("e", (code_pressure, ["energy_density"], None)),
-                ("b1", ("code_magnetic", ["magnetic_1"], None)),
-                ("b2", ("code_magnetic", ["magnetic_2"], None)),
-                ("b3", ("code_magnetic", ["magnetic_3"], None)),
-            )
-        )
-        + known_dust_fields
-        # in python3, there is no need for this tuple+list conversion, it suffices to write
-        # known_other_fields = (..., *known_dust_fields)
+    # note: aliases will correspond to "gas" typed fields
+    # whereas the native ones are "amrvac" typed
+    known_other_fields = (
+        ("rho", (code_density, ["density"], None)),
+        ("m1", (code_moment, ["moment_1"], None)),
+        ("m2", (code_moment, ["moment_2"], None)),
+        ("m3", (code_moment, ["moment_3"], None)),
+        ("e", (code_pressure, ["energy_density"], None)),
+        ("b1", ("code_magnetic", ["magnetic_1"], None)),
+        ("b2", ("code_magnetic", ["magnetic_2"], None)),
+        ("b3", ("code_magnetic", ["magnetic_3"], None)),
+        *known_dust_fields,
     )
 
     known_particle_fields = ()
@@ -128,12 +121,12 @@ class AMRVACFieldInfo(FieldInfoContainer):
 
     def _setup_dust_fields(self):
         idust = 1
+        imax = self.__class__.MAXN_DUST_SPECIES
         while ("amrvac", "rhod%d" % idust) in self.field_list:
-            if idust > MAXN_DUST_SPECIES:
+            if idust > imax:
                 mylog.error(
                     "Only the first %d dust species are currently read by yt. "
-                    "If you read this, please consider issuing a ticket. ",
-                    MAXN_DUST_SPECIES,
+                    "If you read this, please consider issuing a ticket. ", imax
                 )
                 break
             self._setup_velocity_fields(idust)
@@ -173,7 +166,8 @@ class AMRVACFieldInfo(FieldInfoContainer):
         self._setup_velocity_fields()  # gas velocities
         self._setup_dust_fields()  # dust derived fields (including velocities)
 
-        # fields with nested dependencies are defined thereafter by increasing level of complexity
+        # fields with nested dependencies are defined thereafter
+        # by increasing level of complexity
         us = self.ds.unit_system
 
         def _kinetic_energy_density(field, data):
@@ -197,15 +191,17 @@ class AMRVACFieldInfo(FieldInfoContainer):
                     if not ("amrvac", f"b{idim}") in self.field_list:
                         break
                     emag += 0.5 * data["gas", f"magnetic_{idim}"] ** 2
-                # important note: in AMRVAC the magnetic field is defined in units where mu0 = 1,
+                # in AMRVAC the magnetic field is defined in units where mu0 = 1,
                 # such that
                 # Emag = 0.5*B**2 instead of Emag = 0.5*B**2 / mu0
-                # To correctly transform the dimensionality from gauss**2 -> rho*v**2, we have to
-                # take mu0 into account. If we divide here, units when adding the field should be
-                # us["density"]*us["velocity"]**2. If not, they should be us["magnetic_field"]**2
-                # and division should happen elsewhere.
+                # To correctly transform the dimensionality from gauss**2 -> rho*v**2,
+                # we have to take mu0 into account. If we divide here, units when adding
+                # the field should be us["density"]*us["velocity"]**2.
+                # If not, they should be us["magnetic_field"]**2 and division should
+                # happen elsewhere.
                 emag /= 4 * np.pi
-                # divided by mu0 = 4pi in cgs, yt handles 'mks' and 'code' unit systems internally.
+                # divided by mu0 = 4pi in cgs,
+                # yt handles 'mks' and 'code' unit systems internally.
                 return emag
 
             self.add_field(
@@ -218,12 +214,12 @@ class AMRVACFieldInfo(FieldInfoContainer):
 
         # Adding the thermal pressure field.
         # In AMRVAC we have multiple physics possibilities:
-        # - if HD/MHD + energy equation, pressure is (gamma-1)*(e - ekin (- emag)) for (M)HD
-        # - if HD/MHD but solve_internal_e is true in parfile, pressure is (gamma-1)*e for both
-        # - if (m)hd_energy is false in parfile (isothermal), pressure is c_adiab * rho**gamma
+        # - if HD/MHD + energy equation P = (gamma-1)*(e - ekin (- emag)) for (M)HD
+        # - if HD/MHD but solve_internal_e is true in parfile, P = (gamma-1)*e for both
+        # - if (m)hd_energy is false in parfile (isothermal), P = c_adiab * rho**gamma
 
         def _full_thermal_pressure_HD(field, data):
-            # important note : energy density and pressure are actually expressed in the same unit
+            # energy density and pressure are actually expressed in the same unit
             pthermal = (data.ds.gamma - 1) * (
                 data["gas", "energy_density"] - data["gas", "kinetic_energy_density"]
             )
@@ -257,7 +253,8 @@ class AMRVACFieldInfo(FieldInfoContainer):
             pressure_recipe = _adiabatic_thermal_pressure
             mylog.info("Using adiabatic EoS for thermal pressure (isothermal).")
             mylog.warning(
-                "If you used usr_set_pthermal you should redefine the thermal_pressure field."
+                "If you used usr_set_pthermal you should "
+                "redefine the thermal_pressure field."
             )
 
         if pressure_recipe is not None:

--- a/yt/frontends/amrvac/fields.py
+++ b/yt/frontends/amrvac/fields.py
@@ -43,7 +43,7 @@ def _velocity(field, data, idir, prefix=None):
         mylog.info(
             "zeros found in %sdensity, "
             "patching them to compute corresponding velocity field.",
-            prefix
+            prefix,
         )
         mask2 = moment == 0
         if not ((mask1 & mask2) == mask1).all():
@@ -126,7 +126,8 @@ class AMRVACFieldInfo(FieldInfoContainer):
             if idust > imax:
                 mylog.error(
                     "Only the first %d dust species are currently read by yt. "
-                    "If you read this, please consider issuing a ticket. ", imax
+                    "If you read this, please consider issuing a ticket. ",
+                    imax,
                 )
                 break
             self._setup_velocity_fields(idust)

--- a/yt/frontends/amrvac/io.py
+++ b/yt/frontends/amrvac/io.py
@@ -89,15 +89,17 @@ class AMRVACIOHandler(BaseIOHandler):
         Returns
         -------
         data_dict : dict
-            keys are the (ftype, fname) tuples and values are arrays that have been masked using
-            whatever selector method is appropriate. Arrays have dtype float64.
+            keys are the (ftype, fname) tuples, values are arrays that have been masked
+            using whatever selector method is appropriate. Arrays have dtype float64.
         """
 
         # @Notes from Niels:
         # The chunks list has YTDataChunk objects containing the different grids.
-        # The list of grids can be obtained by doing eg. grids_list = chunks[0].objs or chunks[1].objs etc.
-        # Every element in "grids_list" is then an AMRVACGrid object, and has hence all attributes of a grid
-        #    (Level, ActiveDimensions, LeftEdge, etc.)
+        # The list of grids can be obtained by doing eg.
+        # grids_list = chunks[0].objs or chunks[1].objs etc.
+        # Every element in "grids_list" is then an AMRVACGrid object,
+        # and has hence all attributes of a grid :
+        # (Level, ActiveDimensions, LeftEdge, etc.)
 
         chunks = list(chunks)
         data_dict = {}  # <- return variable

--- a/yt/frontends/amrvac/tests/test_outputs.py
+++ b/yt/frontends/amrvac/tests/test_outputs.py
@@ -138,8 +138,8 @@ def test_rmi_cartesian_dust_2D():
         yield test
 
 
-# Tests for units: verify that overriding certain units yields the correct derived units.
-# The following are correct normalisations based on length, numberdensity and temperature
+# Tests for units: verify that overriding certain units yields the correct derived units
+# The following are correct normalisations based on length, numberdensity and temp
 length_unit = (1e9, "cm")
 numberdensity_unit = (1e9, "cm**-3")
 temperature_unit = (1e6, "K")

--- a/yt/frontends/amrvac/tests/test_read_amrvac_namelist.py
+++ b/yt/frontends/amrvac/tests/test_read_amrvac_namelist.py
@@ -12,7 +12,8 @@ modifier_parfile = path.join(test_dir, "sample_parfiles/tvdlf_scheme.par")
 
 @requires_module("f90nml")
 def test_read_one_file():
-    """when provided a single file, the function should merely act as a wrapper for f90nml.read()"""
+    """when provided a single file, the function should merely act
+    as a wrapper for f90nml.read()"""
     namelist1 = read_amrvac_namelist(blast_wave_parfile)
     namelist2 = f90nml.read(blast_wave_parfile)
     assert namelist1 == namelist2
@@ -20,7 +21,8 @@ def test_read_one_file():
 
 @requires_module("f90nml")
 def test_accumulate_basename():
-    """When two (or more) parfiles are passed, the filelist:base_filename should be special-cased"""
+    """When two (or more) parfiles are passed,
+    the filelist:base_filename should be special-cased"""
     namelist_base = f90nml.read(blast_wave_parfile)
     namelist_update = f90nml.read(modifier_parfile)
 

--- a/yt/frontends/athena/data_structures.py
+++ b/yt/frontends/athena/data_structures.py
@@ -490,8 +490,9 @@ class AthenaDataset(Dataset):
             if k.endswith("_unit") and k not in units_override:
                 if not already_warned:
                     mylog.warning(
-                        "Supplying unit conversions from the parameters dict is deprecated, "
-                        "and will be removed in a future release. Use units_override instead."
+                        "Supplying unit conversions from the parameters dict "
+                        "is deprecated, and will be removed in a future release. "
+                        "Use units_override instead."
                     )
                     already_warned = True
                 units_override[k] = self.specified_parameters.pop(k)

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -471,18 +471,21 @@ class BoxlibHierarchy(GridIndex):
             _header_pattern[self.dimensionality - 1].search(header).groups()
         )
         # Note that previously we were using a different value for BPR than we
-        # use now.  Here is an example set of information directly from BoxLib:
-        #  * DOUBLE data
-        #  * FAB ((8, (64 11 52 0 1 12 0 1023)),(8, (1 2 3 4 5 6 7 8)))((0,0) (63,63) (0,0)) 27
-        #  * FLOAT data
-        #  * FAB ((8, (32 8 23 0 1 9 0 127)),(4, (1 2 3 4)))((0,0) (63,63) (0,0)) 27
+        # use now.  Here is an example set of information directly from BoxLib
+        """
+        * DOUBLE data
+        * FAB ((8, (64 11 52 0 1 12 0 1023)),(8, (1 2 3 4 5 6 7 8)))((0,0) (63,63) (0,0)) 27  # NOQA: E501
+        * FLOAT data
+        * FAB ((8, (32 8 23 0 1 9 0 127)),(4, (1 2 3 4)))((0,0) (63,63) (0,0)) 27
+        """
         if bpr == endian[0]:
             dtype = f"<f{bpr}"
         elif bpr == endian[-1]:
             dtype = f">f{bpr}"
         else:
             raise ValueError(
-                "FAB header is neither big nor little endian. Perhaps the file is corrupt?"
+                "FAB header is neither big nor little endian. "
+                "Perhaps the file is corrupt?"
             )
 
         mylog.debug("FAB header suggests dtype of %s", dtype)
@@ -721,10 +724,10 @@ class BoxlibDataset(Dataset):
             if param == "amr.n_cell":
                 vals = self.domain_dimensions = np.array(vals.split(), dtype="int32")
 
-                # For 1D and 2D simulations in BoxLib usually only the relevant dimensions
-                # have a specified number of zones, but yt requires domain_dimensions to
-                # have three elements, with 1 in the additional slots if we're not in 3D,
-                # so append them as necessary.
+                # For 1D and 2D simulations in BoxLib usually only the relevant
+                # dimensions have a specified number of zones, but yt requires
+                # domain_dimensions to have three elements, with 1 in the additional
+                # slots if we're not in 3D, so append them as necessary.
 
                 if len(vals) == 1:
                     vals = self.domain_dimensions = np.array([vals[0], 1, 1])
@@ -1157,8 +1160,10 @@ class CastroDataset(BoxlibDataset):
                     p, v = line.strip().split(":")
                     self.parameters[p] = v.strip()
                 if "git describe" in line or "git hash" in line:
-                    # Castro release 17.02 and later - line format: codename git describe:  the-hash
-                    # Castro before release 17.02    - line format: codename git hash:  the-hash
+                    # Castro release 17.02 and later
+                    #    line format: codename git describe:  the-hash
+                    # Castro before release 17.02
+                    #    line format: codename git hash:  the-hash
                     fields = line.split(":")
                     self.parameters[fields[0]] = fields[1].strip()
                 line = next(f)

--- a/yt/frontends/enzo/simulation_handling.py
+++ b/yt/frontends/enzo/simulation_handling.py
@@ -573,7 +573,8 @@ class EnzoSimulation(SimulationTimeSeries):
 
     def _set_parameter_defaults(self):
         """
-        Set some default parameters to avoid problems if they are not in the parameter file.
+        Set some default parameters to avoid problems
+        if they are not in the parameter file.
         """
 
         self.parameters["GlobalDir"] = self.directory

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -880,7 +880,7 @@ class EventsFITSDataset(SkyDataFITSDataset):
         for k, v in self.primary_header.items():
             if k.startswith("TTYP"):
                 if v.lower() in ["x", "y"]:
-                    num = k.strip("TTYPE")
+                    num = k.replace("TTYPE", "")
                     self.events_info[v.lower()] = (
                         self.primary_header["TLMIN" + num],
                         self.primary_header["TLMAX" + num],
@@ -890,7 +890,7 @@ class EventsFITSDataset(SkyDataFITSDataset):
                         self.primary_header["TCRPX" + num],
                     )
                 elif v.lower() in ["energy", "time"]:
-                    num = k.strip("TTYPE")
+                    num = k.replace("TTYPE", "")
                     unit = self.primary_header["TUNIT" + num].lower()
                     if unit.endswith("ev"):
                         unit = unit.replace("ev", "eV")

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -174,13 +174,14 @@ class FITSHierarchy(GridIndex):
                         mylog.info("Adding field %s to the list of fields.", fname)
                         if units == "dimensionless":
                             mylog.warning(
-                                "Could not determine dimensions for field %s, setting to dimensionless.",
+                                "Could not determine dimensions for field %s, "
+                                "setting to dimensionless.",
                                 fname,
                             )
                 else:
                     mylog.warning(
-                        "Image block %s does not have the same dimensions as the primary and will not be "
-                        "available as a field.",
+                        "Image block %s does not have the same dimensions "
+                        "as the primary and will not be available as a field.",
                         hdu.name.lower(),
                     )
 

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -267,7 +267,7 @@ class GadgetDataset(SPHDataset):
                 "Otherwise something is wrong, "
                 "and you might want to check how the dataset is loaded. "
                 "Futher information about header specification can be found in "
-                "https://yt-project.org/docs/dev/examining/loading_data.html#header-specification.",
+                "https://yt-project.org/docs/dev/examining/loading_data.html#header-specification.",  # NOQA E501
                 header_size,
             )
         self._field_spec = self._setup_binary_spec(field_spec, gadget_field_specs)
@@ -646,7 +646,8 @@ class GadgetHDF5Dataset(GadgetDataset):
 
         # note the contents of the HDF5 Units group are in _unit_base
         # note the velocity stored on disk is sqrt(a) dx/dt
-        # physical velocity [cm/s] = a dx/dt = sqrt(a) * velocity_on_disk * UnitVelocity_in_cm_per_s
+        # physical velocity [cm/s] = a dx/dt
+        # = sqrt(a) * velocity_on_disk * UnitVelocity_in_cm_per_s
         self.length_unit = self.quan(self._unit_base["UnitLength_in_cm"], "cmcm/h")
         self.mass_unit = self.quan(self._unit_base["UnitMass_in_g"], "g/h")
         self.velocity_unit = self.quan(

--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -179,14 +179,21 @@ class GAMERHierarchy(GridIndex):
             # edges between children and parent
             for c in grid.Children:
                 for d in range(0, 3):
-                    assert grid.LeftEdge[d] <= c.LeftEdge[d], (
-                        "Grid %d, Children %d, Grid->EdgeL %14.7e, Children->EdgeL %14.7e"
+                    msgL = (
+                        "Grid %d, Child %d, Grid->EdgeL %14.7e, Children->EdgeL %14.7e"
                         % (grid.id, c.id, grid.LeftEdge[d], c.LeftEdge[d])
                     )
-                    assert grid.RightEdge[d] >= c.RightEdge[d], (
-                        "Grid %d, Children %d, Grid->EdgeR %14.7e, Children->EdgeR %14.7e"
+                    msgR = (
+                        "Grid %d, Child %d, Grid->EdgeR %14.7e, Children->EdgeR %14.7e"
                         % (grid.id, c.id, grid.RightEdge[d], c.RightEdge[d])
                     )
+                    if not grid.LeftEdge[d] <= c.LeftEdge[d]:
+
+                        raise ValueError(msgL)
+
+                    if not grid.RightEdge[d] >= c.RightEdge[d]:
+                        raise ValueError(msgR)
+
         mylog.info("Check passed")
 
 
@@ -342,7 +349,7 @@ class GAMERDataset(Dataset):
         else:
             self.mhd = 0
 
-        # old data format (version < 2210) does not contain any information of code units
+        # old data format (version < 2210) did not contain any information of code units
         self.parameters.setdefault("Opt__Unit", 0)
 
         self.geometry = geometry_parameters[parameters.get("Coordinate", 1)]

--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -188,7 +188,6 @@ class GAMERHierarchy(GridIndex):
                         % (grid.id, c.id, grid.RightEdge[d], c.RightEdge[d])
                     )
                     if not grid.LeftEdge[d] <= c.LeftEdge[d]:
-
                         raise ValueError(msgL)
 
                     if not grid.RightEdge[d] >= c.RightEdge[d]:

--- a/yt/frontends/open_pmd/data_structures.py
+++ b/yt/frontends/open_pmd/data_structures.py
@@ -29,8 +29,8 @@ class OpenPMDGrid(AMRGridPatch):
     """Represents chunk of data on-disk.
 
     This defines the index and offset for every mesh and particle type.
-    It also defines parents and children grids. Since openPMD does not have multiple levels of refinement,
-    there are no parents or children for any grid.
+    It also defines parents and children grids. Since openPMD does not have multiple
+    levels of refinement there are no parents or children for any grid.
     """
 
     _id_offset = 0
@@ -112,8 +112,9 @@ class OpenPMDHierarchy(GridIndex):
     def _detect_output_fields(self):
         """Populates ``self.field_list`` with native fields (mesh and particle) on disk.
 
-        Each entry is a tuple of two strings. The first element is the on-disk fluid type or particle type.
-        The second element is the name of the field in yt. This string is later used for accessing the data.
+        Each entry is a tuple of two strings. The first element is the on-disk fluid
+        type or particle type. The second element is the name of the field in yt.
+        This string is later used for accessing the data.
         Convention suggests that the on-disk fluid type should be "openPMD",
         the on-disk particle type (for a single species of particles) is "io"
         or (for multiple species of particles) the particle name on-disk.
@@ -152,8 +153,8 @@ class OpenPMDHierarchy(GridIndex):
                         )
                     elif "particlePatches" not in recname:
                         try:
-                            # Create a field for every axis (x,y,z) of every property (position)
-                            # of every species (electrons)
+                            # Create a field for every axis (x,y,z) of every
+                            # property (position) of every species (electrons)
                             axes = list(record.keys())
                             if str(recname) == "position":
                                 recname = "positionCoarse"
@@ -176,7 +177,8 @@ class OpenPMDHierarchy(GridIndex):
                     else:
                         pass
             if len(list(particles.keys())) > 1:
-                # There is more than one particle species, use the specific names as field types
+                # There is more than one particle species,
+                # use the specific names as field types
                 self.field_list.extend(
                     [
                         (
@@ -386,7 +388,8 @@ class OpenPMDHierarchy(GridIndex):
                 particle_names = []
                 for (pname, size) in self.numparts.items():
                     if size == count:
-                        # Since this is not part of a particlePatch, we can include multiple same-sized ptypes
+                        # Since this is not part of a particlePatch,
+                        # we can include multiple same-sized ptypes
                         particle_names.append(str(pname))
                         handled_ptypes.append(str(pname))
             else:
@@ -426,9 +429,10 @@ class OpenPMDDataset(Dataset):
 
     Notes
     -----
-    It is assumed that all meshes cover the same region. Their resolution can be different.
-    It is assumed that all particles reside in this same region exclusively.
-    It is assumed that the particle and mesh positions are *absolute* with respect to the simulation origin.
+    It is assumed that
+    - all meshes cover the same region. Their resolution can be different.
+    - all particles reside in this same region exclusively.
+    - particle and mesh positions are *absolute* with respect to the simulation origin.
     """
 
     _index_class = OpenPMDHierarchy
@@ -535,7 +539,8 @@ class OpenPMDDataset(Dataset):
         """Handle conversion between different physical units and the code units.
 
         Every dataset in openPMD can have different code <-> physical scaling.
-        The individual factor is obtained by multiplying with "unitSI" reading getting data from disk.
+        The individual factor is obtained by multiplying with "unitSI" reading getting
+        data from disk.
         """
         setdefaultattr(self, "length_unit", self.quan(1.0, "m"))
         setdefaultattr(self, "mass_unit", self.quan(1.0, "kg"))

--- a/yt/frontends/open_pmd/fields.py
+++ b/yt/frontends/open_pmd/fields.py
@@ -215,7 +215,9 @@ class OpenPMDFieldInfo(FieldInfoContainer):
                         if recname != "particlePatches":
                             mylog.info(
                                 "open_pmd - %s_%s does not seem to have "
-                                "unitDimension", pname, recname
+                                "unitDimension",
+                                pname,
+                                recname,
                             )
             for i in self.known_particle_fields:
                 mylog.debug("open_pmd - known_particle_fields - %s", i)

--- a/yt/frontends/open_pmd/fields.py
+++ b/yt/frontends/open_pmd/fields.py
@@ -134,7 +134,7 @@ class OpenPMDFieldInfo(FieldInfoContainer):
     References
     ----------
     * http://yt-project.org/docs/dev/analyzing/fields.html
-    * http://yt-project.org/docs/dev/developing/creating_frontend.html#data-meaning-structures
+    * http://yt-project.org/docs/dev/developing/creating_frontend.html#data-meaning-structures  # NOQA E501
     * https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md
     * [1] http://yt-project.org/docs/dev/reference/field_list.html#universal-fields
     """
@@ -152,7 +152,8 @@ class OpenPMDFieldInfo(FieldInfoContainer):
             for fname in fields.keys():
                 field = fields[fname]
                 if isinstance(field, h5.Dataset) or is_const_component(field):
-                    # Don't consider axes. This appears to be a vector field of single dimensionality
+                    # Don't consider axes.
+                    # This appears to be a vector field of single dimensionality
                     ytname = str("_".join([fname.replace("_", "-")]))
                     parsed = parse_unit_dimension(
                         np.asarray(field.attrs["unitDimension"], dtype=np.int)
@@ -195,7 +196,7 @@ class OpenPMDFieldInfo(FieldInfoContainer):
                         if ytattrib == "position":
                             # Symbolically rename position to preserve yt's
                             # interpretation of the pfield particle_position is later
-                            # derived in setup_absolute_positions in the way yt expects it
+                            # derived in setup_absolute_positions in the way yt expects
                             ytattrib = "positionCoarse"
                         if isinstance(record, h5.Dataset) or is_const_component(record):
                             name = ["particle", ytattrib]
@@ -213,9 +214,8 @@ class OpenPMDFieldInfo(FieldInfoContainer):
                     except (KeyError):
                         if recname != "particlePatches":
                             mylog.info(
-                                "open_pmd - %s_%s does not seem to have unitDimension",
-                                pname,
-                                recname,
+                                "open_pmd - %s_%s does not seem to have "
+                                "unitDimension", pname, recname
                             )
             for i in self.known_particle_fields:
                 mylog.debug("open_pmd - known_particle_fields - %s", i)
@@ -237,7 +237,8 @@ class OpenPMDFieldInfo(FieldInfoContainer):
     def setup_particle_fields(self, ptype):
         """Defines which derived particle fields to create.
 
-        This will be called for every entry in `OpenPMDDataset``'s ``self.particle_types``.
+        This will be called for every entry in
+        `OpenPMDDataset``'s ``self.particle_types``.
         If a field can not be calculated, it will simply be skipped.
         """
         setup_absolute_positions(self, ptype)

--- a/yt/frontends/open_pmd/io.py
+++ b/yt/frontends/open_pmd/io.py
@@ -55,7 +55,7 @@ class IOHandlerOpenPMDHDF5(BaseIOHandler):
                     self.cache[i] = np.zeros(offset)
 
     def _read_particle_selection(self, chunks, selector, fields):
-        """Reads given particle fields for given particle species masked by a given selection.
+        """Read particle fields for particle species masked by a selection.
 
         Parameters
         ----------
@@ -63,8 +63,8 @@ class IOHandlerOpenPMDHDF5(BaseIOHandler):
             A list of chunks
             A chunk is a list of grids
         selector
-            A region (inside your domain) specifying which parts of the field you want to read
-            See [1] and [2]
+            A region (inside your domain) specifying which parts of the field
+            you want to read. See [1] and [2]
         fields : array_like
             Tuples (ptype, pfield) representing a field
 
@@ -89,7 +89,8 @@ class IOHandlerOpenPMDHDF5(BaseIOHandler):
 
         for (ptype, pname) in fields:
             pfield = (ptype, pname)
-            # Overestimate the size of all pfields so they include all particles, shrink it later
+            # Overestimate the size of all pfields so they include all particles
+            # and shrink it later
             particle_count[pfield] = 0
             if ptype in unions:
                 for pt in unions[ptype]:
@@ -147,8 +148,8 @@ class IOHandlerOpenPMDHDF5(BaseIOHandler):
             A list of chunks
             A chunk is a list of grids
         selector
-            A region (inside your domain) specifying which parts of the field you want to read
-            See [1] and [2]
+            A region (inside your domain) specifying which parts of the field
+            you want to read. See [1] and [2]
         fields : array_like
             Tuples (fname, ftype) representing a field
         size : int

--- a/yt/frontends/open_pmd/misc.py
+++ b/yt/frontends/open_pmd/misc.py
@@ -9,7 +9,8 @@ def parse_unit_dimension(unit_dimension):
     Parameters
     ----------
     unit_dimension : array_like
-        integer array of length 7 with one entry for the dimensional component of every SI unit
+        integer array of length 7 with one entry for the dimensional component of every
+        SI unit
 
         [0] length L,
         [1] mass M,
@@ -21,7 +22,9 @@ def parse_unit_dimension(unit_dimension):
 
     References
     ----------
-    .. https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#unit-systems-and-dimensionality
+    ..
+    https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#unit-systems-and-dimensionality  # NOQA E501
+
 
     Returns
     -------
@@ -101,17 +104,9 @@ def get_component(group, component_name, index=0, offset=None):
         else:
             shape[0] = offset
         # component is constant, craft an array by hand
-        # mylog.debug(
-        #    "open_pmd - get_component: {}/{} [const {}]".format(group.name, component_name, shape)
-        # )
         return np.full(shape, record_component.attrs["value"] * unit_si)
     else:
         if offset is not None:
             offset += index
         # component is a dataset, return it (possibly masked)
-        # mylog.debug(
-        #    "open_pmd - get_component: {}/{}[{}:{}]".format(
-        #        group.name, component_name, index, offset
-        #    )
-        # )
         return np.multiply(record_component[index:offset], unit_si)

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -221,8 +221,8 @@ class RAMSESDomainSubset(OctreeSubset):
             self._base_domain = base_domain
         elif num_ghost_zones < 0:
             raise RuntimeError(
-                "Cannot initialize a domain subset with a negative number of ghost zones,"
-                " was called with num_ghost_zones=%s" % num_ghost_zones
+                "Cannot initialize a domain subset with a negative number "
+                "of ghost zones, was called with num_ghost_zones=%s" % num_ghost_zones
             )
 
     def _fill_no_ghostzones(self, fd, fields, selector, file_handler):
@@ -569,8 +569,8 @@ class RAMSESDataset(Dataset):
 
         if group_folder == "group_00001":
             # Count the number of groups
-            # note: we exclude the unlikely event that one of the group is actually a file
-            # instad of a folder
+            # note: we exclude the unlikely event that one of the group is actually a
+            # file instad of a folder
             self.num_groups = len(
                 [
                     _
@@ -632,8 +632,8 @@ class RAMSESDataset(Dataset):
         # Check max_level_convention is set and acceptable
         if max_level_convention is None:
             raise ValueError(
-                "You specified `max_level` without specifying any `max_level_convention`. "
-                "You have to pick either 'yt' or 'ramses'."
+                f"Received `max_level`={max_level}, but no `max_level_convention`. "
+                "Valid conventions are 'yt' and 'ramses'."
             )
         if max_level_convention not in ("ramses", "yt"):
             raise ValueError(
@@ -752,7 +752,8 @@ class RAMSESDataset(Dataset):
         self.domain_left_edge = np.zeros(3, dtype="float64")
         self.domain_dimensions = np.ones(3, dtype="int32") * 2 ** (self.min_level + 1)
         self.domain_right_edge = np.ones(3, dtype="float64")
-        # This is likely not true, but it's not clear how to determine the boundary conditions
+        # This is likely not true, but it's not clear
+        # how to determine the boundary conditions
         self.periodicity = (True, True, True)
 
         if self.force_cosmological is not None:

--- a/yt/frontends/ramses/field_handlers.py
+++ b/yt/frontends/ramses/field_handlers.py
@@ -341,7 +341,8 @@ class HydroFieldFileHandler(FieldFileHandler):
             else:
                 if nvar < 5:
                     mylog.debug(
-                        "nvar=%s is too small! YT doesn't currently support 1D/2D runs in RAMSES %s"
+                        "nvar=%s is too small! YT doesn't currently "
+                        "support 1D/2D runs in RAMSES %s"
                     )
                     raise ValueError
                 # Basic hydro runs
@@ -362,7 +363,8 @@ class HydroFieldFileHandler(FieldFileHandler):
                         "Pressure",
                         "Metallicity",
                     ]
-                # MHD runs - NOTE: THE MHD MODULE WILL SILENTLY ADD 3 TO THE NVAR IN THE MAKEFILE
+                # MHD runs - NOTE:
+                # THE MHD MODULE WILL SILENTLY ADD 3 TO THE NVAR IN THE MAKEFILE
                 if nvar == 11:
                     fields = [
                         "Density",
@@ -500,8 +502,8 @@ class RTFieldFileHandler(FieldFileHandler):
                 read_rhs(float)
 
             # Read rt_c_frac
-            # Note: when using variable speed of light, this line will contain multiple values
-            # corresponding the the velocity at each level
+            # Note: when using variable speed of light, this line will contain multiple
+            # values corresponding the the velocity at each level
             read_rhs(lambda line: [float(e) for e in line.split()])
             f.readline()
 

--- a/yt/frontends/ramses/fields.py
+++ b/yt/frontends/ramses/fields.py
@@ -368,10 +368,11 @@ class RAMSESFieldInfo(FieldInfoContainer):
             for i, (tname, unit) in enumerate(_cool_arrs):
                 var = fd.read_vector("d")
                 if var.size == n1 and i == 0:
-                    # If this case occurs, the cooling files were produced pre-2010 in a format
-                    # that is no longer supported
+                    # If this case occurs, the cooling files were produced pre-2010 in
+                    # a format that is no longer supported
                     mylog.warning(
-                        "This cooling file format is no longer supported. Cooling field loading skipped."
+                        "This cooling file format is no longer supported. "
+                        "Cooling field loading skipped."
                     )
                     return
                 if var.size == n1 * n2:

--- a/yt/frontends/sdf/tests/test_outputs.py
+++ b/yt/frontends/sdf/tests/test_outputs.py
@@ -13,7 +13,8 @@ ncsa_scivis_data = "http://use.yt/upload/744abba3"
 scivis_data = ncsa_scivis_data
 
 # Answer on http://stackoverflow.com/questions/3764291/checking-network-connection
-# Better answer on http://stackoverflow.com/questions/2712524/handling-urllib2s-timeout-python
+# Better answer on
+# http://stackoverflow.com/questions/2712524/handling-urllib2s-timeout-python
 def internet_on():
     try:
         urllib.request.urlopen(scivis_data, timeout=1)

--- a/yt/frontends/stream/io.py
+++ b/yt/frontends/stream/io.py
@@ -17,9 +17,6 @@ class IOHandlerStream(BaseIOHandler):
 
     def _read_data_set(self, grid, field):
         # This is where we implement processor-locking
-        # if grid.id not in self.grids_in_memory:
-        #    mylog.error("Was asked for %s but I have %s", grid.id, self.grids_in_memory.keys())
-        #    raise KeyError
         tr = self.fields[grid.id][field]
         # If it's particles, we copy.
         if len(tr.shape) == 1:

--- a/yt/frontends/tipsy/io.py
+++ b/yt/frontends/tipsy/io.py
@@ -420,8 +420,8 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
         return self._field_list, {}
 
     def _calculate_particle_offsets(self, data_file, pcounts):
-        # This computes the offsets for each particle type into a "data_file."  Note that
-        # the term "data_file" here is a bit overloaded, and also refers to a
+        # This computes the offsets for each particle type into a "data_file."
+        # Note that the term "data_file" here is a bit overloaded, and also refers to a
         # "chunk" of particles inside a data file.
         # data_file.start represents the *particle count* that we should start at.
         #

--- a/yt/geometry/grid_geometry_handler.py
+++ b/yt/geometry/grid_geometry_handler.py
@@ -290,7 +290,8 @@ class GridIndex(Index, abc.ABC):
 
     def _find_points(self, x, y, z):
         """
-        Returns the (objects, indices) of leaf grids containing a number of (x,y,z) points
+        Returns the (objects, indices) of leaf grids
+        containing a number of (x,y,z) points
         """
         x = ensure_numpy_array(x)
         y = ensure_numpy_array(y)

--- a/yt/tests/test_load_errors.py
+++ b/yt/tests/test_load_errors.py
@@ -20,9 +20,10 @@ def test_load_nonexistent_data():
             FileNotFoundError, simulation, os.path.join(tmpdir, "not_a_file"), "Enzo"
         )
 
-        # this one is a design choice: it is preferable to report the most important
-        # problem in an error message (missing data is worse than a typo in
-        # simulation_type), so we make sure the error raised is not YTSimulationNotIdentified
+        # this one is a design choice:
+        # it is preferable to report the most important problem in an error message
+        # (missing data is worse than a typo insimulation_type)
+        # so we make sure the error raised is not YTSimulationNotIdentified
         assert_raises(
             FileNotFoundError,
             simulation,

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -608,7 +608,8 @@ _common_options = dict(
         type=float,
         dest="halo_radius",
         default=0.1,
-        help="Constant radius for profiling halos if using hop output files with no radius entry. Default: 0.1.",
+        help="Constant radius for profiling halos if using hop output files with no "
+        + "radius entry. Default: 0.1.",
     ),
     halo_radius_units=dict(
         longname="--halo_radius_units",
@@ -616,7 +617,8 @@ _common_options = dict(
         type=str,
         dest="halo_radius_units",
         default="1",
-        help="Units for radius used with --halo_radius flag. Default: '1' (code units).",
+        help="Units for radius used with --halo_radius flag. "
+        + "Default: '1' (code units).",
     ),
     halo_hop_style=dict(
         longname="--halo_hop_style",
@@ -624,7 +626,8 @@ _common_options = dict(
         type=str,
         dest="halo_hop_style",
         default="new",
-        help="Style of hop output file.  'new' for yt_hop files and 'old' for enzo_hop files.",
+        help="Style of hop output file. "
+        + "'new' for yt_hop files and 'old' for enzo_hop files.",
     ),
     halo_dataset=dict(
         longname="--halo_dataset",

--- a/yt/utilities/cosmology.py
+++ b/yt/utilities/cosmology.py
@@ -625,8 +625,9 @@ class Cosmology:
         note that there's a typo in his eq. There should be no negative sign).
 
         At the moment, this only works using the parameterization given in Linder 2002
-        eq. 7: w(a) = w0 + wa(1 - a) = w0 + wa * z / (1+z). This gives rise to an analytic
-        expression. It is also only functional for Gadget simulations, at the moment.
+        eq. 7: w(a) = w0 + wa(1 - a) = w0 + wa * z / (1+z). This gives rise to an
+        analytic expression.
+        It is also only functional for Gadget simulations, at the moment.
 
         Parameters
         ----------

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -176,8 +176,8 @@ class NoStoppingCondition(YTException):
 
     def __str__(self):
         return (
-            "Simulation %s has no stopping condition.  StopTime or StopCycle should be set."
-            % self.ds
+            "Simulation %s has no stopping condition. "
+            "StopTime or StopCycle should be set." % self.ds
         )
 
 

--- a/yt/utilities/linear_interpolators.py
+++ b/yt/utilities/linear_interpolators.py
@@ -197,7 +197,8 @@ class TrilinearFieldInterpolator:
             self.z_bins = boundaries[2]
         else:
             mylog.error(
-                "Boundaries must be given as (x0, x1, y0, y1, z0, z1) or as (x_bins, y_bins, z_bins)"
+                "Boundaries must be given as (x0, x1, y0, y1, z0, z1) "
+                "or as (x_bins, y_bins, z_bins)"
             )
             raise ValueError
 

--- a/yt/utilities/math_utils.py
+++ b/yt/utilities/math_utils.py
@@ -165,9 +165,16 @@ def periodic_ray(start, end, left=None, right=None):
     >>> start = yt.YTArray([0.5, 0.5, 0.5])
     >>> end = yt.YTArray([1.25, 1.25, 1.25])
     >>> periodic_ray(start, end)
-    [[YTArray([0.5, 0.5, 0.5]) (dimensionless), YTArray([1., 1., 1.]) (dimensionless)],
-     [YTArray([0., 0., 0.]) (dimensionless), YTArray([0.25, 0.25, 0.25]) (dimensionless)]]
-
+    [
+        [
+            YTArray([0.5, 0.5, 0.5]) (dimensionless),
+            YTArray([1., 1., 1.]) (dimensionless)
+        ],
+        [
+            YTArray([0., 0., 0.]) (dimensionless),
+            YTArray([0.25, 0.25, 0.25]) (dimensionless)
+        ]
+     ]
     """
 
     if left is None:

--- a/yt/utilities/object_registries.py
+++ b/yt/utilities/object_registries.py
@@ -1,4 +1,5 @@
-# These are some of the data object registries that are used in different places in the code.  Not all of the self-registering objects are included in these.
+# These are some of the data object registries that are used in different places in the
+# code. Not all of the self-registering objects are included in these.
 
 analysis_task_registry = {}
 data_object_registry = {}

--- a/yt/utilities/orientation.py
+++ b/yt/utilities/orientation.py
@@ -70,8 +70,9 @@ class Orientation:
             t = np.cross(normal_vector, vecs).sum(axis=1)
             ax = t.argmax()
             east_vector = np.cross(vecs[ax, :], normal_vector).ravel()
-            # self.north_vector must remain None otherwise rotations about a fixed axis will break.
-            # The north_vector calculated here will still be included in self.unit_vectors.
+            # self.north_vector must remain None otherwise rotations about a fixed axis
+            # will break. The north_vector calculated here will still be included
+            # in self.unit_vectors.
             north_vector = np.cross(normal_vector, east_vector).ravel()
         else:
             if self.steady_north or (np.dot(north_vector, normal_vector) != 0.0):

--- a/yt/utilities/particle_generator.py
+++ b/yt/utilities/particle_generator.py
@@ -150,7 +150,7 @@ class ParticleGenerator:
         Examples
         --------
         >>> field_map = {'density':'particle_density',
-        >>>              'temperature':'particle_temperature'}
+        ...              'temperature':'particle_temperature'}
         >>> particles.map_grid_fields_to_particles(field_map)
         """
         pbar = get_pbar("Mapping fields to particles", self.num_grids)
@@ -245,7 +245,7 @@ class FromListParticleGenerator(ParticleGenerator):
         >>> posz = np.random.random((num_p))
         >>> mass = np.ones((num_p))
         >>> data = {'particle_position_x': posx, 'particle_position_y': posy,
-        >>>         'particle_position_z': posz, 'particle_mass': mass}
+        ...         'particle_position_z': posz, 'particle_mass': mass}
         >>> particles = FromListParticleGenerator(ds, num_p, data)
         """
 
@@ -308,8 +308,8 @@ class LatticeParticleGenerator(ParticleGenerator):
         >>> le = np.array([0.25,0.25,0.25])
         >>> re = np.array([0.75,0.75,0.75])
         >>> fields = ["particle_position_x","particle_position_y",
-        >>>           "particle_position_z",
-        >>>           "particle_density","particle_temperature"]
+        ...           "particle_position_z",
+        ...           "particle_density","particle_temperature"]
         >>> particles = LatticeParticleGenerator(ds, dims, le, re, fields)
         """
 
@@ -384,8 +384,13 @@ class WithDensityParticleGenerator(ParticleGenerator):
         >>> fields = ["particle_position_x","particle_position_y",
         >>>           "particle_position_z",
         >>>           "particle_density","particle_temperature"]
-        >>> particles = WithDensityParticleGenerator(ds, sphere, num_particles,
-        >>>                                          fields, density_field='Dark_Matter_Density')
+        >>> particles = WithDensityParticleGenerator(
+        ...                ds,
+        ...                sphere,
+        ...                num_particles,
+        ...                fields,
+        ...                density_field='Dark_Matter_Density'
+        ...             )
         """
 
         super(WithDensityParticleGenerator, self).__init__(

--- a/yt/utilities/sdf.py
+++ b/yt/utilities/sdf.py
@@ -897,8 +897,8 @@ class SDFIndex:
         return data
 
     def get_next_nonzero_chunk(self, key, stop=None):
-        # These next two while loops are to squeeze the keys if they are empty. Would be better
-        # to go through and set base equal to the last non-zero base, i think.
+        # These next two while loops are to squeeze the keys if they are empty.
+        # Would be better to go through and set base equal to the last non-zero base.
         if stop is None:
             stop = self._max_key
         while key < stop:
@@ -910,8 +910,8 @@ class SDFIndex:
         return key
 
     def get_previous_nonzero_chunk(self, key, stop=None):
-        # These next two while loops are to squeeze the keys if they are empty. Would be better
-        # to go through and set base equal to the last non-zero base, i think.
+        # These next two while loops are to squeeze the keys if they are empty.
+        # Would be better to go through and set base equal to the last non-zero base.
         if stop is None:
             stop = self.indexdata["index"][0]
         while key > stop:

--- a/yt/utilities/sdf.py
+++ b/yt/utilities/sdf.py
@@ -414,7 +414,7 @@ class SDFRead(dict):
                 str_types.append((v, vtype))
             l = ascfile.readline()
         num = l.strip("}[]")
-        num = num.strip("\;\\\n]")
+        num = num.strip("\;\\\n]")  # NOQA B005
         if len(num) == 0:
             # We need to compute the number of records.  The DataStruct will
             # handle this.

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -562,7 +562,7 @@ class FITSImageData:
         if output is None:
             output = sys.stdout
         if num_cols == 8:
-            header = "No.    Name      Ver    Type      Cards   Dimensions   Format     Units"
+            header = "No.    Name      Ver    Type      Cards   Dimensions   Format     Units"  # NOQA E501
             format = "{:3d}  {:10}  {:3} {:11}  {:5d}   {}   {}   {}"
         else:
             header = (

--- a/yt/visualization/image_writer.py
+++ b/yt/visualization/image_writer.py
@@ -168,7 +168,8 @@ def write_image(image, filename, color_bounds=None, cmap_name=None, func=lambda 
 
     This function will scale an image and directly call libpng to write out a
     colormapped version of that image.  It is designed for rapid-fire saving of
-    image buffers generated using `yt.visualization.api.FixedResolutionBuffers` and the like.
+    image buffers generated using `yt.visualization.api.FixedResolutionBuffers`
+    and the likes.
 
     Parameters
     ----------
@@ -212,7 +213,8 @@ def apply_colormap(image, color_bounds=None, cmap_name=None, func=lambda x: x):
 
     This function will scale an image and directly call libpng to write out a
     colormapped version of that image.  It is designed for rapid-fire saving of
-    image buffers generated using `yt.visualization.api.FixedResolutionBuffers` and the like.
+    image buffers generated using `yt.visualization.api.FixedResolutionBuffers`
+    and the likes.
 
     Parameters
     ----------

--- a/yt/visualization/line_plot.py
+++ b/yt/visualization/line_plot.py
@@ -232,11 +232,17 @@ class LinePlot(PlotContainer):
 
         Example
         --------
-        >>> ds = yt.load('SecondOrderTris/RZ_p_no_parts_do_nothing_bcs_cone_out.e', step=-1)
+        >>> ds = yt.load(
+        >>>          'SecondOrderTris/RZ_p_no_parts_do_nothing_bcs_cone_out.e',
+        >>>          step=-1
+        >>> )
         >>> fields = [field for field in ds.field_list if field[0] == 'all']
-        >>> lines = []
-        >>> lines.append(yt.LineBuffer(ds, [0.25, 0, 0], [0.25, 1, 0], 100, label='x = 0.25'))
-        >>> lines.append(yt.LineBuffer(ds, [0.5, 0, 0], [0.5, 1, 0], 100, label='x = 0.5'))
+        >>> lines = [
+        ...    yt.LineBuffer(ds, [0.25, 0, 0], [0.25, 1, 0], 100, label='x = 0.25'),
+        ...    yt.LineBuffer(ds, [0.5, 0, 0], [0.5, 1, 0], 100, label='x = 0.5')
+        ... ]
+        >>> lines.append()
+
         >>> plot = yt.LinePlot.from_lines(ds, fields, lines)
         >>> plot.save()
 

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -92,8 +92,9 @@ def apply_callback(f):
 
 
 def accepts_all_fields(f):
-    """Decorate a function whose second argument is <field> and deal with the special case
-    field == 'all', looping over all fields already present in the PlotContainer instance.
+    """
+    Decorate a function whose second argument is <field> and deal with the special case
+    field == 'all', looping over all fields already present in the PlotContainer object.
 
     """
     # This is to be applied to PlotContainer class methods with the following signature:
@@ -271,7 +272,8 @@ class PlotContainer:
             if field == 'all', applies to all plots.
 
         """
-        # devnote : accepts_all_fields decorator is not applicable here because the return variable isn't self
+        # devnote : accepts_all_fields decorator is not applicable here because
+        # the return variable isn't self
         log = {}
         if field == "all":
             fields = list(self.plots.keys())
@@ -909,7 +911,8 @@ class ImagePlotContainer(PlotContainer):
                     plot_units = self.frb[_field].units
                     z = z.to(plot_units).value
                 except AttributeError:
-                    # only certain subclasses have a frb attribute they can rely on for inspecting units
+                    # only certain subclasses have a frb attribute
+                    # they can rely on for inspecting units
                     mylog.warning(
                         "%s class doesn't support zmin/zmax set as tuples or YTQuantity",
                         self.__class__.__name__,
@@ -943,7 +946,7 @@ class ImagePlotContainer(PlotContainer):
     def set_cbar_minorticks(self, field, state):
         """Deprecated alias, kept for backward compatibility.
 
-        turn colorbar minor ticks "on" or "off" in the current plot, according to *state*
+        turn colorbar minor ticks "on" or "off" in the current plot, follwoin *state*
 
         Parameters
         ----------

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -946,7 +946,7 @@ class ImagePlotContainer(PlotContainer):
     def set_cbar_minorticks(self, field, state):
         """Deprecated alias, kept for backward compatibility.
 
-        turn colorbar minor ticks "on" or "off" in the current plot, follwoin *state*
+        turn colorbar minor ticks "on" or "off" in the current plot, following *state*
 
         Parameters
         ----------

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -914,7 +914,8 @@ class ImagePlotContainer(PlotContainer):
                     # only certain subclasses have a frb attribute
                     # they can rely on for inspecting units
                     mylog.warning(
-                        "%s class doesn't support zmin/zmax set as tuples or YTQuantity",
+                        "%s class doesn't support zmin/zmax"
+                        " as tuples or unyt_quantitiy",
                         self.__class__.__name__,
                     )
                     z = z.value

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -791,7 +791,7 @@ class GridBoundaryCallback(PlotCallback):
         min_level = self.min_level or 0
         max_level = self.max_level or levels.max()
 
-        # sorts the four arrays in order of ascending level - this makes images look nicer
+        # sort the four arrays in order of ascending level, this makes images look nicer
         new_indices = np.argsort(levels)
         levels = levels[new_indices]
         GLE = GLE[new_indices]
@@ -1776,7 +1776,8 @@ class HaloCatalogCallback(PlotCallback):
 
     Parameters
     ----------
-    halo_catalog : Dataset, DataContainer, or ~yt.analysis_modules.halo_analysis.halo_catalog.HaloCatalog
+    halo_catalog : Dataset, DataContainer,
+                   or ~yt.analysis_modules.halo_analysis.halo_catalog.HaloCatalog
         The object containing halos to be overplotted. This can
         be a HaloCatalog object, a loaded halo catalog dataset,
         or a data container from a halo catalog dataset.
@@ -2349,13 +2350,10 @@ class TimestampCallback(PlotCallback):
         This string defines the coordinate system of the coordinates of pos
         Valid coordinates are:
 
-            "data" -- the 3D dataset coordinates
-
-            "plot" -- the 2D coordinates defined by the actual plot limits
-
-            "axis" -- the MPL axis coordinates: (0,0) is lower left; (1,1) is upper right
-
-            "figure" -- the MPL figure coordinates: (0,0) is lower left, (1,1) is upper right
+        - "data": 3D dataset coordinates
+        - "plot": 2D coordinates defined by the actual plot limits
+        - "axis": MPL axis coordinates: (0,0) is lower left; (1,1) is upper right
+        - "figure": MPL figure coordinates: (0,0) is lower left, (1,1) is upper right
 
     time_offset : float, (value, unit) tuple, or YTQuantity, optional
         Apply an offset to the time shown in the annotation from the
@@ -2583,13 +2581,10 @@ class ScaleCallback(PlotCallback):
         This string defines the coordinate system of the coordinates of pos
         Valid coordinates are:
 
-            "data" -- the 3D dataset coordinates
-
-            "plot" -- the 2D coordinates defined by the actual plot limits
-
-            "axis" -- the MPL axis coordinates: (0,0) is lower left; (1,1) is upper right
-
-            "figure" -- the MPL figure coordinates: (0,0) is lower left, (1,1) is upper right
+        - "data": 3D dataset coordinates
+        - "plot": 2D coordinates defined by the actual plot limits
+        - "axis": MPL axis coordinates: (0,0) is lower left; (1,1) is upper right
+        - "figure": MPL figure coordinates: (0,0) is lower left, (1,1) is upper right
 
     text_args : dictionary, optional
         A dictionary of parameters to used to update the font_properties

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1157,7 +1157,9 @@ class PWViewerMPL(PlotWindow):
                 else:
                     mylog.error(
                         "Unable to draw cbar minorticks for field "
-                        "%s with transform %s ", f, self._field_transform[f]
+                        "%s with transform %s ",
+                        f,
+                        self._field_transform[f],
                     )
                     self._cbar_minorticks[f] = False
 

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -153,7 +153,8 @@ class PlotWindow(ImagePlotContainer):
     Parameters
     ----------
 
-    data_source : :class:`yt.data_objects.selection_data_containers.YTSelectionContainer2D`
+    data_source :
+        :class:`yt.data_objects.selection_data_containers.YTSelectionContainer2D`
         This is the source to be pixelized, which can be a projection,
         slice, or a cutting plane.
     bounds : sequence of floats
@@ -457,20 +458,20 @@ class PlotWindow(ImagePlotContainer):
            coordinate space can be given. If plain numeric types are input,
            units of `code_length` are assumed. Further examples:
 
-           ===============================================    ==================================
-           format                                             example
-           ===============================================    ==================================
-           '{space}'                                          'domain'
-           '{xloc}-{space}'                                   'left-window'
-           '{yloc}-{space}'                                   'upper-domain'
-           '{yloc}-{xloc}-{space}'                            'lower-right-window'
-           ('{space}',)                                       ('window',)
-           ('{xloc}', '{space}')                              ('right', 'domain')
-           ('{yloc}', '{space}')                              ('lower', 'window')
-           ('{yloc}', '{xloc}', '{space}')                    ('lower', 'right', 'window')
-           ((yloc, '{unit}'), (xloc, '{unit}'), '{space}')    ((0.5, 'm'), (0.4, 'm'), 'window')
-           (xloc, yloc, '{space}')                            (0.23, 0.5, 'domain')
-           ===============================================    ==================================
+        ===============================================  ===============================
+        format                                           example
+        ===============================================  ===============================
+        '{space}'                                        'domain'
+        '{xloc}-{space}'                                 'left-window'
+        '{yloc}-{space}'                                 'upper-domain'
+        '{yloc}-{xloc}-{space}'                          'lower-right-window'
+        ('{space}',)                                     ('window',)
+        ('{xloc}', '{space}')                            ('right', 'domain')
+        ('{yloc}', '{space}')                            ('lower', 'window')
+        ('{yloc}', '{xloc}', '{space}')                  ('lower', 'right', 'window')
+        ((yloc, '{unit}'), (xloc, '{unit}'), '{space}')  ((0, 'm'), (.4, 'm'), 'window')
+        (xloc, yloc, '{space}')                          (0.23, 0.5, 'domain')
+        ===============================================  ===============================
         """
         self.origin = origin
         return self
@@ -497,7 +498,8 @@ class PlotWindow(ImagePlotContainer):
            if passed as a string, mpl_proj is the specified projection type,
            if passed as a tuple, then tuple will take the form of
            ``("ProjectionType", (args))`` or ``("ProjectionType", (args), {kwargs})``
-           Valid projection type options include: 'PlateCarree', 'LambertConformal', 'LabmbertCylindrical',
+           Valid projection type options include:
+           'PlateCarree', 'LambertConformal', 'LabmbertCylindrical',
            'Mercator', 'Miller', 'Mollweide', 'Orthographic',
            'Robinson', 'Stereographic', 'TransverseMercator',
            'InterruptedGoodeHomolosine', 'RotatedPole', 'OGSB',
@@ -1154,9 +1156,8 @@ class PWViewerMPL(PlotWindow):
 
                 else:
                     mylog.error(
-                        "Unable to draw cbar minorticks for field %s with transform %s ",
-                        f,
-                        self._field_transform[f],
+                        "Unable to draw cbar minorticks for field "
+                        "%s with transform %s ", f, self._field_transform[f]
                     )
                     self._cbar_minorticks[f] = False
 
@@ -1290,10 +1291,10 @@ class PWViewerMPL(PlotWindow):
         cbar_pad="0%",
     ):
         r"""
-        Creates a matplotlib figure object with the specified axes arrangement, nrows_ncols,
-        and maps the underlying figures to the matplotlib axes.  Note that all of these
-        parameters are fed directly to the matplotlib ImageGrid class to create the new figure
-        layout.
+        Creates a matplotlib figure object with the specified axes arrangement,
+        nrows_ncols, and maps the underlying figures to the matplotlib axes.
+        Note that all of these parameters are fed directly to the matplotlib ImageGrid
+        class to create the new figure layout.
 
         Parameters
         ----------
@@ -1430,20 +1431,20 @@ class AxisAlignedSlicePlot(PWViewerMPL):
          coordinate space can be given. If plain numeric types are input,
          units of `code_length` are assumed. Further examples:
 
-         ===============================================    ==================================
-         format                                             example
-         ===============================================    ==================================
-         '{space}'                                          'domain'
-         '{xloc}-{space}'                                   'left-window'
-         '{yloc}-{space}'                                   'upper-domain'
-         '{yloc}-{xloc}-{space}'                            'lower-right-window'
-         ('{space}',)                                       ('window',)
-         ('{xloc}', '{space}')                              ('right', 'domain')
-         ('{yloc}', '{space}')                              ('lower', 'window')
-         ('{yloc}', '{xloc}', '{space}')                    ('lower', 'right', 'window')
-         ((yloc, '{unit}'), (xloc, '{unit}'), '{space}')    ((0.5, 'm'), (0.4, 'm'), 'window')
-         (xloc, yloc, '{space}')                            (0.23, 0.5, 'domain')
-         ===============================================    ==================================
+         =============================================== ===============================
+         format                                          example
+         =============================================== ===============================
+         '{space}'                                       'domain'
+         '{xloc}-{space}'                                'left-window'
+         '{yloc}-{space}'                                'upper-domain'
+         '{yloc}-{xloc}-{space}'                         'lower-right-window'
+         ('{space}',)                                    ('window',)
+         ('{xloc}', '{space}')                           ('right', 'domain')
+         ('{yloc}', '{space}')                           ('lower', 'window')
+         ('{yloc}', '{xloc}', '{space}')                 ('lower', 'right', 'window')
+         ((yloc, '{unit}'), (xloc, '{unit}'), '{space}') ((0, 'm'), (.4, 'm'), 'window')
+         (xloc, yloc, '{space}')                         (0.23, 0.5, 'domain')
+         =============================================== ===============================
     axes_unit : string
          The name of the unit for the tick labels on the x and y axes.
          Defaults to None, which automatically picks an appropriate unit.
@@ -1620,20 +1621,20 @@ class ProjectionPlot(PWViewerMPL):
          coordinate space can be given. If plain numeric types are input,
          units of `code_length` are assumed. Further examples:
 
-         ===============================================    ==================================
-         format                                             example
-         ===============================================    ==================================
-         '{space}'                                          'domain'
-         '{xloc}-{space}'                                   'left-window'
-         '{yloc}-{space}'                                   'upper-domain'
-         '{yloc}-{xloc}-{space}'                            'lower-right-window'
-         ('{space}',)                                       ('window',)
-         ('{xloc}', '{space}')                              ('right', 'domain')
-         ('{yloc}', '{space}')                              ('lower', 'window')
-         ('{yloc}', '{xloc}', '{space}')                    ('lower', 'right', 'window')
-         ((yloc, '{unit}'), (xloc, '{unit}'), '{space}')    ((0.5, 'm'), (0.4, 'm'), 'window')
+         =============================================== ===============================
+         format                                          example
+         =============================================== ===============================
+         '{space}'                                       'domain'
+         '{xloc}-{space}'                                'left-window'
+         '{yloc}-{space}'                                'upper-domain'
+         '{yloc}-{xloc}-{space}'                         'lower-right-window'
+         ('{space}',)                                    ('window',)
+         ('{xloc}', '{space}')                           ('right', 'domain')
+         ('{yloc}', '{space}')                           ('lower', 'window')
+         ('{yloc}', '{xloc}', '{space}')                 ('lower', 'right', 'window')
+         ((yloc, '{unit}'), (xloc, '{unit}'), '{space}') ((0, 'm'), (.4, 'm'), 'window')
          (xloc, yloc, '{space}')                            (0.23, 0.5, 'domain')
-         ===============================================    ==================================
+         =============================================== ===============================
 
     right_handed : boolean
          Whether the implicit east vector for the image generated is set to make a right
@@ -1844,8 +1845,8 @@ class OffAxisSlicePlot(PWViewerMPL):
          set, an arbitrary grid-aligned north-vector is chosen.
     right_handed : boolean
          Whether the implicit east vector for the image generated is set to make a right
-         handed coordinate system with the north vector and the normal, the direction of the
-         'window' into the data.
+         handed coordinate system with the north vector and the normal, the direction of
+         the 'window' into the data.
     fontsize : integer
          The size of the fonts for the axis, colorbar, and tick labels.
     field_parameters : dictionary
@@ -2031,8 +2032,8 @@ class OffAxisProjectionPlot(PWViewerMPL):
          set, an arbitrary grid-aligned north-vector is chosen.
     right_handed : boolean
          Whether the implicit east vector for the image generated is set to make a right
-         handed coordinate system with the north vector and the normal, the direction of the
-         'window' into the data.
+         handed coordinate system with the north vector and the normal, the direction of
+         the 'window' into the data.
     fontsize : integer
          The size of the fonts for the axis, colorbar, and tick labels.
     method : string
@@ -2303,20 +2304,20 @@ def SlicePlot(ds, normal=None, fields=None, axis=None, *args, **kwargs):
          coordinate space can be given. If plain numeric types are input,
          units of `code_length` are assumed. Further examples:
 
-         ===============================================    ==================================
-         format                                             example
-         ===============================================    ==================================
-         '{space}'                                          'domain'
-         '{xloc}-{space}'                                   'left-window'
-         '{yloc}-{space}'                                   'upper-domain'
-         '{yloc}-{xloc}-{space}'                            'lower-right-window'
-         ('{space}',)                                       ('window',)
-         ('{xloc}', '{space}')                              ('right', 'domain')
-         ('{yloc}', '{space}')                              ('lower', 'window')
-         ('{yloc}', '{xloc}', '{space}')                    ('lower', 'right', 'window')
-         ((yloc, '{unit}'), (xloc, '{unit}'), '{space}')    ((0.5, 'm'), (0.4, 'm'), 'window')
-         (xloc, yloc, '{space}')                            (0.23, 0.5, 'domain')
-         ===============================================    ==================================
+         =============================================== ===============================
+         format                                          example
+         =============================================== ===============================
+         '{space}'                                       'domain'
+         '{xloc}-{space}'                                'left-window'
+         '{yloc}-{space}'                                'upper-domain'
+         '{yloc}-{xloc}-{space}'                         'lower-right-window'
+         ('{space}',)                                    ('window',)
+         ('{xloc}', '{space}')                           ('right', 'domain')
+         ('{yloc}', '{space}')                           ('lower', 'window')
+         ('{yloc}', '{xloc}', '{space}')                 ('lower', 'right', 'window')
+         ((yloc, '{unit}'), (xloc, '{unit}'), '{space}') ((0, 'm'), (.4, 'm'), 'window')
+         (xloc, yloc, '{space}')                         (0.23, 0.5, 'domain')
+         =============================================== ===============================
     north_vector : a sequence of floats
         A vector defining the 'up' direction in the `OffAxisSlicePlot`; not
         used in `AxisAlignedSlicePlot`.  This option sets the orientation of the
@@ -2470,20 +2471,20 @@ def plot_2d(
          coordinate space can be given. If plain numeric types are input,
          units of `code_length` are assumed. Further examples:
 
-         ===============================================    ==================================
-         format                                             example
-         ===============================================    ==================================
-         '{space}'                                          'domain'
-         '{xloc}-{space}'                                   'left-window'
-         '{yloc}-{space}'                                   'upper-domain'
-         '{yloc}-{xloc}-{space}'                            'lower-right-window'
-         ('{space}',)                                       ('window',)
-         ('{xloc}', '{space}')                              ('right', 'domain')
-         ('{yloc}', '{space}')                              ('lower', 'window')
-         ('{yloc}', '{xloc}', '{space}')                    ('lower', 'right', 'window')
-         ((yloc, '{unit}'), (xloc, '{unit}'), '{space}')    ((0.5, 'm'), (0.4, 'm'), 'window')
-         (xloc, yloc, '{space}')                            (0.23, 0.5, 'domain')
-         ===============================================    ==================================
+         =============================================== ===============================
+         format                                          example
+         =============================================== ===============================
+         '{space}'                                       'domain'
+         '{xloc}-{space}'                                'left-window'
+         '{yloc}-{space}'                                'upper-domain'
+         '{yloc}-{xloc}-{space}'                         'lower-right-window'
+         ('{space}',)                                    ('window',)
+         ('{xloc}', '{space}')                           ('right', 'domain')
+         ('{yloc}', '{space}')                           ('lower', 'window')
+         ('{yloc}', '{xloc}', '{space}')                 ('lower', 'right', 'window')
+         ((yloc, '{unit}'), (xloc, '{unit}'), '{space}') ((0, 'm'), (.4, 'm'), 'window')
+         (xloc, yloc, '{space}')                         (0.23, 0.5, 'domain')
+         =============================================== ===============================
     axes_unit : string
          The name of the unit for the tick labels on the x and y axes.
          Defaults to None, which automatically picks an appropriate unit.

--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -114,7 +114,8 @@ def off_axis_projection(
 
     if interpolated:
         raise NotImplementedError(
-            "Only interpolated=False methods are currently implemented for off-axis-projections"
+            "Only interpolated=False methods are currently implemented "
+            "for off-axis-projections"
         )
 
     data_source = data_source_or_all(data_source)

--- a/yt/visualization/volume_rendering/render_source.py
+++ b/yt/visualization/volume_rendering/render_source.py
@@ -424,9 +424,9 @@ class VolumeSource(RenderSource):
 
         Parameters
         ----------
-        camera: :class:`yt.visualization.volume_rendering.camera.Camera` instance
+        camera: :class:`yt.visualization.volume_rendering.camera.Camera`
             A volume rendering camera. Can be any type of camera.
-        zbuffer: :class:`yt.visualization.volume_rendering.zbuffer_array.Zbuffer` instance
+        zbuffer: :class:`yt.visualization.volume_rendering.zbuffer_array.Zbuffer`
             A zbuffer array. This is used for opaque sources to determine the
             z position of the source relative to other sources. Only useful if
             you are manually calling render on multiple sources. Scene.render
@@ -434,7 +434,7 @@ class VolumeSource(RenderSource):
 
         Returns
         -------
-        A :class:`yt.data_objects.image_array.ImageArray` instance containing
+        A :class:`yt.data_objects.image_array.ImageArray` containing
         the rendered image.
 
         """
@@ -469,9 +469,9 @@ class VolumeSource(RenderSource):
 
         Parameters
         ----------
-        camera: :class:`yt.visualization.volume_rendering.camera.Camera` instance
+        camera: :class:`yt.visualization.volume_rendering.camera.Camera`
             The camera used to produce the volume rendering image.
-        image: :class:`yt.data_objects.image_array.ImageArray` instance
+        image: :class:`yt.data_objects.image_array.ImageArray`
             A reference to an image to fill
         """
         if self._volume is not None:
@@ -673,9 +673,9 @@ class MeshSource(OpaqueSource):
 
         Parameters
         ----------
-        camera: :class:`yt.visualization.volume_rendering.camera.Camera` instance
+        camera: :class:`yt.visualization.volume_rendering.camera.Camera`
             A volume rendering camera. Can be any type of camera.
-        zbuffer: :class:`yt.visualization.volume_rendering.zbuffer_array.Zbuffer` instance
+        zbuffer: :class:`yt.visualization.volume_rendering.zbuffer_array.Zbuffer`
             A zbuffer array. This is used for opaque sources to determine the
             z position of the source relative to other sources. Only useful if
             you are manually calling render on multiple sources. Scene.render
@@ -683,7 +683,7 @@ class MeshSource(OpaqueSource):
 
         Returns
         -------
-        A :class:`yt.data_objects.image_array.ImageArray` instance containing
+        A :class:`yt.data_objects.image_array.ImageArray` containing
         the rendered image.
 
         """
@@ -873,9 +873,9 @@ class PointSource(OpaqueSource):
 
         Parameters
         ----------
-        camera: :class:`yt.visualization.volume_rendering.camera.Camera` instance
+        camera: :class:`yt.visualization.volume_rendering.camera.Camera`
             A volume rendering camera. Can be any type of camera.
-        zbuffer: :class:`yt.visualization.volume_rendering.zbuffer_array.Zbuffer` instance
+        zbuffer: :class:`yt.visualization.volume_rendering.zbuffer_array.Zbuffer`
             A zbuffer array. This is used for opaque sources to determine the
             z position of the source relative to other sources. Only useful if
             you are manually calling render on multiple sources. Scene.render
@@ -883,7 +883,7 @@ class PointSource(OpaqueSource):
 
         Returns
         -------
-        A :class:`yt.data_objects.image_array.ImageArray` instance containing
+        A :class:`yt.data_objects.image_array.ImageArray` containing
         the rendered image.
 
         """
@@ -995,17 +995,16 @@ class LineSource(OpaqueSource):
 
         Parameters
         ----------
-        camera: :class:`yt.visualization.volume_rendering.camera.Camera` instance
+        camera: :class:`yt.visualization.volume_rendering.camera.Camera`
             A volume rendering camera. Can be any type of camera.
-        zbuffer: :class:`yt.visualization.volume_rendering.zbuffer_array.Zbuffer` instance
-            A zbuffer array. This is used for opaque sources to determine the
+        zbuffer: :class:`yt.visualization.volume_rendering.zbuffer_array.Zbuffer`
             z position of the source relative to other sources. Only useful if
             you are manually calling render on multiple sources. Scene.render
             uses this internally.
 
         Returns
         -------
-        A :class:`yt.data_objects.image_array.ImageArray` instance containing
+        A :class:`yt.data_objects.image_array.ImageArray` containing
         the rendered image.
 
         """
@@ -1282,9 +1281,9 @@ class CoordinateVectorSource(OpaqueSource):
 
         Parameters
         ----------
-        camera: :class:`yt.visualization.volume_rendering.camera.Camera` instance
+        camera: :class:`yt.visualization.volume_rendering.camera.Camera`
             A volume rendering camera. Can be any type of camera.
-        zbuffer: :class:`yt.visualization.volume_rendering.zbuffer_array.Zbuffer` instance
+        zbuffer: :class:`yt.visualization.volume_rendering.zbuffer_array.Zbuffer`
             A zbuffer array. This is used for opaque sources to determine the
             z position of the source relative to other sources. Only useful if
             you are manually calling render on multiple sources. Scene.render
@@ -1292,7 +1291,7 @@ class CoordinateVectorSource(OpaqueSource):
 
         Returns
         -------
-        A :class:`yt.data_objects.image_array.ImageArray` instance containing
+        A :class:`yt.data_objects.image_array.ImageArray` containing
         the rendered image.
 
         """

--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -121,7 +121,8 @@ class Scene:
 
         Parameters
         ----------
-        render_source: :class:`yt.visualization.volume_rendering.render_source.RenderSource`
+        render_source:
+            :class:`yt.visualization.volume_rendering.render_source.RenderSource`
             A source to contribute to the volume rendering scene.
 
         keyname: string (optional)
@@ -287,7 +288,7 @@ class Scene:
         >>> sc.save('test.png', sigma_clip=4)
 
         When saving multiple images without modifying the scene (camera,
-        sources,etc.), render=False can be used to avoid re-rendering when a scene is saved.
+        sources,etc.), render=False can be used to avoid re-rendering.
         This is useful for generating images at a range of sigma_clip values:
 
         >>> import yt

--- a/yt/visualization/volume_rendering/shader_objects.py
+++ b/yt/visualization/volume_rendering/shader_objects.py
@@ -24,11 +24,11 @@ class ShaderProgram:
     ----------
 
     vertex_shader : string
-                    or :class:`yt.visualization.volume_rendering.shader_objects.VertexShader`
+        or :class:`yt.visualization.volume_rendering.shader_objects.VertexShader`
         The vertex shader used in the Interactive Data Visualization pipeline.
 
     fragment_shader : string
-                      or :class:`yt.visualization.volume_rendering.shader_objects.FragmentShader`
+        or :class:`yt.visualization.volume_rendering.shader_objects.FragmentShader`
         The fragment shader used in the Interactive Data Visualization pipeline.
     """
 

--- a/yt/visualization/volume_rendering/tests/test_off_axis_SPH.py
+++ b/yt/visualization/volume_rendering/tests/test_off_axis_SPH.py
@@ -44,8 +44,8 @@ def test_no_rotation():
 @requires_module("scipy")
 def test_basic_rotation_1():
     """ All particles on Z-axis should now be on the negative Y-Axis
-        fake_sph_orientation has three z-axis particles, so there should be three y-axis particles
-        after rotation
+        fake_sph_orientation has three z-axis particles,
+        so there should be three y-axis particles after rotation
         (0, 0, 1) -> (0, -1)
         (0, 0, 2) -> (0, -2)
         (0, 0, 3) -> (0, -3)
@@ -79,9 +79,9 @@ def test_basic_rotation_1():
 
 @requires_module("scipy")
 def test_basic_rotation_2():
-    """ Rotation of x-axis onto z-axis. All particles on z-axis should now be on the negative x-Axis
-    fake_sph_orientation has three z-axis particles, so there should be three x-axis particles
-    after rotation
+    """ Rotation of x-axis onto z-axis.
+    All particles on z-axis should now be on the negative x-Axis fake_sph_orientation
+    has three z-axis particles, so there should be three x-axis particles after rotation
     (0, 0, 1) -> (-1, 0)
     (0, 0, 2) -> (-2, 0)
     (0, 0, 3) -> (-3, 0)
@@ -118,9 +118,10 @@ def test_basic_rotation_2():
 
 @requires_module("scipy")
 def test_basic_rotation_3():
-    """ Rotation of z-axis onto negative z-axis. All fake particles on z-axis should now be on
-    the negative z-Axis.
-    fake_sph_orientation has three z-axis particles, so we should have a local maxima at (0, 0)
+    """Rotation of z-axis onto negative z-axis.
+    All fake particles on z-axis should now be of the negative z-Axis.
+    fake_sph_orientation has three z-axis particles,
+    so we should have a local maxima at (0, 0)
     (0, 0, 1) -> (0, 0)
     (0, 0, 2) -> (0, 0)
     (0, 0, 3) -> (0, 0)

--- a/yt/visualization/volume_rendering/transfer_functions.py
+++ b/yt/visualization/volume_rendering/transfer_functions.py
@@ -237,7 +237,8 @@ class TransferFunction:
 
     def __repr__(self):
         disp = (
-            "<Transfer Function Object>: x_bounds:(%3.2g, %3.2g) nbins:%3.2g features:%s"
+            "<Transfer Function Object>: "
+            "x_bounds:(%3.2g, %3.2g) nbins:%3.2g features:%s"
             % (self.x_bounds[0], self.x_bounds[1], self.nbins, self.features)
         )
         return disp


### PR DESCRIPTION
## PR Summary

fix some previously ignored flake8 errors. Most notably, some "line-too-long" errors that need manual tweaking and can't be solved with black since they touch strings and comments, so here's the manual tweaking for those.

## PR Checklist

- [x] pass `black --check yt/`
- [x] pass `isort . --check --diff`
- [x] pass `flake8 yt/`
- [x] New features are documented, with docstrings and narrative docs