### PR TITLE
hotfix: make Dataset an abstract class again

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -131,7 +131,7 @@ def requires_index(attr_name):
     return ireq
 
 
-class Dataset:
+class Dataset(abc.ABC):
 
     default_fluid_type = "gas"
     default_field = ("gas", "density")


### PR DESCRIPTION
## PR Summary

Just noticed we lost the inheritance from abc.ABC (from #2556) in `Dataset`, as a side effect of #2823 
fix it.