### PR TITLE
ENH: uniformize mpl_kwargs

### DIFF
--- a/doc/cheatsheet.tex
+++ b/doc/cheatsheet.tex
@@ -255,7 +255,7 @@ perpendicular to \textit{axis} (specified via 'x', 'y', or 'z') or a normal vect
 
 \subsection{Plot Annotations}
 \settowidth{\MyLen}{\texttt{multicol} }
-Plot callbacks are functions itemized in a registry that is attached to every plot object. They can be accessed and then called like \texttt{ prj.annotate\_velocity(factor=16, normalize=False)}. Most callbacks also accept a \textit{plot\_args} dict that is fed to matplotlib annotator. \\
+Plot callbacks are functions itemized in a registry that is attached to every plot object. They can be accessed and then called like \texttt{ prj.annotate\_velocity(factor=16, normalize=False)}. Most callbacks also accept a \textit{mpl\_kwargs} dict that is fed to matplotlib annotator. \\
 \texttt{velocity(\textit{factor=},\textit{scale=},\textit{scale\_units=}, \textit{normalize=})} \textemdash\ Uses field "x-velocity" to draw quivers\\
 \texttt{magnetic\_field(\textit{factor=},\textit{scale=},\textit{scale\_units=}, \textit{normalize=})} \textemdash\ Uses field "Bx" to draw quivers\\
 \texttt{quiver(\textit{field\_x},\textit{field\_y},\textit{factor=},\textit{scale=},\textit{scale\_units=}, \textit{normalize=})} \\

--- a/doc/source/analyzing/filtering.rst
+++ b/doc/source/analyzing/filtering.rst
@@ -313,7 +313,7 @@ distributed throughout the dataset.
     )
 
     # Mark the center with a big X
-    prj.annotate_marker(center, "x", plot_args={"s": 100})
+    prj.annotate_marker(center, "x", mpl_kwargs={"s": 100})
 
     prj.show()
 

--- a/doc/source/cookbook/annotations.py
+++ b/doc/source/cookbook/annotations.py
@@ -7,12 +7,12 @@ p.annotate_sphere(
     [0.65, 0.38, 0.3],
     radius=(1.5, "Mpc"),
     coord_system="data",
-    circle_args={"color": "green", "linewidth": 4, "linestyle": "dashed"},
+    mpl_kwargs={"color": "green", "linewidth": 4, "linestyle": "dashed"},
 )
-p.annotate_arrow([0.87, 0.59, 0.2], coord_system="data", plot_args={"color": "red"})
+p.annotate_arrow([0.87, 0.59, 0.2], coord_system="data", mpl_kwargs={"color": "red"})
 p.annotate_text([10, 20], "Some halos", coord_system="plot")
 p.annotate_marker(
-    [0.45, 0.1, 0.4], coord_system="data", plot_args={"color": "yellow", "s": 500}
+    [0.45, 0.1, 0.4], coord_system="data", mpl_kwargs={"color": "yellow", "s": 500}
 )
 p.annotate_line([0.2, 0.4], [0.3, 0.9], coord_system="axis")
 p.annotate_timestamp(redshift=True)

--- a/doc/source/cookbook/simple_contour_in_slice.py
+++ b/doc/source/cookbook/simple_contour_in_slice.py
@@ -12,7 +12,7 @@ sp.annotate_contour(
     ncont=3,
     clim=(1e-2, 1e-1),
     label=True,
-    plot_args={"colors": "red", "linewidths": 2},
+    mpl_kwargs={"colors": "red", "linewidths": 2},
 )
 
 # What about some nice temperature contours in blue?
@@ -21,7 +21,7 @@ sp.annotate_contour(
     ncont=3,
     clim=(1e-8, 1e-6),
     label=True,
-    plot_args={"colors": "blue", "linewidths": 2},
+    mpl_kwargs={"colors": "blue", "linewidths": 2},
 )
 
 # This is the plot object.

--- a/doc/source/visualizing/callbacks.rst
+++ b/doc/source/visualizing/callbacks.rst
@@ -79,12 +79,12 @@ of the x-plane (i.e. with axes in the y and z directions):
 
     # Plot marker and text in figure coords
     # N.B. marker will not render outside of axis bounds
