### PR TITLE
adds pickleability to geometric selection objects

### DIFF
--- a/yt/geometry/selection_routines.pxd
+++ b/yt/geometry/selection_routines.pxd
@@ -18,10 +18,10 @@ from yt.utilities.lib.fp_utils cimport _ensure_code
 cdef class SelectorObject:
     cdef public np.int32_t min_level
     cdef public np.int32_t max_level
-    cdef int overlap_cells
-    cdef np.float64_t domain_width[3]
-    cdef np.float64_t domain_center[3]
-    cdef bint periodicity[3]
+    cdef public int overlap_cells
+    cdef public np.float64_t domain_width[3]
+    cdef public np.float64_t domain_center[3]
+    cdef public bint periodicity[3]
     cdef bint _hash_initialized
     cdef np.int64_t _hash
 
@@ -81,4 +81,3 @@ cdef inline np.float64_t _periodic_dist(np.float64_t x1, np.float64_t x2,
     elif rel < -dw * 0.5:
         rel += dw
     return rel
-

--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -703,7 +703,7 @@ cdef class SelectorObject:
                 ("domain_width[1]", self.domain_width[1]),
                 ("domain_width[2]", self.domain_width[2]))
 
-    def _getstatelist_(self):
+    def _get_state_list(self):
         # return a list of attrs needed for __setstate__: implement for each subclass
         if isinstance(self,SelectorObject):
           return []
@@ -715,7 +715,7 @@ cdef class SelectorObject:
         # get list of the attributes we need to rebuild the state:
         base_atts = ["min_level","max_level","overlap_cells",
                      "periodicity","domain_width","domain_center"]
-        child_atts = self._getstatelist_()
+        child_atts = self._get_state_list()
         
         # assemble the state_tuple (('a1',a1val),('a2',a2val),...)
         state_tuple = () 
@@ -808,7 +808,7 @@ cdef class PointSelector(SelectorObject):
                 ("p[1]", self.p[1]),
                 ("p[2]", self.p[2]))
 
-    def _getstatelist_(self):
+    def _get_state_list(self):
         return ['p']
 
 point_selector = PointSelector
@@ -978,7 +978,7 @@ cdef class SphereSelector(SelectorObject):
                 ("center[1]", self.center[1]),
                 ("center[2]", self.center[2]))
 
-    def _getstatelist_(self):
+    def _get_state_list(self):
         return ["radius","radius2","center","check_box"]
         
     def __setstate__(self, hashes):
@@ -1197,7 +1197,7 @@ cdef class RegionSelector(SelectorObject):
                 ("right_edge[1]", self.right_edge[1]),
                 ("right_edge[2]", self.right_edge[2]))
 
-    def _getstatelist_(self):
+    def _get_state_list(self):
         return ['left_edge','right_edge','right_edge_shift','check_period',
                 'is_all_data','loose_selection']
 
@@ -1407,7 +1407,7 @@ cdef class DiskSelector(SelectorObject):
                 ("radius2", self.radius2),
                 ("height", self.height))
 
-    def _getstatelist_(self):
+    def _get_state_list(self):
         return ['radius','radius2','height','norm_vec','center']
 
 
@@ -1526,7 +1526,7 @@ cdef class CuttingPlaneSelector(SelectorObject):
                 ("norm_vec[2]", self.norm_vec[2]),
                 ("d", self.d))
 
-    def _getstatelist_(self):
+    def _get_state_list(self):
         return ['d','norm_vec']
 
 cutting_selector = CuttingPlaneSelector
@@ -1649,7 +1649,7 @@ cdef class SliceSelector(SelectorObject):
         return (("axis", self.axis),
                 ("coord", self.coord))
 
-    def _getstatelist_(self):
+    def _get_state_list(self):
         return ["axis","coord","ax","ay","reduced_dimensionality"]
 
 slice_selector = SliceSelector
@@ -1766,7 +1766,7 @@ cdef class OrthoRaySelector(SelectorObject):
                 ("py", self.py),
                 ("axis", self.axis))
 
