### PR TITLE
code deduplication: image filename validation

### DIFF
--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -775,16 +775,6 @@ def fix_axis(axis, ds):
     return ds.coordinates.axis_id.get(axis, axis)
 
 
-def get_image_suffix(name):
-    suffix = os.path.splitext(name)[1]
-    supported_suffixes = [".png", ".eps", ".ps", ".pdf", ".jpg", ".jpeg"]
-    if suffix in supported_suffixes or suffix == "":
-        return suffix
-    else:
-        mylog.warning("Unsupported image suffix requested (%s)", suffix)
-        return ""
-
-
 def get_output_filename(name, keyword, suffix):
     r"""Return an appropriate filename for output.
 

--- a/yt/visualization/_commons.py
+++ b/yt/visualization/_commons.py
@@ -1,7 +1,5 @@
 from pathlib import Path
 
-from yt.utilities.logger import ytLogger
-
 from ._mpl_imports import FigureCanvasAgg, FigureCanvasPdf, FigureCanvasPS
 
 SUPPORTED_IMAGE_SUFFIXES = [".png", ".eps", ".ps", ".pdf", ".jpg", ".jpeg"]
@@ -23,7 +21,7 @@ def validate_image_name(filename, ext=".png"):
     return str(fn.with_suffix(ext))
 
 
-def get_canvas(figure, filename, default=None):
+def get_canvas(figure, filename):
 
     suffix = Path(filename).suffix
 
@@ -35,10 +33,6 @@ def get_canvas(figure, filename, default=None):
 
     if suffix in (".eps", ".ps"):
         return FigureCanvasPS(figure)
-
-    if default is not None:
-        ytLogger.warning("Unknown suffix %s, using default canvas", suffix)
-        return default
 
     raise ValueError(
         f"No matching canvas for filename {filename} with extension {suffix}"

--- a/yt/visualization/_commons.py
+++ b/yt/visualization/_commons.py
@@ -1,5 +1,9 @@
 from pathlib import Path
 
+from yt.utilities.logger import ytLogger
+
+from ._mpl_imports import FigureCanvasAgg, FigureCanvasPdf, FigureCanvasPS
+
 SUPPORTED_IMAGE_SUFFIXES = [".png", ".eps", ".ps", ".pdf", ".jpg", ".jpeg"]
 
 
@@ -13,3 +17,25 @@ def validate_image_name(filename, ext=".png"):
         ext = f".{ext}"
 
     return str(fn.with_suffix(ext))
+
+
+def get_canvas(figure, filename, default=None):
+
+    suffix = Path(filename).suffix
+
+    if suffix == ".png":
+        return FigureCanvasAgg(figure)
+
+    if suffix == ".pdf":
+        return FigureCanvasPdf(figure)
+
+    if suffix in (".eps", ".ps"):
+        return FigureCanvasPS(figure)
+
+    if default is not None:
+        ytLogger.warning("Unknown suffix %s, using default canvas", suffix)
+        return default
+
+    raise ValueError(
+        f"No matching canvas for filename {filename} with extension {suffix}"
+    )

--- a/yt/visualization/_commons.py
+++ b/yt/visualization/_commons.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+SUPPORTED_IMAGE_SUFFIXES = [".png", ".eps", ".ps", ".pdf", ".jpg", ".jpeg"]
+
+
+def validate_image_name(filename, ext=".png"):
+
+    fn = Path(filename)
+    if fn.suffix in SUPPORTED_IMAGE_SUFFIXES:
+        return str(filename)
+
+    if not ext.startswith("."):
+        ext = f".{ext}"
+
+    return str(fn.with_suffix(ext))

--- a/yt/visualization/_commons.py
+++ b/yt/visualization/_commons.py
@@ -1,4 +1,6 @@
-from pathlib import Path
+import os
+
+from yt.utilities.logger import ytLogger as mylog
 
 from ._mpl_imports import (
     FigureCanvasAgg,
@@ -11,27 +13,35 @@ AGG_FORMATS = [".png", ".jpg", ".jpeg", ".raw", ".rgba", ".tif", ".tiff"]
 SUPPORTED_FORMATS = AGG_FORMATS + [".eps", ".ps", ".pdf", ".svg"]
 
 
-def validate_image_name(filename, suffix=".png"):
+def validate_image_name(filename, suffix: str = ".png") -> str:
     """
     Build a valid image filename with a specified extension (default to png).
     The suffix parameter is ignored if the input filename has a valid extension already.
     Otherwise, suffix is appended to the filename, replacing any existing extension.
     """
-    fn = Path(filename)
-    if fn.suffix in SUPPORTED_FORMATS:
+    # sanitizing: normalize leading '.'
+    suffix = f".{suffix.lstrip('.')}"
+
+    name, psuffix = os.path.splitext(filename)
+    if psuffix in SUPPORTED_FORMATS:
+        if suffix:
+            mylog.warning(
+                "Ignoring supplied suffix '%s' in favour of '%s'", suffix, psuffix
+            )
         return str(filename)
+    elif psuffix:
+        mylog.warning(
+            "Found unsupported suffix '%s', using '%s' instead.", psuffix, suffix
+        )
 
-    if not suffix.startswith("."):
-        suffix = f".{suffix}"
-
-    return str(fn.with_suffix(suffix))
+    return f"{name}{suffix}"
 
 
 def get_canvas(figure, filename):
 
-    suffix = Path(filename).suffix
+    name, suffix = os.path.splitext(filename)
 
-    if suffix == "":
+    if not suffix:
         raise ValueError(
             f"Can not determine canvas class from filename '{filename}' "
             f"without an extension."
@@ -50,5 +60,5 @@ def get_canvas(figure, filename):
         return FigureCanvasPS(figure)
 
     raise ValueError(
-        f"No matching canvas for filename '{filename}' with extension '{suffix}'"
+        f"No matching canvas for filename '{filename}' with extension '{suffix}'."
     )

--- a/yt/visualization/_commons.py
+++ b/yt/visualization/_commons.py
@@ -2,7 +2,8 @@ from pathlib import Path
 
 from ._mpl_imports import FigureCanvasAgg, FigureCanvasPdf, FigureCanvasPS
 
-SUPPORTED_IMAGE_SUFFIXES = [".png", ".eps", ".ps", ".pdf", ".jpg", ".jpeg"]
+AGG_FORMATS = [".png", ".jpg", ".jpeg", ".raw", ".rgba", ".tif", ".tiff"]
+SUPPORTED_FORMATS = AGG_FORMATS + [".eps", ".ps", ".pdf"]
 
 
 def validate_image_name(filename, suffix=".png"):
@@ -12,7 +13,7 @@ def validate_image_name(filename, suffix=".png"):
     Otherwise, suffix is appended to the filename, replacing any existing extension.
     """
     fn = Path(filename)
