### PR TITLE
Dead code detection: now with pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,3 +49,7 @@ repos:
     hooks:
     -   id: blacken-docs
         additional_dependencies: [black==20.8b1]
+-   repo: https://github.com/jendrikseipp/vulture
+    rev: v2.3
+    hooks:
+    - id: vulture

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,3 +73,9 @@ addopts = '''
     --ignore='yt/frontends/owls_subfind/tests/test_outputs.py'
     --ignore='yt/frontends/ramses/tests/test_outputs.py'
 '''
+
+[tool.vulture]
+paths = ["yt"]
+# incrementaly lower this value to 90, 80 ... to report larger
+# amounts of unused code that is harder to qualify as such
+min_confidence = 100

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -2636,7 +2636,6 @@ class YTOctree(YTSelectionContainer3D):
         over_refine_factor=1,
         density_factor=1,
         ptypes=None,
-        force_build=False,
         ds=None,
         field_parameters=None,
     ):

--- a/yt/data_objects/level_sets/contour_finder.py
+++ b/yt/data_objects/level_sets/contour_finder.py
@@ -12,7 +12,7 @@ from yt.utilities.lib.contour_finding import (
 from yt.utilities.lib.partitioned_grid import PartitionedGrid
 
 
-def identify_contours(data_source, field, min_val, max_val, cached_fields=None):
+def identify_contours(data_source, field, min_val, max_val):
     tree = ContourTree()
     gct = TileContourTree(min_val, max_val)
     total_contours = 0

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -70,7 +70,7 @@ class MutableAttribute:
         self.data = weakref.WeakKeyDictionary()
         self.display_array = display_array
 
-    def __get__(self, instance, owner):
+    def __get__(self, instance, _owner):
         if not instance:
             return None
         ret = self.data.get(instance, None)
@@ -393,7 +393,7 @@ class Dataset(abc.ABC):
         return False
 
     @classmethod
-    def _guess_candidates(cls, base, directories, files):
+    def _guess_candidates(cls, _base, _files):
         """
         This is a class method that accepts a directory (base), a list of files
         in that directory, and a list of subdirectories.  It should return a
@@ -403,10 +403,13 @@ class Dataset(abc.ABC):
         This function doesn't need to catch all possibilities, nor does it need
         to filter possibilities.
         """
+        # arguments named should be prefixed by a '_' if and only if they are not used
+        # in the function's body
         return [], True
 
     def close(self):
-        pass
+        # This is implemented in some subclasses, but is not required.
+        mylog.debug("Calling Dataset.close() has no effect.")
 
     def __getitem__(self, key):
         """ Returns units, parameters, or conversion_factors in that order. """
@@ -1650,7 +1653,11 @@ class Dataset(abc.ABC):
         return ("deposit", field_name)
 
     def add_smoothed_particle_field(
-        self, smooth_field, method="volume_weighted", nneighbors=64, kernel_name="cubic"
+        self,
+        _smooth_field,
+        _method="volume_weighted",
+        _nneighbors=64,
+        _kernel_name="cubic",
     ):
         """Add a new smoothed particle field
 

--- a/yt/fields/field_detector.py
+++ b/yt/fields/field_detector.py
@@ -66,7 +66,7 @@ class FieldDetector(defaultdict):
 
         class fake_index:
             class fake_io:
-                def _read_data_set(io_self, data, field):
+                def _read_data_set(_grid, field):
                     return self._read_data(field)
 
                 _read_exception = RuntimeError

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -400,7 +400,7 @@ class FieldInfoContainer(dict):
             only_on_root(mylog.debug, "Loaded %s (%s new fields)", n, len(loaded))
         self.find_dependencies(loaded)
 
-    def load_plugin(self, plugin_name, ftype="gas", skip_check=False):
+    def load_plugin(self, plugin_name, ftype="gas"):
         if callable(plugin_name):
             f = plugin_name
         else:

--- a/yt/fields/particle_fields.py
+++ b/yt/fields/particle_fields.py
@@ -794,33 +794,6 @@ def add_particle_average(
     return fn
 
 
-def add_volume_weighted_smoothed_field(
-    ptype,
-    coord_name,
-    mass_name,
-    smoothing_length_name,
-    density_name,
-    smoothed_field,
-    registry,
-    nneighbors=64,
-    kernel_name="cubic",
-):
-    from yt._maintenance.deprecation import issue_deprecation_warning
-
-    issue_deprecation_warning(
-        "This function is deprecated. "
-        "Since yt-4.0, it's no longer necessary to add a field specifically for "
-        "smoothing, because the global octree is removed. The old behavior of "
-        "interpolating onto a grid structure can be recovered through data objects "
-        "like ds.arbitrary_grid, ds.covering_grid, and most closely ds.octree. The "
-        "visualization machinery now treats SPH fields properly by smoothing onto "
-        "pixel locations. See this page to learn more: "
-        "https://yt-project.org/doc/yt4differences.html",
-        since="4.0.0",
-        removal="4.1.0",
-    )
-
-
 def add_nearest_neighbor_field(ptype, coord_name, registry, nneighbors=64):
     field_name = (ptype, f"nearest_neighbor_distance_{nneighbors}")
 

--- a/yt/frontends/arepo/io.py
+++ b/yt/frontends/arepo/io.py
@@ -11,7 +11,7 @@ class IOHandlerArepoHDF5(IOHandlerGadgetHDF5):
         # This is handled below in _get_smoothing_length
         return
 
-    def _get_smoothing_length(self, data_file, position_dtype, position_shape):
+    def _get_smoothing_length(self, data_file, position_dtype, _position_shape):
         ptype = self.ds._sph_ptypes[0]
         ind = int(ptype[-1])
         si, ei = data_file.start, data_file.end

--- a/yt/frontends/athena_pp/io.py
+++ b/yt/frontends/athena_pp/io.py
@@ -27,11 +27,6 @@ class IOHandlerAthenaPP(BaseIOHandler):
         super().__init__(ds)
         self._handle = ds._handle
 
-    def _read_particles(
-        self, fields_to_read, type, args, grid_list, count_list, conv_factors
-    ):
-        pass
-
     def _read_fluid_selection(self, chunks, selector, fields, size):
         chunks = list(chunks)
         if any((ftype != "athena_pp" for ftype, fname in fields)):

--- a/yt/frontends/enzo/data_structures.py
+++ b/yt/frontends/enzo/data_structures.py
@@ -987,7 +987,7 @@ class EnzoDataset(Dataset):
         return os.path.exists(f"{filename}.hierarchy")
 
     @classmethod
-    def _guess_candidates(cls, base, directories, files):
+    def _guess_candidates(cls, base, files):
         candidates = [
             _
             for _ in files

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -537,7 +537,7 @@ class FITSDataset(Dataset):
             return True
 
     @classmethod
-    def _guess_candidates(cls, base, directories, files):
+    def _guess_candidates(cls, base, files):
         candidates = []
         for fn, fnl in ((_, _.lower()) for _ in files):
             if (

--- a/yt/frontends/fits/io.py
+++ b/yt/frontends/fits/io.py
@@ -13,11 +13,6 @@ class IOHandlerFITS(BaseIOHandler):
         self.ds = ds
         self._handle = ds._handle
 
-    def _read_particles(
-        self, fields_to_read, type, args, grid_list, count_list, conv_factors
-    ):
-        pass
-
     def _read_particle_coords(self, chunks, ptf):
         pdata = self.ds._handle[self.ds.first_image].data
         assert len(ptf) == 1

--- a/yt/frontends/flash/data_structures.py
+++ b/yt/frontends/flash/data_structures.py
@@ -464,7 +464,7 @@ class FLASHDataset(Dataset):
         return False
 
     @classmethod
-    def _guess_candidates(cls, base, directories, files):
+    def _guess_candidates(cls, base, files):
         candidates = [
             _ for _ in files if ("_hdf5_plt_cnt_" in _) or ("_hdf5_chk_" in _)
         ]
@@ -535,7 +535,7 @@ class FLASHParticleDataset(FLASHDataset):
         return False
 
     @classmethod
-    def _guess_candidates(cls, base, directories, files):
+    def _guess_candidates(cls, base, files):
         candidates = [_ for _ in files if "_hdf5_part_" in _]
         # Typically, Flash won't have nested outputs.
         return candidates, (len(candidates) == 0)

--- a/yt/frontends/flash/io.py
+++ b/yt/frontends/flash/io.py
@@ -43,11 +43,6 @@ class IOHandlerFLASH(BaseIOHandler):
         self._particle_handle = ds._particle_handle
         self._particle_fields = determine_particle_fields(self._particle_handle)
 
-    def _read_particles(
-        self, fields_to_read, type, args, grid_list, count_list, conv_factors
-    ):
-        pass
-
     def io_iter(self, chunks, fields):
         f = self._handle
         for chunk in chunks:

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -138,7 +138,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
                 end = min(ei, d.size) + offsets[fn]
                 d[si:ei] = hsml[begin:end]
 
-    def _get_smoothing_length(self, data_file, position_dtype, position_shape):
+    def _get_smoothing_length(self, data_file, position_dtype, _position_shape):
         ptype = self.ds._sph_ptypes[0]
         si, ei = data_file.start, data_file.end
         if self.ds.gen_hsmls:
@@ -455,7 +455,7 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
                 pp.shape = (count, 3)
                 yield ptype, pp
 
-    def _get_smoothing_length(self, data_file, position_dtype, position_shape):
+    def _get_smoothing_length(self, data_file, position_dtype, _position_shape):
         ret = self._get_field(data_file, "SmoothingLength", "Gas")
         if position_dtype is not None and ret.dtype != position_dtype:
             # Sometimes positions are stored in double precision

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -393,15 +393,15 @@ def is_root():
 #
 
 
-def signal_print_traceback(signo, frame):
+def signal_print_traceback(_signo, frame):
     print(traceback.print_stack(frame))
 
 
-def signal_problem(signo, frame):
+def signal_problem(_signo, _frame):
     raise RuntimeError()
 
 
-def signal_ipython(signo, frame):
+def signal_ipython(_signo, _frame):
     insert_ipython(2)
 
 

--- a/yt/startup_tasks.py
+++ b/yt/startup_tasks.py
@@ -54,7 +54,7 @@ except (ValueError, RuntimeError, AttributeError):  # Not in main thread
 
 
 class SetExceptionHandling(argparse.Action):
-    def __call__(self, parser, namespace, values, option_string=None):
+    def __call__(self, parser, namespace, values, _option_string=None):
         # If we recognize one of the arguments on the command line as indicating a
         # different mechanism for handling tracebacks, we attach one of those handlers
         # and remove the argument from sys.argv.
@@ -76,7 +76,7 @@ class SetExceptionHandling(argparse.Action):
 
 
 class SetConfigOption(argparse.Action):
-    def __call__(self, parser, namespace, values, option_string=None):
+    def __call__(self, parser, namespace, values, _option_string):
         param, val = values.split("=")
         mylog.debug("Overriding config: %s = %s", param, val)
         ytcfg["yt", param] = val

--- a/yt/utilities/answer_testing/utils.py
+++ b/yt/utilities/answer_testing/utils.py
@@ -267,32 +267,6 @@ def _handle_hashes(save_dir_name, fname, hashes, answer_store):
         _compare_result(hashes, answer_file)
 
 
-def _save_arrays(save_dir_name, fbasename, arrays, answer_store):
-    r"""
-    Driver routine for either saving the raw arrays resulting from the
-    tests, or compare them to previously saved results.
-
-    Parameters
-    ----------
-    save_dir_name : str
-        Name of the directory to save results or where results are
-        already saved.
-
-    fbasename : str
-        Base name (no extension) of the file to either save results
-        to or where results are already saved.
-
-    arrays : dict
-        The raw arrays generated from the tests, with the test name
-        as a key.
-
-    answer_store : bool
-        If true, save the just-generated test results, otherwise,
-        compare them to the previously saved results.
-    """
-    pass
-
-
 def can_run_ds(ds_fn, file_check=False):
     r"""
     Validates whether or not a given input can be loaded and used as a

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -256,7 +256,7 @@ class YTCommand(metaclass=YTCommandSubtype):
 
 
 class GetParameterFiles(argparse.Action):
-    def __call__(self, parser, namespace, values, option_string=None):
+    def __call__(self, _parser, namespace, values, _option_string=None):
         if len(values) == 1:
             datasets = values
         elif len(values) == 2 and namespace.basename is not None:
@@ -1830,7 +1830,7 @@ class YTSearchCmd(YTCommand):
             if args.check_all:
                 candidates.extend([os.path.join(base, _) for _ in files])
             for _, otr in sorted(output_type_registry.items()):
-                c, r = otr._guess_candidates(base, dirs, files)
+                c, r = otr._guess_candidates(base, files)
                 candidates.extend([os.path.join(base, _) for _ in c])
                 recurse.append(r)
             if len(recurse) > 0 and not all(recurse):

--- a/yt/utilities/lib/cykdtree/tests/__init__.py
+++ b/yt/utilities/lib/cykdtree/tests/__init__.py
@@ -61,7 +61,6 @@ def call_subprocess(np, func, args, kwargs):
     if exit_code != 0:
         print(err.decode("utf-8"))
         raise Exception("Error on spawned process. See output.")
-        return None
     return output.decode("utf-8")
 
 

--- a/yt/utilities/parallel_tools/parallel_analysis_interface.py
+++ b/yt/utilities/parallel_tools/parallel_analysis_interface.py
@@ -861,7 +861,7 @@ class Communicator:
             data = self.comm.bcast(data, root=root)
             return data
 
-    def preload(self, grids, fields, io_handler):
+    def preload(self, _grids, _fields, _io_handler):
         # This is non-functional.
         return
 

--- a/yt/utilities/parameter_file_storage.py
+++ b/yt/utilities/parameter_file_storage.py
@@ -48,7 +48,7 @@ class ParameterFileStore:
         self.__dict__ = cls._shared_state
         return self
 
-    def __init__(self, in_memory=False):
+    def __init__(self):
         """
         Create the dataset database if yt is configured to store them.
         Otherwise, use read-only settings.


### PR DESCRIPTION
## PR Summary

This is a revamp of #2973, using the newly defined pre-commit hook from vulture instead of a harder-to-maintained unique GitHub workflow.

The idea is still to prevent code to rot in place long after it stops being useful.
Important note: vulture doesn't honor noqas too well, but in some situations it reports function arguments as unused that we can't just remove because e.g. they are part of the original signature from the parent class and breaking compatibility is not worth it. The way around this problem is to prefix said argument's names with `_`, which makes vulture happy and is also a common indication for unused arguments. It might still not be satisfactory, but IMHO this is reasonable on the condition that it breaks no existing test.

I also note that vulture has a whitelisting mechanism but I'd rather avoid using it because it requires adding an obscure generated `.py` file to the repo, which is counter productive as the goal here is to de-clutter the project.

~edit: this is currently failing with errors tracing back to lines that are de facto in conflict with  #3007, so I'd rather keep this waiting in line for _that_ PR to be dealt with.~ ✅