-    def _getstatelist_(self):
+    def _get_state_list(self):
         return ['px_ax','py_ax','px','py','axis']
 
 ortho_ray_selector = OrthoRaySelector
@@ -2056,7 +2056,7 @@ cdef class RaySelector(SelectorObject):
                 ("vec[1]", self.vec[1]),
                 ("vec[2]", self.vec[2]))
 
-    def _getstatelist_(self):
+    def _get_state_list(self):
         return ['p1','p2','vec']
 
 ray_selector = RaySelector
@@ -2241,7 +2241,7 @@ cdef class EllipsoidSelector(SelectorObject):
                 ("center[1]", self.center[1]),
                 ("center[2]", self.center[2]))
         
-    def _getstatelist_(self):
+    def _get_state_list(self):
         return ['mag','center','vec']
 
 

--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -708,15 +708,15 @@ cdef class SelectorObject:
         if isinstance(self, SelectorObject):
           return []
         else:
-          raise NotImplementedError 
-        
+          raise NotImplementedError
+
     def __getstate__(self):
         # returns a tuple containing (attribute name, attribute value) tuples needed to
         # rebuild the state:
         base_atts = ["min_level", "max_level", "overlap_cells",
                      "periodicity", "domain_width", "domain_center"]
         child_atts = self._get_state_list()
-        
+
         # assemble the state_tuple (('a1', a1val), ('a2', a2val),...)
         state_tuple = () 
         for fld in base_atts + child_atts:
@@ -980,12 +980,11 @@ cdef class SphereSelector(SelectorObject):
 
     def _get_state_list(self):
         return ["radius", "radius2", "center", "check_box"]
-        
+
     def __setstate__(self, hashes):
         super(SphereSelector, self).__setstate__(hashes)
         self.set_bbox(self.center)
-        
-    
+
 
 sphere_selector = SphereSelector
 
@@ -2240,7 +2239,7 @@ cdef class EllipsoidSelector(SelectorObject):
                 ("center[0]", self.center[0]),
                 ("center[1]", self.center[1]),
                 ("center[2]", self.center[2]))
-        
+
     def _get_state_list(self):
         return ['mag', 'center', 'vec']
 

--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -705,7 +705,7 @@ cdef class SelectorObject:
 
     def _get_state_list(self):
         # return a list of attrs needed for __setstate__: implement for each subclass
-        if isinstance(self,SelectorObject):
+        if isinstance(self, SelectorObject):
           return []
         else:
           raise NotImplementedError 
@@ -713,14 +713,14 @@ cdef class SelectorObject:
     def __getstate__(self):
         # returns a tuple containing (attribute name, attribute value) tuples needed to
         # rebuild the state:
-        base_atts = ["min_level","max_level","overlap_cells",
-                     "periodicity","domain_width","domain_center"]
+        base_atts = ["min_level", "max_level", "overlap_cells",
+                     "periodicity", "domain_width", "domain_center"]
         child_atts = self._get_state_list()
         
-        # assemble the state_tuple (('a1',a1val),('a2',a2val),...)
+        # assemble the state_tuple (('a1', a1val), ('a2', a2val),...)
         state_tuple = () 
         for fld in base_atts + child_atts:
-            state_tuple += ((fld,getattr(self,fld)),)
+            state_tuple += ((fld, getattr(self,fld)), )
         return state_tuple
 
     def __getnewargs__(self):
@@ -728,12 +728,12 @@ cdef class SelectorObject:
         # to __cinit__. We will give it None so we dont error then set attributes in
         # __setstate__ Note that we could avoid this by making dobj an optional argument
         # to __cinit__
-        return (None,)
+        return (None, )
 
     def __setstate__(self, state_tuple):
         # parse and set attributes from the state_tuple: (('a1',a1val),('a2',a2val),...)
         for attr in state_tuple:
-            setattr(self,attr[0],attr[1])
+            setattr(self, attr[0], attr[1])
 
 cdef class PointSelector(SelectorObject):
     cdef public np.float64_t p[3]
