### PR TITLE
fix: refactor boxlib dataformat validators (code deduplication), fix bugs revealed on the way there

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -131,7 +131,7 @@ answer_tests:
     - yt/frontends/boxlib/tests/test_outputs.py:test_units_override
     - yt/frontends/boxlib/tests/test_outputs.py:test_raw_fields
 
-  local_boxlib_particles_006:
+  local_boxlib_particles_007:
     - yt/frontends/boxlib/tests/test_outputs.py:test_LyA
     - yt/frontends/boxlib/tests/test_outputs.py:test_nyx_particle_io
     - yt/frontends/boxlib/tests/test_outputs.py:test_castro_particle_io

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -675,26 +675,10 @@ class BoxlibDataset(Dataset):
     def _is_valid(cls, *args, **kwargs):
         # fill our args
         output_dir = args[0]
-        # boxlib datasets are always directories
-        if not os.path.isdir(output_dir):
-            return False
         header_filename = os.path.join(output_dir, "Header")
-        jobinfo_filename = os.path.join(output_dir, "job_info")
-        if not os.path.exists(header_filename):
-            # We *know* it's not boxlib if Header doesn't exist.
-            return False
-        args = inspect.getcallargs(cls.__init__, args, kwargs)
-        # This might need to be localized somehow
-        if args["cparam_filename"] is None:
-            return True  # Treat as generic boxlib data
-        inputs_filename = os.path.join(
-            os.path.dirname(os.path.abspath(output_dir)), args["cparam_filename"]
-        )
-        if not os.path.exists(inputs_filename) and not os.path.exists(jobinfo_filename):
-            return True  # We have no parameters to go off of
-        # If we do have either inputs or jobinfo, we should be deferring to a
-        # different frontend.
-        return False
+        # boxlib datasets are always directories, and
+        # We *know* it's not boxlib if Header doesn't exist.
+        return os.path.exists(header_filename)
 
     def _parse_parameter_file(self):
         """
@@ -1041,24 +1025,16 @@ class OrionDataset(BoxlibDataset):
 
     @classmethod
     def _is_valid(cls, *args, **kwargs):
-        # fill our args
+        if not super(OrionDataset, cls)._is_valid(*args, **kwargs):
+            return False
         output_dir = args[0]
-        # boxlib datasets are always directories
-        if not os.path.isdir(output_dir):
-            return False
-        header_filename = os.path.join(output_dir, "Header")
         jobinfo_filename = os.path.join(output_dir, "job_info")
-        if not os.path.exists(header_filename):
-            # We *know* it's not boxlib if Header doesn't exist.
-            return False
+
         args = inspect.getcallargs(cls.__init__, args, kwargs)
-        # This might need to be localized somehow
         inputs_filename = os.path.join(
             os.path.dirname(os.path.abspath(output_dir)), args["cparam_filename"]
         )
-        if not os.path.exists(inputs_filename):
-            return False
-        if os.path.exists(jobinfo_filename):
+        if not os.path.exists(inputs_filename) or os.path.exists(jobinfo_filename):
             return False
         # Now we check for all the others
         warpx_jobinfo_filename = os.path.join(output_dir, "warpx_job_info")
@@ -1127,23 +1103,18 @@ class CastroDataset(BoxlibDataset):
 
     @classmethod
     def _is_valid(cls, *args, **kwargs):
-        # fill our args
+        if not super(CastroDataset, cls)._is_valid(*args, **kwargs):
+            return False
+
         output_dir = args[0]
-        # boxlib datasets are always directories
-        if not os.path.isdir(output_dir):
-            return False
-        header_filename = os.path.join(output_dir, "Header")
         jobinfo_filename = os.path.join(output_dir, "job_info")
-        if not os.path.exists(header_filename):
-            # We *know* it's not boxlib if Header doesn't exist.
-            return False
+
         if not os.path.exists(jobinfo_filename):
             return False
+
         # Now we check for all the others
         lines = open(jobinfo_filename).readlines()
-        if any(line.startswith("Castro   ") for line in lines):
-            return True
-        return False
+        return any(line.startswith("Castro   ") for line in lines)
 
     def _parse_parameter_file(self):
         super(CastroDataset, self)._parse_parameter_file()
@@ -1222,23 +1193,18 @@ class MaestroDataset(BoxlibDataset):
 
     @classmethod
     def _is_valid(cls, *args, **kwargs):
-        # fill our args
+        if not super(MaestroDataset, cls)._is_valid(*args, **kwargs):
+            return False
+
         output_dir = args[0]
-        # boxlib datasets are always directories
-        if not os.path.isdir(output_dir):
-            return False
-        header_filename = os.path.join(output_dir, "Header")
         jobinfo_filename = os.path.join(output_dir, "job_info")
-        if not os.path.exists(header_filename):
-            # We *know* it's not boxlib if Header doesn't exist.
-            return False
+
         if not os.path.exists(jobinfo_filename):
             return False
+
         # Now we check the job_info for the mention of maestro
         lines = open(jobinfo_filename).readlines()
-        if any(line.startswith("MAESTRO   ") for line in lines):
-            return True
-        return False
+        return any(line.startswith("MAESTRO   ") for line in lines)
 
     def _parse_parameter_file(self):
         super(MaestroDataset, self)._parse_parameter_file()
@@ -1327,25 +1293,20 @@ class NyxDataset(BoxlibDataset):
 
     @classmethod
     def _is_valid(cls, *args, **kwargs):
-        # fill our args
+        if not super(NyxDataset, cls)._is_valid(*args, **kwargs):
+            return False
+
         output_dir = args[0]
-        # boxlib datasets are always directories
-        if not os.path.isdir(output_dir):
-            return False
-        header_filename = os.path.join(output_dir, "Header")
         jobinfo_filename = os.path.join(output_dir, "job_info")
-        if not os.path.exists(header_filename):
-            # We *know* it's not boxlib if Header doesn't exist.
-            return False
+
         if not os.path.exists(jobinfo_filename):
             return False
+
         # Now we check the job_info for the mention of maestro
         lines = open(jobinfo_filename).readlines()
-        if any(line.startswith("Nyx  ") for line in lines):
-            return True
-        if any(line.startswith("nyx.") for line in lines):
-            return True
-        return False
+        return any(line.startswith("Nyx  ") for line in lines) or any(
+            line.startswith("nyx.") for line in lines
+        )
 
     def _parse_parameter_file(self):
         super(NyxDataset, self)._parse_parameter_file()
@@ -1621,19 +1582,13 @@ class WarpXDataset(BoxlibDataset):
 
     @classmethod
     def _is_valid(cls, *args, **kwargs):
-        # fill our args
+        if not super(WarpXDataset, cls)._is_valid(*args, **kwargs):
+            return False
+
         output_dir = args[0]
-        # boxlib datasets are always directories
-        if not os.path.isdir(output_dir):
-            return False
-        header_filename = os.path.join(output_dir, "Header")
         jobinfo_filename = os.path.join(output_dir, "warpx_job_info")
-        if not os.path.exists(header_filename):
-            # We *know* it's not boxlib if Header doesn't exist.
-            return False
-        if os.path.exists(jobinfo_filename):
-            return True
-        return False
+
+        return os.path.exists(jobinfo_filename)
 
     def _parse_parameter_file(self):
         super(WarpXDataset, self)._parse_parameter_file()

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -1113,8 +1113,8 @@ class CastroDataset(BoxlibDataset):
             return False
 
         # Now we check for all the others
-        lines = open(jobinfo_filename).readlines()
-        return any(line.startswith("Castro   ") for line in lines)
+        lines = [line.lower() for line in open(jobinfo_filename).readlines()]
+        return any(line.startswith("castro") for line in lines)
 
     def _parse_parameter_file(self):
         super(CastroDataset, self)._parse_parameter_file()

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -631,7 +631,7 @@ class BoxlibDataset(Dataset):
     def __init__(
         self,
         output_dir,
-        cparam_filename="job_info",
+        cparam_filename="job_info",  # todo: harmonise this default value with docstring
         fparam_filename=None,
         dataset_type="boxlib_native",
         storage_filename=None,

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -757,7 +757,11 @@ class BoxlibDataset(Dataset):
             elif param == "castro.use_comoving":
                 vals = self.cosmological_simulation = int(vals)
             else:
-                vals = _guess_pcast(vals)
+                try:
+                    vals = _guess_pcast(vals)
+                except IndexError:
+                    # hitting an empty string
+                    vals = None
             self.parameters[param] = vals
 
         if getattr(self, "cosmological_simulation", 0) == 1:

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -1277,24 +1277,30 @@ class NyxDataset(BoxlibDataset):
         self.cosmological_simulation = 1
 
         jobinfo_filename = os.path.join(self.output_dir, "job_info")
-        line = ""
+
+        has_cosmo_info = False
         with open(jobinfo_filename, "r") as f:
-            while not line.startswith(" Cosmology Information"):
+            for line in f:
                 # get the code git hashes
                 if "git hash" in line:
                     # line format: codename git hash:  the-hash
                     fields = line.split(":")
                     self.parameters[fields[0]] = fields[1].strip()
-                line = next(f)
 
-            # get the cosmology
-            for line in f:
-                if "Omega_m (comoving)" in line:
-                    self.omega_matter = float(line.split(":")[1])
-                elif "Omega_lambda (comoving)" in line:
-                    self.omega_lambda = float(line.split(":")[1])
-                elif "h (comoving)" in line:
-                    self.hubble_constant = float(line.split(":")[1])
+                if line.startswith(" Cosmology Information"):
+                    has_cosmo_info = True
+                    break
+
+            if has_cosmo_info:
+                for line in f:
+                    if "Omega_m (comoving)" in line:
+                        self.omega_matter = float(line.split(":")[1])
+                    elif "Omega_lambda (comoving)" in line:
+                        self.omega_lambda = float(line.split(":")[1])
+                    elif "h (comoving)" in line:
+                        self.hubble_constant = float(line.split(":")[1])
+            else:
+                raise NotImplementedError
 
         # Read in the `comoving_a` file and parse the value. We should fix this
         # in the new Nyx output format...

--- a/yt/frontends/boxlib/tests/test_outputs.py
+++ b/yt/frontends/boxlib/tests/test_outputs.py
@@ -274,9 +274,9 @@ def test_NyxDataset():
     assert isinstance(data_dir_load(LyA), NyxDataset)
 
 
-@requires_file("nyx_small")
+@requires_file("nyx_small/nyx_small_00000")
 def test_NyxDataset_2():
-    assert isinstance(data_dir_load("nyx_small"), NyxDataset)
+    assert isinstance(data_dir_load("nyx_small/nyx_small_00000"), NyxDataset)
 
 
 @requires_file(RT_particles)

--- a/yt/frontends/boxlib/tests/test_outputs.py
+++ b/yt/frontends/boxlib/tests/test_outputs.py
@@ -196,6 +196,11 @@ beam = "GaussianBeam/plt03008"
 def test_beam():
     ds = data_dir_load(beam)
     assert_equal(str(ds), "plt03008")
+    for param in ("number of boxes", "maximum zones"):
+        # PR 2807
+        # these parameters are only populated if the config file attached to this
+        # dataset is read correctly
+        assert param in ds.parameters
     for test in small_patch_amr(ds, _warpx_fields, input_center="c", input_weight="Ex"):
         test_beam.__name__ = test.description
         yield test

--- a/yt/frontends/boxlib/tests/test_outputs.py
+++ b/yt/frontends/boxlib/tests/test_outputs.py
@@ -255,14 +255,13 @@ def test_warpx_particle_io():
 
 _raw_fields = [("raw", "Bx"), ("raw", "Ey"), ("raw", "jz")]
 
-raw_fields = "Laser/plt00015"
+laser = "Laser/plt00015"
 
 
-@requires_ds(raw_fields)
+@requires_ds(laser)
 def test_raw_fields():
-    ds_fn = raw_fields
     for field in _raw_fields:
-        yield GridValuesTest(ds_fn, field)
+        yield GridValuesTest(laser, field)
 
 
 @requires_file(rt)
@@ -275,14 +274,29 @@ def test_NyxDataset():
     assert isinstance(data_dir_load(LyA), NyxDataset)
 
 
+@requires_file("nyx_small")
+def test_NyxDataset_2():
+    assert isinstance(data_dir_load("nyx_small"), NyxDataset)
+
+
 @requires_file(RT_particles)
 def test_CastroDataset():
     assert isinstance(data_dir_load(RT_particles), CastroDataset)
 
 
+@requires_file("castro_sod_x_plt00036")
+def test_CastroDataset_2():
+    assert isinstance(data_dir_load("castro_sod_x_plt00036"), CastroDataset)
+
+
 @requires_file(LyA)
 def test_WarpXDataset():
     assert isinstance(data_dir_load(plasma), WarpXDataset)
+
+
+@requires_ds(laser)
+def test_WarpXDataset_2():
+    assert isinstance(data_dir_load(laser), WarpXDataset)
 
 
 @requires_file(rt)


### PR DESCRIPTION
## PR Summary

this is part of #2806, I want to see if it breaks stuff on its own.

`WarpXDataset._is_valid` is probably too permissive as it stands, it makes other classes easily interfere with it.

adresses #2708

Edit: found more bugs along the way (and added tests)