### PR TITLE
cleanup amrvac frontend __init__.py

### DIFF
--- a/yt/frontends/amrvac/__init__.py
+++ b/yt/frontends/amrvac/__init__.py
@@ -1,5 +1,0 @@
-import os
-
-from yt.funcs import ensure_list
-
-from .io import read_amrvac_namelist

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -18,9 +18,9 @@ from yt.funcs import mylog, setdefaultattr
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.utilities.physical_constants import boltzmann_constant_cgs as kb_cgs
 
-from . import read_amrvac_namelist
 from .datfile_utils import get_header, get_tree_info
 from .fields import AMRVACFieldInfo
+from .io import read_amrvac_namelist
 
 
 class AMRVACGrid(AMRGridPatch):

--- a/yt/frontends/amrvac/tests/test_read_amrvac_namelist.py
+++ b/yt/frontends/amrvac/tests/test_read_amrvac_namelist.py
@@ -2,7 +2,7 @@ import os
 from copy import deepcopy
 from pathlib import Path
 
-from yt.frontends.amrvac import read_amrvac_namelist
+from yt.frontends.amrvac.api import read_amrvac_namelist
 from yt.testing import requires_module
 from yt.utilities.on_demand_imports import _f90nml as f90nml
 


### PR DESCRIPTION
## PR Summary

Remove dead import statements from `yt/frontends/amrvac/__init__.py`
The only important difference is that `read_amrvac_parfiles` should not be imported on the user side from `yt.frontends.amrvac` but from `yt.frontends.amrvac.api`. I expect to be the only user potentially affected by this change since since function is not well known.

