### PR TITLE
[BUGFIX] Fix figure width in HTML output

### DIFF
--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -582,7 +582,7 @@ class PlotContainer:
         for field in self.plots:
             img = base64.b64encode(self.plots[field]._repr_png_()).decode()
             ret += (
-                r'<img style="max-width:100%%;max-height:100%%;" '
+                r'<img style="max-width:100%;max-height:100%;" '
                 r'src="data:image/png;base64,{0}"><br>'.format(img)
             )
         return ret

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -379,7 +379,7 @@ class ProfilePlot:
                 img = plot._repr_png_()
             img = base64.b64encode(img).decode()
             ret += (
-                r'<img style="max-width:100%%;max-height:100%%;" '
+                r'<img style="max-width:100%;max-height:100%;" '
                 r'src="data:image/png;base64,{0}"><br>'.format(img)
             )
         return ret


### PR DESCRIPTION
## PR Summary
There is a minor mistake in the HTML representation of images that prevents the max-width to be correctly set to "100%". This PR fixes it.
