### PR TITLE
add pooch and pyyaml to test_requirements

### DIFF
--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -29,3 +29,5 @@ f90nml>=1.1.2
 MiniballCpp>=0.2.1
 pooch>=0.7.0
 pykdtree==1.3.1
+pooch>=1.1.1
+pyyaml>=5.3.1


### PR DESCRIPTION
## PR Summary

In order to build a fully fletched dev env for yt, `pip install -r tests/tests_requirement.txt` is currently insufficient; Namely, I've identified two missing packages that are used in tests: pooch, and pyyaml 
This fixes it.