-    if fn.suffix in SUPPORTED_IMAGE_SUFFIXES:
+    if fn.suffix in SUPPORTED_FORMATS:
         return str(filename)
 
     if not suffix.startswith("."):
@@ -31,7 +32,7 @@ def get_canvas(figure, filename):
             f"without an extension."
         )
 
-    if suffix == ".png":
+    if suffix in AGG_FORMATS:
         return FigureCanvasAgg(figure)
 
     if suffix == ".pdf":

--- a/yt/visualization/_commons.py
+++ b/yt/visualization/_commons.py
@@ -5,25 +5,31 @@ from ._mpl_imports import FigureCanvasAgg, FigureCanvasPdf, FigureCanvasPS
 SUPPORTED_IMAGE_SUFFIXES = [".png", ".eps", ".ps", ".pdf", ".jpg", ".jpeg"]
 
 
-def validate_image_name(filename, ext=".png"):
+def validate_image_name(filename, suffix=".png"):
     """
     Build a valid image filename with a specified extension (default to png).
-    The ext parameter is ignored if the input filename has a valid extension already.
-    Otherwise, ext is appended to filename, taking the place of any existing extension.
+    The suffix parameter is ignored if the input filename has a valid extension already.
+    Otherwise, suffix is appended to the filename, replacing any existing extension.
     """
     fn = Path(filename)
     if fn.suffix in SUPPORTED_IMAGE_SUFFIXES:
         return str(filename)
 
-    if not ext.startswith("."):
-        ext = f".{ext}"
+    if not suffix.startswith("."):
+        suffix = f".{suffix}"
 
-    return str(fn.with_suffix(ext))
+    return str(fn.with_suffix(suffix))
 
 
 def get_canvas(figure, filename):
 
     suffix = Path(filename).suffix
