### PR TITLE
maint: drop mock as a third party dependency 

### DIFF
--- a/tests/test_minimal_requirements.txt
+++ b/tests/test_minimal_requirements.txt
@@ -8,4 +8,3 @@ pyyaml>=4.2b1
 coverage~=4.5.1
 codecov~=2.0.15
 unyt~=2.8.0
-mock

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -6,7 +6,6 @@ glueviz~=0.13.3
 h5py~=2.10.0
 ipython~=7.6.1
 matplotlib~=3.3
-mock
 nose-timer~=1.0.0
 nose~=1.3.7
 pandas~=1.1.2

--- a/yt/data_objects/tests/test_projection.py
+++ b/yt/data_objects/tests/test_projection.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
+from unittest import mock
 
-import mock
 import numpy as np
 
 from yt.testing import assert_equal, assert_rel_equal, fake_amr_ds, fake_random_ds

--- a/yt/data_objects/tests/test_slice.py
+++ b/yt/data_objects/tests/test_slice.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
+from unittest import mock
 
-import mock
 import numpy as np
 
 from yt.testing import assert_equal, fake_random_ds

--- a/yt/utilities/tests/test_config.py
+++ b/yt/utilities/tests/test_config.py
@@ -78,10 +78,6 @@ class TestYTConfig(unittest.TestCase):
 
 class TestYTConfigCommands(TestYTConfig):
     def testConfigCommands(self):
-        # stub out test if mock isn't installed in Python2
-        if mock is None:
-            return
-
         def remove_spaces_and_breaks(s):
             return "".join(s.split())
 

--- a/yt/visualization/tests/test_particle_plot.py
+++ b/yt/visualization/tests/test_particle_plot.py
@@ -2,8 +2,8 @@ import os
 import shutil
 import tempfile
 import unittest
+from unittest import mock
 
-import mock
 import numpy as np
 
 from yt.data_objects.particle_filters import add_particle_filter


### PR DESCRIPTION
Rationale:
`mock` was standardized in Python 3.3