### PR TITLE
Fix uninitialized values in bbox selection

### DIFF
--- a/yt/geometry/selection_routines.pxd
+++ b/yt/geometry/selection_routines.pxd
@@ -20,6 +20,7 @@ cdef class SelectorObject:
     cdef public np.int32_t max_level
     cdef int overlap_cells
     cdef np.float64_t domain_width[3]
+    cdef np.float64_t domain_center[3]
     cdef bint periodicity[3]
     cdef bint _hash_initialized
     cdef np.int64_t _hash

--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -149,6 +149,7 @@ cdef class SelectorObject:
             DRE = _ensure_code(ds.domain_right_edge)
             for i in range(3):
                 self.domain_width[i] = DRE[i] - DLE[i]
+                self.domain_center[i] = DLE[i] + 0.5 * self.domain_width[i]
                 self.periodicity[i] = ds.periodicity[i]
 
     def get_periodicity(self):
@@ -449,7 +450,7 @@ cdef class SelectorObject:
         mask = np.zeros(npoints, dtype='uint8')
         for i in range(npoints):
             selected = 0
-            for k in range(ndim):
+            for k in range(3):
                 le[k] = 1e60
                 re[k] = -1e60
             for j in range(nv):
@@ -457,6 +458,9 @@ cdef class SelectorObject:
                     pos = coords[indices[i, j] - offset, k]
                     le[k] = fmin(pos, le[k])
                     re[k] = fmax(pos, re[k])
+                for k in range(2, ndim - 1, -1):
+                    le[k] = self.domain_center[k]
+                    re[k] = self.domain_center[k]
             selected = self.select_bbox(le, re)
             total += selected
             mask[i] = selected


### PR DESCRIPTION
This provided sane values for the reduced dimension while selecting region of a 2d mesh. Not a full and proper fix, but hopefully will make the annoying error on travis go away. It's similar to #2539 but I hope to merge this before we figure out a proper fix for 2D data.