@@ -979,7 +979,7 @@ cdef class SphereSelector(SelectorObject):
                 ("center[2]", self.center[2]))
 
     def _get_state_list(self):
-        return ["radius","radius2","center","check_box"]
+        return ["radius", "radius2", "center", "check_box"]
         
     def __setstate__(self, hashes):
         super(SphereSelector, self).__setstate__(hashes)
@@ -1198,8 +1198,8 @@ cdef class RegionSelector(SelectorObject):
                 ("right_edge[2]", self.right_edge[2]))
 
     def _get_state_list(self):
-        return ['left_edge','right_edge','right_edge_shift','check_period',
-                'is_all_data','loose_selection']
+        return ['left_edge', 'right_edge', 'right_edge_shift', 'check_period',
+                'is_all_data', 'loose_selection']
 
 region_selector = RegionSelector
 
@@ -1408,7 +1408,7 @@ cdef class DiskSelector(SelectorObject):
                 ("height", self.height))
 
     def _get_state_list(self):
-        return ['radius','radius2','height','norm_vec','center']
+        return ['radius', 'radius2', 'height', 'norm_vec', 'center']
 
 
 disk_selector = DiskSelector
@@ -1527,7 +1527,7 @@ cdef class CuttingPlaneSelector(SelectorObject):
                 ("d", self.d))
 
     def _get_state_list(self):
-        return ['d','norm_vec']
+        return ['d', 'norm_vec']
 
 cutting_selector = CuttingPlaneSelector
 
@@ -1650,7 +1650,7 @@ cdef class SliceSelector(SelectorObject):
                 ("coord", self.coord))
 
     def _get_state_list(self):
-        return ["axis","coord","ax","ay","reduced_dimensionality"]
+        return ["axis", "coord", "ax", "ay", "reduced_dimensionality"]
 
 slice_selector = SliceSelector
 
@@ -1767,7 +1767,7 @@ cdef class OrthoRaySelector(SelectorObject):
                 ("axis", self.axis))
 
     def _get_state_list(self):
-        return ['px_ax','py_ax','px','py','axis']
+        return ['px_ax', 'py_ax', 'px', 'py', 'axis']
 
 ortho_ray_selector = OrthoRaySelector
 
@@ -2057,7 +2057,7 @@ cdef class RaySelector(SelectorObject):
                 ("vec[2]", self.vec[2]))
 
     def _get_state_list(self):
-        return ['p1','p2','vec']
+        return ['p1', 'p2', 'vec']
 
 ray_selector = RaySelector
 
@@ -2242,7 +2242,7 @@ cdef class EllipsoidSelector(SelectorObject):
                 ("center[2]", self.center[2]))
         
     def _get_state_list(self):
-        return ['mag','center','vec']
+        return ['mag', 'center', 'vec']
 
 
 ellipsoid_selector = EllipsoidSelector

--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -962,9 +962,7 @@ cdef class SphereSelector(SelectorObject):
             return 2  # Sphere only partially overlaps box
 
     def _hash_vals(self):
-        scalar_fields = ["radius","radius2"]
-        arraylike_fields = ["center","check_box"]
-        return self._gen_hash_tuple(scalar_fields,arraylike_fields)
+        return self._gen_hash_tuple(["radius","radius2"],["center","check_box"])
 
     def __setstate__(self, hashes):
         super(SphereSelector, self).__setstate__(hashes)
@@ -1172,11 +1170,9 @@ cdef class RegionSelector(SelectorObject):
                 pos[0] += dds[0]
         return total
 
-
-    def _hash_vals(self):      
+    def _hash_vals(self):
         arraylike_fields = ['left_edge','right_edge','right_edge_shift','check_period']
-        scalar_flds = ['is_all_data','loose_selection']
-        return self._gen_hash_tuple(scalar_flds,arraylike_fields)
+        return self._gen_hash_tuple(['is_all_data','loose_selection'],arraylike_fields)
 
 region_selector = RegionSelector
 
@@ -1222,10 +1218,10 @@ cdef class CutRegionSelector(SelectorObject):
 cut_region_selector = CutRegionSelector
 
 cdef class DiskSelector(SelectorObject):
