### PR TITLE
hotfix: register "vertex" fields only in unstructured meshes

### DIFF
--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -1,9 +1,7 @@
 from numbers import Number as numeric_type
 
 import numpy as np
-from unyt.exceptions import UnitConversionError
 
-from yt.fields.field_exceptions import NeedsConfiguration
 from yt.funcs import issue_deprecation_warning, mylog, only_on_root
 from yt.geometry.geometry_handler import is_curvilinear
 from yt.units.dimensions import dimensionless
@@ -473,7 +471,7 @@ class FieldInfoContainer(dict):
             try:
                 # fd: field detector
                 fd = fi.get_dependencies(ds=self.ds)
-            except (YTFieldNotFound, NeedsConfiguration, UnitConversionError) as e:
+            except Exception as e:
                 if field in self._show_field_errors:
                     raise
                 if not isinstance(e, YTFieldNotFound):

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -501,9 +501,9 @@ class FieldInfoContainer(dict):
         dfl = list(sorted(dfl, key=tupleize))
 
         if not hasattr(self.ds.index, "meshes"):
-            # the meshes attribute characterizes a unstructured-mesh data structure
+            # the meshes attribute characterizes an unstructured-mesh data structure
 
-            # ideally this fitlering should not be required
+            # ideally this filtering should not be required
             # and this could maybe be handled in fi.get_dependencies
             # but it's a lot easier to do here
 

--- a/yt/fields/tests/test_field_name_container.py
+++ b/yt/fields/tests/test_field_name_container.py
@@ -1,5 +1,5 @@
 from yt import load
-from yt.testing import requires_file
+from yt.testing import fake_amr_ds, requires_file
 
 
 def do_field_type(ft):
@@ -31,3 +31,9 @@ def test_field_name_container():
     for field_type in ds.fields:
         assert field_type in ds.fields
         do_field_type(field_type)
+
+
+def test_no_vertex_fields_in_structured_ds():
+    ds = fake_amr_ds()
+    vertex_fields = [(ft, fn) for ft, fn in ds.derived_field_list if "vertex" in fn]
+    assert not vertex_fields

--- a/yt/fields/tests/test_field_name_container.py
+++ b/yt/fields/tests/test_field_name_container.py
@@ -1,5 +1,5 @@
 from yt import load
-from yt.testing import fake_amr_ds, requires_file
+from yt.testing import fake_amr_ds, fake_hexahedral_ds, requires_file
 
 
 def do_field_type(ft):
@@ -33,7 +33,25 @@ def test_field_name_container():
         do_field_type(field_type)
 
 
-def test_no_vertex_fields_in_structured_ds():
+def test_vertex_fields_only_in_unstructured_ds():
+    def get_vertex_fields(ds):
+        return [(ft, fn) for ft, fn in ds.derived_field_list if "vertex" in fn]
+
     ds = fake_amr_ds()
-    vertex_fields = [(ft, fn) for ft, fn in ds.derived_field_list if "vertex" in fn]
+    vertex_fields = get_vertex_fields(ds)
     assert not vertex_fields
+
+    ds = fake_hexahedral_ds()
+    actual = get_vertex_fields(ds)
+    expected = [
+        ("all", "vertex_x"),
+        ("all", "vertex_y"),
+        ("all", "vertex_z"),
+        ("connect1", "vertex_x"),
+        ("connect1", "vertex_y"),
+        ("connect1", "vertex_z"),
+        ("index", "vertex_x"),
+        ("index", "vertex_y"),
+        ("index", "vertex_z"),
+    ]
+    assert actual == expected


### PR DESCRIPTION
## PR Summary

fix https://github.com/yt-project/yt/issues/2430

This is a hotfix, I'm convinced there are better ways to solve this but they would require much more work (refactoring).

## PR Checklist

- [x] pass `black --check yt/`
- [x] pass `isort . --check --diff`
- [x] pass `flake8 yt/`
- [x] pass `flynt yt/ --fail-on-change --dry-run -e yt/extern`
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.
