### PR TITLE
bugfix: fix a brittle array conversion

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -938,9 +938,10 @@ class Dataset(abc.ABC):
             alt_coords = []
             for x in coords:
                 alt_coords.append(
-                    self.quan(x.v, "code_length") if x.units.is_dimensionless else x
+                    self.quan(x.v, "code_length")
+                    if x.units.is_dimensionless
+                    else x.to("code_length")
                 )
-
             coords = self.arr(alt_coords, dtype="float64").to("code_length")
         return val, coords
 


### PR DESCRIPTION
## PR Summary

This fixes a "Heinseinbug" I encounter in a complicated notebook + yt plugin situation, and that I can't seem to reproduce simply for now.

In my plugin file I have a line
```python
ds.find_max("density")  # ds is a polar 2D dataset
```
that raises a `unyt.exceptions.IterableUnitCoercionError`.
I'm sorry to open a bugfix when I can't clearly expose the bug in question, but I do hope the fix is uncontroversial and can be accepted as is. I don't have enough time on my hands to inspect this further :/