### PR TITLE
[hotfix] Downgrade mpl until PR#2902 is merged

### DIFF
--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -5,7 +5,7 @@ fastcache==1.0.2
 glueviz==0.13.3
 h5py==2.10.0
 ipython==7.6.1
-matplotlib==3.3.0
+matplotlib==3.1.3
 mock
 nose-timer==1.0.0
 nose==1.3.7


### PR DESCRIPTION
## PR Summary

Jenkins needs mpl<3.3 for test to pass right now. New set of answers is generated in #2902, but this should go in to prevent blocking other PRs.

