### PR TITLE
Simplify isort conf

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
     - id: black
       language_version: python3.7
 -   repo: https://github.com/timothycrosley/isort
-    rev: '5.2.1'  # keep in sync with tests/lint_requirements.txt
+    rev: '5.5.3'  # keep in sync with tests/lint_requirements.txt
     hooks:
     -   id: isort
 -   repo: https://gitlab.com/pycqa/flake8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,29 @@ exclude = '''
 )/
 | yt/visualization/_colormap_data.py
 '''
+
+
+# To be kept consistent with "Import Formatting" section in CONTRIBUTING.rst
+[tool.isort]
+profile = "black"
+combine_as_imports = true
+# isort can't be applied to yt/__init__.py because it creates circular imports
+skip =  ["venv", "doc", "benchmarks", "yt/__init__.py", "yt/extern"]
+known_third_party = [
+  "IPython",
+  "nose",
+  "numpy",
+  "sympy",
+  "matplotlib",
+  "unyt",
+  "git",
+  "yaml",
+  "dateutil",
+  "requests",
+  "coverage",
+  "pytest",
+  "pyx",
+  "glue",
+]
+known_first_party = ["yt"]
+sections = ["FUTURE", "STDLIB", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,16 +39,3 @@ ignore = E203, # Whitespace before ':' (black compatibility)
          B302, # this is a python 3 compatibility warning, not relevant since don't support python 2 anymore
 
 jobs=8
-
-# To be kept consistent with "Import Formatting" section in CONTRIBUTING.rst
-[tool:isort]
-multi_line_output=3
-include_trailing_comma=True
-force_grid_wrap=0
-combine_as_imports=True
-line_length=88
-# isort can't be applied to yt/__init__.py because it creates circular imports
-skip = venv, doc, benchmarks, yt/__init__.py, yt/extern
-known_third_party = IPython, nose, numpy, sympy, matplotlib, unyt, git, yaml, dateutil, requests, coverage, pytest, pyx, glue
-known_first_party = yt
-sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER

--- a/tests/lint_requirements.txt
+++ b/tests/lint_requirements.txt
@@ -2,7 +2,7 @@ flake8==3.8.1  # keep in sync with .pre-commit-config.yaml
 mccabe==0.6.1
 pycodestyle==2.6.0
 pyflakes==2.2.0
-isort==5.2.1   # keep in sync with .pre-commit-config.yaml
+isort==5.5.3   # keep in sync with .pre-commit-config.yaml
 black==19.10b0
 flake8-bugbear
 flynt==0.52   # keep in sync with .pre-commit-config.yaml

--- a/yt/utilities/lib/basic_octree.pyx
+++ b/yt/utilities/lib/basic_octree.pyx
@@ -12,6 +12,7 @@ A refine-by-two AMR-specific octree
 import numpy as np
 
 cimport cython
+
 # Double up here for def'd functions
 cimport numpy as np
 cimport numpy as cnp

--- a/yt/utilities/lib/grid_traversal.pyx
+++ b/yt/utilities/lib/grid_traversal.pyx
@@ -34,6 +34,7 @@ from libc.math cimport (
     sin,
     sqrt,
 )
+
 #cimport healpix_interface
 from libc.stdlib cimport abs, calloc, free, malloc
 


### PR DESCRIPTION
## PR Summary

Moving the isort conf from setup.cfg to pyproject.toml (recommended by isort's doc), and using `profile="black"` to simplify the configuration, guaranteeing we won't get conflicts between isort and black.
While I'm at it I bumped isort's version. I doesn't affect the stability of the code base right now (almost 0 churn except for 2 additional newlines) but there were a number of bugfix since last time so it seems worth the shot.