### PR TITLE
[load_sample] Don't try to untar hdf5 files

### DIFF
--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -1336,11 +1336,11 @@ def load_sample(fn=None, specific_file=None, pbar=True):
         except ImportError:
             mylog.warning("tqdm is not installed, progress bar can not be displayed.")
 
-    if extension == "h5":
-        processor = pooch.pooch.Untar()
-    else:
+    if extension != "h5":
         # we are going to assume most files that exist on the hub are
         # compressed in .tar folders. Some may not.
+        processor = pooch.pooch.Untar()
+    else:
         processor = None
 
     storage_fname = fido.pooch_obj.fetch(


### PR DESCRIPTION
## PR Summary

Logic deciding whether to untar a file downloaded by pooch was accidentally reversed in 853621cc5a1d74e9eba532e1962376cd6a921b32 . Originally reported by @chrishavlin on slack.