### PR TITLE
[refactor] Convert data_files and total_particles into properties

### DIFF
--- a/yt/data_objects/octree_subset.py
+++ b/yt/data_objects/octree_subset.py
@@ -604,7 +604,8 @@ class OctreeSubsetBlockSlice:
     def get_vertex_centered_data(self, fields, smoothed=False, no_ghost=False):
         if no_ghost is True:
             raise NotImplementedError(
-                "get_vertex_centered_data without ghost zones for oct-based datasets has not been implemented."
+                "get_vertex_centered_data without ghost zones for "
+                "oct-based datasets has not been implemented."
             )
 
         # Make sure the field list has only unique entries

--- a/yt/frontends/adaptahop/data_structures.py
+++ b/yt/frontends/adaptahop/data_structures.py
@@ -39,9 +39,6 @@ class AdaptaHOPParticleIndex(ParticleIndex):
             self.data_files = [
                 cls(self.dataset, self.io, self.dataset.parameter_filename, 0, None,)
             ]
-        self.total_particles = sum(
-            sum(d.total_particles.values()) for d in self.data_files
-        )
 
 
 class AdaptaHOPDataset(Dataset):

--- a/yt/frontends/art/data_structures.py
+++ b/yt/frontends/art/data_structures.py
@@ -414,9 +414,6 @@ class ARTParticleIndex(ParticleIndex):
             df = cls(self.dataset, self.io, template % {"num": i}, fi)
             fi += 1
             self.data_files.append(df)
-        self.total_particles = sum(
-            sum(d.total_particles.values()) for d in self.data_files
-        )
 
 
 class DarkMatterARTDataset(ARTDataset):

--- a/yt/frontends/gadget_fof/data_structures.py
+++ b/yt/frontends/gadget_fof/data_structures.py
@@ -93,22 +93,16 @@ class GadgetFOFParticleIndex(ParticleIndex):
         ds.particle_types_raw = ds.particle_types
 
     def _setup_filenames(self):
-        if not hasattr(self, "data_files"):
-            template = self.ds.filename_template
-            ndoms = self.ds.file_count
-            cls = self.ds._file_class
-            self.data_files = [
-                cls(self.ds, self.io, template % {"num": i}, i, frange=None)
-                for i in range(ndoms)
-            ]
-        if not hasattr(self, "total_particles"):
-            self.total_particles = sum(
-                sum(d.total_particles.values()) for d in self.data_files
-            )
+        template = self.ds.filename_template
+        ndoms = self.ds.file_count
+        cls = self.ds._file_class
+        self.data_files = [
+            cls(self.ds, self.io, template % {"num": i}, i, frange=None)
+            for i in range(ndoms)
+        ]
 
     def _setup_data_io(self):
         super(GadgetFOFParticleIndex, self)._setup_data_io()
-        self._setup_filenames()
         self._calculate_particle_count()
         self._calculate_particle_index_starts()
         self._calculate_file_offset_map()

--- a/yt/frontends/halo_catalog/data_structures.py
+++ b/yt/frontends/halo_catalog/data_structures.py
@@ -22,7 +22,6 @@ from .fields import YTHaloCatalogFieldInfo, YTHaloCatalogHaloFieldInfo
 class HaloCatalogFile(ParticleFile):
     """
     Base class for data files of halo catalog datasets.
->>>>>>> master
 
     This is mainly here to correct for periodicity when
     reading particle positions.

--- a/yt/frontends/halo_catalog/data_structures.py
+++ b/yt/frontends/halo_catalog/data_structures.py
@@ -31,9 +31,6 @@ class HaloCatalogParticleIndex(ParticleIndex):
                     range=None,
                 )
             ]
-        self.total_particles = sum(
-            sum(d.total_particles.values()) for d in self.data_files
-        )
 
 
 class HaloCatalogFile(ParticleFile):

--- a/yt/frontends/owls_subfind/data_structures.py
+++ b/yt/frontends/owls_subfind/data_structures.py
@@ -50,7 +50,6 @@ class OWLSSubfindParticleIndex(ParticleIndex):
 
     def _detect_output_fields(self):
         # TODO: Add additional fields
-        self._setup_filenames()
         self._calculate_particle_index_starts()
         self._calculate_file_offset_map()
         dsl = []

--- a/yt/geometry/particle_geometry_handler.py
+++ b/yt/geometry/particle_geometry_handler.py
@@ -72,9 +72,6 @@ class ParticleIndex(Index):
         return self._total_particles
 
     def _setup_filenames(self):
-        if hasattr(self, "data_files"):
-            return
-
         template = self.dataset.filename_template
         ndoms = self.dataset.file_count
         cls = self.dataset._file_class

--- a/yt/geometry/particle_geometry_handler.py
+++ b/yt/geometry/particle_geometry_handler.py
@@ -45,6 +45,32 @@ class ParticleIndex(Index):
     def convert(self, unit):
         return self.dataset.conversion_factors[unit]
 
+    _data_files = None
+
+    @property
+    def data_files(self):
+        if self._data_files is not None:
+            return self._data_files
+
+        self._setup_filenames()
+        return self._data_files
+
+    @data_files.setter
+    def data_files(self, value):
+        self._data_files = value
+
+    _total_particles = None
+
+    @property
+    def total_particles(self):
+        if self._total_particles is not None:
+            return self._total_particles
+
+        self._total_particles = sum(
+            sum(d.total_particles.values()) for d in self.data_files
+        )
+        return self._total_particles
+
     def _setup_filenames(self):
         template = self.dataset.filename_template
         ndoms = self.dataset.file_count
@@ -62,9 +88,6 @@ class ParticleIndex(Index):
                 self.data_files.append(df)
                 start = end
                 end += CHUNKSIZE
-        self.total_particles = sum(
-            sum(d.total_particles.values()) for d in self.data_files
-        )
 
     def _initialize_index(self):
         ds = self.dataset
@@ -233,7 +256,6 @@ class ParticleIndex(Index):
 
     def _detect_output_fields(self):
         # TODO: Add additional fields
-        self._setup_filenames()
         dsl = []
         units = {}
         pcounts = self._get_particle_type_counts()


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

This converts two attributes of `ParticleIndex`, `data_files` and `total_particles`, into properties that call `ParticleIndex._setup_filenames` under the hood. This reduces a little bit of code duplication and should eliminate any instances of `_setup_filenames` being called more than once.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] pass `black --check yt/`
- [ ] pass `isort . --check --diff`
- [ ] pass `flake8 yt/`
- [ ] pass `flynt yt/ --fail-on-change --dry-run -e yt/extern`
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
