### PR TITLE
doc: add minimal structure to SkeletonDataset class

### DIFF
--- a/doc/source/developing/creating_frontend.rst
+++ b/doc/source/developing/creating_frontend.rst
@@ -27,20 +27,30 @@ be classified into a couple categories:
  * Data reading: This is the set of routines that actually perform a read of
    either all data in a region or a subset of that data.
 
-Data Meaning Structures
------------------------
 
 If you are interested in adding a new code, be sure to drop us a line on
 `yt-dev <https://mail.python.org/archives/list/yt-dev@python.org/>`_!
 
-To get started, make a new directory in ``yt/frontends`` with the name
-of your code and add the name into ``yt/frontends/api.py``.
-Copying the contents of the ``yt/frontends/_skeleton``
-directory will add a lot of boilerplate for the required classes and
-methods that are needed.  In particular, you'll have to create a
-subclass of ``Dataset`` in the data_structures.py file. This subclass
-will need to handle conversion between the different physical units
-and the code units (typically in the ``_set_code_unit_attributes()``
+
+Boostraping a new frontend
+--------------------------
+
+To get started
+
+* make a new directory in ``yt/frontends`` with the name of your code and add the name
+into ``yt/frontends/api.py:_frontends`` (in alphabetical order).
+
+* copy the contents of the ``yt/frontends/_skeleton`` directory, and replace every
+occurence of ``Skeleton`` with your frontend's name (preserving case). This adds a lot of
+boilerplate for the required classes and methods that are needed.
+
+
+Data Meaning Structures
+-----------------------
+
+You will need to create a subclass of ``Dataset`` in the ``data_structures.py``
+file. This subclass will need to handle conversion between the different physical
+units and the code units (typically in the ``_set_code_unit_attributes()``
 method), read in metadata describing the overall data on disk (via the
 ``_parse_parameter_file()`` method), and provide a ``classmethod``
 called ``_is_valid()`` that lets the ``yt.load`` method help identify an

--- a/yt/frontends/_skeleton/data_structures.py
+++ b/yt/frontends/_skeleton/data_structures.py
@@ -148,7 +148,8 @@ class SkeletonDataset(Dataset):
         #   self.geometry  <= a lower case string
         #                     ("cartesian", "polar", "cylindrical"...)
         #                     (defaults to 'cartesian')
-        pass
+        self.current_time = -1  # required, change this !
+        self.cosmological_simulation = 0  # required. Change this if need be.
 
     @classmethod
     def _is_valid(self, *args, **kwargs):

--- a/yt/frontends/_skeleton/data_structures.py
+++ b/yt/frontends/_skeleton/data_structures.py
@@ -148,8 +148,14 @@ class SkeletonDataset(Dataset):
         #   self.geometry  <= a lower case string
         #                     ("cartesian", "polar", "cylindrical"...)
         #                     (defaults to 'cartesian')
-        self.current_time = -1  # required, change this !
-        self.cosmological_simulation = 0  # required. Change this if need be.
+
+        # this attribute is required.
+        # Change this value to a constant 0 if time is not relevant to your dataset.
+        # Otherwise, parse its value in any appropriate fashion.
+        self.current_time = -1
+
+        # required. Change this if need be.
+        self.cosmological_simulation = 0
 
     @classmethod
     def _is_valid(self, *args, **kwargs):

--- a/yt/frontends/_skeleton/data_structures.py
+++ b/yt/frontends/_skeleton/data_structures.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from yt.data_objects.index_subobjects.grid_patch import AMRGridPatch
 from yt.data_objects.static_output import Dataset
+from yt.funcs import setdefaultattr
 from yt.geometry.grid_geometry_handler import GridIndex
 
 from .fields import SkeletonFieldInfo
@@ -109,7 +110,11 @@ class SkeletonDataset(Dataset):
         # These can also be set:
         # self.velocity_unit = self.quan(1.0, "cm/s")
         # self.magnetic_unit = self.quan(1.0, "gauss")
-        pass
+
+        # this minimalistic implementation fills the requirements for
+        # this frontend to run, change it to make it run _correctly_ !
+        for key, unit in self.__class__.default_units.items():
+            setdefaultattr(self, key, self.quan(1, unit))
 
     def _parse_parameter_file(self):
         # This needs to set up the following items.  Note that these are all


### PR DESCRIPTION
## PR Summary

- Init required instance attributes in order to leave a valid Dataset structure.
- minor doc update (hopefully making the instructions a little clearer)


edit:
the changes to `SkeletonDataset` make it so the following code pass without error
```python
yt.load("myfile.from.a.new.format")
```
where the only changes required from the author of a new frontend are
- adding the frontend to `yt/frontends/api.py`
- implementing `NewDataset._is_valid()`