### PR TITLE
fix silenced unit conversion bugs

### DIFF
--- a/yt/data_objects/tests/test_numpy_ops.py
+++ b/yt/data_objects/tests/test_numpy_ops.py
@@ -90,6 +90,8 @@ def test_mean_sum_integrate():
 
 
 def test_min_max():
+    fields = ("density", "temperature")
+    units = ("g/cm**3", "K")
     for nprocs in [-1, 1, 2, 16]:
         fields = ["density", "temperature"]
         units = ["g/cm**3", "K"]

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -588,7 +588,7 @@ class FieldInfoContainer(dict):
             AttributeError,
             KeyError,
             # code smells -> those are very likely bugs
-            UnitConversionError,  # solved in GH PR 2897 ?
+            # UnitConversionError,  # solved in GH PR 2897 ?
             # RecursionError is clearly a bug, and was already solved once
             # in GH PR 2851
             RecursionError,

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -2,7 +2,6 @@ from numbers import Number as numeric_type
 from typing import Optional, Tuple
 
 import numpy as np
-from unyt.exceptions import UnitConversionError
 
 from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.fields.field_exceptions import NeedsConfiguration

--- a/yt/fields/vector_operations.py
+++ b/yt/fields/vector_operations.py
@@ -170,10 +170,10 @@ def create_vector_fields(registry, basename, field_units, ftype="gas", slice_inf
     xn, yn, zn = [(ftype, f"{basename}_{ax}") for ax in "xyz"]
 
     # Is this safe?
-    if registry.ds.dimensionality < 3:
-        zn = ("index", "zeros")
-    if registry.ds.dimensionality < 2:
-        yn = ("index", "zeros")
+    # if registry.ds.dimensionality < 3:
+    #    zn = ("index", "zeros")
+    # if registry.ds.dimensionality < 2:
+    #    yn = ("index", "zeros")
 
     create_relative_field(
         registry,

--- a/yt/utilities/lib/tests/test_geometry_utils.py
+++ b/yt/utilities/lib/tests/test_geometry_utils.py
@@ -14,7 +14,6 @@ from yt.utilities.lib.misc_utilities import (
 
 _fields = ("density", "velocity_x", "velocity_y", "velocity_z")
 _units = ("g/cm**3", "cm/s", "cm/s", "cm/s")
-
 # TODO: error compact/spread bits for incorrect size
 # TODO: test msdb for [0,0], [1,1], [2,2] etc.
 

--- a/yt/visualization/volume_rendering/tests/test_lenses.py
+++ b/yt/visualization/volume_rendering/tests/test_lenses.py
@@ -30,6 +30,7 @@ class LensTest(TestCase):
             self.curdir, self.tmpdir = None, None
 
         self.field = ("gas", "density")
+        # TODO: Check this (I wrote this as self.field[1] in an earlier draft)
         self.ds = fake_random_ds(32, fields=(self.field,), units=("g/cm**3",))
         self.ds.index
 


### PR DESCRIPTION
## PR Summary

Another bug discovered in https://github.com/yt-project/yt/pull/2851
Opening as a draft to expose the bug in CI before I apply the fix.

update:
Apparently the main issue is that `fake_random_ds` has a very fragile api: the kwargs `fields` and `units` have default values but there is no mechanism to prevent using non-default fields without explicitly specifying their units. As a results we have a bunch of tests where we build a `"temperature"` field with units `"cm/s"`.
These should now be fixed here, but I'm not fixing  `fake_random_ds`'s api as a whole for now (too much work for the time I have on my hands).

A different error is revealed in 
`yt/data_objects/tests/test_covering_grid.py::test_smoothed_covering_grid_2d_dataset`, I'll try to investigate on this one.