### PR TITLE
[artio] follow YTEP-0003

### DIFF
--- a/yt/fields/field_aliases.py
+++ b/yt/fields/field_aliases.py
@@ -116,11 +116,13 @@ _field_name_aliases = [
     ("VorticityRPGrowthTimescale", "vorticity_radiation_pressure_growth_timescale"),
     ("DiskAngle", "theta"),
     ("Height", "height"),
-    ("HI density", "H_density"),
+    ("HI density", "H_p0_density"),
     ("HII density", "H_p1_density"),
-    ("HeI density", "He_density"),
+    ("HeI density", "He_p0_density"),
     ("HeII density", "He_p1_density"),
     ("HeIII density", "He_p2_density"),
+    ("H_density", "H_p0_density"),
+    ("He_density", "He_p0_density"),
 ]
 
 _field_units_aliases = [

--- a/yt/frontends/artio/fields.py
+++ b/yt/frontends/artio/fields.py
@@ -28,10 +28,10 @@ class ARTIOFieldInfo(FieldInfoContainer):
         ("HVAR_METAL_DENSITY_II", (rho_units, ["metal_ii_density"], None)),
         ("VAR_POTENTIAL", ("", ["potential"], None)),
         ("VAR_POTENTIAL_HYDRO", ("", ["gas_potential"], None)),
-        ("RT_HVAR_HI", (rho_units, ["H_density"], None)),
+        ("RT_HVAR_HI", (rho_units, ["H_p0_density"], None)),
         ("RT_HVAR_HII", (rho_units, ["H_p1_density"], None)),
         ("RT_HVAR_H2", (rho_units, ["H2_density"], None)),
-        ("RT_HVAR_HeI", (rho_units, ["He_density"], None)),
+        ("RT_HVAR_HeI", (rho_units, ["He_p0_density"], None)),
         ("RT_HVAR_HeII", (rho_units, ["He_p1_density"], None)),
         ("RT_HVAR_HeIII", (rho_units, ["He_p2_density"], None)),
     )


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary
Just saw some stuff (that we edited in [PR #2613](https://github.com/yt-project/yt/pull/2613) ) that needed some minor adjustment to be compliant to [YTEP-0003](https://ytep.readthedocs.io/en/latest/YTEPs/YTEP-0003.html) standards. 

One thing that the YTEP-0003 mentions is that backwards compatibility should be maintained to insure that neutral ionic species written as `MM_p0_` are mirrored to `MM_`, but I don't know of a good way to do that besides adding it to the field aliases. Thoughts?
<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist
(I'm afraid that I don't know how to manage these checklists, so I could use some guidance as to which of these I should look out for)
<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] pass `black --check yt/`
- [x] pass `isort . --check --diff`
- [x] pass `flake8 yt/`
- [x] pass `flynt yt/ --fail-on-change --dry-run -e yt/extern`
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
