### PR TITLE
Correct child mask for sibling grids

### DIFF
--- a/yt/data_objects/grid_patch.py
+++ b/yt/data_objects/grid_patch.py
@@ -214,7 +214,7 @@ class AMRGridPatch(YTSelectionContainer):
         for child in self.Children:
             self._fill_child_mask(child, child_mask, 0)
         for sibling in self.OverlappingSiblings or []:
-            self._fill_child_mask(sibling, child_mask, 0)
+            self._fill_child_mask(sibling, child_mask, 0, dlevel=0)
         return child_mask
 
     @property
@@ -232,7 +232,7 @@ class AMRGridPatch(YTSelectionContainer):
         for child in self.Children:
             self._fill_child_mask(child, child_index_mask, child.id)
         for sibling in self.OverlappingSiblings or []:
-            self._fill_child_mask(sibling, child_index_mask, sibling.id)
+            self._fill_child_mask(sibling, child_index_mask, sibling.id, dlevel=0)
         return child_index_mask
 
     def retrieve_ghost_zones(self, n_zones, fields, all_levels=False, smoothed=False):


### PR DESCRIPTION
## PR Summary

This pull request corrects how `AMRGridPatch` handles sibling grids (`OverlappingSiblings`) when calculating `child_mask` and `child_index_mask` by passing `dlevel=0` to all relevant calls to `_fill_child_mask`. This parameter specifies the number of refinement levels by which the two grids differ and is used to compare indices between them. The default value of `dlevel=1` is appropriate for true child grids (in the sense that they belong to the next highest refinement level),  but for siblings at the same level this should be called with `dlevel=0`.

This appears to have been addressed a while back in 8ef99073fa8fbd5b4b4af3cb828e801815ee3ede, but it was (unintentionally it seems) reverted with fcaa302a89f4edb8ffb23d9cef60c9a7717a89a5.

## PR Checklist

- [x] pass `black --check yt/`
- [x] pass `isort . --check --diff`
- [x] pass `flake8 yt/`