-    cdef np.float64_t norm_vec[3]
-    cdef np.float64_t center[3]
-    cdef np.float64_t radius, radius2
-    cdef np.float64_t height
+    cdef public np.float64_t norm_vec[3]
+    cdef public np.float64_t center[3]
+    cdef public np.float64_t radius, radius2
+    cdef public np.float64_t height
 
     def __init__(self, dobj):
         cdef int i
@@ -1374,21 +1370,13 @@ cdef class DiskSelector(SelectorObject):
         # return 0
 
     def _hash_vals(self):
-        return (("norm_vec[0]", self.norm_vec[0]),
-                ("norm_vec[1]", self.norm_vec[1]),
-                ("norm_vec[2]", self.norm_vec[2]),
-                ("center[0]", self.center[0]),
-                ("center[1]", self.center[1]),
-                ("center[2]", self.center[2]),
-                ("radius", self.radius),
-                ("radius2", self.radius2),
-                ("height", self.height))
+        return self._gen_hash_tuple(['radius','radius2','height'],['norm_vec','center'])
 
 disk_selector = DiskSelector
 
 cdef class CuttingPlaneSelector(SelectorObject):
-    cdef np.float64_t norm_vec[3]
-    cdef np.float64_t d
+    cdef public np.float64_t norm_vec[3]
+    cdef public np.float64_t d
 
     def __init__(self, dobj):
         cdef int i
@@ -1494,10 +1482,7 @@ cdef class CuttingPlaneSelector(SelectorObject):
         return 2 # a box of non-zeros volume can't be inside a plane
 
     def _hash_vals(self):
-        return (("norm_vec[0]", self.norm_vec[0]),
-                ("norm_vec[1]", self.norm_vec[1]),
-                ("norm_vec[2]", self.norm_vec[2]),
-                ("d", self.d))
+        return self._gen_hash_tuple(['d'],['norm_vec'])
 
 cutting_selector = CuttingPlaneSelector
 
@@ -2060,9 +2045,9 @@ cdef class DataCollectionSelector(SelectorObject):
 data_collection_selector = DataCollectionSelector
 
 cdef class EllipsoidSelector(SelectorObject):
-    cdef np.float64_t vec[3][3]
-    cdef np.float64_t mag[3]
-    cdef np.float64_t center[3]
+    cdef public np.float64_t vec[3][3]
+    cdef public np.float64_t mag[3]
+    cdef public np.float64_t center[3]
 
     def __init__(self, dobj):
         cdef int i
@@ -2186,21 +2171,22 @@ cdef class EllipsoidSelector(SelectorObject):
             return 2
 
     def _hash_vals(self):
-        return (("vec[0][0]", self.vec[0][0]),
-                ("vec[0][1]", self.vec[0][1]),
-                ("vec[0][2]", self.vec[0][2]),
-                ("vec[1][0]", self.vec[1][0]),
-                ("vec[1][1]", self.vec[1][1]),
-                ("vec[1][2]", self.vec[1][2]),
-                ("vec[2][0]", self.vec[2][0]),
-                ("vec[2][1]", self.vec[2][1]),
-                ("vec[2][2]", self.vec[2][2]),
-                ("mag[0]", self.mag[0]),
-                ("mag[1]", self.mag[1]),
-                ("mag[2]", self.mag[2]),
-                ("center[0]", self.center[0]),
-                ("center[1]", self.center[1]),
-                ("center[2]", self.center[2]))
+        return self._gen_hash_tuple(arraylike_fields=['mag','center','vec']) 
+        # return (("vec[0][0]", self.vec[0][0]),
+        #         ("vec[0][1]", self.vec[0][1]),
+        #         ("vec[0][2]", self.vec[0][2]),
+        #         ("vec[1][0]", self.vec[1][0]),
+        #         ("vec[1][1]", self.vec[1][1]),
+        #         ("vec[1][2]", self.vec[1][2]),
+        #         ("vec[2][0]", self.vec[2][0]),
+        #         ("vec[2][1]", self.vec[2][1]),
+        #         ("vec[2][2]", self.vec[2][2]),
+        #         ("mag[0]", self.mag[0]),
+        #         ("mag[1]", self.mag[1]),
+        #         ("mag[2]", self.mag[2]),
+        #         ("center[0]", self.center[0]),
+        #         ("center[1]", self.center[1]),
+        #         ("center[2]", self.center[2]))
 
 ellipsoid_selector = EllipsoidSelector
 

