### PR TITLE
Allow .plot() to run outside of the notebook

### DIFF
--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -27,6 +27,7 @@ from yt.units.unit_object import Unit
 from yt.units.yt_array import YTArray, uconcatenate
 from yt.utilities.exceptions import (
     YTNoAPIKey,
+    YTNotInsideNotebook,
     YTParticleDepositionNotImplemented,
     YTTooManyVertices,
 )
@@ -327,7 +328,10 @@ class YTProj(YTSelectionContainer2D):
             width = self.ds.domain_width
             center = self.ds.domain_center
         pw = self._get_pw(fields, center, width, "native", "Projection")
-        pw.show()
+        try:
+            pw.show()
+        except YTNotInsideNotebook:
+            pass
         return pw
 
     def _initialize_projected_units(self, fields, chunk):

--- a/yt/data_objects/selection_objects/slices.py
+++ b/yt/data_objects/selection_objects/slices.py
@@ -15,6 +15,7 @@ from yt.funcs import (
     validate_object,
     validate_width_tuple,
 )
+from yt.utilities.exceptions import YTNotInsideNotebook
 from yt.utilities.minimal_representation import MinimalSliceData
 from yt.utilities.orientation import Orientation
 
@@ -131,7 +132,10 @@ class YTSlice(YTSelectionContainer2D):
             width = self.ds.domain_width
             center = self.ds.domain_center
         pw = self._get_pw(fields, center, width, "native", "Slice")
-        pw.show()
+        try:
+            pw.show()
+        except YTNotInsideNotebook:
+            pass
         return pw
 
 


### PR DESCRIPTION
## PR Summary

We shouldn't necessarily fail if we call `.plot()` on slices or projections
outside of the notebook, since it's also useful just to get a `PlotWindow`
object back.  This catches the one non-fatal Exception.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] pass `black --check yt/`
- [x] pass `isort . --check --diff`
- [x] pass `flake8 yt/`
- [x] pass `flynt yt/ --fail-on-change --dry-run -e yt/extern`
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
