### PR TITLE
boxlib: Fix _read_header for 2D data

### DIFF
--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -1408,7 +1408,7 @@ def _read_header(raw_file, field):
 
             if nghost is None:
                 try:
-                    nghost = np.array(len(lo_corner)*[ng])
+                    nghost = np.array(len(lo_corner) * [ng])
                 except NameError:
                     # If lo_corner is not defined.
                     # Will this ever happen?

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -1387,14 +1387,10 @@ def _read_header(raw_file, field):
             f.readline()  # version
             f.readline()  # how
             f.readline()  # ncomp
-            nghost_lines = f.readline().strip().split()
-            try:
-                ng = int(nghost_lines[0])
-                # nghost will be set below after the number of dimensions is determined
-                nghost = None
-            except ValueError:
-                nghosts = nghost_lines[0][1:-1].split(",")
-                nghost = np.array([int(ng) for ng in nghosts])
+
+            # nghost_line will be parsed below after the number of dimensions is determined
+            nghost_line = f.readline().strip().split()
+
             f.readline()  # num boxes
 
             # read boxes
@@ -1406,13 +1402,15 @@ def _read_header(raw_file, field):
                 lo_corner, hi_corner, node_type = _line_to_numpy_arrays(clean_line)
                 boxes.append((lo_corner, hi_corner, node_type))
 
-            if nghost is None:
-                try:
-                    nghost = np.array(len(lo_corner) * [ng])
-                except NameError:
-                    # If lo_corner is not defined.
-                    # Will this ever happen?
-                    nghost = np.array([ng, ng, ng])
+            try:
+                # nghost_line is a single number
+                ng = int(nghost_line[0])
+                ndims = len(lo_corner)
+                nghost = np.array(ndims * [ng])
+            except ValueError:
+                # nghost_line is (#,#,#)
+                nghost_list = nghost_line[0][1:-1].split(",")
+                nghost = np.array([int(ng) for ng in nghost_list])
 
             # read the file and offset position for the corresponding box
             file_names = []

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -1404,14 +1404,14 @@ def _read_header(raw_file, field):
                 boxes.append((lo_corner, hi_corner, node_type))
 
             try:
-                # nghost_line is a single number
+                # nghost_line[0] is a single number
                 ng = int(nghost_line[0])
                 ndims = len(lo_corner)
                 nghost = np.array(ndims * [ng])
             except ValueError:
-                # nghost_line is (#,#,#)
-                nghost_list = nghost_line[0][1:-1].split(",")
-                nghost = np.array([int(ng) for ng in nghost_list])
+                # nghost_line[0] is (#,#,#)
+                nghost_list = nghost_line[0].strip("()").split(",")
+                nghost = np.array(nghost_list, dtype=int)
 
             # read the file and offset position for the corresponding box
             file_names = []

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -1390,7 +1390,8 @@ def _read_header(raw_file, field):
             nghost_lines = f.readline().strip().split()
             try:
                 ng = int(nghost_lines[0])
-                nghost = np.array([ng, ng, ng])
+                # nghost will be set below after the number of dimensions is determined
+                nghost = None
             except ValueError:
                 nghosts = nghost_lines[0][1:-1].split(",")
                 nghost = np.array([int(ng) for ng in nghosts])
@@ -1404,6 +1405,14 @@ def _read_header(raw_file, field):
                     break
                 lo_corner, hi_corner, node_type = _line_to_numpy_arrays(clean_line)
                 boxes.append((lo_corner, hi_corner, node_type))
+
+            if nghost is None:
+                try:
+                    nghost = np.array(len(lo_corner)*[ng])
+                except NameError:
+                    # If lo_corner is not defined.
+                    # Will this ever happen?
+                    nghost = np.array([ng, ng, ng])
 
             # read the file and offset position for the corresponding box
             file_names = []

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -1388,7 +1388,8 @@ def _read_header(raw_file, field):
             f.readline()  # how
             f.readline()  # ncomp
 
-            # nghost_line will be parsed below after the number of dimensions is determined
+            # nghost_line will be parsed below after the number of dimensions
+            # is determined when the boxes are read in
             nghost_line = f.readline().strip().split()
 
             f.readline()  # num boxes


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of master, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

When reading in raw data from a WarpX plot file for a 2D run, at line 76 of the routine _read_raw_field in boxlib/io.py it does box[0] - nghost, but box[0] is length 2 and nghost is length 3, raising an error. nghost is length 3 when it was set in _read_header in boxlib/data_structures.py since it is nghost = [ng, ng, ng]. This fix checks the number of dimensions and instead sets nghost accordingly.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] pass `black --check yt/`
- [x] pass `isort . --check --diff`
- [x] pass `flake8 yt/`
- [ ] pass `flynt yt/ --fail-on-change --dry-run -e yt/extern`
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
