### PR TITLE
fix: bump bugbear to latest version and fix newly detected bugs

### DIFF
--- a/tests/lint_requirements.txt
+++ b/tests/lint_requirements.txt
@@ -4,5 +4,5 @@ pycodestyle~=2.6.0
 pyflakes~=2.2.0
 isort==5.6.4   # keep in sync with .pre-commit-config.yaml
 black==19.10b0 # keep in sync with .pre-commit-config.yaml
-flake8-bugbear
+flake8-bugbear~=20.11.1
 flynt==0.52    # keep in sync with .pre-commit-config.yaml

--- a/yt/utilities/parallel_tools/parallel_analysis_interface.py
+++ b/yt/utilities/parallel_tools/parallel_analysis_interface.py
@@ -747,11 +747,11 @@ class Communicator:
         if datatype is not None:
             pass
         elif isinstance(data, dict):
-            datatype == "dict"
+            datatype = "dict"
         elif isinstance(data, np.ndarray):
-            datatype == "array"
+            datatype = "array"
         elif isinstance(data, list):
-            datatype == "list"
+            datatype = "list"
         # Now we have our datatype, and we conduct our operation
         if datatype == "dict" and op == "join":
             if self.comm.rank == 0:


### PR DESCRIPTION
## PR Summary

A new feature in flake8-bugbear detects pointless comparisons, here I think the problem is that `==` was used instead of `=`.
