### PR TITLE
Rename YTOutputNotIdentified to YTUnidentifiedDataType

### DIFF
--- a/doc/source/reference/configuration.rst
+++ b/doc/source/reference/configuration.rst
@@ -102,7 +102,7 @@ used internally.
   setting will provide instructions for setting this.
 * ``requires_ds_strict`` (default: ``True``): If true, answer tests wrapped
   with :func:`~yt.utilities.answer_testing.framework.requires_ds` will raise
-  :class:`~yt.utilities.exceptions.YTOutputNotIdentified` rather than consuming
+  :class:`~yt.utilities.exceptions.YTUnidentifiedDataType` rather than consuming
   it if required dataset is not present.
 * ``serialize`` (default: ``False``): If true, perform automatic
   :ref:`object serialization <object-serialization>`

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -12,7 +12,7 @@ from yt.data_objects.analyzer_objects import AnalysisTask, create_quantity_proxy
 from yt.data_objects.particle_trajectories import ParticleTrajectories
 from yt.funcs import ensure_list, issue_deprecation_warning, iterable, mylog
 from yt.units.yt_array import YTArray, YTQuantity
-from yt.utilities.exceptions import YTException, YTOutputNotIdentified
+from yt.utilities.exceptions import YTException, YTUnidentifiedDataType
 from yt.utilities.object_registries import (
     analysis_task_registry,
     data_object_registry,
@@ -168,7 +168,7 @@ class DatasetSeries:
         try:
             ret._pre_outputs = outputs[:]
         except TypeError:
-            raise YTOutputNotIdentified(outputs)
+            raise YTUnidentifiedDataType(outputs)
         return ret
 
     def __init__(

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -167,8 +167,8 @@ class DatasetSeries:
         ret = super(DatasetSeries, cls).__new__(cls)
         try:
             ret._pre_outputs = outputs[:]
-        except TypeError:
-            raise YTUnidentifiedDataType(outputs)
+        except TypeError as e:
+            raise YTUnidentifiedDataType(outputs) from e
         return ret
 
     def __init__(

--- a/yt/frontends/enzo/simulation_handling.py
+++ b/yt/frontends/enzo/simulation_handling.py
@@ -13,7 +13,7 @@ from yt.utilities.exceptions import (
     InvalidSimulationTimeSeries,
     MissingParameter,
     NoStoppingCondition,
-    YTOutputNotIdentified,
+    YTUnidentifiedDataType,
 )
 from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.parallel_tools.parallel_analysis_interface import parallel_objects
@@ -659,7 +659,7 @@ class EnzoSimulation(SimulationTimeSeries):
             )
             try:
                 ds = load(filename)
-            except (FileNotFoundError, YTOutputNotIdentified):
+            except (FileNotFoundError, YTUnidentifiedDataType):
                 mylog.error("Failed to load %s", filename)
                 continue
             my_storage.result = {

--- a/yt/frontends/exodus_ii/simulation_handling.py
+++ b/yt/frontends/exodus_ii/simulation_handling.py
@@ -3,7 +3,7 @@ import glob
 from yt.data_objects.time_series import DatasetSeries
 from yt.funcs import only_on_root
 from yt.loaders import load
-from yt.utilities.exceptions import YTOutputNotIdentified
+from yt.utilities.exceptions import YTUnidentifiedDataType
 from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.parallel_tools.parallel_analysis_interface import parallel_objects
 
@@ -91,7 +91,7 @@ class ExodusIISimulation(DatasetSeries):
         ):
             try:
                 ds = load(output)
-            except (FileNotFoundError, YTOutputNotIdentified):
+            except (FileNotFoundError, YTUnidentifiedDataType):
                 mylog.error("Failed to load %s", output)
                 continue
             my_storage.result = {"filename": output, "num_steps": ds.num_steps}

--- a/yt/frontends/gadget/simulation_handling.py
+++ b/yt/frontends/gadget/simulation_handling.py
@@ -13,7 +13,7 @@ from yt.utilities.exceptions import (
     InvalidSimulationTimeSeries,
     MissingParameter,
     NoStoppingCondition,
-    YTOutputNotIdentified,
+    YTUnidentifiedDataType,
 )
 from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.parallel_tools.parallel_analysis_interface import parallel_objects
@@ -522,7 +522,7 @@ class GadgetSimulation(SimulationTimeSeries):
         ):
             try:
                 ds = load(output)
-            except (FileNotFoundError, YTOutputNotIdentified):
+            except (FileNotFoundError, YTUnidentifiedDataType):
                 mylog.error("Failed to load %s", output)
                 continue
             my_storage.result = {

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -13,8 +13,8 @@ from yt.utilities.decompose import decompose_array, get_psize
 from yt.utilities.exceptions import (
     YTAmbiguousDataType,
     YTIllDefinedAMR,
-    YTOutputNotIdentified,
     YTSimulationNotIdentified,
+    YTUnidentifiedDataType,
 )
 from yt.utilities.hierarchy_inspection import find_lowest_subclasses
 from yt.utilities.lib.misc_utilities import get_box_grids_level
@@ -57,7 +57,7 @@ def load(fn, *args, **kwargs):
     FileNotFoundError
         If fn does not match any existing file or directory.
 
-    yt.utilities.exceptions.YTOutputNotIdentified
+    yt.utilities.exceptions.YTUnidentifiedDataType
         If fn matches existing files or directories with undetermined format.
 
     yt.utilities.exceptions.YTAmbiguousDataType
@@ -97,7 +97,7 @@ def load(fn, *args, **kwargs):
     if len(candidates) > 1:
         raise YTAmbiguousDataType(fn, candidates)
 
-    raise YTOutputNotIdentified(fn, args, kwargs)
+    raise YTUnidentifiedDataType(fn, args, kwargs)
 
 
 def load_simulation(fn, simulation_type, find_outputs=False):

--- a/yt/tests/test_load_errors.py
+++ b/yt/tests/test_load_errors.py
@@ -7,8 +7,8 @@ from yt.loaders import load, load_simulation
 from yt.testing import assert_raises
 from yt.utilities.exceptions import (
     YTAmbiguousDataType,
-    YTOutputNotIdentified,
     YTSimulationNotIdentified,
+    YTUnidentifiedDataType,
 )
 from yt.utilities.object_registries import output_type_registry
 
@@ -39,8 +39,8 @@ def test_load_unidentified_data():
     with tempfile.TemporaryDirectory() as tmpdir:
         empty_file_path = Path(tmpdir) / "empty_file"
         empty_file_path.touch()
-        assert_raises(YTOutputNotIdentified, load, tmpdir)
-        assert_raises(YTOutputNotIdentified, load, empty_file_path)
+        assert_raises(YTUnidentifiedDataType, load, tmpdir)
+        assert_raises(YTUnidentifiedDataType, load, empty_file_path)
         assert_raises(
             YTSimulationNotIdentified,
             load_simulation,

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -33,7 +33,7 @@ from yt.utilities.configure import set_config
 from yt.utilities.exceptions import (
     YTCommandRequiresModule,
     YTFieldNotParseable,
-    YTOutputNotIdentified,
+    YTUnidentifiedDataType,
 )
 from yt.utilities.metadata import get_metadata
 from yt.visualization.plot_window import ProjectionPlot, SlicePlot
@@ -1742,7 +1742,7 @@ class YTSearchCmd(YTCommand):
             print("(% 10i/% 10i) Evaluating %s" % (i, len(candidates), c))
             try:
                 record = get_metadata(c, args.full_output)
-            except YTOutputNotIdentified:
+            except YTUnidentifiedDataType:
                 continue
             records.append(record)
         with open(args.output, "w") as f:

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -13,7 +13,7 @@ class YTException(Exception):
 # Data access exceptions:
 
 
-class YTOutputNotIdentified(YTException):
+class YTUnidentifiedDataType(YTException):
     def __init__(self, filename, args=None, kwargs=None):
         self.filename = filename
         self.args = args
@@ -29,7 +29,19 @@ class YTOutputNotIdentified(YTException):
         return msg
 
 
-class YTAmbiguousDataType(YTOutputNotIdentified):
+class YTOutputNotIdentified(YTUnidentifiedDataType):
+    # kept for backwards compatibility
+    def __init__(self, filename, args=None, kwargs=None):
+        super(YTUnidentifiedDataType, self).__init__(filename, args, kwargs)
+        # this cannot be imported at the module level (creates circular imports)
+        from yt.funcs import issue_deprecation_warning
+
+        issue_deprecation_warning(
+            "YTOutputNotIdentified is a deprecated alias for YTUnidentifiedDataType"
+        )
+
+
+class YTAmbiguousDataType(YTUnidentifiedDataType):
     def __init__(self, filename, candidates):
         self.filename = filename
         self.candidates = candidates


### PR DESCRIPTION
## PR Summary

This is a follow up to #2695.
Rationale:
In discussing #2695 with @matthewturk , I realised the word "output" is a bit weird in the context this error is used, since the data in question is an _input_ to `yt.load()` (but in general is an _output_ from a simulation, hence the term).

This change makes the original error a subclass of the new one, so as not to break any downstream code that relies on catching it.


Opening as a draft until #2695 is accepted.

## PR Checklist

- [x] pass `black --check yt/`
- [x] pass `isort . --check --diff`
- [x] pass `flake8 yt/`
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.