+
+    if suffix == "":
+        raise ValueError(
+            f"Can not determine canvas class from filename '{filename}' "
+            f"without an extension."
+        )
 
     if suffix == ".png":
         return FigureCanvasAgg(figure)
@@ -35,5 +41,5 @@ def get_canvas(figure, filename):
         return FigureCanvasPS(figure)
 
     raise ValueError(
-        f"No matching canvas for filename {filename} with extension {suffix}"
+        f"No matching canvas for filename '{filename}' with extension '{suffix}'"
     )

--- a/yt/visualization/_commons.py
+++ b/yt/visualization/_commons.py
@@ -8,7 +8,11 @@ SUPPORTED_IMAGE_SUFFIXES = [".png", ".eps", ".ps", ".pdf", ".jpg", ".jpeg"]
 
 
 def validate_image_name(filename, ext=".png"):
-
+    """
+    Build a valid image filename with a specified extension (default to png).
+    The ext parameter is ignored if the input filename has a valid extension already.
+    Otherwise, ext is appended to filename, taking the place of any existing extension.
+    """
     fn = Path(filename)
     if fn.suffix in SUPPORTED_IMAGE_SUFFIXES:
         return str(filename)

--- a/yt/visualization/_commons.py
+++ b/yt/visualization/_commons.py
@@ -1,9 +1,14 @@
 from pathlib import Path
 
-from ._mpl_imports import FigureCanvasAgg, FigureCanvasPdf, FigureCanvasPS
+from ._mpl_imports import (
+    FigureCanvasAgg,
+    FigureCanvasPdf,
+    FigureCanvasPS,
+    FigureCanvasSVG,
+)
 
 AGG_FORMATS = [".png", ".jpg", ".jpeg", ".raw", ".rgba", ".tif", ".tiff"]
-SUPPORTED_FORMATS = AGG_FORMATS + [".eps", ".ps", ".pdf"]
+SUPPORTED_FORMATS = AGG_FORMATS + [".eps", ".ps", ".pdf", ".svg"]
 
 
 def validate_image_name(filename, suffix=".png"):
@@ -37,6 +42,9 @@ def get_canvas(figure, filename):
 
     if suffix == ".pdf":
         return FigureCanvasPdf(figure)
+
+    if suffix == ".svg":
+        return FigureCanvasSVG(figure)
 
     if suffix in (".eps", ".ps"):
         return FigureCanvasPS(figure)

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -1,3 +1,4 @@
+import os
 from distutils.version import LooseVersion
 from io import BytesIO
 
@@ -6,12 +7,13 @@ import numpy as np
 
 from yt.funcs import (
     get_brewer_cmap,
-    get_image_suffix,
     get_interactivity,
     is_sequence,
     matplotlib_style_context,
     mylog,
 )
+
+from ._commons import validate_image_name
 
 backend_dict = {
     "GTK": ["backend_gtk", "FigureCanvasGTK", "FigureManagerGTK"],
@@ -138,10 +140,8 @@ class PlotMPL:
         ) < LooseVersion("3.3.0"):
             mpl_kwargs["papertype"] = "auto"
 
-        suffix = get_image_suffix(name)
-        if suffix == "":
-            suffix = ".png"
-            name = f"{name}{suffix}"
+        name = validate_image_name(name)
+        suffix = os.path.splitext(name)[-1]
 
         mylog.info("Saving plot %s", name)
 

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -112,7 +112,13 @@ class PlotMPL:
         except KeyError:
             return
 
-        mod = __import__("matplotlib.backends", globals(), locals(), [module], 0,)
+        mod = __import__(
+            "matplotlib.backends",
+            globals(),
+            locals(),
+            [module],
+            0,
+        )
         submod = getattr(mod, module)
         FigureCanvas = getattr(submod, fig_canvas)
         if fig_manager is not None:

--- a/yt/visualization/image_writer.py
+++ b/yt/visualization/image_writer.py
@@ -4,13 +4,14 @@ import numpy as np
 
 from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.config import ytcfg
-from yt.funcs import get_brewer_cmap, get_image_suffix, mylog
+from yt.funcs import get_brewer_cmap, mylog
 from yt.units.yt_array import YTQuantity
 from yt.utilities import png_writer as pw
 from yt.utilities.exceptions import YTNotInsideNotebook
 from yt.utilities.lib import image_utilities as au
 
 from . import _colormap_data as cmd
