### PR TITLE
Add a check for reduced dimensionality slices

### DIFF
--- a/yt/frontends/stream/tests/test_stream_unstructured.py
+++ b/yt/frontends/stream/tests/test_stream_unstructured.py
@@ -22,8 +22,11 @@ def test_multi_mesh():
     ds = load_unstructured_mesh(connectList, coordsMulti, dataList)
 
     sl = SlicePlot(ds, "z", ("connect1", "test"))
+    assert sl.data_source.field_data["connect1", "test"].shape == (1, 3)
     sl = SlicePlot(ds, "z", ("connect2", "test"))
+    assert sl.data_source.field_data["connect2", "test"].shape == (1, 3)
     sl = SlicePlot(ds, "z", ("all", "test"))
+    assert sl.data_source.field_data["all", "test"].shape == (2, 3)
     sl.annotate_mesh_lines()
 
 


### PR DESCRIPTION
This adds a check to the `SliceSelector`.  When we are slicing along an axis that is greater than or equal to the dimensionality of the dataset, we want to always say "yes" we are selecting a zone.

Note that I did not modify the grid selection, since it *should* work out of the box with the way we clip to the edges.

There may be other objects that need this, but Slice is the most obvious one from my reading.

This should fix the Phantom Bugs in the other PRs, and I've also added a test (that fails without this changeset) to verify it's working.
