### PR TITLE
Add reqs that needs to be installed before test_requirements.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ install:
       # pyproject.toml in cartopy.
       # These versions are pinned, so we will need to update/remove them when
       # the hack is no longer necessary.
-      $PIP install numpy==1.18.1 cython==0.29.14
+      $PIP install -r tests/test_prerequirements.txt
       CFLAGS="$CFLAGS -DACCEPT_USE_OF_DEPRECATED_PROJ_API_H" $PIP install -r tests/test_requirements.txt
     fi
     $PIP install -e .

--- a/tests/test_prerequirements.txt
+++ b/tests/test_prerequirements.txt
@@ -1,0 +1,3 @@
+# We need this file mostly because of Cartopy..
+numpy==1.17.5
+cython==0.29.14

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -86,7 +86,7 @@ answer_tests:
     - yt/frontends/owls/tests/test_outputs.py:test_snapshot_033
     - yt/frontends/owls/tests/test_outputs.py:test_OWLS_particlefilter
 
-  local_pw_030:  # PR 2735
+  local_pw_031:  # PR 2902
     - yt/visualization/tests/test_plotwindow.py:test_attributes
     - yt/visualization/tests/test_plotwindow.py:test_attributes_wt
     - yt/visualization/tests/test_particle_plot.py:test_particle_projection_answers
@@ -162,7 +162,7 @@ answer_tests:
   local_axialpix_006:
     - yt/geometry/coordinates/tests/test_axial_pixelization.py:test_axial_pixelization
 
-  local_cylindrical_background_002:
+  local_cylindrical_background_003:  # PR 2902
     - yt/geometry/coordinates/tests/test_cylindrical_coordinates.py:test_noise_plots
 
   #local_particle_trajectory_001:

--- a/yt/visualization/tests/test_particle_plot.py
+++ b/yt/visualization/tests/test_particle_plot.py
@@ -41,8 +41,8 @@ PROJ_ATTR_ARGS["set_cmap"] = [
 ]
 PROJ_ATTR_ARGS["set_log"] = [(("particle_mass", False), {})]
 PROJ_ATTR_ARGS["set_zlim"] = [
-    (("particle_mass", 1e-25, 1e-23), {}),
-    (("particle_mass", 1e-25, None), {"dynamic_range": 4}),
+    (("particle_mass", 1e39, 1e42), {}),
+    (("particle_mass", 1e39, None), {"dynamic_range": 4}),
 ]
 
 PHASE_ATTR_ARGS = {


### PR DESCRIPTION
## PR Summary

This PR introduces additional file (`tests/test_prerequirements.txt`) that can be used to install basic packages required by anything in `test_requirements.txt` (I'm looking at you Cartopy...). It allows me to remove hardcoded deps that are currently defined in the Jenkins' job. I also dropped pinning mpl to 3.1.3, so there's a high chance this will fail and will require some answers to be regenerated.
