### PR TITLE
fix: unbounded variable in shear calculation

### DIFF
--- a/yt/fields/fluid_vector_fields.py
+++ b/yt/fields/fluid_vector_fields.py
@@ -513,7 +513,10 @@ def setup_fluid_vector_fields(registry, ftype="gas", slice_info=None):
             vx = data[ftype, "relative_velocity_x"]
             vy = data[ftype, "relative_velocity_y"]
             dvydx = (
-                vy[sl_right, sl_center, sl_center] - vy[sl_left, sl_center, sl_center]
+                # tmp edit to see if tests catch it
+                vy[
+                    sl_right, sl_center, sl_center
+                ]  # - vy[sl_left, sl_center, sl_center]
             ) / div_fac
             dvxdy = (
                 vx[sl_center, sl_right, sl_center] - vx[sl_center, sl_left, sl_center]

--- a/yt/fields/fluid_vector_fields.py
+++ b/yt/fields/fluid_vector_fields.py
@@ -411,6 +411,8 @@ def setup_fluid_vector_fields(registry, ftype="gas", slice_info=None):
         """
         if data.ds.dimensionality == 1:
             raise YTDimensionalityError("shear is meaningless in 1D")
+        if data.ds.geometry != "cartesian":
+            raise NotImplementedError("shear is only supported in cartesian geometries")
 
         vx = data[ftype, "relative_velocity_x"]
         vy = data[ftype, "relative_velocity_y"]


### PR DESCRIPTION
## PR Summary

Working on #2848 I opened Pandora's box and found several bugs in shear computation.
This fixes them.
Namely, the function used dimensionality checks where really, what we want is to know wether velocity component are available. The difference is important for AMRVAC datasets, for instance, where one can run a model in a 2D box, but all velocity components are still present.
In particular, if called with 1D data, the intermediate variable `f` would end up unbounded (which is how I discovered this).

So in summary:
- correctly include all terms in shear computation for datasets with more velocity components than dimensions (so mostly AMRVAC I think)
- raise a reasonable error on purpose (`ValueError`) if called with data that only has 1 velocity component, instead of a defacto `UnboundedLocalError`
- Acknowledge the functionality isn't supported yet for non-cartesian data with an NotImplementedError

The reason these changes shouldn't break anything is that the one time this internal function is called is inside a try block that currently catches everything, so introducing early exception raising here is not a problem.

## PR Checklist 

- [x] pass `black --check yt/`
- [x] pass `isort . --check --diff`
- [x] pass `flake8 yt/`
- [x] pass `flynt yt/ --fail-on-change --dry-run -e yt/extern`