### PR TITLE
Clarify some utility functions (`yt.funcs`) with more_itertools

### DIFF
--- a/doc/source/reference/api/api.rst
+++ b/doc/source/reference/api/api.rst
@@ -731,7 +731,6 @@ Function List
    ~yt.funcs.humanize_time
    ~yt.funcs.insert_ipython
    ~yt.funcs.is_root
-   ~yt.funcs.is_iterable
    ~yt.funcs.is_sequence
    ~yt.funcs.just_one
    ~yt.funcs.only_on_root

--- a/doc/source/reference/api/api.rst
+++ b/doc/source/reference/api/api.rst
@@ -732,6 +732,7 @@ Function List
    ~yt.funcs.insert_ipython
    ~yt.funcs.is_root
    ~yt.funcs.is_sequence
+   ~yt.funcs.iter_fields
    ~yt.funcs.just_one
    ~yt.funcs.only_on_root
    ~yt.funcs.paste_traceback

--- a/doc/source/reference/api/api.rst
+++ b/doc/source/reference/api/api.rst
@@ -732,7 +732,7 @@ Function List
    ~yt.funcs.insert_ipython
    ~yt.funcs.is_root
    ~yt.funcs.is_iterable
-   ~yt.funcs.has_len
+   ~yt.funcs.is_sequence
    ~yt.funcs.just_one
    ~yt.funcs.only_on_root
    ~yt.funcs.paste_traceback

--- a/doc/source/reference/api/api.rst
+++ b/doc/source/reference/api/api.rst
@@ -726,13 +726,13 @@ Function List
    ~yt.data_objects.static_output.Dataset.all_data
    ~yt.data_objects.static_output.Dataset.box
    ~yt.funcs.deprecate
-   ~yt.funcs.ensure_list
    ~yt.funcs.enable_plugins
    ~yt.funcs.get_pbar
    ~yt.funcs.humanize_time
    ~yt.funcs.insert_ipython
    ~yt.funcs.is_root
-   ~yt.funcs.iterable
+   ~yt.funcs.is_iterable
+   ~yt.funcs.has_len
    ~yt.funcs.just_one
    ~yt.funcs.only_on_root
    ~yt.funcs.paste_traceback

--- a/tests/test_minimal_requirements.txt
+++ b/tests/test_minimal_requirements.txt
@@ -8,3 +8,4 @@ pyyaml>=4.2b1
 coverage~=4.5.1
 codecov~=2.0.15
 unyt~=2.8.0
+more_itertools==8.4

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -30,3 +30,4 @@ MiniballCpp>=0.2.1
 pooch>=0.7.0
 pykdtree~=1.3.1
 nose-exclude
+more_itertools>=8.4

