### PR TITLE
update amrvac error printing

### DIFF
--- a/doc/source/cookbook/multiplot_export_to_mpl.py
+++ b/doc/source/cookbook/multiplot_export_to_mpl.py
@@ -2,16 +2,15 @@ import yt
 
 ds = yt.load_sample("IsolatedGalaxy")
 
-fields = ['density', 'velocity_x', 'velocity_y', 'velocity_magnitude']
-p = yt.SlicePlot(ds, 'z', fields)
-p.set_log('velocity_x', False)
-p.set_log('velocity_y', False)
+fields = ["density", "velocity_x", "velocity_y", "velocity_magnitude"]
+p = yt.SlicePlot(ds, "z", fields)
+p.set_log("velocity_x", False)
+p.set_log("velocity_y", False)
 
 # this returns a matplotlib figure with an ImageGrid and the slices
 # added to the grid of axes (in this case, 2x2)
-fig = p.export_to_mpl_figure((2,2))
+fig = p.export_to_mpl_figure((2, 2))
 
 fig.tight_layout()
 
 fig.savefig("multiplot_export_to_mpl.png")
-

--- a/yt/frontends/amrvac/fields.py
+++ b/yt/frontends/amrvac/fields.py
@@ -42,9 +42,8 @@ def _velocity(field, data, idir, prefix=None):
     mask1 = rho == 0
     if mask1.any():
         warnings.warn(
-            "zeros found in %sdensity, "
+            f"zeros found in {prefix}density"
             "patching them to compute corresponding velocity field.",
-            prefix,
             category=RuntimeWarning
         )
         mask2 = moment == 0

--- a/yt/frontends/amrvac/fields.py
+++ b/yt/frontends/amrvac/fields.py
@@ -7,6 +7,7 @@ AMRVAC-specific fields
 import functools
 
 import numpy as np
+import warnings
 
 from yt import mylog
 from yt.fields.field_info_container import FieldInfoContainer
@@ -43,6 +44,7 @@ def _velocity(field, data, idir, prefix=None):
         warnings.warn(
             "zeros found in %sdensity, "
             "patching them to compute corresponding velocity field.",
+            prefix,
             category=RuntimeWarning
         )
         mask2 = moment == 0

--- a/yt/frontends/amrvac/fields.py
+++ b/yt/frontends/amrvac/fields.py
@@ -42,7 +42,7 @@ def _velocity(field, data, idir, prefix=None):
     mask1 = rho == 0
     if mask1.any():
         warnings.warn(
-            f"zeros found in {prefix}density"
+            f"zeros found in {prefix}density, "
             "patching them to compute corresponding velocity field.",
             category=RuntimeWarning
         )

--- a/yt/frontends/amrvac/fields.py
+++ b/yt/frontends/amrvac/fields.py
@@ -44,7 +44,7 @@ def _velocity(field, data, idir, prefix=None):
         warnings.warn(
             f"zeros found in {prefix}density, "
             "patching them to compute corresponding velocity field.",
-            category=RuntimeWarning
+            category=RuntimeWarning,
         )
         mask2 = moment == 0
         if not ((mask1 & mask2) == mask1).all():

--- a/yt/frontends/amrvac/fields.py
+++ b/yt/frontends/amrvac/fields.py
@@ -5,9 +5,9 @@ AMRVAC-specific fields
 
 
 import functools
+import warnings
 
 import numpy as np
-import warnings
 
 from yt import mylog
 from yt.fields.field_info_container import FieldInfoContainer

--- a/yt/frontends/amrvac/fields.py
+++ b/yt/frontends/amrvac/fields.py
@@ -40,10 +40,10 @@ def _velocity(field, data, idir, prefix=None):
 
     mask1 = rho == 0
     if mask1.any():
-        mylog.info(
+        warnings.warn(
             "zeros found in %sdensity, "
             "patching them to compute corresponding velocity field.",
-            prefix,
+            category=RuntimeWarning
         )
         mask2 = moment == 0
         if not ((mask1 & mask2) == mask1).all():


### PR DESCRIPTION
## PR Summary
Relegates the notification of zero-density to RuntimeWarning to prevent the copious printing of the same error. Expect this fix to be temporary in the event a debug option is preferred.

Addresses the error in issue #2859.

## PR Checklist

- [x] pass `black --check yt/`
- [x] pass `isort . --check --diff`
- [x] pass `flake8 yt/`
- [x] pass `flynt yt/ --fail-on-change --dry-run -e yt/extern`
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
