### PR TITLE
expose ytLogger.setLevel with a user facing method yt.set_log_level

### DIFF
--- a/doc/source/faq/index.rst
+++ b/doc/source/faq/index.rst
@@ -440,6 +440,12 @@ which would produce debug (as well as info, warning, and error) messages, or at 
 
    yt.set_log_level("error")
 
+This is the same as doing:
+
+.. code-block:: python
+
+   yt.set_log_level(40)
+
 which in this case would suppress everything below error messages. For reference,
 the numerical values corresponding to different log levels are:
 

--- a/doc/source/faq/index.rst
+++ b/doc/source/faq/index.rst
@@ -423,12 +423,12 @@ behavior in yt-3.0.
 How can I change yt's log level?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-yt's default log level is ``INFO``. However, you may want less voluminous logging, especially
-if you are in an IPython notebook or running a long or parallel script. On the other
-hand, you may want it to output a lot more, since you can't figure out exactly what's going
-wrong, and you want to output some debugging information. The yt log level can be
-changed using the :ref:`configuration-file`, either by setting it in the
-``$HOME/.config/yt/ytrc`` file:
+yt's default log level is ``INFO``. However, you may want less voluminous logging,
+especially if you are in an IPython notebook or running a long or parallel script.
+On the other hand, you may want it to output a lot more, since you can't figure out
+exactly what's going wrong, and you want to output some debugging information.
+The default yt log level can be changed using the :ref:`configuration-file`,
+either by setting it in the ``$HOME/.config/yt/ytrc`` file:
 
 .. code-block:: bash
 
@@ -438,11 +438,10 @@ which would produce debug (as well as info, warning, and error) messages, or at 
 
 .. code-block:: python
 
-   from yt.funcs import mylog
-   mylog.setLevel(40) # This sets the log level to "ERROR"
+   yt.set_log_level("error")
 
-which in this case would suppress everything below error messages. For reference, the numerical
-values corresponding to different log levels are:
+which in this case would suppress everything below error messages. For reference,
+the numerical values corresponding to different log levels are:
 
 .. csv-table::
    :header: Level, Numeric Value

--- a/doc/source/reference/configuration.rst
+++ b/doc/source/reference/configuration.rst
@@ -63,7 +63,7 @@ Here is an example script, where we adjust the logging at startup:
 .. code-block:: python
 
    import yt
-   yt.funcs.mylog.setLevel(1)
+   yt.set_log_level(1)
 
    ds = yt.load("my_data0001")
    ds.print_stats()

--- a/yt/__init__.py
+++ b/yt/__init__.py
@@ -39,6 +39,8 @@ from yt.funcs import (
     toggle_interactivity,
 )
 from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import set_log_level
+
 
 import yt.utilities.physical_constants as physical_constants
 import yt.units as units

--- a/yt/mods.py
+++ b/yt/mods.py
@@ -12,12 +12,12 @@ import os
 import yt.startup_tasks as __startup_tasks
 from yt import *
 from yt.config import ytcfg, ytcfg_defaults
-from yt.utilities.logger import level as __level
+from yt.utilities.logger import _level
 
 unparsed_args = __startup_tasks.unparsed_args
 
 
-if __level >= int(ytcfg_defaults["loglevel"]):
+if _level >= int(ytcfg_defaults["loglevel"]):
     # This won't get displayed.
     mylog.debug("Turning off NumPy error reporting")
     np.seterr(all="ignore")

--- a/yt/utilities/logger.py
+++ b/yt/utilities/logger.py
@@ -93,6 +93,8 @@ def uncolorize_logging():
         pass
 
 
+_level = min(max(ytcfg.getint("yt", "loglevel"), 0), 50)
+
 if ytcfg.getboolean("yt", "suppressStreamLogging"):
     disable_stream_logging()
 else:
@@ -102,8 +104,7 @@ else:
     yt_sh.setFormatter(formatter)
     # add the handler to the logger
     ytLogger.addHandler(yt_sh)
-    level = min(max(ytcfg.getint("yt", "loglevel"), 0), 50)
-    set_log_level(level)
+    set_log_level(_level)
     ytLogger.propagate = False
 
     original_emitter = yt_sh.emit

