### PR TITLE
[bugfix] fix yt halo container

### DIFF
--- a/yt/frontends/halo_catalog/data_structures.py
+++ b/yt/frontends/halo_catalog/data_structures.py
@@ -306,8 +306,8 @@ class YTHaloParticleIndex(ParticleIndex):
             self.real_ds.index
 
         # inherit some things from parent index
-        for attr in ["data_files", "total_particles"]:
-            setattr(self, attr, getattr(self.real_ds.index, attr))
+        self._data_files = self.real_ds.index.data_files
+        self._total_particles = self.real_ds.index.total_particles
 
         self._calculate_particle_index_starts()
 


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

This was broken by PR #2857. We just need to set the attributes properly now that they're properties. I'd rather do this than make a setter for `total_particles` because we don't really want anyone setting that.

PR #2857 should have failed a halo container test, but the data must not be on the testing box. @Xarthisius, can you put the [tiny_fof_halos](http://yt-project.org/data/tiny_fof_halos.tar.gz) dataset on the testing box?

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] pass `black --check yt/`
- [ ] pass `isort . --check --diff`
- [ ] pass `flake8 yt/`
- [ ] pass `flynt yt/ --fail-on-change --dry-run -e yt/extern`
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
