### PR TITLE
Fix GCC 5 Builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ cythonize_aliases = {
     "FIXED_INTERP": "yt/utilities/lib/fixed_interpolator.cpp",
     "ARTIO_SOURCE": glob.glob("yt/frontends/artio/artio_headers/*.c"),
     "CPP14_FLAG": CPP14_FLAG,
+    "CPP03_FLAG": CPP03_FLAG,
 }
 
 lib_exts = [

--- a/setup.py
+++ b/setup.py
@@ -38,13 +38,13 @@ with open("README.md") as file:
     long_description = file.read()
 
 OMP_CONFIG = defaultdict(
-    lambda: ["--fopenmp"], {"unix": ["--fopenmp"], "msvc": ["/openmp"]}
+    lambda: ["-fopenmp"], {"unix": ["-fopenmp"], "msvc": ["/openmp"]}
 )
 CPP14_CONFIG = defaultdict(
-    lambda: ["--std=c++14"], {"unix": ["--std=c++14"], "msvc": ["/std:c++14"]}
+    lambda: ["-std=c++14"], {"unix": ["-std=c++14"], "msvc": ["/std:c++14"]}
 )
 CPP03_CONFIG = defaultdict(
-    lambda: ["--std=c++03"], {"unix": ["--std=c++03"], "msvc": ["/std:c++03"]}
+    lambda: ["-std=c++03"], {"unix": ["-std=c++03"], "msvc": ["/std:c++03"]}
 )
 
 _COMPILER = get_default_compiler()

--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,6 @@ if os.path.exists("MANIFEST"):
 with open("README.md") as file:
     long_description = file.read()
 
-OMP_CONFIG = defaultdict(
-    lambda: ["-fopenmp"], {"unix": ["-fopenmp"], "msvc": ["/openmp"]}
-)
 CPP14_CONFIG = defaultdict(
     lambda: ["-std=c++14"], {"unix": ["-std=c++14"], "msvc": ["/std:c++14"]}
 )
@@ -49,10 +46,7 @@ CPP03_CONFIG = defaultdict(
 
 _COMPILER = get_default_compiler()
 
-if check_for_openmp():
-    omp_args = OMP_CONFIG[_COMPILER]
-else:
-    omp_args = []
+omp_args, _ = check_for_openmp()
 
 if os.name == "nt":
     std_libs = []

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import glob
 import os
 import sys
+from collections import defaultdict
 from distutils.ccompiler import get_default_compiler
 from distutils.version import LooseVersion
 
@@ -36,8 +37,20 @@ if os.path.exists("MANIFEST"):
 with open("README.md") as file:
     long_description = file.read()
 
+OMP_CONFIG = defaultdict(
+    lambda: ["--fopenmp"], {"unix": ["--fopenmp"], "msvc": ["/openmp"]}
+)
+CPP14_CONFIG = defaultdict(
+    lambda: ["--std=c++14"], {"unix": ["--std=c++14"], "msvc": ["/std:c++14"]}
+)
+CPP03_CONFIG = defaultdict(
+    lambda: ["--std=c++03"], {"unix": ["--std=c++03"], "msvc": ["/std:c++03"]}
+)
+
+_COMPILER = get_default_compiler()
+
 if check_for_openmp():
-    omp_args = ["-fopenmp"]
+    omp_args = OMP_CONFIG[_COMPILER]
 else:
     omp_args = []
 
@@ -46,10 +59,8 @@ if os.name == "nt":
 else:
     std_libs = ["m"]
 
-if get_default_compiler() == "msvc":
-    CPP14_FLAG = ["/std:c++14"]
-else:
-    CPP14_FLAG = ["--std=c++14"]
+CPP14_FLAG = CPP14_CONFIG[_COMPILER]
+CPP03_FLAG = CPP03_CONFIG[_COMPILER]
 
 cythonize_aliases = {
     "LIB_DIR": "yt/utilities/lib/",
@@ -65,6 +76,7 @@ cythonize_aliases = {
     "FIXED_INTERP": "yt/utilities/lib/fixed_interpolator.cpp",
     "ARTIO_SOURCE": glob.glob("yt/frontends/artio/artio_headers/*.c"),
     "CPP14_FLAG": CPP14_FLAG,
+    "CPP03_FLAG": CPP03_FLAG,
 }
 
 lib_exts = [

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,6 @@ cythonize_aliases = {
     "FIXED_INTERP": "yt/utilities/lib/fixed_interpolator.cpp",
     "ARTIO_SOURCE": glob.glob("yt/frontends/artio/artio_headers/*.c"),
     "CPP14_FLAG": CPP14_FLAG,
-    "CPP03_FLAG": CPP03_FLAG,
 }
 
 lib_exts = [

--- a/setupext.py
+++ b/setupext.py
@@ -59,7 +59,8 @@ def stdchannel_redirected(stdchannel, dest_filename):
 
 
 def check_for_openmp():
-    """Returns True if local setup supports OpenMP, False otherwise
+    """Returns OpenMP compiler and linker flags if local setup supports
+    OpenMP or [], [] otherwise
 
     Code adapted from astropy_helpers, originally written by Tom
     Robitaille and Curtis McCully.
@@ -72,15 +73,17 @@ def check_for_openmp():
     tmp_dir = tempfile.mkdtemp()
     start_dir = os.path.abspath(".")
 
+    # TODO: test more known compilers:
+    # MinGW, AppleClang with libomp, MSVC, ICC, XL, PGI, ...
     if os.name == "nt":
         # TODO: make this work with mingw
         # AFAICS there's no easy way to get the compiler distutils
         # will be using until compilation actually happens
-        compile_flag = "-openmp"
-        link_flag = ""
+        compile_flags = ["-openmp"]
+        link_flags = [""]
     else:
-        compile_flag = "-fopenmp"
-        link_flag = "-fopenmp"
+        compile_flags = ["-fopenmp"]
+        link_flags = ["-fopenmp"]
 
     try:
         os.chdir(tmp_dir)
@@ -93,12 +96,12 @@ def check_for_openmp():
         # Compile, link, and run test program
         with stdchannel_redirected(sys.stderr, os.devnull):
             ccompiler.compile(
-                ["test_openmp.c"], output_dir="objects", extra_postargs=[compile_flag]
+                ["test_openmp.c"], output_dir="objects", extra_postargs=compile_flags
             )
             ccompiler.link_executable(
                 glob.glob(os.path.join("objects", "*")),
                 "test_openmp",
-                extra_postargs=[link_flag],
+                extra_postargs=link_flags,
             )
             output = (
                 subprocess.check_output("./test_openmp")
@@ -136,7 +139,10 @@ def check_for_openmp():
             "extensions will be compiled without parallel support"
         )
 
-    return using_openmp
+    if using_openmp:
+        return compile_flags, link_flags
+    else:
+        return [], []
 
 
 def check_for_pyembree(std_libs):

--- a/yt/geometry/particle_oct_container.pyx
+++ b/yt/geometry/particle_oct_container.pyx
@@ -1,5 +1,6 @@
 # distutils: include_dirs = LIB_DIR_EWAH
 # distutils: language = c++
+# distutils: extra_compile_args = CPP14_FLAG
 # distutils: libraries = STD_LIBS
 """
 Oct container tuned for Particles

--- a/yt/utilities/lib/cykdtree/kdtree.pyx
+++ b/yt/utilities/lib/cykdtree/kdtree.pyx
@@ -3,7 +3,7 @@
 # distutils: sources = yt/utilities/lib/cykdtree/c_utils.cpp
 # distutils: depends = yt/utilities/lib/cykdtree/c_kdtree.hpp, yt/utilities/lib/cykdtree/c_utils.hpp
 # distutils: language = c++
-# distutils: extra_compile_args = CPP03_FLAG
+# distutils: extra_compile_args = CPP14_FLAG
 import cython
 import numpy as np
 

--- a/yt/utilities/lib/cykdtree/kdtree.pyx
+++ b/yt/utilities/lib/cykdtree/kdtree.pyx
@@ -3,7 +3,7 @@
 # distutils: sources = yt/utilities/lib/cykdtree/c_utils.cpp
 # distutils: depends = yt/utilities/lib/cykdtree/c_kdtree.hpp, yt/utilities/lib/cykdtree/c_utils.hpp
 # distutils: language = c++
-# distutils: extra_compile_args = CPP14_FLAG
+# distutils: extra_compile_args = CPP03_FLAG
 import cython
 import numpy as np
 

--- a/yt/utilities/lib/cykdtree/kdtree.pyx
+++ b/yt/utilities/lib/cykdtree/kdtree.pyx
@@ -3,7 +3,7 @@
 # distutils: sources = yt/utilities/lib/cykdtree/c_utils.cpp
 # distutils: depends = yt/utilities/lib/cykdtree/c_kdtree.hpp, yt/utilities/lib/cykdtree/c_utils.hpp
 # distutils: language = c++
-# distutils: extra_compile_args = -std=c++03
+# distutils: extra_compile_args = CPP03_FLAG
 import cython
 import numpy as np
 

--- a/yt/utilities/lib/cykdtree/utils.pyx
+++ b/yt/utilities/lib/cykdtree/utils.pyx
@@ -2,7 +2,7 @@
 # distutils: sources = yt/utilities/lib/cykdtree/c_utils.cpp
 # distutils: depends = yt/utilities/lib/cykdtree/c_utils.hpp
 # distutils: language = c++
-# distutils: extra_compile_args = CPP03_FLAG
+# distutils: extra_compile_args = CPP14_FLAG
 import numpy as np
 
 cimport cython

--- a/yt/utilities/lib/cykdtree/utils.pyx
+++ b/yt/utilities/lib/cykdtree/utils.pyx
@@ -2,7 +2,7 @@
 # distutils: sources = yt/utilities/lib/cykdtree/c_utils.cpp
 # distutils: depends = yt/utilities/lib/cykdtree/c_utils.hpp
 # distutils: language = c++
-# distutils: extra_compile_args = -std=c++03
+# distutils: extra_compile_args = CPP03_FLAG
 import numpy as np
 
 cimport cython

--- a/yt/utilities/lib/cykdtree/utils.pyx
+++ b/yt/utilities/lib/cykdtree/utils.pyx
@@ -2,7 +2,7 @@
 # distutils: sources = yt/utilities/lib/cykdtree/c_utils.cpp
 # distutils: depends = yt/utilities/lib/cykdtree/c_utils.hpp
 # distutils: language = c++
-# distutils: extra_compile_args = CPP14_FLAG
+# distutils: extra_compile_args = CPP03_FLAG
 import numpy as np
 
 cimport cython

--- a/yt/utilities/lib/cyoctree.pyx
+++ b/yt/utilities/lib/cyoctree.pyx
@@ -1,6 +1,6 @@
 # distutils: libraries = STD_LIBS
-# distutils: extra_link_args = OMP_ARGS
-# distutils: extra_compile_args = OMP_ARGS
+# distutils: extra_link_args = CPP14_FLAG OMP_ARGS
+# distutils: extra_compile_args = CPP14_FLAG OMP_ARGS
 # distutils: include_dirs = LIB_DIR
 # distutils: language = c++
 """

--- a/yt/utilities/lib/field_interpolation_tables.pxd
+++ b/yt/utilities/lib/field_interpolation_tables.pxd
@@ -1,3 +1,6 @@
+# distutils: language = c++
+# distutils: extra_compile_args = CPP14_FLAG
+# distutils: extra_link_args = CPP14_FLAG
 """
 Field Interpolation Tables
 
@@ -8,11 +11,10 @@ Field Interpolation Tables
 
 cimport cython
 cimport numpy as np
-from libc.math cimport isnormal
+from yt.utilities.lib.fp_utils cimport imax, fmax, imin, fmin, iclip, fclip, fabs
 from libc.stdlib cimport malloc
-
-from yt.utilities.lib.fp_utils cimport fabs, fclip, fmax, fmin, iclip, imax, imin
-
+cdef extern from "<cmath>" namespace "std":
+    bint isnormal(double x) nogil
 
 cdef struct FieldInterpolationTable:
     # Note that we make an assumption about retaining a reference to values

--- a/yt/utilities/lib/field_interpolation_tables.pxd
+++ b/yt/utilities/lib/field_interpolation_tables.pxd
@@ -16,6 +16,7 @@ from libc.stdlib cimport malloc
 cdef extern from "<cmath>" namespace "std":
     bint isnormal(double x) nogil
 
+
 cdef struct FieldInterpolationTable:
     # Note that we make an assumption about retaining a reference to values
     # externally.

--- a/yt/utilities/lib/field_interpolation_tables.pxd
+++ b/yt/utilities/lib/field_interpolation_tables.pxd
@@ -17,6 +17,10 @@ cdef extern from "<cmath>" namespace "std":
     bint isnormal(double x) nogil
 
 
+cdef extern from "platform_dep_math.hpp":
+    bint __isnormal(double) nogil
+
+
 cdef struct FieldInterpolationTable:
     # Note that we make an assumption about retaining a reference to values
     # externally.
@@ -61,7 +65,7 @@ cdef inline np.float64_t FIT_get_value(const FieldInterpolationTable *fit,
     cdef np.float64_t dd, dout
     cdef int bin_id
     if dvs[fit.field_id] >= fit.bounds[1] or dvs[fit.field_id] <= fit.bounds[0]: return 0.0
-    if not isnormal(dvs[fit.field_id]): return 0.0
+    if not __isnormal(dvs[fit.field_id]): return 0.0
     bin_id = <int> ((dvs[fit.field_id] - fit.bounds[0]) * fit.idbin)
     bin_id = iclip(bin_id, 0, fit.nbins-2)
 

--- a/yt/utilities/lib/field_interpolation_tables.pxd
+++ b/yt/utilities/lib/field_interpolation_tables.pxd
@@ -11,8 +11,11 @@ Field Interpolation Tables
 
 cimport cython
 cimport numpy as np
-from yt.utilities.lib.fp_utils cimport imax, fmax, imin, fmin, iclip, fclip, fabs
 from libc.stdlib cimport malloc
+
+from yt.utilities.lib.fp_utils cimport fabs, fclip, fmax, fmin, iclip, imax, imin
+
+
 cdef extern from "<cmath>" namespace "std":
     bint isnormal(double x) nogil
 

--- a/yt/utilities/lib/geometry_utils.pyx
+++ b/yt/utilities/lib/geometry_utils.pyx
@@ -1,6 +1,6 @@
 # distutils: libraries = STD_LIBS
-# distutils: extra_compile_args = OMP_ARGS
-# distutils: extra_link_args = OMP_ARGS
+# distutils: extra_compile_args = CPP14_FLAG OMP_ARGS
+# distutils: extra_link_args = CPP14_FLAG OMP_ARGS
 """
 Simple integrators for the radiative transfer equation
 

--- a/yt/utilities/lib/geometry_utils.pyx
+++ b/yt/utilities/lib/geometry_utils.pyx
@@ -1,4 +1,5 @@
 # distutils: libraries = STD_LIBS
+# distutils: language = c++
 # distutils: extra_compile_args = CPP14_FLAG OMP_ARGS
 # distutils: extra_link_args = CPP14_FLAG OMP_ARGS
 """

--- a/yt/utilities/lib/grid_traversal.pyx
+++ b/yt/utilities/lib/grid_traversal.pyx
@@ -1,6 +1,9 @@
 # distutils: include_dirs = LIB_DIR
 # distutils: libraries = STD_LIBS
 # distutils: sources = FIXED_INTERP
+# distutils: language = c++
+# distutils: extra_compile_args = CPP14_FLAG
+# distutils: extra_link_args = CPP14_FLAG
 """
 Simple integrators for the radiative transfer equation
 
@@ -13,12 +16,6 @@ import numpy as np
 
 cimport cython
 cimport numpy as np
-from field_interpolation_tables cimport (
-    FieldInterpolationTable,
-    FIT_eval_transfer,
-    FIT_eval_transfer_with_light,
-    FIT_initialize_table,
-)
 from fixed_interpolator cimport *
 from libc.math cimport (
     M_PI,

--- a/yt/utilities/lib/image_samplers.pyx
+++ b/yt/utilities/lib/image_samplers.pyx
@@ -1,6 +1,6 @@
 # distutils: include_dirs = LIB_DIR
-# distutils: extra_compile_args = OMP_ARGS
-# distutils: extra_link_args = OMP_ARGS
+# distutils: extra_compile_args = CPP14_FLAG OMP_ARGS
+# distutils: extra_link_args = CPP14_FLAG OMP_ARGS
 # distutils: libraries = STD_LIBS
 # distutils: sources = FIXED_INTERP
 # distutils: language = c++

--- a/yt/utilities/lib/misc_utilities.pyx
+++ b/yt/utilities/lib/misc_utilities.pyx
@@ -1,6 +1,7 @@
 # distutils: libraries = STD_LIBS
-# distutils: extra_compile_args = OMP_ARGS
-# distutils: extra_link_args = OMP_ARGS
+# distutils: language = c++
+# distutils: extra_compile_args = CPP14_FLAG OMP_ARGS
+# distutils: extra_link_args = CPP14_FLAG OMP_ARGS
 """
 Simple utilities that don't fit anywhere else
 

--- a/yt/utilities/lib/partitioned_grid.pyx
+++ b/yt/utilities/lib/partitioned_grid.pyx
@@ -2,6 +2,8 @@
 # distutils: include_dirs = LIB_DIR
 # distutils: libraries = STD_LIBS
 # distutils: language = c++
+# distutils: extra_compile_args = CPP14_FLAG
+# distutils: extra_link_args = CPP14_FLAG
 """
 Image sampler definitions
 

--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -1,6 +1,6 @@
 # distutils: include_dirs = LIB_DIR
-# distutils: extra_compile_args = OMP_ARGS
-# distutils: extra_link_args = OMP_ARGS
+# distutils: extra_compile_args = CPP14_FLAG OMP_ARGS
+# distutils: extra_link_args = CPP14_FLAG OMP_ARGS
 # distutils: language = c++
 # distutils: libraries = STD_LIBS
 # distutils: sources = yt/utilities/lib/pixelization_constants.cpp

--- a/yt/utilities/lib/platform_dep.h
+++ b/yt/utilities/lib/platform_dep.h
@@ -60,5 +60,3 @@ double erf(double x)
 #include "alloca.h"
 #include <math.h>
 #endif
-
-

--- a/yt/utilities/lib/platform_dep_math.hpp
+++ b/yt/utilities/lib/platform_dep_math.hpp
@@ -1,0 +1,18 @@
+/*
+This file provides a compatibility layout between MSVC, and different version of GCC.
+
+MSVC does not define isnormal in the std:: namespace, so we cannot import it from <cmath>, but from <math.h> instead.
+However with GCC-5, there is a clash between the definition of isnormal in <math.h> and using C++14, so we need to import from cmath instead.
+*/
+
+#if _MSC_VER
+#include <math.h>
+inline bool __isnormal(double x) {
+    return isnormal(x);
+}
+#else
+#include <cmath>
+inline bool __isnormal(double x) {
+    return std::isnormal(x);
+}
+#endif


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

Use GCC 5 to trigger compiler errors with non-default  C++14 compilers.

Follow-up to regressions from #2575 and #2610
Fix #2892

```
export CC=$(which gcc-5)
export CXX=$(which g++-5)
python3 -m pip wheel -v .
```

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] pass `black --check yt/`
- [ ] pass `isort . --check --diff`
- [ ] pass `flake8 yt/`
- [ ] pass `flynt yt/ --fail-on-change --dry-run -e yt/extern`
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
