### PR TITLE
futurefix: normalize pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+repos:
 -   repo: https://github.com/ambv/black
     rev: 19.10b0  # keep in sync with tests/lint_requirements.txt
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 19.10b0  # keep in sync with tests/lint_requirements.txt
     hooks:
     - id: black
-      language_version: python3.7
+      language_version: python3
 -   repo: https://github.com/timothycrosley/isort
     rev: '5.5.3'  # keep in sync with tests/lint_requirements.txt
     hooks:


### PR DESCRIPTION
## PR Summary

Our current pre-commit configuration file isn't future proof:
```bash
pre-commit-validate-config .pre-commit-config.yaml
```
outputs
```
[WARNING] normalizing pre-commit configuration to a top-level map.  support for top level list will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
```
This fixes it.

While I'm at it I also release a strict python version requirement for the black hook since I noticed it broke on my machine after I cleaned it. The error in question, and its solution, was found here https://github.com/pre-commit/pre-commit/issues/1375