### PR TITLE
fix a FutureWarning from numpy

### DIFF
--- a/yt/geometry/grid_container.pyx
+++ b/yt/geometry/grid_container.pyx
@@ -142,7 +142,7 @@ cdef class GridTree:
             elif name.endswith("_y") or name.endswith("_z"):
                 continue
             else:
-                f = (d.char, 1)
+                f = d.char
             dtn[n] = (f, o)
         return grids_basic.view(dtype=np.dtype(dtn))
 


### PR DESCRIPTION
## PR Summary

CI logs still contain one FutureWarning from numpy
for instance
```
yt/geometry/tests/test_grid_container.py::test_grid_arrays_view
  /Users/clm/.pyenv/versions/3.8.5/envs/yt_dev/lib/python3.8/site-packages/numpy/core/_internal.py:38: FutureWarning: Passing (type, 1) or '1type' as a synonym of type is deprecated; in a future version of numpy, it will be understood as (type, (1,)) / '(1,)type'.
    format = dtype(obj[0], align=align)
```

This fixes it. However, I expect this to break the minimal setup run so I'll open as a draft for now.
