### PR TITLE
Refactor walk_volume in volume rendering

### DIFF
--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -28,8 +28,8 @@ from yt.utilities.lib.geometry_utils cimport (
     morton_neighbors_coarse,
     morton_neighbors_refined,
 )
-from yt.utilities.lib.grid_traversal cimport sampler_function, walk_volume
 from yt.utilities.lib.volume_container cimport VolumeContainer
+from yt.utilities.lib.grid_traversal cimport sampler_function, volume_walker, get_volume_walker
 
 from .oct_container cimport Oct, OctreeContainer
 from .oct_visitors cimport cind
@@ -1713,9 +1713,11 @@ cdef class RaySelector(SelectorObject):
     cdef np.float64_t p1[3]
     cdef np.float64_t p2[3]
     cdef np.float64_t vec[3]
+    cdef volume_walker walk_volume
 
     def __init__(self, dobj):
         cdef int i
+        self.walk_volume = get_volume_walker(dobj.ds.geometry)
         _ensure_code(dobj.start_point)
         _ensure_code(dobj.end_point)
         for i in range(3):
@@ -1751,7 +1753,7 @@ cdef class RaySelector(SelectorObject):
             vc.dds[i] = gobj.dds[i]
             vc.idds[i] = 1.0/gobj.dds[i]
             vc.dims[i] = dt.shape[i]
-        walk_volume(&vc, self.p1, self.vec, dt_sampler, <void*> ia)
+        self.walk_volume(&vc, self.p1, self.vec, dt_sampler, <void*> ia)
         for i in range(dt.shape[0]):
             for j in range(dt.shape[1]):
                 for k in range(dt.shape[2]):
@@ -1789,7 +1791,7 @@ cdef class RaySelector(SelectorObject):
             vc.dds[i] = gobj.dds[i]
             vc.idds[i] = 1.0/gobj.dds[i]
             vc.dims[i] = dt.shape[i]
-        walk_volume(&vc, self.p1, self.vec, dt_sampler, <void*> ia)
+        self.walk_volume(&vc, self.p1, self.vec, dt_sampler, <void*> ia)
         tr = np.zeros(ia.hits, dtype="float64")
         dtr = np.zeros(ia.hits, dtype="float64")
         ni = 0
@@ -1853,7 +1855,7 @@ cdef class RaySelector(SelectorObject):
                 vc.idds[j] = 1.0/vc.dds[j]
                 vc.dims[j] = 1
             t[0,0,0] = dt[0,0,0] = -1
-            walk_volume(&vc, self.p1, self.vec, dt_sampler, <void*> ia)
+            self.walk_volume(&vc, self.p1, self.vec, dt_sampler, <void*> ia)
             if dt[0,0,0] >= 0:
                 tr[ni] = t[0,0,0]
                 dtr[ni] = dt[0,0,0]
@@ -1912,7 +1914,7 @@ cdef class RaySelector(SelectorObject):
         ia.dt = dt
         ia.child_mask = cm
         ia.hits = 0
-        walk_volume(&vc, self.p1, self.vec, dt_sampler, <void*> ia)
+        self.walk_volume(&vc, self.p1, self.vec, dt_sampler, <void*> ia)
         rv = 0
         if ia.hits > 0:
             rv = 1
@@ -1940,7 +1942,7 @@ cdef class RaySelector(SelectorObject):
         ia.dt = &dt
         ia.child_mask = &cm
         ia.hits = 0
-        walk_volume(&vc, self.p1, self.vec, dt_sampler, <void*> &ia)
+        self.walk_volume(&vc, self.p1, self.vec, dt_sampler, <void*> &ia)
         if ia.hits > 0:
             return 2 # a box of non-zero volume cannot be inside a ray
         return 0

--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -1753,7 +1753,7 @@ cdef class RaySelector(SelectorObject):
             vc.dds[i] = gobj.dds[i]
             vc.idds[i] = 1.0/gobj.dds[i]
             vc.dims[i] = dt.shape[i]
-        self.walk_volume(&vc, self.p1, self.vec, dt_sampler, <void*> ia)
+        self.walk_volume(&vc, self.p1, self.vec, dt_sampler, <void*> ia, NULL, 1.0)
         for i in range(dt.shape[0]):
             for j in range(dt.shape[1]):
                 for k in range(dt.shape[2]):
@@ -1791,7 +1791,7 @@ cdef class RaySelector(SelectorObject):
             vc.dds[i] = gobj.dds[i]
             vc.idds[i] = 1.0/gobj.dds[i]
             vc.dims[i] = dt.shape[i]
