### PR TITLE
Enable ghost zones > 1 for octrees

### DIFF
--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -370,7 +370,9 @@ class RAMSESDomainSubset(OctreeSubset):
         try:
             new_subset = _subset_with_gz[ngz]
             mylog.debug(
-                "Reusing previous subset with ghost zone for domain %s", self.domain_id
+                "Reusing previous subset with %s ghost zones for domain %s",
+                ngz,
+                self.domain_id,
             )
         except KeyError:
             new_subset = RAMSESDomainSubset(

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -286,7 +286,7 @@ class RAMSESDomainSubset(OctreeSubset):
                 file_inds,
                 domains,
             ) = self.oct_handler.file_index_octs_with_ghost_zones(
-                selector, self.domain_id, cell_count
+                selector, self.domain_id, cell_count, self._num_ghost_zones
             )
             self._ghost_zone_cache = gz_cache
 
@@ -334,10 +334,13 @@ class RAMSESDomainSubset(OctreeSubset):
         oh = self.oct_handler
 
         indices = oh.fill_index(self.selector).reshape(-1, 8)
-        oct_inds, cell_inds = oh.fill_octcellindex_neighbours(self.selector)
+        oct_inds, cell_inds = oh.fill_octcellindex_neighbours(
+            self.selector, self._num_ghost_zones
+        )
 
-        oct_inds = oct_inds.reshape(-1, 64)
-        cell_inds = cell_inds.reshape(-1, 64)
+        N_per_oct = self.nz ** 3
+        oct_inds = oct_inds.reshape(-1, N_per_oct)
+        cell_inds = cell_inds.reshape(-1, N_per_oct)
 
         inds = indices[oct_inds, cell_inds]
 

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -384,8 +384,8 @@ class RAMSESDomainSubset(OctreeSubset):
             )
             _subset_with_gz[ngz] = new_subset
 
-            # Cache the fields
-            new_subset.get_data(fields)
+        # Cache the fields
+        new_subset.get_data(fields)
         self._subset_with_gz = _subset_with_gz
 
         return new_subset

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -365,12 +365,14 @@ class RAMSESDomainSubset(OctreeSubset):
             )
             smoothed = False
 
+        _subset_with_gz = getattr(self, "_subset_with_gz", {})
+
         try:
-            new_subset = self._subset_with_gz
+            new_subset = _subset_with_gz[ngz]
             mylog.debug(
                 "Reusing previous subset with ghost zone for domain %s", self.domain_id
             )
-        except AttributeError:
+        except KeyError:
             new_subset = RAMSESDomainSubset(
                 self.base_region,
                 self.domain,
@@ -378,10 +380,11 @@ class RAMSESDomainSubset(OctreeSubset):
                 num_ghost_zones=ngz,
                 base_grid=self,
             )
-            self._subset_with_gz = new_subset
+            _subset_with_gz[ngz] = new_subset
 
             # Cache the fields
             new_subset.get_data(fields)
+        self._subset_with_gz = _subset_with_gz
 
         return new_subset
 

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -4,6 +4,7 @@ import numpy as np
 
 import yt
 from yt.config import ytcfg
+from yt.fields.field_detector import FieldDetector
 from yt.frontends.ramses.api import RAMSESDataset
 from yt.frontends.ramses.field_handlers import DETECTED_FIELDS, HydroFieldFileHandler
 from yt.testing import (
@@ -562,6 +563,35 @@ def test_field_accession():
     ):
         for field in fields:
             reg[field]
+
+
+def test_ghost_zones():
+    ds = yt.load(output_00080)
+
+    def gen_dummy(ngz):
+        def dummy(field, data):
+            if not isinstance(data, FieldDetector):
+                shape = data["gas", "mach_number"].shape[:3]
+                np.testing.assert_equal(shape, (2 + 2 * ngz, 2 + 2 * ngz, 2 + 2 * ngz))
+            return data["gas", "mach_number"]
+
+        return dummy
+
+    fields = []
+    for ngz in (1, 2, 3):
+        fname = ("gas", f"density_ghost_zone_{ngz}")
+        ds.add_field(
+            fname,
+            gen_dummy(ngz),
+            sampling_type="cell",
+            validators=[yt.ValidateSpatial(ghost_zones=ngz)],
+        )
+        fields.append(fname)
+
+    box = ds.box([0, 0, 0], [0.1, 0.1, 0.1])
+    for f in fields:
+        print("Getting ", f)
+        box[f]
 
 
 @requires_file(output_00080)

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -565,6 +565,7 @@ def test_field_accession():
             reg[field]
 
 
+@requires_file(output_00080)
 def test_ghost_zones():
     ds = yt.load(output_00080)
 

--- a/yt/geometry/oct_container.pyx
+++ b/yt/geometry/oct_container.pyx
@@ -762,7 +762,7 @@ cdef class OctreeContainer:
 
         return np.asarray(cell_inds)
 
