### PR TITLE
A path forward for the long-standing periodicity-hack

### DIFF
--- a/doc/source/cookbook/hse_field.py
+++ b/doc/source/cookbook/hse_field.py
@@ -37,9 +37,8 @@ ds.add_field(
 )
 
 # The gradient operator requires periodic boundaries.  This dataset has
-# open boundary conditions.  We need to hack it for now (this will be fixed
-# in future version of yt)
-ds.periodicity = (True, True, True)
+# open boundary conditions.
+ds.force_periodicity()
 
 # Take a slice through the center of the domain
 slc = yt.SlicePlot(ds, 2, ["density", "HSE"], width=(1, "Mpc"))

--- a/doc/source/cookbook/render_two_fields.py
+++ b/doc/source/cookbook/render_two_fields.py
@@ -3,7 +3,7 @@ from yt.visualization.volume_rendering.api import Scene, create_volume_source
 
 filePath = "Sedov_3d/sedov_hdf5_chk_0003"
 ds = yt.load(filePath)
-ds.periodicity = (True, True, True)
+ds.force_periodicity()
 
 sc = Scene()
 

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -293,9 +293,9 @@ class Dataset(abc.ABC):
             raise TypeError(err_msg)
         if len(val) != 3:
             raise ValueError(err_msg)
-        if any(not isinstance(p, bool) for p in val):
+        if any(not isinstance(p, (bool, np.bool_)) for p in val):
             raise TypeError(err_msg)
