### PR TITLE
fix np deprecation warnings for non-tuple sequence in multi-dim indexing

### DIFF
--- a/yt/data_objects/grid_patch.py
+++ b/yt/data_objects/grid_patch.py
@@ -414,7 +414,7 @@ class AMRGridPatch(YTSelectionContainer):
         else:
             slices = get_nodal_slices(source.shape, nodal_flag, dim)
             for i, sl in enumerate(slices):
-                dest[offset : offset + count, i] = source[sl][np.squeeze(mask)]
+                dest[offset : offset + count, i] = source[tuple(sl)][np.squeeze(mask)]
         return count
 
     def count(self, selector):

--- a/yt/frontends/boxlib/io.py
+++ b/yt/frontends/boxlib/io.py
@@ -82,10 +82,14 @@ class IOHandlerBoxlib(BaseIOHandler):
             arr = np.fromfile(f, "float64", np.product(shape))
             arr = arr.reshape(shape, order="F")
         return arr[
-            [
-                slice(None) if (nghost[dim] == 0) else slice(nghost[dim], -nghost[dim])
-                for dim in range(self.ds.dimensionality)
-            ]
+            tuple(
+                [
+                    slice(None)
+                    if (nghost[dim] == 0)
+                    else slice(nghost[dim], -nghost[dim])
+                    for dim in range(self.ds.dimensionality)
+                ]
+            )
         ]
 
     def _read_chunk_data(self, chunk, fields):


### PR DESCRIPTION
## PR Summary

in recent versions of numpy, this pattern is deprecated:

```python
# let arr be a 3D array
arr[[slice(None) for _ in range(3)]]
```
and one gets this warning:
```
FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different
```

I discovered the places this pattern was used in yt by checking the logs on Travis.

Note that this is not a bug _yet_, but I'm still using the label since it will become an error.

## PR Checklist

- [x] pass `black --check yt/`
- [x] pass `isort . --check --diff`
- [x] pass `flake8 yt/`
- [x] pass `flynt yt/ --fail-on-change --dry-run -e yt/extern`
