### PR TITLE
Particle trajectories minor improvements

### DIFF
--- a/yt/data_objects/particle_trajectories.py
+++ b/yt/data_objects/particle_trajectories.py
@@ -241,8 +241,10 @@ class ParticleTrajectories:
         pbar = get_pbar(
             f"Generating [{fields_str}] fields in trajectories", self.num_steps,
         )
-        my_storage = {}
 
+        # Note: we explicitly pass dynamic=False to prevent any change in piter from
+        # breaking the assumption that the same processors load the same datasets
+        my_storage = {}
         for i, (sto, ds) in enumerate(
             self.data_series.piter(storage=my_storage, dynamic=False)
         ):

--- a/yt/data_objects/particle_trajectories.py
+++ b/yt/data_objects/particle_trajectories.py
@@ -65,7 +65,7 @@ class ParticleTrajectories:
         self.num_steps = len(outputs)
         self.times = []
         self.suppress_logging = suppress_logging
-        self.ptype = ptype
+        self.ptype = ptype if ptype else "all"
 
         if fields is None:
             fields = []
@@ -84,7 +84,7 @@ class ParticleTrajectories:
             "particle_position_y",
             "particle_position_z",
         ):
-            fds[field] = self._get_full_field_name(field, ds_first, dd_first)[0]
+            fds[field] = dd_first._determine_fields((self.ptype, field))[0]
 
         # Note: we explicitly pass dynamic=False to prevent any change in piter from
         # breaking the assumption that the same processors load the same datasets
@@ -147,14 +147,6 @@ class ParticleTrajectories:
 
     def keys(self):
         return self.field_data.keys()
-
-    def _get_full_field_name(self, field, ds_first=None, dd_first=None):
-        if ds_first is None:
-            ds_first = self.data_series[0]
-        if dd_first is None:
-            dd_first = ds_first.all_data()
-        ptype = self.ptype if self.ptype else "all"
-        return dd_first._determine_fields((ptype, field))
 
     def __getitem__(self, key):
         """

--- a/yt/data_objects/particle_trajectories.py
+++ b/yt/data_objects/particle_trajectories.py
@@ -115,10 +115,10 @@ class ParticleTrajectories:
             mylog.setLevel(old_level)
 
         sorted_storage = sorted(my_storage.items())
-        times = [time.to("Myr") for _fn, (time, *_) in sorted_storage]
-        self.times = self.data_series[0].arr(
-            [time.value for time in times], times[0].units
-        )
+        _fn, (time, *_) = sorted_storage[0]
+        time_units = time.units
+        times = [time.to(time_units) for _fn, (time, *_) in sorted_storage]
+        self.times = self.data_series[0].arr([time.value for time in times], time_units)
 
         self.particle_fields = []
         output_field = np.empty((self.num_indices, self.num_steps))

--- a/yt/data_objects/particle_trajectories.py
+++ b/yt/data_objects/particle_trajectories.py
@@ -84,7 +84,7 @@ class ParticleTrajectories:
             "particle_position_y",
             "particle_position_z",
         ):
-            fds[field] = self._get_full_field_name(field)[0]
+            fds[field] = self._get_full_field_name(field, ds_first, dd_first)[0]
 
         my_storage = {}
         pbar = get_pbar("Constructing trajectory information", len(self.data_series))
@@ -142,9 +142,11 @@ class ParticleTrajectories:
     def keys(self):
         return self.field_data.keys()
 
-    def _get_full_field_name(self, field):
-        ds_first = self.data_series[0]
-        dd_first = ds_first.all_data()
+    def _get_full_field_name(self, field, ds_first=None, dd_first=None):
+        if ds_first is None:
+            ds_first = self.data_series[0]
+        if dd_first is None:
+            dd_first = ds_first.all_data()
         ptype = self.ptype if self.ptype else "all"
         return dd_first._determine_fields((ptype, field))
 

--- a/yt/data_objects/particle_trajectories.py
+++ b/yt/data_objects/particle_trajectories.py
@@ -111,8 +111,8 @@ class ParticleTrajectories:
             mylog.setLevel(old_level)
 
         sorted_storage = sorted(my_storage.items())
-        times = [time for _fn, (time, *_) in sorted_storage]
-        self.times = self.data_series[0].arr(times, times[0].units)
+        times = [time.to("Myr") for _fn, (time, *_) in sorted_storage]
+        self.times = self.data_series[0].arr([time.value for time in times], times[0].units)
 
         self.particle_fields = []
         output_field = np.empty((self.num_indices, self.num_steps))

--- a/yt/data_objects/particle_trajectories.py
+++ b/yt/data_objects/particle_trajectories.py
@@ -239,8 +239,9 @@ class ParticleTrajectories:
             field for field in missing_fields if field not in self.particle_fields
         ]
         step = int(0)
+        fields_str = ", ".join(str(f) for f in missing_fields)
         pbar = get_pbar(
-            f"Generating [{', '.join(missing_fields)}] fields in trajectories",
+            f"Generating [{fields_str}] fields in trajectories",
             self.num_steps,
         )
         my_storage = {}


### PR DESCRIPTION
## PR Summary

This addresses some issues on the particle trajectory machinery.

- prevent datasets from being loaded multiple times
- specify non-dynamic runs, to prevent bug if changes are made to the `piter` API

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] pass `black --check yt/`
- [x] pass `isort . --check --diff`
- [x] pass `flake8 yt/`
- [x] pass `flynt yt/ --fail-on-change --dry-run -e yt/extern`
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