-        self._periodicity = tuple(val)
+        self._periodicity = tuple(bool(p) for p in val)
 
     def force_periodicity(self, val=True):
         """

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -288,10 +288,14 @@ class Dataset(abc.ABC):
             "In the future, this will become an error. "
             "Use `Dataset.force_periodicity` instead."
         )
-
+        err_msg = f"Expected a 3-element boolean tuple, received `{val}`."
+        if not is_sequence(val):
+            raise TypeError(err_msg)
         if len(val) != 3:
-            raise ValueError("periodicity setter expected a 3-element boolean tuple.")
-        self._periodicity = ensure_tuple(val)
+            raise ValueError(err_msg)
+        if any(not isinstance(p, bool) for p in val):
+            raise TypeError(err_msg)
+        self._periodicity = tuple(val)
 
     def force_periodicity(self, val=True):
         """

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -300,10 +300,9 @@ class Dataset(abc.ABC):
         """
         # This is a user-facing method that embrace a long-standing
         # workaround in yt user codes.
-        try:
-            self._force_periodicity = bool(val)
-        except TypeError as e:
-            raise TypeError("force_periodicity expected a boolean.") from e
+        if not isinstance(val, bool):
+            raise TypeError("force_periodicity expected a boolean.")
+        self._force_periodicity = val
 
     # abstract methods require implementation in subclasses
     @classmethod

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -158,7 +158,8 @@ class Dataset(abc.ABC):
     domain_left_edge = MutableAttribute(True)
     domain_right_edge = MutableAttribute(True)
     domain_dimensions = MutableAttribute(True)
-    periodicity = MutableAttribute()
+    _periodicity = MutableAttribute()
+    _force_periodicity = False
 
     # these are set in self._set_derived_attrs()
     domain_width = MutableAttribute(True)
@@ -272,6 +273,31 @@ class Dataset(abc.ABC):
     @unique_identifier.setter
     def unique_identifier(self, value):
         self._unique_identifier = value
+
+    @property
+    def periodicity(self):
+        if self._force_periodicity:
+            return (True, True, True)
+        return self._periodicity
+
+    @periodicity.setter
+    def periodicity(self, val):
+        # sanitize
+        issue_deprecation_warning(
+            "Dataset.periodicity should not be overriden manually. "
+            "In the future, this will become an error. "
+            "Use `Dataset.force_periodicity` instead."
+        )
+        self._periodicity = tuple(val)
+
+    def force_periodicity(self, val=True):
+        """Override box periodicity to (True, True, True)"""
+        # This is a user-facing method that embrace a long-standing
+        # workaround in yt user codes.
+        try:
+            self._force_periodicity = bool(val)
+        except TypeError as e:
+            raise TypeError("force_periodicity expected a boolean.") from e
 
     # abstract methods require implementation in subclasses
     @classmethod

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -282,16 +282,22 @@ class Dataset(abc.ABC):
 
     @periodicity.setter
     def periodicity(self, val):
-        # sanitize
+        # remove this setter to break backward compatibility
         issue_deprecation_warning(
             "Dataset.periodicity should not be overriden manually. "
             "In the future, this will become an error. "
             "Use `Dataset.force_periodicity` instead."
         )
-        self._periodicity = tuple(val)
+
+        if len(val) != 3:
+            raise ValueError("periodicity setter expected a 3-element boolean tuple.")
+        self._periodicity = ensure_tuple(val)
 
     def force_periodicity(self, val=True):
-        """Override box periodicity to (True, True, True)"""
+        """
+        Override box periodicity to (True, True, True).
+        Use ds.force_periodicty(False) to use the actual box periodicity.
+        """
         # This is a user-facing method that embrace a long-standing
         # workaround in yt user codes.
         try:

--- a/yt/data_objects/tests/test_covering_grid.py
+++ b/yt/data_objects/tests/test_covering_grid.py
@@ -213,7 +213,7 @@ def test_octree_cg():
 
 def test_smoothed_covering_grid_2d_dataset():
     ds = fake_random_ds([32, 32, 1], nprocs=4)
-    ds.periodicity = (True, True, True)
+    ds.force_periodicity()
     scg = ds.smoothed_covering_grid(1, [0.0, 0.0, 0.0], [32, 32, 1])
     assert_equal(scg["density"].shape, [32, 32, 1])
 

--- a/yt/fields/field_detector.py
+++ b/yt/fields/field_detector.py
@@ -60,7 +60,7 @@ class FieldDetector(defaultdict):
             ds.domain_left_edge = np.zeros(3, "float64")
             ds.domain_right_edge = np.ones(3, "float64")
             ds.dimensionality = 3
-            ds.periodicity = (True, True, True)
+            ds.force_periodicity()
         self.ds = ds
 
         class fake_index:

--- a/yt/frontends/adaptahop/data_structures.py
+++ b/yt/frontends/adaptahop/data_structures.py
@@ -107,7 +107,7 @@ class AdaptaHOPDataset(Dataset):
         self.current_time = self.quan(params["age"], "Gyr")
         self.omega_lambda = 0.724  # hard coded if not inferred from parent ds
         self.hubble_constant = 0.7  # hard coded if not inferred from parent ds
-        self.periodicity = (True, True, True)
+        self._periodicity = (True, True, True)
         self.particle_types = "halos"
         self.particle_types_raw = "halos"
 

--- a/yt/frontends/ahf/data_structures.py
+++ b/yt/frontends/ahf/data_structures.py
@@ -103,7 +103,7 @@ class AHFHalosDataset(Dataset):
         self.domain_left_edge = np.array([0.0, 0.0, 0.0])
         # Note that boxsize is in Mpc but particle positions are in kpc.
         self.domain_right_edge = np.array([simu["boxsize"]] * 3) * 1000
-        self.periodicity = (True, True, True)
+        self._periodicity = (True, True, True)
 
         # Set up cosmological information.
         self.cosmological_simulation = 1

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -345,7 +345,7 @@ class AMRVACDataset(Dataset):
         # parse peridiocity
         periodicity = self.parameters.get("periodic", ())
         missing_dim = 3 - len(periodicity)
-        self.periodicity = (*periodicity, *(missing_dim * (False,)))
+        self._periodicity = (*periodicity, *(missing_dim * (False,)))
 
         self.gamma = self.parameters.get("gamma", 5.0 / 3.0)
 

--- a/yt/frontends/art/data_structures.py
+++ b/yt/frontends/art/data_structures.py
@@ -246,7 +246,7 @@ class ARTDataset(Dataset):
         self.domain_right_edge = np.zeros(3, dtype="float") + 1.0
         self.dimensionality = 3
         self.refine_by = 2
-        self.periodicity = (True, True, True)
+        self._periodicity = (True, True, True)
         self.cosmological_simulation = True
         self.parameters = {}
         self.parameters.update(constants)
@@ -525,7 +525,7 @@ class DarkMatterARTDataset(ARTDataset):
         self.domain_right_edge = np.zeros(3, dtype="float") + 1.0
         self.dimensionality = 3
         self.refine_by = 2
-        self.periodicity = (True, True, True)
+        self._periodicity = (True, True, True)
         self.cosmological_simulation = True
         self.parameters = {}
         self.parameters.update(constants)

--- a/yt/frontends/artio/data_structures.py
+++ b/yt/frontends/artio/data_structures.py
@@ -483,7 +483,7 @@ class ARTIODataset(Dataset):
             self.parameters["unit_m"] = self.artio_parameters["mass_unit"][0]
 
         # hard coded assumption of 3D periodicity
-        self.periodicity = (True, True, True)
+        self._periodicity = (True, True, True)
 
     def create_field_info(self):
         super(ARTIODataset, self).create_field_info()

--- a/yt/frontends/athena/data_structures.py
+++ b/yt/frontends/athena/data_structures.py
@@ -591,7 +591,7 @@ class AthenaDataset(Dataset):
         self.num_ghost_zones = 0
         self.field_ordering = "fortran"
         self.boundary_conditions = [1] * 6
-        self.periodicity = tuple(
+        self._periodicity = tuple(
             self.specified_parameters.get("periodicity", (True, True, True))
         )
         if "gamma" in self.specified_parameters:

--- a/yt/frontends/athena_pp/data_structures.py
+++ b/yt/frontends/athena_pp/data_structures.py
@@ -331,7 +331,7 @@ class AthenaPPDataset(Dataset):
         self.num_ghost_zones = 0
         self.field_ordering = "fortran"
         self.boundary_conditions = [1] * 6
-        self.periodicity = tuple(
+        self._periodicity = tuple(
             self.specified_parameters.get("periodicity", (True, True, True))
         )
         if "gamma" in self.specified_parameters:

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -762,7 +762,7 @@ class BoxlibDataset(Dataset):
                 assert len(vals) == self.dimensionality
                 periodicity = [False, False, False]  # default to non periodic
                 periodicity[: self.dimensionality] = vals  # fill in ndim parsed values
-                self.periodicity = tuple(periodicity)
+                self._periodicity = tuple(periodicity)
             elif param == "castro.use_comoving":
                 vals = self.cosmological_simulation = int(vals)
             else:
@@ -1139,7 +1139,7 @@ class CastroDataset(BoxlibDataset):
             except KeyError:
                 break
 
-        self.periodicity = tuple(periodicity)
+        self._periodicity = tuple(periodicity)
 
         if os.path.isdir(os.path.join(self.output_dir, "Tracer")):
             # we have particles
@@ -1211,7 +1211,7 @@ class MaestroDataset(BoxlibDataset):
             except KeyError:
                 pass
 
-        self.periodicity = tuple(periodicity)
+        self._periodicity = tuple(periodicity)
 
 
 class NyxHierarchy(BoxlibHierarchy):
@@ -1573,7 +1573,7 @@ class WarpXDataset(BoxlibDataset):
             periodicity[: len(is_periodic)] = [p == "1" for p in is_periodic]
         except KeyError:
             pass
-        self.periodicity = tuple(periodicity)
+        self._periodicity = tuple(periodicity)
 
         particle_types = glob.glob(self.output_dir + "/*/Header")
         particle_types = [cpt.split(os.sep)[-2] for cpt in particle_types]

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -632,7 +632,7 @@ class BoxlibDataset(Dataset):
     _field_info_class = BoxlibFieldInfo
     _output_prefix = None
     _default_cparam_filename = "job_info"
-    periodicity = (False, False, False)
+    _periodicity = (False, False, False)
 
     def __init__(
         self,

--- a/yt/frontends/chombo/data_structures.py
+++ b/yt/frontends/chombo/data_structures.py
@@ -334,7 +334,7 @@ class ChomboDataset(Dataset):
                 ]
             except KeyError:
                 is_periodic[dir] = True
-        self.periodicity = tuple(is_periodic)
+        self._periodicity = tuple(is_periodic)
 
     def _calc_left_edge(self):
         fileh = self._handle
@@ -516,7 +516,7 @@ class PlutoDataset(ChomboDataset):
             ):
                 domain_left_edge[il] = float(ll.split()[2])
                 domain_right_edge[il] = float(ll.split()[-1])
-            self.periodicity = [0] * 3
+            self._periodicity = [0] * 3
             for il, ll in enumerate(
                 lines[
                     lines.index("[Boundary]")
@@ -526,7 +526,7 @@ class PlutoDataset(ChomboDataset):
                 ]
             ):
                 self.periodicity[il] = ll.split()[1] == "periodic"
-            self.periodicity = tuple(self.periodicity)
+            self._periodicity = tuple(self.periodicity)
             for ll in lines[lines.index("[Parameters]") + 2 :]:
                 if ll.split()[0] == "GAMMA":
                     self.gamma = float(ll.split()[1])
@@ -535,7 +535,7 @@ class PlutoDataset(ChomboDataset):
         else:
             self.domain_left_edge = self._calc_left_edge()
             self.domain_right_edge = self._calc_right_edge()
-            self.periodicity = (True, True, True)
+            self._periodicity = (True, True, True)
 
         # if a lower-dimensional dataset, set up pseudo-3D stuff here.
         if self.dimensionality == 1:

--- a/yt/frontends/enzo/data_structures.py
+++ b/yt/frontends/enzo/data_structures.py
@@ -774,7 +774,7 @@ class EnzoDataset(Dataset):
         internal = p["Internal"]
         phys = p["Physics"]
         self.refine_by = sim["AMR"]["RefineBy"]
-        self.periodicity = tuple(
+        self._periodicity = tuple(
             a == 3 for a in sim["Domain"]["LeftFaceBoundaryCondition"]
         )
         self.dimensionality = sim["Domain"]["TopGridRank"]
@@ -853,7 +853,7 @@ class EnzoDataset(Dataset):
             else:
                 self.parameters[param] = vals
         self.refine_by = self.parameters["RefineBy"]
-        self.periodicity = tuple(
+        self._periodicity = tuple(
             always_iterable(self.parameters["LeftFaceBoundaryCondition"] == 3)
         )
         self.dimensionality = self.parameters["TopGridRank"]
@@ -1031,7 +1031,7 @@ class EnzoDatasetInMemory(EnzoDataset):
         for p, v in self._conversion_override.items():
             self.conversion_factors[p] = v
         self.refine_by = self.parameters["RefineBy"]
-        self.periodicity = tuple(
+        self._periodicity = tuple(
             always_iterable(self.parameters["LeftFaceBoundaryCondition"] == 3)
         )
         self.dimensionality = self.parameters["TopGridRank"]

--- a/yt/frontends/enzo_p/data_structures.py
+++ b/yt/frontends/enzo_p/data_structures.py
@@ -351,7 +351,7 @@ class EnzoPDataset(Dataset):
         root_blocks = get_root_blocks(b0)
         f.close()
         self.dimensionality = left0.size
-        self.periodicity = tuple(np.ones(self.dimensionality, dtype=bool))
+        self._periodicity = tuple(np.ones(self.dimensionality, dtype=bool))
 
         lcfn = self.parameter_filename[: -len(self._suffix)] + ".libconfig"
         if os.path.exists(lcfn):

--- a/yt/frontends/exodus_ii/data_structures.py
+++ b/yt/frontends/exodus_ii/data_structures.py
@@ -169,7 +169,7 @@ class ExodusIIDataset(Dataset):
             self.parameters["elem_names"] = self._get_elem_names()
             self.parameters["nod_names"] = self._get_nod_names()
             self.domain_left_edge, self.domain_right_edge = self._load_domain_edge()
-            self.periodicity = (False, False, False)
+            self._periodicity = (False, False, False)
 
         # These attributes don't really make sense for unstructured
         # mesh data, but yt warns if they are not present, so we set

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -460,7 +460,7 @@ class FITSDataset(Dataset):
             pass
 
         # For now we'll ignore these
-        self.periodicity = (False,) * 3
+        self._periodicity = (False,) * 3
         self.current_redshift = (
             self.omega_lambda
         ) = (

--- a/yt/frontends/flash/data_structures.py
+++ b/yt/frontends/flash/data_structures.py
@@ -433,7 +433,7 @@ class FLASHDataset(Dataset):
             self.parameters.get(f"{ax}l_boundary_type", None) == "periodic"
             for ax in "xyz"
         ]
-        self.periodicity = tuple(p)
+        self._periodicity = tuple(p)
 
         # Determine cosmological parameters.
         try:

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -358,7 +358,7 @@ class GadgetDataset(SPHDataset):
             self.domain_right_edge = np.ones(3, "float64") * hvals["BoxSize"]
 
         self.domain_dimensions = np.ones(3, "int32")
-        self.periodicity = (True, True, True)
+        self._periodicity = (True, True, True)
 
         self.cosmological_simulation = 1
 
@@ -629,7 +629,7 @@ class GadgetHDF5Dataset(GadgetDataset):
         self.domain_dimensions = np.ones(3, "int32")
 
         self.cosmological_simulation = 1
-        self.periodicity = (True, True, True)
+        self._periodicity = (True, True, True)
 
         prefix = os.path.abspath(
             os.path.join(

--- a/yt/frontends/gadget_fof/data_structures.py
+++ b/yt/frontends/gadget_fof/data_structures.py
@@ -217,7 +217,7 @@ class GadgetFOFDataset(ParticleDataset):
         self.domain_right_edge = np.ones(3, "float64") * self.parameters["BoxSize"]
         self.domain_dimensions = np.ones(3, "int32")
         self.cosmological_simulation = 1
-        self.periodicity = (True, True, True)
+        self._periodicity = (True, True, True)
         self.current_redshift = self.parameters["Redshift"]
         self.omega_lambda = self.parameters["OmegaLambda"]
         self.omega_matter = self.parameters["Omega0"]

--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -321,7 +321,7 @@ class GAMERDataset(Dataset):
             periodic_bc = 1
         else:
             periodic_bc = 0
-        self.periodicity = (
+        self._periodicity = (
             bool(parameters["Opt__BC_Flu"][0] == periodic_bc),
             bool(parameters["Opt__BC_Flu"][2] == periodic_bc),
             bool(parameters["Opt__BC_Flu"][4] == periodic_bc),

--- a/yt/frontends/gdf/data_structures.py
+++ b/yt/frontends/gdf/data_structures.py
@@ -264,7 +264,7 @@ class GDFDataset(Dataset):
         self.num_ghost_zones = sp["num_ghost_zones"]
         self.field_ordering = sp["field_ordering"]
         self.boundary_conditions = sp["boundary_conditions"][:]
-        self.periodicity = tuple(bnd == 0 for bnd in self.boundary_conditions[::2])
+        self._periodicity = tuple(bnd == 0 for bnd in self.boundary_conditions[::2])
         if self.cosmological_simulation:
             self.current_redshift = sp["current_redshift"]
             self.omega_lambda = sp["omega_lambda"]

--- a/yt/frontends/halo_catalog/data_structures.py
+++ b/yt/frontends/halo_catalog/data_structures.py
@@ -160,7 +160,7 @@ class YTHaloCatalogDataset(SavedDataset):
         self.refine_by = 2
         self.dimensionality = 3
         self.domain_dimensions = np.ones(self.dimensionality, "int32")
-        self.periodicity = (True, True, True)
+        self._periodicity = (True, True, True)
         prefix = ".".join(self.parameter_filename.rsplit(".", 2)[:-2])
         self.filename_template = f"{prefix}.%(num)s{self._suffix}"
         self.file_count = len(glob.glob(prefix + "*" + self._suffix))

--- a/yt/frontends/http_stream/data_structures.py
+++ b/yt/frontends/http_stream/data_structures.py
@@ -64,7 +64,7 @@ class HTTPStreamDataset(ParticleDataset):
         self.domain_left_edge = np.array(header["domain_left_edge"], "float64")
         self.domain_right_edge = np.array(header["domain_right_edge"], "float64")
         self.domain_dimensions = np.ones(3, "int32")
-        self.periodicity = (True, True, True)
+        self._periodicity = (True, True, True)
 
         self.current_time = header["current_time"]
         self.unique_identifier = header.get("unique_identifier", time.time())

--- a/yt/frontends/nc4_cm1/data_structures.py
+++ b/yt/frontends/nc4_cm1/data_structures.py
@@ -160,7 +160,7 @@ class CM1Dataset(Dataset):
 
         self.dimensionality = 3
         self.domain_dimensions = np.array(dims, dtype="int64")
-        self.periodicity = (False, False, False)
+        self._periodicity = (False, False, False)
 
         # Set cosmological information to zero for non-cosmological.
         self.cosmological_simulation = 0

--- a/yt/frontends/open_pmd/data_structures.py
+++ b/yt/frontends/open_pmd/data_structures.py
@@ -556,7 +556,7 @@ class OpenPMDDataset(Dataset):
 
         self.unique_identifier = 0
         self.parameters = 0
-        self.periodicity = np.zeros(3, dtype=np.bool)
+        self._periodicity = np.zeros(3, dtype=np.bool)
         self.refine_by = 1
         self.cosmological_simulation = 0
 

--- a/yt/frontends/owls_subfind/data_structures.py
+++ b/yt/frontends/owls_subfind/data_structures.py
@@ -117,7 +117,7 @@ class OWLSSubfindDataset(ParticleDataset):
         self.domain_right_edge = np.ones(3, "float64") * hvals["BoxSize"]
         self.domain_dimensions = np.ones(3, "int32")
         self.cosmological_simulation = 1
-        self.periodicity = (True, True, True)
+        self._periodicity = (True, True, True)
         self.current_redshift = hvals["Redshift"]
         self.omega_lambda = hvals["OmegaLambda"]
         self.omega_matter = hvals["Omega0"]

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -876,7 +876,7 @@ class RAMSESDataset(Dataset):
         self.domain_right_edge = np.ones(3, dtype="float64")
         # This is likely not true, but it's not clear
         # how to determine the boundary conditions
-        self.periodicity = (True, True, True)
+        self._periodicity = (True, True, True)
 
         if self.force_cosmological is not None:
             is_cosmological = self.force_cosmological

--- a/yt/frontends/rockstar/data_structures.py
+++ b/yt/frontends/rockstar/data_structures.py
@@ -94,7 +94,7 @@ class RockstarDataset(ParticleDataset):
         self.current_time = cosmo.lookback_time(self.current_redshift, 1e6).in_units(
             "s"
         )
-        self.periodicity = (True, True, True)
+        self._periodicity = (True, True, True)
         self.particle_types = "halos"
         self.particle_types_raw = "halos"
 

--- a/yt/frontends/sdf/data_structures.py
+++ b/yt/frontends/sdf/data_structures.py
@@ -122,9 +122,9 @@ class SDFDataset(ParticleDataset):
 
         self.domain_dimensions = np.ones(3, "int32")
         if "do_periodic" in self.parameters and self.parameters["do_periodic"]:
-            self.periodicity = (True, True, True)
+            self._periodicity = (True, True, True)
         else:
-            self.periodicity = (False, False, False)
+            self._periodicity = (False, False, False)
 
         self.cosmological_simulation = 1
 

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -106,7 +106,7 @@ class StreamHandler:
         self.code_units = code_units
         self.io = io
         self.particle_types = particle_types
-        self._periodicity = periodicity
+        self.periodicity = periodicity
 
     def get_fields(self):
         return self.fields.all_fields

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -106,7 +106,7 @@ class StreamHandler:
         self.code_units = code_units
         self.io = io
         self.particle_types = particle_types
-        self.periodicity = periodicity
+        self._periodicity = periodicity
 
     def get_fields(self):
         return self.fields.all_fields
@@ -291,7 +291,7 @@ class StreamDataset(Dataset):
         self.domain_right_edge = self.stream_handler.domain_right_edge.copy()
         self.refine_by = self.stream_handler.refine_by
         self.dimensionality = self.stream_handler.dimensionality
-        self.periodicity = self.stream_handler.periodicity
+        self._periodicity = self.stream_handler.periodicity
         self.domain_dimensions = self.stream_handler.domain_dimensions
         self.current_time = self.stream_handler.simulation_time
         self.gamma = 5.0 / 3.0

--- a/yt/frontends/swift/data_structures.py
+++ b/yt/frontends/swift/data_structures.py
@@ -107,9 +107,9 @@ class SwiftDataset(SPHDataset):
         periodic = int(runtime_parameters["PeriodicBoundariesOn"])
 
         if periodic:
-            self.periodicity = [True] * self.dimensionality
+            self._periodicity = [True] * self.dimensionality
         else:
-            self.periodicity = [False] * self.dimensionality
+            self._periodicity = [False] * self.dimensionality
 
         # Units get attached to this
         self.current_time = float(header["Time"])

--- a/yt/frontends/tipsy/data_structures.py
+++ b/yt/frontends/tipsy/data_structures.py
@@ -168,7 +168,7 @@ class TipsyDataset(SPHDataset):
         self.domain_dimensions = np.ones(3, "int32")
         periodic = self.parameters.get("bPeriodic", True)
         period = self.parameters.get("dPeriod", None)
-        self.periodicity = (periodic, periodic, periodic)
+        self._periodicity = (periodic, periodic, periodic)
         self.cosmological_simulation = float(
             self.parameters.get("bComove", self._cosmology_parameters is not None)
         )

--- a/yt/frontends/ytdata/data_structures.py
+++ b/yt/frontends/ytdata/data_structures.py
@@ -519,7 +519,7 @@ class YTGridDataset(YTDataset):
                     self.domain_right_edge - self.domain_left_edge
                 ) / self.domain_dimensions
 
-            self.periodicity = (
+            self._periodicity = (
                 np.abs(self.domain_left_edge - self.base_domain_left_edge) < 0.5 * dx
             )
             self.periodicity &= (

--- a/yt/frontends/ytdata/data_structures.py
+++ b/yt/frontends/ytdata/data_structures.py
@@ -103,7 +103,12 @@ class SavedDataset(Dataset):
             del self.parameters[par]
 
         for attr in self._con_attrs:
-            setattr(self, attr, self.parameters.get(attr))
+            try:
+                setattr(self, attr, self.parameters.get(attr))
+            except TypeError:
+                # some Dataset attributes are properties with setters
+                # which may not accept None as an input
+                pass
 
         if self.geometry is None:
             self.geometry = "cartesian"

--- a/yt/geometry/_selection_routines/region_selector.pxi
+++ b/yt/geometry/_selection_routines/region_selector.pxi
@@ -66,8 +66,8 @@ cdef class RegionSelector(SelectorObject):
                         "up to the domain boundary. Two possible solutions are to "
                         "select a smaller region that does not border domain edge "
                         "(see https://yt-project.org/docs/analyzing/objects.html?highlight=region)\n"
-                        "or override the periodicity with e.g\n"
-                        "ds.periodicity = 3*[True]" % \
+                        "or override the periodicity with\n"
+                        "ds.force_periodicity()" % \
                         (i, dobj.left_edge[i], dobj.right_edge[i],
                          dobj.ds.domain_left_edge[i], dobj.ds.domain_right_edge[i])
                     )


### PR DESCRIPTION
## PR Summary

There's a long standing hack in yt user codes, that's been encouraged in the cookbook itself for lack of a better approach where some methods require periodicity in the simulation box to function. For instance

```python
ds = yt.load(filename)
ds.periodicity = (True, True, True)
yt.boundary_requiring_method()
```

Here I propose to separate this hack from the normal setup for the underlying periodicity attribute, by introducing a user-facing `Dataset.force_periodicity()` method and protecting the original data in a hidden attribute `Dataset._periodicity` that is accessed in other classes as a property `Dataset.periodicity`.

This provides a way forward in making this hack unnecessary. For instance:
- in 4.0, keep backwards compatibility but deprecate the old hack in favour of `force_periodicity`
- in 4.1, remove the setter (break backwards compatibility) so that
```python
ds.periodicity = (True, True, True)
```
becomes an error.
We can also start using `force_periodicity` internally in methods that can't work without it, which would provide the following benefits:
- make the hack completely unnecessary in user codes (but a warning would still be due)
- give devs an easy way to track down where the hack is used so it can be fixed.

I'll need to add some documentation for this.
A nice followup to this would be to harmonize type diversity in existing _periodicity attributes: most are tuples, but some are lists, or ndarrays.

## PR Checklist

- [x] pass `black --check yt/`
- [x] pass `isort . --check --diff`
- [x] pass `flake8 yt/`
- [x] pass `flynt yt/ --fail-on-change --dry-run -e yt/extern`
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