-    def fill_octcellindex_neighbours(self, SelectorObject selector, int num_octs = -1, domain_id = -1):
+    def fill_octcellindex_neighbours(self, SelectorObject selector, int num_octs=-1, int domain_id=-1, int n_ghost_zones=1):
         """Compute the oct and cell indices of all the cells within all selected octs, extended
         by one cell in all directions (for ghost zones computations).
 
@@ -797,7 +797,7 @@ cdef class OctreeContainer:
         cell_inds = np.full(num_octs*4**3, 8, dtype=np.uint8)
         oct_inds = np.full(num_octs*4**3, -1, dtype=np.int64)
 
-        visitor = NeighbourCellIndexVisitor(self, -1)
+        visitor = NeighbourCellIndexVisitor(self, -1, n_ghost_zones)
         visitor.cell_inds = cell_inds
         visitor.domain_inds = oct_inds
 
@@ -850,7 +850,7 @@ cdef class OctreeContainer:
     @cython.cdivision(True)
     def file_index_octs_with_ghost_zones(
             self, SelectorObject selector, int domain_id,
-            int num_cells = -1):
+            int num_cells=1, int n_ghost_zones=1):
         """Similar as file_index_octs, but returns the level, cell index,
         file index and domain of the neighbouring cells as well.
 
@@ -913,7 +913,7 @@ cdef class OctreeContainer:
         cell_inds = np.full(num_cells, 8, dtype="uint8")
         domains = np.full(num_cells, -1, dtype="int32")
 
-        visitor = NeighbourCellVisitor(self, -1)
+        visitor = NeighbourCellVisitor(self, -1, n_ghost_zones)
         # output: level, file_ind and cell_ind of the neighbouring cells
         visitor.levels = levels
         visitor.file_inds = file_inds

--- a/yt/geometry/oct_geometry_handler.py
+++ b/yt/geometry/oct_geometry_handler.py
@@ -45,7 +45,13 @@ class OctreeIndex(Index):
             Nobjs = len(data._current_chunk.objs)
             Nbits = int(np.ceil(np.log2(Nobjs)))
 
-            for i, obj in enumerate(data._current_chunk.objs):
+            # Sort objs by decreasing number of octs
+            enumerated_objs = sorted(
+                enumerate(data._current_chunk.objs),
+                key=lambda arg: arg[1].oct_handler.nocts,
+                reverse=True,
+            )
+            for i, obj in enumerated_objs:
                 if Nremaining == 0:
                     break
                 icell = (

--- a/yt/geometry/oct_visitors.pxd
+++ b/yt/geometry/oct_visitors.pxd
@@ -156,6 +156,7 @@ cdef class BaseNeighbourVisitor(OctVisitor):
     cdef Oct *neighbour
     cdef OctreeContainer octree
     cdef OctInfo oi
+    cdef int n_ghost_zones
 
     cdef void set_neighbour_info(self, Oct *o, int ishift[3])
 

--- a/yt/geometry/oct_visitors.pyx
+++ b/yt/geometry/oct_visitors.pyx
@@ -354,11 +354,12 @@ cdef class StoreIndex(OctVisitor):
         self.index += 1
 
 cdef class BaseNeighbourVisitor(OctVisitor):
-    def __init__(self, OctreeContainer octree, int domain_id = -1):
+    def __init__(self, OctreeContainer octree, int domain_id=-1, int n_ghost_zones=1):
         self.octree = octree
         self.neigh_ind[0] = 0
         self.neigh_ind[1] = 0
         self.neigh_ind[2] = 0
+        self.n_ghost_zones = n_ghost_zones
         super(BaseNeighbourVisitor, self).__init__(octree, domain_id)
 
     @cython.boundscheck(False)
@@ -456,12 +457,15 @@ cdef class NeighbourCellIndexVisitor(BaseNeighbourVisitor):
 
         self.last = o.domain_ind
 
+        cdef int i0, i1
+        i0 = -self.n_ghost_zones
+        i1 = 2 + self.n_ghost_zones
         # Loop over cells in and directly around oct
-        for i in range(-1, 3):
+        for i in range(i0, i1):
             ishift[0] = i
-            for j in range(-1, 3):
+            for j in range(i0, i1):
                 ishift[1] = j
-                for k in range(-1, 3):
+                for k in range(i0, i1):
                     ishift[2] = k
                     self.set_neighbour_info(o, ishift)
 
@@ -499,12 +503,15 @@ cdef class NeighbourCellVisitor(BaseNeighbourVisitor):
 
         self.last = o.domain_ind
 
+        cdef int i0, i1
+        i0 = -self.n_ghost_zones
+        i1 = 2 + self.n_ghost_zones
         # Loop over cells in and directly around oct
-        for i in range(-1, 3):
+        for i in range(i0, i1):
             ishift[0] = i
-            for j in range(-1, 3):
+            for j in range(i0, i1):
                 ishift[1] = j
-                for k in range(-1, 3):
+                for k in range(i0, i1):
                     ishift[2] = k
                     self.set_neighbour_info(o, ishift)
 


### PR DESCRIPTION
## PR Summary

This enables support for more than 1 ghost zones with octree datasets.

Also add a minor speed improvement of the mesh-sampling implementation (always start with the largest domain).

## PR Checklist

- [x] pass `black --check yt/`
- [x] pass `isort . --check --diff`
- [x] pass `flake8 yt/`
- [x] pass `flynt yt/ --fail-on-change --dry-run -e yt/extern`
- [x] Adds a test for any bugs fixed. Adds tests for new features.