+from ._commons import get_canvas, validate_image_name
 from .color_maps import mcm
 
 
@@ -402,8 +403,6 @@ def write_projection(
     import matplotlib.colors
     import matplotlib.figure
 
-    from ._mpl_imports import FigureCanvasAgg, FigureCanvasPdf, FigureCanvasPS
-
     if limits is not None:
         if vmin is not None or vmax is not None:
             raise ValueError(
@@ -455,19 +454,10 @@ def write_projection(
         if colorbar_label:
             cbar.ax.set_ylabel(colorbar_label)
 
-    suffix = get_image_suffix(filename)
+    filename = validate_image_name(filename)
+    canvas = get_canvas(fig, filename)
 
-    if suffix == "":
-        suffix = ".png"
-        filename = f"{filename}{suffix}"
     mylog.info("Saving plot %s", filename)
-    if suffix == ".pdf":
-        canvas = FigureCanvasPdf(fig)
-    elif suffix in (".eps", ".ps"):
-        canvas = FigureCanvasPS(fig)
-    else:
-        canvas = FigureCanvasAgg(fig)
-
     fig.tight_layout()
 
     canvas.print_figure(filename, dpi=dpi)

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -461,7 +461,7 @@ class PlotContainer:
         return self
 
     @validate_plot
-    def save(self, name=None, suffix=None, mpl_kwargs=None):
+    def save(self, name=None, suffix=".png", mpl_kwargs=None):
         """saves the plot to disk.
 
         Parameters

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -10,12 +10,14 @@ import numpy as np
 from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.config import ytcfg
 from yt.data_objects.time_series import DatasetSeries
-from yt.funcs import ensure_dir, get_image_suffix, is_sequence, iter_fields, mylog
+from yt.funcs import ensure_dir, is_sequence, iter_fields, mylog
 from yt.units import YTQuantity
 from yt.units.unit_object import Unit
 from yt.utilities.definitions import formatted_length_unit_names
 from yt.utilities.exceptions import YTNotInsideNotebook
 from yt.visualization.color_maps import yt_colormaps
+
+from ._commons import validate_image_name
 
 latex_prefixes = {
     "u": r"\mu",
@@ -491,11 +493,11 @@ class PlotContainer:
         if os.path.isdir(name) and name != str(self.ds):
             name = name + (os.sep if name[-1] != os.sep else "") + str(self.ds)
         if suffix is None:
-            suffix = get_image_suffix(name)
-            if suffix != "":
-                for v in self.plots.values():
-                    names.append(v.save(name, mpl_kwargs))
-                return names
+            name = validate_image_name(name)
+            for v in self.plots.values():
+                out_name = v.save(name, mpl_kwargs)
+                names.append(out_name)
+            return names
         if hasattr(self.data_source, "axis"):
             axis = self.ds.coordinates.axis_name.get(self.data_source.axis, "")
         else:

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -522,7 +522,7 @@ class PlotContainer:
             name_elements = [prefix, plot_type]
             if axis:
                 name_elements.append(axis)
-            name.elements.append(k.replace(" ", "_"))
+            name_elements.append(k.replace(" ", "_"))
             if weight:
                 name_elements.append(weight)
 

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -12,11 +12,7 @@ from more_itertools.more import always_iterable, unzip
 from yt.data_objects.profiles import create_profile, sanitize_field_tuple_keys
 from yt.data_objects.static_output import Dataset
 from yt.frontends.ytdata.data_structures import YTProfileDataset
-from yt.funcs import (
-    is_sequence,
-    iter_fields,
-    matplotlib_style_context,
-)
+from yt.funcs import is_sequence, iter_fields, matplotlib_style_context
 from yt.utilities.exceptions import YTNotInsideNotebook
 from yt.utilities.logger import ytLogger as mylog
 

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -1251,7 +1251,7 @@ class PhasePlot(ImagePlotContainer):
         return self
 
     @validate_plot
-    def save(self, name=None, suffix=None, mpl_kwargs=None):
+    def save(self, name=None, suffix=".png", mpl_kwargs=None):
         r"""
         Saves a 2d profile plot.
 

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -1294,7 +1294,14 @@ class PhasePlot(ImagePlotContainer):
                 name = name + (os.sep if name[-1] != os.sep else "")
                 name += str(self.profile.ds)
 
-            name = validate_image_name(name, suffix)
+            new_name = validate_image_name(name, suffix)
+            if new_name == name:
+                for v in self.plots.values():
+                    out_name = v.save(name, mpl_kwargs)
+                    names.append(out_name)
+                return names
+
+            name = new_name
             prefix, suffix = os.path.splitext(name)
             name = f"{prefix}_{middle}{suffix}"
 

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -291,7 +291,7 @@ class ProfilePlot:
             else:
                 name = "Multi-data"
 
-        name = validate_image_name(name, ext=suffix)
+        name = validate_image_name(name, suffix)
         prefix, suffix = os.path.splitext(name)
 
         xfn = self.profiles[0].x_field
@@ -1294,7 +1294,7 @@ class PhasePlot(ImagePlotContainer):
                 name = name + (os.sep if name[-1] != os.sep else "")
                 name += str(self.profile.ds)
 
-            name = validate_image_name(name, ext=suffix)
+            name = validate_image_name(name, suffix)
             prefix, suffix = os.path.splitext(name)
             name = f"{prefix}_{middle}{suffix}"
 

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -285,16 +285,13 @@ class ProfilePlot:
         else:
             iters = self.plots.items()
 
-        try:
-            new_name = validate_image_name(name, ext=suffix)
-        except ValueError:
-            # name is an empty string or path, or None
+        if name is None:
             if len(self.profiles) == 1:
-                prefix = self.profiles[0].ds
+                name = str(self.profiles[0].ds)
             else:
-                prefix = "Multi-data"
-            new_name = validate_image_name(prefix)
+                name = "Multi-data"
 
+        new_name = validate_image_name(name, ext=suffix)
         prefix, suffix = os.path.splitext(new_name)
 
         xfn = self.profiles[0].x_field

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -291,24 +291,23 @@ class ProfilePlot:
             else:
                 name = "Multi-data"
 
-        new_name = validate_image_name(name, ext=suffix)
-        prefix, suffix = os.path.splitext(new_name)
+        name = validate_image_name(name, ext=suffix)
+        prefix, suffix = os.path.splitext(name)
 
         xfn = self.profiles[0].x_field
         if isinstance(xfn, tuple):
             xfn = xfn[1]
-        fns = []
+
+        names = []
         for uid, plot in iters:
             if isinstance(uid, tuple):
                 uid = uid[1]
-            if new_name == name:
-                fns.append(new_name)
-            else:
-                fns.append(f"{prefix}_1d-Profile_{xfn}_{uid}{suffix}")
-            mylog.info("Saving %s", fns[-1])
+            uid_name = f"{prefix}_1d-Profile_{xfn}_{uid}{suffix}"
+            names.append(uid_name)
+            mylog.info("Saving %s", uid_name)
             with matplotlib_style_context():
-                plot.save(fns[-1], mpl_kwargs=mpl_kwargs)
-        return fns
+                plot.save(uid_name, mpl_kwargs=mpl_kwargs)
+        return names
 
     @validate_plot
     def show(self):

--- a/yt/visualization/tests/test_commons.py
+++ b/yt/visualization/tests/test_commons.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from yt.visualization._commons import validate_image_name
 
 # todo
-# - move this to yt/visualization/tests
 # - remove yt.funcs.get_image_suffix
 
 filename_no_ext = Path("a_file_is_no_one")

--- a/yt/visualization/tests/test_commons.py
+++ b/yt/visualization/tests/test_commons.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+from yt.visualization._commons import validate_image_name
+
+# todo
+# - move this to yt/visualization/tests
+# - remove yt.funcs.get_image_suffix
+
+filename_no_ext = Path("a_file_is_no_one")
+filename_png = filename_no_ext.with_suffix(".png")
+filename_pdf = filename_no_ext.with_suffix(".pdf")
+
+
+def test_default():
+    result = validate_image_name(filename_no_ext)
+    expected = f"{filename_no_ext}.png"
+    assert result == expected
+
+    result = validate_image_name(filename_png)
+    assert result == expected
+
+    result = validate_image_name(filename_pdf)
+    expected = str(filename_pdf)
+    assert result == expected
+
+
+def test_custom_valid_ext():
+    for ext in ["png", "jpg", "pdf", "eps"]:
+        dext = f".{ext}"
+        result1 = validate_image_name(filename_no_ext, ext=ext)
+        result2 = validate_image_name(filename_no_ext, ext=dext)
+        expected = f"{filename_no_ext}.{ext}"
+
+        assert result1 == expected
+        assert result2 == expected

--- a/yt/visualization/tests/test_commons.py
+++ b/yt/visualization/tests/test_commons.py
@@ -1,9 +1,6 @@
 from pathlib import Path
 
-from yt.visualization._commons import validate_image_name
-
-# todo
-# - remove yt.funcs.get_image_suffix
+from yt.visualization._commons import SUPPORTED_IMAGE_SUFFIXES, validate_image_name
 
 filename_no_ext = Path("a_file_is_no_one")
 filename_png = filename_no_ext.with_suffix(".png")
@@ -24,8 +21,8 @@ def test_default():
 
 
 def test_custom_valid_ext():
-    for ext in ["png", "jpg", "pdf", "eps"]:
-        dext = f".{ext}"
+    for dext in SUPPORTED_IMAGE_SUFFIXES:
+        ext = dext.replace(".", "")
         result1 = validate_image_name(filename_no_ext, ext=ext)
         result2 = validate_image_name(filename_no_ext, ext=dext)
         expected = f"{filename_no_ext}.{ext}"

--- a/yt/visualization/tests/test_commons.py
+++ b/yt/visualization/tests/test_commons.py
@@ -23,8 +23,8 @@ def test_default():
 def test_custom_valid_ext():
     for dext in SUPPORTED_IMAGE_SUFFIXES:
         ext = dext.replace(".", "")
-        result1 = validate_image_name(filename_no_ext, ext=ext)
-        result2 = validate_image_name(filename_no_ext, ext=dext)
+        result1 = validate_image_name(filename_no_ext, suffix=ext)
+        result2 = validate_image_name(filename_no_ext, suffix=dext)
         expected = f"{filename_no_ext}.{ext}"
 
         assert result1 == expected

--- a/yt/visualization/tests/test_commons.py
+++ b/yt/visualization/tests/test_commons.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from yt.visualization._commons import SUPPORTED_IMAGE_SUFFIXES, validate_image_name
+from yt.visualization._commons import SUPPORTED_FORMATS, validate_image_name
 
 filename_no_ext = Path("a_file_is_no_one")
 filename_png = filename_no_ext.with_suffix(".png")
@@ -21,7 +21,7 @@ def test_default():
 
 
 def test_custom_valid_ext():
-    for dext in SUPPORTED_IMAGE_SUFFIXES:
+    for dext in SUPPORTED_FORMATS:
         ext = dext.replace(".", "")
         result1 = validate_image_name(filename_no_ext, suffix=ext)
         result2 = validate_image_name(filename_no_ext, suffix=dext)

--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -469,9 +469,7 @@ class Scene:
 
                 ax.axes.text(xy[0], xy[1], string, transform=f.transFigure, **opt)
 
-        self._render_figure.canvas = get_canvas(
-            self._render_figure, fname, default=self.canvas
-        )
+        self._render_figure.canvas = get_canvas(self._render_figure, fname)
         self._render_figure.tight_layout()
         self._render_figure.savefig(fname, facecolor="black", pad_inches=0)
 

--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -229,23 +229,50 @@ class Scene:
         self._last_render = bmp
         return bmp
 
-    def _sanitize_render(self, render):
-        # checks for existing render before saving, in most cases we want to
+    def _render_on_demand(self, render):
+        # checks for existing render before rendering, in most cases we want to
         # render every time, but in some cases pulling the previous render is
         # desirable (e.g., if only changing sigma_clip or
         # saving after a call to sc.show()).
+
+        if self._last_render is not None and not render:
+            mylog.info("Found previously rendered image to save.")
+            return
+
         if self._last_render is None:
             mylog.warning("No previously rendered image found, rendering now.")
-            render = True
         elif render:
             mylog.warning(
                 "Previously rendered image exists, but rendering anyway. "
                 "Supply 'render=False' to save previously rendered image directly."
             )
-        else:
-            mylog.info("Found previously rendered image to save.")
+        self.render()
 
-        return render
+    def _get_render_sources(self):
+        return [s for s in self.sources.values() if isinstance(s, RenderSource)]
+
+    def _setup_save(self, fname, render):
+
+        self._render_on_demand(render)
+
+        rensources = self._get_render_sources()
+        if fname is None:
+            # if a volume source present, use its affiliated ds for fname
+            if len(rensources) > 0:
+                rs = rensources[0]
+                basename = rs.data_source.ds.basename
+                if isinstance(rs.field, str):
+                    field = rs.field
+                else:
+                    field = rs.field[-1]
+                fname = f"{basename}_Render_{field}"
+            # if no volume source present, use a default filename
+            else:
+                fname = "Render_opaque"
+
+        fname = validate_image_name(fname)
+        mylog.info("Saving rendered image to %s", fname)
+        return fname
 
     def save(self, fname=None, sigma_clip=None, render=True):
         r"""Saves a rendered image of the Scene to disk.
@@ -303,27 +330,7 @@ class Scene:
         >>> sc.save('clipped_4.png', sigma_clip=4, render=False)
 
         """
-        if fname is None:
-            sources = list(self.sources.values())
-            rensources = [s for s in sources if isinstance(s, RenderSource)]
-            # if a volume source present, use its affiliated ds for fname
-            if len(rensources) > 0:
-                rs = rensources[0]
-                basename = rs.data_source.ds.basename
-                if isinstance(rs.field, str):
-                    field = rs.field
-                else:
-                    field = rs.field[-1]
-                fname = f"{basename}_Render_{field}.png"
-            # if no volume source present, use a default filename
-            else:
-                fname = "Render_opaque.png"
-        fname = validate_image_name(fname)
-
-        render = self._sanitize_render(render)
-        if render:
-            self.render()
-        mylog.info("Saving rendered image to %s", fname)
+        fname = self._setup_save(fname, render)
 
         # We can render pngs natively but for other formats we defer to
         # matplotlib.
@@ -418,32 +425,10 @@ class Scene:
         ...                                        horizontalalignment="center")]])
 
         """
-
-        sources = list(self.sources.values())
-        rensources = [s for s in sources if isinstance(s, RenderSource)]
-
-        if fname is None:
-            # if a volume source present, use its affiliated ds for fname
-            if len(rensources) > 0:
-                rs = rensources[0]
-                basename = rs.data_source.ds.basename
-                if isinstance(rs.field, str):
-                    field = rs.field
-                else:
-                    field = rs.field[-1]
-                fname = f"{basename}_Render_{field}.png"
-            # if no volume source present, use a default filename
-            else:
-                fname = "Render_opaque.png"
-        fname = validate_image_name(fname)
-
-        render = self._sanitize_render(render)
-        if render:
-            self.render()
-        mylog.info("Saving rendered image to %s", fname)
+        fname = self._setup_save(fname, render)
 
         # which transfer function?
-        rs = rensources[0]
+        rs = self._get_render_sources()[0]
         tf = rs.transfer_function
         label = rs.data_source.ds._get_field_info(rs.field).get_label()
 

--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -334,7 +334,7 @@ class Scene:
 
             shape = self._last_render.shape
             fig = Figure((shape[0] / 100.0, shape[1] / 100.0))
-            canvas = get_canvas(fname, fig)
+            canvas = get_canvas(fig, fname)
 
             ax = fig.add_axes([0, 0, 1, 1])
             ax.set_axis_off()


### PR DESCRIPTION
## PR Summary

Refactoring around `yt.funcs.get_image_suffix`, which gives noisy warnings on Travis such as

```
WARNING:yt:Unsupported image suffix requested (.h5)
WARNING:yt:Unsupported image suffix requested (.h5_Slice_z_density)
WARNING:yt:Unsupported image suffix requested (.h5)
WARNING:yt:Unsupported image suffix requested (.h5_Projection_z_density)
```
while the images are still saved in the end, as png.
Since calls to this function are almost _always_ followed by some way to default to `".png"` as a suffix, I
replaced this function with `yt.visualization._commons.validate_image_name`
Doing so, I ended up removing duplicated code with the function `get_canvas`, which already existed but wasn't used

Since some of the affected parts of the code use a lot of nested ifs, I'm pretty sure I must have broken stuff on the way there, so I'm opening as a draft for now🤞 

## PR Checklist

- [x] pass `black --check yt/`
- [x] pass `isort . --check --diff`
- [x] pass `flake8 yt/`
- [x] pass `flynt yt/ --fail-on-change --dry-run -e yt/extern`
- [ ] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.
