### PR TITLE
Update isort

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,6 +1,7 @@
 # transition to isort
 7edfcee093cca277307aabdb180e0ffc69768291
 81418e459f16c48d6b7a75d6ef8035dfe9651b39
+60f670d75a23a6d094879437a8df455a66acbeaf
 
 # transition to black
 ebadee629414aed2c7b6526e22a419205329ec38

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
     - id: black
       language_version: python3.7
 -   repo: https://github.com/timothycrosley/isort
-    rev: '5.5.3'  # keep in sync with tests/lint_requirements.txt
+    rev: '5.6.4'  # keep in sync with tests/lint_requirements.txt
     hooks:
     -   id: isort
 -   repo: https://gitlab.com/pycqa/flake8

--- a/tests/lint_requirements.txt
+++ b/tests/lint_requirements.txt
@@ -2,7 +2,7 @@ flake8==3.8.1  # keep in sync with .pre-commit-config.yaml
 mccabe~=0.6.1
 pycodestyle~=2.6.0
 pyflakes~=2.2.0
-isort==5.5.3   # keep in sync with .pre-commit-config.yaml
+isort==5.6.4   # keep in sync with .pre-commit-config.yaml
 black==19.10b0 # keep in sync with .pre-commit-config.yaml
 flake8-bugbear
 flynt==0.52    # keep in sync with .pre-commit-config.yaml

--- a/yt/geometry/grid_container.pxd
+++ b/yt/geometry/grid_container.pxd
@@ -7,16 +7,22 @@ Matching points on the grid to specific grids
 
 
 import numpy as np
-cimport numpy as np
-cimport cython
 
-from libc.stdlib cimport malloc, free
+cimport cython
+cimport grid_visitors
+cimport numpy as np
+from grid_visitors cimport (
+    GridTreeNode,
+    GridTreeNodePadded,
+    GridVisitorData,
+    grid_visitor_function,
+)
+from libc.stdlib cimport free, malloc
+
 from yt.geometry.selection_routines cimport SelectorObject, _ensure_code
-from yt.utilities.lib.fp_utils cimport iclip
-from grid_visitors cimport GridTreeNode, GridVisitorData, \
-    grid_visitor_function, GridTreeNodePadded
-cimport grid_visitors 
 from yt.utilities.lib.bitarray cimport bitarray
+from yt.utilities.lib.fp_utils cimport iclip
+
 
 cdef class GridTree:
     cdef GridTreeNode *grids

--- a/yt/geometry/grid_visitors.pxd
+++ b/yt/geometry/grid_visitors.pxd
@@ -9,6 +9,7 @@ Grid visitor definitions file
 
 cimport numpy as np
 
+
 cdef struct GridTreeNode:
     np.int32_t num_children
     np.int32_t level

--- a/yt/geometry/oct_container.pxd
+++ b/yt/geometry/oct_container.pxd
@@ -9,14 +9,16 @@ Oct definitions file
 
 cimport cython
 cimport numpy as np
-from yt.utilities.lib.fp_utils cimport *
 cimport oct_visitors
 cimport selection_routines
-from .oct_visitors cimport OctVisitor, Oct, cind, OctInfo
-from libc.stdlib cimport bsearch, qsort, realloc, malloc, free
 from libc.math cimport floor
-from yt.utilities.lib.allocation_container cimport \
-    ObjectPool, AllocationContainer
+from libc.stdlib cimport bsearch, free, malloc, qsort, realloc
+
+from yt.utilities.lib.allocation_container cimport AllocationContainer, ObjectPool
+from yt.utilities.lib.fp_utils cimport *
+
+from .oct_visitors cimport Oct, OctInfo, OctVisitor, cind
+
 
 cdef int ORDER_MAX
 

--- a/yt/geometry/oct_visitors.pxd
+++ b/yt/geometry/oct_visitors.pxd
@@ -9,6 +9,7 @@ Oct visitor definitions file
 
 cimport numpy as np
 
+
 cdef struct Oct
 cdef struct Oct:
     np.int64_t file_ind     # index with respect to the order in which it was
