### PR TITLE
Solve some h5py deprecation warnings

### DIFF
--- a/.github/workflows/rules-checks.yaml
+++ b/.github/workflows/rules-checks.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: check h5py import
+    - name: check-h5py-import
       # check that we don't alias h5py to h5
       # reason: discoverability is important since this module's api
       # is unstable and we want to be able to check for potential future failures
@@ -24,7 +24,7 @@ jobs:
       # check that a mode argument is always present in calls to h5py.File()
       # reason: the default value is different in older versions 'w' VS newer ones 'r'
       run: |
-        egrep -r -n "h5py\.File\([^,]+\)" yt > h5-mode.log
+        grep -E -r -n "h5py\.File\([^,]+\)" yt | cat > h5-mode.log
         if [ -s h5-mode.log ] ; then
           echo "h5py.File() should never be called without an explicit mode argument."
           echo "Here are the faulty lines."

--- a/.github/workflows/rules-checks.yaml
+++ b/.github/workflows/rules-checks.yaml
@@ -1,0 +1,33 @@
+name: Auto review bad practice
+on: [pull_request]
+
+jobs:
+  h5py-bad-practices:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: check h5py import
+      # check that we don't alias h5py to h5
+      # reason: discoverability is important since this module's api
+      # is unstable and we want to be able to check for potential future failures
+      id: h5-import
+      run: |
+        grep -r -n "import _h5py as h5" yt | grep -v "import _h5py as h5py" | cat > h5-imports.log
+        if [ -s h5-imports.log ] ; then
+          echo "Please do not import h5py as h5. Here are the faulty lines."
+          cat h5-imports.log
+          exit 1
+        fi
+
+    - name: check-h5py-filemode
+      id: h5-file-mode
+      # check that a mode argument is always present in calls to h5py.File()
+      # reason: the default value is different in older versions 'w' VS newer ones 'r'
+      run: |
+        egrep -r -n "h5py\.File\([^,]+\)" yt > h5-mode.log
+        if [ -s h5-mode.log ] ; then
+          echo "h5py.File() should never be called without an explicit mode argument."
+          echo "Here are the faulty lines."
+          cat h5-mode.log
+          exit 1
+        fi

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -69,7 +69,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
 
     def _yield_coordinates(self, data_file, needed_ptype=None):
         si, ei = data_file.start, data_file.end
-        f = h5py.File(data_file.filename, "r")
+        f = h5py.File(data_file.filename, mode="r")
         pcount = f["/Header"].attrs["NumPart_ThisFile"][:].astype("int")
         np.clip(pcount - si, 0, ei - si, out=pcount)
         pcount = pcount.sum()

--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -60,7 +60,7 @@ class GAMERHierarchy(GridIndex):
     def _parse_index(self):
         parameters = self.dataset.parameters
         gid0 = 0
-        grid_corner = self._handle["Tree/Corner"].value[:: self.pgroup]
+        grid_corner = self._handle["Tree/Corner"][()][:: self.pgroup]
         convert2physical = self._handle["Tree/Corner"].attrs["Cvt2Phy"]
 
         self.grid_dimensions[:] = parameters["PatchSize"] * self.refine_by
@@ -99,7 +99,7 @@ class GAMERHierarchy(GridIndex):
         # number of particles in each grid
         try:
             self.grid_particle_count[:] = np.sum(
-                self._handle["Tree/NPar"].value.reshape(-1, self.pgroup), axis=1
+                self._handle["Tree/NPar"][()].reshape(-1, self.pgroup), axis=1
             )[:, None]
         except KeyError:
             self.grid_particle_count[:] = 0.0
@@ -113,7 +113,7 @@ class GAMERHierarchy(GridIndex):
         )
 
     def _populate_grid_objects(self):
-        son_list = self._handle["Tree/Son"].value
+        son_list = self._handle["Tree/Son"][()]
 
         for gid in range(self.num_grids):
             grid = self.grids[gid]