--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -711,8 +711,8 @@ cdef class SelectorObject:
           raise NotImplementedError 
         
     def __getstate__(self):
-        # returns a tuble containing (attribute name, attribute value) tuples
-        # get list of the attributes we need to rebuild the state:
+        # returns a tuple containing (attribute name, attribute value) tuples needed to
+        # rebuild the state:
         base_atts = ["min_level","max_level","overlap_cells",
                      "periodicity","domain_width","domain_center"]
         child_atts = self._get_state_list()

--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -703,24 +703,21 @@ cdef class SelectorObject:
                 ("domain_width[1]", self.domain_width[1]),
                 ("domain_width[2]", self.domain_width[2]))
 
-    def _get_state_list(self):
-        # return a list of attrs needed for __setstate__: implement for each subclass
-        if isinstance(self, SelectorObject):
-          return []
-        else:
-          raise NotImplementedError
+    def _get_state_attnames(self):
+        # return a tupe of attr names for __setstate__: implement for each subclass
+        raise NotImplementedError
 
     def __getstate__(self):
         # returns a tuple containing (attribute name, attribute value) tuples needed to
         # rebuild the state:
-        base_atts = ["min_level", "max_level", "overlap_cells",
-                     "periodicity", "domain_width", "domain_center"]
-        child_atts = self._get_state_list()
+        base_atts = ("min_level", "max_level", "overlap_cells",
+                     "periodicity", "domain_width", "domain_center")
+        child_atts = self._get_state_attnames()
 
         # assemble the state_tuple (('a1', a1val), ('a2', a2val),...)
         state_tuple = () 
         for fld in base_atts + child_atts:
-            state_tuple += ((fld, getattr(self,fld)), )
+            state_tuple += ((fld, getattr(self, fld)), )
         return state_tuple
 
     def __getnewargs__(self):
@@ -808,8 +805,8 @@ cdef class PointSelector(SelectorObject):
                 ("p[1]", self.p[1]),
                 ("p[2]", self.p[2]))
 
-    def _get_state_list(self):
-        return ['p']
+    def _get_state_attnames(self):
+        return ('p', )
 
 point_selector = PointSelector
 
@@ -978,8 +975,8 @@ cdef class SphereSelector(SelectorObject):
                 ("center[1]", self.center[1]),
                 ("center[2]", self.center[2]))
 
-    def _get_state_list(self):
-        return ["radius", "radius2", "center", "check_box"]
+    def _get_state_attnames(self):
+        return ("radius", "radius2", "center", "check_box")
 
     def __setstate__(self, hashes):
         super(SphereSelector, self).__setstate__(hashes)
@@ -1196,9 +1193,9 @@ cdef class RegionSelector(SelectorObject):
                 ("right_edge[1]", self.right_edge[1]),
                 ("right_edge[2]", self.right_edge[2]))
 
-    def _get_state_list(self):
-        return ['left_edge', 'right_edge', 'right_edge_shift', 'check_period',
-                'is_all_data', 'loose_selection']
+    def _get_state_attnames(self):
+        return ('left_edge', 'right_edge', 'right_edge_shift', 'check_period',
+                'is_all_data', 'loose_selection')
 
 region_selector = RegionSelector
 
@@ -1406,8 +1403,8 @@ cdef class DiskSelector(SelectorObject):
                 ("radius2", self.radius2),
                 ("height", self.height))
 
-    def _get_state_list(self):
-        return ['radius', 'radius2', 'height', 'norm_vec', 'center']
+    def _get_state_attnames(self):
+        return ("radius", "radius2", "height", "norm_vec", "center")
 
 
 disk_selector = DiskSelector
