### PR TITLE
[bugfix] save_as_dataset with ArbitraryGrid

### DIFF
--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -1174,6 +1174,7 @@ class YTArbitraryGrid(YTCoveringGrid):
     """
 
     _spatial = True
+    _always_grid_fields = True
     _type_name = "arbitrary_grid"
     _con_args = ("left_edge", "right_edge", "ActiveDimensions")
     _container_fields = (

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -614,7 +614,9 @@ class YTDataContainer:
         ptypes = []
         ftypes = {}
         for field in data_fields:
-            if field in self._container_fields or getattr(self, "_always_grid_fields", False):
+            if field in self._container_fields or getattr(
+                self, "_always_grid_fields", False
+            ):
                 ftypes[field] = "grid"
                 need_grid_positions = True
             elif self.ds.field_info[field].sampling_type == "particle":

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -614,7 +614,7 @@ class YTDataContainer:
         ptypes = []
         ftypes = {}
         for field in data_fields:
-            if field in self._container_fields:
+            if field in self._container_fields or getattr(self, "_always_grid_fields", False):
                 ftypes[field] = "grid"
                 need_grid_positions = True
             elif self.ds.field_info[field].sampling_type == "particle":


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

As reported on slack, if one creates an `ArbitraryGrid` from a particle dataset and then saves it with `save_as_dataset`, the data is not saved with the correct field type. Specifically, since all fields are deposited onto the `ArbitraryGrid`, they are always of grid type there even if they were originally of particle type. An example of this can be found [here](http://paste.yt-project.org/show/302/).

This fix represents the simplest solution to the problem, i.e., marking the `ArbitraryGrid` class as always using grid-type fields. I'm open to suggestions on whether this is the right approach or if I should use a different attribute name.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] pass `black --check yt/`
- [ ] pass `isort . --check --diff`
- [ ] pass `flake8 yt/`
- [ ] pass `flynt yt/ --fail-on-change --dry-run -e yt/extern`
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
