### PR TITLE
refactor: remove yt.funcs.ensure_tuple

### DIFF
--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -343,9 +343,9 @@ class AMRVACDataset(Dataset):
             self.geometry = "cartesian"
 
         # parse peridiocity
-        per = self.parameters.get("periodic", np.array([False, False, False]))
-        missing_dim = 3 - len(per)
-        self.periodicity = np.append(per, [False] * missing_dim)
+        periodicity = self.parameters.get("periodic", ())
+        missing_dim = 3 - len(periodicity)
+        self.periodicity = (*periodicity, *(missing_dim * (False,)))
 
         self.gamma = self.parameters.get("gamma", 5.0 / 3.0)
 

--- a/yt/frontends/athena/data_structures.py
+++ b/yt/frontends/athena/data_structures.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from yt.data_objects.index_subobjects.grid_patch import AMRGridPatch
 from yt.data_objects.static_output import Dataset
-from yt.funcs import ensure_tuple, mylog, sglob
+from yt.funcs import mylog, sglob
 from yt.geometry.geometry_handler import YTDataChunk
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.utilities.chemical_formulas import default_mu
@@ -591,14 +591,9 @@ class AthenaDataset(Dataset):
         self.num_ghost_zones = 0
         self.field_ordering = "fortran"
         self.boundary_conditions = [1] * 6
-        if "periodicity" in self.specified_parameters:
-            self.periodicity = ensure_tuple(self.specified_parameters["periodicity"])
-        else:
-            self.periodicity = (
-                True,
-                True,
-                True,
-            )
+        self.periodicity = tuple(
+            self.specified_parameters.get("periodicity", (True, True, True))
+        )
         if "gamma" in self.specified_parameters:
             self.gamma = float(self.specified_parameters["gamma"])
         else:

--- a/yt/frontends/athena_pp/data_structures.py
+++ b/yt/frontends/athena_pp/data_structures.py
@@ -7,7 +7,7 @@ import numpy as np
 from yt.data_objects.index_subobjects.grid_patch import AMRGridPatch
 from yt.data_objects.index_subobjects.unstructured_mesh import SemiStructuredMesh
 from yt.data_objects.static_output import Dataset
-from yt.funcs import ensure_tuple, get_pbar, mylog
+from yt.funcs import get_pbar, mylog
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.geometry.unstructured_mesh_handler import UnstructuredIndex
 from yt.utilities.chemical_formulas import default_mu
@@ -331,10 +331,9 @@ class AthenaPPDataset(Dataset):
         self.num_ghost_zones = 0
         self.field_ordering = "fortran"
         self.boundary_conditions = [1] * 6
-        if "periodicity" in self.specified_parameters:
-            self.periodicity = ensure_tuple(self.specified_parameters["periodicity"])
-        else:
-            self.periodicity = (True, True, True)
+        self.periodicity = tuple(
+            self.specified_parameters.get("periodicity", (True, True, True))
+        )
         if "gamma" in self.specified_parameters:
             self.gamma = float(self.specified_parameters["gamma"])
         else:

--- a/yt/frontends/enzo/data_structures.py
+++ b/yt/frontends/enzo/data_structures.py
@@ -12,7 +12,7 @@ from yt.data_objects.index_subobjects.grid_patch import AMRGridPatch
 from yt.data_objects.static_output import Dataset
 from yt.fields.field_info_container import NullFunc
 from yt.frontends.enzo.misc import cosmology_get_units
-from yt.funcs import ensure_tuple, get_pbar, iter_fields, setdefaultattr
+from yt.funcs import get_pbar, iter_fields, setdefaultattr
 from yt.geometry.geometry_handler import YTDataChunk
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.utilities.logger import ytLogger as mylog
@@ -852,9 +852,7 @@ class EnzoDataset(Dataset):
             else:
                 self.parameters[param] = vals
         self.refine_by = self.parameters["RefineBy"]
-        self.periodicity = ensure_tuple(
-            self.parameters["LeftFaceBoundaryCondition"] == 3
-        )
+        self.periodicity = tuple(self.parameters["LeftFaceBoundaryCondition"] == 3)
         self.dimensionality = self.parameters["TopGridRank"]
         if "MetaDataDatasetUUID" in self.parameters:
             self.unique_identifier = self.parameters["MetaDataDatasetUUID"]
@@ -1030,9 +1028,7 @@ class EnzoDatasetInMemory(EnzoDataset):
         for p, v in self._conversion_override.items():
             self.conversion_factors[p] = v
         self.refine_by = self.parameters["RefineBy"]
-        self.periodicity = ensure_tuple(
-            self.parameters["LeftFaceBoundaryCondition"] == 3
-        )
+        self.periodicity = tuple(self.parameters["LeftFaceBoundaryCondition"] == 3)
         self.dimensionality = self.parameters["TopGridRank"]
         self.domain_dimensions = self.parameters["TopGridDimensions"]
         self.current_time = self.parameters["InitialTime"]

--- a/yt/frontends/enzo/data_structures.py
+++ b/yt/frontends/enzo/data_structures.py
@@ -7,6 +7,7 @@ import weakref
 from collections import defaultdict
 
 import numpy as np
+from more_itertools import always_iterable
 
 from yt.data_objects.index_subobjects.grid_patch import AMRGridPatch
 from yt.data_objects.static_output import Dataset