-    s.annotate_marker((0.1, 0.2), coord_system="figure", plot_args={"color": "black"})
+    s.annotate_marker((0.1, 0.2), coord_system="figure", mpl_kwargs={"color": "black"})
     s.annotate_text(
         (0.1, 0.2),
         "figure: (0.1, 0.2)",
         coord_system="figure",
-        text_args={"color": "black"},
+        text_kwargs={"color": "black"},
     )
     s.save()
 
@@ -183,7 +183,7 @@ Overplot Arrow
 ~~~~~~~~~~~~~~
 
 .. function:: annotate_arrow(self, pos, length=0.03, coord_system='data', \
-                             plot_args=None)
+                             mpl_kwargs=None)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.ArrowCallback`.)
@@ -198,7 +198,7 @@ Overplot Arrow
 
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
    slc = yt.SlicePlot(ds, "z", ("gas", "density"), width=(10, "kpc"), center="c")
-   slc.annotate_arrow((0.5, 0.5, 0.5), length=0.06, plot_args={"color": "blue"})
+   slc.annotate_arrow((0.5, 0.5, 0.5), length=0.06, mpl_kwargs={"color": "blue"})
    slc.save()
 
 .. _annotate-clumps:
@@ -206,7 +206,7 @@ Overplot Arrow
 Clump Finder Callback
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: annotate_clumps(self, clumps, plot_args=None)
+.. function:: annotate_clumps(self, clumps, mpl_kwargs=None)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.ClumpContourCallback`.)
@@ -243,8 +243,8 @@ Overplot Contours
 ~~~~~~~~~~~~~~~~~
 
 .. function:: annotate_contour(self, field, ncont=5, factor=4, take_log=False,\
-                               clim=None, plot_args=None, label=False, \
-                               text_args=None, data_source=None)
+                               clim=None, mpl_kwargs=None, label=False, \
+                               text_kwargs=None, data_source=None)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.ContourCallback`.)
@@ -272,7 +272,7 @@ Axis-Aligned Data Sources
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. function:: annotate_quiver(self, field_x, field_y, factor=16, scale=None, \
-                              scale_units=None, normalize=False, plot_args=None)
+                              scale_units=None, normalize=False, mpl_kwargs=None)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.QuiverCallback`.)
@@ -283,7 +283,7 @@ Axis-Aligned Data Sources
    ``scale_units``. If ``normalize`` is ``True``, the fields will be scaled by
    their local (in-plane) length, allowing morphological features to be more
    clearly seen for fields with substantial variation in field strength.
-   Additional arguments can be passed to the ``plot_args`` dictionary, see
+   Additional arguments can be passed to the ``mpl_kwargs`` dictionary, see
    matplotlib.axes.Axes.quiver for more info.
 
 .. python-script::
@@ -300,14 +300,14 @@ Axis-Aligned Data Sources
        width=(20, "kpc"),
    )
    p.annotate_quiver(("gas", "velocity_x"), ("gas", "velocity_y"), factor=16,
-                     plot_args={"color": "purple"})
+                     mpl_kwargs={"color": "purple"})
    p.save()
 
 Off-Axis Data Sources
 ^^^^^^^^^^^^^^^^^^^^^
 
 .. function:: annotate_cquiver(self, field_x, field_y, factor=16, scale=None, \
-                               scale_units=None, normalize=False, plot_args=None)
+                               scale_units=None, normalize=False, mpl_kwargs=None)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.CuttingQuiverCallback`.)
@@ -318,7 +318,7 @@ Off-Axis Data Sources
    ``scale_units``. If ``normalize`` is ``True``, the fields will be scaled by
    their local (in-plane) length, allowing morphological features to be more
    clearly seen for fields with substantial variation in field strength.
-   Additional arguments can be passed to the ``plot_args`` dictionary, see
+   Additional arguments can be passed to the ``mpl_kwargs`` dictionary, see
    matplotlib.axes.Axes.quiver for more info.
 
 .. python-script::
@@ -331,7 +331,7 @@ Off-Axis Data Sources
        ("gas", "cutting_plane_velocity_x"),
        ("gas", "cutting_plane_velocity_y"),
        factor=10,
-       plot_args={"color": "orange"},
+       mpl_kwargs={"color": "orange"},
    )
    s.zoom(1.5)
    s.save()
@@ -395,11 +395,11 @@ Overplot Cell Edges
 Overplot Halo Annotations
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: annotate_halos(self, halo_catalog, circle_args=None, \
+.. function:: annotate_halos(self, halo_catalog, mpl_kwargs=None, \
                              width=None, annotate_field=None, \
                              radius_field='virial_radius', \
                              center_field_prefix="particle_position", \
-                             text_args=None, factor=1.0)
+                             text_kwargs=None, factor=1.0)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.HaloCatalogCallback`.)
@@ -450,7 +450,7 @@ Overplot Halo Annotations
 Overplot a Straight Line
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: annotate_line(self, p1, p2, coord_system='data', plot_args=None)
+.. function:: annotate_line(self, p1, p2, coord_system='data', mpl_kwargs=None)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.LinePlotCallback`.)
@@ -475,7 +475,7 @@ Overplot Magnetic Field Quivers
 
 .. function:: annotate_magnetic_field(self, factor=16, scale=None, \
                                       scale_units=None, normalize=False, \
-                                      plot_args=None)
+                                      mpl_kwargs=None)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.MagFieldCallback`.)
@@ -486,7 +486,7 @@ Overplot Magnetic Field Quivers
    magnetic fields will be scaled by their local (in-plane) length, allowing
    morphological features to be more clearly seen for fields with substantial
    variation in field strength. Additional arguments can be passed to the
