### PR TITLE
add whitespace between url and '.' to make link clickable.

### DIFF
--- a/tests/report_failed_answers.py
+++ b/tests/report_failed_answers.py
@@ -201,7 +201,7 @@ def generate_answers(answer_dir, answers):
         "-d",
         "-v",
         "--local",
-        "--local-dir=%s" % answer_dir,
+        f"--local-dir={answer_dir}",
         "--answer-store",
     ]
 
@@ -433,7 +433,7 @@ if __name__ == "__main__":
                 + COLOR_CYAN
                 + "Successfully uploaded answer(s) for failed test at URL: "
                 + response.text.split("\n")[1]
-                + ". Please commit these "
+                + " . Please commit these "
                 "answers in the repository's answer-store." + COLOR_RESET + FLAG_EMOJI
             )
             log.info(msg)
@@ -446,7 +446,7 @@ if __name__ == "__main__":
                 + COLOR_CYAN
                 + "Successfully uploaded missing answer(s) at URL: "
                 + response.text.split("\n")[1]
-                + ". Please commit these "
+                + " . Please commit these "
                 "answers in the repository's answer-store." + COLOR_RESET + FLAG_EMOJI
             )
             log.info(msg)


### PR DESCRIPTION
## PR Summary

Avoid adding a '.' at the end of download urls so that they remain valid when clicked.