### PR TITLE
fix: replace all spurious occurences of 'raise SyntaxError'

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -459,8 +459,8 @@ class Dataset(abc.ABC):
                 "fs",
             ]
         else:
-            raise SyntaxError(
-                "Specified quantity must be equal to 'distance'" "or 'time'."
+            raise ValueError(
+                "Specified quantity must be equal to 'distance' or 'time'."
             )
         for unit in unit_list:
             uq = self.quan(1.0, unit)

--- a/yt/utilities/math_utils.py
+++ b/yt/utilities/math_utils.py
@@ -305,7 +305,7 @@ def rotate_vector_3D(a, dim, angle):
         mod = True
         a = np.array([a])
     if a.shape[1] != 3:
-        raise SyntaxError("The second dimension of the array a must be == 3!")
+        raise ValueError("The second dimension of the array a must be == 3!")
     if dim == 0:
         R = np.array(
             [
@@ -331,7 +331,7 @@ def rotate_vector_3D(a, dim, angle):
             ]
         )
     else:
-        raise SyntaxError("dim must be 0, 1, or 2!")
+        raise ValueError("dim must be 0, 1, or 2!")
     if mod:
         return np.dot(R, a.T).T[0]
     else:

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -103,14 +103,12 @@ class PlotCallback:
                 # right-handed coord system
                 coord = (y, x)
             else:
-                raise SyntaxError(
-                    "Object being plot must have a `data.axis` " "defined"
-                )
+                raise ValueError("Object being plot must have a `data.axis` defined")
 
         # if the position is already two-coords, it is expected to be
         # in the proper projected orientation
         else:
-            raise SyntaxError("'data' coordinates must be 3 dimensions")
+            raise ValueError("'data' coordinates must be 3 dimensions")
         return coord
 
     def _convert_to_plot(self, plot, coord, offset=True):
@@ -203,8 +201,8 @@ class PlotCallback:
         # if in data coords, project them to plot coords
         if coord_system == "data":
             if len(coord) < 3:
-                raise SyntaxError(
-                    "Coordinates in 'data' coordinate system " "need to be in 3D"
+                raise ValueError(
+                    "Coordinates in 'data' coordinate system need to be in 3D"
                 )
             coord = self._project_coords(plot, coord)
             coord = self._convert_to_plot(plot, coord)
@@ -216,8 +214,8 @@ class PlotCallback:
         if coord_system == "axis":
             self.transform = plot._axes.transAxes
             if len(coord) > 2:
-                raise SyntaxError(
-                    "Coordinates in 'axis' coordinate system " "need to be in 2D"
+                raise ValueError(
+                    "Coordinates in 'axis' coordinate system need to be in 2D"
                 )
             return coord
         # if in figure coords, define the transform correctly
@@ -225,7 +223,7 @@ class PlotCallback:
             self.transform = plot._figure.transFigure
             return coord
         else:
-            raise SyntaxError(
+            raise ValueError(
                 "Argument coord_system must have a value of "
                 "'data', 'plot', 'axis', or 'figure'."
             )
@@ -2459,7 +2457,7 @@ class TimestampCallback(PlotCallback):
                 self.text_args["horizontalalignment"] = "center"
                 self.text_args["verticalalignment"] = "center"
             else:
-                raise SyntaxError(
+                raise ValueError(
                     "Argument 'corner' must be set to "
                     "'upper_left', 'upper_right', 'lower_left', "
                     "'lower_right', or None"
@@ -2692,7 +2690,7 @@ class ScaleCallback(PlotCallback):
             elif self.corner is None:
                 self.pos = (0.5, 0.5)
             else:
-                raise SyntaxError(
+                raise ValueError(
                     "Argument 'corner' must be set to "
                     "'upper_left', 'upper_right', 'lower_left', "
                     "'lower_right', or None"
@@ -2876,7 +2874,7 @@ class RayCallback(PlotCallback):
             start_coord, end_coord = self._process_light_ray(plot)
 
         else:
-            raise SyntaxError("ray must be a YTRay, YTOrthoRay, or " "LightRay object.")
+            raise ValueError("ray must be a YTRay, YTOrthoRay, or LightRay object.")
 
         # if start_coord and end_coord are all False, it means no intersecting
         # ray segment with this plot.
@@ -3012,7 +3010,7 @@ class LineIntegralConvolutionCallback(PlotCallback):
         if self.texture is None:
             self.texture = np.random.rand(nx, ny).astype(np.double)
         elif self.texture.shape != (nx, ny):
-            raise SyntaxError(
+            raise ValueError(
                 "'texture' must have the same shape "
                 "with that of output image (%d, %d)" % (nx, ny)
             )


### PR DESCRIPTION
## PR Summary

Fix a number of `raise SyntaxError` which are really `ValueError`s.
There's a slight possibility of backwards compatibility breakage if any downstream code is currently catching any of those as `SyntaxError` but I hope this is not likely enough to prevent us from performing this clean up.
