### PR TITLE
More fixes for load_sample

### DIFF
--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -1337,7 +1337,7 @@ def load_sample(fn=None, specific_file=None, pbar=True):
             mylog.warning("tqdm is not installed, progress bar can not be displayed.")
 
     if extension == "h5":
-        processor = pooch.Untar()
+        processor = pooch.pooch.Untar()
     else:
         # we are going to assume most files that exist on the hub are
         # compressed in .tar folders. Some may not.

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -1291,7 +1291,7 @@ def load_sample(fn=None, specific_file=None, pbar=True):
 
     Parameters
     ----------
-    fn : str or None
+    name : str or None
         The name of the sample data to load. This is generally the name of the
         folder of the dataset. For IsolatedGalaxy, the name would be
         `IsolatedGalaxy`.  If `None` is supplied, the return value
@@ -1312,7 +1312,7 @@ def load_sample(fn=None, specific_file=None, pbar=True):
 
     fido = PoochHandle()
 
-    if fn is None:
+    if name is None:
         keys = []
         for key in fido._registry:
             for ext in _extensions_to_strip:

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -1284,14 +1284,14 @@ def load_unstructured_mesh(
 # If not, it will download it.
 
 
-def load_sample(name=None, specific_file=None, pbar=True):
+def load_sample(fn=None, specific_file=None, pbar=True):
     """
     Load sample data with yt. Simple wrapper around yt.load to include fetching
     data with pooch.
 
     Parameters
     ----------
-    name : str or None
+    fn : str or None
         The name of the sample data to load. This is generally the name of the
         folder of the dataset. For IsolatedGalaxy, the name would be
         `IsolatedGalaxy`.  If `None` is supplied, the return value
@@ -1312,7 +1312,7 @@ def load_sample(name=None, specific_file=None, pbar=True):
 
     fido = PoochHandle()
 
-    if name is None:
+    if fn is None:
         keys = []
         for key in fido._registry:
             for ext in _extensions_to_strip:
@@ -1324,7 +1324,7 @@ def load_sample(name=None, specific_file=None, pbar=True):
     base_path = fido.pooch_obj.path
 
     registered_fname, name, extension = fido._validate_sample_fname(
-        name
+        fn
     )  # todo: make this part of the class
 
     downloader = None

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -1284,7 +1284,7 @@ def load_unstructured_mesh(
 # If not, it will download it.
 
 
-def load_sample(fn=None, specific_file=None, pbar=True):
+def load_sample(name=None, specific_file=None, pbar=True):
     """
     Load sample data with yt. Simple wrapper around yt.load to include fetching
     data with pooch.
@@ -1324,7 +1324,7 @@ def load_sample(fn=None, specific_file=None, pbar=True):
     base_path = fido.pooch_obj.path
 
     registered_fname, name, extension = fido._validate_sample_fname(
-        fn
+        name
     )  # todo: make this part of the class
 
     downloader = None


### PR DESCRIPTION
## PR Summary

I noticed the name of the first arg in load sample changed from name to fn, even though this argument is specific to a file name. I've changed it back because name is clearer.

I've also fixed the import of pooch.Untar() since it was transferred with an error. 

## PR Checklist

- [x] pass `black --check yt/`
- [x] pass `isort . --check --diff`
- [x] pass `flake8 yt/`
- [x] pass `flynt yt/ --fail-on-change --dry-run -e yt/extern`
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

