### PR TITLE
futurefix: fix a deprecation warning from mpl 3.3

### DIFF
--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -241,7 +241,7 @@ class ImagePlotMPL(PlotMPL):
                 # note that this creates an inconsistency between mpl versions
                 # since the default value previous to mpl 3.4.0 is np.e
                 # but it is only exposed since 3.2.0
-                cbnorm_kwargs.update(dict(base=10))
+                cbnorm_kwargs["base"] = 10
 
             cbnorm_cls = matplotlib.colors.SymLogNorm
         else:

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -218,7 +218,7 @@ class ImagePlotMPL(PlotMPL):
     def _init_image(self, data, cbnorm, cblinthresh, cmap, extent, aspect):
         """Store output of imshow in image variable"""
         cbnorm_kwargs = dict(
-            vmin=float(self.zmin) if self.zmax is not None else None,
+            vmin=float(self.zmin) if self.zmin is not None else None,
             vmax=float(self.zmax) if self.zmax is not None else None,
         )
         if cbnorm == "log10":

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -217,34 +217,43 @@ class ImagePlotMPL(PlotMPL):
 
     def _init_image(self, data, cbnorm, cblinthresh, cmap, extent, aspect):
         """Store output of imshow in image variable"""
+        cbnorm_kwargs = dict(
+            vmin=float(self.zmin) if self.zmax is not None else None,
+            vmax=float(self.zmax) if self.zmax is not None else None,
+        )
         if cbnorm == "log10":
-            norm = matplotlib.colors.LogNorm()
+            cbnorm_cls = matplotlib.colors.LogNorm
         elif cbnorm == "linear":
-            norm = matplotlib.colors.Normalize()
+            cbnorm_cls = matplotlib.colors.Normalize
         elif cbnorm == "symlog":
             if cblinthresh is None:
                 cblinthresh = float((np.nanmax(data) - np.nanmin(data)) / 10.0)
 
-            symlog_kwargs = dict(
-                linthresh=cblinthresh,
-                vmin=float(np.nanmin(data)),
-                vmax=float(np.nanmax(data)),
+            cbnorm_kwargs.update(
+                dict(
+                    linthresh=cblinthresh,
+                    vmin=float(np.nanmin(data)),
+                    vmax=float(np.nanmax(data)),
+                )
             )
             MPL_VERSION = LooseVersion(matplotlib.__version__)
             if MPL_VERSION >= "3.2.0":
                 # note that this creates an inconsistency between mpl versions
                 # since the default value previous to mpl 3.4.0 is np.e
                 # but it is only exposed since 3.2.0
-                symlog_kwargs.update(dict(base=10))
+                cbnorm_kwargs.update(dict(base=10))
 
-            norm = matplotlib.colors.SymLogNorm(**symlog_kwargs)
+            cbnorm_cls = matplotlib.colors.SymLogNorm
+        else:
+            raise ValueError(f"Unknown value `cbnorm` == {cbnorm}")
+
+        norm = cbnorm_cls(**cbnorm_kwargs)
 
         extent = [float(e) for e in extent]
         # tuple colormaps are from palettable (or brewer2mpl)
         if isinstance(cmap, tuple):
             cmap = get_brewer_cmap(cmap)
-        vmin = float(self.zmin) if self.zmax is not None else None
-        vmax = float(self.zmax) if self.zmax is not None else None
+
         if self._transform is None:
             # sets the transform to be an ax.TransData object, where the
             # coordiante system of the data is controlled by the xlim and ylim
@@ -276,8 +285,6 @@ class ImagePlotMPL(PlotMPL):
             origin="lower",
             extent=extent,
             norm=norm,
-            vmin=vmin,
-            vmax=vmax,
             aspect=aspect,
             cmap=cmap,
             interpolation="nearest",


### PR DESCRIPTION
## PR Summary

the warning in question is seen in Jenkins logs, e.g.
```
/home/fido/workspace/yt_py38_git/yt/visualization/base_plot_types.py:274:
MatplotlibDeprecationWarning: Passing parameters norm and vmin/vmax simultaneously is deprecated since 3.3 
and will become an error two minor releases later. Please pass vmin/vmax directly to the norm when creating it.
  self.image = self.axes.imshow(
```