### PR TITLE
fix: adapt PhasePlot's to future upstream api change in matplotlib

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -86,7 +86,7 @@ answer_tests:
     - yt/frontends/owls/tests/test_outputs.py:test_snapshot_033
     - yt/frontends/owls/tests/test_outputs.py:test_OWLS_particlefilter
 
-  local_pw_031:  # PR 2902
+  local_pw_032:  # PR 2881
     - yt/visualization/tests/test_plotwindow.py:test_attributes
     - yt/visualization/tests/test_plotwindow.py:test_attributes_wt
     - yt/visualization/tests/test_particle_plot.py:test_particle_projection_answers

--- a/yt/visualization/particle_plots.py
+++ b/yt/visualization/particle_plots.py
@@ -369,6 +369,7 @@ class ParticlePhasePlot(PhasePlot):
         deposition="ngp",
         fontsize=18,
         figure_size=8.0,
+        shading="nearest",
     ):
 
         # if no z_fields are passed in, use a constant color
@@ -387,7 +388,7 @@ class ParticlePhasePlot(PhasePlot):
         )
 
         type(self)._initialize_instance(
-            self, data_source, profile, fontsize, figure_size
+            self, data_source, profile, fontsize, figure_size, shading
         )
 
 

--- a/yt/visualization/particle_plots.py
+++ b/yt/visualization/particle_plots.py
@@ -335,6 +335,11 @@ class ParticlePhasePlot(PhasePlot):
     figure_size : int
         Size in inches of the image.
         Default: 8 (8x8)
+    shading : str
+        This argument is directly passed down to matplotlib.axes.Axes.pcolormesh
+        see
+        https://matplotlib.org/3.3.1/gallery/images_contours_and_fields/pcolormesh_grids.html#sphx-glr-gallery-images-contours-and-fields-pcolormesh-grids-py  # noqa
+        Default: 'nearest'
 
     Examples
     --------

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -937,6 +937,7 @@ class PhasePlot(ImagePlotContainer):
         fractional=False,
         fontsize=18,
         figure_size=8.0,
+        shading="nearest",
     ):
 
         data_source = data_object_or_all_data(data_source)
@@ -955,11 +956,13 @@ class PhasePlot(ImagePlotContainer):
             )
 
         type(self)._initialize_instance(
-            self, data_source, profile, fontsize, figure_size
+            self, data_source, profile, fontsize, figure_size, shading
         )
 
     @classmethod
-    def _initialize_instance(cls, obj, data_source, profile, fontsize, figure_size):
+    def _initialize_instance(
+        cls, obj, data_source, profile, fontsize, figure_size, shading
+    ):
         obj.plot_title = {}
         obj.z_log = {}
         obj.z_title = {}
@@ -971,6 +974,7 @@ class PhasePlot(ImagePlotContainer):
         obj._text_ypos = {}
         obj._text_kwargs = {}
         obj._profile = profile
+        obj._shading = shading
         obj._profile_valid = True
         obj._xlim = (None, None)
         obj._ylim = (None, None)
@@ -1115,6 +1119,7 @@ class PhasePlot(ImagePlotContainer):
                 fig,
                 axes,
                 cax,
+                shading=self._shading,
             )
 
             self.plots[f]._toggle_axes(draw_axes)
@@ -1182,7 +1187,7 @@ class PhasePlot(ImagePlotContainer):
         self._plot_valid = True
 
     @classmethod
