### PR TITLE
cut region AMRGrid selector fix

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -1,6 +1,6 @@
 answer_tests:
 
-  local_amrvac_006:
+  local_amrvac_007: # PR 2945
     - yt/frontends/amrvac/tests/test_outputs.py:test_domain_size
     - yt/frontends/amrvac/tests/test_outputs.py:test_bw_polar_2d
     - yt/frontends/amrvac/tests/test_outputs.py:test_blastwave_cartesian_3D
@@ -20,7 +20,7 @@ answer_tests:
   local_artio_003:
     - yt/frontends/artio/tests/test_outputs.py:test_sizmbhloz
 
-  local_athena_007:
+  local_athena_008: # PR 2945
     - yt/frontends/athena/tests/test_outputs.py:test_cloud
     - yt/frontends/athena/tests/test_outputs.py:test_blast
     - yt/frontends/athena/tests/test_outputs.py:test_stripping
@@ -44,7 +44,7 @@ answer_tests:
     - yt/frontends/enzo/tests/test_outputs.py:test_ecp
     - yt/frontends/enzo/tests/test_outputs.py:test_nuclei_density_fields
 
-  local_enzo_p_008:  # PR 2735
+  local_enzo_p_009: # PR 2945
     - yt/frontends/enzo_p/tests/test_outputs.py:test_hello_world
     - yt/frontends/enzo_p/tests/test_outputs.py:test_particle_fields
 

--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -517,18 +517,15 @@ cdef class SelectorObject:
         if level == self.max_level:
             this_level = 1
         with nogil:
-            pos[0] = left_edge[0] + dds[0] * 0.5
             for i in range(dim[0]):
-                pos[1] = left_edge[1] + dds[1] * 0.5
+                pos[0] = left_edge[0] + (i + 0.5) * dds[0]
                 for j in range(dim[1]):
-                    pos[2] = left_edge[2] + dds[2] * 0.5
+                    pos[1] = left_edge[1] + (j + 0.5) * dds[1]
                     for k in range(dim[2]):
+                        pos[2] = left_edge[2] + (k + 0.5) * dds[2]
                         if child_mask[i, j, k] == 1 or this_level == 1:
                             mask[i, j, k] = self.select_cell(pos, dds)
                             total += mask[i, j, k]
-                        pos[2] += dds[2]
-                    pos[1] += dds[1]
-                pos[0] += dds[0]
         return total
 
     @cython.boundscheck(False)
@@ -1129,18 +1126,16 @@ cdef class RegionSelector(SelectorObject):
                 si[i] = 0
                 ei[i] = dim[i]
         with nogil:
-            pos[0] = left_edge[0] + (si[0] + 0.5) * dds[0]
+
             for i in range(si[0], ei[0]):
-                pos[1] = left_edge[1] + (si[1] + 0.5) * dds[1]
+                pos[0] = left_edge[0] + (i + 0.5) * dds[0]
                 for j in range(si[1], ei[1]):
-                    pos[2] = left_edge[2] + (si[2] + 0.5) * dds[2]
+                    pos[1] = left_edge[1] + (j + 0.5) * dds[1]
                     for k in range(si[2], ei[2]):
+                        pos[2] = left_edge[2] + (k + 0.5) * dds[2]
                         if child_mask[i, j, k] == 1 or this_level == 1:
                             mask[i, j, k] = self.select_cell(pos, dds)
                             total += mask[i, j, k]
-                        pos[2] += dds[2]
-                    pos[1] += dds[1]
-                pos[0] += dds[0]
         return total
 
 


### PR DESCRIPTION
## PR Summary

This is a tentative fix for issue #2720, but needs some discussion! The origin of the bug in #2720 is a floating point comparison. The `SelectorObject` traverses grid coordinates by incrementing positions in a nested loop while the `AMRGridPatch.select_fcoords` re-calculates the same coordinates by multiplication of indices, resulting in small differences at the level of floating point precision. Since the `CutRegion` selector identifies masked coordinates by comparison of floating point values, these differences lead to points not being selected that should be.

The current fix in this PR feels a bit hacky -- simply changing how the `SelectorObject` nested loop calculates coordinates are calculated seems to have been sufficient, but there may be a better fix (e.g., have the `SelectorObject` return the coordinates, not just the mask indices?). It also will currently fail the `amrvac` answer tests but given the nature of the bug, those answer stores may simply need updating (this code passed all the other answer tests I ran locally, but I did not run them all...). 