@@ -143,6 +144,7 @@ cdef inline int cind(int i, int j, int k) nogil:
     return (((i*2)+j)*2+k)
 
 from oct_container cimport OctreeContainer
+
 
 cdef class StoreIndex(OctVisitor):
     cdef np.int64_t[:,:,:,:] cell_inds

--- a/yt/geometry/particle_deposit.pxd
+++ b/yt/geometry/particle_deposit.pxd
@@ -8,14 +8,18 @@ Particle Deposition onto Octs
 
 
 cimport numpy as np
+
 import numpy as np
-from libc.stdlib cimport malloc, free
+
 cimport cython
 from libc.math cimport sqrt
+from libc.stdlib cimport free, malloc
 from numpy.math cimport PI as NPY_PI
 
 from yt.utilities.lib.fp_utils cimport *
+
 from .oct_container cimport Oct, OctreeContainer
+
 
 cdef extern from "platform_dep.h":
     void *alloca(int)

--- a/yt/geometry/particle_smooth.pxd
+++ b/yt/geometry/particle_smooth.pxd
@@ -8,16 +8,24 @@ Particle Deposition onto Octs
 
 
 cimport numpy as np
+
 import numpy as np
-from libc.stdlib cimport malloc, free, qsort
+
 cimport cython
 from libc.math cimport sqrt
-
-from yt.utilities.lib.fp_utils cimport *
+from libc.stdlib cimport free, malloc, qsort
 from oct_container cimport Oct, OctreeContainer
-from .particle_deposit cimport kernel_func, get_kernel_func, gind
-from yt.utilities.lib.distance_queue cimport NeighborList, Neighbor_compare, \
-    r2dist, DistanceQueue
+
+from yt.utilities.lib.distance_queue cimport (
+    DistanceQueue,
+    Neighbor_compare,
+    NeighborList,
+    r2dist,
+)
+from yt.utilities.lib.fp_utils cimport *
+
+from .particle_deposit cimport get_kernel_func, gind, kernel_func
+
 
 cdef extern from "platform_dep.h":
     void *alloca(int)

--- a/yt/geometry/selection_routines.pxd
+++ b/yt/geometry/selection_routines.pxd
@@ -8,12 +8,18 @@ Geometry selection routine imports.
 
 
 cimport numpy as np
-from oct_visitors cimport Oct, OctVisitor
+from grid_visitors cimport (
+    GridTreeNode,
+    GridVisitorData,
+    check_child_masked,
+    grid_visitor_function,
+)
 from oct_container cimport OctreeContainer
-from grid_visitors cimport GridTreeNode, GridVisitorData, \
-    grid_visitor_function, check_child_masked
-from yt.utilities.lib.geometry_utils cimport decode_morton_64bit
+from oct_visitors cimport Oct, OctVisitor
+
 from yt.utilities.lib.fp_utils cimport _ensure_code
+from yt.utilities.lib.geometry_utils cimport decode_morton_64bit
+
 
 cdef class SelectorObject:
     cdef public np.int32_t min_level

--- a/yt/utilities/cython_fortran_utils.pxd
+++ b/yt/utilities/cython_fortran_utils.pxd
@@ -1,5 +1,5 @@
-from libc.stdio cimport FILE
 cimport numpy as np
+from libc.stdio cimport FILE
 
 ctypedef np.int32_t INT32_t
 ctypedef np.int64_t INT64_t

--- a/yt/utilities/lib/_octree_raytracing.pxd
+++ b/yt/utilities/lib/_octree_raytracing.pxd
@@ -4,16 +4,21 @@ It relies on the seminal paper by  J. Revelles,, C.Ureña and M.Lastra.
 
 
 cimport numpy as np
+
 import numpy as np
-from libcpp.vector cimport vector
+
 cimport cython
-from cython.parallel import prange, parallel
+from libcpp.vector cimport vector
+
+from cython.parallel import parallel, prange
+
 from libc.stdlib cimport free, malloc
 
-from .image_samplers cimport ImageAccumulator, ImageSampler
 from .grid_traversal cimport sampler_function