-   ``plot_args`` dictionary, see matplotlib.axes.Axes.quiver for more info.
+   ``mpl_kwargs`` dictionary, see matplotlib.axes.Axes.quiver for more info.
 
 .. python-script::
 
@@ -501,7 +501,7 @@ Overplot Magnetic Field Quivers
        },
    )
    p = yt.ProjectionPlot(ds, "z", ("gas", "density"), center="c", width=(300, "kpc"))
-   p.annotate_magnetic_field(plot_args={"headlength": 3})
+   p.annotate_magnetic_field(mpl_kwargs={"headlength": 3})
    p.save()
 
 .. _annotate-marker:
@@ -510,7 +510,7 @@ Annotate a Point With a Marker
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. function:: annotate_marker(self, pos, marker='x', coord_system='data', \
-                              plot_args=None)
+                              mpl_kwargs=None)
 
     (This is a proxy for
     :class:`~yt.visualization.plot_modifications.MarkerAnnotateCallback`.)
@@ -523,7 +523,7 @@ Annotate a Point With a Marker
 
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
    s = yt.SlicePlot(ds, "z", ("gas", "density"), center="c", width=(10, "kpc"))
-   s.annotate_marker((-2, -2), coord_system="plot", plot_args={"color": "blue", "s": 500})
+   s.annotate_marker((-2, -2), coord_system="plot", mpl_kwargs={"color": "blue", "s": 500})
    s.save()
 
 .. _annotate-particles:
@@ -572,8 +572,8 @@ To plot only the central particles
 Overplot a Circle on a Plot
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: annotate_sphere(self, center, radius, circle_args=None, \
-                              coord_system='data', text=None, text_args=None)
+.. function:: annotate_sphere(self, center, radius, mpl_kwargs=None, \
+                              coord_system='data', text=None, text_kwargs=None)
 
     (This is a proxy for
     :class:`~yt.visualization.plot_modifications.SphereCallback`.)
@@ -586,7 +586,7 @@ Overplot a Circle on a Plot
 
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
    p = yt.ProjectionPlot(ds, "z", ("gas", "density"), center="c", width=(20, "kpc"))
-   p.annotate_sphere([0.5, 0.5, 0.5], radius=(2, "kpc"), circle_args={"color": "black"})
+   p.annotate_sphere([0.5, 0.5, 0.5], radius=(2, "kpc"), mpl_kwargs={"color": "black"})
    p.save()
 
 .. _annotate-streamlines:
@@ -596,7 +596,7 @@ Overplot Streamlines
 
 .. function:: annotate_streamlines(self, field_x, field_y, factor=16, \
                                    density=1, display_threshold=None, \
-                                   plot_args=None)
+                                   mpl_kwargs=None)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.StreamlineCallback`.)
@@ -653,13 +653,13 @@ Overplot Text
 ~~~~~~~~~~~~~
 
 .. function:: annotate_text(self, pos, text, coord_system='data', \
-                            text_args=None, inset_box_args=None)
+                            text_kwargs=None, inset_box_kwargs=None)
 
     (This is a proxy for
     :class:`~yt.visualization.plot_modifications.TextLabelCallback`.)
 
     Overplot text on the plot at a specified position. If you desire an inset
-    box around your text, set one with the inset_box_args dictionary
+    box around your text, set one with the inset_box_kwargs dictionary
     keyword.
 
 .. python-script::
@@ -698,7 +698,7 @@ Overplot Quivers for the Velocity Field
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. function:: annotate_velocity(self, factor=16, scale=None, scale_units=None, \
-                                normalize=False, plot_args=None)
+                                normalize=False, mpl_kwargs=None)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.VelocityCallback`.)
@@ -709,7 +709,7 @@ Overplot Quivers for the Velocity Field
    velocity fields will be scaled by their local (in-plane) length, allowing
    morphological features to be more clearly seen for fields with substantial
    variation in field strength. Additional arguments can be passed to the
-   ``plot_args`` dictionary, see matplotlib.axes.Axes.quiver for more info.
+   ``mpl_kwargs`` dictionary, see matplotlib.axes.Axes.quiver for more info.
 
 .. python-script::
 
@@ -717,7 +717,7 @@ Overplot Quivers for the Velocity Field
 
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
    p = yt.SlicePlot(ds, "z", ("gas", "density"), center="m", width=(10, "kpc"))
-   p.annotate_velocity(plot_args={"headwidth": 4})
+   p.annotate_velocity(mpl_kwargs={"headwidth": 4})
    p.save()
 
 .. _annotate-timestamp:
@@ -731,7 +731,7 @@ Add the Current Time and/or Redshift
                                  time_unit=None, time_offset=None, \
                                  redshift_format='z = {redshift:.2f}', \
                                  draw_inset_box=False, coord_system='axis', \
-                                 text_args=None, inset_box_args=None)
+                                 text_kwargs=None, inset_box_kwargs=None)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.TimestampCallback`.)
@@ -762,9 +762,9 @@ Add a Physical Scale Bar
                              unit=None, pos=None, \
                              scale_text_format="{scale} {units}", \
                              max_frac=0.16, min_frac=0.015, \
-                             coord_system='axis', text_args=None, \
-                             size_bar_args=None, draw_inset_box=False, \
-                             inset_box_args=None)
+                             coord_system='axis', text_kwargs=None, \
+                             size_bar_kwargs=None, draw_inset_box=False, \
+                             inset_box_kwargs=None)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.ScaleCallback`.)
@@ -776,9 +776,9 @@ Add a Physical Scale Bar
     specified, an appropriate pair will be determined such that your scale bar
     is never smaller than min_frac or greater than max_frac of your plottable
     axis length.  Additional customization of the scale bar is possible by
-    adjusting the text_args and size_bar_args dictionaries.  The text_args
+    adjusting the text_kwargs and size_bar_kwargs dictionaries.  The text_kwargs
     dictionary accepts matplotlib's font_properties arguments to override
-    the default font_properties for the current plot.  The size_bar_args
+    the default font_properties for the current plot.  The size_bar_kwargs
     dictionary accepts keyword arguments for the AnchoredSizeBar class in
     matplotlib's axes_grid toolkit. Finally, the format of the scale bar text
     can be adjusted using the scale_text_format keyword argument.
@@ -797,7 +797,7 @@ Add a Physical Scale Bar
 Annotate Triangle Facets Callback
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: annotate_triangle_facets(triangle_vertices, plot_args=None)
+.. function:: annotate_triangle_facets(triangle_vertices, mpl_kwargs=None)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.TriangleFacetsCallback`.)
@@ -832,7 +832,7 @@ Annotate Triangle Facets Callback
    points = coords[conn - 1]
 
    # Annotate slice-triangle intersection contours to the plot
-   s.annotate_triangle_facets(points, plot_args={"colors": "black"})
+   s.annotate_triangle_facets(points, mpl_kwargs={"colors": "black"})
    s.save()
 
 .. _annotate-mesh-lines:
@@ -840,7 +840,7 @@ Annotate Triangle Facets Callback
 Annotate Mesh Lines Callback
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: annotate_mesh_lines(plot_args=None)
+.. function:: annotate_mesh_lines(mpl_kwargs=None)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.MeshLinesCallback`.)
@@ -855,7 +855,7 @@ Annotate Mesh Lines Callback
 
    ds = yt.load("MOOSE_sample_data/out.e")
    sl = yt.SlicePlot(ds, "z", ("connect1", "nodal_aux"))