-    def from_profile(cls, profile, fontsize=18, figure_size=8.0):
+    def from_profile(cls, profile, fontsize=18, figure_size=8.0, shading="nearest"):
         r"""
         Instantiate a PhasePlot object from a profile object created
         with :func:`~yt.data_objects.profiles.create_profile`.
@@ -1215,7 +1220,7 @@ class PhasePlot(ImagePlotContainer):
         obj = cls.__new__(cls)
         data_source = profile.data_source
         return cls._initialize_instance(
-            obj, data_source, profile, fontsize, figure_size
+            obj, data_source, profile, fontsize, figure_size, shading
         )
 
     def annotate_text(self, xpos=0.0, ypos=0.0, text=None, **text_kwargs):
@@ -1607,12 +1612,13 @@ class PhasePlotMPL(ImagePlotMPL):
         figure,
         axes,
         cax,
+        shading="nearest",
     ):
         self._initfinished = False
         self._draw_colorbar = True
         self._draw_axes = True
         self._figure_size = figure_size
-
+        self._shading = shading
         # Compute layout
         fontscale = float(fontsize) / 18.0
         if fontscale < 1.0:
@@ -1646,12 +1652,14 @@ class PhasePlotMPL(ImagePlotMPL):
             norm = matplotlib.colors.Normalize(zlim[0], zlim[1])
         self.image = None
         self.cb = None
+
         self.image = self.axes.pcolormesh(
             np.array(x_data),
             np.array(y_data),
             np.array(image_data.T),
             norm=norm,
             cmap=cmap,
+            shading=self._shading,
         )
 
         self.axes.set_xscale(x_scale)

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -898,6 +898,11 @@ class PhasePlot(ImagePlotContainer):
     figure_size : int
         Size in inches of the image.
         Default: 8 (8x8)
+    shading : str
+        This argument is directly passed down to matplotlib.axes.Axes.pcolormesh
+        see
+        https://matplotlib.org/3.3.1/gallery/images_contours_and_fields/pcolormesh_grids.html#sphx-glr-gallery-images-contours-and-fields-pcolormesh-grids-py  # noqa
+        Default: 'nearest'
 
     Examples
     --------
@@ -1200,6 +1205,11 @@ class PhasePlot(ImagePlotContainer):
              The fontsize to use, in points.
         figure_size : float
              The figure size to use, in inches.
+        shading : str
+            This argument is directly passed down to matplotlib.axes.Axes.pcolormesh
+            see
+            https://matplotlib.org/3.3.1/gallery/images_contours_and_fields/pcolormesh_grids.html#sphx-glr-gallery-images-contours-and-fields-pcolormesh-grids-py  # noqa
+            Default: 'nearest'
 
         Examples
         --------


### PR DESCRIPTION
## PR Summary

Future proof yt for matplotlib 3.5.
rationale:
mpl 3.3 deprecated the current default behaviour in `Axis.pcolormesh(x, y, c)`, see details there
https://matplotlib.org/3.3.1/gallery/images_contours_and_fields/pcolormesh_grids.html#sphx-glr-gallery-images-contours-and-fields-pcolormesh-grids-py

This is only used in `yt.PhasePlot`. In short, the easiest fix is to explicitly pass a `shading` value. The current default `"flat"` will break in mpl 3.5, so the easiest fix is to use `"nearest"` instead, which will output very similar but not quite identical results (we'd need to update answers).

Just in case someone would absolutely need to use the `"flat"` shading again, it's easy enough to expose it in yt. This also allows to use the `"gouraud"` shading mode for phase plots, see the following examples.

```python
import yt
ds = yt.load_sample("HiresIsolatedGalaxy", specific_file="DD0044/DD0044")
ad = ds.all_data()
for shading in ("nearest", "gouraud", "flat"):
    p = yt.PhasePlot(ad, "density", "temperature", "cell_mass", weight_field=None, shading=shading)
    p.show()
    p.save(f"/tmp/phase_{shading}")
```
## flat (current default)
![phase_flat_2d-Profile_density_temperature_cell_mass](https://user-images.githubusercontent.com/14075922/93019392-f9255000-f5d6-11ea-98ae-51df36c4b7e1.png)

## nearest (proposed new default for yt)
![phase_nearest_2d-Profile_density_temperature_cell_mass](https://user-images.githubusercontent.com/14075922/93019552-0c84eb00-f5d8-11ea-8768-7645bb63f4c9.png)

## Gouraud (continuous linear interpolation in between grid nodes)
![phase_gouraud_2d-Profile_density_temperature_cell_mass](https://user-images.githubusercontent.com/14075922/93019557-14448f80-f5d8-11ea-9244-2deff6c4e90f.png)
