### PR TITLE
Squeeze domain center array in data_containers

### DIFF
--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -207,6 +207,11 @@ class YTDataContainer:
                 self.center = self.ds.find_min(center[4:])[1]
         else:
             self.center = self.ds.arr(center, "code_length", dtype="float64")
+
+        if self.center.ndim > 1:
+            mylog.warning("Removing singleton dimensions from 'center'.")
+            self.center = np.squeeze(self.center)
+
         self.set_field_parameter("center", self.center)
 
     def get_field_parameter(self, name, default=None):

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -211,6 +211,12 @@ class YTDataContainer:
         if self.center.ndim > 1:
             mylog.debug("Removing singleton dimensions from 'center'.")
             self.center = np.squeeze(self.center)
+            if self.center.ndim > 1:
+                msg = (
+                    "center array must be 1 dimensional, supplied center has "
+                    f"{self.center.ndim} dimensions with shape {self.center.shape}."
+                )
+                raise YTException(msg)
 
         self.set_field_parameter("center", self.center)
 

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -209,7 +209,7 @@ class YTDataContainer:
             self.center = self.ds.arr(center, "code_length", dtype="float64")
 
         if self.center.ndim > 1:
-            mylog.warning("Removing singleton dimensions from 'center'.")
+            mylog.debug("Removing singleton dimensions from 'center'.")
             self.center = np.squeeze(self.center)
 
         self.set_field_parameter("center", self.center)

--- a/yt/data_objects/tests/test_center_squeeze.py
+++ b/yt/data_objects/tests/test_center_squeeze.py
@@ -6,15 +6,15 @@ def test_center_squeeze():
     # to the data container.
 
     # list of fields to populate fake datasets with
-    fldz = ("density", "velocity_x", "velocity_y", "velocity_z")
+    fldz = ("Density",)
 
     # create and test amr, random and particle data
-    check_single_ds(fake_amr_ds(fields=fldz))
-    check_single_ds(fake_random_ds(16, fields=fldz))
-    check_single_ds(fake_particle_ds(npart=100), check_morton=False)
+    check_single_ds(fake_amr_ds(fields=fldz), True)
+    check_single_ds(fake_random_ds(16, fields=fldz), True)
+    check_single_ds(fake_particle_ds(npart=100), False)
 
 
-def check_single_ds(ds, check_morton=True):
+def check_single_ds(ds, check_morton):
     # compares values for range of data containers using different center array shapes
 
     center = ds.domain_center  # reference center array

--- a/yt/data_objects/tests/test_center_squeeze.py
+++ b/yt/data_objects/tests/test_center_squeeze.py
@@ -1,0 +1,57 @@
+from yt.testing import assert_array_equal, fake_amr_ds, fake_particle_ds, fake_random_ds
+
+
+def test_center_squeeze():
+    # tests that selected values match when supplying center arrays of different shapes
+    # to the data container.
+
+    # list of fields to populate fake datasets with
+    fldz = ("density", "velocity_x", "velocity_y", "velocity_z")
+
+    # create and test amr, random and particle data
+    check_single_ds(fake_amr_ds(fields=fldz))
+    check_single_ds(fake_random_ds(16, fields=fldz))
+    check_single_ds(fake_particle_ds(npart=100), check_morton=False)
+
+
+def check_single_ds(ds, check_morton=True):
+    # compares values for range of data containers using different center array shapes
+
+    center = ds.domain_center  # reference center array
+
+    # build some data containers
+    sp0 = ds.sphere(center, 0.25)
+    sl0 = ds.slice(0, 0.25, center=center)
+    reg0 = ds.region(center, [-0.25, -0.25, -0.25], [0.25, 0.25, 0.25])
+
+    # store morton indices of each
+    i_sp0 = None
+    i_sl0 = None
+    i_reg0 = None
+    if check_morton:
+        i_sp0 = sp0["index", "morton_index"]
+        i_sp0.sort()
+        i_sl0 = sl0["index", "morton_index"]
+        i_sl0.sort()
+        i_reg0 = reg0["index", "morton_index"]
+        i_reg0.sort()
+
+    # create new containers for different shapes of the center array
+    for test_shape in [(1, 3), (1, 1, 3)]:
+        new_center = center.reshape(test_shape)
+        sp = ds.sphere(new_center, 0.25)
+        sl = ds.slice(0, 0.25, center=new_center)
+        reg = ds.region(new_center, [-0.25, -0.25, -0.25], [0.25, 0.25, 0.25])
+
+        # compare each to the reference containers
+        for ob, ob0, i_ob0 in [(sp, sp0, i_sp0), (sl, sl0, i_sl0), (reg, reg0, i_reg0)]:
+
+            # check that selection field values match the reference
+            for fld in ds.field_list:
+                assert_array_equal(ob[fld], ob0[fld])
+
+            if check_morton:
+                # check that morton indices match the reference
+                i_ob = ob["index", "morton_index"]
+                i_ob.sort()
+                assert_array_equal(i_ob, i_ob0)