-from .volume_container cimport VolumeContainer
+from .image_samplers cimport ImageAccumulator, ImageSampler
 from .partitioned_grid cimport PartitionedGrid
+from .volume_container cimport VolumeContainer
+
 
 cdef extern from "_octree_raytracing.hpp":
     cdef cppclass RayInfo[T]:

--- a/yt/utilities/lib/allocation_container.pxd
+++ b/yt/utilities/lib/allocation_container.pxd
@@ -7,7 +7,8 @@ An allocation container and memory pool
 
 
 cimport numpy as np
-from libc.stdlib cimport malloc, free, realloc
+from libc.stdlib cimport free, malloc, realloc
+
 
 cdef struct AllocationContainer:
     np.uint64_t n

--- a/yt/utilities/lib/amr_kdtools.pxd
+++ b/yt/utilities/lib/amr_kdtools.pxd
@@ -8,6 +8,7 @@ AMR kD-Tree Cython Tools
 
 cimport numpy as np
 
+
 cdef struct Split:
     int dim
     np.float64_t pos

--- a/yt/utilities/lib/bitarray.pxd
+++ b/yt/utilities/lib/bitarray.pxd
@@ -7,8 +7,10 @@ Bit array functions
 
 
 import numpy as np
-cimport numpy as np
+
 cimport cython
+cimport numpy as np
+
 
 cdef inline void ba_set_value(np.uint8_t *buf, np.uint64_t ind,
                               np.uint8_t val) nogil:

--- a/yt/utilities/lib/bounded_priority_queue.pxd
+++ b/yt/utilities/lib/bounded_priority_queue.pxd
@@ -8,7 +8,9 @@ been added to it.
 """
 
 import numpy as np
+
 cimport numpy as np
+
 
 cdef class BoundedPriorityQueue:
     cdef public np.float64_t[:] heap

--- a/yt/utilities/lib/bounding_volume_hierarchy.pxd
+++ b/yt/utilities/lib/bounding_volume_hierarchy.pxd
@@ -1,8 +1,12 @@
 cimport cython
+
 import numpy as np
+
 cimport numpy as np
+
 from yt.utilities.lib.element_mappings cimport ElementSampler
 from yt.utilities.lib.primitives cimport BBox, Ray
+
 
 cdef extern from "mesh_triangulation.h":
     enum:

--- a/yt/utilities/lib/contour_finding.pxd
+++ b/yt/utilities/lib/contour_finding.pxd
@@ -7,8 +7,9 @@ Contour finding exports
 
 
 
-cimport numpy as np
 cimport cython
+cimport numpy as np
+
 
 cdef inline np.int64_t i64max(np.int64_t i0, np.int64_t i1):
     if i0 > i1: return i0

--- a/yt/utilities/lib/cykdtree/kdtree.pxd
+++ b/yt/utilities/lib/cykdtree/kdtree.pxd
@@ -1,8 +1,9 @@
 cimport numpy as np
-from libcpp.vector cimport vector
-from libcpp.pair cimport pair
+from libc.stdint cimport int32_t, int64_t, uint32_t, uint64_t
 from libcpp cimport bool
-from libc.stdint cimport uint32_t, uint64_t, int64_t, int32_t
+from libcpp.pair cimport pair
+from libcpp.vector cimport vector
+
 
 cdef extern from "<iostream>" namespace "std":
     cdef cppclass istream:

--- a/yt/utilities/lib/cykdtree/utils.pxd
+++ b/yt/utilities/lib/cykdtree/utils.pxd
@@ -1,8 +1,8 @@
 cimport numpy as np
-from libcpp.vector cimport vector
-from libcpp.pair cimport pair
+from libc.stdint cimport int32_t, int64_t, uint32_t, uint64_t
 from libcpp cimport bool
-from libc.stdint cimport uint32_t, uint64_t, int64_t, int32_t
+from libcpp.pair cimport pair
+from libcpp.vector cimport vector
 
 
 cdef extern from "c_utils.hpp":

--- a/yt/utilities/lib/distance_queue.pxd
+++ b/yt/utilities/lib/distance_queue.pxd
@@ -9,8 +9,10 @@ A queue for evaluating distances to discrete points
 
 cimport cython
 cimport numpy as np
+
 import numpy as np
-from libc.stdlib cimport malloc, free
+
+from libc.stdlib cimport free, malloc
 from libc.string cimport memmove
 
 # THESE TWO STRUCTS MUST BE EQUIVALENT

--- a/yt/utilities/lib/element_mappings.pxd
+++ b/yt/utilities/lib/element_mappings.pxd
@@ -1,8 +1,11 @@
+cimport cython
 cimport numpy as np
 from numpy cimport ndarray
-cimport cython
+
 import numpy as np
+
 from libc.math cimport fabs, fmax
+
 
 cdef class ElementSampler:
 

--- a/yt/utilities/lib/embree_mesh/mesh_construction.pxd
+++ b/yt/utilities/lib/embree_mesh/mesh_construction.pxd
@@ -1,8 +1,5 @@
-from pyembree.rtcore cimport \
-    Vertex, \
-    Triangle, \
-    Vec3f
 cimport numpy as np
+from pyembree.rtcore cimport Triangle, Vec3f, Vertex
 
 ctypedef struct MeshDataContainer:
     Vertex* vertices       # array of triangle vertices

--- a/yt/utilities/lib/embree_mesh/mesh_intersection.pxd
+++ b/yt/utilities/lib/embree_mesh/mesh_intersection.pxd
@@ -1,8 +1,10 @@
-cimport pyembree.rtcore as rtc
-cimport pyembree.rtcore_ray as rtcr
-cimport pyembree.rtcore_geometry as rtcg
-from .mesh_construction cimport Patch, Tet_Patch
 cimport cython
+cimport pyembree.rtcore as rtc
+cimport pyembree.rtcore_geometry as rtcg
+cimport pyembree.rtcore_ray as rtcr
+
+from .mesh_construction cimport Patch, Tet_Patch
+
 
 cdef void patchIntersectFunc(Patch* patches,
                              rtcr.RTCRay& ray,

--- a/yt/utilities/lib/embree_mesh/mesh_samplers.pxd
+++ b/yt/utilities/lib/embree_mesh/mesh_samplers.pxd
@@ -1,6 +1,7 @@
+cimport cython
 cimport pyembree.rtcore as rtc
 cimport pyembree.rtcore_ray as rtcr
-cimport cython
+
 
 cdef void sample_hex(void* userPtr,
                      rtcr.RTCRay& ray) nogil

--- a/yt/utilities/lib/embree_mesh/mesh_traversal.pxd
+++ b/yt/utilities/lib/embree_mesh/mesh_traversal.pxd
@@ -1,6 +1,7 @@
 cimport pyembree.rtcore
-cimport pyembree.rtcore_scene as rtcs
 cimport pyembree.rtcore_ray
+cimport pyembree.rtcore_scene as rtcs
+
 
 cdef class YTEmbreeScene:
     cdef rtcs.RTCScene scene_i

--- a/yt/utilities/lib/ewah_bool_array.pxd
+++ b/yt/utilities/lib/ewah_bool_array.pxd
@@ -6,11 +6,12 @@ Wrapper for EWAH Bool Array: https://github.com/lemire/EWAHBoolArray
 """
 
 
-from libcpp.vector cimport vector
+from libc.stdint cimport uint32_t, uint64_t
+from libcpp cimport bool
 from libcpp.map cimport map as cmap
 from libcpp.string cimport string
-from libcpp cimport bool
-from libc.stdint cimport uint64_t, uint32_t
+from libcpp.vector cimport vector
+
 
 # Streams req for c++ IO
 cdef extern from "<ostream>" namespace "std":
@@ -87,8 +88,8 @@ cdef extern from "boolarray.h":
         uword getWord(size_t pos)
         size_t wordinbits
 
-cimport numpy as np
 cimport cython
+cimport numpy as np
 
 IF UNAME_SYSNAME == "Windows":
     ctypedef uint32_t ewah_word_type

