### PR TITLE
More flexible RAMSES loader

### DIFF
--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -74,7 +74,7 @@ class RAMSESFileSanitizer:
 
     @staticmethod
     def check_standard_files(folder, iout):
-        """Return true if the folder contains an amr file and the info file."""
+        """Return True if the folder contains an amr file and the info file."""
         # Check that the "amr_" and "info_" files exist
         ok = (folder / f"amr_{iout}.out00001").is_file()
         ok &= (folder / f"info_{iout}.txt").is_file()
@@ -690,7 +690,7 @@ class RAMSESDataset(Dataset):
 
         # This should not happen, but let's check nonetheless.
         if not file_handler.is_valid:
-            raise RuntimeError(
+            raise ValueError(
                 "Invalid filename found when building a RAMSESDataset object: %s",
                 filename,
             )

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -37,6 +37,10 @@ class RAMSESFileSanitizer:
     """A class to handle the different files that can be passed and associated
     safely to a RAMSES output."""
 
+    root_folder = None  # Path | None: path to the root folder
+    info_fname = None  # Path | None: path to the info file
+    group_name = None  # str | None: name of the first group folder (if any)
+
     def __init__(self, filename):
         # Resolve so that it works with symlinks
         filename = Path(filename).resolve()
@@ -58,10 +62,10 @@ class RAMSESFileSanitizer:
         # Special case when organized in groups
         if output_dir.name == "group_00001":
             self.root_folder = output_dir.parent
-            self.group_folder = output_dir.name
+            self.group_name = output_dir.name
         else:
             self.root_folder = output_dir
-            self.group_folder = None
+            self.group_name = None
         self.info_fname = info_fname
 
     @property
@@ -694,7 +698,7 @@ class RAMSESDataset(Dataset):
         # Sanitize the filename
         info_fname = file_handler.info_fname
 
-        if file_handler.group_folder is not None:
+        if file_handler.group_name is not None:
             self.num_groups = len(
                 [
                     _

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -1,7 +1,6 @@
 import os
 import weakref
 from collections import defaultdict
-from glob import glob
 from pathlib import Path
 
 import numpy as np
@@ -700,11 +699,7 @@ class RAMSESDataset(Dataset):
 
         if file_handler.group_name is not None:
             self.num_groups = len(
-                [
-                    _
-                    for _ in glob(str(file_handler.root_folder / "group_?????"))
-                    if os.path.isdir(_)
-                ]
+                [_ for _ in file_handler.root_folder.glob("group_?????") if _.is_dir()]
             )
         else:
             self.num_groups = 0

--- a/yt/frontends/ramses/definitions.py
+++ b/yt/frontends/ramses/definitions.py
@@ -53,6 +53,9 @@ VERSION_RE = re.compile(r"# version: *(\d+)")
 # on the left hand side
 VAR_DESC_RE = re.compile(r"\s*([^\s]+),\s*([^\s]+),\s*([^\s]+)")
 
+OUTPUT_DIR_RE = re.compile("(output|group)_(\d{5})")
+STANDARD_FILE_RE = re.compile("((amr|hydro|part|grav)_\d{5}\.out\d{5}|info_\d{5}.txt)")
+
 
 ## Configure family mapping
 particle_families = {

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -55,10 +55,15 @@ def test_output_00080():
 
 @requires_file(output_00080)
 def test_RAMSESDataset():
+    assert isinstance(data_dir_load(output_00080), RAMSESDataset)
+
+
+@requires_file(output_00080)
+def test_RAMSES_alternative_load():
     # Test that we can load a RAMSES dataset by giving it the folder name,
     # the info file name or an amr file name
     base_dir, info_file_fname = os.path.split(output_00080)
-    for fname in (output_00080, base_dir, os.path.join(base_dir, "amr_00080.out00001")):
+    for fname in (base_dir, os.path.join(base_dir, "amr_00080.out00001")):
         assert isinstance(data_dir_load(fname), RAMSESDataset)
 
 

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -55,7 +55,11 @@ def test_output_00080():
 
 @requires_file(output_00080)
 def test_RAMSESDataset():
-    assert isinstance(data_dir_load(output_00080), RAMSESDataset)
+    # Test that we can load a RAMSES dataset by giving it the folder name,
+    # the info file name or an amr file name
+    base_dir, info_file_fname = os.path.split(output_00080)
+    for fname in (output_00080, base_dir, os.path.join(base_dir, "amr_00080.out00001")):
+        assert isinstance(data_dir_load(fname), RAMSESDataset)
 
 
 @requires_file(output_00080)


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

This adds the possibility to load a RAMSES dataset given the name of its folder, of any of its (supported) output file or the info filename (only the latter was supported before).

This comes very handy when you get tired of always writing
```python
import yt
ds = yt.load('output_00123/info_00123.txt')
# now you can do
ds = yt.load('output_00123')
# or even
ds = yt.load('output_00123/amr_00123.out00001')
```

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] pass `black --check yt/`
- [x] pass `isort . --check --diff`
- [x] pass `flake8 yt/`
- [x] pass `flynt yt/ --fail-on-change --dry-run -e yt/extern`
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
