### PR TITLE
[EXP] ci: simplify windows build, stop using conda

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -38,13 +38,6 @@ jobs:
       with:
         submodules: recursive
         fetch-depth: 0
-    - uses: s-weigand/setup-conda@v1
-      if: matrix.os == 'windows-latest'
-      with:
-        update-conda: true
-        conda-channels: conda-forge
-        activate-conda: true
-        python-version: ${{matrix.python-version}}
     - name: Install dependencies and yt
       shell: bash
       env:

--- a/tests/ci_install.sh
+++ b/tests/ci_install.sh
@@ -27,24 +27,9 @@ cat $HOME/.config/yt/ytrc
 cp tests/matplotlibrc .
 
 # Step 1: pre-install required packages
-if [[ "${RUNNER_OS}" == "Windows" ]] && [[ ${dependencies} != "minimal" ]]; then
-    # Install some dependencies using conda (if not doing a minimal run)
-    CYTHON=$(grep cython tests/test_prerequirements.txt)
-    NUMPY=$(grep numpy tests/test_prerequirements.txt)
-
-    CARTOPY=$(grep cartopy tests/test_requirements.txt)
-    H5PY=$(grep h5py tests/test_requirements.txt)
-    MATPLOTLIB=$(grep matplotlib tests/test_requirements.txt)
-    SCIPY=$(grep scipy tests/test_requirements.txt)
-    conda config --set always_yes yes
-    conda info -a
-    conda install --quiet --yes -c conda-forge \
-      $CYTHON $NUMPY $CARTOPY $H5PY $MATPLOTLIB $SCIPY
-else
-    python -m pip install --upgrade pip
-    python -m pip install --upgrade wheel
-    python -m pip install --upgrade setuptools
-fi
+python -m pip install --upgrade pip
+python -m pip install --upgrade wheel
+python -m pip install --upgrade setuptools
 
 # Step 2: install required packages (depending on whether the build is minimal)
 if [[ ${dependencies} == "minimal" ]]; then


### PR DESCRIPTION
## PR Summary
In support of #2978 , I'm trying here to get rid of conda in the windows test build. According to @cphyc , the original motivation to use conda there was to easily select a python version on windows. I think it is likely not necessary anymore since we moved out of travis to GitHub actions. Let's try this out.