--- a/yt/utilities/lib/ewah_bool_wrap.pxd
+++ b/yt/utilities/lib/ewah_bool_wrap.pxd
@@ -1,10 +1,15 @@
-from libcpp.vector cimport vector
-from libcpp.set cimport set as cset
-from libcpp.pair cimport pair
-from yt.utilities.lib.ewah_bool_array cimport \
-    sstream, ewah_map, ewah_bool_array, ewah_bool_iterator
-
 cimport numpy as np
+from libcpp.pair cimport pair
+from libcpp.set cimport set as cset
+from libcpp.vector cimport vector
+
+from yt.utilities.lib.ewah_bool_array cimport (
+    ewah_bool_array,
+    ewah_bool_iterator,
+    ewah_map,
+    sstream,
+)
+
 ctypedef bint bitarrtype
 ctypedef pair[np.uint64_t, np.uint64_t] ind_pair
 

--- a/yt/utilities/lib/field_interpolation_tables.pxd
+++ b/yt/utilities/lib/field_interpolation_tables.pxd
@@ -8,9 +8,11 @@ Field Interpolation Tables
 
 cimport cython
 cimport numpy as np
-from yt.utilities.lib.fp_utils cimport imax, fmax, imin, fmin, iclip, fclip, fabs
-from libc.stdlib cimport malloc
 from libc.math cimport isnormal
+from libc.stdlib cimport malloc
+
+from yt.utilities.lib.fp_utils cimport fabs, fclip, fmax, fmin, iclip, imax, imin
+
 
 cdef struct FieldInterpolationTable:
     # Note that we make an assumption about retaining a reference to values

--- a/yt/utilities/lib/fnv_hash.pxd
+++ b/yt/utilities/lib/fnv_hash.pxd
@@ -9,6 +9,8 @@ Definitions for fnv_hash
 
 
 import numpy as np
+
 cimport numpy as np
+
 
 cdef np.int64_t c_fnv_hash(unsigned unsigned char[:] octets) nogil

--- a/yt/utilities/lib/fp_utils.pxd
+++ b/yt/utilities/lib/fp_utils.pxd
@@ -6,8 +6,9 @@ Shareable definitions for common fp/int Cython utilities
 """
 
 
-cimport numpy as np
 cimport cython
+cimport numpy as np
+
 
 cdef inline np.int64_t imax(np.int64_t i0, np.int64_t i1) nogil:
     if i0 > i1: return i0

--- a/yt/utilities/lib/geometry_utils.pxd
+++ b/yt/utilities/lib/geometry_utils.pxd
@@ -6,8 +6,8 @@ Particle Deposition onto Octs
 
 """
 
-cimport numpy as np
 cimport cython
+cimport numpy as np
 from libc.float cimport DBL_MANT_DIG
 from libc.math cimport frexp, ldexp, sqrt
 

--- a/yt/utilities/lib/grid_traversal.pxd
+++ b/yt/utilities/lib/grid_traversal.pxd
@@ -8,8 +8,10 @@ Definitions for the traversal code
 
 
 import numpy as np
-cimport numpy as np
+
 cimport cython
+cimport numpy as np
+
 from .image_samplers cimport ImageSampler
 from .volume_container cimport VolumeContainer, vc_index, vc_pos_index
 

--- a/yt/utilities/lib/healpix_interface.pxd
+++ b/yt/utilities/lib/healpix_interface.pxd
@@ -7,10 +7,11 @@ A light interface to a few HEALPix routines
 
 
 import numpy as np
-cimport numpy as np
-cimport cython
 
-from libc.stdio cimport fopen, fclose, FILE
+cimport cython
+cimport numpy as np
+from libc.stdio cimport FILE, fclose, fopen
+
 
 cdef extern from "healpix_vectors.h":
     int pix2vec_nest(long nside, long ipix, double *v)

--- a/yt/utilities/lib/image_samplers.pxd
+++ b/yt/utilities/lib/image_samplers.pxd
@@ -8,10 +8,12 @@ Definitions for image samplers
 
 
 import numpy as np
-cimport numpy as np
+
 cimport cython
