### PR TITLE
switch csv writer file IO mode for python 3

### DIFF
--- a/yt/utilities/parameter_file_storage.py
+++ b/yt/utilities/parameter_file_storage.py
@@ -196,4 +196,5 @@ class ParameterFileStore:
                 v["last_seen"] = 0.0
             else:
                 v["last_seen"] = float(v["last_seen"])
+        f.close()
         return db

--- a/yt/utilities/parameter_file_storage.py
+++ b/yt/utilities/parameter_file_storage.py
@@ -173,7 +173,7 @@ class ParameterFileStore:
         if self._read_only:
             return
         fn = self._get_db_name()
-        f = open(f"{fn}.tmp", "wb")
+        f = open(f"{fn}.tmp", "w")
         w = csv.DictWriter(f, _field_names)
         maxn = ytcfg.getint("yt", "maximumstoreddatasets")  # number written
         for h, v in islice(
@@ -187,7 +187,7 @@ class ParameterFileStore:
     @parallel_simple_proxy
     def read_db(self):
         """ This will read the storage device from disk. """
-        f = open(self._get_db_name(), "rb")
+        f = open(self._get_db_name(), "r")
         vals = csv.DictReader(f, _field_names)
         db = {}
         for v in vals:


### PR DESCRIPTION
This PR fixes a bug in the on-disk dataset parameter file storage. 

To reproduce the bug on master, enable in the on disk parameter file storage in the `ytrc` config with `StoreParameterFiles = True` then on importing yt you'll get this error: 

```python
>>> import yt
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/chavlin/src/yt/yt/__init__.py", line 80, in <module>
    from yt.data_objects.api import (
  File "/home/chavlin/src/yt/yt/data_objects/api.py", line 1, in <module>
    from . import construction_data_containers as __cdc, selection_objects as __sdc
  File "/home/chavlin/src/yt/yt/data_objects/construction_data_containers.py", line 14, in <module>
    from yt.data_objects.selection_objects.data_selection_objects import (
  File "/home/chavlin/src/yt/yt/data_objects/selection_objects/__init__.py", line 1, in <module>
    from .boolean_operations import (
  File "/home/chavlin/src/yt/yt/data_objects/selection_objects/boolean_operations.py", line 8, in <module>
    from yt.data_objects.static_output import Dataset
  File "/home/chavlin/src/yt/yt/data_objects/static_output.py", line 63, in <module>
    _ds_store = ParameterFileStore()
  File "/home/chavlin/src/yt/yt/utilities/parameter_file_storage.py", line 62, in __init__
    self._records = self.read_db()
  File "/home/chavlin/src/yt/yt/utilities/parallel_tools/parallel_analysis_interface.py", line 243, in single_proc_results
    return func(self, *args, **kwargs)
  File "/home/chavlin/src/yt/yt/utilities/parameter_file_storage.py", line 193, in read_db
    for v in vals:
  File "/home/chavlin/miniconda3/envs/yt_dev/lib/python3.7/csv.py", line 112, in __next__
    row = next(self.reader)
_csv.Error: iterator should return strings, not bytes (did you open the file in text mode?)
```

The error comes from a difference in the csv writer behavior in python 2 vs 3: python 2 required the file to be opened in binary mode, python 3 switched to plain text. Obviously no one has used this in a while... but this option simplified some parallel operations with dask that I've been experimenting with.