@@ -1525,8 +1522,8 @@ cdef class CuttingPlaneSelector(SelectorObject):
                 ("norm_vec[2]", self.norm_vec[2]),
                 ("d", self.d))
 
-    def _get_state_list(self):
-        return ['d', 'norm_vec']
+    def _get_state_attnames(self):
+        return ("d", "norm_vec")
 
 cutting_selector = CuttingPlaneSelector
 
@@ -1648,8 +1645,8 @@ cdef class SliceSelector(SelectorObject):
         return (("axis", self.axis),
                 ("coord", self.coord))
 
-    def _get_state_list(self):
-        return ["axis", "coord", "ax", "ay", "reduced_dimensionality"]
+    def _get_state_attnames(self):
+        return ("axis", "coord", "ax", "ay", "reduced_dimensionality")
 
 slice_selector = SliceSelector
 
@@ -1765,8 +1762,8 @@ cdef class OrthoRaySelector(SelectorObject):
                 ("py", self.py),
                 ("axis", self.axis))
 
-    def _get_state_list(self):
-        return ['px_ax', 'py_ax', 'px', 'py', 'axis']
+    def _get_state_attnames(self):
+        return ("px_ax", "py_ax", "px", "py", "axis")
 
 ortho_ray_selector = OrthoRaySelector
 
@@ -2055,8 +2052,8 @@ cdef class RaySelector(SelectorObject):
                 ("vec[1]", self.vec[1]),
                 ("vec[2]", self.vec[2]))
 
-    def _get_state_list(self):
-        return ['p1', 'p2', 'vec']
+    def _get_state_attnames(self):
+        return ("p1", "p2", "vec")
 
 ray_selector = RaySelector
 
@@ -2240,8 +2237,8 @@ cdef class EllipsoidSelector(SelectorObject):
                 ("center[1]", self.center[1]),
                 ("center[2]", self.center[2]))
 
-    def _get_state_list(self):
-        return ['mag', 'center', 'vec']
+    def _get_state_attnames(self):
+        return ("mag", "center", "vec")
 
 
 ellipsoid_selector = EllipsoidSelector

--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -1656,11 +1656,11 @@ slice_selector = SliceSelector
 
 cdef class OrthoRaySelector(SelectorObject):
 
-    cdef np.uint8_t px_ax
-    cdef np.uint8_t py_ax
-    cdef np.float64_t px
-    cdef np.float64_t py
-    cdef int axis
+    cdef public np.uint8_t px_ax
+    cdef public np.uint8_t py_ax
+    cdef public np.float64_t px
+    cdef public np.float64_t py
+    cdef public int axis
 
     def __init__(self, dobj):
         self.axis = dobj.axis
@@ -1766,6 +1766,9 @@ cdef class OrthoRaySelector(SelectorObject):
                 ("py", self.py),
                 ("axis", self.axis))
 
+    def _getstatelist_(self):
+        return ['px_ax','py_ax','px','py','axis']
+
 ortho_ray_selector = OrthoRaySelector
 
 cdef struct IntegrationAccumulator:
@@ -1792,9 +1795,9 @@ cdef void dt_sampler(
 
 cdef class RaySelector(SelectorObject):
 
-    cdef np.float64_t p1[3]
-    cdef np.float64_t p2[3]
-    cdef np.float64_t vec[3]
+    cdef public np.float64_t p1[3]
+    cdef public np.float64_t p2[3]
+    cdef public np.float64_t vec[3]
 
     def __init__(self, dobj):
         cdef int i
@@ -2052,6 +2055,9 @@ cdef class RaySelector(SelectorObject):
                 ("vec[0]", self.vec[0]),
                 ("vec[1]", self.vec[1]),
                 ("vec[2]", self.vec[2]))
+
+    def _getstatelist_(self):
+        return ['p1','p2','vec']
 
 ray_selector = RaySelector
 

