### PR TITLE
[WIP] Use a fake array for Nd dds

### DIFF
--- a/yt/data_objects/index_subobjects/grid_patch.py
+++ b/yt/data_objects/index_subobjects/grid_patch.py
@@ -73,6 +73,12 @@ class AMRGridPatch(YTSelectionContainer):
         self.start_index = (start_index * self.ds.refine_by).astype("int64").ravel()
         return self.start_index
 
+    @property
+    def ndds(self):
+        return np.lib.stride_tricks.as_strided(
+            self.dds, shape=tuple(self.ActiveDimensions) + (3,), strides=(0, 0, 0, 8)
+        )
+
     def __getitem__(self, key):
         tr = super(AMRGridPatch, self).__getitem__(key)
         try:

--- a/yt/geometry/selection_routines.pxd
+++ b/yt/geometry/selection_routines.pxd
@@ -55,7 +55,7 @@ cdef class SelectorObject:
                                np.float64_t right_edge[3]) nogil
     cdef int fill_mask_selector(self, np.float64_t left_edge[3],
                                 np.float64_t right_edge[3], 
-                                np.float64_t dds[3], int dim[3],
+                                np.float64_t[:,:,:,:] dds, int dim[3],
                                 np.ndarray[np.uint8_t, ndim=3, cast=True] child_mask,
                                 np.ndarray[np.uint8_t, ndim=3] mask,
                                 int level)


### PR DESCRIPTION
This is a work in progress attempt at being able to handle the more generic case of stretched or irregular grids using the base AMRGridPatch machinery.  At present, it gets rid of a couple optimizations in the selector routines, which will need to come back at some point.  But, it allows us to pretend that the `dds` array is (I,J,K,3) in shape/size, without *actually* allocating it to be that size.

It may be worth noting that this is *not* ideal for the cases when it should really just be of size `(I*3 + J*3 + K*3)`, which would be indexed like `dds[0][i]` and the like.
