### PR TITLE
Optimize Athena++ i/o

### DIFF
--- a/yt/frontends/athena_pp/data_structures.py
+++ b/yt/frontends/athena_pp/data_structures.py
@@ -8,7 +8,6 @@ from yt.data_objects.index_subobjects.grid_patch import AMRGridPatch
 from yt.data_objects.index_subobjects.unstructured_mesh import SemiStructuredMesh
 from yt.data_objects.static_output import Dataset
 from yt.funcs import ensure_tuple, get_pbar, mylog
-from yt.geometry.geometry_handler import YTDataChunk
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.geometry.unstructured_mesh_handler import UnstructuredIndex
 from yt.utilities.chemical_formulas import default_mu
@@ -138,13 +137,6 @@ class AthenaPPLogarithmicIndex(UnstructuredIndex):
     def _detect_output_fields(self):
         self.field_list = [("athena_pp", k) for k in self.ds._field_map]
 
-    def _chunk_io(self, dobj, cache=True, local_only=False):
-        gobjs = getattr(dobj._current_chunk, "objs", dobj._chunk_info)
-        for subset in gobjs:
-            yield YTDataChunk(
-                dobj, "io", [subset], self._count_selection(dobj, [subset]), cache=cache
-            )
-
 
 class AthenaPPGrid(AMRGridPatch):
     _id_offset = 0
@@ -199,13 +191,21 @@ class AthenaPPHierarchy(GridIndex):
         self.grid_right_edge = np.zeros((num_grids, 3), dtype="float64")
         self.grid_dimensions = np.zeros((num_grids, 3), dtype="int32")
 
+        # TODO: In an unlikely case this would use too much memory, implement
+        #       chunked read along 1 dim
+        x = self._handle["x1f"][:, :]
+        y = self._handle["x2f"][:, :]
+        z = self._handle["x3f"][:, :]
+        mesh_block_size = self._handle.attrs["MeshBlockSize"]
+
         for i in range(num_grids):
-            x = self._handle["x1f"][i, :]
-            y = self._handle["x2f"][i, :]
-            z = self._handle["x3f"][i, :]
-            self.grid_left_edge[i] = np.array([x[0], y[0], z[0]], dtype="float64")
-            self.grid_right_edge[i] = np.array([x[-1], y[-1], z[-1]], dtype="float64")
-            self.grid_dimensions[i] = self._handle.attrs["MeshBlockSize"]
+            self.grid_left_edge[i] = np.array(
+                [x[i, 0], y[i, 0], z[i, 0]], dtype="float64"
+            )
+            self.grid_right_edge[i] = np.array(
+                [x[i, -1], y[i, -1], z[i, -1]], dtype="float64"
+            )
+            self.grid_dimensions[i] = mesh_block_size
         levels = self._handle["Levels"][:]
 
         self.grid_left_edge = self.ds.arr(self.grid_left_edge, "code_length")
@@ -226,13 +226,6 @@ class AthenaPPHierarchy(GridIndex):
             g._prepare_grid()
             g._setup_dx()
         self.max_level = self._handle.attrs["MaxLevel"]
-
-    def _chunk_io(self, dobj, cache=True, local_only=False):
-        gobjs = getattr(dobj._current_chunk, "objs", dobj._chunk_info)
-        for subset in gobjs:
-            yield YTDataChunk(
-                dobj, "io", [subset], self._count_selection(dobj, [subset]), cache=cache
-            )
 
 
 class AthenaPPDataset(Dataset):
@@ -318,7 +311,7 @@ class AthenaPPDataset(Dataset):
         self._field_map = {}
         k = 0
         for dname, num_var in zip(
-            self._handle.attrs["DatasetNames"], self._handle.attrs["NumVariables"],
+            self._handle.attrs["DatasetNames"], self._handle.attrs["NumVariables"]
         ):
             for j in range(num_var):
                 fname = self._handle.attrs["VariableNames"][k].decode("ascii", "ignore")
@@ -341,11 +334,7 @@ class AthenaPPDataset(Dataset):
         if "periodicity" in self.specified_parameters:
             self.periodicity = ensure_tuple(self.specified_parameters["periodicity"])
         else:
-            self.periodicity = (
-                True,
-                True,
-                True,
-            )
+            self.periodicity = (True, True, True)
         if "gamma" in self.specified_parameters:
             self.gamma = float(self.specified_parameters["gamma"])
         else:

--- a/yt/frontends/athena_pp/io.py
+++ b/yt/frontends/athena_pp/io.py
@@ -48,10 +48,12 @@ class IOHandlerAthenaPP(BaseIOHandler):
             [f2 for f1, f2 in fields],
             ng,
         )
+        last_dname = None
         for field in fields:
             ftype, fname = field
             dname, fdi = self.ds._field_map[fname]
-            ds = f[f"/{dname}"]
+            if dname != last_dname:
+                ds = f[f"/{dname}"]
             ind = 0
             for chunk in chunks:
                 if self.ds.logarithmic:
@@ -72,6 +74,7 @@ class IOHandlerAthenaPP(BaseIOHandler):
                         data = ds[fdi, start:end, :, :, :].transpose()
                         for i, g in enumerate(gs):
                             ind += g.select(selector, data[..., i], rv[field], ind)
+            last_dname = dname
         return rv
 
     def _read_chunk_data(self, chunk, fields):


### PR DESCRIPTION
* Read coordinates in one op instead of for loop over grids
* Do not override default _chunk_io to properly chunk grid reads

The main issue was a custom `_chunk_io` that was for some reason returning chunks of size 1, which in turn resulted in very costly reads of 16^3 floats for each grid. Let's see if the default works fine and tests pass.