### PR TITLE
[bugfix] fix saved FRB dimensions

### DIFF
--- a/yt/frontends/ytdata/tests/test_unit.py
+++ b/yt/frontends/ytdata/tests/test_unit.py
@@ -2,8 +2,17 @@ import os
 import shutil
 import tempfile
 
+import numpy as np
+
 from yt.convenience import load
-from yt.testing import assert_fname, fake_random_ds, requires_file, requires_module
+from yt.frontends.stream.data_structures import load_uniform_grid
+from yt.testing import (
+    assert_array_equal,
+    assert_fname,
+    fake_random_ds,
+    requires_file,
+    requires_module,
+)
 from yt.utilities.answer_testing.framework import data_dir_load
 from yt.visualization.plot_window import ProjectionPlot, SlicePlot
 
@@ -71,6 +80,50 @@ def test_plot_data():
     p = SlicePlot(ds_oas, [1, 1, 1], "density")
     fn = p.save()
     assert_fname(fn[0])
+
+    os.chdir(curdir)
+    if tmpdir != ".":
+        shutil.rmtree(tmpdir)
+
+
+@requires_module("h5py")
+def test_non_square_frb():
+    tmpdir = tempfile.mkdtemp()
+    curdir = os.getcwd()
+    os.chdir(tmpdir)
+
+    # construct an arbitrary dataset
+    arr = np.arange(8.0 * 9.0 * 10.0).reshape((8, 9, 10))
+    data = dict(density=(arr, "g/cm**3"))
+    bbox = np.array([[-4, 4.0], [-4.5, 4.5], [-5.0, 5]])
+    ds = load_uniform_grid(
+        data, arr.shape, length_unit="Mpc", bbox=bbox, periodicity=(False, False, False)
+    )
+
+    # make a slice
+    slc = ds.slice(axis="z", coord=ds.quan(0.0, "code_length"))
+    # make a frb and save it to disk
+    center = (ds.quan(0.0, "code_length"), ds.quan(0.0, "code_length"))
+    xax, yax = ds.coordinates.x_axis[slc.axis], ds.coordinates.y_axis[slc.axis]
+    res = [ds.domain_dimensions[xax], ds.domain_dimensions[yax]]  # = [8,9]
+    width = ds.domain_right_edge[xax] - ds.domain_left_edge[xax]  # = 8 code_length
+    height = ds.domain_right_edge[yax] - ds.domain_left_edge[yax]  # = 9 code_length
+    frb = slc.to_frb(width=width, height=height, resolution=res, center=center)
+    fname = "test_frb_roundtrip.h5"
+    frb.save_as_dataset(fname, fields=["density"])
+
+    expected_vals = arr[:, :, 5].T
+    print(
+        "\nConfirmation that initial frb results are expected:",
+        (expected_vals == frb["density"].v).all(),
+        "\n",
+    )
+
+    # yt-reload:
+    reloaded_ds = load(fname)
+
+    assert_array_equal(frb["density"].shape, reloaded_ds.data["density"].shape)
+    assert_array_equal(frb["density"], reloaded_ds.data["density"])
 
     os.chdir(curdir)
     if tmpdir != ".":

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -534,7 +534,8 @@ class FixedResolutionBuffer:
         extra_attrs["con_args"] = self.data_source._con_args
         extra_attrs["left_edge"] = self.ds.arr([self.bounds[0], self.bounds[2]])
         extra_attrs["right_edge"] = self.ds.arr([self.bounds[1], self.bounds[3]])
-        extra_attrs["ActiveDimensions"] = self.buff_size
+        # The data dimensions are [NY, NX] but buff_size is [NX, NY].
+        extra_attrs["ActiveDimensions"] = self.buff_size[::-1]
         extra_attrs["level"] = 0
         extra_attrs["data_type"] = "yt_frb"
         extra_attrs["container_type"] = self.data_source._type_name


### PR DESCRIPTION
## PR Summary

This fixes Issue #2858. The array dimensions of the FRB were being saved as NX,NY when they should have been saved as NY,NX.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] pass `black --check yt/`
- [x] pass `isort . --check --diff`
- [x] pass `flake8 yt/`
- [x] pass `flynt yt/ --fail-on-change --dry-run -e yt/extern`
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