-        self.walk_volume(&vc, self.p1, self.vec, dt_sampler, <void*> ia)
+        self.walk_volume(&vc, self.p1, self.vec, dt_sampler, <void*> ia, NULL, 1.0)
         tr = np.zeros(ia.hits, dtype="float64")
         dtr = np.zeros(ia.hits, dtype="float64")
         ni = 0
@@ -1855,7 +1855,7 @@ cdef class RaySelector(SelectorObject):
                 vc.idds[j] = 1.0/vc.dds[j]
                 vc.dims[j] = 1
             t[0,0,0] = dt[0,0,0] = -1
-            self.walk_volume(&vc, self.p1, self.vec, dt_sampler, <void*> ia)
+            self.walk_volume(&vc, self.p1, self.vec, dt_sampler, <void*> ia, NULL, 1.0)
             if dt[0,0,0] >= 0:
                 tr[ni] = t[0,0,0]
                 dtr[ni] = dt[0,0,0]
@@ -1914,7 +1914,7 @@ cdef class RaySelector(SelectorObject):
         ia.dt = dt
         ia.child_mask = cm
         ia.hits = 0
-        self.walk_volume(&vc, self.p1, self.vec, dt_sampler, <void*> ia)
+        self.walk_volume(&vc, self.p1, self.vec, dt_sampler, <void*> ia, NULL, 1.0)
         rv = 0
         if ia.hits > 0:
             rv = 1
@@ -1942,7 +1942,7 @@ cdef class RaySelector(SelectorObject):
         ia.dt = &dt
         ia.child_mask = &cm
         ia.hits = 0
-        self.walk_volume(&vc, self.p1, self.vec, dt_sampler, <void*> &ia)
+        self.walk_volume(&vc, self.p1, self.vec, dt_sampler, <void*> &ia, NULL, 1.0)
         if ia.hits > 0:
             return 2 # a box of non-zero volume cannot be inside a ray
         return 0

--- a/yt/utilities/lib/grid_traversal.pxd
+++ b/yt/utilities/lib/grid_traversal.pxd
@@ -10,7 +10,6 @@ Definitions for the traversal code
 import numpy as np
 cimport numpy as np
 cimport cython