@@ -139,7 +139,7 @@ class GAMERHierarchy(GridIndex):
     def _validate_parent_children_relationship(self):
         mylog.info("Validating the parent-children relationship ...")
 
-        father_list = self._handle["Tree/Father"].value
+        father_list = self._handle["Tree/Father"][()]
 
         for grid in self.grids:
             # parent->children == itself

--- a/yt/frontends/gdf/data_structures.py
+++ b/yt/frontends/gdf/data_structures.py
@@ -202,7 +202,7 @@ class GDFDataset(Dataset):
         if "dataset_units" in h5f:
             for unit_name in h5f["/dataset_units"]:
                 current_unit = h5f[f"/dataset_units/{unit_name}"]
-                value = current_unit.value
+                value = current_unit[()]
                 unit = current_unit.attrs["unit"]
                 # need to convert to a Unit object and check dimensions
                 # because unit can be things like

--- a/yt/frontends/open_pmd/data_structures.py
+++ b/yt/frontends/open_pmd/data_structures.py
@@ -15,7 +15,7 @@ from yt.funcs import setdefaultattr
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.utilities.file_handler import HDF5FileHandler, warn_h5py
 from yt.utilities.logger import ytLogger as mylog
-from yt.utilities.on_demand_imports import _h5py as h5
+from yt.utilities.on_demand_imports import _h5py as h5py
 
 ompd_known_versions = [
     StrictVersion("1.0.0"),
@@ -133,7 +133,7 @@ class OpenPMDHierarchy(GridIndex):
                     for axis in mesh.keys():
                         mesh_fields.append(mname.replace("_", "-") + "_" + axis)
                 except AttributeError:
-                    # This is a h5.Dataset (i.e. no axes)
+                    # This is a h5py.Dataset (i.e. no axes)
                     mesh_fields.append(mname.replace("_", "-"))
         except (KeyError, TypeError, AttributeError):
             pass
@@ -218,7 +218,7 @@ class OpenPMDHierarchy(GridIndex):
             meshes = f[bp + mp]
             for mname in meshes.keys():
                 mesh = meshes[mname]
-                if isinstance(mesh, h5.Group):
+                if isinstance(mesh, h5py.Group):
                     shape = mesh[list(mesh.keys())[0]].shape
                 else:
                     shape = mesh.shape
@@ -568,7 +568,7 @@ class OpenPMDDataset(Dataset):
             meshes = f[bp + mp]
             for mname in meshes.keys():
                 mesh = meshes[mname]
-                if isinstance(mesh, h5.Group):
+                if isinstance(mesh, h5py.Group):
                     shape = np.asarray(mesh[list(mesh.keys())[0]].shape)
                 else:
                     shape = np.asarray(mesh.shape)
@@ -612,7 +612,7 @@ class OpenPMDDataset(Dataset):
         """
         warn_h5py(args[0])
         try:
-            with h5.File(args[0], "r") as f:
+            with h5py.File(args[0], mode="r") as f:
                 attrs = list(f["/"].attrs.keys())
                 for i in opmd_required_attributes:
                     if i not in attrs:
@@ -641,7 +641,7 @@ class OpenPMDDatasetSeries(DatasetSeries):
 
     def __init__(self, filename):
         super(OpenPMDDatasetSeries, self).__init__([])
-        self.handle = h5.File(filename, "r")
+        self.handle = h5py.File(filename, mode="r")
         self.filename = filename
         self._pre_outputs = sorted(
             np.asarray(list(self.handle["/data"].keys()), dtype=np.int)
@@ -678,7 +678,7 @@ class OpenPMDGroupBasedDataset(Dataset):
     def _is_valid(self, *args, **kwargs):
         warn_h5py(args[0])
         try:
-            with h5.File(args[0], "r") as f:
+            with h5py.File(args[0], mode="r") as f:
                 attrs = list(f["/"].attrs.keys())
                 for i in opmd_required_attributes:
                     if i not in attrs:

--- a/yt/frontends/open_pmd/fields.py
+++ b/yt/frontends/open_pmd/fields.py
@@ -5,7 +5,7 @@ from yt.fields.magnetic_field import setup_magnetic_field_aliases
 from yt.frontends.open_pmd.misc import is_const_component, parse_unit_dimension
 from yt.units.yt_array import YTQuantity
 from yt.utilities.logger import ytLogger as mylog
-from yt.utilities.on_demand_imports import _h5py as h5
+from yt.utilities.on_demand_imports import _h5py as h5py
 from yt.utilities.physical_constants import mu_0, speed_of_light
 
 
@@ -151,7 +151,7 @@ class OpenPMDFieldInfo(FieldInfoContainer):
             fields = f[bp + mp]
             for fname in fields.keys():
                 field = fields[fname]
-                if isinstance(field, h5.Dataset) or is_const_component(field):
+                if isinstance(field, h5py.Dataset) or is_const_component(field):
                     # Don't consider axes.
                     # This appears to be a vector field of single dimensionality
                     ytname = str("_".join([fname.replace("_", "-")]))
@@ -198,7 +198,9 @@ class OpenPMDFieldInfo(FieldInfoContainer):
                             # interpretation of the pfield particle_position is later
                             # derived in setup_absolute_positions in the way yt expects
                             ytattrib = "positionCoarse"
-                        if isinstance(record, h5.Dataset) or is_const_component(record):
+                        if isinstance(record, h5py.Dataset) or is_const_component(
+                            record
+                        ):
                             name = ["particle", ytattrib]
                             self.known_particle_fields += (
                                 (str("_".join(name)), (unit, [], None)),

--- a/yt/geometry/geometry_handler.py
+++ b/yt/geometry/geometry_handler.py
@@ -94,7 +94,7 @@ class Index(ParallelAnalysisInterface, abc.ABC):
             self._data_mode = "r"
 
         self.__data_filename = fn
-        self._data_file = h5py.File(fn, self._data_mode)
+        self._data_file = h5py.File(fn, mode=self._data_mode)
 
     def __create_data_file(self, fn):
         # Note that this used to be parallel_root_only; it no longer is,
@@ -143,7 +143,7 @@ class Index(ParallelAnalysisInterface, abc.ABC):
             return
         self._data_file.close()
         del self._data_file
-        self._data_file = h5py.File(self.__data_filename, self._data_mode)
+        self._data_file = h5py.File(self.__data_filename, mode=self._data_mode)
 
     def get_data(self, node, name):
         """

--- a/yt/utilities/grid_data_format/conversion/conversion_athena.py
+++ b/yt/utilities/grid_data_format/conversion/conversion_athena.py
@@ -3,7 +3,7 @@ from glob import glob
 import numpy as np
 
 from yt.utilities.grid_data_format.conversion.conversion_abc import Converter
-from yt.utilities.on_demand_imports import _h5py as h5
+from yt.utilities.on_demand_imports import _h5py as h5py
 
 translation_dict = {}
 translation_dict["density"] = "density"
@@ -304,7 +304,7 @@ class AthenaDistributedConverter(Converter):
                 this_field.attrs["field_to_cgs"] = np.float64("1.0")  # For Now
 
     def convert(self, index=True, data=True):
-        self.handle = h5.File(self.outname, "a")
+        self.handle = h5py.File(self.outname, mode="a")
         if index:
             self.read_and_write_index(self.basename, self.ddn, self.outname)
         if data:
@@ -413,7 +413,7 @@ class AthenaConverter(Converter):
         return grid
 
     def write_to_gdf(self, fn, grid):
-        f = h5.File(fn, "a")
+        f = h5py.File(fn, mode="a")
 
         ## --------- Begin level nodes --------- ##
         g = f.create_group("gridded_data_format")

--- a/yt/utilities/grid_data_format/tests/test_writer.py
+++ b/yt/utilities/grid_data_format/tests/test_writer.py
@@ -6,7 +6,7 @@ from yt.frontends.gdf.data_structures import GDFDataset
 from yt.loaders import load
 from yt.testing import assert_equal, fake_random_ds, requires_module
 from yt.utilities.grid_data_format.writer import write_to_gdf
-from yt.utilities.on_demand_imports import _h5py as h5
+from yt.utilities.on_demand_imports import _h5py as h5py
 
 TEST_AUTHOR = "yt test runner"
 TEST_COMMENT = "Testing write_to_gdf"
@@ -33,7 +33,7 @@ def test_write_gdf():
         del test_ds
         assert isinstance(load(tmpfile), GDFDataset)
 
-        h5f = h5.File(tmpfile, "r")
+        h5f = h5py.File(tmpfile, mode="r")
         gdf = h5f["gridded_data_format"].attrs
         assert_equal(gdf["data_author"], TEST_AUTHOR)
         assert_equal(gdf["data_comment"], TEST_COMMENT)

--- a/yt/utilities/minimal_representation.py
+++ b/yt/utilities/minimal_representation.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from yt.funcs import compare_dicts, iterable
 from yt.units.yt_array import YTArray, YTQuantity
-from yt.utilities.on_demand_imports import _h5py as h5
+from yt.utilities.on_demand_imports import _h5py as h5py
 
 
 def _sanitize_list(flist):
@@ -51,7 +51,7 @@ def _deserialize_from_h5(g, ds):
                 result[item] = ds.arr(g[item][:], g[item].attrs["units"])
             else:
                 result[item] = ds.quan(g[item][()], g[item].attrs["units"])
-        elif isinstance(g[item], h5.Group):
+        elif isinstance(g[item], h5py.Group):
             result[item] = _deserialize_from_h5(g[item], ds)
         elif g[item] == "None":
             result[item] = None
@@ -113,7 +113,7 @@ class MinimalRepresentation(metaclass=abc.ABCMeta):
             self._ds_mrep.store(storage)
         metadata, (final_name, chunks) = self._generate_post()
         metadata["obj_type"] = self.type
-        with h5.File(storage) as h5f:
+        with h5py.File(storage, mode="w") as h5f:
             dset = str(uuid4())[:8]
             h5f.create_group(dset)
             _serialize_to_h5(h5f[dset], metadata)
@@ -226,7 +226,7 @@ class MinimalProjectionData(MinimalMappableData):
         if hasattr(self, "_ds_mrep"):
             self._ds_mrep.restore(storage, ds)
         metadata, (final_name, chunks) = self._generate_post()
-        with h5.File(storage, "r") as h5f:
+        with h5py.File(storage, mode="r") as h5f:
             for dset in h5f:
                 stored_metadata = _deserialize_from_h5(h5f[dset], ds)
                 if compare_dicts(metadata, stored_metadata):

--- a/yt/utilities/minimal_representation.py
+++ b/yt/utilities/minimal_representation.py
@@ -113,7 +113,7 @@ class MinimalRepresentation(metaclass=abc.ABCMeta):
             self._ds_mrep.store(storage)
         metadata, (final_name, chunks) = self._generate_post()
         metadata["obj_type"] = self.type
-        with h5py.File(storage, mode="w") as h5f:
+        with h5py.File(storage, mode="r") as h5f:
             dset = str(uuid4())[:8]
             h5f.create_group(dset)
             _serialize_to_h5(h5f[dset], metadata)


### PR DESCRIPTION
## PR Summary

`h5py` deprecated their `dataset.value` attribute and now recommend using `dataset[()]` instead.
The change was already performed in most of the code, this PR adresses the remaining occurrences.

## PR Checklist

- [x] pass `black --check yt/`
- [x] pass `isort . --check --diff`
- [x] pass `flake8 yt/`
- [x] pass `flynt yt/ --fail-on-change --dry-run -e yt/extern`
- [x] add tests (a new GH workflow)