### PR TITLE
[bugfix] preserve result_id with dynamic_parallel_objects

### DIFF
--- a/yt/utilities/parallel_tools/task_queue.py
+++ b/yt/utilities/parallel_tools/task_queue.py
@@ -76,9 +76,9 @@ class TaskQueueRoot(TaskQueueNonRoot):
         self.comm.probe_loop(1, self.handle_assignment)
         return self.finalize(self.results)
 
-    def insert_result(self, source_id, result):
-        task_id = self.assignments[source_id]
-        self.results[task_id] = result
+    def insert_result(self, source_id, rstore):
+        task_id = rstore.result_id
+        self.results[task_id] = rstore.result
 
     def assign_task(self, source_id):
         if self._remaining == 0:
@@ -176,7 +176,7 @@ def dynamic_parallel_objects(tasks, njobs=0, storage=None, broadcast=True):
             for task in my_q:
                 rstore = ResultsStorage()
                 yield rstore, task
-                my_q.send_result(rstore.result)
+                my_q.send_result(rstore)
 
     if storage is not None:
         if broadcast:


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

This resolves Issue #2987 by sending the entire `ResultsStorage` object instead of just the result.

For the example shown in the issue, I now get:
```
yt : [INFO     ] 2020-12-03 14:19:09,904 Global parallel computation enabled: 1 / 5
yt : [INFO     ] 2020-12-03 14:19:09,905 Global parallel computation enabled: 3 / 5
yt : [INFO     ] 2020-12-03 14:19:09,905 Global parallel computation enabled: 0 / 5
yt : [INFO     ] 2020-12-03 14:19:09,905 Global parallel computation enabled: 2 / 5
yt : [INFO     ] 2020-12-03 14:19:09,905 Global parallel computation enabled: 4 / 5
P000 yt : [INFO     ] 2020-12-03 14:19:09,906 Begin with dynamic=False.
P000 yt : [INFO     ] 2020-12-03 14:19:09,906 5, 5
P000 yt : [INFO     ] 2020-12-03 14:19:09,906 6, 6
P000 yt : [INFO     ] 2020-12-03 14:19:09,907 7, 7
P000 yt : [INFO     ] 2020-12-03 14:19:09,907 8, 8
P000 yt : [INFO     ] 2020-12-03 14:19:09,907 9, 9
P000 yt : [INFO     ] 2020-12-03 14:19:09,907 Begin with dynamic=True.
P000 yt : [INFO     ] 2020-12-03 14:19:09,908 5, 5
P000 yt : [INFO     ] 2020-12-03 14:19:09,908 6, 6
P000 yt : [INFO     ] 2020-12-03 14:19:09,908 7, 7
P000 yt : [INFO     ] 2020-12-03 14:19:09,908 8, 8
P000 yt : [INFO     ] 2020-12-03 14:19:09,908 9, 9
```

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] pass `black --check yt/`
- [ ] pass `isort . --check --diff`
- [ ] pass `flake8 yt/`
- [ ] pass `flynt yt/ --fail-on-change --dry-run -e yt/extern`
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
