### PR TITLE
[bugfix] Construct log message using args.

### DIFF
--- a/yt/utilities/logger.py
+++ b/yt/utilities/logger.py
@@ -74,7 +74,8 @@ class DuplicateFilter(logging.Filter):
     # source
     # https://stackoverflow.com/questions/44691558/suppress-multiple-messages-with-same-content-in-python-logging-module-aka-log-co  # noqa
     def filter(self, record):
-        current_log = (record.module, record.levelno, record.msg)
+        msg = record.msg % record.args
+        current_log = (record.module, record.levelno, msg)
         if current_log != getattr(self, "last_log", None):
             self.last_log = current_log
             return True

--- a/yt/utilities/logger.py
+++ b/yt/utilities/logger.py
@@ -74,8 +74,7 @@ class DuplicateFilter(logging.Filter):
     # source
     # https://stackoverflow.com/questions/44691558/suppress-multiple-messages-with-same-content-in-python-logging-module-aka-log-co  # noqa
     def filter(self, record):
-        msg = record.msg % record.args
-        current_log = (record.module, record.levelno, msg)
+        current_log = (record.module, record.levelno, record.msg, record.args)
         if current_log != getattr(self, "last_log", None):
             self.last_log = current_log
             return True


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

The log filtering added in PR #2871 introduced a small issue when the logger is called as `mylog.info(message, arg1, arg2, ...)`. Within the logger, only the `msg` attribute was being used to check for similarity to the last log. This caused the prints that happen in `yt.load` to be skipped since they all use the same formatting string.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] pass `black --check yt/`
- [ ] pass `isort . --check --diff`
- [ ] pass `flake8 yt/`
- [ ] pass `flynt yt/ --fail-on-change --dry-run -e yt/extern`
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