-from .image_samplers cimport ImageSampler
 from .volume_container cimport VolumeContainer, vc_index, vc_pos_index
 
 ctypedef void sampler_function(
@@ -42,19 +41,20 @@ ctypedef void sampler_function(
 # See: https://www.researchgate.net/publication/2611491_A_Fast_Voxel_Traversal_Algorithm_for_Ray_Tracing
 # Returns: The number of voxels hit during the traversal phase. If the traversal phase is not reached, returns 0.
 #-----------------------------------------------------------------------------
-ctypedef int (*volume_walker)(VolumeContainer *vc,
-                     np.float64_t v_pos[3],
-                     np.float64_t v_dir[3],
-                     sampler_function *sampler,
-                     void *data,
-                     np.float64_t *return_t = *,
-                     np.float64_t max_t = *) nogil
+ctypedef int (*volume_walker)(VolumeContainer *,
+                     np.float64_t[3],
+                     np.float64_t[3],
+                     sampler_function*,
+                     void *,
+                     np.float64_t*,
+                     np.float64_t) nogil
 
-cdef volume_walker walk_volume_cartesian
+cdef int walk_volume_cartesian(VolumeContainer *,
+                     np.float64_t[3],
+                     np.float64_t[3],
+                     sampler_function*,
+                     void *,
+                     np.float64_t*,
+                     np.float64_t) nogil
 
-cdef inline volume_walker get_volume_walker(str geometry) nogil:
-    with gil:
-        if geometry == "cartesian":
-            return walk_volume_cartesian
-        else:
-            raise NotImplementedError
+cdef volume_walker get_volume_walker(str geometry) nogil

--- a/yt/utilities/lib/grid_traversal.pxd
+++ b/yt/utilities/lib/grid_traversal.pxd
@@ -42,10 +42,19 @@ ctypedef void sampler_function(
 # See: https://www.researchgate.net/publication/2611491_A_Fast_Voxel_Traversal_Algorithm_for_Ray_Tracing
 # Returns: The number of voxels hit during the traversal phase. If the traversal phase is not reached, returns 0.
 #-----------------------------------------------------------------------------
-cdef int walk_volume(VolumeContainer *vc,
+ctypedef int (*volume_walker)(VolumeContainer *vc,
                      np.float64_t v_pos[3],
                      np.float64_t v_dir[3],
                      sampler_function *sampler,
                      void *data,
                      np.float64_t *return_t = *,
                      np.float64_t max_t = *) nogil
+
+cdef volume_walker walk_volume_cartesian
+
+cdef inline volume_walker get_volume_walker(str geometry) nogil:
+    with gil:
+        if geometry == "cartesian":
+            return walk_volume_cartesian
+        else:
+            raise NotImplementedError

--- a/yt/utilities/lib/grid_traversal.pyx
+++ b/yt/utilities/lib/grid_traversal.pyx
@@ -41,10 +41,12 @@ from yt.utilities.lib.fp_utils cimport fclip, fmax, fmin, i64clip, iclip, imax, 
 
 DEF Nch = 4
 
+
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
-cdef int walk_volume(VolumeContainer *vc,
+cdef int walk_volume_cartesian(VolumeContainer *vc,
                      np.float64_t v_pos[3],
                      np.float64_t v_dir[3],
                      sampler_function *sample,

--- a/yt/utilities/lib/grid_traversal.pyx
+++ b/yt/utilities/lib/grid_traversal.pyx
@@ -51,8 +51,8 @@ cdef int walk_volume_cartesian(VolumeContainer *vc,
                      np.float64_t v_dir[3],
                      sampler_function *sample,
                      void *data,
-                     np.float64_t *return_t = NULL,
-                     np.float64_t max_t = 1.0) nogil:
+                     np.float64_t *return_t,
+                     np.float64_t max_t) nogil:
     cdef int cur_ind[3]
     cdef int step[3]
     cdef int x, y, i, hit, direction
@@ -372,4 +372,11 @@ def arr_fisheye_vectors(int resolution, np.float64_t fov, int nimx=1, int
             vp[i,j,2] = cos(theta)
     return vp
 
+
+cdef volume_walker get_volume_walker(str geometry) nogil:
+    with gil:
+        if geometry == "cartesian":
+            return walk_volume_cartesian
+        else:
+            raise NotImplementedError
 

--- a/yt/utilities/lib/image_samplers.pxd
+++ b/yt/utilities/lib/image_samplers.pxd
@@ -12,6 +12,7 @@ cimport numpy as np
 cimport cython
 from .volume_container cimport VolumeContainer
 from .partitioned_grid cimport PartitionedGrid
+from .grid_traversal cimport volume_walker
 
 DEF Nch = 4
 
@@ -56,6 +57,7 @@ cdef class ImageSampler:
     cdef calculate_extent_function *extent_function
     cdef generate_vector_info_function *vector_function
     cdef void setup(self, PartitionedGrid pg)
+    cdef volume_walker walk_volume
     @staticmethod
     cdef void sample(VolumeContainer *vc,
                 np.float64_t v_pos[3],

--- a/yt/utilities/lib/image_samplers.pyx
+++ b/yt/utilities/lib/image_samplers.pyx
@@ -88,7 +88,7 @@ cdef class ImageSampler:
                   *args, **kwargs):
         cdef int i
 
-        cdef char* geometry = kwargs.pop("geometry", "cartesian")
+        cdef str geometry = kwargs.pop("geometry", "cartesian")
         self.walk_volume = get_volume_walker(geometry)
         camera_data = kwargs.pop("camera_data", None)
         if camera_data is not None:

--- a/yt/utilities/lib/image_samplers.pyx
+++ b/yt/utilities/lib/image_samplers.pyx
@@ -48,7 +48,7 @@ from .fixed_interpolator cimport (
     trilinear_interpolate,
     vertex_interp,
 )
-from .grid_traversal cimport walk_volume
+from .grid_traversal cimport get_volume_walker, volume_walker
 
 
 cdef extern from "platform_dep.h":
@@ -88,6 +88,8 @@ cdef class ImageSampler:
                   *args, **kwargs):
         cdef int i
 
+        cdef char* geometry = kwargs.pop("geometry", "cartesian")
+        self.walk_volume = get_volume_walker(geometry)
         camera_data = kwargs.pop("camera_data", None)
         if camera_data is not None:
             self.camera_data = camera_data
@@ -189,7 +191,7 @@ cdef class ImageSampler:
                 for i in range(Nch):
                     idata.rgba[i] = self.image[vi, vj, i]
                 max_t = fclip(self.zbuffer[vi, vj], 0.0, 1.0)
-                walk_volume(vc, v_pos, v_dir, self.sample,
+                self.walk_volume(vc, v_pos, v_dir, self.sample,
                             (<void *> idata), NULL, max_t)
                 if (j % (10*chunksize)) == 0:
                     with gil:


### PR DESCRIPTION
## PR Summary

In order to support non-Cartesian volume rendering, we need to be able to switch the volume walk algorithm on the fly.  This sets up the preliminary means to do that, by turning `walk_volume` into a function pointer, and (similar to the smoothing kernel work) using a getter function that looks up the type of geometry and supplies the correct one.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] pass `black --check yt/`
- [x] pass `isort . --check --diff`
- [x] pass `flake8 yt/`
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