--- a/yt/geometry/tests/test_pickleable_selections.py
+++ b/yt/geometry/tests/test_pickleable_selections.py
@@ -9,7 +9,7 @@ def test_pickleability():
     # tests the pickleability of the selection objects.
 
     def pickle_test(sel_obj):
-        assert_fields = sel_obj._get_state_list()  # the attrs used in get/set state
+        assert_fields = sel_obj._get_state_attnames()  # the attrs used in get/set state
         new_sel_obj = pickle.loads(pickle.dumps(sel_obj))
         for attr in assert_fields:
             assert_equal(getattr(new_sel_obj, attr), getattr(sel_obj, attr))

--- a/yt/geometry/tests/test_pickleable_selections.py
+++ b/yt/geometry/tests/test_pickleable_selections.py
@@ -9,29 +9,29 @@ from yt.testing import (  # fake_amr_ds,; fake_random_ds,; requires_module,
 
 
 def test_pickleability():
-    # only tests the pickleability of the selection objects.
+    # tests the pickleability of the selection objects.
 
-    def pickle_test(sel_obj, assert_fields=[]):
+    def pickle_test(sel_obj):
+        assert_fields = sel_obj._getstatelist_()  # the attrs used in get/set state
         new_sel_obj = pickle.loads(pickle.dumps(sel_obj))
         for attr in assert_fields:
             assert_equal(getattr(new_sel_obj, attr), getattr(sel_obj, attr))
 
+    # list of selection types and argument tuples for each selection type
+    c = np.array([0.5, 0.5, 0.5])
+    sargs = (
+        ("point", (c,)),
+        ("sphere", (c, 0.25)),
+        ("box", (c - 0.3, c)),
+        ("ellipsoid", (c, 0.3, 0.2, 0.1, c - 0.4, 0.2)),
+        ("disk", (c, [1, 0, 0], 0.2, 0.2)),
+        ("cutting", ([0.1, 0.2, -0.9], [0.5, 0.42, 0.6])),
+        ("ortho_ray", ("z", c)),
+        ("ray", (c, [0.1, 0.1, 0.1])),
+    )
+
+    # load fake data
     ds = fake_particle_ds()
-    c = [0.5, 0.5, 0.5]
-    pickle_test(ds.point(c).selector, ["p"])
-    pickle_test(ds.sphere(c, 0.25).selector, ["center", "radius", "radius2"])
-    sel_ob = ds.box([0.2, 0.2, 0.2], c)
-    pickle_test(sel_ob.selector, ["left_edge", "right_edge", "is_all_data"])
-    sel_ob = ds.ellipsoid(c, 0.3, 0.2, 0.1, np.array([0.1, 0.1, 0.1]), 0.2)
-    pickle_test(sel_ob.selector, ["vec", "center", "mag"])
-    sel_ob = ds.disk(c, [1, 0, 0], 0.2, 0.2)
-    pickle_test(sel_ob.selector, ["center", "radius", "radius2", "norm_vec", "height"])
-    sel_ob = ds.cutting([0.1, 0.2, -0.9], [0.5, 0.42, 0.6])
-    pickle_test(sel_ob.selector, ["d", "norm_vec"])
-
-
-# def test_unpickled_selections():
-#     # TO DO: use fake dataset to test selections
-#     return
-
-# TO DO: add some answer test
+    for sel_type, args in sargs:
+        sel = getattr(ds, sel_type)(*args)  # instantiate this selection type
+        pickle_test(sel.selector)  # make sure it (un)pickles

--- a/yt/geometry/tests/test_pickleable_selections.py
+++ b/yt/geometry/tests/test_pickleable_selections.py
@@ -2,10 +2,7 @@ import pickle
 
 import numpy as np
 
-from yt.testing import (  # fake_amr_ds,; fake_random_ds,; requires_module,
-    assert_equal,
-    fake_particle_ds,
-)
+from yt.testing import assert_equal, fake_particle_ds
 
 
 def test_pickleability():

--- a/yt/geometry/tests/test_pickleable_selections.py
+++ b/yt/geometry/tests/test_pickleable_selections.py
@@ -12,7 +12,7 @@ def test_pickleability():
     # tests the pickleability of the selection objects.
 
     def pickle_test(sel_obj):
-        assert_fields = sel_obj._getstatelist_()  # the attrs used in get/set state
+        assert_fields = sel_obj._get_state_list()  # the attrs used in get/set state
         new_sel_obj = pickle.loads(pickle.dumps(sel_obj))
         for attr in assert_fields:
             assert_equal(getattr(new_sel_obj, attr), getattr(sel_obj, attr))

--- a/yt/geometry/tests/test_pickleable_selections.py
+++ b/yt/geometry/tests/test_pickleable_selections.py
@@ -1,0 +1,30 @@
+import pickle
+
+from yt.testing import (  # fake_amr_ds,; fake_random_ds,; requires_module,
+    assert_equal,
+    fake_particle_ds,
+)
+
+
+def test_pickleability():
+    # only tests the pickleability of the selection objects.
+
+    def pickle_test(sel_obj, assert_fields=[]):
+        new_sel_obj = pickle.loads(pickle.dumps(sel_obj))
+        for attr in assert_fields:
+            assert_equal(getattr(new_sel_obj, attr), getattr(sel_obj, attr))
+
+    ds = fake_particle_ds()
+    c = [0.5, 0.5, 0.5]
+    pickle_test(ds.point(c).selector, ["p"])
+    pickle_test(ds.sphere(c, 0.25).selector, ["center", "radius", "radius2"])
+    pickle_test(
+        ds.box([0.2, 0.2, 0.2], c).selector, ["left_edge", "right_edge", "is_all_data"]
+    )
+
+
+# def test_unpickled_selections():
+#     # TO DO: use fake dataset to test selections
+#     return
+
+# TO DO: add some answer test

--- a/yt/geometry/tests/test_pickleable_selections.py
+++ b/yt/geometry/tests/test_pickleable_selections.py
@@ -1,5 +1,7 @@
 import pickle
 
+import numpy as np
+
 from yt.testing import (  # fake_amr_ds,; fake_random_ds,; requires_module,
     assert_equal,
     fake_particle_ds,
@@ -18,9 +20,14 @@ def test_pickleability():
     c = [0.5, 0.5, 0.5]
     pickle_test(ds.point(c).selector, ["p"])
     pickle_test(ds.sphere(c, 0.25).selector, ["center", "radius", "radius2"])
-    pickle_test(
-        ds.box([0.2, 0.2, 0.2], c).selector, ["left_edge", "right_edge", "is_all_data"]
-    )
+    sel_ob = ds.box([0.2, 0.2, 0.2], c)
+    pickle_test(sel_ob.selector, ["left_edge", "right_edge", "is_all_data"])
+    sel_ob = ds.ellipsoid(c, 0.3, 0.2, 0.1, np.array([0.1, 0.1, 0.1]), 0.2)
+    pickle_test(sel_ob.selector, ["vec", "center", "mag"])
+    sel_ob = ds.disk(c, [1, 0, 0], 0.2, 0.2)
+    pickle_test(sel_ob.selector, ["center", "radius", "radius2", "norm_vec", "height"])
+    sel_ob = ds.cutting([0.1, 0.2, -0.9], [0.5, 0.42, 0.6])
+    pickle_test(sel_ob.selector, ["d", "norm_vec"])
 
 
 # def test_unpickled_selections():


### PR DESCRIPTION
## PR Summary

This PR adds support for pickling the geometric `selector` objects in `yt/geometry/selection_routines.pyx` (`PointSelector`,`SphereSelector`,`RegionSelector`, `DiskSelector`, `CuttingPlaneSelector`,`SliceSelector`,  `OrthoRaySelector`,`RaySelector`,`EllipsoidSelector`). A subsequent PR will add pickle support for the remaining `selector` types. 

## PR Checklist

- [ ] pass `black --check yt/`
- [ ] pass `isort . --check --diff`
- [ ] pass `flake8 yt/`
- [ ] pass `flynt yt/ --fail-on-change --dry-run -e yt/extern`
- [ ] Adds tests for new features.