@@ -852,7 +853,9 @@ class EnzoDataset(Dataset):
             else:
                 self.parameters[param] = vals
         self.refine_by = self.parameters["RefineBy"]
-        self.periodicity = 3 * (self.parameters["LeftFaceBoundaryCondition"] == 3,)
+        self.periodicity = tuple(
+            always_iterable(self.parameters["LeftFaceBoundaryCondition"] == 3)
+        )
         self.dimensionality = self.parameters["TopGridRank"]
         if "MetaDataDatasetUUID" in self.parameters:
             self.unique_identifier = self.parameters["MetaDataDatasetUUID"]
@@ -1028,7 +1031,9 @@ class EnzoDatasetInMemory(EnzoDataset):
         for p, v in self._conversion_override.items():
             self.conversion_factors[p] = v
         self.refine_by = self.parameters["RefineBy"]
-        self.periodicity = 3 * (self.parameters["LeftFaceBoundaryCondition"] == 3,)
+        self.periodicity = tuple(
+            always_iterable(self.parameters["LeftFaceBoundaryCondition"] == 3)
+        )
         self.dimensionality = self.parameters["TopGridRank"]
         self.domain_dimensions = self.parameters["TopGridDimensions"]
         self.current_time = self.parameters["InitialTime"]

--- a/yt/frontends/enzo/data_structures.py
+++ b/yt/frontends/enzo/data_structures.py
@@ -852,7 +852,7 @@ class EnzoDataset(Dataset):
             else:
                 self.parameters[param] = vals
         self.refine_by = self.parameters["RefineBy"]
-        self.periodicity = tuple(self.parameters["LeftFaceBoundaryCondition"] == 3)
+        self.periodicity = 3 * (self.parameters["LeftFaceBoundaryCondition"] == 3,)
         self.dimensionality = self.parameters["TopGridRank"]
         if "MetaDataDatasetUUID" in self.parameters:
             self.unique_identifier = self.parameters["MetaDataDatasetUUID"]
@@ -1028,7 +1028,7 @@ class EnzoDatasetInMemory(EnzoDataset):
         for p, v in self._conversion_override.items():
             self.conversion_factors[p] = v
         self.refine_by = self.parameters["RefineBy"]
-        self.periodicity = tuple(self.parameters["LeftFaceBoundaryCondition"] == 3)
+        self.periodicity = 3 * (self.parameters["LeftFaceBoundaryCondition"] == 3,)
         self.dimensionality = self.parameters["TopGridRank"]
         self.domain_dimensions = self.parameters["TopGridDimensions"]
         self.current_time = self.parameters["InitialTime"]

--- a/yt/frontends/enzo_p/data_structures.py
+++ b/yt/frontends/enzo_p/data_structures.py
@@ -17,7 +17,7 @@ from yt.frontends.enzo_p.misc import (
     is_parent,
     nested_dict_get,
 )
-from yt.funcs import ensure_tuple, get_pbar, setdefaultattr
+from yt.funcs import get_pbar, setdefaultattr
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.utilities.cosmology import Cosmology
 from yt.utilities.logger import ytLogger as mylog
@@ -351,7 +351,7 @@ class EnzoPDataset(Dataset):
         root_blocks = get_root_blocks(b0)
         f.close()
         self.dimensionality = left0.size
-        self.periodicity = ensure_tuple(np.ones(self.dimensionality, dtype=bool))
+        self.periodicity = tuple(np.ones(self.dimensionality, dtype=bool))
 
         lcfn = self.parameter_filename[: -len(self._suffix)] + ".libconfig"
         if os.path.exists(lcfn):

--- a/yt/frontends/gdf/data_structures.py
+++ b/yt/frontends/gdf/data_structures.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from yt.data_objects.index_subobjects.grid_patch import AMRGridPatch
 from yt.data_objects.static_output import Dataset
-from yt.funcs import ensure_tuple, just_one, setdefaultattr
+from yt.funcs import just_one, setdefaultattr
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.units.dimensions import dimensionless as sympy_one
 from yt.units.unit_object import Unit
@@ -264,8 +264,7 @@ class GDFDataset(Dataset):
         self.num_ghost_zones = sp["num_ghost_zones"]
         self.field_ordering = sp["field_ordering"]
         self.boundary_conditions = sp["boundary_conditions"][:]
-        p = [bnd == 0 for bnd in self.boundary_conditions[::2]]
-        self.periodicity = ensure_tuple(p)
+        self.periodicity = tuple(bnd == 0 for bnd in self.boundary_conditions[::2])
         if self.cosmological_simulation:
             self.current_redshift = sp["current_redshift"]
             self.omega_lambda = sp["omega_lambda"]

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -96,15 +96,6 @@ def ensure_numpy_array(obj):
         return np.asarray([obj])
 
 
-def ensure_tuple(obj):
-    """
-    This function ensures that *obj* is a tuple. Typically used to convert
-    scalar, list, or array arguments specified by a user in a context where
-    we assume a tuple internally
-    """
-    return tuple(always_iterable(obj))
-
-
 def read_struct(f, fmt):
     """
     This reads a struct, and only that struct, from an open file.


### PR DESCRIPTION
## PR Summary

This is a follow up to #2893.
`ensure_tuple` is only used to sanitize `Dataset.periodicity` attributes in a such a fashion that it doesn't make any difference to use builtin tuple conversion. Hence, the function serves no purpose anymore and can be removed.