--- a/yt/data_objects/tests/test_center_squeeze.py
+++ b/yt/data_objects/tests/test_center_squeeze.py
@@ -1,57 +1,23 @@
-from yt.testing import assert_array_equal, fake_amr_ds, fake_particle_ds, fake_random_ds
+from yt.testing import assert_equal, fake_amr_ds, fake_particle_ds, fake_random_ds
 
 
 def test_center_squeeze():
-    # tests that selected values match when supplying center arrays of different shapes
-    # to the data container.
-
-    # list of fields to populate fake datasets with
-    fldz = ("Density",)
+    # checks that the center is reshaped correctly
 
     # create and test amr, random and particle data
-    check_single_ds(fake_amr_ds(fields=fldz), True)
-    check_single_ds(fake_random_ds(16, fields=fldz), True)
-    check_single_ds(fake_particle_ds(npart=100), False)
+    check_single_ds(fake_amr_ds(fields=("Density",)))
+    check_single_ds(fake_random_ds(16, fields=("Density",)))
+    check_single_ds(fake_particle_ds(npart=100, fields=("Density",)))
 
 
-def check_single_ds(ds, check_morton):
-    # compares values for range of data containers using different center array shapes
-
-    center = ds.domain_center  # reference center array
-
-    # build some data containers
-    sp0 = ds.sphere(center, 0.25)
-    sl0 = ds.slice(0, 0.25, center=center)
-    reg0 = ds.region(center, [-0.25, -0.25, -0.25], [0.25, 0.25, 0.25])
-
-    # store morton indices of each
-    i_sp0 = None
-    i_sl0 = None
-    i_reg0 = None
-    if check_morton:
-        i_sp0 = sp0["index", "morton_index"]
-        i_sp0.sort()
-        i_sl0 = sl0["index", "morton_index"]
-        i_sl0.sort()
-        i_reg0 = reg0["index", "morton_index"]
-        i_reg0.sort()
-
-    # create new containers for different shapes of the center array
+def check_single_ds(ds):
+    # checks that the center
+    center = ds.domain_center  # reference center value
     for test_shape in [(1, 3), (1, 1, 3)]:
         new_center = center.reshape(test_shape)
-        sp = ds.sphere(new_center, 0.25)
-        sl = ds.slice(0, 0.25, center=new_center)
-        reg = ds.region(new_center, [-0.25, -0.25, -0.25], [0.25, 0.25, 0.25])
-
-        # compare each to the reference containers
-        for ob, ob0, i_ob0 in [(sp, sp0, i_sp0), (sl, sl0, i_sl0), (reg, reg0, i_reg0)]:
-
-            # check that selection field values match the reference
-            for fld in ds.field_list:
-                assert_array_equal(ob[fld], ob0[fld])
-
-            if check_morton:
-                # check that morton indices match the reference
-                i_ob = ob["index", "morton_index"]
-                i_ob.sort()
-                assert_array_equal(i_ob, i_ob0)
+        assert_equal(ds.sphere(new_center, 0.25).center, center)
+        assert_equal(ds.slice(0, 0.25, center=new_center).center, center)
+        assert_equal(
+            ds.region(new_center, [-0.25, -0.25, -0.25], [0.25, 0.25, 0.25]).center,
+            center,
+        )

--- a/yt/data_objects/tests/test_center_squeeze.py
+++ b/yt/data_objects/tests/test_center_squeeze.py
@@ -7,7 +7,7 @@ def test_center_squeeze():
     # create and test amr, random and particle data
     check_single_ds(fake_amr_ds(fields=("Density",)))
     check_single_ds(fake_random_ds(16, fields=("Density",)))
-    check_single_ds(fake_particle_ds(npart=100, fields=("Density",)))
+    check_single_ds(fake_particle_ds(npart=100))
 
 
 def check_single_ds(ds):


### PR DESCRIPTION
## PR Summary

Squeezes the center array to remove extra dimensions so that the user can supply center arrays of arbitrary shape (e.g., shape of `(1,3)`, `(3,1)`, `(1,3,1)`, etc. are reduced to `(3,)`). Fixes issue #2393 

## PR Checklist

- [x] pass `black --check yt/`
- [x] pass `isort . --check --diff`
- [x] pass `flake8 yt/`
- [x] pass `flynt yt/ --fail-on-change --dry-run -e yt/extern`
- [x] Adds a test for any bugs fixed. Adds tests for new features.

