### PR TITLE
update flynt version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,6 @@
     hooks:
     -   id: flake8
 -   repo: https://github.com/ikamensh/flynt
-    rev: '0.51'  # keep in sync with tests/lint_requirements.txt
+    rev: '0.52'  # keep in sync with tests/lint_requirements.txt
     hooks:
     -   id: flynt

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ jobs:
       name: "flynt"
       python: 3.6
       script: |
-        flynt -h | head -n 1 # this is a workaround to print only the version number
+        flynt --version
         flynt yt/ --fail-on-change --dry-run -e yt/extern
 
     - stage: tests

--- a/tests/lint_requirements.txt
+++ b/tests/lint_requirements.txt
@@ -5,4 +5,4 @@ pyflakes==2.2.0
 isort==5.2.1   # keep in sync with .pre-commit-config.yaml
 black==19.10b0
 flake8-bugbear
-flynt==0.51   # keep in sync with .pre-commit-config.yaml
+flynt==0.52   # keep in sync with .pre-commit-config.yaml


### PR DESCRIPTION
## PR Summary

A very quick followup to the "flyting" Prs we just merged. Flynt just got a new `--version` option so there's no need for the workaround on Travis anymore.
