### PR TITLE
hotfix/flaking_ramses

### DIFF
--- a/yt/frontends/ramses/field_handlers.py
+++ b/yt/frontends/ramses/field_handlers.py
@@ -60,7 +60,8 @@ class HandlerMixin:
             self.fname = full_path
         else:
             raise FileNotFoundError(
-                f"Could not find {self._file_type} file (type: {self.ftype}). Tried {full_path}"
+                f"Could not find {self._file_type} file (type: {self.ftype}). "
+                f"Tried {full_path}"
             )
 
         if self.file_descriptor is not None:


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] pass `black --check yt/`
- [x] pass `isort . --check --diff`
- [x] pass `flake8 yt/`
- [x] pass `flynt yt/ --fail-on-change --dry-run -e yt/extern`
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

This should fix the flaking errors that's poping up in other PRs.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
