### PR TITLE
[BUGFIX] RAMSES: Fix creation of photon flux

### DIFF
--- a/yt/frontends/ramses/fields.py
+++ b/yt/frontends/ramses/fields.py
@@ -312,9 +312,9 @@ class RAMSESFieldInfo(FieldInfoContainer):
 
             return _photon_flux
 
-        flux_unit = str(
+        flux_unit = (
             1 / self.ds.unit_system["time"] / self.ds.unit_system["length"] ** 2
-        )
+        ).units
         for key in "xyz":
             for igroup in range(ngroups):
                 self.add_field(

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -194,6 +194,12 @@ def test_ramses_rt():
         assert field in ds.derived_field_list
         ad[field]
 
+    # Test the creation of rt fields
+    rt_fields = [("rt", "photon_density_1")] + [("rt", f"photon_flux_{d}_1") for d in "xyz"]
+    for field in rt_fields:
+        assert field in ds.derived_field_list
+        ad[field]
+
 
 ramses_sink = "ramses_sink_00016/output_00016/info_00016.txt"
 

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -195,7 +195,9 @@ def test_ramses_rt():
         ad[field]
 
     # Test the creation of rt fields
-    rt_fields = [("rt", "photon_density_1")] + [("rt", f"photon_flux_{d}_1") for d in "xyz"]
+    rt_fields = [("rt", "photon_density_1")] + [
+        ("rt", f"photon_flux_{d}_1") for d in "xyz"
+    ]
     for field in rt_fields:
         assert field in ds.derived_field_list
         ad[field]


### PR DESCRIPTION
## PR Summary

This is a followup on issues reported by Aniket Bhagwat with RAMSES-rt support.
This fixes the erroneous units set for the photon flux density.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] pass `black --check yt/`
- [x] pass `isort . --check --diff`
- [x] pass `flake8 yt/`
- [x] pass `flynt yt/ --fail-on-change --dry-run`
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
