### PR TITLE
hotfix: only trigger style checks on PR (avoid duplicated runs)

### DIFF
--- a/.github/workflows/style-checks.yaml
+++ b/.github/workflows/style-checks.yaml
@@ -1,5 +1,5 @@
 name: Style Checks
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   flake8:


### PR DESCRIPTION
## PR Summary

Another hotfix for the GH style checks workflow. I noticed that currently, one gets duplicate notifications when something is wrong since the workflow is triggered both on the main repo side and the fork.