--- a/yt/__init__.py
+++ b/yt/__init__.py
@@ -21,7 +21,7 @@ import numpy as np  # For modern purposes
 import numpy  # In case anyone wishes to use it by name
 
 from yt.funcs import (
-    iterable,
+    has_len,
     get_memory_usage,
     print_tb,
     rootonly,

--- a/yt/__init__.py
+++ b/yt/__init__.py
@@ -21,7 +21,7 @@ import numpy as np  # For modern purposes
 import numpy  # In case anyone wishes to use it by name
 
 from yt.funcs import (
-    has_len,
+    is_sequence,
     get_memory_usage,
     print_tb,
     rootonly,

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -19,7 +19,7 @@ from yt.data_objects.selection_objects.data_selection_objects import (
 from yt.extern.tqdm import tqdm
 from yt.fields.field_exceptions import NeedsGridType, NeedsOriginalGrid
 from yt.frontends.sph.data_structures import ParticleDataset
-from yt.funcs import get_memory_usage, has_len, iter_fields, mylog, only_on_root
+from yt.funcs import get_memory_usage, is_sequence, iter_fields, mylog, only_on_root
 from yt.geometry import particle_deposit as particle_deposit
 from yt.geometry.coordinates.cartesian_coordinates import all_data
 from yt.loaders import load_uniform_grid
@@ -742,7 +742,7 @@ class YTCoveringGrid(YTSelectionContainer3D):
             self._data_source.set_field_parameter(name, val)
 
     def _sanitize_dims(self, dims):
-        if not has_len(dims):
+        if not is_sequence(dims):
             dims = [dims] * len(self.ds.domain_left_edge)
         if len(dims) != len(self.ds.domain_left_edge):
             raise RuntimeError(
@@ -751,7 +751,7 @@ class YTCoveringGrid(YTSelectionContainer3D):
         return np.array(dims, dtype="int32")
 
     def _sanitize_edge(self, edge):
-        if not has_len(edge):
+        if not is_sequence(edge):
             edge = [edge] * len(self.ds.domain_left_edge)
         if len(edge) != len(self.ds.domain_left_edge):
             raise RuntimeError(
@@ -978,7 +978,7 @@ class YTCoveringGrid(YTSelectionContainer3D):
             "int64"
         ) * self.ds.relative_refinement(0, self.level)
         refine_by = self.ds.refine_by
-        if not has_len(self.ds.refine_by):
+        if not is_sequence(self.ds.refine_by):
             refine_by = [refine_by, refine_by, refine_by]
         refine_by = np.array(refine_by, dtype="i8")
         for chunk in parallel_objects(self._data_source.chunks(fields, "io")):
@@ -1359,7 +1359,7 @@ class YTSmoothedCoveringGrid(YTCoveringGrid):
         # NOTE: This usage of "refine_by" is actually *okay*, because it's
         # being used with respect to iref, which is *already* scaled!
         refine_by = self.ds.refine_by
-        if not has_len(self.ds.refine_by):
+        if not is_sequence(self.ds.refine_by):
             refine_by = [refine_by, refine_by, refine_by]
         refine_by = np.array(refine_by, dtype="i8")
 
@@ -2757,7 +2757,7 @@ class YTOctree(YTSelectionContainer3D):
     def _sanitize_edge(self, edge, default):
         if edge is None:
             return default.copy()
-        if not has_len(edge):
+        if not is_sequence(edge):
             edge = [edge] * len(self.ds.domain_left_edge)
         if len(edge) != len(self.ds.domain_left_edge):
             raise RuntimeError(

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -204,14 +204,11 @@ class YTProj(YTSelectionContainer2D):
         else:
             self.weight_field = self._determine_fields(weight_field)[0]
 
-        field = field or []
-        field = self._determine_fields(field)
-
-        for f in field:
+        for f in self._determine_fields(field):
             nodal_flag = self.ds._get_field_info(f).nodal_flag
             if any(nodal_flag):
                 raise RuntimeError(
-                    "Nodal fields are currently not supported " "for projections."
+                    "Nodal fields are currently not supported for projections."
                 )
 
     @property

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -19,7 +19,14 @@ from yt.data_objects.selection_objects.data_selection_objects import (
 from yt.extern.tqdm import tqdm
 from yt.fields.field_exceptions import NeedsGridType, NeedsOriginalGrid
 from yt.frontends.sph.data_structures import ParticleDataset
-from yt.funcs import ensure_list, get_memory_usage, iterable, mylog, only_on_root
+from yt.funcs import (
+    ensure_list,
+    get_memory_usage,
+    iter_fields,
+    iterable,
+    mylog,
+    only_on_root,
+)
 from yt.geometry import particle_deposit as particle_deposit
 from yt.geometry.coordinates.cartesian_coordinates import all_data
 from yt.loaders import load_uniform_grid
@@ -205,7 +212,7 @@ class YTProj(YTSelectionContainer2D):
             self.weight_field = self._determine_fields(weight_field)[0]
 
         field = field or []
-        field = self._determine_fields(ensure_list(field))
+        field = self._determine_fields(field)
 
         for f in field:
             nodal_flag = self.ds._get_field_info(f).nodal_flag
@@ -1143,7 +1150,7 @@ class YTCoveringGrid(YTSelectionContainer3D):
 
         if length_unit is None:
             length_unit = self.ds.length_unit
-        fields = ensure_list(fields)
+        fields = list(iter_fields(fields))
         fid = FITSImageData(self, fields, length_unit=length_unit)
         return fid
 

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -19,14 +19,7 @@ from yt.data_objects.selection_objects.data_selection_objects import (
 from yt.extern.tqdm import tqdm
 from yt.fields.field_exceptions import NeedsGridType, NeedsOriginalGrid
 from yt.frontends.sph.data_structures import ParticleDataset
-from yt.funcs import (
-    ensure_list,
-    get_memory_usage,
-    iter_fields,
-    iterable,
-    mylog,
-    only_on_root,
-)
+from yt.funcs import get_memory_usage, iter_fields, iterable, mylog, only_on_root
 from yt.geometry import particle_deposit as particle_deposit
 from yt.geometry.coordinates.cartesian_coordinates import all_data
 from yt.loaders import load_uniform_grid
@@ -230,8 +223,7 @@ class YTProj(YTSelectionContainer2D):
         return [k for k in self.field_data.keys() if k not in self._container_fields]
 
     def get_data(self, fields=None):
-        fields = fields or []
-        fields = self._determine_fields(ensure_list(fields))
+        fields = self._determine_fields(fields)
         # We need a new tree for every single set of fields we add
         if len(fields) == 0:
             return
@@ -793,7 +785,7 @@ class YTCoveringGrid(YTSelectionContainer3D):
     def get_data(self, fields=None):
         if fields is None:
             return
-        fields = self._determine_fields(ensure_list(fields))
+        fields = self._determine_fields(fields)
         fields_to_get = [f for f in fields if f not in self.field_data]
         fields_to_get = self._identify_dependencies(fields_to_get)
         if len(fields_to_get) == 0:

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -19,7 +19,7 @@ from yt.data_objects.selection_objects.data_selection_objects import (
 from yt.extern.tqdm import tqdm
 from yt.fields.field_exceptions import NeedsGridType, NeedsOriginalGrid
 from yt.frontends.sph.data_structures import ParticleDataset
-from yt.funcs import get_memory_usage, iter_fields, iterable, mylog, only_on_root
+from yt.funcs import get_memory_usage, has_len, iter_fields, mylog, only_on_root
 from yt.geometry import particle_deposit as particle_deposit
 from yt.geometry.coordinates.cartesian_coordinates import all_data
 from yt.loaders import load_uniform_grid
@@ -742,7 +742,7 @@ class YTCoveringGrid(YTSelectionContainer3D):
             self._data_source.set_field_parameter(name, val)
 
     def _sanitize_dims(self, dims):
-        if not iterable(dims):
+        if not has_len(dims):
             dims = [dims] * len(self.ds.domain_left_edge)
         if len(dims) != len(self.ds.domain_left_edge):
             raise RuntimeError(
@@ -751,7 +751,7 @@ class YTCoveringGrid(YTSelectionContainer3D):
         return np.array(dims, dtype="int32")
 
     def _sanitize_edge(self, edge):
-        if not iterable(edge):
+        if not has_len(edge):
             edge = [edge] * len(self.ds.domain_left_edge)
         if len(edge) != len(self.ds.domain_left_edge):
             raise RuntimeError(
@@ -978,7 +978,7 @@ class YTCoveringGrid(YTSelectionContainer3D):
             "int64"
         ) * self.ds.relative_refinement(0, self.level)
         refine_by = self.ds.refine_by
-        if not iterable(self.ds.refine_by):
+        if not has_len(self.ds.refine_by):
             refine_by = [refine_by, refine_by, refine_by]
         refine_by = np.array(refine_by, dtype="i8")
         for chunk in parallel_objects(self._data_source.chunks(fields, "io")):
@@ -1359,7 +1359,7 @@ class YTSmoothedCoveringGrid(YTCoveringGrid):
         # NOTE: This usage of "refine_by" is actually *okay*, because it's
         # being used with respect to iref, which is *already* scaled!
         refine_by = self.ds.refine_by
-        if not iterable(self.ds.refine_by):
+        if not has_len(self.ds.refine_by):
             refine_by = [refine_by, refine_by, refine_by]
         refine_by = np.array(refine_by, dtype="i8")
 
@@ -2757,7 +2757,7 @@ class YTOctree(YTSelectionContainer3D):
     def _sanitize_edge(self, edge, default):
         if edge is None:
             return default.copy()
-        if not iterable(edge):
+        if not has_len(edge):
             edge = [edge] * len(self.ds.domain_left_edge)
         if len(edge) != len(self.ds.domain_left_edge):
             raise RuntimeError(

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -515,7 +515,6 @@ class YTDataContainer:
         import pandas as pd
 
         data = {}
-        fields = ensure_list(fields)
         fields = self._determine_fields(fields)
         for field in fields:
             data[field[-1]] = self[field]
@@ -1437,10 +1436,9 @@ class YTDataContainer:
         raise YTFieldNotParseable(field)
 
     def _determine_fields(self, fields):
-        from more_itertools import collapse
 
         explicit_fields = []
-        for field in collapse(fields, base_type=tuple, levels=1):
+        for field in iter_fields(fields):
             if field in self._container_fields:
                 explicit_fields.append(field)
                 continue

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1437,9 +1437,10 @@ class YTDataContainer:
         raise YTFieldNotParseable(field)
 
     def _determine_fields(self, fields):
-        fields = ensure_list(fields)
+        from more_itertools import collapse
+
         explicit_fields = []
-        for field in fields:
+        for field in collapse(fields, base_type=tuple, levels=1):
             if field in self._container_fields:
                 explicit_fields.append(field)
                 continue

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -10,7 +10,7 @@ from yt.data_objects.field_data import YTFieldData
 from yt.data_objects.profiles import create_profile
 from yt.fields.field_exceptions import NeedsGridType
 from yt.frontends.ytdata.utilities import save_as_dataset
-from yt.funcs import get_output_filename, has_len, mylog
+from yt.funcs import get_output_filename, is_sequence, mylog
 from yt.units.yt_array import YTArray, YTQuantity, uconcatenate
 from yt.utilities.amr_kdtree.api import AMRKDTree
 from yt.utilities.exceptions import (
@@ -1392,7 +1392,7 @@ class YTDataContainer:
         except AttributeError:
             pass
 
-        if has_len(field) and not isinstance(field, str):
+        if is_sequence(field) and not isinstance(field, str):
             try:
                 ftype, fname = field
                 if not all(isinstance(_, str) for _ in field):

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -3,12 +3,14 @@ import weakref
 from contextlib import contextmanager
 
 import numpy as np
+from more_itertools import always_iterable
+from unyt.exceptions import UnitConversionError, UnitParseError
 
 from yt.data_objects.field_data import YTFieldData
 from yt.data_objects.profiles import create_profile
 from yt.fields.field_exceptions import NeedsGridType
 from yt.frontends.ytdata.utilities import save_as_dataset
-from yt.funcs import get_output_filename, iterable, mylog
+from yt.funcs import get_output_filename, has_len, mylog
 from yt.units.yt_array import YTArray, YTQuantity, uconcatenate
 from yt.utilities.amr_kdtree.api import AMRKDTree
 from yt.utilities.exceptions import (

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -3,14 +3,12 @@ import weakref
 from contextlib import contextmanager
 
 import numpy as np
-from more_itertools import always_iterable
-from unyt.exceptions import UnitConversionError, UnitParseError
 
 from yt.data_objects.field_data import YTFieldData
 from yt.data_objects.profiles import create_profile
 from yt.fields.field_exceptions import NeedsGridType
 from yt.frontends.ytdata.utilities import save_as_dataset
-from yt.funcs import get_output_filename, is_sequence, mylog
+from yt.funcs import get_output_filename, is_sequence, iter_fields, mylog
 from yt.units.yt_array import YTArray, YTQuantity, uconcatenate
 from yt.utilities.amr_kdtree.api import AMRKDTree
 from yt.utilities.exceptions import (

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1006,14 +1006,10 @@ class YTDataContainer:
         >>> max_temp_proj = reg.max("temperature", axis="x")
         """
         if axis is None:
-            rv = ()
-            fields = ensure_list(field)
-            for f in fields:
-                rv += (self._compute_extrema(f)[1],)
-            if len(fields) == 1:
+            rv = tuple(self._compute_extrema(f)[1] for f in iter_fields(field))
+            if len(rv) == 1:
                 return rv[0]
-            else:
-                return rv
+            return rv
         elif axis in self.ds.coordinates.axis_name:
             r = self.ds.proj(field, axis, data_source=self, method="mip")
             return r
@@ -1044,14 +1040,9 @@ class YTDataContainer:
         >>> min_temp = reg.min("temperature")
         """
         if axis is None:
-            rv = ()
-            fields = ensure_list(field)
-            for f in ensure_list(fields):
-                rv += (self._compute_extrema(f)[0],)
-            if len(fields) == 1:
+            rv = tuple(self._compute_extrema(f)[0] for f in iter_fields(field))
+            if len(rv) == 1:
                 return rv[0]
-            else:
-                return rv
             return rv
         elif axis in self.ds.coordinates.axis_name:
             raise NotImplementedError(

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -8,7 +8,7 @@ from yt.data_objects.field_data import YTFieldData
 from yt.data_objects.profiles import create_profile
 from yt.fields.field_exceptions import NeedsGridType
 from yt.frontends.ytdata.utilities import save_as_dataset
-from yt.funcs import ensure_list, get_output_filename, iterable, mylog
+from yt.funcs import get_output_filename, iterable, mylog
 from yt.units.yt_array import YTArray, YTQuantity, uconcatenate
 from yt.utilities.amr_kdtree.api import AMRKDTree
 from yt.utilities.exceptions import (
@@ -1390,7 +1390,7 @@ class YTDataContainer:
         except AttributeError:
             pass
 
-        if iterable(field) and not isinstance(field, str):
+        if has_len(field) and not isinstance(field, str):
             try:
                 ftype, fname = field
                 if not all(isinstance(_, str) for _ in field):

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -544,7 +544,6 @@ class YTDataContainer:
         from astropy.table import QTable
 
         t = QTable()
-        fields = ensure_list(fields)
         fields = self._determine_fields(fields)
         for field in fields:
             t[field[-1]] = self[field].to_astropy()

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1428,7 +1428,6 @@ class YTDataContainer:
         raise YTFieldNotParseable(field)
 
     def _determine_fields(self, fields):
-
         explicit_fields = []
         for field in iter_fields(fields):
             if field in self._container_fields:

--- a/yt/data_objects/derived_quantities.py
+++ b/yt/data_objects/derived_quantities.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from yt.funcs import camelcase_to_underscore, ensure_list
+from yt.funcs import camelcase_to_underscore, iter_fields
 from yt.units.yt_array import array_like_field
 from yt.utilities.exceptions import YTParticleTypeNotFound
 from yt.utilities.object_registries import derived_quantity_registry
@@ -126,7 +126,7 @@ class WeightedAverageQuantity(DerivedQuantity):
         self.num_vals = len(fields) + 1
 
     def __call__(self, fields, weight):
-        fields = ensure_list(fields)
+        fields = list(iter_fields(fields))
         rv = super(WeightedAverageQuantity, self).__call__(fields, weight)
         if len(rv) == 1:
             rv = rv[0]
@@ -165,7 +165,7 @@ class TotalQuantity(DerivedQuantity):
         self.num_vals = len(fields)
 
     def __call__(self, fields):
-        fields = ensure_list(fields)
+        fields = list(iter_fields(fields))
         rv = super(TotalQuantity, self).__call__(fields)
         if len(rv) == 1:
             rv = rv[0]
@@ -408,7 +408,7 @@ class WeightedVariance(DerivedQuantity):
         self.num_vals = 2 * len(fields) + 1
 
     def __call__(self, fields, weight):
-        fields = ensure_list(fields)
+        fields = list(iter_fields(fields))
         units = [self.data_source.ds._get_field_info(field).units for field in fields]
         rv = super(WeightedVariance, self).__call__(fields, weight)
         rv = [self.data_source.ds.arr(v, u) for v, u in zip(rv, units)]
@@ -588,7 +588,7 @@ class Extrema(DerivedQuantity):
         self.num_vals = len(fields) * 2
 
     def __call__(self, fields, non_zero=False):
-        fields = ensure_list(fields)
+        fields = list(iter_fields(fields))
         rv = super(Extrema, self).__call__(fields, non_zero)
         if len(rv) == 1:
             rv = rv[0]

--- a/yt/data_objects/index_subobjects/grid_patch.py
+++ b/yt/data_objects/index_subobjects/grid_patch.py
@@ -8,7 +8,7 @@ from yt.config import ytcfg
 from yt.data_objects.selection_objects.data_selection_objects import (
     YTSelectionContainer,
 )
-from yt.funcs import iterable
+from yt.funcs import has_len
 from yt.geometry.selection_routines import convert_mask_to_indices
 from yt.units.yt_array import YTArray
 from yt.utilities.exceptions import (
@@ -170,7 +170,7 @@ class AMRGridPatch(YTSelectionContainer):
         # This can be expensive so we allow people to disable this behavior
         # via a config option
         if RECONSTRUCT_INDEX:
-            if iterable(self.Parent) and len(self.Parent) > 0:
+            if has_len(self.Parent) and len(self.Parent) > 0:
                 p = self.Parent[0]
             else:
                 p = self.Parent

--- a/yt/data_objects/index_subobjects/grid_patch.py
+++ b/yt/data_objects/index_subobjects/grid_patch.py
@@ -8,7 +8,7 @@ from yt.config import ytcfg
 from yt.data_objects.selection_objects.data_selection_objects import (
     YTSelectionContainer,
 )
-from yt.funcs import has_len
+from yt.funcs import is_sequence
 from yt.geometry.selection_routines import convert_mask_to_indices
 from yt.units.yt_array import YTArray
 from yt.utilities.exceptions import (
@@ -170,7 +170,7 @@ class AMRGridPatch(YTSelectionContainer):
         # This can be expensive so we allow people to disable this behavior
         # via a config option
         if RECONSTRUCT_INDEX:
-            if has_len(self.Parent) and len(self.Parent) > 0:
+            if is_sequence(self.Parent) and len(self.Parent) > 0:
                 p = self.Parent[0]
             else:
                 p = self.Parent

--- a/yt/data_objects/index_subobjects/particle_container.py
+++ b/yt/data_objects/index_subobjects/particle_container.py
@@ -4,7 +4,7 @@ from yt.data_objects.data_containers import YTFieldData
 from yt.data_objects.selection_objects.data_selection_objects import (
     YTSelectionContainer,
 )
-from yt.funcs import ensure_list
+from more_itertools import always_iterable
 from yt.utilities.exceptions import (
     YTDataSelectorNotImplemented,
     YTNonIndexedDataContainer,
@@ -29,8 +29,8 @@ class ParticleContainer(YTSelectionContainer):
             overlap_files = []
         self.field_data = YTFieldData()
         self.field_parameters = {}
-        self.data_files = ensure_list(data_files)
-        self.overlap_files = ensure_list(overlap_files)
+        self.data_files = list(always_iterable(data_files))
+        self.overlap_files = list(always_iterable(overlap_files))
         self.ds = self.data_files[0].ds
         self._last_mask = None
         self._last_selector_id = None

--- a/yt/data_objects/index_subobjects/particle_container.py
+++ b/yt/data_objects/index_subobjects/particle_container.py
@@ -1,10 +1,11 @@
 import contextlib
 
+from more_itertools import always_iterable
+
 from yt.data_objects.data_containers import YTFieldData
 from yt.data_objects.selection_objects.data_selection_objects import (
     YTSelectionContainer,
 )
-from more_itertools import always_iterable
 from yt.utilities.exceptions import (
     YTDataSelectorNotImplemented,
     YTNonIndexedDataContainer,

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -5,7 +5,7 @@ from yt.fields.derived_field import DerivedField
 from yt.frontends.ytdata.utilities import save_as_dataset
 from yt.funcs import (
     get_output_filename,
-    has_len,
+    is_sequence,
     issue_deprecation_warning,
     iter_fields,
     mylog,
@@ -1338,9 +1338,9 @@ def create_profile(
         wf = data_source.ds._get_field_info(weight_field)
         if not wf.sampling_type == "particle":
             weight_field = None
-    if not has_len(n_bins):
+    if not is_sequence(n_bins):
         n_bins = [n_bins] * len(bin_fields)
-    if not has_len(accumulation):
+    if not is_sequence(accumulation):
         accumulation = [accumulation] * len(bin_fields)
     if logs is None:
         logs = {}
@@ -1406,10 +1406,10 @@ def create_profile(
                     fe = data_source.ds.arr(field_ex, bf_units)
             fe.convert_to_units(bf_units)
             field_ex = [fe[0].v, fe[1].v]
-            if has_len(field_ex[0]):
+            if is_sequence(field_ex[0]):
                 field_ex[0] = data_source.ds.quan(field_ex[0][0], field_ex[0][1])
                 field_ex[0] = field_ex[0].in_units(bf_units)
-            if has_len(field_ex[1]):
+            if is_sequence(field_ex[1]):
                 field_ex[1] = data_source.ds.quan(field_ex[1][0], field_ex[1][1])
                 field_ex[1] = field_ex[1].in_units(bf_units)
             ex.append(field_ex)

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -4,9 +4,9 @@ from yt.data_objects.field_data import YTFieldData
 from yt.fields.derived_field import DerivedField
 from yt.frontends.ytdata.utilities import save_as_dataset
 from yt.funcs import (
-    ensure_list,
     get_output_filename,
     issue_deprecation_warning,
+    iter_fields,
     iterable,
     mylog,
 )
@@ -566,7 +566,6 @@ class Profile1D(ProfileND):
         if fields is None:
             fields = self.field_data.keys()
         else:
-            fields = ensure_list(fields)
             fields = self.data_source._determine_fields(fields)
         return idxs, masked, fields
 
@@ -1271,7 +1270,7 @@ def create_profile(
 
     """
     bin_fields = data_source._determine_fields(bin_fields)
-    fields = ensure_list(fields)
+    fields = list(iter_fields(fields))
     is_pfield = [
         data_source.ds._get_field_info(f).sampling_type == "particle"
         for f in bin_fields + fields

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -5,9 +5,9 @@ from yt.fields.derived_field import DerivedField
 from yt.frontends.ytdata.utilities import save_as_dataset
 from yt.funcs import (
     get_output_filename,
+    has_len,
     issue_deprecation_warning,
     iter_fields,
-    iterable,
     mylog,
 )
 from yt.units.unit_object import Unit
@@ -1338,9 +1338,9 @@ def create_profile(
         wf = data_source.ds._get_field_info(weight_field)
         if not wf.sampling_type == "particle":
             weight_field = None
-    if not iterable(n_bins):
+    if not has_len(n_bins):
         n_bins = [n_bins] * len(bin_fields)
-    if not iterable(accumulation):
+    if not has_len(accumulation):
         accumulation = [accumulation] * len(bin_fields)
     if logs is None:
         logs = {}
@@ -1406,10 +1406,10 @@ def create_profile(
                     fe = data_source.ds.arr(field_ex, bf_units)
             fe.convert_to_units(bf_units)
             field_ex = [fe[0].v, fe[1].v]
-            if iterable(field_ex[0]):
+            if has_len(field_ex[0]):
                 field_ex[0] = data_source.ds.quan(field_ex[0][0], field_ex[0][1])
                 field_ex[0] = field_ex[0].in_units(bf_units)
-            if iterable(field_ex[1]):
+            if has_len(field_ex[1]):
                 field_ex[1] = data_source.ds.quan(field_ex[1][0], field_ex[1][1])
                 field_ex[1] = field_ex[1].in_units(bf_units)
             ex.append(field_ex)

--- a/yt/data_objects/selection_objects/boolean_operations.py
+++ b/yt/data_objects/selection_objects/boolean_operations.py
@@ -1,4 +1,5 @@
 import numpy as np
+from more_itertools import always_iterable
 
 import yt.geometry
 from yt.data_objects.selection_objects.data_selection_objects import (
@@ -6,7 +7,7 @@ from yt.data_objects.selection_objects.data_selection_objects import (
     YTSelectionContainer3D,
 )
 from yt.data_objects.static_output import Dataset
-from yt.funcs import ensure_list, validate_iterable, validate_object
+from yt.funcs import validate_object, validate_sequence
 
 
 class YTBooleanContainer(YTSelectionContainer3D):
@@ -94,17 +95,14 @@ class YTIntersectionContainer3D(YTSelectionContainer3D):
     _con_args = ("data_objects",)
 
     def __init__(self, data_objects, ds=None, field_parameters=None, data_source=None):
-        validate_iterable(data_objects)
+        validate_sequence(data_objects)
         for obj in data_objects:
             validate_object(obj, YTSelectionContainer)
         validate_object(ds, Dataset)
         validate_object(field_parameters, dict)
         validate_object(data_source, YTSelectionContainer)
         YTSelectionContainer3D.__init__(self, None, ds, field_parameters, data_source)
-        # ensure_list doesn't check for tuples
-        if isinstance(data_objects, tuple):
-            data_objects = list(data_objects)
-        self.data_objects = ensure_list(data_objects)
+        self.data_objects = list(always_iterable(data_objects))
 
 
 class YTDataObjectUnion(YTSelectionContainer3D):
@@ -137,14 +135,11 @@ class YTDataObjectUnion(YTSelectionContainer3D):
     _con_args = ("data_objects",)
 
     def __init__(self, data_objects, ds=None, field_parameters=None, data_source=None):
-        validate_iterable(data_objects)
+        validate_sequence(data_objects)
         for obj in data_objects:
             validate_object(obj, YTSelectionContainer)
         validate_object(ds, Dataset)
         validate_object(field_parameters, dict)
         validate_object(data_source, YTSelectionContainer)
         YTSelectionContainer3D.__init__(self, None, ds, field_parameters, data_source)
-        # ensure_list doesn't check for tuples
-        if isinstance(data_objects, tuple):
-            data_objects = list(data_objects)
-        self.data_objects = ensure_list(data_objects)
+        self.data_objects = list(always_iterable(data_objects))

--- a/yt/data_objects/selection_objects/cut_region.py
+++ b/yt/data_objects/selection_objects/cut_region.py
@@ -1,11 +1,12 @@
 import numpy as np
+from more_itertools import always_iterable
 
 from yt.data_objects.selection_objects.data_selection_objects import (
     YTSelectionContainer,
     YTSelectionContainer3D,
 )
 from yt.data_objects.static_output import Dataset
-from yt.funcs import ensure_list, validate_iterable, validate_object
+from yt.funcs import iter_fields, validate_object, validate_sequence
 from yt.geometry.selection_routines import points_in_cells
 from yt.utilities.exceptions import YTIllDefinedCutRegion
 from yt.utilities.on_demand_imports import _scipy
@@ -51,7 +52,7 @@ class YTCutRegion(YTSelectionContainer3D):
         if locals is None:
             locals = {}
         validate_object(data_source, YTSelectionContainer)
-        validate_iterable(conditionals)
+        validate_sequence(conditionals)
         for condition in conditionals:
             validate_object(condition, str)
         validate_object(ds, Dataset)
@@ -64,7 +65,7 @@ class YTCutRegion(YTSelectionContainer3D):
                 raise RuntimeError("Cannot use both base_object and data_source")
             data_source = base_object
 
-        self.conditionals = ensure_list(conditionals)
+        self.conditionals = list(always_iterable(conditionals))
         if isinstance(data_source, YTCutRegion):
             # If the source is also a cut region, add its conditionals
             # and set the source to be its source.
@@ -91,7 +92,7 @@ class YTCutRegion(YTSelectionContainer3D):
                     yield self
 
     def get_data(self, fields=None):
-        fields = ensure_list(fields)
+        fields = list(iter_fields(fields))
         self.base_object.get_data(fields)
         ind = self._cond_ind
         for field in fields:

--- a/yt/data_objects/selection_objects/data_selection_objects.py
+++ b/yt/data_objects/selection_objects/data_selection_objects.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 
 import numpy as np
+from more_itertools import always_iterable
 from unyt.exceptions import UnitConversionError, UnitParseError
 
 import yt.geometry
@@ -12,7 +13,7 @@ from yt.data_objects.data_containers import YTDataContainer
 from yt.data_objects.derived_quantities import DerivedQuantityCollection
 from yt.data_objects.field_data import YTFieldData
 from yt.fields.field_exceptions import NeedsGridType
-from yt.funcs import ensure_list, fix_axis, validate_width_tuple
+from yt.funcs import fix_axis, is_sequence, iter_fields, validate_width_tuple
 from yt.geometry.selection_routines import compose_selector
 from yt.units import dimensions as ytdims
 from yt.utilities.exceptions import (
@@ -90,7 +91,7 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface):
         # those are the ones that will be.
         chunk_ind = kwargs.pop("chunk_ind", None)
         if chunk_ind is not None:
-            chunk_ind = ensure_list(chunk_ind)
+            chunk_ind = list(always_iterable(chunk_ind))
         for ci, chunk in enumerate(self.index._chunk(self, chunking_style, **kwargs)):
             if chunk_ind is not None and ci not in chunk_ind:
                 continue
@@ -522,7 +523,7 @@ class YTSelectionContainer2D(YTSelectionContainer):
         skip += list(set(frb._exclude_fields).difference(set(self._key_fields)))
         self.fields = [k for k in self.field_data if k not in skip]
         if fields is not None:
-            self.fields = ensure_list(fields) + self.fields
+            self.fields = list(iter_fields(fields)) + self.fields
         if len(self.fields) == 0:
             raise ValueError("No fields found to plot in get_pw")
         (bounds, center, display_center) = get_window_parameters(
@@ -594,7 +595,7 @@ class YTSelectionContainer2D(YTSelectionContainer):
             )
 
             validate_width_tuple(width)
-            if iterable(resolution):
+            if is_sequence(resolution):
                 resolution = max(resolution)
             frb = CylindricalFixedResolutionBuffer(self, width, resolution)
             return frb
@@ -603,9 +604,9 @@ class YTSelectionContainer2D(YTSelectionContainer):
             center = self.center
             if center is None:
                 center = (self.ds.domain_right_edge + self.ds.domain_left_edge) / 2.0
-        elif iterable(center) and not isinstance(center, YTArray):
+        elif is_sequence(center) and not isinstance(center, YTArray):
             center = self.ds.arr(center, "code_length")
-        if iterable(width):
+        if is_sequence(width):
             w, u = width
             if isinstance(w, tuple) and isinstance(u, tuple):
                 height = u
@@ -615,7 +616,7 @@ class YTSelectionContainer2D(YTSelectionContainer):
             width = self.ds.quan(width, "code_length")
         if height is None:
             height = width
-        elif iterable(height):
+        elif is_sequence(height):
             h, u = height
             height = self.ds.quan(h, units=u)
         elif not isinstance(height, YTArray):

--- a/yt/data_objects/selection_objects/data_selection_objects.py
+++ b/yt/data_objects/selection_objects/data_selection_objects.py
@@ -8,7 +8,7 @@ from more_itertools import always_iterable
 from unyt.exceptions import UnitConversionError, UnitParseError
 
 import yt.geometry
-from yt import YTArray, iterable
+from yt import YTArray
 from yt.data_objects.data_containers import YTDataContainer
 from yt.data_objects.derived_quantities import DerivedQuantityCollection
 from yt.data_objects.field_data import YTFieldData
@@ -621,7 +621,7 @@ class YTSelectionContainer2D(YTSelectionContainer):
             height = self.ds.quan(h, units=u)
         elif not isinstance(height, YTArray):
             height = self.ds.quan(height, "code_length")
-        if not iterable(resolution):
+        if not is_sequence(resolution):
             resolution = (resolution, resolution)
         from yt.visualization.fixed_resolution import FixedResolutionBuffer
 

--- a/yt/data_objects/selection_objects/disk.py
+++ b/yt/data_objects/selection_objects/disk.py
@@ -10,8 +10,8 @@ from yt.funcs import (
     validate_3d_array,
     validate_center,
     validate_float,
-    validate_iterable,
     validate_object,
+    validate_sequence,
 )
 
 
@@ -71,7 +71,7 @@ class YTDisk(YTSelectionContainer3D):
         validate_3d_array(normal)
         validate_float(radius)
         validate_float(height)
-        validate_iterable(fields)
+        validate_sequence(fields)
         validate_object(ds, Dataset)
         validate_object(field_parameters, dict)
         validate_object(data_source, YTSelectionContainer)

--- a/yt/data_objects/selection_objects/object_collection.py
+++ b/yt/data_objects/selection_objects/object_collection.py
@@ -5,7 +5,7 @@ from yt.data_objects.selection_objects.data_selection_objects import (
     YTSelectionContainer3D,
 )
 from yt.data_objects.static_output import Dataset
-from yt.funcs import validate_center, validate_iterable, validate_object
+from yt.funcs import validate_center, validate_object, validate_sequence
 
 
 class YTDataCollection(YTSelectionContainer3D):
@@ -20,7 +20,7 @@ class YTDataCollection(YTSelectionContainer3D):
     def __init__(
         self, obj_list, ds=None, field_parameters=None, data_source=None, center=None
     ):
-        validate_iterable(obj_list)
+        validate_sequence(obj_list)
         validate_object(ds, Dataset)
         validate_object(field_parameters, dict)
         validate_object(data_source, YTSelectionContainer)

--- a/yt/data_objects/selection_objects/ray.py
+++ b/yt/data_objects/selection_objects/ray.py
@@ -13,8 +13,8 @@ from yt.funcs import (
     validate_3d_array,
     validate_axis,
     validate_float,
-    validate_iterable,
     validate_object,
+    validate_sequence,
 )
 from yt.utilities.lib.pixelization_routines import SPHKernelInterpolationTable
 from yt.utilities.logger import ytLogger as mylog
@@ -74,7 +74,7 @@ class YTOrthoRay(YTSelectionContainer1D):
 
     def __init__(self, axis, coords, ds=None, field_parameters=None, data_source=None):
         validate_axis(ds, axis)
-        validate_iterable(coords)
+        validate_sequence(coords)
         for c in coords:
             validate_float(c)
         validate_object(ds, Dataset)

--- a/yt/data_objects/selection_objects/region.py
+++ b/yt/data_objects/selection_objects/region.py
@@ -7,8 +7,8 @@ from yt.data_objects.static_output import Dataset
 from yt.funcs import (
     validate_3d_array,
     validate_center,
-    validate_iterable,
     validate_object,
+    validate_sequence,
 )
 
 
@@ -48,7 +48,7 @@ class YTRegion(YTSelectionContainer3D):
             validate_center(center)
         validate_3d_array(left_edge)
         validate_3d_array(right_edge)
-        validate_iterable(fields)
+        validate_sequence(fields)
         validate_object(ds, Dataset)
         validate_object(field_parameters, dict)
         validate_object(data_source, YTSelectionContainer)

--- a/yt/data_objects/selection_objects/slices.py
+++ b/yt/data_objects/selection_objects/slices.py
@@ -1,13 +1,13 @@
 import numpy as np
 
-from yt import iterable
 from yt.data_objects.selection_objects.data_selection_objects import (
     YTSelectionContainer,
     YTSelectionContainer2D,
 )
 from yt.data_objects.static_output import Dataset
 from yt.funcs import (
-    ensure_list,
+    is_sequence,
+    iter_fields,
     validate_3d_array,
     validate_axis,
     validate_center,
@@ -285,7 +285,7 @@ class YTCuttingPlane(YTSelectionContainer2D):
         """
         normal = self.normal
         center = self.center
-        self.fields = ensure_list(fields) + [
+        self.fields = list(iter_fields(fields)) + [
             k for k in self.field_data.keys() if k not in self._key_fields
         ]
         from yt.visualization.fixed_resolution import FixedResolutionBuffer
@@ -353,15 +353,15 @@ class YTCuttingPlane(YTSelectionContainer2D):
         >>> frb = cutting.to_frb( (1.0, 'pc'), 1024)
         >>> write_image(np.log10(frb["Density"]), 'density_1pc.png')
         """
-        if iterable(width):
+        if is_sequence(width):
             validate_width_tuple(width)
             width = self.ds.quan(width[0], width[1])
         if height is None:
             height = width
-        elif iterable(height):
+        elif is_sequence(height):
             validate_width_tuple(height)
             height = self.ds.quan(height[0], height[1])
-        if not iterable(resolution):
+        if not is_sequence(resolution):
             resolution = (resolution, resolution)
         from yt.visualization.fixed_resolution import FixedResolutionBuffer
 

--- a/yt/data_objects/selection_objects/spheroids.py
+++ b/yt/data_objects/selection_objects/spheroids.py
@@ -11,8 +11,8 @@ from yt.funcs import (
     validate_3d_array,
     validate_center,
     validate_float,
-    validate_iterable,
     validate_object,
+    validate_sequence,
 )
 from yt.utilities.exceptions import YTEllipsoidOrdering, YTException, YTSphereTooSmall
 from yt.utilities.logger import ytLogger as mylog
@@ -175,7 +175,7 @@ class YTEllipsoid(YTSelectionContainer3D):
         validate_float(C)
         validate_3d_array(e0)
         validate_float(tilt)
-        validate_iterable(fields)
+        validate_sequence(fields)
         validate_object(ds, Dataset)
         validate_object(field_parameters, dict)
         validate_object(data_source, YTSelectionContainer)

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -20,9 +20,9 @@ from yt.fields.field_type_container import FieldTypeContainer
 from yt.fields.fluid_fields import setup_gradient_fields
 from yt.fields.particle_fields import DEP_MSG_SMOOTH_FIELD
 from yt.funcs import (
+    has_len,
     issue_deprecation_warning,
     iter_fields,
-    iterable,
     mylog,
     set_intersection,
     setdefaultattr,
@@ -1880,7 +1880,7 @@ class ParticleDataset(Dataset):
 def validate_index_order(index_order):
     if index_order is None:
         index_order = (7, 5)
-    elif not iterable(index_order):
+    elif not has_len(index_order):
         index_order = (int(index_order), 1)
     else:
         if len(index_order) != 2:

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -20,7 +20,6 @@ from yt.fields.field_type_container import FieldTypeContainer
 from yt.fields.fluid_fields import setup_gradient_fields
 from yt.fields.particle_fields import DEP_MSG_SMOOTH_FIELD
 from yt.funcs import (
-    ensure_list,
     issue_deprecation_warning,
     iter_fields,
     iterable,
@@ -971,11 +970,8 @@ class Dataset(abc.ABC):
         the input *fields*.
         """
         point = self.point(coords)
-        ret = []
-        field_list = ensure_list(fields)
-        for field in field_list:
-            ret.append(point[field])
-        if len(field_list) == 1:
+        ret = [point[f] for f in iter_fields(fields)]
+        if len(ret) == 1:
             return ret[0]
         else:
             return ret

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -20,7 +20,7 @@ from yt.fields.field_type_container import FieldTypeContainer
 from yt.fields.fluid_fields import setup_gradient_fields
 from yt.fields.particle_fields import DEP_MSG_SMOOTH_FIELD
 from yt.funcs import (
-    has_len,
+    is_sequence,
     issue_deprecation_warning,
     iter_fields,
     mylog,
@@ -1880,7 +1880,7 @@ class ParticleDataset(Dataset):
 def validate_index_order(index_order):
     if index_order is None:
         index_order = (7, 5)
-    elif not has_len(index_order):
+    elif not is_sequence(index_order):
         index_order = (int(index_order), 1)
     else:
         if len(index_order) != 2:

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -22,6 +22,7 @@ from yt.fields.particle_fields import DEP_MSG_SMOOTH_FIELD
 from yt.funcs import (
     ensure_list,
     issue_deprecation_warning,
+    iter_fields,
     iterable,
     mylog,
     set_intersection,
@@ -992,7 +993,7 @@ class Dataset(abc.ABC):
         except AttributeError:
             pass
 
-        fields = ensure_list(fields)
+        fields = list(iter_fields(fields))
         out = []
 
         # This may be slow because it creates a data object for each point

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -6,11 +6,12 @@ import weakref
 from functools import wraps
 
 import numpy as np
+from more_itertools import always_iterable
 
 from yt.config import ytcfg
 from yt.data_objects.analyzer_objects import AnalysisTask, create_quantity_proxy
 from yt.data_objects.particle_trajectories import ParticleTrajectories
-from yt.funcs import ensure_list, issue_deprecation_warning, iterable, mylog
+from yt.funcs import issue_deprecation_warning, iterable, mylog
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.exceptions import YTException
 from yt.utilities.object_registries import (
@@ -341,11 +342,10 @@ class DatasetSeries:
             yield next_ret
 
     def eval(self, tasks, obj=None):
-        tasks = ensure_list(tasks)
         return_values = {}
         for store, ds in self.piter(return_values):
             store.result = []
-            for task in tasks:
+            for task in always_iterable(tasks):
                 try:
                     style = inspect.getargspec(task.eval)[0][1]
                     if style == "ds":

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -11,7 +11,7 @@ from more_itertools import always_iterable
 from yt.config import ytcfg
 from yt.data_objects.analyzer_objects import AnalysisTask, create_quantity_proxy
 from yt.data_objects.particle_trajectories import ParticleTrajectories
-from yt.funcs import has_len, issue_deprecation_warning, mylog
+from yt.funcs import is_sequence, issue_deprecation_warning, mylog
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.exceptions import YTException
 from yt.utilities.object_registries import (
@@ -166,7 +166,7 @@ class DatasetSeries:
     ):
         # This is needed to properly set _pre_outputs for Simulation subclasses.
         self._mixed_dataset_types = mixed_dataset_types
-        if has_len(outputs) and not isinstance(outputs, str):
+        if is_sequence(outputs) and not isinstance(outputs, str):
             self._pre_outputs = outputs[:]
         self.tasks = AnalysisTaskProxy(self)
         self.params = TimeSeriesParametersContainer(self)

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -11,7 +11,7 @@ from more_itertools import always_iterable
 from yt.config import ytcfg
 from yt.data_objects.analyzer_objects import AnalysisTask, create_quantity_proxy
 from yt.data_objects.particle_trajectories import ParticleTrajectories
-from yt.funcs import issue_deprecation_warning, iterable, mylog
+from yt.funcs import has_len, issue_deprecation_warning, mylog
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.exceptions import YTException
 from yt.utilities.object_registries import (
@@ -166,7 +166,7 @@ class DatasetSeries:
     ):
         # This is needed to properly set _pre_outputs for Simulation subclasses.
         self._mixed_dataset_types = mixed_dataset_types
-        if iterable(outputs) and not isinstance(outputs, str):
+        if has_len(outputs) and not isinstance(outputs, str):
             self._pre_outputs = outputs[:]
         self.tasks = AnalysisTaskProxy(self)
         self.params = TimeSeriesParametersContainer(self)

--- a/yt/data_objects/unions.py
+++ b/yt/data_objects/unions.py
@@ -1,4 +1,4 @@
-from yt.funcs import ensure_list
+from more_itertools import always_iterable
 
 
 class Union:
@@ -6,7 +6,7 @@ class Union:
 
     def __init__(self, name, sub_types):
         self.name = name
-        self.sub_types = ensure_list(sub_types)
+        self.sub_types = list(always_iterable(sub_types))
 
     def __iter__(self):
         for st in self.sub_types:

--- a/yt/fields/derived_field.py
+++ b/yt/fields/derived_field.py
@@ -6,7 +6,7 @@ import warnings
 from more_itertools import always_iterable
 
 import yt.units.dimensions as ytdims
-from yt.funcs import VisibleDeprecationWarning, ensure_list
+from yt.funcs import VisibleDeprecationWarning, iter_fields
 from yt.units.unit_object import Unit
 from yt.utilities.exceptions import YTFieldNotFound
 
@@ -481,7 +481,7 @@ class ValidateParameter(FieldValidator):
         is available for all permutations of the field parameter.
         """
         FieldValidator.__init__(self)
-        self.parameters = ensure_list(parameters)
+        self.parameters = list(always_iterable(parameters))
         self.parameter_values = parameter_values
 
     def __call__(self, data):
@@ -501,7 +501,7 @@ class ValidateDataField(FieldValidator):
         in it.
         """
         FieldValidator.__init__(self)
-        self.fields = ensure_list(field)
+        self.fields = list(iter_fields(field))
 
     def __call__(self, data):
         doesnt_have = []
@@ -521,7 +521,7 @@ class ValidateProperty(FieldValidator):
         This validator ensures that the data object has a given python attribute.
         """
         FieldValidator.__init__(self)
-        self.prop = ensure_list(prop)
+        self.prop = list(always_iterable(prop))
 
     def __call__(self, data):
         doesnt_have = []

--- a/yt/fields/derived_field.py
+++ b/yt/fields/derived_field.py
@@ -3,6 +3,8 @@ import inspect
 import re
 import warnings
 
+from more_itertools import always_iterable
+
 import yt.units.dimensions as ytdims
 from yt.funcs import VisibleDeprecationWarning, ensure_list
 from yt.units.unit_object import Unit
@@ -136,10 +138,7 @@ class DerivedField:
 
         self._function = function
 
-        if validators:
-            self.validators = ensure_list(validators)
-        else:
-            self.validators = []
+        self.validators = list(always_iterable(validators))
 
         # handle units
         if units is None:

--- a/yt/fields/local_fields.py
+++ b/yt/fields/local_fields.py
@@ -1,4 +1,4 @@
-from yt.funcs import iterable
+from yt.funcs import has_len
 from yt.utilities.logger import ytLogger as mylog
 
 from .field_info_container import FieldInfoContainer
@@ -12,7 +12,7 @@ class LocalFieldInfoContainer(FieldInfoContainer):
             sampling_type, kwargs.get("particle_type")
         )
 
-        if isinstance(name, str) or not iterable(name):
+        if isinstance(name, str) or not has_len(name):
             if sampling_type == "particle":
                 ftype = "all"
             else:

--- a/yt/fields/local_fields.py
+++ b/yt/fields/local_fields.py
@@ -1,4 +1,4 @@
-from yt.funcs import has_len
+from yt.funcs import is_sequence
 from yt.utilities.logger import ytLogger as mylog
 
 from .field_info_container import FieldInfoContainer
@@ -12,7 +12,7 @@ class LocalFieldInfoContainer(FieldInfoContainer):
             sampling_type, kwargs.get("particle_type")
         )
 
-        if isinstance(name, str) or not has_len(name):
+        if isinstance(name, str) or not is_sequence(name):
             if sampling_type == "particle":
                 ftype = "all"
             else:

--- a/yt/fields/vector_operations.py
+++ b/yt/fields/vector_operations.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from yt.funcs import iterable, just_one
+from yt.funcs import has_len, just_one
 from yt.geometry.geometry_handler import is_curvilinear
 from yt.utilities.lib.misc_utilities import obtain_relative_velocity_vector
 from yt.utilities.math_utils import (
@@ -105,7 +105,7 @@ def create_los_field(registry, basename, field_units, ftype="gas", slice_info=No
         else:
             fns = field_comps
         ax = data.get_field_parameter("axis")
-        if iterable(ax):
+        if has_len(ax):
             # Make sure this is a unit vector
             ax /= np.sqrt(np.dot(ax, ax))
             ret = data[fns[0]] * ax[0] + data[fns[1]] * ax[1] + data[fns[2]] * ax[2]

--- a/yt/fields/vector_operations.py
+++ b/yt/fields/vector_operations.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from yt.funcs import has_len, just_one
+from yt.funcs import is_sequence, just_one
 from yt.geometry.geometry_handler import is_curvilinear
 from yt.utilities.lib.misc_utilities import obtain_relative_velocity_vector
 from yt.utilities.math_utils import (
@@ -105,7 +105,7 @@ def create_los_field(registry, basename, field_units, ftype="gas", slice_info=No
         else:
             fns = field_comps
         ax = data.get_field_parameter("axis")
-        if has_len(ax):
+        if is_sequence(ax):
             # Make sure this is a unit vector
             ax /= np.sqrt(np.dot(ax, ax))
             ret = data[fns[0]] * ax[0] + data[fns[1]] * ax[1] + data[fns[2]] * ax[2]

--- a/yt/frontends/amrvac/io.py
+++ b/yt/frontends/amrvac/io.py
@@ -7,8 +7,8 @@ AMRVAC-specific IO functions
 import os
 
 import numpy as np
+from more_itertools import always_iterable
 
-from yt.funcs import ensure_list
 from yt.geometry.selection_routines import GridSelector
 from yt.utilities.io_handler import BaseIOHandler
 from yt.utilities.on_demand_imports import _f90nml as f90nml
@@ -35,7 +35,7 @@ def read_amrvac_namelist(parfiles):
         A single namelist object. The class inherits from ordereddict.
 
     """
-    parfiles = [os.path.expanduser(pf) for pf in ensure_list(parfiles)]
+    parfiles = (os.path.expanduser(pf) for pf in always_iterable(parfiles))
 
     # first merge the namelists
     namelists = [f90nml.read(parfile) for parfile in parfiles]

--- a/yt/frontends/enzo/data_structures.py
+++ b/yt/frontends/enzo/data_structures.py
@@ -12,7 +12,7 @@ from yt.data_objects.index_subobjects.grid_patch import AMRGridPatch
 from yt.data_objects.static_output import Dataset
 from yt.fields.field_info_container import NullFunc
 from yt.frontends.enzo.misc import cosmology_get_units
-from yt.funcs import ensure_list, ensure_tuple, get_pbar, setdefaultattr
+from yt.funcs import ensure_tuple, get_pbar, iter_fields, setdefaultattr
 from yt.geometry.geometry_handler import YTDataChunk
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.utilities.logger import ytLogger as mylog
@@ -129,7 +129,7 @@ class EnzoGridGZ(EnzoGrid):
         sl = tuple([slice(start_zone, end_zone) for i in range(3)])
         if fields is None:
             return cube
-        for field in ensure_list(fields):
+        for field in iter_fields(fields):
             if field in self.field_list:
                 conv_factor = 1.0
                 if field in self.ds.field_info:

--- a/yt/frontends/enzo_p/misc.py
+++ b/yt/frontends/enzo_p/misc.py
@@ -1,6 +1,5 @@
 import numpy as np
-
-from yt.funcs import ensure_tuple
+from more_itertools import always_iterable
 
 
 def bdecode(block):
@@ -115,12 +114,10 @@ def nested_dict_get(pdict, keys, default=None):
     then nested_dict_get(a, ('b', 'c')) returns 'd'.
     """
 
-    keys = ensure_tuple(keys)
     val = pdict
-    for key in keys:
-        if val is None:
-            break
-        val = val.get(key)
-    if val is None:
-        val = default
+    for key in always_iterable(keys):
+        try:
+            val = val[key]
+        except KeyError:
+            return default
     return val

--- a/yt/frontends/enzo_p/tests/test_misc.py
+++ b/yt/frontends/enzo_p/tests/test_misc.py
@@ -145,3 +145,9 @@ def test_nested_dict_get():
 
     my_def = "devron"
     assert nested_dict_get(my_dict, "system", default=my_def) == my_def
+
+
+def test_nested_dict_get_real_none():
+    my_dict = {"a": None}
+    response = nested_dict_get(my_dict, "a", default="fail")
+    assert response is None

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -7,11 +7,12 @@ from collections import defaultdict
 
 import numpy as np
 import numpy.core.defchararray as np_char
+from more_itertools import always_iterable
 
 from yt.config import ytcfg
 from yt.data_objects.index_subobjects.grid_patch import AMRGridPatch
 from yt.data_objects.static_output import Dataset
-from yt.funcs import ensure_list, issue_deprecation_warning, mylog, setdefaultattr
+from yt.funcs import issue_deprecation_warning, mylog, setdefaultattr
 from yt.geometry.geometry_handler import YTDataChunk
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.units import dimensions
@@ -330,8 +331,6 @@ class FITSDataset(Dataset):
         unit_system="cgs",
     ):
 
-        if auxiliary_files is None:
-            auxiliary_files = []
         if parameters is None:
             parameters = {}
         parameters["nprocs"] = nprocs
@@ -339,8 +338,8 @@ class FITSDataset(Dataset):
 
         if suppress_astropy_warnings:
             warnings.filterwarnings("ignore", module="astropy", append=True)
-        auxiliary_files = ensure_list(auxiliary_files)
-        self.filenames = [filename] + auxiliary_files
+
+        self.filenames = [filename] + list(always_iterable(auxiliary_files))
         self.num_files = len(self.filenames)
         self.fluid_types += ("fits",)
         if nan_mask is None:

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -6,6 +6,7 @@ from itertools import chain, product, repeat
 from numbers import Number as numeric_type
 
 import numpy as np
+from more_itertools import always_iterable
 
 from yt.data_objects.field_data import YTFieldData
 from yt.data_objects.index_subobjects.grid_patch import AMRGridPatch
@@ -18,7 +19,6 @@ from yt.data_objects.particle_unions import ParticleUnion
 from yt.data_objects.static_output import Dataset, ParticleFile
 from yt.data_objects.unions import MeshUnion
 from yt.frontends.sph.data_structures import SPHParticleIndex
-from yt.funcs import ensure_list
 from yt.geometry.geometry_handler import YTDataChunk
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.geometry.oct_container import OctreeContainer
@@ -843,11 +843,12 @@ class StreamUnstructuredIndex(UnstructuredIndex):
         super(StreamUnstructuredIndex, self).__init__(ds, dataset_type)
 
     def _initialize_mesh(self):
-        coords = ensure_list(self.stream_handler.fields.pop("coordinates"))
-        connect = ensure_list(self.stream_handler.fields.pop("connectivity"))
+        coords = self.stream_handler.fields.pop("coordinates")
+        connect = always_iterable(self.stream_handler.fields.pop("connectivity"))
+
         self.meshes = [
             StreamUnstructuredMesh(i, self.index_filename, c1, c2, self)
-            for i, (c1, c2) in enumerate(zip(connect, repeat(coords[0])))
+            for i, (c1, c2) in enumerate(zip(connect, repeat(coords)))
         ]
         self.mesh_union = MeshUnion("mesh_union", self.meshes)
 

--- a/yt/frontends/stream/definitions.py
+++ b/yt/frontends/stream/definitions.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 
 import numpy as np
 
-from yt.funcs import iterable
+from yt.funcs import has_len
 from yt.geometry.grid_container import GridTree, MatchPointsToGrids
 from yt.utilities.exceptions import (
     YTInconsistentGridFieldShape,
@@ -161,7 +161,7 @@ def process_data(data, grid_dims=None):
                 raise RuntimeError("The data dict appears to be invalid.\n" + str(e))
 
         # val is a list of data to be turned into an array
-        elif iterable(val):
+        elif has_len(val):
             field_units[field] = ""
             new_data[field] = np.asarray(val)
 

--- a/yt/frontends/stream/definitions.py
+++ b/yt/frontends/stream/definitions.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 
 import numpy as np
 
-from yt.funcs import has_len
+from yt.funcs import is_sequence
 from yt.geometry.grid_container import GridTree, MatchPointsToGrids
 from yt.utilities.exceptions import (
     YTInconsistentGridFieldShape,
@@ -161,7 +161,7 @@ def process_data(data, grid_dims=None):
                 raise RuntimeError("The data dict appears to be invalid.\n" + str(e))
 
         # val is a list of data to be turned into an array
-        elif has_len(val):
+        elif is_sequence(val):
             field_units[field] = ""
             new_data[field] = np.asarray(val)
 

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -1446,7 +1446,7 @@ def validate_float(obj):
         )
 
 
-def validate_iterable(obj):
+def validate_sequence(obj):
     if obj is not None and not is_sequence(obj):
         raise TypeError(
             "Expected an iterable object,"

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -46,6 +46,12 @@ def iterable(obj):
     return True
 
 
+def iter_fields(obj):
+    from more_itertools import always_iterable
+
+    return always_iterable(obj, base_type=(tuple, str, bytes))
+
+
 def ensure_list(obj):
     """
     This function ensures that *obj* is a list.  Typically used to convert a

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -34,7 +34,18 @@ from yt.utilities.logger import ytLogger as mylog
 # Some functions for handling sequences and other types
 
 
-def iterable(obj):
+def is_iterable(obj):
+    """Whether obj is iterable (bool)."""
+    try:
+        iter(obj)
+        return True
+    except TypeError:
+        return False
+
+
+def has_len(obj):
+    # todo : deprecate this in favour of is_iterable
+    # this was previously named "iterable" which was both confusing and inaccurate
     """
     Grabbed from Python Cookbook / matplotlib.cbook.  Returns true/false for
     *obj* iterable.
@@ -109,7 +120,7 @@ def just_one(obj):
         if isinstance(obj, YTArray):
             return YTQuantity(obj.flat[0], obj.units, registry=obj.units.registry)
         return obj.flat[0]
-    elif iterable(obj):
+    elif has_len(obj):
         return obj[0]
     return obj
 
@@ -1005,7 +1016,7 @@ def ensure_dir(path):
 
 
 def validate_width_tuple(width):
-    if not iterable(width) or len(width) != 2:
+    if not has_len(width) or len(width) != 2:
         raise YTInvalidWidthError(f"width ({width}) is not a two element tuple")
     is_numeric = isinstance(width[0], numeric_type)
     length_has_units = isinstance(width[0], YTArray)
@@ -1338,7 +1349,7 @@ def issue_deprecation_warning(msg, stacklevel=3):
 
 
 def obj_length(v):
-    if iterable(v):
+    if has_len(v):
         return len(v)
     else:
         # If something isn't iterable, we return 0
@@ -1367,7 +1378,7 @@ def array_like_field(data, x, field):
 
 
 def validate_3d_array(obj):
-    if not iterable(obj) or len(obj) != 3:
+    if not has_len(obj) or len(obj) != 3:
         raise TypeError(
             "Expected an array of size (3,), received '%s' of "
             "length %s" % (str(type(obj)).split("'")[1], len(obj))
@@ -1419,7 +1430,7 @@ def validate_float(obj):
             )
         else:
             return
-    if iterable(obj) and (len(obj) != 1 or not isinstance(obj[0], numeric_type)):
+    if has_len(obj) and (len(obj) != 1 or not isinstance(obj[0], numeric_type)):
         raise TypeError(
             "Expected a numeric value (or size-1 array), "
             "received '%s' of length %s" % (str(type(obj)).split("'")[1], len(obj))
@@ -1427,7 +1438,7 @@ def validate_float(obj):
 
 
 def validate_iterable(obj):
-    if obj is not None and not iterable(obj):
+    if obj is not None and not has_len(obj):
         raise TypeError(
             "Expected an iterable object,"
             " received '%s'" % str(type(obj)).split("'")[1]
@@ -1467,7 +1478,7 @@ def validate_center(center):
                 "'m', 'max', 'min'] or the prefix to be "
                 "'max_'/'min_', received '%s'." % center
             )
-    elif not isinstance(center, (numeric_type, YTQuantity)) and not iterable(center):
+    elif not isinstance(center, (numeric_type, YTQuantity)) and not has_len(center):
         raise TypeError(
             "Expected 'center' to be a numeric object of type "
             "list/tuple/np.ndarray/YTArray/YTQuantity, "

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -44,7 +44,7 @@ def is_iterable(obj):
         return False
 
 
-def has_len(obj):
+def is_sequence(obj):
     # todo : deprecate this in favour of is_iterable
     # this was previously named "iterable" which was both confusing and inaccurate
     """
@@ -1025,7 +1025,7 @@ def ensure_dir(path):
 
 
 def validate_width_tuple(width):
-    if not has_len(width) or len(width) != 2:
+    if not is_sequence(width) or len(width) != 2:
         raise YTInvalidWidthError(f"width ({width}) is not a two element tuple")
     is_numeric = isinstance(width[0], numeric_type)
     length_has_units = isinstance(width[0], YTArray)
@@ -1358,7 +1358,7 @@ def issue_deprecation_warning(msg, stacklevel=3):
 
 
 def obj_length(v):
-    if has_len(v):
+    if is_sequence(v):
         return len(v)
     else:
         # If something isn't iterable, we return 0
@@ -1387,7 +1387,7 @@ def array_like_field(data, x, field):
 
 
 def validate_3d_array(obj):
-    if not has_len(obj) or len(obj) != 3:
+    if not is_sequence(obj) or len(obj) != 3:
         raise TypeError(
             "Expected an array of size (3,), received '%s' of "
             "length %s" % (str(type(obj)).split("'")[1], len(obj))
@@ -1439,7 +1439,7 @@ def validate_float(obj):
             )
         else:
             return
-    if has_len(obj) and (len(obj) != 1 or not isinstance(obj[0], numeric_type)):
+    if is_sequence(obj) and (len(obj) != 1 or not isinstance(obj[0], numeric_type)):
         raise TypeError(
             "Expected a numeric value (or size-1 array), "
             "received '%s' of length %s" % (str(type(obj)).split("'")[1], len(obj))
@@ -1447,7 +1447,7 @@ def validate_float(obj):
 
 
 def validate_iterable(obj):
-    if obj is not None and not has_len(obj):
+    if obj is not None and not is_sequence(obj):
         raise TypeError(
             "Expected an iterable object,"
             " received '%s'" % str(type(obj)).split("'")[1]
@@ -1487,7 +1487,7 @@ def validate_center(center):
                 "'m', 'max', 'min'] or the prefix to be "
                 "'max_'/'min_', received '%s'." % center
             )
-    elif not isinstance(center, (numeric_type, YTQuantity)) and not has_len(center):
+    elif not isinstance(center, (numeric_type, YTQuantity)) and not is_sequence(center):
         raise TypeError(
             "Expected 'center' to be a numeric object of type "
             "list/tuple/np.ndarray/YTArray/YTQuantity, "

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -45,8 +45,6 @@ def is_iterable(obj):
 
 
 def is_sequence(obj):
-    # todo : deprecate this in favour of is_iterable
-    # this was previously named "iterable" which was both confusing and inaccurate
     """
     Grabbed from Python Cookbook / matplotlib.cbook.  Returns true/false for
     *obj* iterable.

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -25,6 +25,7 @@ from numbers import Number as numeric_type
 
 import matplotlib
 import numpy as np
+from more_itertools import always_iterable
 
 from yt.extern.tqdm import tqdm
 from yt.units import YTArray, YTQuantity
@@ -52,15 +53,42 @@ def has_len(obj):
     """
     try:
         len(obj)
+        return True
     except TypeError:
         return False
-    return True
 
 
-def iter_fields(obj):
-    from more_itertools import always_iterable
+def iter_fields(field_or_fields):
+    """
+    Create an iterator for field names, specified as single strings or tuples(fname,
+    ftype) alike.
+    This can safely be used in places where we accept a single field or a list as input.
 
-    return always_iterable(obj, base_type=(tuple, str, bytes))
+    Parameters
+    ----------
+    obj: str, tuple(str, str), or any iterable of the previous types.
+
+    Examples
+    --------
+
+    >>> fields = "density"
+    >>> for field is iter_fields(fields):
+    ...     print(field)
+    "density"
+
+    >>> fields = ("gas", "density")
+    >>> for field is iter_fields(fields):
+    ...     print(field)
+    "gas", "density"
+
+    >>> fields = ["density", "temperature", ("index", "dx")]
+    >>> for field is iter_fields(fields):
+    ...     print(field)
+    "density"
+    "temperature"
+    ("index", "dx")
+    """
+    return always_iterable(field_or_fields, base_type=(tuple, str, bytes))
 
 
 def ensure_list(obj):

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -25,7 +25,7 @@ from numbers import Number as numeric_type
 
 import matplotlib
 import numpy as np
-from more_itertools import always_iterable
+from more_itertools import always_iterable, collapse, first
 
 from yt.extern.tqdm import tqdm
 from yt.units import YTArray, YTQuantity
@@ -144,13 +144,7 @@ def read_struct(f, fmt):
 
 def just_one(obj):
     # If we have an iterable, sometimes we only want one item
-    if hasattr(obj, "flat"):
-        if isinstance(obj, YTArray):
-            return YTQuantity(obj.flat[0], obj.units, registry=obj.units.registry)
-        return obj.flat[0]
-    elif has_len(obj):
-        return obj[0]
-    return obj
+    return first(collapse(obj))
 
 
 def compare_dicts(dict1, dict2):

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -35,15 +35,6 @@ from yt.utilities.logger import ytLogger as mylog
 # Some functions for handling sequences and other types
 
 
-def is_iterable(obj):
-    """Whether obj is iterable (bool)."""
-    try:
-        iter(obj)
-        return True
-    except TypeError:
-        return False
-
-
 def is_sequence(obj):
     """
     Grabbed from Python Cookbook / matplotlib.cbook.  Returns true/false for
@@ -107,16 +98,11 @@ def ensure_numpy_array(obj):
 
 def ensure_tuple(obj):
     """
-    This function ensures that *obj* is a tuple.  Typically used to convert
+    This function ensures that *obj* is a tuple. Typically used to convert
     scalar, list, or array arguments specified by a user in a context where
     we assume a tuple internally
     """
-    if isinstance(obj, tuple):
-        return obj
-    elif isinstance(obj, (list, np.ndarray)):
-        return tuple(obj)
-    else:
-        return (obj,)
+    return tuple(always_iterable(obj))
 
 
 def read_struct(f, fmt):

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -61,21 +61,21 @@ def iter_fields(field_or_fields):
     --------
 
     >>> fields = "density"
-    >>> for field is iter_fields(fields):
+    >>> for field in iter_fields(fields):
     ...     print(field)
-    "density"
+    density
 
     >>> fields = ("gas", "density")
-    >>> for field is iter_fields(fields):
+    >>> for field in iter_fields(fields):
     ...     print(field)
-    "gas", "density"
+    ('gas', 'density')
 
     >>> fields = ["density", "temperature", ("index", "dx")]
-    >>> for field is iter_fields(fields):
+    >>> for field in iter_fields(fields):
     ...     print(field)
-    "density"
-    "temperature"
-    ("index", "dx")
+    density
+    temperature
+    ('index', 'dx')
     """
     return always_iterable(field_or_fields, base_type=(tuple, str, bytes))
 

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -91,19 +91,6 @@ def iter_fields(field_or_fields):
     return always_iterable(field_or_fields, base_type=(tuple, str, bytes))
 
 
-def ensure_list(obj):
-    """
-    This function ensures that *obj* is a list.  Typically used to convert a
-    string to a list, for instance ensuring the *fields* as an argument is a
-    list.
-    """
-    if obj is None:
-        return [obj]
-    if not isinstance(obj, list):
-        return [obj]
-    return obj
-
-
 def ensure_numpy_array(obj):
     """
     This function ensures that *obj* is a numpy array. Typically used to

--- a/yt/geometry/coordinates/coordinate_handler.py
+++ b/yt/geometry/coordinates/coordinate_handler.py
@@ -3,7 +3,7 @@ from numbers import Number
 
 import numpy as np
 
-from yt.funcs import fix_unitary, has_len, validate_width_tuple
+from yt.funcs import fix_unitary, is_sequence, validate_width_tuple
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.exceptions import YTCoordinateNotImplemented, YTInvalidWidthError
 
@@ -198,7 +198,7 @@ class CoordinateHandler:
         raise NotImplementedError
 
     def sanitize_depth(self, depth):
-        if has_len(depth):
+        if is_sequence(depth):
             validate_width_tuple(depth)
             depth = (self.ds.quan(depth[0], fix_unitary(depth[1])),)
         elif isinstance(depth, Number):
@@ -216,7 +216,7 @@ class CoordinateHandler:
             # initialize the index if it is not already initialized
             self.ds.index
             # Default to code units
-            if not has_len(axis):
+            if not is_sequence(axis):
                 xax = self.x_axis[axis]
                 yax = self.y_axis[axis]
                 w = self.ds.domain_width[np.array([xax, yax])]
@@ -226,7 +226,7 @@ class CoordinateHandler:
                 mi = np.argmin(self.ds.domain_width)
                 w = self.ds.domain_width[np.array((mi, mi))]
             width = (w[0], w[1])
-        elif has_len(width):
+        elif is_sequence(width):
             width = validate_iterable_width(width, self.ds)
         elif isinstance(width, YTQuantity):
             width = (width, width)
@@ -256,7 +256,7 @@ class CoordinateHandler:
                 raise RuntimeError(f'center keyword "{center}" not recognized')
         elif isinstance(center, YTArray):
             return self.ds.arr(center), self.convert_to_cartesian(center)
-        elif has_len(center):
+        elif is_sequence(center):
             if isinstance(center[0], str) and isinstance(center[1], str):
                 if center[0].lower() == "min":
                     v, center = self.ds.find_min(center[1])
@@ -265,7 +265,7 @@ class CoordinateHandler:
                 else:
                     raise RuntimeError(f'center keyword "{center}" not recognized')
                 center = self.ds.arr(center, "code_length")
-            elif has_len(center[0]) and isinstance(center[1], str):
+            elif is_sequence(center[0]) and isinstance(center[1], str):
                 center = self.ds.arr(center[0], center[1])
             else:
                 center = self.ds.arr(center, "code_length")

--- a/yt/geometry/coordinates/coordinate_handler.py
+++ b/yt/geometry/coordinates/coordinate_handler.py
@@ -3,7 +3,7 @@ from numbers import Number
 
 import numpy as np
 
-from yt.funcs import fix_unitary, iterable, validate_width_tuple
+from yt.funcs import fix_unitary, has_len, validate_width_tuple
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.exceptions import YTCoordinateNotImplemented, YTInvalidWidthError
 
@@ -198,7 +198,7 @@ class CoordinateHandler:
         raise NotImplementedError
 
     def sanitize_depth(self, depth):
-        if iterable(depth):
+        if has_len(depth):
             validate_width_tuple(depth)
             depth = (self.ds.quan(depth[0], fix_unitary(depth[1])),)
         elif isinstance(depth, Number):
@@ -216,7 +216,7 @@ class CoordinateHandler:
             # initialize the index if it is not already initialized
             self.ds.index
             # Default to code units
-            if not iterable(axis):
+            if not has_len(axis):
                 xax = self.x_axis[axis]
                 yax = self.y_axis[axis]
                 w = self.ds.domain_width[np.array([xax, yax])]
@@ -226,7 +226,7 @@ class CoordinateHandler:
                 mi = np.argmin(self.ds.domain_width)
                 w = self.ds.domain_width[np.array((mi, mi))]
             width = (w[0], w[1])
-        elif iterable(width):
+        elif has_len(width):
             width = validate_iterable_width(width, self.ds)
         elif isinstance(width, YTQuantity):
             width = (width, width)
@@ -256,7 +256,7 @@ class CoordinateHandler:
                 raise RuntimeError(f'center keyword "{center}" not recognized')
         elif isinstance(center, YTArray):
             return self.ds.arr(center), self.convert_to_cartesian(center)
-        elif iterable(center):
+        elif has_len(center):
             if isinstance(center[0], str) and isinstance(center[1], str):
                 if center[0].lower() == "min":
                     v, center = self.ds.find_min(center[1])
@@ -265,7 +265,7 @@ class CoordinateHandler:
                 else:
                     raise RuntimeError(f'center keyword "{center}" not recognized')
                 center = self.ds.arr(center, "code_length")
-            elif iterable(center[0]) and isinstance(center[1], str):
+            elif has_len(center[0]) and isinstance(center[1], str):
                 center = self.ds.arr(center[0], center[1])
             else:
                 center = self.ds.arr(center, "code_length")

--- a/yt/geometry/coordinates/coordinate_handler.py
+++ b/yt/geometry/coordinates/coordinate_handler.py
@@ -32,7 +32,7 @@ def _get_vert_fields(axi, units="code_length"):
     return _vert
 
 
-def validate_iterable_width(width, ds, unit=None):
+def validate_sequence_width(width, ds, unit=None):
     if isinstance(width[0], tuple) and isinstance(width[1], tuple):
         validate_width_tuple(width[0])
         validate_width_tuple(width[1])
@@ -227,7 +227,7 @@ class CoordinateHandler:
                 w = self.ds.domain_width[np.array((mi, mi))]
             width = (w[0], w[1])
         elif is_sequence(width):
-            width = validate_iterable_width(width, self.ds)
+            width = validate_sequence_width(width, self.ds)
         elif isinstance(width, YTQuantity):
             width = (width, width)
         elif isinstance(width, Number):

--- a/yt/geometry/grid_geometry_handler.py
+++ b/yt/geometry/grid_geometry_handler.py
@@ -8,7 +8,7 @@ from yt.arraytypes import blankRecordArray
 from yt.config import ytcfg
 from yt.fields.derived_field import ValidateSpatial
 from yt.fields.field_detector import FieldDetector
-from yt.funcs import ensure_list, ensure_numpy_array
+from yt.funcs import ensure_numpy_array, iter_fields
 from yt.geometry.geometry_handler import ChunkDataCache, Index, YTDataChunk
 from yt.utilities.definitions import MAXLEVEL
 from yt.utilities.logger import ytLogger as mylog
@@ -245,7 +245,7 @@ class GridIndex(Index, abc.ABC):
         """
         coords = self.ds.arr(ensure_numpy_array(coords), "code_length")
         grids = self._find_points(coords[:, 0], coords[:, 1], coords[:, 2])[0]
-        fields = ensure_list(fields)
+        fields = list(iter_fields(fields))
         mark = np.zeros(3, dtype=np.int)
         out = []
 

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -14,7 +14,7 @@ from numpy.random import RandomState
 from unyt.exceptions import UnitOperationError
 
 from yt.config import ytcfg
-from yt.funcs import has_len
+from yt.funcs import is_sequence
 from yt.loaders import load
 from yt.units.yt_array import YTArray, YTQuantity
 
@@ -204,11 +204,11 @@ def fake_random_ds(
     from yt.loaders import load_uniform_grid
 
     prng = RandomState(0x4D3D3D3)
-    if not has_len(ndims):
+    if not is_sequence(ndims):
         ndims = [ndims, ndims, ndims]
     else:
         assert len(ndims) == 3
-    if not has_len(negative):
+    if not is_sequence(negative):
         negative = [negative for f in fields]
     assert len(fields) == len(negative)
     offsets = []
@@ -312,7 +312,7 @@ def fake_particle_ds(
     from yt.loaders import load_particles
 
     prng = RandomState(0x4D3D3D3)
-    if not has_len(negative):
+    if not is_sequence(negative):
         negative = [negative for f in fields]
     assert len(fields) == len(negative)
     offsets = []

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -14,7 +14,7 @@ from numpy.random import RandomState
 from unyt.exceptions import UnitOperationError
 
 from yt.config import ytcfg
-from yt.funcs import iterable
+from yt.funcs import has_len
 from yt.loaders import load
 from yt.units.yt_array import YTArray, YTQuantity
 
@@ -204,11 +204,11 @@ def fake_random_ds(
     from yt.loaders import load_uniform_grid
 
     prng = RandomState(0x4D3D3D3)
-    if not iterable(ndims):
+    if not has_len(ndims):
         ndims = [ndims, ndims, ndims]
     else:
         assert len(ndims) == 3
-    if not iterable(negative):
+    if not has_len(negative):
         negative = [negative for f in fields]
     assert len(fields) == len(negative)
     offsets = []
@@ -312,7 +312,7 @@ def fake_particle_ds(
     from yt.loaders import load_particles
 
     prng = RandomState(0x4D3D3D3)
-    if not iterable(negative):
+    if not has_len(negative):
         negative = [negative for f in fields]
     assert len(fields) == len(negative)
     offsets = []

--- a/yt/tests/test_funcs.py
+++ b/yt/tests/test_funcs.py
@@ -1,8 +1,8 @@
 from nose.tools import assert_raises
 
-from yt import YTQuantity
-from yt.funcs import validate_axis, validate_center
+from yt.funcs import just_one, validate_axis, validate_center
 from yt.testing import assert_equal, fake_amr_ds
+from yt.units import YTArray, YTQuantity
 
 
 def test_validate_axis():
@@ -51,3 +51,13 @@ def test_validate_center():
         "CustomCenter'."
     )
     assert_equal(str(ex.exception)[:50], desired[:50])
+
+
+def test_just_one():
+    # Check that behaviour of this function is consistent before and after refactor
+    # PR 2893
+    for unit in ["mm", "cm", "km", "pc", "g", "kg", "M_sun"]:
+        obj = YTArray([0.0, 1.0], unit)
+        expected = YTQuantity(obj.flat[0], obj.units, registry=obj.units.registry)
+        jo = just_one(obj)
+        assert jo == expected

--- a/yt/utilities/amr_kdtree/amr_kdtree.py
+++ b/yt/utilities/amr_kdtree/amr_kdtree.py
@@ -2,7 +2,7 @@ import operator
 
 import numpy as np
 
-from yt.funcs import has_len, mylog
+from yt.funcs import is_sequence, mylog
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.utilities.amr_kdtree.amr_kdtools import (
     receive_and_reduce,
@@ -214,7 +214,7 @@ class AMRKDTree(ParallelAnalysisInterface):
             or self.fields != new_fields
             or force
         )
-        if not has_len(log_fields):
+        if not is_sequence(log_fields):
             log_fields = [log_fields]
         new_log_fields = list(log_fields)
         self.tree.trunk.set_dirty(regenerate_data)

--- a/yt/utilities/amr_kdtree/amr_kdtree.py
+++ b/yt/utilities/amr_kdtree/amr_kdtree.py
@@ -2,7 +2,7 @@ import operator
 
 import numpy as np
 
-from yt.funcs import iterable, mylog
+from yt.funcs import has_len, mylog
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.utilities.amr_kdtree.amr_kdtools import (
     receive_and_reduce,
@@ -214,7 +214,7 @@ class AMRKDTree(ParallelAnalysisInterface):
             or self.fields != new_fields
             or force
         )
-        if not iterable(log_fields):
+        if not has_len(log_fields):
             log_fields = [log_fields]
         new_log_fields = list(log_fields)
         self.tree.trunk.set_dirty(regenerate_data)

--- a/yt/utilities/grid_data_format/writer.py
+++ b/yt/utilities/grid_data_format/writer.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 import numpy as np
 
 from yt import __version__ as yt_version
-from yt.funcs import ensure_list, issue_deprecation_warning
+from yt.funcs import issue_deprecation_warning, iter_fields
 from yt.utilities.exceptions import YTGDFAlreadyExists
 from yt.utilities.on_demand_imports import _h5py as h5py
 from yt.utilities.parallel_tools.parallel_analysis_interface import (
@@ -79,7 +79,7 @@ def write_to_gdf(
     if fields is None:
         fields = ds.field_list
 
-    fields = ensure_list(fields)
+    fields = list(iter_fields(fields))
 
     with _create_new_gdf(
         ds,
@@ -110,7 +110,7 @@ def save_field(ds, fields, field_parameters=None):
         A dictionary of field parameters to set.
     """
 
-    fields = ensure_list(fields)
+    fields = list(iter_fields(fields))
     for field_name in fields:
         if isinstance(field_name, tuple):
             field_name = field_name[1]

--- a/yt/utilities/minimal_representation.py
+++ b/yt/utilities/minimal_representation.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 import numpy as np
 
-from yt.funcs import compare_dicts, iterable
+from yt.funcs import compare_dicts, has_len
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.on_demand_imports import _h5py as h5py
 
@@ -47,7 +47,7 @@ def _deserialize_from_h5(g, ds):
         if item == "chunks":
             continue
         if "units" in g[item].attrs:
-            if iterable(g[item]):
+            if has_len(g[item]):
                 result[item] = ds.arr(g[item][:], g[item].attrs["units"])
             else:
                 result[item] = ds.quan(g[item][()], g[item].attrs["units"])

--- a/yt/utilities/minimal_representation.py
+++ b/yt/utilities/minimal_representation.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 import numpy as np
 
-from yt.funcs import compare_dicts, has_len
+from yt.funcs import compare_dicts, is_sequence
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.on_demand_imports import _h5py as h5py
 
@@ -47,7 +47,7 @@ def _deserialize_from_h5(g, ds):
         if item == "chunks":
             continue
         if "units" in g[item].attrs:
-            if has_len(g[item]):
+            if is_sequence(g[item]):
                 result[item] = ds.arr(g[item][:], g[item].attrs["units"])
             else:
                 result[item] = ds.quan(g[item][()], g[item].attrs["units"])

--- a/yt/utilities/parallel_tools/parallel_analysis_interface.py
+++ b/yt/utilities/parallel_tools/parallel_analysis_interface.py
@@ -7,11 +7,12 @@ from functools import wraps
 from io import StringIO
 
 import numpy as np
+from more_itertools import always_iterable
 
 import yt.utilities.logger
 from yt.config import ytcfg
 from yt.data_objects.image_array import ImageArray
-from yt.funcs import ensure_list, has_len
+from yt.funcs import has_len
 from yt.units.unit_registry import UnitRegistry
 from yt.units.yt_array import YTArray
 from yt.utilities.exceptions import YTNoDataInObjectError
@@ -409,10 +410,9 @@ class ProcessorPool:
 
     @classmethod
     def from_sizes(cls, sizes):
-        sizes = ensure_list(sizes)
         pool = cls()
         rank = pool.comm.rank
-        for i, size in enumerate(sizes):
+        for i, size in enumerate(always_iterable(sizes)):
             if has_len(size):
                 size, name = size
             else:
@@ -1186,7 +1186,9 @@ class ParallelAnalysisInterface:
         for field in fields:
             if any(getattr(v, "ghost_zones", 0) > 0 for v in fi[field].validators):
                 continue
-            deps += ensure_list(fi[field].get_dependencies(ds=self.ds).requested)
+            deps += list(
+                always_iterable(fi[field].get_dependencies(ds=self.ds).requested)
+            )
         return list(set(deps))
 
     def _initialize_parallel(self):

--- a/yt/utilities/parallel_tools/parallel_analysis_interface.py
+++ b/yt/utilities/parallel_tools/parallel_analysis_interface.py
@@ -12,7 +12,7 @@ from more_itertools import always_iterable
 import yt.utilities.logger
 from yt.config import ytcfg
 from yt.data_objects.image_array import ImageArray
-from yt.funcs import has_len
+from yt.funcs import is_sequence
 from yt.units.unit_registry import UnitRegistry
 from yt.units.yt_array import YTArray
 from yt.utilities.exceptions import YTNoDataInObjectError
@@ -413,7 +413,7 @@ class ProcessorPool:
         pool = cls()
         rank = pool.comm.rank
         for i, size in enumerate(always_iterable(sizes)):
-            if has_len(size):
+            if is_sequence(size):
                 size, name = size
             else:
                 name = "workgroup_%02i" % i

--- a/yt/utilities/parallel_tools/parallel_analysis_interface.py
+++ b/yt/utilities/parallel_tools/parallel_analysis_interface.py
@@ -11,7 +11,7 @@ import numpy as np
 import yt.utilities.logger
 from yt.config import ytcfg
 from yt.data_objects.image_array import ImageArray
-from yt.funcs import ensure_list, iterable
+from yt.funcs import ensure_list, has_len
 from yt.units.unit_registry import UnitRegistry
 from yt.units.yt_array import YTArray
 from yt.utilities.exceptions import YTNoDataInObjectError
@@ -413,7 +413,7 @@ class ProcessorPool:
         pool = cls()
         rank = pool.comm.rank
         for i, size in enumerate(sizes):
-            if iterable(size):
+            if has_len(size):
                 size, name = size
             else:
                 name = "workgroup_%02i" % i

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -8,7 +8,7 @@ from yt.funcs import (
     get_brewer_cmap,
     get_image_suffix,
     get_interactivity,
-    iterable,
+    has_len,
     matplotlib_style_context,
     mylog,
 )
@@ -74,7 +74,7 @@ class PlotMPL:
 
         self._plot_valid = True
         if figure is None:
-            if not iterable(fsize):
+            if not has_len(fsize):
                 fsize = (fsize, fsize)
             self.figure = matplotlib.figure.Figure(figsize=fsize, frameon=True)
         else:
@@ -346,7 +346,7 @@ class ImagePlotMPL(PlotMPL):
     def _get_best_layout(self):
 
         # Ensure the figure size along the long axis is always equal to _figure_size
-        if iterable(self._figure_size):
+        if has_len(self._figure_size):
             x_fig_size = self._figure_size[0]
             y_fig_size = self._figure_size[1]
         else:

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -8,7 +8,7 @@ from yt.funcs import (
     get_brewer_cmap,
     get_image_suffix,
     get_interactivity,
-    has_len,
+    is_sequence,
     matplotlib_style_context,
     mylog,
 )
@@ -74,7 +74,7 @@ class PlotMPL:
 
         self._plot_valid = True
         if figure is None:
-            if not has_len(fsize):
+            if not is_sequence(fsize):
                 fsize = (fsize, fsize)
             self.figure = matplotlib.figure.Figure(figsize=fsize, frameon=True)
         else:
@@ -346,7 +346,7 @@ class ImagePlotMPL(PlotMPL):
     def _get_best_layout(self):
 
         # Ensure the figure size along the long axis is always equal to _figure_size
-        if has_len(self._figure_size):
+        if is_sequence(self._figure_size):
             x_fig_size = self._figure_size[0]
             y_fig_size = self._figure_size[1]
         else:

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -8,7 +8,14 @@ import numpy as np
 from yt.data_objects.construction_data_containers import YTCoveringGrid
 from yt.data_objects.image_array import ImageArray
 from yt.fields.derived_field import DerivedField
-from yt.funcs import ensure_list, fix_axis, issue_deprecation_warning, iterable, mylog
+from yt.funcs import (
+    ensure_list,
+    fix_axis,
+    issue_deprecation_warning,
+    iter_fields,
+    iterable,
+    mylog,
+)
 from yt.units import dimensions
 from yt.units.unit_object import Unit
 from yt.units.yt_array import YTArray, YTQuantity
@@ -128,7 +135,7 @@ class FITSImageData:
         """
 
         if fields is not None:
-            fields = ensure_list(fields)
+            fields = list(iter_fields(fields))
 
         if "units" in kwargs:
             issue_deprecation_warning(
@@ -977,7 +984,7 @@ class FITSSlice(FITSImageData):
         length_unit=None,
         **kwargs,
     ):
-        fields = ensure_list(fields)
+        fields = list(iter_fields(fields))
         axis = fix_axis(axis, ds)
         center, dcenter = ds.coordinates.sanitize_center(center, axis)
         slc = ds.slice(axis, center[axis], **kwargs)
@@ -1051,7 +1058,7 @@ class FITSProjection(FITSImageData):
         length_unit=None,
         **kwargs,
     ):
-        fields = ensure_list(fields)
+        fields = list(iter_fields(fields))
         axis = fix_axis(axis, ds)
         center, dcenter = ds.coordinates.sanitize_center(center, axis)
         prj = ds.proj(fields[0], axis, weight_field=weight_field, **kwargs)
@@ -1128,7 +1135,7 @@ class FITSOffAxisSlice(FITSImageData):
         north_vector=None,
         length_unit=None,
     ):
-        fields = ensure_list(fields)
+        fields = list(iter_fields(fields))
         center, dcenter = ds.coordinates.sanitize_center(center, 4)
         cut = ds.cutting(normal, center, north_vector=north_vector)
         center = ds.arr([0.0] * 2, "code_length")
@@ -1233,7 +1240,7 @@ class FITSOffAxisProjection(FITSImageData):
         method="integrate",
         length_unit=None,
     ):
-        fields = ensure_list(fields)
+        fields = list(iter_fields(fields))
         center, dcenter = ds.coordinates.sanitize_center(center, 4)
         buf = {}
         width = ds.coordinates.sanitize_width(normal, width, depth)

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -8,7 +8,13 @@ from more_itertools import first, mark_ends
 from yt.data_objects.construction_data_containers import YTCoveringGrid
 from yt.data_objects.image_array import ImageArray
 from yt.fields.derived_field import DerivedField
-from yt.funcs import fix_axis, has_len, issue_deprecation_warning, iter_fields, mylog
+from yt.funcs import (
+    fix_axis,
+    is_sequence,
+    issue_deprecation_warning,
+    iter_fields,
+    mylog,
+)
 from yt.units import dimensions
 from yt.units.unit_object import Unit
 from yt.units.yt_array import YTArray, YTQuantity
@@ -320,7 +326,7 @@ class FITSImageData:
             else:
                 # If img_data is just an array we use the width and img_ctr
                 # parameters to determine the cell widths
-                if not has_len(width):
+                if not is_sequence(width):
                     width = [width] * self.dimensionality
                 if isinstance(width[0], YTQuantity):
                     cdelt = [
@@ -847,7 +853,7 @@ def construct_image(ds, axis, data_source, center, image_res, width, length_unit
     else:
         width = ds.coordinates.sanitize_width(axis, width, None)
         unit = str(width[0].units)
-    if has_len(image_res):
+    if is_sequence(image_res):
         nx, ny = image_res
     else:
         nx, ny = image_res, image_res
@@ -866,12 +872,12 @@ def construct_image(ds, axis, data_source, center, image_res, width, length_unit
     cunit = [length_unit] * 2
     ctype = ["LINEAR"] * 2
     cdelt = [dx.in_units(length_unit), dy.in_units(length_unit)]
-    if has_len(axis):
+    if is_sequence(axis):
         crval = center.in_units(length_unit)
     else:
         crval = [center[idx].in_units(length_unit) for idx in axis_wcs[axis]]
     if hasattr(data_source, "to_frb"):
-        if has_len(axis):
+        if is_sequence(axis):
             frb = data_source.to_frb(width[0], (nx, ny), height=width[1])
         else:
             frb = data_source.to_frb(width[0], (nx, ny), center=center, height=width[1])
@@ -1238,7 +1244,7 @@ class FITSOffAxisProjection(FITSImageData):
         buf = {}
         width = ds.coordinates.sanitize_width(normal, width, depth)
         wd = tuple(el.in_units("code_length").v for el in width)
-        if not has_len(image_res):
+        if not is_sequence(image_res):
             image_res = (image_res, image_res)
         res = (image_res[0], image_res[1])
         if data_source is None:

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -11,9 +11,9 @@ from yt.fields.derived_field import DerivedField
 from yt.funcs import (
     ensure_list,
     fix_axis,
+    has_len,
     issue_deprecation_warning,
     iter_fields,
-    iterable,
     mylog,
 )
 from yt.units import dimensions
@@ -327,7 +327,7 @@ class FITSImageData:
             else:
                 # If img_data is just an array we use the width and img_ctr
                 # parameters to determine the cell widths
-                if not iterable(width):
+                if not has_len(width):
                     width = [width] * self.dimensionality
                 if isinstance(width[0], YTQuantity):
                     cdelt = [
@@ -854,7 +854,7 @@ def construct_image(ds, axis, data_source, center, image_res, width, length_unit
     else:
         width = ds.coordinates.sanitize_width(axis, width, None)
         unit = str(width[0].units)
-    if iterable(image_res):
+    if has_len(image_res):
         nx, ny = image_res
     else:
         nx, ny = image_res, image_res
@@ -873,12 +873,12 @@ def construct_image(ds, axis, data_source, center, image_res, width, length_unit
     cunit = [length_unit] * 2
     ctype = ["LINEAR"] * 2
     cdelt = [dx.in_units(length_unit), dy.in_units(length_unit)]
-    if iterable(axis):
+    if has_len(axis):
         crval = center.in_units(length_unit)
     else:
         crval = [center[idx].in_units(length_unit) for idx in axis_wcs[axis]]
     if hasattr(data_source, "to_frb"):
-        if iterable(axis):
+        if has_len(axis):
             frb = data_source.to_frb(width[0], (nx, ny), height=width[1])
         else:
             frb = data_source.to_frb(width[0], (nx, ny), center=center, height=width[1])
@@ -1245,7 +1245,7 @@ class FITSOffAxisProjection(FITSImageData):
         buf = {}
         width = ds.coordinates.sanitize_width(normal, width, depth)
         wd = tuple(el.in_units("code_length").v for el in width)
-        if not iterable(image_res):
+        if not has_len(image_res):
             image_res = (image_res, image_res)
         res = (image_res[0], image_res[1])
         if data_source is None:

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -3,7 +3,7 @@ import sys
 from numbers import Number as numeric_type
 
 import numpy as np
-from more_itertools import always_iterable, first, mark_ends
+from more_itertools import first, mark_ends
 
 from yt.data_objects.construction_data_containers import YTCoveringGrid
 from yt.data_objects.image_array import ImageArray
@@ -721,12 +721,13 @@ class FITSImageData:
         image_list : list of FITSImageData instances
             The images to be combined.
         """
-        image_list = always_iterable(image_list)
+        image_list = image_list if isinstance(image_list, list) else [image_list]
         first_image = first(image_list)
+
         w = first_image.wcs
         img_shape = first_image.shape
         data = []
-        for is_first, _, fid in mark_ends(image_list):
+        for is_first, _is_last, fid in mark_ends(image_list):
             assert_same_wcs(w, fid.wcs)
             if img_shape != fid.shape:
                 raise RuntimeError("Images do not have the same shape!")

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -3,7 +3,7 @@ import sys
 from numbers import Number as numeric_type
 
 import numpy as np
-from more_itertools.more import always_iterable, first, mark_ends
+from more_itertools import always_iterable, first, mark_ends
 
 from yt.data_objects.construction_data_containers import YTCoveringGrid
 from yt.data_objects.image_array import ImageArray

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -7,9 +7,9 @@ from yt.data_objects.image_array import ImageArray
 from yt.frontends.ytdata.utilities import save_as_dataset
 from yt.funcs import (
     deprecate,
-    ensure_list,
     get_output_filename,
     issue_deprecation_warning,
+    iter_fields,
     mylog,
 )
 from yt.loaders import load_uniform_grid
@@ -363,7 +363,7 @@ class FixedResolutionBuffer:
         if fields is None:
             fields = list(self.data.keys())
         else:
-            fields = ensure_list(fields)
+            fields = list(iter_fields(fields))
 
         if len(fields) == 0:
             raise RuntimeError(

--- a/yt/visualization/line_plot.py
+++ b/yt/visualization/line_plot.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 
 import numpy as np
 
-from yt.funcs import has_len, mylog
+from yt.funcs import is_sequence, mylog
 from yt.units.unit_object import Unit
 from yt.units.yt_array import YTArray
 from yt.visualization.base_plot_types import PlotMPL
@@ -261,7 +261,7 @@ class LinePlot(PlotContainer):
         y_axis_size = 0.7 * fontscale
         right_buff_size = 0.2 * fontscale
 
-        if has_len(self.figure_size):
+        if is_sequence(self.figure_size):
             figure_size = self.figure_size
         else:
             figure_size = (self.figure_size, self.figure_size)
@@ -437,7 +437,7 @@ class LinePlot(PlotContainer):
 
 
 def _validate_point(point, ds, start=False):
-    if not has_len(point):
+    if not is_sequence(point):
         raise RuntimeError("Input point must be array-like")
     if not isinstance(point, YTArray):
         point = ds.arr(point, "code_length", dtype=np.float64)

--- a/yt/visualization/line_plot.py
+++ b/yt/visualization/line_plot.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 
 import numpy as np
 
-from yt.funcs import iterable, mylog
+from yt.funcs import has_len, mylog
 from yt.units.unit_object import Unit
 from yt.units.yt_array import YTArray
 from yt.visualization.base_plot_types import PlotMPL
@@ -261,7 +261,7 @@ class LinePlot(PlotContainer):
         y_axis_size = 0.7 * fontscale
         right_buff_size = 0.2 * fontscale
 
-        if iterable(self.figure_size):
+        if has_len(self.figure_size):
             figure_size = self.figure_size
         else:
             figure_size = (self.figure_size, self.figure_size)
@@ -437,7 +437,7 @@ class LinePlot(PlotContainer):
 
 
 def _validate_point(point, ds, start=False):
-    if not iterable(point):
+    if not has_len(point):
         raise RuntimeError("Input point must be array-like")
     if not isinstance(point, YTArray):
         point = ds.arr(point, "code_length", dtype=np.float64)

--- a/yt/visualization/particle_plots.py
+++ b/yt/visualization/particle_plots.py
@@ -1,7 +1,8 @@
 import numpy as np
+from more_itertools import always_iterable
 
 from yt.data_objects.profiles import create_profile
-from yt.funcs import ensure_list, fix_axis
+from yt.funcs import fix_axis
 from yt.units.yt_array import YTArray
 from yt.visualization.fixed_resolution import ParticleImageBuffer
 from yt.visualization.profile_plotter import PhasePlot
@@ -386,7 +387,7 @@ class ParticlePhasePlot(PhasePlot):
         profile = create_profile(
             data_source,
             [x_field, y_field],
-            ensure_list(z_fields),
+            list(always_iterable(z_fields)),
             n_bins=[x_bins, y_bins],
             weight_field=weight_field,
             deposition=deposition,

--- a/yt/visualization/particle_plots.py
+++ b/yt/visualization/particle_plots.py
@@ -1,8 +1,7 @@
 import numpy as np
-from more_itertools import always_iterable
 
 from yt.data_objects.profiles import create_profile
-from yt.funcs import fix_axis
+from yt.funcs import fix_axis, iter_fields
 from yt.units.yt_array import YTArray
 from yt.visualization.fixed_resolution import ParticleImageBuffer
 from yt.visualization.profile_plotter import PhasePlot
@@ -387,7 +386,7 @@ class ParticlePhasePlot(PhasePlot):
         profile = create_profile(
             data_source,
             [x_field, y_field],
-            list(always_iterable(z_fields)),
+            list(iter_fields(z_fields)),
             n_bins=[x_bins, y_bins],
             weight_field=weight_field,
             deposition=deposition,

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -275,6 +275,8 @@ class PlotContainer:
         log = {}
         if field == "all":
             fields = list(self.plots.keys())
+        else:
+            fields = field
         for field in self.data_source._determine_fields(fields):
             log[field] = self._field_transform[field] == log_transform
         return log
@@ -915,6 +917,8 @@ class ImagePlotContainer(PlotContainer):
 
         if field == "all":
             fields = list(self.plots.keys())
+        else:
+            fields = field
         for field in self.data_source._determine_fields(fields):
             myzmin = _sanitize_units(zmin, field)
             myzmax = _sanitize_units(zmax, field)

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -12,7 +12,7 @@ from yt.data_objects.time_series import DatasetSeries
 from yt.funcs import (
     ensure_dir,
     get_image_suffix,
-    has_len,
+    is_sequence,
     issue_deprecation_warning,
     iter_fields,
     mylog,
@@ -220,7 +220,7 @@ class PlotContainer:
         self.data_source = data_source
         self.ds = data_source.ds
         self.ts = self._initialize_dataset(self.ds)
-        if has_len(figure_size):
+        if is_sequence(figure_size):
             self.figure_size = float(figure_size[0]), float(figure_size[1])
         else:
             self.figure_size = float(figure_size)
@@ -321,7 +321,7 @@ class PlotContainer:
 
     def _initialize_dataset(self, ts):
         if not isinstance(ts, DatasetSeries):
-            if not has_len(ts):
+            if not is_sequence(ts):
                 ts = [ts]
             ts = DatasetSeries(ts)
         return ts

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -13,8 +13,8 @@ from yt.funcs import (
     ensure_dir,
     ensure_list,
     get_image_suffix,
+    has_len,
     issue_deprecation_warning,
-    iterable,
     mylog,
 )
 from yt.units import YTQuantity
@@ -222,7 +222,7 @@ class PlotContainer:
         self.data_source = data_source
         self.ds = data_source.ds
         self.ts = self._initialize_dataset(self.ds)
-        if iterable(figure_size):
+        if has_len(figure_size):
             self.figure_size = float(figure_size[0]), float(figure_size[1])
         else:
             self.figure_size = float(figure_size)
@@ -323,7 +323,7 @@ class PlotContainer:
 
     def _initialize_dataset(self, ts):
         if not isinstance(ts, DatasetSeries):
-            if not iterable(ts):
+            if not has_len(ts):
                 ts = [ts]
             ts = DatasetSeries(ts)
         return ts

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -676,7 +676,6 @@ class PlotContainer:
                 axes_unit_labels[i] = r"\ \ (" + un + ")"
         return axes_unit_labels
 
-    @accepts_all_fields
     def hide_colorbar(self, field=None):
         """
         Hides the colorbar for a plot and updates the size of the
@@ -711,7 +710,10 @@ class PlotContainer:
         >>> s.hide_colorbar()
         >>> s.save()
         """
-        self.plots[field].hide_colorbar()
+        if field is None or field == "all":
+            field = self.plots.keys()
+        for f in self.data_source._determine_fields(field):
+            self.plots[f].hide_colorbar()
         return self
 
     def show_colorbar(self, field=None):

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -105,7 +105,7 @@ def accepts_all_fields(func):
         if field == "all":
             field = self.plots.keys()
         for f in self.data_source._determine_fields(field):
-            func(self, field, *args, **kwargs)
+            func(self, f, *args, **kwargs)
         return self
 
     return newfunc

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -11,7 +11,7 @@ from yt.data_objects.level_sets.clump_handling import Clump
 from yt.data_objects.selection_objects.cut_region import YTCutRegion
 from yt.data_objects.static_output import Dataset
 from yt.frontends.ytdata.data_structures import YTClumpContainer
-from yt.funcs import iterable, mylog, validate_width_tuple
+from yt.funcs import has_len, mylog, validate_width_tuple
 from yt.geometry.geometry_handler import is_curvilinear
 from yt.geometry.unstructured_mesh_handler import UnstructuredIndex
 from yt.units import dimensions
@@ -1380,7 +1380,7 @@ class ArrowCallback(PlotCallback):
                 "the length keyword in 'axis' units instead. "
                 "Setting code_size overrides length value."
             )
-            if iterable(self.code_size):
+            if has_len(self.code_size):
                 self.code_size = plot.data.ds.quan(self.code_size[0], self.code_size[1])
                 self.code_size = np.float64(self.code_size.in_units(plot.xlim[0].units))
             self.code_size = self.code_size * self._pixel_scale(plot)[0]
@@ -1588,7 +1588,7 @@ class SphereCallback(PlotCallback):
     def __call__(self, plot):
         from matplotlib.patches import Circle
 
-        if iterable(self.radius):
+        if has_len(self.radius):
             self.radius = plot.data.ds.quan(self.radius[0], self.radius[1])
             self.radius = np.float64(self.radius.in_units(plot.xlim[0].units))
         if isinstance(self.radius, YTQuantity):
@@ -2042,7 +2042,7 @@ class ParticleCallback(PlotCallback):
 
     def __call__(self, plot):
         data = plot.data
-        if iterable(self.width):
+        if has_len(self.width):
             validate_width_tuple(self.width)
             self.width = plot.data.ds.quan(self.width[0], self.width[1])
         elif isinstance(self.width, YTQuantity):

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -11,7 +11,7 @@ from yt.data_objects.level_sets.clump_handling import Clump
 from yt.data_objects.selection_objects.cut_region import YTCutRegion
 from yt.data_objects.static_output import Dataset
 from yt.frontends.ytdata.data_structures import YTClumpContainer
-from yt.funcs import has_len, mylog, validate_width_tuple
+from yt.funcs import is_sequence, mylog, validate_width_tuple
 from yt.geometry.geometry_handler import is_curvilinear
 from yt.geometry.unstructured_mesh_handler import UnstructuredIndex
 from yt.units import dimensions
@@ -1380,7 +1380,7 @@ class ArrowCallback(PlotCallback):
                 "the length keyword in 'axis' units instead. "
                 "Setting code_size overrides length value."
             )
-            if has_len(self.code_size):
+            if is_sequence(self.code_size):
                 self.code_size = plot.data.ds.quan(self.code_size[0], self.code_size[1])
                 self.code_size = np.float64(self.code_size.in_units(plot.xlim[0].units))
             self.code_size = self.code_size * self._pixel_scale(plot)[0]
@@ -1588,7 +1588,7 @@ class SphereCallback(PlotCallback):
     def __call__(self, plot):
         from matplotlib.patches import Circle
 
-        if has_len(self.radius):
+        if is_sequence(self.radius):
             self.radius = plot.data.ds.quan(self.radius[0], self.radius[1])
             self.radius = np.float64(self.radius.in_units(plot.xlim[0].units))
         if isinstance(self.radius, YTQuantity):
@@ -2042,7 +2042,7 @@ class ParticleCallback(PlotCallback):
 
     def __call__(self, plot):
         data = plot.data
-        if has_len(self.width):
+        if is_sequence(self.width):
             validate_width_tuple(self.width)
             self.width = plot.data.ds.quan(self.width[0], self.width[1])
         elif isinstance(self.width, YTQuantity):

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -6,13 +6,13 @@ from numbers import Number
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
+from more_itertools import always_iterable, zip_equal
 from mpl_toolkits.axes_grid1 import ImageGrid
 from unyt.exceptions import UnitConversionError
 
 from yt.data_objects.image_array import ImageArray
 from yt.frontends.ytdata.data_structures import YTSpatialPlotDataset
 from yt.funcs import (
-    ensure_list,
     fix_axis,
     fix_unitary,
     has_len,
@@ -420,13 +420,7 @@ class PlotWindow(ImagePlotContainer):
         if equivalency_kwargs is None:
             equivalency_kwargs = {}
         field = self.data_source._determine_fields(field)[0]
-        field = ensure_list(field)
-        new_unit = ensure_list(new_unit)
-        if len(field) > 1 and len(new_unit) != len(field):
-            raise RuntimeError(
-                f"Field list {field} and unit list {new_unit} are incompatible"
-            )
-        for f, u in zip(field, new_unit):
+        for f, u in zip_equal(iter_fields(field), always_iterable(new_unit)):
             self.frb.set_unit(f, u, equivalency, equivalency_kwargs)
             self._equivalencies[f] = (equivalency, equivalency_kwargs)
         return self

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -16,6 +16,7 @@ from yt.funcs import (
     fix_axis,
     fix_unitary,
     issue_deprecation_warning,
+    iter_fields,
     iterable,
     mylog,
     obj_length,
@@ -204,10 +205,8 @@ class PlotWindow(ImagePlotContainer):
 
         self.aspect = aspect
         skip = list(FixedResolutionBuffer._exclude_fields) + data_source._key_fields
-        if fields is None:
-            fields = []
-        else:
-            fields = ensure_list(fields)
+
+        fields = list(iter_fields(fields))
         self.override_fields = list(set(fields).intersection(set(skip)))
         self.fields = [f for f in fields if f not in skip]
         super(PlotWindow, self).__init__(data_source, window_size, fontsize)
@@ -2087,7 +2086,7 @@ class OffAxisProjectionPlot(PWViewerMPL):
         (bounds, center_rot) = get_oblique_window_parameters(
             normal, center, width, ds, depth=depth
         )
-        fields = ensure_list(fields)[:]
+        fields = list(iter_fields(fields))[:]
         oap_width = ds.arr(
             (bounds[1] - bounds[0], bounds[3] - bounds[2], bounds[5] - bounds[4])
         )

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -15,9 +15,9 @@ from yt.funcs import (
     ensure_list,
     fix_axis,
     fix_unitary,
+    has_len,
     issue_deprecation_warning,
     iter_fields,
-    iterable,
     mylog,
     obj_length,
 )
@@ -101,10 +101,10 @@ def get_axes_unit(width, ds):
     """
     if ds.no_cgs_equiv_length:
         return ("code_length",) * 2
-    if iterable(width):
+    if has_len(width):
         if isinstance(width[1], str):
             axes_unit = (width[1], width[1])
-        elif iterable(width[1]):
+        elif has_len(width[1]):
             axes_unit = (width[0][1], width[1][1])
         elif isinstance(width[0], YTArray):
             axes_unit = (str(width[0].units), str(width[1].units))
@@ -681,7 +681,7 @@ class PlotWindow(ImagePlotContainer):
         )
         if new_center is None:
             self.center = None
-        elif iterable(new_center):
+        elif has_len(new_center):
             if len(new_center) != 2:
                 raise error
             for el in new_center:
@@ -715,7 +715,7 @@ class PlotWindow(ImagePlotContainer):
             The number of data elements in the buffer on the x and y axes.
             If a scalar is provided,  then the buffer is assumed to be square.
         """
-        if iterable(size):
+        if has_len(size):
             self.buff_size = size
         else:
             self.buff_size = (size, size)
@@ -2171,7 +2171,7 @@ class WindowPlotMPL(ImagePlotMPL):
         if fontscale < 1.0:
             fontscale = np.sqrt(fontscale)
 
-        if iterable(figure_size):
+        if has_len(figure_size):
             fsize = figure_size[0]
         else:
             fsize = figure_size
@@ -2369,7 +2369,7 @@ def SlicePlot(ds, normal=None, fields=None, axis=None, *args, **kwargs):
 
     # use an AxisAlignedSlicePlot where possible, e.g.:
     # maybe someone passed normal=[0,0,0.2] when they should have just used "z"
-    if iterable(normal) and not isinstance(normal, str):
+    if has_len(normal) and not isinstance(normal, str):
         if np.count_nonzero(normal) == 1:
             normal = ("x", "y", "z")[np.nonzero(normal)[0][0]]
         else:
@@ -2377,7 +2377,7 @@ def SlicePlot(ds, normal=None, fields=None, axis=None, *args, **kwargs):
             np.divide(normal, np.dot(normal, normal), normal)
 
     # by now the normal should be properly set to get either a On/Off Axis plot
-    if iterable(normal) and not isinstance(normal, str):
+    if has_len(normal) and not isinstance(normal, str):
         # OffAxisSlicePlot has hardcoded origin; remove it if in kwargs
         if "origin" in kwargs:
             mylog.warning(

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -15,7 +15,7 @@ from yt.frontends.ytdata.data_structures import YTSpatialPlotDataset
 from yt.funcs import (
     fix_axis,
     fix_unitary,
-    has_len,
+    is_sequence,
     issue_deprecation_warning,
     iter_fields,
     mylog,
@@ -101,10 +101,10 @@ def get_axes_unit(width, ds):
     """
     if ds.no_cgs_equiv_length:
         return ("code_length",) * 2
-    if has_len(width):
+    if is_sequence(width):
         if isinstance(width[1], str):
             axes_unit = (width[1], width[1])
-        elif has_len(width[1]):
+        elif is_sequence(width[1]):
             axes_unit = (width[0][1], width[1][1])
         elif isinstance(width[0], YTArray):
             axes_unit = (str(width[0].units), str(width[1].units))
@@ -675,7 +675,7 @@ class PlotWindow(ImagePlotContainer):
         )
         if new_center is None:
             self.center = None
-        elif has_len(new_center):
+        elif is_sequence(new_center):
             if len(new_center) != 2:
                 raise error
             for el in new_center:
@@ -709,7 +709,7 @@ class PlotWindow(ImagePlotContainer):
             The number of data elements in the buffer on the x and y axes.
             If a scalar is provided,  then the buffer is assumed to be square.
         """
-        if has_len(size):
+        if is_sequence(size):
             self.buff_size = size
         else:
             self.buff_size = (size, size)
@@ -2165,7 +2165,7 @@ class WindowPlotMPL(ImagePlotMPL):
         if fontscale < 1.0:
             fontscale = np.sqrt(fontscale)
 
-        if has_len(figure_size):
+        if is_sequence(figure_size):
             fsize = figure_size[0]
         else:
             fsize = figure_size
@@ -2363,7 +2363,7 @@ def SlicePlot(ds, normal=None, fields=None, axis=None, *args, **kwargs):
 
     # use an AxisAlignedSlicePlot where possible, e.g.:
     # maybe someone passed normal=[0,0,0.2] when they should have just used "z"
-    if has_len(normal) and not isinstance(normal, str):
+    if is_sequence(normal) and not isinstance(normal, str):
         if np.count_nonzero(normal) == 1:
             normal = ("x", "y", "z")[np.nonzero(normal)[0][0]]
         else:
@@ -2371,7 +2371,7 @@ def SlicePlot(ds, normal=None, fields=None, axis=None, *args, **kwargs):
             np.divide(normal, np.dot(normal, normal), normal)
 
     # by now the normal should be properly set to get either a On/Off Axis plot
-    if has_len(normal) and not isinstance(normal, str):
+    if is_sequence(normal) and not isinstance(normal, str):
         # OffAxisSlicePlot has hardcoded origin; remove it if in kwargs
         if "origin" in kwargs:
             mylog.warning(

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -12,13 +12,7 @@ from more_itertools.more import always_iterable, unzip
 from yt.data_objects.profiles import create_profile, sanitize_field_tuple_keys
 from yt.data_objects.static_output import Dataset
 from yt.frontends.ytdata.data_structures import YTProfileDataset
-from yt.funcs import (
-    ensure_list,
-    get_image_suffix,
-    has_len,
-    iter_fields,
-    matplotlib_style_context,
-)
+from yt.funcs import get_image_suffix, has_len, iter_fields, matplotlib_style_context
 from yt.utilities.exceptions import YTNotInsideNotebook
 from yt.utilities.logger import ytLogger as mylog
 
@@ -102,7 +96,7 @@ class AxesContainer(OrderedDict):
 
 
 def sanitize_label(labels, nprofiles):
-    labels = ensure_list(labels)
+    labels = list(always_iterable(labels)) or [None]
 
     if len(labels) == 1:
         labels = labels * nprofiles

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -11,7 +11,7 @@ import numpy as np
 from yt.data_objects.profiles import create_profile, sanitize_field_tuple_keys
 from yt.data_objects.static_output import Dataset
 from yt.frontends.ytdata.data_structures import YTProfileDataset
-from yt.funcs import ensure_list, get_image_suffix, iterable, matplotlib_style_context
+from yt.funcs import ensure_list, get_image_suffix, has_len, matplotlib_style_context
 from yt.utilities.exceptions import YTNotInsideNotebook
 from yt.utilities.logger import ytLogger as mylog
 
@@ -1634,7 +1634,7 @@ class PhasePlotMPL(ImagePlotMPL):
         if fontscale < 1.0:
             fontscale = np.sqrt(fontscale)
 
-        if iterable(figure_size):
+        if has_len(figure_size):
             self._cb_size = 0.0375 * figure_size[0]
         else:
             self._cb_size = 0.0375 * figure_size

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -12,7 +12,12 @@ from more_itertools.more import always_iterable, unzip
 from yt.data_objects.profiles import create_profile, sanitize_field_tuple_keys
 from yt.data_objects.static_output import Dataset
 from yt.frontends.ytdata.data_structures import YTProfileDataset
-from yt.funcs import get_image_suffix, has_len, iter_fields, matplotlib_style_context
+from yt.funcs import (
+    get_image_suffix,
+    is_sequence,
+    iter_fields,
+    matplotlib_style_context,
+)
 from yt.utilities.exceptions import YTNotInsideNotebook
 from yt.utilities.logger import ytLogger as mylog
 
@@ -1636,7 +1641,7 @@ class PhasePlotMPL(ImagePlotMPL):
         if fontscale < 1.0:
             fontscale = np.sqrt(fontscale)
 
-        if has_len(figure_size):
+        if is_sequence(figure_size):
             self._cb_size = 0.0375 * figure_size[0]
         else:
             self._cb_size = 0.0375 * figure_size

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -703,10 +703,7 @@ class ProfilePlot:
         >>> pp.save()
 
         """
-        if field == "all":
-            fields = list(self.axes.keys())
-        else:
-            fields = ensure_list(field)
+        fields = list(self.axes.keys()) if field == "all" else field
         for profile in self.profiles:
             for field in profile.data_source._determine_fields(fields):
                 if field in profile.field_map:
@@ -787,10 +784,7 @@ class ProfilePlot:
                                 ["temperature", "dark_matter_density"])
 
         """
-        if field == "all":
-            fields = list(self.axes.keys())
-        else:
-            fields = ensure_list(field)
+        fields = list(self.axes.keys()) if field == "all" else field
         for profile in self.profiles:
             for field in profile.data_source._determine_fields(fields):
                 if field in profile.field_map:
@@ -840,10 +834,7 @@ class ProfilePlot:
         >>>  plot.save()
 
         """
-        if field == "all":
-            fields = list(self.axes.keys())
-        else:
-            fields = ensure_list(field)
+        fields = list(self.axes.keys()) if field == "all" else field
         for profile in self.profiles:
             for field in profile.data_source._determine_fields(fields):
                 if field in profile.field_map:

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -7,11 +7,18 @@ from functools import wraps
 
 import matplotlib
 import numpy as np
+from more_itertools.more import always_iterable
 
 from yt.data_objects.profiles import create_profile, sanitize_field_tuple_keys
 from yt.data_objects.static_output import Dataset
 from yt.frontends.ytdata.data_structures import YTProfileDataset
-from yt.funcs import ensure_list, get_image_suffix, has_len, matplotlib_style_context
+from yt.funcs import (
+    ensure_list,
+    get_image_suffix,
+    has_len,
+    iter_fields,
+    matplotlib_style_context,
+)
 from yt.utilities.exceptions import YTNotInsideNotebook
 from yt.utilities.logger import ytLogger as mylog
 
@@ -237,7 +244,7 @@ class ProfilePlot:
     ):
 
         data_source = data_object_or_all_data(data_source)
-        y_fields = ensure_list(y_fields)
+        y_fields = list(iter_fields(y_fields))
         logs = {x_field: bool(x_log)}
         if isinstance(y_log, bool):
             y_log = {y_field: y_log for y_field in y_fields}
@@ -426,7 +433,7 @@ class ProfilePlot:
 
         obj._font_properties = FontProperties(family="stixgeneral", size=18)
         obj._font_color = None
-        obj.profiles = ensure_list(profiles)
+        obj.profiles = list(always_iterable(profiles))
         obj.x_log = None
         obj.y_log = sanitize_field_tuple_keys(y_log, obj.profiles[0].data_source) or {}
         obj.y_title = {}
@@ -953,7 +960,7 @@ class PhasePlot(ImagePlotContainer):
             profile = create_profile(
                 data_source,
                 [x_field, y_field],
-                ensure_list(z_fields),
+                list(always_iterable(z_fields)),
                 n_bins=[x_bins, y_bins],
                 weight_field=weight_field,
                 accumulation=accumulation,

--- a/yt/visualization/volume_rendering/camera.py
+++ b/yt/visualization/volume_rendering/camera.py
@@ -3,7 +3,7 @@ from numbers import Number as numeric_type
 
 import numpy as np
 
-from yt.funcs import ensure_numpy_array, has_len
+from yt.funcs import ensure_numpy_array, is_sequence
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.math_utils import get_rotation_matrix
 from yt.utilities.orientation import Orientation
@@ -13,7 +13,7 @@ from .utils import data_source_or_all
 
 
 def _sanitize_camera_property_units(value, scene):
-    if has_len(value):
+    if is_sequence(value):
         if len(value) == 1:
             return _sanitize_camera_property_units(value[0], scene)
         elif isinstance(value, YTArray) and len(value) == 3:
@@ -25,7 +25,7 @@ def _sanitize_camera_property_units(value, scene):
         ):
             return scene.arr([scene.arr(value[0], value[1]).in_units("unitary")] * 3)
         if len(value) == 3:
-            if all([has_len(v) for v in value]):
+            if all([is_sequence(v) for v in value]):
                 if all(
                     [
                         isinstance(v[0], numeric_type) and isinstance(v[1], str)
@@ -258,7 +258,7 @@ class Camera(Orientation):
             return self._resolution
 
         def fset(self, value):
-            if has_len(value):
+            if is_sequence(value):
                 if len(value) != 2:
                     raise RuntimeError
             else:
@@ -333,11 +333,11 @@ class Camera(Orientation):
         width = np.sqrt((xma - xmi) ** 2 + (yma - ymi) ** 2 + (zma - zmi) ** 2)
         focus = data_source.get_field_parameter("center")
 
-        if has_len(width) and len(width) > 1 and isinstance(width[1], str):
+        if is_sequence(width) and len(width) > 1 and isinstance(width[1], str):
             width = data_source.ds.quan(width[0], units=width[1])
             # Now convert back to code length for subsequent manipulation
             width = width.in_units("code_length")  # .value
-        if not has_len(width):
+        if not is_sequence(width):
             width = data_source.ds.arr([width, width, width], units="code_length")
             # left/right, top/bottom, front/back
         if not isinstance(width, YTArray):

--- a/yt/visualization/volume_rendering/camera.py
+++ b/yt/visualization/volume_rendering/camera.py
@@ -3,7 +3,7 @@ from numbers import Number as numeric_type
 
 import numpy as np
 
-from yt.funcs import ensure_numpy_array, iterable
+from yt.funcs import ensure_numpy_array, has_len
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.math_utils import get_rotation_matrix
 from yt.utilities.orientation import Orientation
@@ -13,7 +13,7 @@ from .utils import data_source_or_all
 
 
 def _sanitize_camera_property_units(value, scene):
-    if iterable(value):
+    if has_len(value):
         if len(value) == 1:
             return _sanitize_camera_property_units(value[0], scene)
         elif isinstance(value, YTArray) and len(value) == 3:
@@ -25,7 +25,7 @@ def _sanitize_camera_property_units(value, scene):
         ):
             return scene.arr([scene.arr(value[0], value[1]).in_units("unitary")] * 3)
         if len(value) == 3:
-            if all([iterable(v) for v in value]):
+            if all([has_len(v) for v in value]):
                 if all(
                     [
                         isinstance(v[0], numeric_type) and isinstance(v[1], str)
@@ -258,7 +258,7 @@ class Camera(Orientation):
             return self._resolution
 
         def fset(self, value):
-            if iterable(value):
+            if has_len(value):
                 if len(value) != 2:
                     raise RuntimeError
             else:
@@ -333,11 +333,11 @@ class Camera(Orientation):
         width = np.sqrt((xma - xmi) ** 2 + (yma - ymi) ** 2 + (zma - zmi) ** 2)
         focus = data_source.get_field_parameter("center")
 
-        if iterable(width) and len(width) > 1 and isinstance(width[1], str):
+        if has_len(width) and len(width) > 1 and isinstance(width[1], str):
             width = data_source.ds.quan(width[0], units=width[1])
             # Now convert back to code length for subsequent manipulation
             width = width.in_units("code_length")  # .value
-        if not iterable(width):
+        if not has_len(width):
             width = data_source.ds.arr([width, width, width], units="code_length")
             # left/right, top/bottom, front/back
         if not isinstance(width, YTArray):

--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from yt.data_objects.api import ImageArray
-from yt.funcs import has_len, mylog
+from yt.funcs import is_sequence, mylog
 from yt.units.unit_object import Unit
 from yt.utilities.lib.partitioned_grid import PartitionedGrid
 from yt.utilities.lib.pixelization_routines import (
@@ -332,10 +332,10 @@ def off_axis_projection(
     vol.set_transfer_function(ptf)
     camera = sc.add_camera(data_source)
     camera.set_width(width)
-    if not has_len(resolution):
+    if not is_sequence(resolution):
         resolution = [resolution] * 2
     camera.resolution = resolution
-    if not has_len(width):
+    if not is_sequence(width):
         width = data_source.ds.arr([width] * 3)
     normal = np.array(normal_vector)
     normal = normal / np.linalg.norm(normal)

--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from yt.data_objects.api import ImageArray
-from yt.funcs import iterable, mylog
+from yt.funcs import has_len, mylog
 from yt.units.unit_object import Unit
 from yt.utilities.lib.partitioned_grid import PartitionedGrid
 from yt.utilities.lib.pixelization_routines import (
@@ -332,10 +332,10 @@ def off_axis_projection(
     vol.set_transfer_function(ptf)
     camera = sc.add_camera(data_source)
     camera.set_width(width)
-    if not iterable(resolution):
+    if not has_len(resolution):
         resolution = [resolution] * 2
     camera.resolution = resolution
-    if not iterable(width):
+    if not has_len(width):
         width = data_source.ds.arr([width] * 3)
     normal = np.array(normal_vector)
     normal = normal / np.linalg.norm(normal)

--- a/yt/visualization/volume_rendering/old_camera.py
+++ b/yt/visualization/volume_rendering/old_camera.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from yt.config import ytcfg
 from yt.data_objects.api import ImageArray
-from yt.funcs import ensure_numpy_array, get_num_threads, get_pbar, has_len, mylog
+from yt.funcs import ensure_numpy_array, get_num_threads, get_pbar, is_sequence, mylog
 from yt.units.yt_array import YTArray
 from yt.utilities.amr_kdtree.api import AMRKDTree
 from yt.utilities.exceptions import YTNotInsideNotebook
@@ -172,16 +172,16 @@ class Camera(ParallelAnalysisInterface):
         ParallelAnalysisInterface.__init__(self)
         if ds is not None:
             self.ds = ds
-        if not has_len(resolution):
+        if not is_sequence(resolution):
             resolution = (resolution, resolution)
         self.resolution = resolution
         self.sub_samples = sub_samples
         self.rotation_vector = north_vector
-        if has_len(width) and len(width) > 1 and isinstance(width[1], str):
+        if is_sequence(width) and len(width) > 1 and isinstance(width[1], str):
             width = self.ds.quan(width[0], units=width[1])
             # Now convert back to code length for subsequent manipulation
             width = width.in_units("code_length").value
-        if not has_len(width):
+        if not is_sequence(width):
             width = (width, width, width)  # left/right, top/bottom, front/back
         if not isinstance(width, YTArray):
             width = self.ds.arr(width, units="code_length")
@@ -632,7 +632,7 @@ class Camera(ParallelAnalysisInterface):
         """
         if width is None:
             width = self.width
-        if not has_len(width):
+        if not is_sequence(width):
             width = (width, width, width)  # left/right, tom/bottom, front/back
         self.width = width
         if center is not None:
@@ -1015,7 +1015,7 @@ class Camera(ParallelAnalysisInterface):
             final = self.ds.arr(final, units="code_length")
         if exponential:
             if final_width is not None:
-                if not has_len(final_width):
+                if not is_sequence(final_width):
                     final_width = [final_width, final_width, final_width]
                 if not isinstance(final_width, YTArray):
                     final_width = self.ds.arr(final_width, units="code_length")
@@ -1030,7 +1030,7 @@ class Camera(ParallelAnalysisInterface):
             dx = position_diff ** (1.0 / n_steps)
         else:
             if final_width is not None:
-                if not has_len(final_width):
+                if not is_sequence(final_width):
                     final_width = [final_width, final_width, final_width]
                 if not isinstance(final_width, YTArray):
                     final_width = self.ds.arr(final_width, units="code_length")
@@ -1706,7 +1706,7 @@ class FisheyeCamera(Camera):
         self.center = np.array(center, dtype="float64")
         self.radius = radius
         self.fov = fov
-        if has_len(resolution):
+        if is_sequence(resolution):
             raise RuntimeError("Resolution must be a single int")
         self.resolution = resolution
         if transfer_function is None:
@@ -1821,13 +1821,13 @@ class MosaicCamera(Camera):
         self.procs_per_wg = procs_per_wg
         if ds is not None:
             self.ds = ds
-        if not has_len(resolution):
+        if not is_sequence(resolution):
             resolution = (int(resolution / nimx), int(resolution / nimy))
         self.resolution = resolution
         self.nimx = nimx
         self.nimy = nimy
         self.sub_samples = sub_samples
-        if not has_len(width):
+        if not is_sequence(width):
             width = (width, width, width)  # front/back, left/right, top/bottom
         self.width = np.array([width[0], width[1], width[2]])
         self.center = center

--- a/yt/visualization/volume_rendering/old_camera.py
+++ b/yt/visualization/volume_rendering/old_camera.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from yt.config import ytcfg
 from yt.data_objects.api import ImageArray
-from yt.funcs import ensure_numpy_array, get_num_threads, get_pbar, iterable, mylog
+from yt.funcs import ensure_numpy_array, get_num_threads, get_pbar, has_len, mylog
 from yt.units.yt_array import YTArray
 from yt.utilities.amr_kdtree.api import AMRKDTree
 from yt.utilities.exceptions import YTNotInsideNotebook
@@ -172,16 +172,16 @@ class Camera(ParallelAnalysisInterface):
         ParallelAnalysisInterface.__init__(self)
         if ds is not None:
             self.ds = ds
-        if not iterable(resolution):
+        if not has_len(resolution):
             resolution = (resolution, resolution)
         self.resolution = resolution
         self.sub_samples = sub_samples
         self.rotation_vector = north_vector
-        if iterable(width) and len(width) > 1 and isinstance(width[1], str):
+        if has_len(width) and len(width) > 1 and isinstance(width[1], str):
             width = self.ds.quan(width[0], units=width[1])
             # Now convert back to code length for subsequent manipulation
             width = width.in_units("code_length").value
-        if not iterable(width):
+        if not has_len(width):
             width = (width, width, width)  # left/right, top/bottom, front/back
         if not isinstance(width, YTArray):
             width = self.ds.arr(width, units="code_length")
@@ -632,7 +632,7 @@ class Camera(ParallelAnalysisInterface):
         """
         if width is None:
             width = self.width
-        if not iterable(width):
+        if not has_len(width):
             width = (width, width, width)  # left/right, tom/bottom, front/back
         self.width = width
         if center is not None:
@@ -1015,7 +1015,7 @@ class Camera(ParallelAnalysisInterface):
             final = self.ds.arr(final, units="code_length")
         if exponential:
             if final_width is not None:
-                if not iterable(final_width):
+                if not has_len(final_width):
                     final_width = [final_width, final_width, final_width]
                 if not isinstance(final_width, YTArray):
                     final_width = self.ds.arr(final_width, units="code_length")
@@ -1030,7 +1030,7 @@ class Camera(ParallelAnalysisInterface):
             dx = position_diff ** (1.0 / n_steps)
         else:
             if final_width is not None:
-                if not iterable(final_width):
+                if not has_len(final_width):
                     final_width = [final_width, final_width, final_width]
                 if not isinstance(final_width, YTArray):
                     final_width = self.ds.arr(final_width, units="code_length")
@@ -1706,7 +1706,7 @@ class FisheyeCamera(Camera):
         self.center = np.array(center, dtype="float64")
         self.radius = radius
         self.fov = fov
-        if iterable(resolution):
+        if has_len(resolution):
             raise RuntimeError("Resolution must be a single int")
         self.resolution = resolution
         if transfer_function is None:
@@ -1821,13 +1821,13 @@ class MosaicCamera(Camera):
         self.procs_per_wg = procs_per_wg
         if ds is not None:
             self.ds = ds
-        if not iterable(resolution):
+        if not has_len(resolution):
             resolution = (int(resolution / nimx), int(resolution / nimy))
         self.resolution = resolution
         self.nimx = nimx
         self.nimy = nimy
         self.sub_samples = sub_samples
-        if not iterable(width):
+        if not has_len(width):
             width = (width, width, width)  # front/back, left/right, top/bottom
         self.width = np.array([width[0], width[1], width[2]])
         self.center = center

--- a/yt/visualization/volume_rendering/render_source.py
+++ b/yt/visualization/volume_rendering/render_source.py
@@ -5,9 +5,9 @@ import numpy as np
 
 from yt.config import ytcfg
 from yt.data_objects.image_array import ImageArray
-from yt.funcs import ensure_numpy_array, iterable, mylog
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.geometry.oct_geometry_handler import OctreeIndex
+from yt.funcs import ensure_numpy_array, has_len, mylog
 from yt.utilities.amr_kdtree.api import AMRKDTree
 from yt.utilities.lib.bounding_volume_hierarchy import BVH
 from yt.utilities.lib.misc_utilities import zlines, zpoints
@@ -1001,7 +1001,7 @@ class PointSource(OpaqueSource):
         if colors is not None:
             assert colors.ndim == 2 and colors.shape[1] == 4
             assert colors.shape[0] == positions.shape[0]
-        if not iterable(radii):
+        if not has_len(radii):
             if radii is not None:  # broadcast the value
                 radii = radii * np.ones(positions.shape[0], dtype="int64")
             else:  # default radii to 0 pixels (i.e. point is 1 pixel wide)

--- a/yt/visualization/volume_rendering/render_source.py
+++ b/yt/visualization/volume_rendering/render_source.py
@@ -7,7 +7,7 @@ from yt.config import ytcfg
 from yt.data_objects.image_array import ImageArray
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.geometry.oct_geometry_handler import OctreeIndex
-from yt.funcs import ensure_numpy_array, has_len, mylog
+from yt.funcs import ensure_numpy_array, is_sequence, mylog
 from yt.utilities.amr_kdtree.api import AMRKDTree
 from yt.utilities.lib.bounding_volume_hierarchy import BVH
 from yt.utilities.lib.misc_utilities import zlines, zpoints
@@ -1001,7 +1001,7 @@ class PointSource(OpaqueSource):
         if colors is not None:
             assert colors.ndim == 2 and colors.shape[1] == 4
             assert colors.shape[0] == positions.shape[0]
-        if not has_len(radii):
+        if not is_sequence(radii):
             if radii is not None:  # broadcast the value
                 radii = radii * np.ones(positions.shape[0], dtype="int64")
             else:  # default radii to 0 pixels (i.e. point is 1 pixel wide)

--- a/yt/visualization/volume_rendering/render_source.py
+++ b/yt/visualization/volume_rendering/render_source.py
@@ -5,9 +5,9 @@ import numpy as np
 
 from yt.config import ytcfg
 from yt.data_objects.image_array import ImageArray
+from yt.funcs import ensure_numpy_array, is_sequence, mylog
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.geometry.oct_geometry_handler import OctreeIndex
-from yt.funcs import ensure_numpy_array, is_sequence, mylog
 from yt.utilities.amr_kdtree.api import AMRKDTree
 from yt.utilities.lib.bounding_volume_hierarchy import BVH
 from yt.utilities.lib.misc_utilities import zlines, zpoints

--- a/yt/visualization/volume_rendering/transfer_functions.py
+++ b/yt/visualization/volume_rendering/transfer_functions.py
@@ -1,7 +1,8 @@
 import numpy as np
 from matplotlib.cm import get_cmap
+from more_itertools import always_iterable
 
-from yt.funcs import ensure_list, mylog
+from yt.funcs import mylog
 from yt.utilities.physical_constants import clight, hcgs, kboltz
 
 
@@ -354,8 +355,7 @@ class MultiVariateTransferFunction:
         >>> mv.add_field_table(tf, 0)
         >>> mv.link_channels(0, [0,1,2])
         """
-        channels = ensure_list(channels)
-        for c in channels:
+        for c in always_iterable(channels):
             self.field_table_ids[c] = table_id
 
 


### PR DESCRIPTION
## PR Summary

Refactor some internals using `more_itertools` (which is already a transitive dependency).

### remove `yt.funcs.ensure_list`
this function has two use cases
- it is used in many places to iterate over one or more objects transparently. While `ensure_list` is bit clunky and requires maintenance on our part, the more powerful `more_itertools.always_iterable` does the job.
- in places it is used as a sanitizer, it can be replaced by `lambda x: list(always_iterable(x))`

When we specifically need to iterate transparently over a arbitrary number of fields, `always_iterable` doesn't work out of the box since a single 2-tuple should be treated as a single field, but it's easy to configure, so I added a simple `yt.funcs.iter_fields` function:
```python
def iter_fields(field_or_fields):
    return always_iterable(field_or_fields, base_type=(tuple, str, bytes))
```

### rename `yt.funcs.iterable`
This function's name is confusing because it doesn't indicate that it's really a checker that returns a boolean (`is_iterable` would be clearer in that sense). On top of this it is also wrong because it actually only checks that `len(obj)` is valid, while some iterables have no length (e.g. infinite generators).
I renamed the existing function to `is_sequence`.

other associated renames
- `yt.funcs.validate_iterable` -> `validate_sequence`
- `yt.geometry.coordinates.coordinate_handler.validate_sequence_width` -> `validate_sequence_width`


### rework `yt.funcs.ensure_tuple` and `yt.funcs.just_one` 

Each can be simplified as combination of two functions from `more_itertools`.

Additionally, `ensure_tuple` is now only ever used to validate `ds.periodicity`, so there is some overlapping with #2868 and the functionality could be moved to the `Dataset` class directly.

This PR refactors the one place that `ensure_tuple` was used differently, namely `yt.frontends.enzo_p.misc.nested_dict_get`.
I also fixed a bug (and added a test for it) in this function while I was at it.

## PR Checklist

- [x] rename `iterable` to `is_sequence`
- [x] add an `iter_fields` function
- [x] search and replace `ensure_list` calls with either `iter_fields` where an iterator is needed, `list(iter_fields())` where we actually need a list of fields, and `list(always_iterable())` elsewhere.
- [x] remove `ensure_list`
- [x] search and replace `ensure_tuple` calls with `tuple(always_iterable())` (or update ensure_tuple to the same effect ?)
- [x] rework `just_one` 
- [x] explicitly add more_itertools to deps
- [x] pass `black --check yt/`
- [x] pass `isort . --check --diff`
- [x] pass `flake8 yt/`
- [x] pass `flynt yt/ --fail-on-change --dry-run -e yt/extern`
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.