-from .volume_container cimport VolumeContainer
+cimport numpy as np
+
 from .partitioned_grid cimport PartitionedGrid
+from .volume_container cimport VolumeContainer
 
 DEF Nch = 4
 

--- a/yt/utilities/lib/lenses.pxd
+++ b/yt/utilities/lib/lenses.pxd
@@ -8,17 +8,34 @@ Definitions for the lens code
 
 
 import numpy as np
-cimport numpy as np
+
 cimport cython
+cimport numpy as np
+from libc.math cimport (
+    M_PI,
+    acos,
+    asin,
+    atan,
+    atan2,
+    cos,
+    exp,
+    fabs,
+    floor,
+    log2,
+    sin,
+    sqrt,
+)
+from vec3_ops cimport L2_norm, dot, fma, subtract
+
+from yt.utilities.lib.fp_utils cimport fclip, fmax, fmin, i64clip, iclip, imax, imin
+
+from .image_samplers cimport (
+    ImageSampler,
+    calculate_extent_function,
+    generate_vector_info_function,
+)
 from .volume_container cimport VolumeContainer
-from vec3_ops cimport dot, subtract, L2_norm, fma
-from libc.math cimport exp, floor, log2, \
-    fabs, atan, atan2, asin, cos, sin, sqrt, acos, M_PI
-from yt.utilities.lib.fp_utils cimport imax, fmax, imin, fmin, iclip, fclip, i64clip
-from .image_samplers cimport \
-    ImageSampler, \
-    calculate_extent_function, \
-    generate_vector_info_function
+
 
 cdef extern from "platform_dep.h":
     long int lrint(double x) nogil

--- a/yt/utilities/lib/particle_kdtree_tools.pxd
+++ b/yt/utilities/lib/particle_kdtree_tools.pxd
@@ -1,8 +1,9 @@
-cimport numpy as np
 cimport cython
+cimport numpy as np
 
-from yt.utilities.lib.cykdtree.kdtree cimport KDTree, uint64_t
 from yt.utilities.lib.bounded_priority_queue cimport BoundedPriorityQueue
+from yt.utilities.lib.cykdtree.kdtree cimport KDTree, uint64_t
+
 
 cdef struct axes_range:
     int start

--- a/yt/utilities/lib/partitioned_grid.pxd
+++ b/yt/utilities/lib/partitioned_grid.pxd
@@ -8,9 +8,12 @@ Definitions for the partitioned grid
 
 
 import numpy as np
-cimport numpy as np
+
 cimport cython
+cimport numpy as np
+
 from .volume_container cimport VolumeContainer
+
 
 cdef class PartitionedGrid:
     cdef public object my_data

--- a/yt/utilities/lib/primitives.pxd
+++ b/yt/utilities/lib/primitives.pxd
@@ -1,8 +1,11 @@
 cimport cython
 cimport cython.floating
+
 import numpy as np
+
 cimport numpy as np
-from vec3_ops cimport dot, subtract, cross
+from vec3_ops cimport cross, dot, subtract
+
 
 cdef struct Ray:
     np.float64_t origin[3]

--- a/yt/utilities/lib/vec3_ops.pxd
+++ b/yt/utilities/lib/vec3_ops.pxd
@@ -1,4 +1,4 @@
-cimport cython 
+cimport cython
 cimport cython.floating
 from libc.math cimport sqrt
 

--- a/yt/utilities/lib/volume_container.pxd
+++ b/yt/utilities/lib/volume_container.pxd
@@ -9,6 +9,7 @@ A volume container
 
 cimport numpy as np
 
+
 cdef struct VolumeContainer:
     #-----------------------------------------------------------------------------
     # Encapsulates a volume container used for volume rendering.


### PR DESCRIPTION
## PR Summary

isort 5.6.0 just came out. Several bugs were fixed, but the one important change to us is that it now sorts .pxd files as well.

One question for Cython experts out there (@matthewturk, @cphyc ?) 
I notice that in some places we have 
```python
import numpy as np
cimport numpy as np
```
Is the first line useless or am I missing something ?
