### PR TITLE
[bugfix] Use axes unit in scale bar if set by user.

### DIFF
--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -53,6 +53,7 @@ class CallbackWrapper:
         self.ds = frb.ds
         self.xlim = viewer.xlim
         self.ylim = viewer.ylim
+        self._axes_unit_names = viewer._axes_unit_names
         if "OffAxisSlice" in viewer._plot_type:
             self._type_name = "CuttingPlane"
         else:

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -2704,17 +2704,22 @@ class ScaleCallback(PlotCallback):
         max_scale = self.max_frac * xsize
         min_scale = self.min_frac * xsize
 
-        # If no units are set, then identify a best fit distance unit
+        # If no units are set, pick something sensible.
         if self.unit is None:
-            min_scale = plot.ds.get_smallest_appropriate_unit(
-                min_scale, return_quantity=True
-            )
-            max_scale = plot.ds.get_smallest_appropriate_unit(
-                max_scale, return_quantity=True
-            )
-            if self.coeff is None:
-                self.coeff = max_scale.v
-            self.unit = max_scale.units
+            # User has set the axes units and supplied a coefficient.
+            if plot._axes_unit_names is not None and self.coeff is not None:
+                self.unit = plot._axes_unit_names[0]
+            # Nothing provided; identify a best fit distance unit.
+            else:
+                min_scale = plot.ds.get_smallest_appropriate_unit(
+                    min_scale, return_quantity=True
+                )
+                max_scale = plot.ds.get_smallest_appropriate_unit(
+                    max_scale, return_quantity=True
+                )
+                if self.coeff is None:
+                    self.coeff = max_scale.v
+                self.unit = max_scale.units
         elif self.coeff is None:
             self.coeff = 1
         self.scale = plot.ds.quan(self.coeff, self.unit)


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

This is in response to an old email thread. If the user makes a plot, sets the axes unit, and then adds a scale annotation with a coefficient, the most appropriate behavior is to use the axes unit set by the user. The current behavior is to instead figure out an appropriate unit on its own, but this calculation does not take into account the user-provided coefficient. In other words, the following script creates a scale bar with units of Mpc, when Mpccm/h is probably more appropriate.

```
import yt
ds = yt.load('DD0046/DD0046')
p = yt.SlicePlot(ds, 'x', 'density')
p.set_axes_unit('Mpccm/h')
p.annotate_scale(corner='lower_right', coeff=5)
p.save()
```

This PR changes the behavior to use the axes unit in the case described above. This is a very minor issue, but I think this is the correct behavior.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] pass `black --check yt/`
- [ ] pass `isort . --check --diff`
- [ ] pass `flake8 yt/`
- [ ] pass `flynt yt/ --fail-on-change --dry-run -e yt/extern`
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
