### PR TITLE
fix latex rendering of the transfer function

### DIFF
--- a/doc/source/cookbook/amrkdtree_downsampling.py
+++ b/doc/source/cookbook/amrkdtree_downsampling.py
@@ -71,8 +71,13 @@ tf.add_layers(
     alpha=10.0 * np.ones(4, dtype="float64"),
     colormap="RdBu_r",
 )
-tf.add_layers(4, 0.01, col_bounds=[-27.5, -25.5],
-              alpha=10.0 * np.ones(4, dtype='float64'), colormap='RdBu_r')
+tf.add_layers(
+    4,
+    0.01,
+    col_bounds=[-27.5, -25.5],
+    alpha=10.0 * np.ones(4, dtype="float64"),
+    colormap="RdBu_r",
+)
 sc.save("v4.png", sigma_clip=6.0)
 #
 ## This looks pretty good, now lets go back to the full resolution AMRKDTree

--- a/yt/visualization/volume_rendering/transfer_functions.py
+++ b/yt/visualization/volume_rendering/transfer_functions.py
@@ -663,7 +663,7 @@ class ColorTransferFunction(MultiVariateTransferFunction):
                 if abs(val) < 1.0e-3 or abs(val) > 1.0e4:
                     if not val == 0.0:
                         e = np.floor(np.log10(abs(val)))
-                        return r"${:.2f}\times 10^{:d}$".format(val / 10.0 ** e, int(e))
+                        return r"${:.2f}\times 10^{{ {:d} }}$".format(val / 10.0 ** e, int(e))
                     else:
                         return r"$0$"
                 else:

--- a/yt/visualization/volume_rendering/transfer_functions.py
+++ b/yt/visualization/volume_rendering/transfer_functions.py
@@ -663,7 +663,9 @@ class ColorTransferFunction(MultiVariateTransferFunction):
                 if abs(val) < 1.0e-3 or abs(val) > 1.0e4:
                     if not val == 0.0:
                         e = np.floor(np.log10(abs(val)))
-                        return r"${:.2f}\times 10^{{ {:d} }}$".format(val / 10.0 ** e, int(e))
+                        return r"${:.2f}\times 10^{{ {:d} }}$".format(
+                            val / 10.0 ** e, int(e)
+                        )
                     else:
                         return r"$0$"
                 else:


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

The exponent in the latex label needs to be in `{}` if it is not a positive single digit, otherwise it does not render entirely as a superscript.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] pass `black --check yt/`
- [ ] pass `isort . --check --diff`
- [ ] pass `flake8 yt/`
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
