### PR TITLE
Ensure that shapely is built from source. Fixes #2941

### DIFF
--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -17,6 +17,8 @@ sympy~=1.5
 pyqt5~=5.11.3
 netCDF4~=1.5.3
 libconf~=1.0.1
+shapely
+--no-binary=shapely
 cartopy~=0.18.0
 pyaml~=17.10.0
 mpi4py~=3.0.3


### PR DESCRIPTION
## PR Summary

Per https://github.com/Toblerity/Shapely#source-distributions we need to make sure that *shapely* is installed properly...
