### PR TITLE
[BUGFIX] Fix erroneous warning thrown when loading Ramses dataset

### DIFF
--- a/yt/frontends/ramses/field_handlers.py
+++ b/yt/frontends/ramses/field_handlers.py
@@ -462,7 +462,7 @@ class GravFieldFileHandler(FieldFileHandler):
 
         if nvar == ndim + 1:
             fields = ["potential"] + [f"{k}-acceleration" for k in "xyz"[:ndim]]
-            ndetected = ndim
+            ndetected = ndim + 1
         else:
             fields = [f"{k}-acceleration" for k in "xyz"[:ndim]]
             ndetected = ndim

--- a/yt/frontends/ramses/field_handlers.py
+++ b/yt/frontends/ramses/field_handlers.py
@@ -462,10 +462,9 @@ class GravFieldFileHandler(FieldFileHandler):
 
         if nvar == ndim + 1:
             fields = ["potential"] + [f"{k}-acceleration" for k in "xyz"[:ndim]]
-            ndetected = ndim + 1
         else:
             fields = [f"{k}-acceleration" for k in "xyz"[:ndim]]
-            ndetected = ndim
+        ndetected = len(fields)
 
         if ndetected != nvar and not ds._warned_extra_fields["gravity"]:
             mylog.warning("Detected %s extra gravity fields.", nvar - ndetected)


### PR DESCRIPTION
## PR Summary

The RAMSES frontend was erroneously reporting a warning when reading gravity files because of a simple typo. This is not a bug _per se_, just a minor inconvenience.

Thanks to Aniket Bhagwat for reporting it!

## PR Checklist

- [x] pass `black --check yt/`
- [x] pass `isort . --check --diff`
- [x] pass `flake8 yt/`
- [x] pass `flynt yt/ --fail-on-change --dry-run`
- [x] Adds a test for any bugs fixed. Adds tests for new features.