### PR TITLE
ci: only test against latest python version on windows to reduce CI bottleneck

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,6 @@ environment:
       PYTHON: "C:\\Miniconda36-x64"
 
   matrix:
-      - PYTHON_VERSION: "3.6"
       - PYTHON_VERSION: "3.8"
 
 platform:


### PR DESCRIPTION
## PR Summary

As proposed by @Xarthisius on Slack, let's cut the testing time on windows by half and only test against Python 3.8

note: this is superseded by https://github.com/yt-project/yt/pull/2908 !