-   sl.annotate_mesh_lines(plot_args={"color": "black"})
+   sl.annotate_mesh_lines(mpl_kwargs={"color": "black"})
    sl.save()
 
 .. _annotate-ray:
@@ -863,7 +863,7 @@ Annotate Mesh Lines Callback
 Overplot the Path of a Ray
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: annotate_ray(ray, plot_args=None)
+.. function:: annotate_ray(ray, mpl_kwargs=None)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.RayCallback`.)

--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -493,11 +493,11 @@ We can also annotate the mesh lines, as follows:
 
    ds = yt.load("MOOSE_sample_data/out.e-s010")
    sl = yt.SlicePlot(ds, "z", ("connect1", "diffused"))
-   sl.annotate_mesh_lines(plot_args={"color": "black"})
+   sl.annotate_mesh_lines(mpl_kwargs={"color": "black"})
    sl.zoom(0.75)
    sl.save()
 
-The ``plot_args`` parameter is a dictionary of keyword arguments that will be passed
+The ``mpl_kwargs`` parameter is a dictionary of keyword arguments that will be passed
 to matplotlib. It can be used to control the mesh line color, thickness, etc...
 
 The above examples all involve 8-node hexahedral mesh elements. Here is another example from

--- a/yt/_maintenance/deprecation.py
+++ b/yt/_maintenance/deprecation.py
@@ -1,5 +1,21 @@
 import warnings
 
+# This is a singleton object meant to be used as a default value for a deprecated
+# argument in a function signature.
+# Its name signals the deprecataion much better than a None and it is helpful to
+# have a clear distinction with None, which is a perfectly fine default value, in particular
+# for mutables.
+#
+# Intended usage:
+#
+# def foo(a, b_new=None, b_old=DEPRECATED_DEFAULT):
+#     if b_old is not DEPRECATED_DEFAULT:
+#         issue_deprecation_warning(...)
+#         # possibly do something else as redirecting the value
+#         # to another arguement, e.g.,
+#         b_new = b_old
+DEPRECATED_DEFAULT = object()
+
 
 class VisibleDeprecationWarning(UserWarning):
     """Visible deprecation warning, adapted from NumPy

--- a/yt/utilities/answer_testing/answer_tests.py
+++ b/yt/utilities/answer_testing/answer_tests.py
@@ -243,13 +243,13 @@ def phase_plot_attribute(
     attr_name,
     attr_args,
     plot_type="PhasePlot",
-    plot_kwargs=None,
+    mpl_kwargs=None,
 ):
-    if plot_kwargs is None:
-        plot_kwargs = {}
+    if mpl_kwargs is None:
+        mpl_kwargs = {}
     data_source = ds_fn.all_data()
     plot = _create_phase_plot_attribute_plot(
-        data_source, x_field, y_field, z_field, plot_type, plot_kwargs
+        data_source, x_field, y_field, z_field, plot_type, mpl_kwargs
     )
     attr = getattr(plot, attr_name)
     attr(*attr_args[0], **attr_args[1])

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -438,15 +438,15 @@ class AnswerTestingTest:
     def compare(self, new_result, old_result):
         raise RuntimeError
 
-    def create_plot(self, ds, plot_type, plot_field, plot_axis, plot_kwargs=None):
+    def create_plot(self, ds, plot_type, plot_field, plot_axis, mpl_kwargs=None):
         # plot_type should be a string
-        # plot_kwargs should be a dict
+        # mpl_kwargs should be a dict
         if plot_type is None:
             raise RuntimeError("Must explicitly request a plot type")
         cls = getattr(pw, plot_type, None)
         if cls is None:
             cls = getattr(particle_plots, plot_type)
-        plot = cls(*(ds, plot_axis, plot_field), **plot_kwargs)
+        plot = cls(*(ds, plot_axis, plot_field), **mpl_kwargs)
         return plot
 
     @property
@@ -941,16 +941,16 @@ class PhasePlotAttributeTest(AnswerTestingTest):
         self.decimals = decimals
 
     def create_plot(
-        self, data_source, x_field, y_field, z_field, plot_type, plot_kwargs=None
+        self, data_source, x_field, y_field, z_field, plot_type, mpl_kwargs=None
     ):
         # plot_type should be a string
-        # plot_kwargs should be a dict
+        # mpl_kwargs should be a dict
         if plot_type is None:
             raise RuntimeError("Must explicitly request a plot type")
         cls = getattr(profile_plotter, plot_type, None)
         if cls is None:
             cls = getattr(particle_plots, plot_type)
-        plot = cls(*(data_source, x_field, y_field, z_field), **plot_kwargs)
+        plot = cls(*(data_source, x_field, y_field, z_field), **mpl_kwargs)
         return plot
 
     def run(self):

--- a/yt/utilities/answer_testing/testing_utilities.py
+++ b/yt/utilities/answer_testing/testing_utilities.py
@@ -486,7 +486,7 @@ def _create_plot_window_attribute_plot(ds, plot_type, field, axis, pkwargs=None)
 
 
 def _create_phase_plot_attribute_plot(
-    data_source, x_field, y_field, z_field, plot_type, plot_kwargs=None
+    data_source, x_field, y_field, z_field, plot_type, mpl_kwargs=None
 ):
     r"""
     Convenience function used in phase_plot_attribute_test.
@@ -508,7 +508,7 @@ def _create_phase_plot_attribute_plot(
     plot_type : string
         Type of plot to make (e.g., SlicePlot).
 
-    plot_kwargs : dict
+    mpl_kwargs : dict
         Any keywords to be passed when creating the plot.
     """
     if plot_type is None:
@@ -516,7 +516,7 @@ def _create_phase_plot_attribute_plot(
     cls = getattr(profile_plotter, plot_type, None)
     if cls is None:
         cls = getattr(particle_plots, plot_type)
-    plot = cls(*(data_source, x_field, y_field, z_field), **plot_kwargs)
+    plot = cls(*(data_source, x_field, y_field, z_field), **mpl_kwargs)
     return plot
 
 

--- a/yt/visualization/tests/test_callbacks.py
+++ b/yt/visualization/tests/test_callbacks.py
@@ -117,10 +117,10 @@ def test_scale_callback():
         p.annotate_scale(corner="upper_right", coeff=10.0, unit="kpc")
         assert_fname(p.save(prefix)[0])
         p = SlicePlot(ds, "x", ("gas", "density"))
-        p.annotate_scale(text_args={"size": 24})
+        p.annotate_scale(text_kwargs={"size": 24})
         assert_fname(p.save(prefix)[0])
         p = SlicePlot(ds, "x", ("gas", "density"))
-        p.annotate_scale(text_args={"font": 24})
+        p.annotate_scale(text_kwargs={"font": 24})
         assert_raises(YTPlotCallbackError)
 
     with _cleanup_fname() as prefix:
@@ -150,7 +150,7 @@ def test_line_callback():
         # Now we'll check a few additional minor things
         p = SlicePlot(ds, "x", ("gas", "density"))
         p.annotate_line(
-            [0.1, 0.1], [0.5, 0.5], coord_system="axis", plot_args={"color": "red"}
+            [0.1, 0.1], [0.5, 0.5], coord_system="axis", mpl_kwargs={"color": "red"}
         )
         p.save(prefix)
 
@@ -186,7 +186,7 @@ def test_ray_callback():
         # Now we'll check a few additional minor things
         p = SlicePlot(ds, "x", ("gas", "density"))
         p.annotate_ray(oray)
-        p.annotate_ray(ray, plot_args={"color": "red"})
+        p.annotate_ray(ray, mpl_kwargs={"color": "red"})
         p.save(prefix)
 
     with _cleanup_fname() as prefix:
@@ -364,7 +364,7 @@ def test_text_callback():
         # Now we'll check a few additional minor things
         p = SlicePlot(ds, "x", ("gas", "density"))
         p.annotate_text(
-            [0.5, 0.5], "dinosaurs!", coord_system="axis", text_args={"color": "red"}
+            [0.5, 0.5], "dinosaurs!", coord_system="axis", text_kwargs={"color": "red"}
         )
         p.save(prefix)
 
@@ -375,7 +375,7 @@ def test_text_callback():
         assert_raises(YTDataTypeUnsupported, p.save, prefix)
         p = ProjectionPlot(ds, "r", ("gas", "density"))
         p.annotate_text(
-            [0.5, 0.5], "dinosaurs!", coord_system="axis", text_args={"color": "red"}
+            [0.5, 0.5], "dinosaurs!", coord_system="axis", text_kwargs={"color": "red"}
         )
         assert_fname(p.save(prefix)[0])
 
@@ -614,9 +614,9 @@ def test_contour_callback():
             factor=8,
             take_log=False,
             clim=(0.4, 0.6),
-            plot_args={"linewidths": 2.0},
+            mpl_kwargs={"linewidths": 2.0},
             label=True,
-            text_args={"fontsize": "x-large"},
+            text_kwargs={"fontsize": "x-large"},
         )
         p.save(prefix)
 
@@ -628,9 +628,9 @@ def test_contour_callback():
             factor=8,
             take_log=False,
             clim=(0.4, 0.6),
-            plot_args={"linewidths": 2.0},
+            mpl_kwargs={"linewidths": 2.0},
             label=True,
-            text_args={"fontsize": "x-large"},
+            text_kwargs={"fontsize": "x-large"},
             data_source=s2,
         )
         p.save(prefix)
@@ -645,8 +645,8 @@ def test_contour_callback():
             take_log=False,
             clim=(1.0e-1, 1.0e1),
             label=True,
-            plot_args={"colors": ("c", "w"), "linewidths": 1},
-            text_args={"fmt": "%1.1f"},
+            mpl_kwargs={"colors": ("c", "w"), "linewidths": 1},
+            text_kwargs={"fmt": "%1.1f"},
         )
         assert_fname(slc.save(prefix)[0])
 
@@ -663,9 +663,9 @@ def test_contour_callback():
             factor=8,
             take_log=False,
             clim=(0.4, 0.6),
-            plot_args={"linewidths": 2.0},
+            mpl_kwargs={"linewidths": 2.0},
             label=True,
-            text_args={"fontsize": "x-large"},
+            text_kwargs={"fontsize": "x-large"},
         )
         assert_raises(YTDataTypeUnsupported, p.save, prefix)
 
@@ -764,13 +764,13 @@ def test_mesh_lines_callback():
         ds = fake_hexahedral_ds()
         for field in ds.field_list:
             sl = SlicePlot(ds, 1, field)
-            sl.annotate_mesh_lines(plot_args={"color": "black"})
+            sl.annotate_mesh_lines(mpl_kwargs={"color": "black"})
             assert_fname(sl.save(prefix)[0])
 
         ds = fake_tetrahedral_ds()
         for field in ds.field_list:
             sl = SlicePlot(ds, 1, field)
-            sl.annotate_mesh_lines(plot_args={"color": "black"})
+            sl.annotate_mesh_lines(mpl_kwargs={"color": "black"})
             assert_fname(sl.save(prefix)[0])
 
 
@@ -823,7 +823,7 @@ def test_streamline_callback():
                 ("gas", "velocity_y"),
                 field_color=("stream", "magvel"),
                 display_threshold=0.5,
-                plot_args={
+                mpl_kwargs={
                     "cmap": ytcfg.get("yt", "default_colormap"),
                     "arrowstyle": "->",
                 },


### PR DESCRIPTION
## PR Summary

This is targeted at fixing  #547
The issue was left as "needing more discussion" 5 years ago, so I'm moving forward with a patch to revive or close it.

Here's the set of rules I'm enforcing throughout plot callbacks:
- dict-type arguments that is designed to pass arbitrary parameters down to a matplotlib object, should be named `mpl_kwargs`
- ... unless it's a text/box object, in which case, in which case it should be named `text_kwargs` and `inset_box_kwargs`
- another exception is `size_bar_kwargs` in scale annotation callback

The main reason for having "exceptions" here is that these arguments are typically used in the same functions so it's still the easiest way to handle them clearly.
Note that a large portion of the names I changed here originally had a `_args` suffix instead of `_kwargs`. I find that `kwargs` is clearer in that it's the de facto convention (in mpl) for passing arbitrary dicts of arguments down.

All changes performed here come with a deprecation warning so this shouldn't break backward compatibility despite the sheer number of them.

As a last note, I went with `mpl_kwargs` as a uniform varname, but `plot_kwargs` would be closer to the pre-existing convention (`plot_args`), I am fine with either, though I think the latter may turn out a little too restrictive, so my personal preference goes to the former.

Related:
- #2564
- #3007 (deprecation cycle)

fix #547