--- a/yt/utilities/logger.py
+++ b/yt/utilities/logger.py
@@ -47,16 +47,12 @@ def set_log_level(level):
         50 or "critical"
     """
     # this is a user-facing interface to avoid importing from yt.utilities in user code.
+
     if isinstance(level, str):
-        level = {
-            "notset": 0,
-            "all": 1,
-            "debug": 10,
-            "info": 20,
-            "warning": 30,
-            "error": 40,
-            "critical": 50,
-        }[level.lower()]
+        level = level.upper()
+
+    if level == "ALL":  # non-standard alias
+        level = 1
     ytLogger.setLevel(level)
     ytLogger.debug("Set log level to %d", level)
 

--- a/yt/utilities/logger.py
+++ b/yt/utilities/logger.py
@@ -30,7 +30,37 @@ def add_coloring_to_emit_ansi(fn):
     return new
 
 
-level = min(max(ytcfg.getint("yt", "loglevel"), 0), 50)
+def set_log_level(level):
+    """
+    Select which minimal logging level should be displayed.
+
+    Parameters
+    ----------
+    level: int or str
+        Possible values by increasing level:
+        0 or "notset"
+        1 or "all"
+        10 or "debug"
+        20 or "info"
+        30 or "warning"
+        40 or "error"
+        50 or "critical"
+    """
+    # this is a user-facing interface to avoid importing from yt.utilities in user code.
+    if isinstance(level, str):
+        level = {
+            "notset": 0,
+            "all": 1,
+            "debug": 10,
+            "info": 20,
+            "warning": 30,
+            "error": 40,
+            "critical": 50,
+        }[level.lower()]
+    ytLogger.setLevel(level)
+    ytLogger.debug("Set log level to %d", level)
+
+
 ufstring = "%(name)-3s: [%(levelname)-9s] %(asctime)s %(message)s"
 cfstring = "%(name)-3s: [%(levelname)-18s] %(asctime)s %(message)s"
 
@@ -76,12 +106,11 @@ else:
     yt_sh.setFormatter(formatter)
     # add the handler to the logger
     ytLogger.addHandler(yt_sh)
-    ytLogger.setLevel(level)
+    level = min(max(ytcfg.getint("yt", "loglevel"), 0), 50)
+    set_log_level(level)
     ytLogger.propagate = False
 
     original_emitter = yt_sh.emit
 
     if ytcfg.getboolean("yt", "coloredlogs"):
         colorize_logging()
-
-ytLogger.debug("Set log level to %s", level)

--- a/yt/utilities/tests/test_set_log_level.py
+++ b/yt/utilities/tests/test_set_log_level.py
@@ -1,0 +1,19 @@
+from yt.testing import assert_raises
+from yt.utilities.logger import set_log_level
+
+
+def test_valid_level():
+    # test a subset of valid entries to cover
+    # - case-insensitivity
+    # - integer values
+    # - "all" alias, which isn't standard
+    for lvl in ("all", "ALL", 10, 42, "info", "warning", "ERROR", "CRITICAL"):
+        set_log_level(lvl)
+
+
+def test_invalid_level():
+    # these are the exceptions raised by logging.Logger.setLog
+    # since they are perfectly clear and readable, we check that nothing else
+    # happens in the wrapper
+    assert_raises(TypeError, set_log_level, 1.5)
+    assert_raises(ValueError, set_log_level, "invalid_level")


### PR DESCRIPTION
## PR Summary

It is often useful to change the logging level at runtime. Currently, the recommended way to do this is by importing the logger object itself and call its `setLevel` method.
I propose the addition of a user facing method `yt.set_log_level` that provides the following benefit:
- avoid importing ytLogger itself (especially under the somewhat confusing alias "mylog")
- more user-friendly interface: recognise lower-case strings as aliases for integers logging levels, also produce more readable user code for people that are not used to logging in general (which I guess is most of the user base)
- add a string alias "ALL" (or "all") for logging level `1`, which isn't in the standard library but fits other parts of yt rather nicely.

here's a dummy example
```python
import yt
for lvl in ("all", 10, "info", "warning", "ERROR", "CRITICAL"):
   print(f"using level {lvl}")
   yt.set_log_level(lvl)
   yt.load("amrvac/bw_2d0000.dat")
   print("loaded !")
```

```
# output
using level all
yt : [DEBUG    ] 2020-08-15 12:10:41,358 Set log level to 1
yt : [INFO     ] 2020-08-15 12:10:41,416 Parameters: current_time              = 0.05
yt : [INFO     ] 2020-08-15 12:10:41,416 Parameters: domain_dimensions         = [32 32  1]
yt : [INFO     ] 2020-08-15 12:10:41,416 Parameters: domain_left_edge          = [1.         0.12566371 0.        ]
yt : [INFO     ] 2020-08-15 12:10:41,416 Parameters: domain_right_edge         = [3.         3.01592895 1.        ]
yt : [INFO     ] 2020-08-15 12:10:41,417 Parameters: cosmological_simulation   = 0
loaded !
using level 10
yt : [DEBUG    ] 2020-08-15 12:10:41,417 Set log level to 10
yt : [INFO     ] 2020-08-15 12:10:41,469 Parameters: current_time              = 0.05
yt : [INFO     ] 2020-08-15 12:10:41,469 Parameters: domain_dimensions         = [32 32  1]
yt : [INFO     ] 2020-08-15 12:10:41,470 Parameters: domain_left_edge          = [1.         0.12566371 0.        ]
yt : [INFO     ] 2020-08-15 12:10:41,470 Parameters: domain_right_edge         = [3.         3.01592895 1.        ]
yt : [INFO     ] 2020-08-15 12:10:41,470 Parameters: cosmological_simulation   = 0
loaded !
using level info
yt : [INFO     ] 2020-08-15 12:10:41,524 Parameters: current_time              = 0.05
yt : [INFO     ] 2020-08-15 12:10:41,524 Parameters: domain_dimensions         = [32 32  1]
yt : [INFO     ] 2020-08-15 12:10:41,524 Parameters: domain_left_edge          = [1.         0.12566371 0.        ]
yt : [INFO     ] 2020-08-15 12:10:41,524 Parameters: domain_right_edge         = [3.         3.01592895 1.        ]
yt : [INFO     ] 2020-08-15 12:10:41,525 Parameters: cosmological_simulation   = 0
loaded !
using level warning
loaded !
using level ERROR
loaded !
using level CRITICAL
loaded !
````
## PR Checklist

- [x] pass `black --check yt/`
- [x] pass `isort . --check --diff`
- [x] pass `flake8 yt/`
- [x] pass `flynt yt/ --fail-on-change --dry-run -e yt/extern`
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.
