### PR TITLE
bugfix/2892

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ build_ext, sdist = create_build_ext(lib_exts, cythonize_aliases)
 class BinaryDistribution(Distribution):
     """Distribution which always forces a binary package with platform name."""
 
-    def has_ext_modules(foo):
+    def has_ext_modules(self):
         return True
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from distutils.ccompiler import get_default_compiler
 from distutils.version import LooseVersion
 
 import pkg_resources
-from setuptools import find_packages, setup
+from setuptools import Distribution, find_packages, setup
 
 from setupext import (
     check_for_openmp,
@@ -84,6 +84,16 @@ lib_exts += embree_libs
 # This overrides using lib_exts, so it has to happen after lib_exts is fully defined
 build_ext, sdist = create_build_ext(lib_exts, cythonize_aliases)
 
+# Force setuptools to consider that there are ext modules, even if empty.
+# See https://github.com/yt-project/yt/issues/2922 and
+# https://stackoverflow.com/a/62668026/2601223 for the fix.
+class BinaryDistribution(Distribution):
+    """Distribution which always forces a binary package with platform name."""
+
+    def has_ext_modules(foo):
+        return True
+
+
 if __name__ == "__main__":
     setup(
         name="yt",
@@ -141,6 +151,7 @@ if __name__ == "__main__":
         license="BSD 3-Clause",
         zip_safe=False,
         scripts=["scripts/iyt"],
+        distclass=BinaryDistribution,
         ext_modules=[],  # !!! We override this inside build_ext above
         python_requires=">=3.6",
     )


### PR DESCRIPTION
## PR Summary

This fixes #2892. The issue is that `setup.py install` does not call `build_ext` if `ext_modules` is empty.
This is fixed by customizing the distribution class and always assume there are some extensions to be built.

I am not quite sure how to test it, but on my local machine `pip install .` now works from the folder that contains yt, as well as `pip install git+file://path/toyt/source/code`.

## PR Checklist

- [x] pass `black --check yt/`
- [x] pass `isort . --check --diff`
- [x] pass `flake8 yt/`
- [x] pass `flynt yt/ --fail-on-change --dry-run -e yt/extern`
- [ ] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.
