### PR TITLE
Avoid generating kdtree until it's really required. Fixes #2854

### DIFF
--- a/yt/frontends/arepo/io.py
+++ b/yt/frontends/arepo/io.py
@@ -7,7 +7,7 @@ from yt.utilities.on_demand_imports import _h5py as h5py
 class IOHandlerArepoHDF5(IOHandlerGadgetHDF5):
     _dataset_type = "arepo_hdf5"
 
-    def _generate_smoothing_length(self, data_files, kdtree):
+    def _generate_smoothing_length(self, index):
         # This is handled below in _get_smoothing_length
         return
 

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -87,7 +87,8 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
             yield key, pos
         f.close()
 
-    def _generate_smoothing_length(self, data_files, kdtree):
+    def _generate_smoothing_length(self, index):
+        data_files = index.data_files
         if not self.ds.gen_hsmls:
             return
         hsml_fn = data_files[0].filename.replace(".hdf5", ".hsml.hdf5")
@@ -116,6 +117,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
         for fn, count in counts.items():
             offsets[fn] = offset
             offset += count
+        kdtree = index.kdtree
         positions = uconcatenate(positions)[kdtree.idx]
         hsml = generate_smoothing_length(positions, kdtree, self.ds._num_neighbors)
         dtype = positions.dtype

--- a/yt/frontends/sph/data_structures.py
+++ b/yt/frontends/sph/data_structures.py
@@ -84,7 +84,7 @@ class SPHParticleIndex(ParticleIndex):
         ds._file_hash = self._generate_hash()
 
         if hasattr(self.io, "_generate_smoothing_length"):
-            self.io._generate_smoothing_length(self.data_files, self.kdtree)
+            self.io._generate_smoothing_length(self)
 
         super(SPHParticleIndex, self)._initialize_index()
 

--- a/yt/frontends/tipsy/io.py
+++ b/yt/frontends/tipsy/io.py
@@ -117,7 +117,7 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
     def hsml_filename(self):
         return f"{self.ds.parameter_filename}-{'hsml'}"
 
-    def _generate_smoothing_length(self, data_files, kdtree):
+    def _generate_smoothing_length(self, index):
         if os.path.exists(self.hsml_filename):
             with open(self.hsml_filename, "rb") as f:
                 file_hash = struct.unpack("q", f.read(struct.calcsize("q")))[0]
@@ -126,13 +126,14 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
             else:
                 return
         positions = []
-        for data_file in data_files:
+        for data_file in index.data_files:
             for _, ppos in self._yield_coordinates(
                 data_file, needed_ptype=self.ds._sph_ptypes[0]
             ):
                 positions.append(ppos)
         if positions == []:
             return
+        kdtree = index.kdtree
         positions = np.concatenate(positions)[kdtree.idx]
         hsml = generate_smoothing_length(positions, kdtree, self.ds._num_neighbors)
         hsml = hsml[np.argsort(kdtree.idx)]


### PR DESCRIPTION
## PR Summary

This PR defers the generation of the KDTree in `_generate_smoothing_length` until all checks for existing hsmls fail, by simply passing the index as an argument.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] pass `black --check yt/`
- [ ] pass `isort . --check --diff`
- [ ] pass `flake8 yt/`
- [ ] pass `flynt yt/ --fail-on-change --dry-run -e yt/extern`
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.