### PR TITLE
idiomatic python upgrade: Python 3.6

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -27,6 +27,7 @@ e6276f25fc5a570d886b6bbdaa7e3062da2d35ca
 
 # auto-fixes from pre-commit
 f3a0720bb713aead0f0d50888f2176d20fe02ef4
+7931b96a90c20d835a4dc96b81019382f9461351
 
 # legacy conversion commits authored by "convert-repo"
 b7112d4ccbcd309ae2c5c2ee0f9352466a0cecf2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,12 +20,12 @@ repos:
     - id: trailing-whitespace
     - id: end-of-file-fixer
     - id: no-commit-to-branch
-# Note that in rare cases, flynt may undo some of the formating from black.
-# A stable configuration is run black last.
--   repo: https://github.com/ikamensh/flynt
-    rev: '0.58'
+
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v2.7.4
     hooks:
-    - id: flynt
+    - id: pyupgrade
+      args: [--py36-plus]
 
 -   repo: https://github.com/ambv/black
     rev: 20.8b1

--- a/conftest.py
+++ b/conftest.py
@@ -62,7 +62,7 @@ def pytest_configure(config):
         os.mkdir(answer_dir)
     # Read the list of answer test classes and their associated answer
     # file
-    with open(answer_file_list, "r") as f:
+    with open(answer_file_list) as f:
         # devnote: this is never used, likely a bug
         answer_files = yaml.safe_load(f)  # noqa F841
     # Register custom marks for answer tests and big data

--- a/doc/extensions/config_help.py
+++ b/doc/extensions/config_help.py
@@ -29,7 +29,7 @@ class GetConfigHelp(Directive):
             .split("\n")
         )
         ind = next(
-            (i for i, val in enumerate(data) if re.match("\s{0,3}\{.*\}\s*$", val))
+            (i for i, val in enumerate(data) if re.match(r"\s{0,3}\{.*\}\s*$", val))
         )
         lines = [".. code-block:: none", ""] + data[ind + 1 :]
         self.state_machine.insert_input(

--- a/doc/helper_scripts/code_support.py
+++ b/doc/helper_scripts/code_support.py
@@ -10,7 +10,7 @@ vals = [
 ]
 
 
-class CodeSupport(object):
+class CodeSupport:
     def __init__(self, **kwargs):
         self.support = {}
         for v in vals:

--- a/doc/helper_scripts/show_fields.py
+++ b/doc/helper_scripts/show_fields.py
@@ -43,7 +43,7 @@ ds.parameters["HydroMethod"] = "streaming"
 ds.parameters["EOSType"] = 1.0
 ds.parameters["EOSSoundSpeed"] = 1.0
 ds.conversion_factors["Time"] = 1.0
-ds.conversion_factors.update(dict((f, 1.0) for f in fields))
+ds.conversion_factors.update({f: 1.0 for f in fields})
 ds.gamma = 5.0 / 3.0
 ds.current_redshift = 0.0001
 ds.cosmological_simulation = 1
@@ -134,7 +134,7 @@ def fix_units(units, in_cgs=False):
     if in_cgs:
         unit_object = unit_object.get_cgs_equivalent()
     latex = unit_object.latex_representation()
-    return latex.replace("\ ", "~")
+    return latex.replace(r"\ ", "~")
 
 
 def print_all_fields(fl):
@@ -194,7 +194,7 @@ class FieldInfo:
         self.units = ""
         u = field[1][0]
         if len(u) > 0:
-            self.units = ":math:`\mathrm{%s}`" % fix_units(u)
+            self.units = r":math:`\mathrm{%s}`" % fix_units(u)
         a = [f"``{f}``" for f in field[1][1] if f]
         self.aliases = " ".join(a)
         self.dname = ""

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # yt documentation build configuration file, created by
 # sphinx-quickstart on Tue Jan 11 09:46:53 2011.

--- a/doc/source/cookbook/particle_filter_sfr.py
+++ b/doc/source/cookbook/particle_filter_sfr.py
@@ -39,5 +39,5 @@ sfr[sfr == 0] = np.nan
 
 plt.plot(time / 1e6, sfr)
 plt.xlabel("Time  [Myr]")
-plt.ylabel("SFR  [M$_\odot$ yr$^{-1}$]")
+plt.ylabel(r"SFR  [M$_\odot$ yr$^{-1}$]")
 plt.savefig("filter_sfr.png")

--- a/doc/source/cookbook/tests/test_cookbook.py
+++ b/doc/source/cookbook/tests/test_cookbook.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Module for cookbook testing
 
 

--- a/tests/nose_runner.py
+++ b/tests/nose_runner.py
@@ -36,7 +36,7 @@ class NoseWorker(multiprocessing.Process):
         return
 
 
-class NoseTask(object):
+class NoseTask:
     def __init__(self, job):
         argv, exclusive = job
         self.argv = argv
@@ -67,7 +67,7 @@ def generate_tasks_input():
     pyver = f"py{sys.version_info.major}{sys.version_info.minor}"
     test_dir = ytcfg.get("yt", "test_data_dir")
     answers_dir = os.path.join(test_dir, "answers")
-    tests = yaml.load(open("tests/tests.yaml", "r"), Loader=yaml.FullLoader)
+    tests = yaml.load(open("tests/tests.yaml"), Loader=yaml.FullLoader)
 
     base_argv = ["-s", "--nologcapture", "--with-xunit"]
 

--- a/tests/report_failed_answers.py
+++ b/tests/report_failed_answers.py
@@ -5,8 +5,6 @@ on cloud platforms like Travis
 """
 
 
-from __future__ import print_function
-
 import argparse
 import base64
 import collections

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -77,7 +77,7 @@ def run_install_script(install_script_path, inst_py3, binary_yt=False):
     msg = "Testing installation with inst_py3={} and binary_yt={}"
     print(msg.format(inst_py3, binary_yt))
     shutil.copy(install_script_path, os.curdir)
-    with open("install_script.sh", "r") as source:
+    with open("install_script.sh") as source:
         with open("install_script_edited.sh", "w") as target:
             data = source.read()
             for dep in OPTIONAL_DEPS:

--- a/yt/config.py
+++ b/yt/config.py
@@ -108,7 +108,7 @@ if not os.path.exists(CURRENT_CONFIG_FILE):
     try:
         with open(CURRENT_CONFIG_FILE, "w") as new_cfg:
             cp.write(new_cfg)
-    except IOError:
+    except OSError:
         warnings.warn("unable to write new config file")
 
 
@@ -120,7 +120,7 @@ class YTConfigParser(configparser.ConfigParser):
         self.get(key[0], key[1])
 
     def get(self, section, option, *args, **kwargs):
-        val = super(YTConfigParser, self).get(section, option, *args, **kwargs)
+        val = super().get(section, option, *args, **kwargs)
         return os.path.expanduser(os.path.expandvars(val))
 
 

--- a/yt/data_objects/analyzer_objects.py
+++ b/yt/data_objects/analyzer_objects.py
@@ -20,7 +20,7 @@ class AnalysisTask:
     def __repr__(self):
         # Stolen from YTDataContainer.__repr__
         s = f"{self.__class__.__name__}: "
-        s += ", ".join(["%s=%s" % (i, getattr(self, i)) for i in self._params])
+        s += ", ".join(["{}={}".format(i, getattr(self, i)) for i in self._params])
         return s
 
 
@@ -68,7 +68,7 @@ class QuantityProxy(AnalysisTask):
         # Stolen from YTDataContainer.__repr__
         s = f"{self.__class__.__name__}: "
         s += ", ".join(["%s" % [arg for arg in self.args]])
-        s += ", ".join(["%s=%s" % (k, v) for k, v in self.kwargs.items()])
+        s += ", ".join([f"{k}={v}" for k, v in self.kwargs.items()])
         return s
 
     def __init__(self, *args, **kwargs):

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -171,7 +171,7 @@ class YTProj(YTSelectionContainer2D):
         field_parameters=None,
         max_level=None,
     ):
-        super(YTProj, self).__init__(axis, ds, field_parameters)
+        super().__init__(axis, ds, field_parameters)
         # Style is deprecated, but if it is set, then it trumps method
         # keyword.  TODO: Remove this keyword and this check at some point in
         # the future.
@@ -381,7 +381,7 @@ class YTParticleProj(YTProj):
         field_parameters=None,
         max_level=None,
     ):
-        super(YTParticleProj, self).__init__(
+        super().__init__(
             field,
             axis,
             weight_field,
@@ -474,7 +474,7 @@ class YTQuadTreeProj(YTProj):
         field_parameters=None,
         max_level=None,
     ):
-        super(YTQuadTreeProj, self).__init__(
+        super().__init__(
             field,
             axis,
             weight_field,
@@ -738,7 +738,7 @@ class YTCoveringGrid(YTSelectionContainer3D):
         return tr
 
     def set_field_parameter(self, name, val):
-        super(YTCoveringGrid, self).set_field_parameter(name, val)
+        super().set_field_parameter(name, val)
         if self._data_source is not None:
             self._data_source.set_field_parameter(name, val)
 
@@ -1299,7 +1299,7 @@ class YTSmoothedCoveringGrid(YTCoveringGrid):
 
     def _setup_data_source(self, level_state=None):
         if level_state is None:
-            super(YTSmoothedCoveringGrid, self)._setup_data_source()
+            super()._setup_data_source()
             return
         # We need a buffer region to allow for zones that contribute to the
         # interpolation but are not directly inside our bounds
@@ -1550,7 +1550,7 @@ class YTSurface(YTSelectionContainer3D):
                 self.field_value = data_source.ds.quan(field_value, finfo.units)
         self.vertex_samples = YTFieldData()
         center = data_source.get_field_parameter("center")
-        super(YTSurface, self).__init__(center=center, ds=ds)
+        super().__init__(center=center, ds=ds)
 
     def _generate_container_field(self, field):
         self.get_data(field)

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -45,7 +45,7 @@ def _get_ipython_key_completion(ds):
     # with earlier versions, completion works with fname only
     # this implementation should work transparently with all IPython versions
     tuple_keys = ds.field_list + ds.derived_field_list
-    fnames = list(set(k[1] for k in tuple_keys))
+    fnames = list({k[1] for k in tuple_keys})
     return tuple_keys + fnames
 
 
@@ -648,12 +648,9 @@ class YTDataContainer:
                     ftypes[g_field] = "grid"
                     data[g_field] = self[g_field]
 
-        extra_attrs = dict(
-            [
-                (arg, getattr(self, arg, None))
-                for arg in self._con_args + self._tds_attrs
-            ]
-        )
+        extra_attrs = {
+            arg: getattr(self, arg, None) for arg in self._con_args + self._tds_attrs
+        }
         extra_attrs["con_args"] = repr(self._con_args)
         extra_attrs["data_type"] = "yt_data_container"
         extra_attrs["container_type"] = self._type_name
@@ -1346,7 +1343,7 @@ class YTDataContainer:
         s = f"{self.__class__.__name__} ({self.ds}): "
         for i in self._con_args:
             try:
-                s += ", %s=%s" % (
+                s += ", {}={}".format(
                     i,
                     getattr(self, i).in_base(unit_system=self.ds.unit_system),
                 )

--- a/yt/data_objects/derived_quantities.py
+++ b/yt/data_objects/derived_quantities.py
@@ -127,7 +127,7 @@ class WeightedAverageQuantity(DerivedQuantity):
 
     def __call__(self, fields, weight):
         fields = list(iter_fields(fields))
-        rv = super(WeightedAverageQuantity, self).__call__(fields, weight)
+        rv = super().__call__(fields, weight)
         if len(rv) == 1:
             rv = rv[0]
         return rv
@@ -166,7 +166,7 @@ class TotalQuantity(DerivedQuantity):
 
     def __call__(self, fields):
         fields = list(iter_fields(fields))
-        rv = super(TotalQuantity, self).__call__(fields)
+        rv = super().__call__(fields)
         if len(rv) == 1:
             rv = rv[0]
         return rv
@@ -198,11 +198,11 @@ class TotalMass(TotalQuantity):
         self.data_source.ds.index
         fi = self.data_source.ds.field_info
         if ("gas", "mass") in fi:
-            gas = super(TotalMass, self).__call__([("gas", "mass")])
+            gas = super().__call__([("gas", "mass")])
         else:
             gas = self.data_source.ds.arr([0], "g")
         if ("nbody", "particle_mass") in fi:
-            part = super(TotalMass, self).__call__([("nbody", "particle_mass")])
+            part = super().__call__([("nbody", "particle_mass")])
         else:
             part = self.data_source.ds.arr([0], "g")
         return self.data_source.ds.arr([gas, part])
@@ -410,7 +410,7 @@ class WeightedVariance(DerivedQuantity):
     def __call__(self, fields, weight):
         fields = list(iter_fields(fields))
         units = [self.data_source.ds._get_field_info(field).units for field in fields]
-        rv = super(WeightedVariance, self).__call__(fields, weight)
+        rv = super().__call__(fields, weight)
         rv = [self.data_source.ds.arr(v, u) for v, u in zip(rv, units)]
         if len(rv) == 1:
             rv = rv[0]
@@ -589,7 +589,7 @@ class Extrema(DerivedQuantity):
 
     def __call__(self, fields, non_zero=False):
         fields = list(iter_fields(fields))
-        rv = super(Extrema, self).__call__(fields, non_zero)
+        rv = super().__call__(fields, non_zero)
         if len(rv) == 1:
             rv = rv[0]
         return rv
@@ -646,7 +646,7 @@ class SampleAtMaxFieldValues(DerivedQuantity):
         self.num_vals = 1 + len(sample_fields)
 
     def __call__(self, field, sample_fields):
-        rv = super(SampleAtMaxFieldValues, self).__call__(field, sample_fields)
+        rv = super().__call__(field, sample_fields)
         if len(rv) == 1:
             rv = rv[0]
         return rv
@@ -693,7 +693,7 @@ class MaxLocation(SampleAtMaxFieldValues):
         # Make sure we have an index
         self.data_source.index
         sample_fields = get_position_fields(field, self.data_source)
-        rv = super(MaxLocation, self).__call__(field, sample_fields)
+        rv = super().__call__(field, sample_fields)
         if len(rv) == 1:
             rv = rv[0]
         return rv
@@ -749,7 +749,7 @@ class MinLocation(SampleAtMinFieldValues):
         # Make sure we have an index
         self.data_source.index
         sample_fields = get_position_fields(field, self.data_source)
-        rv = super(MinLocation, self).__call__(field, sample_fields)
+        rv = super().__call__(field, sample_fields)
         if len(rv) == 1:
             rv = rv[0]
         return rv

--- a/yt/data_objects/image_array.py
+++ b/yt/data_objects/image_array.py
@@ -76,7 +76,7 @@ class ImageArray(YTArray):
         if input_units is not None:
             warnings.warn("'input_units' is deprecated. Please use 'units'.")
             units = input_units
-        obj = super(ImageArray, cls).__new__(
+        obj = super().__new__(
             cls, input_array, units, registry, bypass_validation=bypass_validation
         )
         if info is None:
@@ -86,7 +86,7 @@ class ImageArray(YTArray):
 
     def __array_finalize__(self, obj):
         # see InfoArray.__array_finalize__ for comments
-        super(ImageArray, self).__array_finalize__(obj)
+        super().__array_finalize__(obj)
         self.info = getattr(obj, "info", None)
 
     def write_hdf5(self, filename, dataset_name=None):
@@ -123,9 +123,7 @@ class ImageArray(YTArray):
         """
         if dataset_name is None:
             dataset_name = self.info.get("name", "image")
-        super(ImageArray, self).write_hdf5(
-            filename, dataset_name=dataset_name, info=self.info
-        )
+        super().write_hdf5(filename, dataset_name=dataset_name, info=self.info)
 
     def add_background_color(self, background="black", inline=True):
         r"""Adds a background color to a 4-channel ImageArray

--- a/yt/data_objects/index_subobjects/grid_patch.py
+++ b/yt/data_objects/index_subobjects/grid_patch.py
@@ -43,7 +43,7 @@ class AMRGridPatch(YTSelectionContainer):
     OverlappingSiblings = None
 
     def __init__(self, id, filename=None, index=None):
-        super(AMRGridPatch, self).__init__(index.dataset, None)
+        super().__init__(index.dataset, None)
         self.id = id
         self._child_mask = self._child_indices = self._child_index_mask = None
         self.ds = index.dataset
@@ -74,7 +74,7 @@ class AMRGridPatch(YTSelectionContainer):
         return self.start_index
 
     def __getitem__(self, key):
-        tr = super(AMRGridPatch, self).__getitem__(key)
+        tr = super().__getitem__(key)
         try:
             fields = self._determine_fields(key)
         except YTFieldTypeNotFound:
@@ -154,7 +154,7 @@ class AMRGridPatch(YTSelectionContainer):
         all field parameters.
 
         """
-        super(AMRGridPatch, self).clear_data()
+        super().clear_data()
         self._setup_dx()
 
     def _prepare_grid(self):

--- a/yt/data_objects/index_subobjects/octree_subset.py
+++ b/yt/data_objects/index_subobjects/octree_subset.py
@@ -45,7 +45,7 @@ class OctreeSubset(YTSelectionContainer):
     def __init__(
         self, base_region, domain, ds, over_refine_factor=1, num_ghost_zones=0
     ):
-        super(OctreeSubset, self).__init__(ds, None)
+        super().__init__(ds, None)
         self._num_zones = 1 << (over_refine_factor)
         self._num_ghost_zones = num_ghost_zones
         self._oref = over_refine_factor
@@ -60,7 +60,7 @@ class OctreeSubset(YTSelectionContainer):
         self.base_selector = base_region.selector
 
     def __getitem__(self, key):
-        tr = super(OctreeSubset, self).__getitem__(key)
+        tr = super().__getitem__(key)
         try:
             fields = self._determine_fields(key)
         except YTFieldTypeNotFound:

--- a/yt/data_objects/index_subobjects/unstructured_mesh.py
+++ b/yt/data_objects/index_subobjects/unstructured_mesh.py
@@ -19,7 +19,7 @@ class UnstructuredMesh(YTSelectionContainer):
     def __init__(
         self, mesh_id, filename, connectivity_indices, connectivity_coords, index
     ):
-        super(UnstructuredMesh, self).__init__(index.dataset, None)
+        super().__init__(index.dataset, None)
         self.filename = filename
         self.mesh_id = mesh_id
         # This is where we set up the connectivity information

--- a/yt/data_objects/level_sets/clump_handling.py
+++ b/yt/data_objects/level_sets/clump_handling.py
@@ -153,7 +153,7 @@ class Clump(TreeContainer):
         # Here, cids is the set of slices and values, keyed by the
         # parent_grid_id, that defines the contours.  So we can figure out all
         # the unique values of the contours by examining the list here.
-        unique_contours = set([])
+        unique_contours = set()
         for sl_list in cids.values():
             for _sl, ff in sl_list:
                 unique_contours.update(np.unique(ff))
@@ -187,8 +187,7 @@ class Clump(TreeContainer):
     def __iter__(self):
         yield self
         for child in self.children:
-            for a_node in child:
-                yield a_node
+            yield from child
 
     def save_as_dataset(self, filename=None, fields=None):
         r"""Export clump tree to a reloadable yt dataset.
@@ -256,14 +255,12 @@ class Clump(TreeContainer):
         filename = get_output_filename(filename, keyword, ".h5")
 
         # collect clump info fields
-        clump_info = dict([(ci.name, []) for ci in self.base.clump_info])
+        clump_info = {ci.name: [] for ci in self.base.clump_info}
         clump_info.update(
-            dict(
-                [
-                    (field, [])
-                    for field in ["clump_id", "parent_id", "contour_key", "contour_id"]
-                ]
-            )
+            {
+                field: []
+                for field in ["clump_id", "parent_id", "contour_key", "contour_id"]
+            }
         )
         for clump in self:
             clump_info["clump_id"].append(clump.clump_id)
@@ -290,7 +287,7 @@ class Clump(TreeContainer):
             else:
                 clump_info[ci] = np.array(clump_info[ci])
 
-        ftypes = dict([(ci, "clump") for ci in clump_info])
+        ftypes = {ci: "clump" for ci in clump_info}
 
         # collect data fields
         if fields is not None:

--- a/yt/data_objects/level_sets/contour_finder.py
+++ b/yt/data_objects/level_sets/contour_finder.py
@@ -19,7 +19,7 @@ def identify_contours(data_source, field, min_val, max_val, cached_fields=None):
     contours = {}
     node_ids = []
     DLE = data_source.ds.domain_left_edge
-    masks = dict((g.id, m) for g, m in data_source.blocks)
+    masks = {g.id: m for g, m in data_source.blocks}
     for (g, node, (sl, dims, gi)) in data_source.tiles.slice_traverse():
         g.field_parameters.update(data_source.field_parameters)
         node.node_ind = len(node_ids)

--- a/yt/data_objects/particle_unions.py
+++ b/yt/data_objects/particle_unions.py
@@ -5,4 +5,4 @@ class ParticleUnion(Union):
     _union_type = "particle"
 
     def __init__(self, name, sub_types):
-        super(ParticleUnion, self).__init__(name, sub_types)
+        super().__init__(name, sub_types)

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -381,9 +381,7 @@ been deprecated, use profile.standard_deviation instead."""
         std = "standard_deviation"
         if self.weight_field is not None:
             std_data = getattr(self, std)
-            data.update(
-                dict(((std, field[1]), std_data[field]) for field in self.field_data)
-            )
+            data.update({(std, field[1]): std_data[field] for field in self.field_data})
 
         dimensionality = 0
         bin_data = []
@@ -406,9 +404,9 @@ been deprecated, use profile.standard_deviation instead."""
             data[getattr(self, f"{ax}_field")] = bin_fields[i]
 
         extra_attrs["dimensionality"] = dimensionality
-        ftypes = dict([(field, "data") for field in data if field[0] != std])
+        ftypes = {field: "data" for field in data if field[0] != std}
         if self.weight_field is not None:
-            ftypes.update(dict(((std, field[1]), std) for field in self.field_data))
+            ftypes.update({(std, field[1]): std for field in self.field_data})
         save_as_dataset(
             self.ds, filename, data, field_types=ftypes, extra_attrs=extra_attrs
         )
@@ -492,7 +490,7 @@ class Profile1D(ProfileND):
         weight_field=None,
         override_bins_x=None,
     ):
-        super(Profile1D, self).__init__(data_source, weight_field)
+        super().__init__(data_source, weight_field)
         self.x_field = data_source._determine_fields(x_field)[0]
         self.field_info[self.x_field] = self.data_source.ds.field_info[self.x_field]
         self.x_log = x_log
@@ -730,7 +728,7 @@ class Profile2D(ProfileND):
         override_bins_x=None,
         override_bins_y=None,
     ):
-        super(Profile2D, self).__init__(data_source, weight_field)
+        super().__init__(data_source, weight_field)
         # X
         self.x_field = data_source._determine_fields(x_field)[0]
         self.x_log = x_log
@@ -907,7 +905,7 @@ class ParticleProfile(Profile2D):
 
         # set the log parameters to False (since that doesn't make much sense
         # for deposited data) and also turn off the weight field.
-        super(ParticleProfile, self).__init__(
+        super().__init__(
             data_source,
             x_field,
             x_n,
@@ -1055,7 +1053,7 @@ class Profile3D(ProfileND):
         override_bins_y=None,
         override_bins_z=None,
     ):
-        super(Profile3D, self).__init__(data_source, weight_field)
+        super().__init__(data_source, weight_field)
         # X
         self.x_field = data_source._determine_fields(x_field)[0]
         self.x_log = x_log
@@ -1372,7 +1370,7 @@ def create_profile(
                     field_ex = list(extrema[bin_field])
                 except KeyError:
                     raise RuntimeError(
-                        "Could not find field {0} or {1} in extrema".format(
+                        "Could not find field {} or {} in extrema".format(
                             bin_field[-1], bin_field
                         )
                     ) from e

--- a/yt/data_objects/selection_objects/boolean_operations.py
+++ b/yt/data_objects/selection_objects/boolean_operations.py
@@ -11,7 +11,7 @@ from yt.funcs import validate_object, validate_sequence
 
 
 class YTBooleanContainer(YTSelectionContainer3D):
-    """
+    r"""
     This is a boolean operation, accepting AND, OR, XOR, and NOT for combining
     multiple data objects.
 

--- a/yt/data_objects/selection_objects/cut_region.py
+++ b/yt/data_objects/selection_objects/cut_region.py
@@ -73,7 +73,7 @@ class YTCutRegion(YTSelectionContainer3D):
             self.conditionals = data_source.conditionals + self.conditionals
             data_source = data_source.base_object
 
-        super(YTCutRegion, self).__init__(
+        super().__init__(
             data_source.center, ds, field_parameters, data_source=data_source
         )
         self.base_object = data_source

--- a/yt/data_objects/selection_objects/data_selection_objects.py
+++ b/yt/data_objects/selection_objects/data_selection_objects.py
@@ -44,7 +44,7 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface):
 
     def __init__(self, ds, field_parameters, data_source=None):
         ParallelAnalysisInterface.__init__(self)
-        super(YTSelectionContainer, self).__init__(ds, field_parameters)
+        super().__init__(ds, field_parameters)
         self._data_source = data_source
         if data_source is not None:
             if data_source.ds != self.ds:
@@ -481,7 +481,7 @@ class YTSelectionContainer0D(YTSelectionContainer):
     _dimensionality = 0
 
     def __init__(self, ds, field_parameters=None, data_source=None):
-        super(YTSelectionContainer0D, self).__init__(ds, field_parameters, data_source)
+        super().__init__(ds, field_parameters, data_source)
 
 
 class YTSelectionContainer1D(YTSelectionContainer):
@@ -489,7 +489,7 @@ class YTSelectionContainer1D(YTSelectionContainer):
     _dimensionality = 1
 
     def __init__(self, ds, field_parameters=None, data_source=None):
-        super(YTSelectionContainer1D, self).__init__(ds, field_parameters, data_source)
+        super().__init__(ds, field_parameters, data_source)
         self._grids = None
         self._sortkey = None
         self._sorted = {}
@@ -505,7 +505,7 @@ class YTSelectionContainer2D(YTSelectionContainer):
     _spatial = False
 
     def __init__(self, axis, ds, field_parameters=None, data_source=None):
-        super(YTSelectionContainer2D, self).__init__(ds, field_parameters, data_source)
+        super().__init__(ds, field_parameters, data_source)
         # We need the ds, which will exist by now, for fix_axis.
         self.axis = fix_axis(axis, self.ds)
         self.set_field_parameter("axis", axis)
@@ -649,7 +649,7 @@ class YTSelectionContainer3D(YTSelectionContainer):
     _dimensionality = 3
 
     def __init__(self, center, ds, field_parameters=None, data_source=None):
-        super(YTSelectionContainer3D, self).__init__(ds, field_parameters, data_source)
+        super().__init__(ds, field_parameters, data_source)
         self._set_center(center)
         self.coords = None
         self._grids = None
@@ -1384,7 +1384,7 @@ class YTSelectionContainer3D(YTSelectionContainer):
             from yt.data_objects.level_sets.clump_handling import add_contour_field
 
             nj, cids = identify_contours(self, field, cons[level], mv)
-            unique_contours = set([])
+            unique_contours = set()
             for sl_list in cids.values():
                 for _sl, ff in sl_list:
                     unique_contours.update(np.unique(ff))

--- a/yt/data_objects/selection_objects/point.py
+++ b/yt/data_objects/selection_objects/point.py
@@ -44,7 +44,7 @@ class YTPoint(YTSelectionContainer0D):
         validate_object(ds, Dataset)
         validate_object(field_parameters, dict)
         validate_object(data_source, YTSelectionContainer)
-        super(YTPoint, self).__init__(ds, field_parameters, data_source)
+        super().__init__(ds, field_parameters, data_source)
         if isinstance(p, YTArray):
             # we pass p through ds.arr to ensure code units are attached
             self.p = self.ds.arr(p)

--- a/yt/data_objects/selection_objects/ray.py
+++ b/yt/data_objects/selection_objects/ray.py
@@ -80,7 +80,7 @@ class YTOrthoRay(YTSelectionContainer1D):
         validate_object(ds, Dataset)
         validate_object(field_parameters, dict)
         validate_object(data_source, YTSelectionContainer)
-        super(YTOrthoRay, self).__init__(ds, field_parameters, data_source)
+        super().__init__(ds, field_parameters, data_source)
         self.axis = fix_axis(axis, self.ds)
         xax = self.ds.coordinates.x_axis[self.axis]
         yax = self.ds.coordinates.y_axis[self.axis]
@@ -164,7 +164,7 @@ class YTRay(YTSelectionContainer1D):
         validate_object(ds, Dataset)
         validate_object(field_parameters, dict)
         validate_object(data_source, YTSelectionContainer)
-        super(YTRay, self).__init__(ds, field_parameters, data_source)
+        super().__init__(ds, field_parameters, data_source)
         if isinstance(start_point, YTArray):
             self.start_point = self.ds.arr(start_point).to("code_length")
         else:

--- a/yt/data_objects/selection_objects/spheroids.py
+++ b/yt/data_objects/selection_objects/spheroids.py
@@ -54,7 +54,7 @@ class YTSphere(YTSelectionContainer3D):
         validate_object(ds, Dataset)
         validate_object(field_parameters, dict)
         validate_object(data_source, YTSelectionContainer)
-        super(YTSphere, self).__init__(center, ds, field_parameters, data_source)
+        super().__init__(center, ds, field_parameters, data_source)
         # Unpack the radius, if necessary
         radius = fix_length(radius, self.ds)
         if radius < self.index.get_smallest_dx():
@@ -114,7 +114,7 @@ class YTMinimalSphere(YTSelectionContainer3D):
 
         center = ds.arr(mb.center(), points.units)
         radius = ds.quan(np.sqrt(mb.squared_radius()), points.units)
-        super(YTMinimalSphere, self).__init__(center, ds, field_parameters, data_source)
+        super().__init__(center, ds, field_parameters, data_source)
         self.set_field_parameter("radius", radius)
         self.set_field_parameter("center", self.center)
         self.radius = radius

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -402,8 +402,7 @@ class Dataset(abc.ABC):
         return self.parameters[key]
 
     def __iter__(self):
-        for i in self.parameters:
-            yield i
+        yield from self.parameters
 
     def get_smallest_appropriate_unit(
         self, v, quantity="distance", return_quantity=False
@@ -618,15 +617,15 @@ class Dataset(abc.ABC):
                 setattr(self, f"_{format_property}_format", value)
             else:
                 raise ValueError(
-                    "{0} not an acceptable value for format_property "
-                    "{1}. Choices are {2}.".format(
+                    "{} not an acceptable value for format_property "
+                    "{}. Choices are {}.".format(
                         value, format_property, available_formats[format_property]
                     )
                 )
         else:
             raise ValueError(
-                "{0} not a recognized format_property. Available"
-                "properties are: {1}".format(
+                "{} not a recognized format_property. Available"
+                "properties are: {}".format(
                     format_property, list(available_formats.keys())
                 )
             )
@@ -691,7 +690,7 @@ class Dataset(abc.ABC):
             return len(fields)
 
         for field in fields:
-            units = set([])
+            units = set()
             for s in union:
                 # First we check our existing fields for units
                 funits = self._get_field_info(s, field).units
@@ -1869,7 +1868,7 @@ class ParticleDataset(Dataset):
     ):
         self.index_order = validate_index_order(index_order)
         self.index_filename = index_filename
-        super(ParticleDataset, self).__init__(
+        super().__init__(
             filename,
             dataset_type=dataset_type,
             file_style=file_style,

--- a/yt/data_objects/tests/test_data_containers.py
+++ b/yt/data_objects/tests/test_data_containers.py
@@ -65,7 +65,7 @@ class TestDataContainers(unittest.TestCase):
         sp = ds.sphere(ds.domain_center, 0.25)
         sp.write_out(filename, fields=["cell_volume"])
 
-        with open(filename, "r") as file:
+        with open(filename) as file:
             file_row_1 = file.readline()
             file_row_2 = file.readline()
             file_row_2 = np.array(file_row_2.split("\t"), dtype=np.float64)

--- a/yt/data_objects/tests/test_io_geometry.py
+++ b/yt/data_objects/tests/test_io_geometry.py
@@ -24,7 +24,7 @@ def test_preserve_geometric_properties():
         assert ds1.geometry == ds2.geometry == geom
 
         expected = set(ds1.coordinates.axis_order)
-        actual = set([fname for ftype, fname in dfl])
+        actual = {fname for ftype, fname in dfl}
         assert expected.difference(actual) == set()
 
 

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -152,7 +152,7 @@ class DatasetSeries:
             outputs = cls._get_filenames_from_glob_pattern(outputs)
         except TypeError:
             pass
-        ret = super(DatasetSeries, cls).__new__(cls)
+        ret = super().__new__(cls)
         ret._pre_outputs = outputs[:]
         return ret
 
@@ -511,12 +511,10 @@ class DatasetSeriesObject:
         self.data_object_name = data_object_name
         self._args = args
         self._kwargs = kwargs
-        qs = dict(
-            [
-                (qn, create_quantity_proxy(qv))
-                for qn, qv in derived_quantity_registry.items()
-            ]
-        )
+        qs = {
+            qn: create_quantity_proxy(qv)
+            for qn, qv in derived_quantity_registry.items()
+        }
         self.quantities = TimeSeriesQuantitiesContainer(self, qs)
 
     def eval(self, tasks):

--- a/yt/data_objects/unions.py
+++ b/yt/data_objects/unions.py
@@ -9,8 +9,7 @@ class Union:
         self.sub_types = list(always_iterable(sub_types))
 
     def __iter__(self):
-        for st in self.sub_types:
-            yield st
+        yield from self.sub_types
 
     def __repr__(self):
         return "{} Union: '{}' composed of: {}".format(
@@ -22,4 +21,4 @@ class MeshUnion(Union):
     _union_type = "mesh"
 
     def __init__(self, name, sub_types):
-        super(MeshUnion, self).__init__(name, sub_types)
+        super().__init__(name, sub_types)

--- a/yt/extensions/__init__.py
+++ b/yt/extensions/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
     yt.extensions
     ~~~~~~~~~~~~~

--- a/yt/exthook.py
+++ b/yt/exthook.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
     yt.exthook
     ~~~~~~~~~~

--- a/yt/fields/derived_field.py
+++ b/yt/fields/derived_field.py
@@ -429,10 +429,10 @@ class DerivedField:
                 roman = pnum2rom[pstr[1:]]
                 label = (
                     species_label
-                    + "\ "
+                    + r"\ "
                     + roman
-                    + "\ "
-                    + "\ ".join(segments[ipstr + 1 :])
+                    + r"\ "
+                    + r"\ ".join(segments[ipstr + 1 :])
                 )
 
             # use +/- for ionization
@@ -445,8 +445,8 @@ class DerivedField:
                     + "^{"
                     + sign
                     + "}"
-                    + "\ "
-                    + "\ ".join(segments[ipstr + 1 :])
+                    + r"\ "
+                    + r"\ ".join(segments[ipstr + 1 :])
                 )
 
         else:
@@ -458,12 +458,12 @@ class DerivedField:
         if label is None:
             if self._is_ion():
                 fname = self._ion_to_label()
-                label = r"$\rm{" + fname.replace("_", "\ ") + r"}$"
+                label = r"$\rm{" + fname.replace("_", r"\ ") + r"}$"
                 label = label.replace("latexsub", "_")
             else:
-                label = r"$\rm{" + self.name[1].replace("_", "\ ").title() + r"}$"
+                label = r"$\rm{" + self.name[1].replace("_", r"\ ").title() + r"}$"
         elif label.find("$") == -1:
-            label = label.replace(" ", "\ ")
+            label = label.replace(" ", r"\ ")
             label = r"$\rm{" + label + r"}$"
         return label
 

--- a/yt/fields/field_detector.py
+++ b/yt/fields/field_detector.py
@@ -88,7 +88,7 @@ class FieldDetector(defaultdict):
             defaultdict.__init__(
                 self,
                 lambda: np.ones((nd * nd * nd), dtype="float64")
-                + 1e-4 * np.random.random((nd * nd * nd)),
+                + 1e-4 * np.random.random(nd * nd * nd),
             )
 
     def _reshape_vals(self, arr):

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -66,7 +66,7 @@ class FieldInfoContainer(dict):
         # Now we get all our index types and set up aliases to them
         if self.ds is None:
             return
-        index_fields = set([f for _, f in self if _ == "index"])
+        index_fields = {f for _, f in self if _ == "index"}
         for ftype in self.ds.fluid_types:
             if ftype in ("index", "deposit"):
                 continue
@@ -460,11 +460,9 @@ class FieldInfoContainer(dict):
         return key in self.fallback
 
     def __iter__(self):
-        for f in dict.__iter__(self):
-            yield f
+        yield from dict.__iter__(self)
         if self.fallback is not None:
-            for f in self.fallback:
-                yield f
+            yield from self.fallback
 
     def keys(self):
         keys = dict.keys(self)

--- a/yt/fields/field_type_container.py
+++ b/yt/fields/field_type_container.py
@@ -16,7 +16,7 @@ def _fill_values(values):
         + "<th>Value</th></tr></thead><tr><td>"
         + "</td></tr><tr><td>".join(
             [
-                "{0}</td><td>{1}</td><td>{2}".format(
+                "{}</td><td>{}</td><td>{}".format(
                     v, type(values[v]).__name__, str(values[v])
                 )
                 for v in sorted(values)
@@ -27,7 +27,7 @@ def _fill_values(values):
     return value
 
 
-class FieldTypeContainer(object):
+class FieldTypeContainer:
     def __init__(self, ds):
         self.ds = weakref.proxy(ds)
 
@@ -43,7 +43,7 @@ class FieldTypeContainer(object):
     @property
     def field_types(self):
         if self._field_types is None:
-            self._field_types = set(t for t, n in self.ds.field_info)
+            self._field_types = {t for t, n in self.ds.field_info}
         return self._field_types
 
     def __dir__(self):
@@ -84,7 +84,7 @@ class FieldTypeContainer(object):
         display(tabs)
 
 
-class FieldNameContainer(object):
+class FieldNameContainer:
     def __init__(self, ds, field_type):
         self.ds = ds
         self.field_type = field_type

--- a/yt/fields/local_fields.py
+++ b/yt/fields/local_fields.py
@@ -27,9 +27,7 @@ class LocalFieldInfoContainer(FieldInfoContainer):
                 name,
             )
 
-        return super(LocalFieldInfoContainer, self).add_field(
-            name, function, sampling_type, **kwargs
-        )
+        return super().add_field(name, function, sampling_type, **kwargs)
 
 
 # Empty FieldInfoContainer

--- a/yt/fields/species_fields.py
+++ b/yt/fields/species_fields.py
@@ -140,7 +140,7 @@ def add_species_field_by_fraction(registry, ftype, species):
 
 
 def add_species_aliases(registry, ftype, alias_species, species):
-    """
+    r"""
     This takes a field registry, a fluid type, and two species names.
     The first species name is one you wish to alias to an existing species
     name.  For instance you might alias all "H_p0" fields to "H\_" fields

--- a/yt/fields/tests/test_fields.py
+++ b/yt/fields/tests/test_fields.py
@@ -142,7 +142,7 @@ def get_base_ds(nprocs):
     ds.parameters["EOSType"] = 1.0
     ds.parameters["EOSSoundSpeed"] = 1.0
     ds.conversion_factors["Time"] = 1.0
-    ds.conversion_factors.update(dict((f, 1.0) for f in fields))
+    ds.conversion_factors.update({f: 1.0 for f in fields})
     ds.gamma = 5.0 / 3.0
     ds.current_redshift = 0.0001
     ds.cosmological_simulation = 1
@@ -484,21 +484,21 @@ def test_ion_field_labels():
 
     # by default labels should use roman numerals
     default_labels = {
-        "O_p1_number_density": "$\\rm{O\ II\ Number\ Density}$",
-        "O2_p1_number_density": "$\\rm{O_{2}\ II\ Number\ Density}$",
-        "CO2_p1_number_density": "$\\rm{CO_{2}\ II\ Number\ Density}$",
-        "Co_p1_number_density": "$\\rm{Co\ II\ Number\ Density}$",
-        "O2_p2_number_density": "$\\rm{O_{2}\ III\ Number\ Density}$",
-        "H2O_p1_number_density": "$\\rm{H_{2}O\ II\ Number\ Density}$",
+        "O_p1_number_density": "$\\rm{O\\ II\\ Number\\ Density}$",
+        "O2_p1_number_density": "$\\rm{O_{2}\\ II\\ Number\\ Density}$",
+        "CO2_p1_number_density": "$\\rm{CO_{2}\\ II\\ Number\\ Density}$",
+        "Co_p1_number_density": "$\\rm{Co\\ II\\ Number\\ Density}$",
+        "O2_p2_number_density": "$\\rm{O_{2}\\ III\\ Number\\ Density}$",
+        "H2O_p1_number_density": "$\\rm{H_{2}O\\ II\\ Number\\ Density}$",
     }
 
     pm_labels = {
-        "O_p1_number_density": "$\\rm{{O}^{+}\ Number\ Density}$",
-        "O2_p1_number_density": "$\\rm{{O_{2}}^{+}\ Number\ Density}$",
-        "CO2_p1_number_density": "$\\rm{{CO_{2}}^{+}\ Number\ Density}$",
-        "Co_p1_number_density": "$\\rm{{Co}^{+}\ Number\ Density}$",
-        "O2_p2_number_density": "$\\rm{{O_{2}}^{++}\ Number\ Density}$",
-        "H2O_p1_number_density": "$\\rm{{H_{2}O}^{+}\ Number\ Density}$",
+        "O_p1_number_density": "$\\rm{{O}^{+}\\ Number\\ Density}$",
+        "O2_p1_number_density": "$\\rm{{O_{2}}^{+}\\ Number\\ Density}$",
+        "CO2_p1_number_density": "$\\rm{{CO_{2}}^{+}\\ Number\\ Density}$",
+        "Co_p1_number_density": "$\\rm{{Co}^{+}\\ Number\\ Density}$",
+        "O2_p2_number_density": "$\\rm{{O_{2}}^{++}\\ Number\\ Density}$",
+        "H2O_p1_number_density": "$\\rm{{H_{2}O}^{+}\\ Number\\ Density}$",
     }
 
     fobj = ds.fields.stream

--- a/yt/fields/xray_emission_fields.py
+++ b/yt/fields/xray_emission_fields.py
@@ -26,12 +26,12 @@ def _get_data_file(table_type, data_dir=None):
         data_dir = supp_data_dir if os.path.exists(supp_data_dir) else "."
     data_path = os.path.join(data_dir, data_file)
     if not os.path.exists(data_path):
-        msg = "Failed to find emissivity data file %s! Please download from %s" % (
+        msg = "Failed to find emissivity data file {}! Please download from {}".format(
             data_file,
             data_url,
         )
         mylog.error(msg)
-        raise IOError(msg)
+        raise OSError(msg)
     return data_path
 
 
@@ -267,7 +267,7 @@ def add_xray_emissivity_field(
     ds.add_field(
         emiss_name,
         function=_emissivity_field,
-        display_name=r"\epsilon_{X} (%s-%s keV)" % (e_min, e_max),
+        display_name=fr"\epsilon_{{X}} ({e_min}-{e_max} keV)",
         sampling_type="local",
         units="erg/cm**3/s",
     )
@@ -279,7 +279,7 @@ def add_xray_emissivity_field(
     ds.add_field(
         lum_name,
         function=_luminosity_field,
-        display_name=r"\rm{L}_{X} (%s-%s keV)" % (e_min, e_max),
+        display_name=fr"\rm{{L}}_{{X}} ({e_min}-{e_max} keV)",
         sampling_type="local",
         units="erg/s",
     )
@@ -304,7 +304,7 @@ def add_xray_emissivity_field(
     ds.add_field(
         phot_name,
         function=_photon_emissivity_field,
-        display_name=r"\epsilon_{X} (%s-%s keV)" % (e_min, e_max),
+        display_name=fr"\epsilon_{{X}} ({e_min}-{e_max} keV)",
         sampling_type="local",
         units="photons/cm**3/s",
     )
@@ -353,7 +353,7 @@ def add_xray_emissivity_field(
         ds.add_field(
             ei_name,
             function=_intensity_field,
-            display_name=r"I_{X} (%s-%s keV)" % (e_min, e_max),
+            display_name=fr"I_{{X}} ({e_min}-{e_max} keV)",
             sampling_type="local",
             units="erg/cm**3/s/arcsec**2",
         )
@@ -367,7 +367,7 @@ def add_xray_emissivity_field(
         ds.add_field(
             i_name,
             function=_photon_intensity_field,
-            display_name=r"I_{X} (%s-%s keV)" % (e_min, e_max),
+            display_name=fr"I_{{X}} ({e_min}-{e_max} keV)",
             sampling_type="local",
             units="photons/cm**3/s/arcsec**2",
         )

--- a/yt/frontends/_skeleton/data_structures.py
+++ b/yt/frontends/_skeleton/data_structures.py
@@ -15,9 +15,7 @@ class SkeletonGrid(AMRGridPatch):
     _id_offset = 0
 
     def __init__(self, id, index, level):
-        super(SkeletonGrid, self).__init__(
-            id, filename=index.index_filename, index=index
-        )
+        super().__init__(id, filename=index.index_filename, index=index)
         self.Parent = None
         self.Children = []
         self.Level = level
@@ -37,7 +35,7 @@ class SkeletonHierarchy(GridIndex):
         self.directory = os.path.dirname(self.index_filename)
         # float type for the simulation edges and must be float64 now
         self.float_type = np.float64
-        super(SkeletonHierarchy, self).__init__(ds, dataset_type)
+        super().__init__(ds, dataset_type)
 
     def _detect_output_fields(self):
         # This needs to set a self.field_list that contains all the available,
@@ -89,9 +87,7 @@ class SkeletonDataset(Dataset):
         units_override=None,
     ):
         self.fluid_types += ("skeleton",)
-        super(SkeletonDataset, self).__init__(
-            filename, dataset_type, units_override=units_override
-        )
+        super().__init__(filename, dataset_type, units_override=units_override)
         self.storage_filename = storage_filename
         # refinement factor between a grid and its subgrid
         # self.refine_by = 2

--- a/yt/frontends/_skeleton/fields.py
+++ b/yt/frontends/_skeleton/fields.py
@@ -17,7 +17,7 @@ class SkeletonFieldInfo(FieldInfoContainer):
     )
 
     def __init__(self, ds, field_list):
-        super(SkeletonFieldInfo, self).__init__(ds, field_list)
+        super().__init__(ds, field_list)
         # If you want, you can check self.field_list
 
     def setup_fluid_fields(self):
@@ -27,5 +27,5 @@ class SkeletonFieldInfo(FieldInfoContainer):
         pass
 
     def setup_particle_fields(self, ptype):
-        super(SkeletonFieldInfo, self).setup_particle_fields(ptype)
+        super().setup_particle_fields(ptype)
         # This will get called for every particle type.

--- a/yt/frontends/adaptahop/data_structures.py
+++ b/yt/frontends/adaptahop/data_structures.py
@@ -76,7 +76,7 @@ class AdaptaHOPDataset(Dataset):
             )
         self.parent_ds = parent_ds
 
-        super(AdaptaHOPDataset, self).__init__(
+        super().__init__(
             filename,
             dataset_type,
             units_override=units_override,
@@ -128,7 +128,7 @@ class AdaptaHOPDataset(Dataset):
     def _is_valid(cls, filename, *args, **kwargs):
         fname = os.path.split(filename)[1]
         if not fname.startswith("tree_bricks") or not re.match(
-            "^tree_bricks\d{3}$", fname
+            r"^tree_bricks\d{3}$", fname
         ):
             return False
         return True
@@ -248,7 +248,7 @@ class AdaptaHOPHaloContainer(YTSelectionContainer):
         self._set_halo_member_data()
 
         # Call constructor
-        super(AdaptaHOPHaloContainer, self).__init__(parent_ds, {})
+        super().__init__(parent_ds, {})
 
     def __repr__(self):
         return "%s_%s_%09d" % (self.ds, self.ptype, self.particle_identifier)

--- a/yt/frontends/adaptahop/fields.py
+++ b/yt/frontends/adaptahop/fields.py
@@ -51,7 +51,7 @@ class AdaptaHOPFieldInfo(FieldInfoContainer):
     )
 
     def setup_particle_fields(self, ptype):
-        super(AdaptaHOPFieldInfo, self).setup_particle_fields(ptype)
+        super().setup_particle_fields(ptype)
 
         # Add particle position
         def generate_pos_field(d):

--- a/yt/frontends/adaptahop/io.py
+++ b/yt/frontends/adaptahop/io.py
@@ -38,7 +38,7 @@ class IOHandlerAdaptaHOPBinary(BaseIOHandler):
     def _read_particle_coords(self, chunks, ptf):
         # This will read chunks and yield the results.
         chunks = list(chunks)
-        data_files = set([])
+        data_files = set()
         # Only support halo reading for now.
         assert len(ptf) == 1
         assert list(ptf.keys())[0] == "halos"
@@ -58,7 +58,7 @@ class IOHandlerAdaptaHOPBinary(BaseIOHandler):
     def _read_particle_fields(self, chunks, ptf, selector):
         # Now we have all the sizes, and we can allocate
         chunks = list(chunks)
-        data_files = set([])
+        data_files = set()
         # Only support halo reading for now.
         assert len(ptf) == 1
         assert list(ptf.keys())[0] == "halos"
@@ -69,8 +69,7 @@ class IOHandlerAdaptaHOPBinary(BaseIOHandler):
         def iterate_over_attributes(attr_list):
             for attr, *_ in attr_list:
                 if isinstance(attr, tuple):
-                    for a in attr:
-                        yield a
+                    yield from attr
                 else:
                     yield attr
 

--- a/yt/frontends/ahf/data_structures.py
+++ b/yt/frontends/ahf/data_structures.py
@@ -21,7 +21,7 @@ class AHFHalosFile(HaloCatalogFile):
         else:
             raise ValueError("Too many AHF_halos files.")
         self.col_names = self._read_column_names(filename)
-        super(AHFHalosFile, self).__init__(ds, io, filename, file_id, range)
+        super().__init__(ds, io, filename, file_id, range)
 
     def read_data(self, usecols=None):
         return np.genfromtxt(self.filename, names=self.col_names, usecols=usecols)
@@ -70,7 +70,7 @@ class AHFHalosDataset(Dataset):
 
         self.n_ref = n_ref
         self.over_refine_factor = over_refine_factor
-        super(AHFHalosDataset, self).__init__(
+        super().__init__(
             filename,
             dataset_type=dataset_type,
             units_override=units_override,
@@ -121,7 +121,7 @@ class AHFHalosDataset(Dataset):
     def _is_valid(cls, filename, *args, **kwargs):
         if not filename.endswith(".parameter"):
             return False
-        with open(filename, "r") as f:
+        with open(filename) as f:
             if f.readlines()[11].startswith("AHF"):
                 return True
         return False

--- a/yt/frontends/ahf/io.py
+++ b/yt/frontends/ahf/io.py
@@ -98,10 +98,9 @@ class IOHandlerAHFHalos(BaseIOHandler):
         assert list(ptf.keys())[0] == "halos"
         # Get data_files
         chunks = list(chunks)
-        data_files = set([])
+        data_files = set()
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
         data_files = sorted(data_files, key=attrgetter("filename"))
-        for data_file in data_files:
-            yield data_file
+        yield from data_files

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -30,7 +30,7 @@ class AMRVACGrid(AMRGridPatch):
 
     def __init__(self, id, index, level):
         # <level> should use yt's convention (start from 0)
-        super(AMRVACGrid, self).__init__(id, filename=index.index_filename, index=index)
+        super().__init__(id, filename=index.index_filename, index=index)
         self.Parent = None
         self.Children = []
         self.Level = level
@@ -57,7 +57,7 @@ class AMRVACGrid(AMRGridPatch):
                 category=RuntimeWarning,
             )
             smoothed = False
-        return super(AMRVACGrid, self).retrieve_ghost_zones(
+        return super().retrieve_ghost_zones(
             n_zones, fields, all_levels=all_levels, smoothed=smoothed
         )
 
@@ -73,7 +73,7 @@ class AMRVACHierarchy(GridIndex):
         self.directory = os.path.dirname(self.index_filename)
         self.float_type = np.float64
 
-        super(AMRVACHierarchy, self).__init__(ds, dataset_type)
+        super().__init__(ds, dataset_type)
 
     def _detect_output_fields(self):
         """Parse field names from the header, as stored in self.dataset.parameters"""
@@ -175,7 +175,7 @@ class AMRVACDataset(Dataset):
         # note: geometry_override and parfiles are specific to this frontend
 
         self._geometry_override = geometry_override
-        super(AMRVACDataset, self).__init__(
+        super().__init__(
             filename,
             dataset_type,
             units_override=units_override,

--- a/yt/frontends/amrvac/datfile_utils.py
+++ b/yt/frontends/amrvac/datfile_utils.py
@@ -24,7 +24,7 @@ def get_header(istream):
     [h["datfile_version"]] = struct.unpack(fmt, istream.read(struct.calcsize(fmt)))
 
     if h["datfile_version"] < 3:
-        raise IOError("Unsupported AMRVAC .dat file version: %d", h["datfile_version"])
+        raise OSError("Unsupported AMRVAC .dat file version: %d", h["datfile_version"])
 
     # Read scalar data at beginning of file
     fmt = ALIGN + 9 * "i" + "d"

--- a/yt/frontends/amrvac/io.py
+++ b/yt/frontends/amrvac/io.py
@@ -150,7 +150,7 @@ class AMRVACIOHandler(BaseIOHandler):
                 data_dict[ftype, fname] = self._read_data(grid, fname)
         else:
             if size is None:
-                size = sum((g.count(selector) for chunk in chunks for g in chunk.objs))
+                size = sum(g.count(selector) for chunk in chunks for g in chunk.objs)
 
             for field in fields:
                 data_dict[field] = np.empty(size, dtype="float64")

--- a/yt/frontends/arepo/data_structures.py
+++ b/yt/frontends/arepo/data_structures.py
@@ -23,7 +23,7 @@ class ArepoHDF5Dataset(GadgetHDF5Dataset):
         units_override=None,
         unit_system="cgs",
     ):
-        super(ArepoHDF5Dataset, self).__init__(
+        super().__init__(
             filename,
             dataset_type=dataset_type,
             unit_base=unit_base,
@@ -77,7 +77,7 @@ class ArepoHDF5Dataset(GadgetHDF5Dataset):
 
     def _set_code_unit_attributes(self):
         self._unit_base = self._get_uvals()
-        super(ArepoHDF5Dataset, self)._set_code_unit_attributes()
+        super()._set_code_unit_attributes()
         munit = np.sqrt(self.mass_unit / (self.time_unit ** 2 * self.length_unit)).to(
             "gauss"
         )

--- a/yt/frontends/arepo/fields.py
+++ b/yt/frontends/arepo/fields.py
@@ -30,7 +30,7 @@ class ArepoFieldInfo(GadgetFieldInfo):
             ("GFM_Metals_07", ("", ["Si_fraction"], None)),
             ("GFM_Metals_08", ("", ["Fe_fraction"], None)),
         )
-        super(ArepoFieldInfo, self).__init__(ds, field_list, slice_info=slice_info)
+        super().__init__(ds, field_list, slice_info=slice_info)
 
     def setup_particle_fields(self, ptype, *args, **kwargs):
         FieldInfoContainer.setup_particle_fields(self, ptype)
@@ -39,7 +39,7 @@ class ArepoFieldInfo(GadgetFieldInfo):
             setup_species_fields(self, ptype)
 
     def setup_gas_particle_fields(self, ptype):
-        super(ArepoFieldInfo, self).setup_gas_particle_fields(ptype)
+        super().setup_gas_particle_fields(ptype)
 
         if (ptype, "InternalEnergy") in self.field_list:
 

--- a/yt/frontends/arepo/tests/test_outputs.py
+++ b/yt/frontends/arepo/tests/test_outputs.py
@@ -72,7 +72,7 @@ def test_index_override():
     )
     assert isinstance(ds, ArepoHDF5Dataset)
     ds.index
-    assert len(open(tmpname, "r").read()) == 0
+    assert len(open(tmpname).read()) == 0
 
 
 @requires_file(tng59_h5)

--- a/yt/frontends/art/data_structures.py
+++ b/yt/frontends/art/data_structures.py
@@ -43,7 +43,7 @@ class ARTIndex(OctreeIndex):
         self.directory = os.path.dirname(self.index_filename)
         self.max_level = ds.max_level
         self.float_type = np.float64
-        super(ARTIndex, self).__init__(ds, dataset_type)
+        super().__init__(ds, dataset_type)
 
     def get_smallest_dx(self):
         """
@@ -359,7 +359,7 @@ class ARTDataset(Dataset):
         mylog.info("Max level is %02i", self.max_level)
 
     def create_field_info(self):
-        super(ARTDataset, self).create_field_info()
+        super().create_field_info()
         if "wspecies" in self.parameters:
             # We create dark_matter and stars unions.
             ptr = self.particle_types_raw
@@ -391,7 +391,7 @@ class ARTDataset(Dataset):
 
 class ARTParticleFile(ParticleFile):
     def __init__(self, ds, io, filename, file_id):
-        super(ARTParticleFile, self).__init__(ds, io, filename, file_id, range=None)
+        super().__init__(ds, io, filename, file_id, range=None)
         self.total_particles = {}
         for ptype, count in zip(
             ds.particle_types_raw, ds.parameters["total_particles"]

--- a/yt/frontends/art/io.py
+++ b/yt/frontends/art/io.py
@@ -28,7 +28,7 @@ class IOHandlerART(BaseIOHandler):
     def __init__(self, *args, **kwargs):
         self.cache = {}
         self.masks = {}
-        super(IOHandlerART, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.ws = self.ds.parameters["wspecies"]
         self.ls = self.ds.parameters["lspecies"]
         self.file_particle = self.ds._file_particle_data
@@ -168,7 +168,7 @@ class IOHandlerART(BaseIOHandler):
             # dark_matter -- stars are regular matter.
             tr[field] /= self.ds.domain_dimensions.prod()
         if tr == {}:
-            tr = dict((f, np.array([])) for f in [field])
+            tr = {f: np.array([]) for f in [field]}
         if self.caching:
             self.cache[field] = tr[field]
             return self.cache[field]
@@ -460,7 +460,7 @@ def read_particles(file, Nrow, idxa, idxb, fields):
     real_size = 4  # for file_particle_data; not always true?
     np_per_page = Nrow ** 2  # defined in ART a_setup.h, # of particles/page
     num_pages = os.path.getsize(file) // (real_size * words * np_per_page)
-    fh = open(file, "r")
+    fh = open(file)
     skip, count = idxa, idxb - idxa
     kwargs = dict(
         words=words, real_size=real_size, np_per_page=np_per_page, num_pages=num_pages

--- a/yt/frontends/artio/data_structures.py
+++ b/yt/frontends/artio/data_structures.py
@@ -67,7 +67,7 @@ class ARTIOOctreeSubset(OctreeSubset):
         self.oct_handler.fill_sfc(
             levels, cell_inds, file_inds, domain_counts, field_indices, tr
         )
-        tr = dict((field, v) for field, v in zip(fields, tr))
+        tr = {field: v for field, v in zip(fields, tr)}
         return tr
 
     def fill_particles(self, fields):
@@ -113,7 +113,7 @@ class ARTIORootMeshSubset(ARTIOOctreeSubset):
         ]
         tr = self.oct_handler.fill_sfc(selector, field_indices)
         self.data_size = tr[0].size
-        tr = dict((field, v) for field, v in zip(fields, tr))
+        tr = {field: v for field, v in zip(fields, tr)}
         return tr
 
     def deposit(self, positions, fields=None, method=None, kernel_name="cubic"):
@@ -154,7 +154,7 @@ class ARTIOIndex(Index):
         self.max_level = ds.max_level
         self.range_handlers = {}
         self.float_type = np.float64
-        super(ARTIOIndex, self).__init__(ds, dataset_type)
+        super().__init__(ds, dataset_type)
 
     @property
     def max_range(self):
@@ -486,7 +486,7 @@ class ARTIODataset(Dataset):
         self.periodicity = (True, True, True)
 
     def create_field_info(self):
-        super(ARTIODataset, self).create_field_info()
+        super().create_field_info()
         # only make the particle union if there are multiple DM species.
         # If there are multiple, "N-BODY_0" will be the first species. If there
         # are not multiple, they will be all under "N-BODY"

--- a/yt/frontends/artio/fields.py
+++ b/yt/frontends/artio/fields.py
@@ -168,4 +168,4 @@ class ARTIOFieldInfo(FieldInfoContainer):
                     function=_creation_redshift,
                 )
 
-        super(ARTIOFieldInfo, self).setup_particle_fields(ptype)
+        super().setup_particle_fields(ptype)

--- a/yt/frontends/artio/io.py
+++ b/yt/frontends/artio/io.py
@@ -7,7 +7,7 @@ class IOHandlerARTIO(BaseIOHandler):
     _dataset_type = "artio"
 
     def _read_fluid_selection(self, chunks, selector, fields):
-        tr = dict((ftuple, np.empty(0, dtype="float64")) for ftuple in fields)
+        tr = {ftuple: np.empty(0, dtype="float64") for ftuple in fields}
         cp = 0
         for onechunk in chunks:
             for artchunk in onechunk.objs:

--- a/yt/frontends/athena_pp/data_structures.py
+++ b/yt/frontends/athena_pp/data_structures.py
@@ -45,7 +45,7 @@ class AthenaPPLogarithmicMesh(SemiStructuredMesh):
         blocks,
         dims,
     ):
-        super(AthenaPPLogarithmicMesh, self).__init__(
+        super().__init__(
             mesh_id, filename, connectivity_indices, connectivity_coords, index
         )
         self.mesh_blocks = blocks
@@ -55,7 +55,7 @@ class AthenaPPLogarithmicMesh(SemiStructuredMesh):
 class AthenaPPLogarithmicIndex(UnstructuredIndex):
     def __init__(self, ds, dataset_type="athena_pp"):
         self._handle = ds._handle
-        super(AthenaPPLogarithmicIndex, self).__init__(ds, dataset_type)
+        super().__init__(ds, dataset_type)
         self.index_filename = self.dataset.filename
         self.directory = os.path.dirname(self.dataset.filename)
         self.dataset_type = dataset_type

--- a/yt/frontends/athena_pp/io.py
+++ b/yt/frontends/athena_pp/io.py
@@ -24,7 +24,7 @@ class IOHandlerAthenaPP(BaseIOHandler):
     _dataset_type = "athena_pp"
 
     def __init__(self, ds):
-        super(IOHandlerAthenaPP, self).__init__(ds)
+        super().__init__(ds)
         self._handle = ds._handle
 
     def _read_particles(

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -60,14 +60,14 @@ class BoxlibGrid(AMRGridPatch):
     _offset = -1
 
     def __init__(self, grid_id, offset, filename=None, index=None):
-        super(BoxlibGrid, self).__init__(grid_id, filename, index)
+        super().__init__(grid_id, filename, index)
         self._base_offset = offset
         self._parent_id = []
         self._children_ids = []
         self._pdata = {}
 
     def _prepare_grid(self):
-        super(BoxlibGrid, self)._prepare_grid()
+        super()._prepare_grid()
         my_ind = self.id - self._id_offset
         self.start_index = self.index.grid_start_index[my_ind]
 
@@ -133,7 +133,7 @@ class BoxLibParticleHeader:
 
         self.particle_type = directory_name
         header_filename = os.path.join(ds.output_dir, directory_name, "Header")
-        with open(header_filename, "r") as f:
+        with open(header_filename) as f:
             self.version_string = f.readline().strip()
 
             particle_real_type = self.version_string.split("_")[-1]
@@ -245,7 +245,7 @@ class AMReXParticleHeader:
         header_filename = os.path.join(ds.output_dir, directory_name, "Header")
         self.real_component_names = []
         self.int_component_names = []
-        with open(header_filename, "r") as f:
+        with open(header_filename) as f:
             self.version_string = f.readline().strip()
 
             particle_real_type = self.version_string.split("_")[-1]
@@ -357,7 +357,7 @@ class BoxlibHierarchy(GridIndex):
         read the global header file for an Boxlib plotfile output.
         """
         self.max_level = self.dataset._max_level
-        header_file = open(self.header_filename, "r")
+        header_file = open(self.header_filename)
 
         self.dimensionality = self.dataset.dimensionality
         _our_dim_finder = _dim_finder[self.dimensionality - 1]
@@ -539,7 +539,7 @@ class BoxlibHierarchy(GridIndex):
         # We can get everything from the Header file, but note that we're
         # duplicating some work done elsewhere.  In a future where we don't
         # pre-allocate grid arrays, this becomes unnecessary.
-        header_file = open(self.header_filename, "r")
+        header_file = open(self.header_filename)
         header_file.seek(self.dataset._header_mesh_start)
         # Skip over the level dxs, geometry and the zero:
         [next(header_file) for i in range(self.dataset._max_level + 3)]
@@ -554,7 +554,7 @@ class BoxlibHierarchy(GridIndex):
             self.num_grids += int(line.split()[1])
 
     def _initialize_grid_arrays(self):
-        super(BoxlibHierarchy, self)._initialize_grid_arrays()
+        super()._initialize_grid_arrays()
         self.grid_start_index = np.zeros((self.num_grids, 3), "int64")
 
     def _initialize_state_variables(self):
@@ -566,7 +566,7 @@ class BoxlibHierarchy(GridIndex):
     def _detect_output_fields(self):
         # This is all done in _parse_header_file
         self.field_list = [("boxlib", f) for f in self.dataset._field_list]
-        self.field_indexes = dict((f[1], i) for i, f in enumerate(self.field_list))
+        self.field_indexes = {f[1]: i for i, f in enumerate(self.field_list)}
         # There are times when field_list may change.  We copy it here to
         # avoid that possibility.
         self.field_order = [f for f in self.field_list]
@@ -576,7 +576,7 @@ class BoxlibHierarchy(GridIndex):
 
     def _determine_particle_output_type(self, directory_name):
         header_filename = self.ds.output_dir + "/" + directory_name + "/Header"
-        with open(header_filename, "r") as f:
+        with open(header_filename) as f:
             version_string = f.readline().strip()
             if version_string.startswith("Version_Two"):
                 return AMReXParticleHeader
@@ -941,7 +941,7 @@ class OrionHierarchy(BoxlibHierarchy):
     def _detect_output_fields(self):
         # This is all done in _parse_header_file
         self.field_list = [("boxlib", f) for f in self.dataset._field_list]
-        self.field_indexes = dict((f[1], i) for i, f in enumerate(self.field_list))
+        self.field_indexes = {f[1]: i for i, f in enumerate(self.field_list)}
         # There are times when field_list may change.  We copy it here to
         # avoid that possibility.
         self.field_order = [f for f in self.field_list]
@@ -977,7 +977,7 @@ class OrionHierarchy(BoxlibHierarchy):
         """actually reads the orion particle data file itself."""
         if not os.path.exists(fn):
             return
-        with open(fn, "r") as f:
+        with open(fn) as f:
             lines = f.readlines()
             self.num_stars = int(lines[0].strip()[0])
             for num, line in enumerate(lines[1:]):
@@ -1048,7 +1048,7 @@ class OrionDataset(BoxlibDataset):
 
 class CastroHierarchy(BoxlibHierarchy):
     def __init__(self, ds, dataset_type="castro_native"):
-        super(CastroHierarchy, self).__init__(ds, dataset_type)
+        super().__init__(ds, dataset_type)
 
         if "particles" in self.ds.parameters:
 
@@ -1087,7 +1087,7 @@ class CastroDataset(BoxlibDataset):
         unit_system="cgs",
     ):
 
-        super(CastroDataset, self).__init__(
+        super().__init__(
             output_dir,
             cparam_filename,
             fparam_filename,
@@ -1098,10 +1098,10 @@ class CastroDataset(BoxlibDataset):
         )
 
     def _parse_parameter_file(self):
-        super(CastroDataset, self)._parse_parameter_file()
+        super()._parse_parameter_file()
         jobinfo_filename = os.path.join(self.output_dir, self.cparam_filename)
         line = ""
-        with open(jobinfo_filename, "r") as f:
+        with open(jobinfo_filename) as f:
             while not line.startswith(" Inputs File Parameters"):
                 # boundary condition info starts with -x:, etc.
                 bcs = ["-x:", "+x:", "-y:", "+y:", "-z:", "+z:"]
@@ -1165,7 +1165,7 @@ class MaestroDataset(BoxlibDataset):
         unit_system="cgs",
     ):
 
-        super(MaestroDataset, self).__init__(
+        super().__init__(
             output_dir,
             cparam_filename,
             fparam_filename,
@@ -1176,10 +1176,10 @@ class MaestroDataset(BoxlibDataset):
         )
 
     def _parse_parameter_file(self):
-        super(MaestroDataset, self)._parse_parameter_file()
+        super()._parse_parameter_file()
         jobinfo_filename = os.path.join(self.output_dir, self.cparam_filename)
 
-        with open(jobinfo_filename, "r") as f:
+        with open(jobinfo_filename) as f:
             for line in f:
                 # get the code git hashes
                 if "git hash" in line:
@@ -1187,7 +1187,7 @@ class MaestroDataset(BoxlibDataset):
                     fields = line.split(":")
                     self.parameters[fields[0]] = fields[1].strip()
 
-        with open(jobinfo_filename, "r") as f:
+        with open(jobinfo_filename) as f:
             # get the runtime parameters
             for line in f:
                 try:
@@ -1216,7 +1216,7 @@ class MaestroDataset(BoxlibDataset):
 
 class NyxHierarchy(BoxlibHierarchy):
     def __init__(self, ds, dataset_type="nyx_native"):
-        super(NyxHierarchy, self).__init__(ds, dataset_type)
+        super().__init__(ds, dataset_type)
 
         if "particles" in self.ds.parameters:
             # extra beyond the base real fields that all Boxlib
@@ -1255,7 +1255,7 @@ class NyxDataset(BoxlibDataset):
         unit_system="cgs",
     ):
 
-        super(NyxDataset, self).__init__(
+        super().__init__(
             output_dir,
             cparam_filename,
             fparam_filename,
@@ -1266,11 +1266,11 @@ class NyxDataset(BoxlibDataset):
         )
 
     def _parse_parameter_file(self):
-        super(NyxDataset, self)._parse_parameter_file()
+        super()._parse_parameter_file()
 
         jobinfo_filename = os.path.join(self.output_dir, self.cparam_filename)
 
-        with open(jobinfo_filename, "r") as f:
+        with open(jobinfo_filename) as f:
             for line in f:
                 # get the code git hashes
                 if "git hash" in line:
@@ -1378,7 +1378,7 @@ def _read_header(raw_file, field):
 
     for level_file in level_files:
         header_file = level_file + "/" + field + "_H"
-        with open(header_file, "r") as f:
+        with open(header_file) as f:
 
             f.readline()  # version
             f.readline()  # how
@@ -1428,7 +1428,7 @@ def _read_header(raw_file, field):
 class WarpXHeader:
     def __init__(self, header_fn):
         self.data = {}
-        with open(header_fn, "r") as f:
+        with open(header_fn) as f:
             self.data["Checkpoint_version"] = int(f.readline().strip().split()[-1])
 
             self.data["num_levels"] = int(f.readline().strip().split()[-1])
@@ -1474,7 +1474,7 @@ class WarpXHeader:
 
 class WarpXHierarchy(BoxlibHierarchy):
     def __init__(self, ds, dataset_type="boxlib_native"):
-        super(WarpXHierarchy, self).__init__(ds, dataset_type)
+        super().__init__(ds, dataset_type)
 
         is_checkpoint = True
         for ptype in self.ds.particle_types:
@@ -1492,7 +1492,7 @@ class WarpXHierarchy(BoxlibHierarchy):
                 self.parameters[mass_name] = val[1]
 
     def _detect_output_fields(self):
-        super(WarpXHierarchy, self)._detect_output_fields()
+        super()._detect_output_fields()
 
         # now detect the optional, non-cell-centered fields
         self.raw_file = self.ds.output_dir + "/raw_fields/"
@@ -1541,7 +1541,7 @@ class WarpXDataset(BoxlibDataset):
         self.default_field = ("mesh", "density")
         self.fluid_types = ("mesh", "index", "raw")
 
-        super(WarpXDataset, self).__init__(
+        super().__init__(
             output_dir,
             cparam_filename,
             fparam_filename,
@@ -1552,9 +1552,9 @@ class WarpXDataset(BoxlibDataset):
         )
 
     def _parse_parameter_file(self):
-        super(WarpXDataset, self)._parse_parameter_file()
+        super()._parse_parameter_file()
         jobinfo_filename = os.path.join(self.output_dir, self.cparam_filename)
-        with open(jobinfo_filename, "r") as f:
+        with open(jobinfo_filename) as f:
             for line in f.readlines():
                 if _skip_line(line):
                     continue
@@ -1595,7 +1595,7 @@ class WarpXDataset(BoxlibDataset):
 
 class AMReXHierarchy(BoxlibHierarchy):
     def __init__(self, ds, dataset_type="boxlib_native"):
-        super(AMReXHierarchy, self).__init__(ds, dataset_type)
+        super().__init__(ds, dataset_type)
 
         if "particles" in self.ds.parameters:
             is_checkpoint = True
@@ -1620,7 +1620,7 @@ class AMReXDataset(BoxlibDataset):
         unit_system="cgs",
     ):
 
-        super(AMReXDataset, self).__init__(
+        super().__init__(
             output_dir,
             cparam_filename,
             fparam_filename,
@@ -1631,7 +1631,7 @@ class AMReXDataset(BoxlibDataset):
         )
 
     def _parse_parameter_file(self):
-        super(AMReXDataset, self)._parse_parameter_file()
+        super()._parse_parameter_file()
         particle_types = glob.glob(self.output_dir + "/*/Header")
         particle_types = [cpt.split(os.sep)[-2] for cpt in particle_types]
         if len(particle_types) > 0:

--- a/yt/frontends/boxlib/fields.py
+++ b/yt/frontends/boxlib/fields.py
@@ -75,7 +75,7 @@ class WarpXFieldInfo(FieldInfoContainer):
     )
 
     def __init__(self, ds, field_list):
-        super(WarpXFieldInfo, self).__init__(ds, field_list)
+        super().__init__(ds, field_list)
 
         # setup nodal flag information
         for field in ds.index.raw_fields:
@@ -88,7 +88,7 @@ class WarpXFieldInfo(FieldInfoContainer):
             self.alias(("mesh", fname), ("boxlib", fname))
 
     def setup_fluid_aliases(self):
-        super(WarpXFieldInfo, self).setup_fluid_aliases("mesh")
+        super().setup_fluid_aliases("mesh")
 
     def setup_particle_fields(self, ptype):
         def get_mass(field, data):
@@ -170,7 +170,7 @@ class WarpXFieldInfo(FieldInfoContainer):
             units="m/s",
         )
 
-        super(WarpXFieldInfo, self).setup_particle_fields(ptype)
+        super().setup_particle_fields(ptype)
 
 
 class NyxFieldInfo(FieldInfoContainer):
@@ -236,7 +236,7 @@ class BoxlibFieldInfo(FieldInfoContainer):
                 units="code_length/code_time",
             )
 
-        super(BoxlibFieldInfo, self).setup_particle_fields(ptype)
+        super().setup_particle_fields(ptype)
 
     def setup_fluid_fields(self):
         unit_system = self.ds.unit_system
@@ -397,13 +397,13 @@ class MaestroFieldInfo(FieldInfoContainer):
         ("S", ("1/s", [], None)),
         ("ad_excess", ("", [], r"\nabla - \nabla_\mathrm{ad}")),
         ("deltaT", ("", [], "[T(\\rho,h,X) - T(\\rho,p,X)]/T(\\rho,h,X)")),
-        ("deltagamma", ("", [], "\Gamma_1 - \overline{\Gamma_1}")),
+        ("deltagamma", ("", [], r"\Gamma_1 - \overline{\Gamma_1}")),
         ("deltap", ("", [], "[p(\\rho,h,X) - p_0] / p_0")),
         ("divw0", ("1/s", [], r"\nabla \cdot \mathbf{w}_0")),
         # Specific entropy
         ("entropy", ("erg/(g*K)", ["entropy"], "s")),
-        ("entropypert", ("", [], "[s - \overline{s}] / \overline{s}")),
-        ("enucdot", ("erg/(g*s)", [], "\dot{\epsilon}_{nuc}")),
+        ("entropypert", ("", [], r"[s - \overline{s}] / \overline{s}")),
+        ("enucdot", ("erg/(g*s)", [], r"\dot{\epsilon}_{nuc}")),
         ("Hext", ("erg/(g*s)", [], "H_{ext}")),
         # Perturbational pressure grad
         ("gpi_x", ("dyne/cm**3", [], r"\left(\nabla\pi\right)_x")),
@@ -415,19 +415,19 @@ class MaestroFieldInfo(FieldInfoContainer):
         # full state.
         ("momentum", ("g*cm/s", ["momentum_magnitude"], r"\rho |\mathbf{U}|")),
         ("p0", ("erg/cm**3", [], "p_0")),
-        ("p0pluspi", ("erg/cm**3", [], "p_0 + \pi")),
-        ("pi", ("erg/cm**3", [], "\pi")),
-        ("pioverp0", ("", [], "\pi/p_0")),
+        ("p0pluspi", ("erg/cm**3", [], r"p_0 + \pi")),
+        ("pi", ("erg/cm**3", [], r"\pi")),
+        ("pioverp0", ("", [], r"\pi/p_0")),
         # Base state density
         ("rho0", ("g/cm**3", [], "\\rho_0")),
         ("rhoh", ("erg/cm**3", ["enthalpy_density"], "(\\rho h)")),
         # Base state enthalpy density
         ("rhoh0", ("erg/cm**3", [], "(\\rho h)_0")),
-        ("rhohpert", ("erg/cm**3", [], "(\\rho h)^\prime")),
-        ("rhopert", ("g/cm**3", [], "\\rho^\prime")),
+        ("rhohpert", ("erg/cm**3", [], "(\\rho h)^\\prime")),
+        ("rhopert", ("g/cm**3", [], "\\rho^\\prime")),
         ("soundspeed", ("cm/s", ["sound_speed"], None)),
         ("sponge", ("", [], None)),
-        ("tpert", ("K", [], "T - \overline{T}")),
+        ("tpert", ("K", [], r"T - \overline{T}")),
         # Again, base state -- so we can't compute ourselves.
         ("vort", ("1/s", ["vorticity_magnitude"], r"|\nabla\times\tilde{U}|")),
         # Base state

--- a/yt/frontends/boxlib/io.py
+++ b/yt/frontends/boxlib/io.py
@@ -21,7 +21,7 @@ class IOHandlerBoxlib(BaseIOHandler):
     _dataset_type = "boxlib_native"
 
     def __init__(self, ds, *args, **kwargs):
-        super(IOHandlerBoxlib, self).__init__(ds)
+        super().__init__(ds)
 
     def _read_fluid_selection(self, chunks, selector, fields, size):
         chunks = list(chunks)
@@ -125,8 +125,7 @@ class IOHandlerBoxlib(BaseIOHandler):
         return data
 
     def _read_particle_coords(self, chunks, ptf):
-        for rv in self._read_particle_fields(chunks, ptf, None):
-            yield rv
+        yield from self._read_particle_fields(chunks, ptf, None)
 
     def _read_particle_fields(self, chunks, ptf, selector):
         for chunk in chunks:  # These should be organized by grid filename
@@ -262,7 +261,7 @@ class IOHandlerOrion(IOHandlerBoxlib):
             return np.array(particles)
         except AttributeError:
             fn = self.particle_filename
-            with open(fn, "r") as f:
+            with open(fn) as f:
                 lines = f.readlines()
                 self._cached_lines = lines
                 for num in grid._particle_line_numbers:

--- a/yt/frontends/chombo/data_structures.py
+++ b/yt/frontends/chombo/data_structures.py
@@ -27,7 +27,7 @@ def is_chombo_hdf5(fn):
     try:
         with h5py.File(fn, mode="r") as fileh:
             valid = "Chombo_global" in fileh["/"]
-    except (KeyError, IOError, ImportError):
+    except (KeyError, OSError, ImportError):
         return False
     return valid
 
@@ -160,7 +160,7 @@ class ChomboHierarchy(GridIndex):
         i = 0
         D = self.dataset.dimensionality
         for lev_index, lev in enumerate(self._levels):
-            level_number = int(re.match("level_(\d+)", lev).groups()[0])
+            level_number = int(re.match(r"level_(\d+)", lev).groups()[0])
             try:
                 boxes = f[lev]["boxes"][()]
             except KeyError:
@@ -414,7 +414,7 @@ class PlutoHierarchy(ChomboHierarchy):
         i = 0
         D = self.dataset.dimensionality
         for lev_index, lev in enumerate(self._levels):
-            level_number = int(re.match("level_(\d+)", lev).groups()[0])
+            level_number = int(re.match(r"level_(\d+)", lev).groups()[0])
             try:
                 boxes = f[lev]["boxes"][()]
             except KeyError:
@@ -594,7 +594,7 @@ class Orion2Hierarchy(ChomboHierarchy):
     def _read_particles(self):
         if not os.path.exists(self.particle_filename):
             return
-        with open(self.particle_filename, "r") as f:
+        with open(self.particle_filename) as f:
             lines = f.readlines()
             self.num_stars = int(lines[0].strip().split(" ")[0])
             for num, line in enumerate(lines[1:]):

--- a/yt/frontends/chombo/fields.py
+++ b/yt/frontends/chombo/fields.py
@@ -79,7 +79,7 @@ class Orion2FieldInfo(ChomboFieldInfo):
                 units="code_length/code_time",
             )
 
-        super(Orion2FieldInfo, self).setup_particle_fields(ptype)
+        super().setup_particle_fields(ptype)
 
     def setup_fluid_fields(self):
         from yt.fields.magnetic_field import setup_magnetic_field_aliases
@@ -291,7 +291,7 @@ class ChomboPICFieldInfo2D(ChomboPICFieldInfo3D):
     )
 
     def __init__(self, ds, field_list):
-        super(ChomboPICFieldInfo2D, self).__init__(ds, field_list)
+        super().__init__(ds, field_list)
 
         for ftype in fluid_field_types:
             self.add_field(
@@ -333,7 +333,7 @@ class ChomboPICFieldInfo1D(ChomboPICFieldInfo3D):
     )
 
     def __init__(self, ds, field_list):
-        super(ChomboPICFieldInfo1D, self).__init__(ds, field_list)
+        super().__init__(ds, field_list)
 
         for ftype in fluid_field_types:
             self.add_field(

--- a/yt/frontends/chombo/io.py
+++ b/yt/frontends/chombo/io.py
@@ -65,7 +65,7 @@ class IOHandlerChomboHDF5(BaseIOHandler):
         field_dict = {}
         for key, val in self._handle.attrs.items():
             if key.startswith("component_"):
-                comp_number = int(re.match("component_(\d+)", key).groups()[0])
+                comp_number = int(re.match(r"component_(\d+)", key).groups()[0])
                 field_dict[val.decode("utf-8")] = comp_number
         self._field_dict = field_dict
         return self._field_dict
@@ -79,7 +79,9 @@ class IOHandlerChomboHDF5(BaseIOHandler):
         field_dict = {}
         for key, val in self._handle.attrs.items():
             if key.startswith("particle_"):
-                comp_number = int(re.match("particle_component_(\d+)", key).groups()[0])
+                comp_number = int(
+                    re.match(r"particle_component_(\d+)", key).groups()[0]
+                )
                 field_dict[val.decode("ascii")] = comp_number
         self._particle_field_index = field_dict
         return self._particle_field_index
@@ -115,7 +117,7 @@ class IOHandlerChomboHDF5(BaseIOHandler):
                 rv[ftype, fname] = self._read_data(grid, fname)
             return rv
         if size is None:
-            size = sum((g.count(selector) for chunk in chunks for g in chunk.objs))
+            size = sum(g.count(selector) for chunk in chunks for g in chunk.objs)
         for field in fields:
             ftype, fname = field
             fsize = size
@@ -194,14 +196,14 @@ class IOHandlerChomboHDF5(BaseIOHandler):
 
 
 def parse_orion_sinks(fn):
-    """
+    r"""
     Orion sink particles are stored in text files. This function
     is for figuring what particle fields are present based on the
     number of entries per line in the \*.sink file.
     """
 
     # Figure out the format of the particle file
-    with open(fn, "r") as f:
+    with open(fn) as f:
         lines = f.readlines()
 
     try:
@@ -295,7 +297,7 @@ class IOHandlerOrion2HDF5(IOHandlerChomboHDF5):
             return np.array(particles)
         except AttributeError:
             fn = grid.ds.fullplotdir[:-4] + "sink"
-            with open(fn, "r") as f:
+            with open(fn) as f:
                 lines = f.readlines()
                 self._cached_lines = lines
                 for num in grid._particle_line_numbers:

--- a/yt/frontends/eagle/fields.py
+++ b/yt/frontends/eagle/fields.py
@@ -128,9 +128,7 @@ class EagleNetworkFieldInfo(OWLSFieldInfo):
     )
 
     def __init__(self, ds, field_list, slice_info=None):
-        super(EagleNetworkFieldInfo, self).__init__(
-            ds, field_list, slice_info=slice_info
-        )
+        super().__init__(ds, field_list, slice_info=slice_info)
 
     def _create_ion_density_func(self, ftype, ion):
         """returns a function that calculates the ion density of a particle."""

--- a/yt/frontends/enzo/data_structures.py
+++ b/yt/frontends/enzo/data_structures.py
@@ -1,4 +1,3 @@
-import io
 import os
 import re
 import string
@@ -73,10 +72,10 @@ class EnzoGrid(AMRGridPatch):
         if not hasattr(self.index, "grid_active_particle_count"):
             return {}
         id = self.id - self._id_offset
-        nap = dict(
-            (ptype, self.index.grid_active_particle_count[ptype][id])
+        nap = {
+            ptype: self.index.grid_active_particle_count[ptype][id]
             for ptype in self.index.grid_active_particle_count
-        )
+        }
         return nap
 
 
@@ -158,7 +157,7 @@ class EnzoHierarchy(GridIndex):
             self._bn = "%s.cpu%%04i"
         self.index_filename = os.path.abspath(f"{ds.parameter_filename}.hierarchy")
         if os.path.getsize(self.index_filename) == 0:
-            raise IOError(-1, "File empty", self.index_filename)
+            raise OSError(-1, "File empty", self.index_filename)
         self.directory = os.path.dirname(self.index_filename)
 
         # For some reason, r8 seems to want Float64
@@ -226,7 +225,7 @@ class EnzoHierarchy(GridIndex):
 
         pattern = r"Pointer: Grid\[(\d*)\]->NextGrid(Next|This)Level = (\d*)\s+$"
         patt = re.compile(pattern)
-        f = open(self.index_filename, "rt")
+        f = open(self.index_filename)
         self.grids = [self.grid(1, self)]
         self.grids[0].Level = 0
         si, ei, LE, RE, fn, npart = [], [], [], [], [], []
@@ -237,12 +236,12 @@ class EnzoHierarchy(GridIndex):
             version = float(params["Internal"]["Provenance"]["VersionNumber"])
         if version >= 3.0:
             active_particles = True
-            nap = dict(
-                (ap_type, [])
+            nap = {
+                ap_type: []
                 for ap_type in params["Physics"]["ActiveParticles"][
                     "ActiveParticlesEnabled"
                 ]
-            )
+            }
         else:
             if "AppendActiveParticleType" in self.parameters:
                 nap = {}
@@ -290,14 +289,14 @@ class EnzoHierarchy(GridIndex):
         self.filenames = fn
 
     def _initialize_grid_arrays(self):
-        super(EnzoHierarchy, self)._initialize_grid_arrays()
+        super()._initialize_grid_arrays()
         if "AppendActiveParticleType" in self.parameters.keys() and len(
             self.parameters["AppendActiveParticleType"]
         ):
-            gac = dict(
-                (ptype, np.zeros(self.num_grids, dtype="i4"))
+            gac = {
+                ptype: np.zeros(self.num_grids, dtype="i4")
                 for ptype in self.parameters["AppendActiveParticleType"]
-            )
+            }
             self.grid_active_particle_count = gac
 
     def _fill_arrays(self, ei, si, LE, RE, npart, nap):
@@ -361,7 +360,7 @@ class EnzoHierarchy(GridIndex):
 
     def _detect_active_particle_fields(self):
         ap_list = self.dataset["AppendActiveParticleType"]
-        _fields = dict((ap, []) for ap in ap_list)
+        _fields = {ap: [] for ap in ap_list}
         fields = []
         for ptype in self.dataset["AppendActiveParticleType"]:
             select_grids = self.grid_active_particle_count[ptype].flat
@@ -388,7 +387,7 @@ class EnzoHierarchy(GridIndex):
         return set(fields)
 
     def _setup_derived_fields(self):
-        super(EnzoHierarchy, self)._setup_derived_fields()
+        super()._setup_derived_fields()
         aps = self.dataset.parameters.get("AppendActiveParticleType", [])
         for fname, field in self.ds.field_info.items():
             if not field.sampling_type == "particle":
@@ -415,7 +414,7 @@ class EnzoHierarchy(GridIndex):
                 try:
                     gf = self.io._read_field_names(grid)
                 except self.io._read_exception as e:
-                    raise IOError("Grid %s is a bit funky?", grid.id) from e
+                    raise OSError("Grid %s is a bit funky?", grid.id) from e
                 mylog.debug("Grid %s has: %s", grid.id, gf)
                 field_list = field_list.union(gf)
             if "AppendActiveParticleType" in self.dataset.parameters:
@@ -468,7 +467,7 @@ class EnzoHierarchy(GridIndex):
                 ret[ptype] = self.grid_active_particle_count[ptype].sum()
             return ret
         except AttributeError:
-            return super(EnzoHierarchy, self)._get_particle_type_counts()
+            return super()._get_particle_type_counts()
 
     def find_particles_by_type(self, ptype, max_num=None, additional_fields=None):
         """
@@ -760,7 +759,7 @@ class EnzoDataset(Dataset):
         dictionaries.
         """
         # Let's read the file
-        with io.open(self.parameter_filename, "r") as f:
+        with open(self.parameter_filename) as f:
             line = f.readline().strip()
             f.seek(0)
             if line == "Internal:":
@@ -1103,6 +1102,5 @@ def rlines(f, keepends=False):
         if lines:
             lines.reverse()
             buf = lines.pop()  # Last line becomes end of new first line.
-            for line in lines:
-                yield line
+            yield from lines
     yield buf  # First line.

--- a/yt/frontends/enzo/fields.py
+++ b/yt/frontends/enzo/fields.py
@@ -121,7 +121,7 @@ class EnzoFieldInfo(FieldInfoContainer):
             sl_right = slice(2, None, None)
             div_fac = 2.0
         slice_info = (sl_left, sl_right, div_fac)
-        super(EnzoFieldInfo, self).__init__(ds, field_list, slice_info)
+        super().__init__(ds, field_list, slice_info)
 
         # setup nodal flag information
         for field in NODAL_FLAGS:
@@ -320,4 +320,4 @@ class EnzoFieldInfo(FieldInfoContainer):
             (ptype, "age"), sampling_type="particle", function=_age, units="yr"
         )
 
-        super(EnzoFieldInfo, self).setup_particle_fields(ptype)
+        super().setup_particle_fields(ptype)

--- a/yt/frontends/enzo/io.py
+++ b/yt/frontends/enzo/io.py
@@ -25,7 +25,7 @@ class IOHandlerPackedHDF5(BaseIOHandler):
         except KeyError:
             group = f
         fields = []
-        dtypes = set([])
+        dtypes = set()
         add_io = "io" in grid.ds.particle_types
         for name, v in group.items():
             # NOTE: This won't work with 1D datasets or references.
@@ -58,8 +58,7 @@ class IOHandlerPackedHDF5(BaseIOHandler):
         return (KeyError,)
 
     def _read_particle_coords(self, chunks, ptf):
-        for rv in self._read_particle_fields(chunks, ptf, None):
-            yield rv
+        yield from self._read_particle_fields(chunks, ptf, None)
 
     def _read_particle_fields(self, chunks, ptf, selector):
         chunks = list(chunks)
@@ -162,14 +161,12 @@ class IOHandlerPackedHDF5GhostZones(IOHandlerPackedHDF5):
     _dataset_type = "enzo_packed_3d_gz"
 
     def __init__(self, *args, **kwargs):
-        super(IOHandlerPackedHDF5GhostZones, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         NGZ = self.ds.parameters.get("NumberOfGhostZones", 3)
         self._base = (slice(NGZ, -NGZ), slice(NGZ, -NGZ), slice(NGZ, -NGZ))
 
     def _read_obj_field(self, *args, **kwargs):
-        return super(IOHandlerPackedHDF5GhostZones, self)._read_obj_field(
-            *args, **kwargs
-        )[self._base]
+        return super()._read_obj_field(*args, **kwargs)[self._base]
 
 
 class IOHandlerInMemory(BaseIOHandler):
@@ -218,7 +215,7 @@ class IOHandlerInMemory(BaseIOHandler):
                 rv[(ftype, fname)] = self.grids_in_memory[g.id][fname].swapaxes(0, 2)
             return rv
         if size is None:
-            size = sum((g.count(selector) for chunk in chunks for g in chunk.objs))
+            size = sum(g.count(selector) for chunk in chunks for g in chunk.objs)
         for field in fields:
             ftype, fname = field
             fsize = size
@@ -314,7 +311,7 @@ class IOHandlerPacked2D(IOHandlerPackedHDF5):
             f.close()
             return rv
         if size is None:
-            size = sum((g.count(selector) for chunk in chunks for g in chunk.objs))
+            size = sum(g.count(selector) for chunk in chunks for g in chunk.objs)
         for field in fields:
             ftype, fname = field
             fsize = size

--- a/yt/frontends/enzo_p/data_structures.py
+++ b/yt/frontends/enzo_p/data_structures.py
@@ -1,4 +1,3 @@
-import io as io
 import os
 import warnings
 
@@ -87,14 +86,14 @@ class EnzoPGrid(AMRGridPatch):
     def particle_count(self):
         if self._particle_count is None:
             with h5py.File(self.filename, mode="r") as f:
-                fnstr = "%s/%s" % (
+                fnstr = "{}/{}".format(
                     self.block_name,
                     self.ds.index.io._sep.join(["particle", "%s", "%s"]),
                 )
-                self._particle_count = dict(
-                    (ptype, f.get(fnstr % (ptype, pfield)).size)
+                self._particle_count = {
+                    ptype: f.get(fnstr % (ptype, pfield)).size
                     for ptype, pfield in self.ds.index.io.sample_pfields.items()
-                )
+                }
         return self._particle_count
 
     _total_particles = None
@@ -130,14 +129,14 @@ class EnzoPHierarchy(GridIndex):
         self.directory = os.path.dirname(ds.parameter_filename)
         self.index_filename = ds.parameter_filename
         if os.path.getsize(self.index_filename) == 0:
-            raise IOError(-1, "File empty", self.index_filename)
+            raise OSError(-1, "File empty", self.index_filename)
 
         GridIndex.__init__(self, ds, dataset_type)
         self.dataset.dataset_type = self.dataset_type
 
     def _count_grids(self):
         fblock_size = 32768
-        f = open(self.ds.parameter_filename, "r")
+        f = open(self.ds.parameter_filename)
         f.seek(0, 2)
         file_size = f.tell()
         nblocks = np.ceil(float(file_size) / fblock_size).astype(np.int64)
@@ -157,7 +156,7 @@ class EnzoPHierarchy(GridIndex):
         self.grids = np.empty(self.num_grids, dtype="object")
 
         pbar = get_pbar("Parsing Hierarchy", self.num_grids)
-        f = open(self.ds.parameter_filename, "r")
+        f = open(self.ds.parameter_filename)
         fblock_size = 32768
         f.seek(0, 2)
         file_size = f.tell()
@@ -253,7 +252,7 @@ class EnzoPHierarchy(GridIndex):
         self.max_level = self.grid_levels.max()
 
     def _setup_derived_fields(self):
-        super(EnzoPHierarchy, self)._setup_derived_fields()
+        super()._setup_derived_fields()
         for fname, field in self.ds.field_info.items():
             if not field.particle_type:
                 continue
@@ -263,10 +262,10 @@ class EnzoPHierarchy(GridIndex):
                 continue
 
     def _get_particle_type_counts(self):
-        return dict(
-            (ptype, sum([g.particle_count[ptype] for g in self.grids]))
+        return {
+            ptype: sum([g.particle_count[ptype] for g in self.grids])
             for ptype in self.ds.particle_types_raw
-        )
+        }
 
     def _detect_output_fields(self):
         self.field_list = []
@@ -344,7 +343,7 @@ class EnzoPDataset(Dataset):
         dictionaries.
         """
 
-        f = open(self.parameter_filename, "r")
+        f = open(self.parameter_filename)
         # get dimension from first block name
         b0, fn0 = f.readline().strip().split()
         level0, left0, right0 = get_block_info(b0, min_dim=0)
@@ -355,7 +354,7 @@ class EnzoPDataset(Dataset):
 
         lcfn = self.parameter_filename[: -len(self._suffix)] + ".libconfig"
         if os.path.exists(lcfn):
-            with io.open(lcfn, "r") as lf:
+            with open(lcfn) as lf:
                 self.parameters = libconf.load(lf)
             cosmo = nested_dict_get(self.parameters, ("Physics", "cosmology"))
             if cosmo is not None:
@@ -367,15 +366,12 @@ class EnzoPDataset(Dataset):
                     "comoving_box_size",
                     "initial_redshift",
                 ]
-                co_dict = dict(
-                    (
-                        attr,
-                        nested_dict_get(
-                            self.parameters, ("Physics", "cosmology", attr)
-                        ),
+                co_dict = {
+                    attr: nested_dict_get(
+                        self.parameters, ("Physics", "cosmology", attr)
                     )
                     for attr in co_pars
-                )
+                }
                 for attr in ["hubble_constant", "omega_matter", "omega_lambda"]:
                     setattr(self, attr, co_dict[f"{attr}_now"])
 
@@ -470,7 +466,7 @@ class EnzoPDataset(Dataset):
         if not filename.endswith(cls._suffix):
             return False
         try:
-            with open(filename, "r") as f:
+            with open(filename) as f:
                 block, block_file = f.readline().strip().split()
                 get_block_info(block)
                 if not os.path.exists(os.path.join(ddir, block_file)):

--- a/yt/frontends/enzo_p/fields.py
+++ b/yt/frontends/enzo_p/fields.py
@@ -38,12 +38,10 @@ class EnzoPFieldInfo(FieldInfoContainer):
     )
 
     def __init__(self, ds, field_list, slice_info=None):
-        super(EnzoPFieldInfo, self).__init__(ds, field_list, slice_info=slice_info)
+        super().__init__(ds, field_list, slice_info=slice_info)
 
     def setup_particle_fields(self, ptype, ftype="gas", num_neighbors=64):
-        super(EnzoPFieldInfo, self).setup_particle_fields(
-            ptype, ftype=ftype, num_neighbors=num_neighbors
-        )
+        super().setup_particle_fields(ptype, ftype=ftype, num_neighbors=num_neighbors)
         self.setup_particle_mass_field(ptype)
 
     def setup_particle_mass_field(self, ptype):

--- a/yt/frontends/enzo_p/io.py
+++ b/yt/frontends/enzo_p/io.py
@@ -15,7 +15,7 @@ class EnzoPIOHandler(BaseIOHandler):
     _sep = "_"
 
     def __init__(self, *args, **kwargs):
-        super(EnzoPIOHandler, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._base = self.ds.dimensionality * (
             slice(self.ds.ghost_zones, -self.ds.ghost_zones),
         )
@@ -67,8 +67,7 @@ class EnzoPIOHandler(BaseIOHandler):
         return fields, ptypes
 
     def _read_particle_coords(self, chunks, ptf):
-        for rv in self._read_particle_fields(chunks, ptf, None):
-            yield rv
+        yield from self._read_particle_fields(chunks, ptf, None)
 
     def _read_particle_fields(self, chunks, ptf, selector):
         chunks = list(chunks)
@@ -81,14 +80,14 @@ class EnzoPIOHandler(BaseIOHandler):
                 if f is None:
                     f = h5py.File(g.filename, mode="r")
                 if g.particle_count is None:
-                    fnstr = "%s/%s" % (
+                    fnstr = "{}/{}".format(
                         g.block_name,
                         self._sep.join(["particle", "%s", "%s"]),
                     )
-                    g.particle_count = dict(
-                        (ptype, f.get(fnstr % (ptype, self.sample_pfields[ptype])).size)
+                    g.particle_count = {
+                        ptype: f.get(fnstr % (ptype, self.sample_pfields[ptype])).size
                         for ptype in self.sample_pfields
-                    )
+                    }
                     g.total_particles = sum(g.particle_count.values())
                 if g.total_particles == 0:
                     continue

--- a/yt/frontends/exodus_ii/data_structures.py
+++ b/yt/frontends/exodus_ii/data_structures.py
@@ -16,12 +16,12 @@ class ExodusIIUnstructuredMesh(UnstructuredMesh):
     _index_offset = 1
 
     def __init__(self, *args, **kwargs):
-        super(ExodusIIUnstructuredMesh, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 
 class ExodusIIUnstructuredIndex(UnstructuredIndex):
     def __init__(self, ds, dataset_type="exodus_ii"):
-        super(ExodusIIUnstructuredIndex, self).__init__(ds, dataset_type)
+        super().__init__(ds, dataset_type)
 
     def _initialize_mesh(self):
         coords = self.ds._read_coordinates()
@@ -135,9 +135,7 @@ class ExodusIIDataset(Dataset):
             self.displacements = {}
         else:
             self.displacements = displacements
-        super(ExodusIIDataset, self).__init__(
-            filename, dataset_type, units_override=units_override
-        )
+        super().__init__(filename, dataset_type, units_override=units_override)
         self.index_filename = filename
         self.storage_filename = storage_filename
         self.default_field = [f for f in self.field_list if f[0] == "connect1"][-1]

--- a/yt/frontends/exodus_ii/fields.py
+++ b/yt/frontends/exodus_ii/fields.py
@@ -17,7 +17,7 @@ class ExodusIIFieldInfo(FieldInfoContainer):
     )
 
     def __init__(self, ds, field_list):
-        super(ExodusIIFieldInfo, self).__init__(ds, field_list)
+        super().__init__(ds, field_list)
         for name in self:
             self[name].take_log = False
         # If you want, you can check self.field_list

--- a/yt/frontends/exodus_ii/io.py
+++ b/yt/frontends/exodus_ii/io.py
@@ -13,7 +13,7 @@ class IOHandlerExodusII(BaseIOHandler):
         self.filename = ds.index_filename
         exodus_ii_handler = NetCDF4FileHandler(self.filename)
         self.handler = exodus_ii_handler
-        super(IOHandlerExodusII, self).__init__(ds)
+        super().__init__(ds)
         self.node_fields = ds._get_nod_names()
         self.elem_fields = ds._get_elem_names()
 

--- a/yt/frontends/exodus_ii/simulation_handling.py
+++ b/yt/frontends/exodus_ii/simulation_handling.py
@@ -72,9 +72,7 @@ class ExodusIISimulation(DatasetSeries):
             fn = output["filename"]
             for step in range(num_steps):
                 ds_list.append((fn, step))
-        super(ExodusIISimulation, self).__init__(
-            ds_list, parallel=parallel, setup_function=setup_function
-        )
+        super().__init__(ds_list, parallel=parallel, setup_function=setup_function)
 
     def _check_for_outputs(self, potential_outputs):
         r"""

--- a/yt/frontends/exodus_ii/util.py
+++ b/yt/frontends/exodus_ii/util.py
@@ -12,7 +12,7 @@ def get_num_pseudo_dims(coords):
 
 
 def sanitize_string(s):
-    _printable = set([ord(_) for _ in string.printable])
+    _printable = {ord(_) for _ in string.printable}
     return "".join([chr(_) for _ in takewhile(lambda a: a in _printable, s)])
 
 
@@ -56,7 +56,7 @@ def group_by_sections(info_records):
 def get_top_levels(info_records):
     top_levels = []
     for idx, line in enumerate(info_records):
-        pattern = re.compile("###[a-zA-Z\s]+")
+        pattern = re.compile(r"###[a-zA-Z\s]+")
         if pattern.match(line):
             clean_line = re.sub(r"[^\w\s]", "", line).lstrip().rstrip()
             top_levels.append([idx, clean_line])

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -115,7 +115,7 @@ class FITSHierarchy(GridIndex):
         dup_field_index = {}
         # Since FITS header keywords are case-insensitive, we only pick a subset of
         # prefixes, ones that we expect to end up in headers.
-        known_units = dict([(unit.lower(), unit) for unit in self.ds.unit_registry.lut])
+        known_units = {unit.lower(): unit for unit in self.ds.unit_registry.lut}
         for unit in list(known_units.values()):
             if unit in self.ds.unit_registry.prefixable_units:
                 for p in ["n", "u", "m", "c", "k"]:
@@ -223,7 +223,7 @@ class FITSHierarchy(GridIndex):
         self.max_level = 0
 
     def _setup_derived_fields(self):
-        super(FITSHierarchy, self)._setup_derived_fields()
+        super()._setup_derived_fields()
         [self.dataset.conversion_factors[field] for field in self.field_list]
         for field in self.field_list:
             if field not in self.derived_field_list:
@@ -565,7 +565,7 @@ class YTFITSDataset(FITSDataset):
     _field_info_class = YTFITSFieldInfo
 
     def _parse_parameter_file(self):
-        super(YTFITSDataset, self)._parse_parameter_file()
+        super()._parse_parameter_file()
         # Get the current time
         if "time" in self.primary_header:
             self.current_time = self.primary_header["time"]
@@ -643,7 +643,7 @@ class SkyDataFITSDataset(FITSDataset):
     _field_info_class = WCSFITSFieldInfo
 
     def _determine_wcs(self):
-        super(SkyDataFITSDataset, self)._determine_wcs()
+        super()._determine_wcs()
         end = min(self.dimensionality + 1, 4)
         self.ctypes = np.array(
             [self.primary_header["CTYPE%d" % (i)] for i in range(1, end)]
@@ -651,7 +651,7 @@ class SkyDataFITSDataset(FITSDataset):
         self.wcs_2d = self.wcs
 
     def _parse_parameter_file(self):
-        super(SkyDataFITSDataset, self)._parse_parameter_file()
+        super()._parse_parameter_file()
 
         end = min(self.dimensionality + 1, 4)
 
@@ -683,7 +683,7 @@ class SkyDataFITSDataset(FITSDataset):
         self.spec_unit = ""
 
     def _set_code_unit_attributes(self):
-        super(SkyDataFITSDataset, self)._set_code_unit_attributes()
+        super()._set_code_unit_attributes()
         units = self.wcs_2d.wcs.cunit[0]
         if units == "deg":
             units = "degree"
@@ -748,7 +748,7 @@ class SpectralCubeFITSDataset(SkyDataFITSDataset):
                 "as this decomposition is now performed for "
                 "spectral-cube FITS datasets automatically."
             )
-        super(SpectralCubeFITSDataset, self).__init__(
+        super().__init__(
             filename,
             nprocs=nprocs,
             auxiliary_files=auxiliary_files,
@@ -761,7 +761,7 @@ class SpectralCubeFITSDataset(SkyDataFITSDataset):
         )
 
     def _parse_parameter_file(self):
-        super(SpectralCubeFITSDataset, self)._parse_parameter_file()
+        super()._parse_parameter_file()
 
         self.geometry = "spectral_cube"
 
@@ -836,7 +836,7 @@ class EventsFITSHierarchy(FITSHierarchy):
         return
 
     def _parse_index(self):
-        super(EventsFITSHierarchy, self)._parse_index()
+        super()._parse_index()
         try:
             self.grid_particle_count[:] = self.dataset.primary_header["naxis2"]
         except KeyError:
@@ -859,7 +859,7 @@ class EventsFITSDataset(SkyDataFITSDataset):
         unit_system="cgs",
     ):
         self.reblock = reblock
-        super(EventsFITSDataset, self).__init__(
+        super().__init__(
             filename,
             nprocs=1,
             storage_filename=storage_filename,

--- a/yt/frontends/fits/fields.py
+++ b/yt/frontends/fits/fields.py
@@ -5,7 +5,7 @@ class FITSFieldInfo(FieldInfoContainer):
     known_other_fields = ()
 
     def __init__(self, ds, field_list, slice_info=None):
-        super(FITSFieldInfo, self).__init__(ds, field_list, slice_info=slice_info)
+        super().__init__(ds, field_list, slice_info=slice_info)
         for field in ds.field_list:
             if field[0] == "fits":
                 self[field].take_log = False
@@ -45,7 +45,7 @@ class YTFITSFieldInfo(FieldInfoContainer):
     )
 
     def __init__(self, ds, field_list, slice_info=None):
-        super(YTFITSFieldInfo, self).__init__(ds, field_list, slice_info=slice_info)
+        super().__init__(ds, field_list, slice_info=slice_info)
 
 
 class WCSFITSFieldInfo(FITSFieldInfo):

--- a/yt/frontends/fits/io.py
+++ b/yt/frontends/fits/io.py
@@ -9,7 +9,7 @@ class IOHandlerFITS(BaseIOHandler):
     _dataset_type = "fits"
 
     def __init__(self, ds):
-        super(IOHandlerFITS, self).__init__(ds)
+        super().__init__(ds)
         self.ds = ds
         self._handle = ds._handle
 

--- a/yt/frontends/flash/data_structures.py
+++ b/yt/frontends/flash/data_structures.py
@@ -263,10 +263,12 @@ class FLASHDataset(Dataset):
         setdefaultattr(self, "temperature_unit", self.quan(temperature_factor, "K"))
 
     def set_code_units(self):
-        super(FLASHDataset, self).set_code_units()
+        super().set_code_units()
 
     def _find_parameter(self, ptype, pname, scalar=False):
-        nn = "/%s %s" % (ptype, {False: "runtime parameters", True: "scalars"}[scalar])
+        nn = "/{} {}".format(
+            ptype, {False: "runtime parameters", True: "scalars"}[scalar]
+        )
         if nn not in self._handle:
             raise KeyError(nn)
         for tpname, pval in zip(
@@ -511,7 +513,7 @@ class FLASHParticleDataset(FLASHDataset):
     def _parse_parameter_file(self):
         # Let the superclass do all the work but then
         # fix the domain dimensions
-        super(FLASHParticleDataset, self)._parse_parameter_file()
+        super()._parse_parameter_file()
         domain_dimensions = np.zeros(3, "int32")
         domain_dimensions[: self.dimensionality] = 1
         self.domain_dimensions = domain_dimensions

--- a/yt/frontends/flash/io.py
+++ b/yt/frontends/flash/io.py
@@ -27,9 +27,7 @@ def determine_particle_fields(handle):
         particle_fields = [
             s[0].decode("ascii", "ignore").strip() for s in handle["/particle names"][:]
         ]
-        _particle_fields = dict(
-            [("particle_" + s, i) for i, s in enumerate(particle_fields)]
-        )
+        _particle_fields = {"particle_" + s: i for i, s in enumerate(particle_fields)}
     except KeyError:
         _particle_fields = {}
     return _particle_fields
@@ -40,7 +38,7 @@ class IOHandlerFLASH(BaseIOHandler):
     _dataset_type = "flash_hdf5"
 
     def __init__(self, ds):
-        super(IOHandlerFLASH, self).__init__(ds)
+        super().__init__(ds)
         # Now we cache the particle fields
         self._handle = ds._handle
         self._particle_handle = ds._particle_handle
@@ -157,7 +155,7 @@ class IOHandlerFLASHParticle(BaseIOHandler):
     _dataset_type = "flash_particle_hdf5"
 
     def __init__(self, ds):
-        super(IOHandlerFLASHParticle, self).__init__(ds)
+        super().__init__(ds)
         # Now we cache the particle fields
         self._handle = ds._handle
         self._particle_fields = determine_particle_fields(self._handle)
@@ -171,7 +169,7 @@ class IOHandlerFLASHParticle(BaseIOHandler):
 
     def _read_particle_coords(self, chunks, ptf):
         chunks = list(chunks)
-        data_files = set([])
+        data_files = set()
         assert len(ptf) == 1
         for chunk in chunks:
             for obj in chunk.objs:
@@ -194,7 +192,7 @@ class IOHandlerFLASHParticle(BaseIOHandler):
 
     def _read_particle_fields(self, chunks, ptf, selector):
         chunks = list(chunks)
-        data_files = set([])
+        data_files = set()
         assert len(ptf) == 1
         for chunk in chunks:
             for obj in chunk.objs:

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -175,7 +175,7 @@ class GadgetBinaryFile(ParticleFile):
         with header.open() as f:
             self._file_size = f.seek(0, os.SEEK_END)
 
-        super(GadgetBinaryFile, self).__init__(ds, io, filename, file_id, range)
+        super().__init__(ds, io, filename, file_id, range)
 
     def _calculate_offsets(self, field_list, pcounts):
         # Note that we ignore pcounts here because it's the global count.  We
@@ -191,7 +191,7 @@ class GadgetBinaryFile(ParticleFile):
 
 class GadgetBinaryIndex(SPHParticleIndex):
     def __init__(self, ds, dataset_type):
-        super(GadgetBinaryIndex, self).__init__(ds, dataset_type)
+        super().__init__(ds, dataset_type)
         self._initialize_index()
 
     def _initialize_index(self):
@@ -200,10 +200,10 @@ class GadgetBinaryIndex(SPHParticleIndex):
         # read in the smoothing lengths for SPH data before we construct the
         # Morton bitmaps.
         self._detect_output_fields()
-        super(GadgetBinaryIndex, self)._initialize_index()
+        super()._initialize_index()
 
     def _initialize_frontend_specific(self):
-        super(GadgetBinaryIndex, self)._initialize_frontend_specific()
+        super()._initialize_frontend_specific()
         self.io._float_type = self.ds._header.float_type
 
 
@@ -305,7 +305,7 @@ class GadgetDataset(SPHDataset):
         self.w_0 = w_0
         self.w_a = w_a
 
-        super(GadgetDataset, self).__init__(
+        super().__init__(
             filename,
             dataset_type=dataset_type,
             unit_system=unit_system,
@@ -574,7 +574,7 @@ class GadgetHDF5Dataset(GadgetDataset):
                 "units_override is not supported for GadgetHDF5Dataset. "
                 "Use unit_base instead."
             )
-        super(GadgetHDF5Dataset, self).__init__(
+        super().__init__(
             filename,
             dataset_type,
             unit_base=unit_base,
@@ -683,7 +683,7 @@ class GadgetHDF5Dataset(GadgetDataset):
             fh = h5py.File(filename, mode="r")
             valid = fh["Header"].attrs["Code"].decode("utf-8") != "SWIFT"
             fh.close()
-        except (IOError, KeyError, ImportError):
+        except (OSError, KeyError, ImportError):
             pass
 
         return valid

--- a/yt/frontends/gadget/fields.py
+++ b/yt/frontends/gadget/fields.py
@@ -8,7 +8,7 @@ class GadgetFieldInfo(SPHFieldInfo):
         if ds.gen_hsmls:
             hsml = (("smoothing_length", ("code_length", [], None)),)
             self.known_particle_fields += hsml
-        super(GadgetFieldInfo, self).__init__(ds, field_list, slice_info=slice_info)
+        super().__init__(ds, field_list, slice_info=slice_info)
 
     def setup_particle_fields(self, ptype, *args, **kwargs):
 
@@ -17,7 +17,7 @@ class GadgetFieldInfo(SPHFieldInfo):
         if (ptype, "FourMetalFractions") in self.ds.field_list:
             self._setup_four_metal_fractions(ptype)
 
-        super(GadgetFieldInfo, self).setup_particle_fields(ptype, *args, **kwargs)
+        super().setup_particle_fields(ptype, *args, **kwargs)
 
         if ptype in ("PartType0", "Gas"):
             self.setup_gas_particle_fields(ptype)

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -45,7 +45,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
     def _read_particle_coords(self, chunks, ptf):
         # This will read chunks and yield the results.
         chunks = list(chunks)
-        data_files = set([])
+        data_files = set()
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
@@ -160,7 +160,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
 
     def _read_particle_fields(self, chunks, ptf, selector):
         # Now we have all the sizes, and we can allocate
-        data_files = set([])
+        data_files = set()
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
@@ -234,7 +234,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
         f.close()
         if None not in (si, ei):
             np.clip(pcount - si, 0, ei - si, out=pcount)
-        npart = dict((f"PartType{i}", v) for i, v in enumerate(pcount))
+        npart = {f"PartType{i}": v for i, v in enumerate(pcount)}
         return npart
 
     def _identify_fields(self, data_file):
@@ -330,12 +330,12 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
         self._vector_fields = dict(self._vector_fields)
         self._fields = ds._field_spec
         self._ptypes = ds._ptype_spec
-        self.data_files = set([])
+        self.data_files = set()
         gformat, endianswap = ds._header.gadget_format
         # gadget format 1 original, 2 with block name
         self._format = gformat
         self._endian = endianswap
-        super(IOHandlerGadgetBinary, self).__init__(ds, *args, **kwargs)
+        super().__init__(ds, *args, **kwargs)
 
     @property
     def var_mass(self):
@@ -351,7 +351,7 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
         raise NotImplementedError
 
     def _read_particle_coords(self, chunks, ptf):
-        data_files = set([])
+        data_files = set()
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
@@ -371,7 +371,7 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
             f.close()
 
     def _read_particle_fields(self, chunks, ptf, selector):
-        data_files = set([])
+        data_files = set()
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
@@ -475,7 +475,7 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
         pcount = np.array(data_file.header["Npart"])
         if None not in (si, ei):
             np.clip(pcount - si, 0, ei - si, out=pcount)
-        npart = dict((self._ptypes[i], v) for i, v in enumerate(pcount))
+        npart = {self._ptypes[i]: v for i, v in enumerate(pcount)}
         return npart
 
     # header is 256, but we have 4 at beginning and end for ints

--- a/yt/frontends/gadget/simulation_handling.py
+++ b/yt/frontends/gadget/simulation_handling.py
@@ -427,7 +427,6 @@ class GadgetSimulation(SimulationTimeSeries):
                         os.path.join(
                             self.data_dir, self.parameters["OutputListFilename"]
                         ),
-                        "r",
                     ).readlines()
                 ]
             else:

--- a/yt/frontends/gadget_fof/data_structures.py
+++ b/yt/frontends/gadget_fof/data_structures.py
@@ -24,12 +24,10 @@ class GadgetFOFParticleIndex(ParticleIndex):
         """
         Calculate the total number of each type of particle.
         """
-        self.particle_count = dict(
-            [
-                (ptype, sum([d.total_particles[ptype] for d in self.data_files]))
-                for ptype in self.ds.particle_types_raw
-            ]
-        )
+        self.particle_count = {
+            ptype: sum([d.total_particles[ptype] for d in self.data_files])
+            for ptype in self.ds.particle_types_raw
+        }
 
     def _calculate_particle_index_starts(self):
         # Halo indices are not saved in the file, so we must count by hand.
@@ -37,25 +35,20 @@ class GadgetFOFParticleIndex(ParticleIndex):
         particle_count = defaultdict(int)
         offset_count = 0
         for data_file in self.data_files:
-            data_file.index_start = dict(
-                [(ptype, particle_count[ptype]) for ptype in data_file.total_particles]
-            )
+            data_file.index_start = {
+                ptype: particle_count[ptype] for ptype in data_file.total_particles
+            }
             data_file.offset_start = offset_count
             for ptype in data_file.total_particles:
                 particle_count[ptype] += data_file.total_particles[ptype]
             offset_count += data_file.total_offset
 
-        self._halo_index_start = dict(
-            [
-                (
-                    ptype,
-                    np.array(
-                        [data_file.index_start[ptype] for data_file in self.data_files]
-                    ),
-                )
-                for ptype in self.ds.particle_types_raw
-            ]
-        )
+        self._halo_index_start = {
+            ptype: np.array(
+                [data_file.index_start[ptype] for data_file in self.data_files]
+            )
+            for ptype in self.ds.particle_types_raw
+        }
 
     def _calculate_file_offset_map(self):
         # After the FOF is performed, a load-balancing step redistributes halos
@@ -75,9 +68,9 @@ class GadgetFOFParticleIndex(ParticleIndex):
     def _detect_output_fields(self):
         field_list = []
         units = {}
-        found_fields = dict(
-            [(ptype, False) for ptype, pnum in self.particle_count.items() if pnum > 0]
-        )
+        found_fields = {
+            ptype: False for ptype, pnum in self.particle_count.items() if pnum > 0
+        }
 
         for data_file in self.data_files:
             fl, _units = self.io._identify_fields(data_file)
@@ -90,7 +83,7 @@ class GadgetFOFParticleIndex(ParticleIndex):
 
         self.field_list = field_list
         ds = self.dataset
-        ds.particle_types = tuple(set(pt for pt, ds in field_list))
+        ds.particle_types = tuple({pt for pt, ds in field_list})
         ds.field_units.update(units)
         ds.particle_types_raw = ds.particle_types
 
@@ -104,7 +97,7 @@ class GadgetFOFParticleIndex(ParticleIndex):
         ]
 
     def _setup_data_io(self):
-        super(GadgetFOFParticleIndex, self)._setup_data_io()
+        super()._setup_data_io()
         self._calculate_particle_count()
         self._calculate_particle_index_starts()
         self._calculate_file_offset_map()
@@ -113,9 +106,7 @@ class GadgetFOFParticleIndex(ParticleIndex):
 class GadgetFOFHDF5File(HaloCatalogFile):
     def __init__(self, ds, io, filename, file_id, frange):
         with h5py.File(filename, mode="r") as f:
-            self.header = dict(
-                (str(field), val) for field, val in f["Header"].attrs.items()
-            )
+            self.header = {str(field): val for field, val in f["Header"].attrs.items()}
             self.group_length_sum = (
                 f["Group/GroupLen"][()].sum() if "Group/GroupLen" in f else 0
             )
@@ -124,7 +115,7 @@ class GadgetFOFHDF5File(HaloCatalogFile):
             )
         self.total_ids = self.header["Nids_ThisFile"]
         self.total_offset = 0
-        super(GadgetFOFHDF5File, self).__init__(ds, io, filename, file_id, frange)
+        super().__init__(ds, io, filename, file_id, frange)
 
     def _read_particle_positions(self, ptype, f=None):
         """
@@ -170,7 +161,7 @@ class GadgetFOFDataset(ParticleDataset):
                 "units_override is not supported for GadgetFOFDataset. "
                 + "Use unit_base instead."
             )
-        super(GadgetFOFDataset, self).__init__(
+        super().__init__(
             filename,
             dataset_type,
             units_override=units_override,
@@ -180,7 +171,7 @@ class GadgetFOFDataset(ParticleDataset):
         )
 
     def add_field(self, *args, **kwargs):
-        super(GadgetFOFDataset, self).add_field(*args, **kwargs)
+        super().add_field(*args, **kwargs)
         self._halos_ds.add_field(*args, **kwargs)
 
     @property
@@ -200,14 +191,14 @@ class GadgetFOFDataset(ParticleDataset):
         return self._instantiated_halo_ds
 
     def _setup_classes(self):
-        super(GadgetFOFDataset, self)._setup_classes()
+        super()._setup_classes()
         self.halo = partial(GadgetFOFHaloContainer, ds=self._halos_ds)
 
     def _parse_parameter_file(self):
         with h5py.File(self.parameter_filename, mode="r") as f:
-            self.parameters = dict(
-                (str(field), val) for field, val in f["Header"].attrs.items()
-            )
+            self.parameters = {
+                str(field): val for field, val in f["Header"].attrs.items()
+            }
 
         self.dimensionality = 3
         self.refine_by = 2
@@ -323,7 +314,7 @@ class GadgetFOFDataset(ParticleDataset):
 class GadgetFOFHaloParticleIndex(GadgetFOFParticleIndex):
     def __init__(self, ds, dataset_type):
         self.real_ds = weakref.proxy(ds.real_ds)
-        super(GadgetFOFHaloParticleIndex, self).__init__(ds, dataset_type)
+        super().__init__(ds, dataset_type)
 
     def _create_halo_id_table(self):
         """
@@ -348,9 +339,9 @@ class GadgetFOFHaloParticleIndex(GadgetFOFParticleIndex):
         field_list = []
         scalar_field_list = []
         units = {}
-        found_fields = dict(
-            [(ptype, False) for ptype, pnum in self.particle_count.items() if pnum > 0]
-        )
+        found_fields = {
+            ptype: False for ptype, pnum in self.particle_count.items() if pnum > 0
+        }
         has_ids = False
 
         for data_file in self.data_files:
@@ -368,7 +359,7 @@ class GadgetFOFHaloParticleIndex(GadgetFOFParticleIndex):
         self.scalar_field_list = scalar_field_list
         ds = self.dataset
         ds.scalar_field_list = scalar_field_list
-        ds.particle_types = tuple(set(pt for pt, ds in field_list))
+        ds.particle_types = tuple({pt for pt, ds in field_list})
         ds.field_units.update(units)
         ds.particle_types_raw = ds.particle_types
 
@@ -430,7 +421,7 @@ class GadgetFOFHaloParticleIndex(GadgetFOFParticleIndex):
         return data
 
     def _setup_data_io(self):
-        super(GadgetFOFHaloParticleIndex, self)._setup_data_io()
+        super()._setup_data_io()
         self._create_halo_id_table()
 
 
@@ -450,9 +441,7 @@ class GadgetFOFHaloDataset(ParticleDataset):
         ]:
             setattr(self, attr, getattr(self.real_ds, attr))
 
-        super(GadgetFOFHaloDataset, self).__init__(
-            self.real_ds.parameter_filename, dataset_type
-        )
+        super().__init__(self.real_ds.parameter_filename, dataset_type)
 
     def print_key_parameters(self):
         pass
@@ -585,7 +574,7 @@ class GadgetFOFHaloContainer(YTSelectionContainer):
 
         self.ptype = ptype
         self._current_particle_type = ptype
-        super(GadgetFOFHaloContainer, self).__init__(ds, {})
+        super().__init__(ds, {})
 
         if ptype == "Subhalo" and isinstance(particle_identifier, tuple):
             self.group_identifier, self.subgroup_identifier = particle_identifier

--- a/yt/frontends/gadget_fof/io.py
+++ b/yt/frontends/gadget_fof/io.py
@@ -13,8 +13,8 @@ class IOHandlerGadgetFOFHDF5(BaseIOHandler):
     _dataset_type = "gadget_fof_hdf5"
 
     def __init__(self, ds):
-        super(IOHandlerGadgetFOFHDF5, self).__init__(ds)
-        self.offset_fields = set([])
+        super().__init__(ds)
+        self.offset_fields = set()
 
     def _read_fluid_selection(self, chunks, selector, fields, size):
         raise NotImplementedError
@@ -22,7 +22,7 @@ class IOHandlerGadgetFOFHDF5(BaseIOHandler):
     def _read_particle_coords(self, chunks, ptf):
         # This will read chunks and yield the results.
         chunks = list(chunks)
-        data_files = set([])
+        data_files = set()
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
@@ -72,7 +72,7 @@ class IOHandlerGadgetFOFHDF5(BaseIOHandler):
     def _read_particle_fields(self, chunks, ptf, selector):
         # Now we have all the sizes, and we can allocate
         chunks = list(chunks)
-        data_files = set([])
+        data_files = set()
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)

--- a/yt/frontends/gamer/fields.py
+++ b/yt/frontends/gamer/fields.py
@@ -45,7 +45,7 @@ class GAMERFieldInfo(FieldInfoContainer):
     )
 
     def __init__(self, ds, field_list):
-        super(GAMERFieldInfo, self).__init__(ds, field_list)
+        super().__init__(ds, field_list)
 
     # add primitive and other derived variables
     def setup_fluid_fields(self):
@@ -165,4 +165,4 @@ class GAMERFieldInfo(FieldInfoContainer):
             setup_magnetic_field_aliases(self, "gamer", [f"CCMag{v}" for v in "XYZ"])
 
     def setup_particle_fields(self, ptype):
-        super(GAMERFieldInfo, self).setup_particle_fields(ptype)
+        super().setup_particle_fields(ptype)

--- a/yt/frontends/gamer/io.py
+++ b/yt/frontends/gamer/io.py
@@ -30,7 +30,7 @@ class IOHandlerGAMER(BaseIOHandler):
     _dataset_type = "gamer"
 
     def __init__(self, ds):
-        super(IOHandlerGAMER, self).__init__(ds)
+        super().__init__(ds)
         self._handle = ds._handle
         self._group_grid = ds._group_grid
         self._group_particle = ds._group_particle

--- a/yt/frontends/gdf/io.py
+++ b/yt/frontends/gdf/io.py
@@ -40,9 +40,7 @@ class IOHandlerGDFHDF5(BaseIOHandler):
             h5f.close()
             return rv
         if size is None:
-            size = sum(
-                (grid.count(selector) for chunk in chunks for grid in chunk.objs)
-            )
+            size = sum(grid.count(selector) for chunk in chunks for grid in chunk.objs)
 
         if any((ftype != "gdf" for ftype, fname in fields)):
             raise NotImplementedError

--- a/yt/frontends/gizmo/data_structures.py
+++ b/yt/frontends/gizmo/data_structures.py
@@ -48,5 +48,5 @@ class GizmoDataset(GadgetHDF5Dataset):
         return valid
 
     def _set_code_unit_attributes(self):
-        super(GizmoDataset, self)._set_code_unit_attributes()
+        super()._set_code_unit_attributes()
         self.magnetic_unit = self.quan(1.0, "gauss")

--- a/yt/frontends/gizmo/fields.py
+++ b/yt/frontends/gizmo/fields.py
@@ -59,7 +59,7 @@ class GizmoFieldInfo(GadgetFieldInfo):
             self.setup_star_particle_fields(ptype)
 
     def setup_gas_particle_fields(self, ptype):
-        super(GizmoFieldInfo, self).setup_gas_particle_fields(ptype)
+        super().setup_gas_particle_fields(ptype)
 
         def _h_p0_density(field, data):
             x_H = 1.0 - data[(ptype, "He_metallicity")] - data[(ptype, "metallicity")]

--- a/yt/frontends/halo_catalog/data_structures.py
+++ b/yt/frontends/halo_catalog/data_structures.py
@@ -30,7 +30,7 @@ class HaloCatalogFile(ParticleFile):
     """
 
     def __init__(self, ds, io, filename, file_id, frange):
-        super(HaloCatalogFile, self).__init__(ds, io, filename, file_id, frange)
+        super().__init__(ds, io, filename, file_id, frange)
 
     def _read_particle_positions(self, ptype, f=None):
         raise NotImplementedError
@@ -62,13 +62,11 @@ class YTHaloCatalogFile(HaloCatalogFile):
 
     def __init__(self, ds, io, filename, file_id, frange):
         with h5py.File(filename, mode="r") as f:
-            self.header = dict(
-                (field, parse_h5_attr(f, field)) for field in f.attrs.keys()
-            )
+            self.header = {field: parse_h5_attr(f, field) for field in f.attrs.keys()}
             pids = f.get("particles/ids")
             self.total_ids = 0 if pids is None else pids.size
             self.group_length_sum = self.total_ids
-        super(YTHaloCatalogFile, self).__init__(ds, io, filename, file_id, frange)
+        super().__init__(ds, io, filename, file_id, frange)
 
     def _read_particle_positions(self, ptype, f=None):
         """
@@ -124,7 +122,7 @@ class YTHaloCatalogDataset(SavedDataset):
         unit_system="cgs",
     ):
         self.index_order = validate_index_order(index_order)
-        super(YTHaloCatalogDataset, self).__init__(
+        super().__init__(
             filename,
             dataset_type,
             units_override=units_override,
@@ -132,7 +130,7 @@ class YTHaloCatalogDataset(SavedDataset):
         )
 
     def add_field(self, *args, **kwargs):
-        super(YTHaloCatalogDataset, self).add_field(*args, **kwargs)
+        super().add_field(*args, **kwargs)
         self._halos_ds.add_field(*args, **kwargs)
 
     @property
@@ -152,7 +150,7 @@ class YTHaloCatalogDataset(SavedDataset):
         return self._instantiated_halo_ds
 
     def _setup_classes(self):
-        super(YTHaloCatalogDataset, self)._setup_classes()
+        super()._setup_classes()
         self.halo = partial(YTHaloCatalogHaloContainer, ds=self._halos_ds)
         self.halo.__doc__ = YTHaloCatalogHaloContainer.__doc__
 
@@ -166,7 +164,7 @@ class YTHaloCatalogDataset(SavedDataset):
         self.file_count = len(glob.glob(prefix + "*" + self._suffix))
         self.particle_types = ("halos",)
         self.particle_types_raw = ("halos",)
-        super(YTHaloCatalogDataset, self)._parse_parameter_file()
+        super()._parse_parameter_file()
 
     @classmethod
     def _is_valid(cls, filename, *args, **kwargs):
@@ -188,7 +186,7 @@ class YTHaloParticleIndex(ParticleIndex):
 
     def __init__(self, ds, dataset_type):
         self.real_ds = weakref.proxy(ds.real_ds)
-        super(YTHaloParticleIndex, self).__init__(ds, dataset_type)
+        super().__init__(ds, dataset_type)
 
     def _calculate_particle_index_starts(self):
         """
@@ -197,9 +195,9 @@ class YTHaloParticleIndex(ParticleIndex):
         particle_count = defaultdict(int)
         offset_count = 0
         for data_file in self.data_files:
-            data_file.index_start = dict(
-                [(ptype, particle_count[ptype]) for ptype in data_file.total_particles]
-            )
+            data_file.index_start = {
+                ptype: particle_count[ptype] for ptype in data_file.total_particles
+            }
             data_file.offset_start = offset_count
             for ptype in data_file.total_particles:
                 particle_count[ptype] += data_file.total_particles[ptype]
@@ -219,7 +217,7 @@ class YTHaloParticleIndex(ParticleIndex):
         for ptype in self.ds.particle_types_raw:
             d = [df.total_particles[ptype] for df in self.data_files]
             pc.update({ptype: sum(d)})
-        found_fields = dict([(ptype, False) for ptype, pnum in pc.items() if pnum > 0])
+        found_fields = {ptype: False for ptype, pnum in pc.items() if pnum > 0}
         has_ids = False
 
         for data_file in self.data_files:
@@ -237,7 +235,7 @@ class YTHaloParticleIndex(ParticleIndex):
         self.scalar_field_list = scalar_field_list
         ds = self.dataset
         ds.scalar_field_list = scalar_field_list
-        ds.particle_types = tuple(set(pt for pt, ds in field_list))
+        ds.particle_types = tuple({pt for pt, ds in field_list})
         ds.field_units.update(units)
         ds.particle_types_raw = ds.particle_types
 
@@ -303,7 +301,7 @@ class YTHaloParticleIndex(ParticleIndex):
         return fields_to_return, fields_to_generate
 
     def _setup_data_io(self):
-        super(YTHaloParticleIndex, self)._setup_data_io()
+        super()._setup_data_io()
         if self.real_ds._instantiated_index is None:
             self.real_ds.index
 
@@ -330,7 +328,7 @@ class HaloDataset(ParticleDataset):
         ]:
             setattr(self, attr, getattr(self.real_ds, attr))
 
-        super(HaloDataset, self).__init__(self.real_ds.parameter_filename, dataset_type)
+        super().__init__(self.real_ds.parameter_filename, dataset_type)
 
     def print_key_parameters(self):
         pass
@@ -379,7 +377,7 @@ class YTHaloDataset(HaloDataset):
     _field_info_class = YTHaloCatalogHaloFieldInfo
 
     def __init__(self, ds, dataset_type="ythalo"):
-        super(YTHaloDataset, self).__init__(ds, dataset_type)
+        super().__init__(ds, dataset_type)
 
     def _set_code_unit_attributes(self):
         pass
@@ -408,7 +406,7 @@ class HaloContainer(YTSelectionContainer):
 
         self.ptype = ptype
         self._current_particle_type = ptype
-        super(HaloContainer, self).__init__(ds, {})
+        super().__init__(ds, {})
 
         self._set_identifiers(particle_identifier)
 
@@ -470,9 +468,7 @@ class HaloContainer(YTSelectionContainer):
         my_data = self.index._get_halo_values(
             self.ptype, np.array([self.particle_identifier]), halo_fields
         )
-        self._io_data = dict(
-            (field, np.int64(val[0])) for field, val in my_data.items()
-        )
+        self._io_data = {field: np.int64(val[0]) for field, val in my_data.items()}
 
     def __repr__(self):
         return f"{self.ds}_{self.ptype}_{self.particle_identifier:09d}"

--- a/yt/frontends/halo_catalog/io.py
+++ b/yt/frontends/halo_catalog/io.py
@@ -18,7 +18,7 @@ class IOHandlerYTHaloCatalog(BaseIOHandler):
     def _read_particle_coords(self, chunks, ptf):
         # This will read chunks and yield the results.
         chunks = list(chunks)
-        data_files = set([])
+        data_files = set()
         # Only support halo reading for now.
         assert len(ptf) == 1
         assert list(ptf.keys())[0] == "halos"
@@ -48,7 +48,7 @@ class IOHandlerYTHaloCatalog(BaseIOHandler):
     def _read_particle_fields(self, chunks, ptf, selector):
         # Now we have all the sizes, and we can allocate
         chunks = list(chunks)
-        data_files = set([])
+        data_files = set()
         # Only support halo reading for now.
         assert len(ptf) == 1
         assert list(ptf.keys())[0] == "halos"
@@ -83,9 +83,7 @@ class IOHandlerYTHaloCatalog(BaseIOHandler):
             fields = [
                 ("halos", field) for field in f if not isinstance(f[field], h5py.Group)
             ]
-            units = dict(
-                [(("halos", field), parse_h5_attr(f[field], "units")) for field in f]
-            )
+            units = {("halos", field): parse_h5_attr(f[field], "units") for field in f}
         return fields, units
 
 
@@ -126,9 +124,7 @@ class IOHandlerYTHalo(HaloDatasetIOHandler, IOHandlerYTHaloCatalog):
             scalar_fields = [
                 ("halos", field) for field in f if not isinstance(f[field], h5py.Group)
             ]
-            units = dict(
-                [(("halos", field), parse_h5_attr(f[field], "units")) for field in f]
-            )
+            units = {("halos", field): parse_h5_attr(f[field], "units") for field in f}
             if "particles" in f:
                 id_fields = [("halos", field) for field in f["particles"]]
             else:

--- a/yt/frontends/halo_catalog/tests/test_outputs.py
+++ b/yt/frontends/halo_catalog/tests/test_outputs.py
@@ -17,7 +17,7 @@ from yt.utilities.answer_testing.framework import data_dir_load
 def fake_halo_catalog(data):
     filename = "catalog.0.h5"
 
-    ftypes = dict((field, ".") for field in data)
+    ftypes = {field: "." for field in data}
     extra_attrs = {"data_type": "halo_catalog", "num_halos": data["particle_mass"].size}
 
     ds = {
@@ -43,10 +43,10 @@ class HaloCatalogTest(TempDirTest):
             f"particle_{name}" for name in ["mass"] + [f"position_{ax}" for ax in "xyz"]
         ]
         units = ["g"] + ["cm"] * 3
-        data = dict(
-            (field, YTArray(rs.random_sample(n_halos), unit))
+        data = {
+            field: YTArray(rs.random_sample(n_halos), unit)
             for field, unit in zip(fields, units)
-        )
+        }
 
         fn = fake_halo_catalog(data)
         ds = yt_load(fn)
@@ -68,10 +68,10 @@ class HaloCatalogTest(TempDirTest):
             f"particle_{name}" for name in ["mass"] + [f"position_{ax}" for ax in "xyz"]
         ]
         units = ["g"] + ["cm"] * 3
-        data = dict(
-            (field, YTArray(rs.random_sample(n_halos), unit))
+        data = {
+            field: YTArray(rs.random_sample(n_halos), unit)
             for field, unit in zip(fields, units)
-        )
+        }
 
         data["particle_position_x"][0] = 1.0
         data["particle_position_x"][1] = 0.0

--- a/yt/frontends/http_stream/data_structures.py
+++ b/yt/frontends/http_stream/data_structures.py
@@ -33,7 +33,7 @@ class HTTPStreamDataset(ParticleDataset):
         if get_requests() is None:
             raise ImportError("This functionality depends on the requests package")
         self.base_url = base_url
-        super(HTTPStreamDataset, self).__init__(
+        super().__init__(
             "",
             dataset_type=dataset_type,
             unit_system=unit_system,
@@ -55,9 +55,9 @@ class HTTPStreamDataset(ParticleDataset):
         if hreq.status_code != 200:
             raise RuntimeError
         header = json.loads(hreq.content)
-        header["particle_count"] = dict(
-            (int(k), header["particle_count"][k]) for k in header["particle_count"]
-        )
+        header["particle_count"] = {
+            int(k): header["particle_count"][k] for k in header["particle_count"]
+        }
         self.parameters = header
 
         # Now we get what we need
@@ -88,7 +88,7 @@ class HTTPStreamDataset(ParticleDataset):
         self._unit_base = {}
         self._unit_base["cm"] = 1.0 / length_unit
         self._unit_base["s"] = 1.0 / time_unit
-        super(HTTPStreamDataset, self)._set_units()
+        super()._set_units()
         self.conversion_factors["velocity"] = velocity_unit
         self.conversion_factors["mass"] = mass_unit
         self.conversion_factors["density"] = density_unit

--- a/yt/frontends/http_stream/io.py
+++ b/yt/frontends/http_stream/io.py
@@ -15,7 +15,7 @@ class IOHandlerHTTPStream(BaseIOHandler):
         self._url = ds.base_url
         # This should eventually manage the IO and cache it
         self.total_bytes = 0
-        super(IOHandlerHTTPStream, self).__init__(ds)
+        super().__init__(ds)
 
     def _open_stream(self, data_file, field):
         # This does not actually stream yet!
@@ -37,7 +37,7 @@ class IOHandlerHTTPStream(BaseIOHandler):
 
     def _read_particle_coords(self, chunks, ptf):
         chunks = list(chunks)
-        data_files = set([])
+        data_files = set()
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
@@ -50,7 +50,7 @@ class IOHandlerHTTPStream(BaseIOHandler):
 
     def _read_particle_fields(self, chunks, ptf, selector):
         # Now we have all the sizes, and we can allocate
-        data_files = set([])
+        data_files = set()
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)

--- a/yt/frontends/moab/data_structures.py
+++ b/yt/frontends/moab/data_structures.py
@@ -117,7 +117,7 @@ class PyneMeshHex8Hierarchy(UnstructuredIndex):
         self.directory = os.getcwd()
         self.pyne_mesh = ds.pyne_mesh
 
-        super(PyneMeshHex8Hierarchy, self).__init__(ds, dataset_type)
+        super().__init__(ds, dataset_type)
 
     def _initialize_mesh(self):
         from pymoab import types

--- a/yt/frontends/moab/io.py
+++ b/yt/frontends/moab/io.py
@@ -13,7 +13,7 @@ class IOHandlerMoabH5MHex8(BaseIOHandler):
     _dataset_type = "moab_hex8"
 
     def __init__(self, ds):
-        super(IOHandlerMoabH5MHex8, self).__init__(ds)
+        super().__init__(ds)
         self._handle = ds._handle
 
     def _read_fluid_selection(self, chunks, selector, fields, size):

--- a/yt/frontends/nc4_cm1/data_structures.py
+++ b/yt/frontends/nc4_cm1/data_structures.py
@@ -18,7 +18,7 @@ class CM1Grid(AMRGridPatch):
     _id_offset = 0
 
     def __init__(self, id, index, level, dimensions):
-        super(CM1Grid, self).__init__(id, filename=index.index_filename, index=index)
+        super().__init__(id, filename=index.index_filename, index=index)
         self.Parent = None
         self.Children = []
         self.Level = level
@@ -39,7 +39,7 @@ class CM1Hierarchy(GridIndex):
         self.directory = os.path.dirname(self.index_filename)
         # float type for the simulation edges and must be float64 now
         self.float_type = np.float64
-        super(CM1Hierarchy, self).__init__(ds, dataset_type)
+        super().__init__(ds, dataset_type)
 
     def _detect_output_fields(self):
         # build list of on-disk fields for dataset_type 'cm1'
@@ -83,7 +83,7 @@ class CM1Dataset(Dataset):
         self._handle = NetCDF4FileHandler(filename)
         # refinement factor between a grid and its subgrid
         self.refine_by = 1
-        super(CM1Dataset, self).__init__(
+        super().__init__(
             filename,
             dataset_type,
             units_override=units_override,
@@ -95,7 +95,7 @@ class CM1Dataset(Dataset):
     def _setup_coordinate_handler(self):
         # ensure correct ordering of axes so plots aren't rotated (z should always be
         # on the vertical axis).
-        super(CM1Dataset, self)._setup_coordinate_handler()
+        super()._setup_coordinate_handler()
         self.coordinates._x_pairs = (("x", "y"), ("y", "x"), ("z", "x"))
         self.coordinates._y_pairs = (("x", "z"), ("y", "z"), ("z", "y"))
 

--- a/yt/frontends/nc4_cm1/fields.py
+++ b/yt/frontends/nc4_cm1/fields.py
@@ -59,5 +59,5 @@ class CM1FieldInfo(FieldInfoContainer):
         pass
 
     def setup_particle_fields(self, ptype):
-        super(CM1FieldInfo, self).setup_particle_fields(ptype)
+        super().setup_particle_fields(ptype)
         # This will get called for every particle type.

--- a/yt/frontends/nc4_cm1/io.py
+++ b/yt/frontends/nc4_cm1/io.py
@@ -11,7 +11,7 @@ class CM1IOHandler(BaseIOHandler):
     def __init__(self, ds):
         self.filename = ds.filename
         self._handle = NetCDF4FileHandler(self.filename)
-        super(CM1IOHandler, self).__init__(ds)
+        super().__init__(ds)
 
     def _read_particle_coords(self, chunks, ptf):
         # This needs to *yield* a series of tuples of (ptype, (x, y, z)).

--- a/yt/frontends/open_pmd/data_structures.py
+++ b/yt/frontends/open_pmd/data_structures.py
@@ -638,7 +638,7 @@ class OpenPMDDatasetSeries(DatasetSeries):
     mixed_dataset_types = False
 
     def __init__(self, filename):
-        super(OpenPMDDatasetSeries, self).__init__([])
+        super().__init__([])
         self.handle = h5py.File(filename, mode="r")
         self.filename = filename
         self._pre_outputs = sorted(

--- a/yt/frontends/open_pmd/fields.py
+++ b/yt/frontends/open_pmd/fields.py
@@ -103,7 +103,7 @@ def setup_absolute_positions(self, ptype):
 
 
 class OpenPMDFieldInfo(FieldInfoContainer):
-    """Specifies which fields from the dataset yt should know about.
+    r"""Specifies which fields from the dataset yt should know about.
 
     ``self.known_other_fields`` and ``self.known_particle_fields`` must be populated.
     Entries for both of these lists must be tuples of the form ("name", ("units",
@@ -226,7 +226,7 @@ class OpenPMDFieldInfo(FieldInfoContainer):
         except (KeyError, TypeError, AttributeError):
             pass
 
-        super(OpenPMDFieldInfo, self).__init__(ds, field_list)
+        super().__init__(ds, field_list)
 
     def setup_fluid_fields(self):
         """Defines which derived mesh fields to create.
@@ -248,4 +248,4 @@ class OpenPMDFieldInfo(FieldInfoContainer):
         setup_absolute_positions(self, ptype)
         setup_kinetic_energy(self, ptype)
         setup_velocity(self, ptype)
-        super(OpenPMDFieldInfo, self).setup_particle_fields(ptype)
+        super().setup_particle_fields(ptype)

--- a/yt/frontends/open_pmd/io.py
+++ b/yt/frontends/open_pmd/io.py
@@ -175,7 +175,7 @@ class IOHandlerOpenPMDHDF5(BaseIOHandler):
                 raise RuntimeError
 
         if size is None:
-            size = sum((g.count(selector) for chunk in chunks for g in chunk.objs))
+            size = sum(g.count(selector) for chunk in chunks for g in chunk.objs)
         for field in fields:
             rv[field] = np.empty(size, dtype=np.float64)
             ind[field] = 0

--- a/yt/frontends/owls/fields.py
+++ b/yt/frontends/owls/fields.py
@@ -104,7 +104,7 @@ class OWLSFieldInfo(SPHFieldInfo):
 
         self.known_particle_fields += new_particle_fields
 
-        super(OWLSFieldInfo, self).__init__(ds, field_list, slice_info=slice_info)
+        super().__init__(ds, field_list, slice_info=slice_info)
 
         # This enables the machinery in yt.fields.species_fields
         self.species_names += list(self._elements)
@@ -140,7 +140,7 @@ class OWLSFieldInfo(SPHFieldInfo):
         else:
             ftype = ptype
 
-        super(OWLSFieldInfo, self).setup_particle_fields(
+        super().setup_particle_fields(
             ptype, num_neighbors=self._num_neighbors, ftype=ftype
         )
 

--- a/yt/frontends/owls_subfind/data_structures.py
+++ b/yt/frontends/owls_subfind/data_structures.py
@@ -17,7 +17,7 @@ from .fields import OWLSSubfindFieldInfo
 
 class OWLSSubfindParticleIndex(ParticleIndex):
     def __init__(self, ds, dataset_type):
-        super(OWLSSubfindParticleIndex, self).__init__(ds, dataset_type)
+        super().__init__(ds, dataset_type)
 
     def _calculate_particle_index_starts(self):
         # Halo indices are not saved in the file, so we must count by hand.
@@ -25,9 +25,9 @@ class OWLSSubfindParticleIndex(ParticleIndex):
         particle_count = defaultdict(int)
         offset_count = 0
         for data_file in self.data_files:
-            data_file.index_start = dict(
-                [(ptype, particle_count[ptype]) for ptype in data_file.total_particles]
-            )
+            data_file.index_start = {
+                ptype: particle_count[ptype] for ptype in data_file.total_particles
+            }
             data_file.offset_start = offset_count
             for ptype in data_file.total_particles:
                 particle_count[ptype] += data_file.total_particles[ptype]
@@ -63,7 +63,7 @@ class OWLSSubfindParticleIndex(ParticleIndex):
                     dsl.append(f)
         self.field_list = dsl
         ds = self.dataset
-        ds.particle_types = tuple(set(pt for pt, ds in dsl))
+        ds.particle_types = tuple({pt for pt, ds in dsl})
         # This is an attribute that means these particle types *actually*
         # exist.  As in, they are real, in the dataset.
         ds.field_units.update(units)
@@ -72,9 +72,9 @@ class OWLSSubfindParticleIndex(ParticleIndex):
 
 class OWLSSubfindHDF5File(ParticleFile):
     def __init__(self, ds, io, filename, file_id, bounds):
-        super(OWLSSubfindHDF5File, self).__init__(ds, io, filename, file_id, bounds)
+        super().__init__(ds, io, filename, file_id, bounds)
         with h5py.File(filename, mode="r") as f:
-            self.header = dict((field, f.attrs[field]) for field in f.attrs.keys())
+            self.header = {field: f.attrs[field] for field in f.attrs.keys()}
 
 
 class OWLSSubfindDataset(ParticleDataset):
@@ -92,7 +92,7 @@ class OWLSSubfindDataset(ParticleDataset):
         units_override=None,
         unit_system="cgs",
     ):
-        super(OWLSSubfindDataset, self).__init__(
+        super().__init__(
             filename,
             dataset_type,
             index_order=index_order,

--- a/yt/frontends/owls_subfind/io.py
+++ b/yt/frontends/owls_subfind/io.py
@@ -11,8 +11,8 @@ class IOHandlerOWLSSubfindHDF5(BaseIOHandler):
     _dataset_type = "subfind_hdf5"
 
     def __init__(self, ds):
-        super(IOHandlerOWLSSubfindHDF5, self).__init__(ds)
-        self.offset_fields = set([])
+        super().__init__(ds)
+        self.offset_fields = set()
 
     def _read_fluid_selection(self, chunks, selector, fields, size):
         raise NotImplementedError
@@ -20,7 +20,7 @@ class IOHandlerOWLSSubfindHDF5(BaseIOHandler):
     def _read_particle_coords(self, chunks, ptf):
         # This will read chunks and yield the results.
         chunks = list(chunks)
-        data_files = set([])
+        data_files = set()
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
@@ -58,7 +58,7 @@ class IOHandlerOWLSSubfindHDF5(BaseIOHandler):
     def _read_particle_fields(self, chunks, ptf, selector):
         # Now we have all the sizes, and we can allocate
         chunks = list(chunks)
-        data_files = set([])
+        data_files = set()
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -289,9 +289,7 @@ class RAMSESDomainSubset(OctreeSubset):
         num_ghost_zones=0,
         base_grid=None,
     ):
-        super(RAMSESDomainSubset, self).__init__(
-            base_region, domain, ds, over_refine_factor, num_ghost_zones
-        )
+        super().__init__(base_region, domain, ds, over_refine_factor, num_ghost_zones)
 
         self._base_grid = base_grid
 
@@ -399,7 +397,7 @@ class RAMSESDomainSubset(OctreeSubset):
 
     @property
     def fwidth(self):
-        fwidth = super(RAMSESDomainSubset, self).fwidth
+        fwidth = super().fwidth
         if self._num_ghost_zones > 0:
             fwidth = fwidth.reshape(-1, 8, 3)
             n_oct = fwidth.shape[0]
@@ -415,7 +413,7 @@ class RAMSESDomainSubset(OctreeSubset):
     def fcoords(self):
         num_ghost_zones = self._num_ghost_zones
         if num_ghost_zones == 0:
-            return super(RAMSESDomainSubset, self).fcoords
+            return super().fcoords
 
         oh = self.oct_handler
 
@@ -487,7 +485,7 @@ class RAMSESIndex(OctreeIndex):
         self.max_level = None
 
         self.float_type = np.float64
-        super(RAMSESIndex, self).__init__(ds, dataset_type)
+        super().__init__(ds, dataset_type)
 
     def _initialize_oct_handler(self):
         if self.ds._bbox is not None:
@@ -508,7 +506,7 @@ class RAMSESIndex(OctreeIndex):
         self.num_grids = total_octs
 
     def _detect_output_fields(self):
-        dsl = set([])
+        dsl = set()
 
         # Get the detected particle fields
         for domain in self.domains:
@@ -522,7 +520,7 @@ class RAMSESIndex(OctreeIndex):
                 self.particle_field_list.append((f[0], "conformal_birth_time"))
 
         # Get the detected fields
-        dsl = set([])
+        dsl = set()
         for fh in self.domains[0].field_handlers:
             dsl.update(set(fh.field_list))
         self.fluid_field_list = list(dsl)
@@ -604,7 +602,7 @@ class RAMSESIndex(OctreeIndex):
 
         self._initialize_level_stats()
 
-        header = "%3s\t%14s\t%14s" % ("level", "# cells", "# cells^3")
+        header = "{:>3}\t{:>14}\t{:>14}".format("level", "# cells", "# cells^3")
         print(header)
         print(f"{len(header.expandtabs()) * '-'}")
         for level in range(self.dataset.min_level + self.dataset.max_level + 2):
@@ -766,7 +764,7 @@ class RAMSESDataset(Dataset):
 
     def create_field_info(self, *args, **kwa):
         """Extend create_field_info to add the particles types."""
-        super(RAMSESDataset, self).create_field_info(*args, **kwa)
+        super().create_field_info(*args, **kwa)
         # Register particle filters
         if ("io", "particle_family") in self.field_list:
             for fname, value in particle_families.items():
@@ -948,7 +946,7 @@ class RAMSESDataset(Dataset):
         namelist_file = os.path.join(self.root_folder, "namelist.txt")
         if os.path.exists(namelist_file):
             try:
-                with open(namelist_file, "r") as f:
+                with open(namelist_file) as f:
                     nml = f90nml.read(f)
             except ImportError as e:
                 nml = f"An error occurred when reading the namelist: {str(e)}"

--- a/yt/frontends/ramses/definitions.py
+++ b/yt/frontends/ramses/definitions.py
@@ -53,8 +53,8 @@ VERSION_RE = re.compile(r"# version: *(\d+)")
 # on the left hand side
 VAR_DESC_RE = re.compile(r"\s*([^\s]+),\s*([^\s]+),\s*([^\s]+)")
 
-OUTPUT_DIR_RE = re.compile("(output|group)_(\d{5})")
-STANDARD_FILE_RE = re.compile("((amr|hydro|part|grav)_\d{5}\.out\d{5}|info_\d{5}.txt)")
+OUTPUT_DIR_RE = re.compile(r"(output|group)_(\d{5})")
+STANDARD_FILE_RE = re.compile(r"((amr|hydro|part|grav)_\d{5}\.out\d{5}|info_\d{5}.txt)")
 
 
 ## Configure family mapping

--- a/yt/frontends/ramses/field_handlers.py
+++ b/yt/frontends/ramses/field_handlers.py
@@ -508,7 +508,7 @@ class RTFieldFileHandler(FieldFileHandler):
             p, v = line.split("=")
             rheader[p.strip()] = cast(v)
 
-        with open(fname, "r") as f:
+        with open(fname) as f:
             # Read nRTvar, nions, ngroups, iions
             for _ in range(4):
                 read_rhs(int)

--- a/yt/frontends/ramses/fields.py
+++ b/yt/frontends/ramses/fields.py
@@ -30,8 +30,8 @@ cooling_function_prime_units = " erg * cm**3 /s/K"
 flux_unit = "1 / code_length**2 / code_time"
 number_density_unit = "1 / code_length**3"
 
-known_species_masses = dict(
-    (sp, mh * v)
+known_species_masses = {
+    sp: mh * v
     for sp, v in [
         ("HI", 1.0),
         ("HII", 1.0),
@@ -46,7 +46,7 @@ known_species_masses = dict(
         ("DII", 2.0),
         ("HDI", 3.0),
     ]
-)
+}
 
 _cool_axes = ("lognH", "logT")  # , "logTeq")
 _cool_arrs = (
@@ -141,7 +141,7 @@ class RAMSESFieldInfo(FieldInfoContainer):
     )
 
     def setup_particle_fields(self, ptype):
-        super(RAMSESFieldInfo, self).setup_particle_fields(ptype)
+        super().setup_particle_fields(ptype)
 
         def particle_age(field, data):
             msg = (

--- a/yt/frontends/ramses/io.py
+++ b/yt/frontends/ramses/io.py
@@ -35,7 +35,7 @@ def convert_ramses_ages(ds, conformal_ages):
     # tables.
     t = tf[iage] * (conformal_ages - tauf[iage - 1]) / (tauf[iage] - tauf[iage - 1])
     t = t + (
-        (tf[iage - 1] * (conformal_ages - tauf[iage]) / (tauf[iage - 1] - tauf[iage]))
+        tf[iage - 1] * (conformal_ages - tauf[iage]) / (tauf[iage - 1] - tauf[iage])
     )
     return (tsim - t) * t_scale
 
@@ -89,7 +89,7 @@ class IOHandlerRAMSES(BaseIOHandler):
         tr = defaultdict(list)
 
         # Set of field types
-        ftypes = set(f[0] for f in fields)
+        ftypes = {f[0] for f in fields}
         for chunk in chunks:
             # Gather fields by type to minimize i/o operations
             for ft in ftypes:
@@ -174,7 +174,7 @@ class IOHandlerRAMSES(BaseIOHandler):
         tr = {}
 
         # Sequential read depending on particle type
-        for ptype in set(f[0] for f in fields):
+        for ptype in {f[0] for f in fields}:
 
             # Select relevant fiels
             subs_fields = filter(lambda f: f[0] == ptype, fields)
@@ -231,7 +231,7 @@ def _read_part_file_descriptor(fname):
     # Convert to dictionary
     mapping = {k: v for k, v in mapping}
 
-    with open(fname, "r") as f:
+    with open(fname) as f:
         line = f.readline()
         tmp = VERSION_RE.match(line)
         mylog.debug("Reading part file descriptor %s.", fname)
@@ -291,7 +291,7 @@ def _read_fluid_file_descriptor(fname):
     # Convert to dictionary
     mapping = {k: v for k, v in mapping}
 
-    with open(fname, "r") as f:
+    with open(fname) as f:
         line = f.readline()
         tmp = VERSION_RE.match(line)
         mylog.debug("Reading fluid file descriptor %s.", fname)

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -524,7 +524,7 @@ def test_ramses_empty_record():
 def test_namelist_reading():
     ds = data_dir_load(ramses_new_format)
     namelist_fname = os.path.join(ds.directory, "namelist.txt")
-    with open(namelist_fname, "r") as f:
+    with open(namelist_fname) as f:
         ref = f90nml.read(f)
 
     nml = ds.parameters["namelist"]

--- a/yt/frontends/rockstar/data_structures.py
+++ b/yt/frontends/rockstar/data_structures.py
@@ -22,7 +22,7 @@ class RockstarBinaryFile(HaloCatalogFile):
             f.seek(0, os.SEEK_END)
             self._file_size = f.tell()
 
-        super(RockstarBinaryFile, self).__init__(ds, io, filename, file_id, range)
+        super().__init__(ds, io, filename, file_id, range)
 
     def _read_particle_positions(self, ptype, f=None):
         """
@@ -63,7 +63,7 @@ class RockstarDataset(ParticleDataset):
         index_order=None,
         index_filename=None,
     ):
-        super(RockstarDataset, self).__init__(
+        super().__init__(
             filename,
             dataset_type,
             units_override=units_override,

--- a/yt/frontends/rockstar/io.py
+++ b/yt/frontends/rockstar/io.py
@@ -14,7 +14,7 @@ class IOHandlerRockstarBinary(BaseIOHandler):
     _dataset_type = "rockstar_binary"
 
     def __init__(self, *args, **kwargs):
-        super(IOHandlerRockstarBinary, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._halo_dt = halo_dts[self.ds.parameters["format_revision"]]
 
     def _read_fluid_selection(self, chunks, selector, fields, size):
@@ -23,7 +23,7 @@ class IOHandlerRockstarBinary(BaseIOHandler):
     def _read_particle_coords(self, chunks, ptf):
         # This will read chunks and yield the results.
         chunks = list(chunks)
-        data_files = set([])
+        data_files = set()
         # Only support halo reading for now.
         assert len(ptf) == 1
         assert list(ptf.keys())[0] == "halos"
@@ -42,7 +42,7 @@ class IOHandlerRockstarBinary(BaseIOHandler):
     def _read_particle_fields(self, chunks, ptf, selector):
         # Now we have all the sizes, and we can allocate
         chunks = list(chunks)
-        data_files = set([])
+        data_files = set()
         # Only support halo reading for now.
         assert len(ptf) == 1
         assert list(ptf.keys())[0] == "halos"

--- a/yt/frontends/sdf/data_structures.py
+++ b/yt/frontends/sdf/data_structures.py
@@ -79,7 +79,7 @@ class SDFDataset(ParticleDataset):
         if filename.startswith("http"):
             prefix += "http_"
         dataset_type = prefix + "sdf_particles"
-        super(SDFDataset, self).__init__(
+        super().__init__(
             filename,
             dataset_type=dataset_type,
             units_override=units_override,

--- a/yt/frontends/sdf/fields.py
+++ b/yt/frontends/sdf/fields.py
@@ -38,4 +38,4 @@ class SDFFieldInfo(FieldInfoContainer):
             (vzf, ("code_velocity", ["particle_velocity_z"], None)),
             (mnf, ("code_mass", ["particle_mass"], None)),
         )
-        super(SDFFieldInfo, self).__init__(ds, field_list)
+        super().__init__(ds, field_list)

--- a/yt/frontends/sdf/io.py
+++ b/yt/frontends/sdf/io.py
@@ -20,7 +20,7 @@ class IOHandlerSDF(BaseIOHandler):
 
     def _read_particle_coords(self, chunks, ptf):
         chunks = list(chunks)
-        data_files = set([])
+        data_files = set()
         assert len(ptf) == 1
         assert ptf.keys()[0] == "dark_matter"
         for chunk in chunks:
@@ -36,7 +36,7 @@ class IOHandlerSDF(BaseIOHandler):
 
     def _read_particle_fields(self, chunks, ptf, selector):
         chunks = list(chunks)
-        data_files = set([])
+        data_files = set()
         assert len(ptf) == 1
         assert ptf.keys()[0] == "dark_matter"
         for chunk in chunks:
@@ -104,7 +104,7 @@ class IOHandlerHTTPSDF(IOHandlerSDF):
 
     def _read_particle_coords(self, chunks, ptf):
         chunks = list(chunks)
-        data_files = set([])
+        data_files = set()
         assert len(ptf) == 1
         assert ptf.keys()[0] == "dark_matter"
         for chunk in chunks:
@@ -121,7 +121,7 @@ class IOHandlerHTTPSDF(IOHandlerSDF):
 
     def _read_particle_fields(self, chunks, ptf, selector):
         chunks = list(chunks)
-        data_files = set([])
+        data_files = set()
         assert len(ptf) == 1
         assert ptf.keys()[0] == "dark_matter"
         for chunk in chunks:

--- a/yt/frontends/sph/data_structures.py
+++ b/yt/frontends/sph/data_structures.py
@@ -31,7 +31,7 @@ class SPHDataset(ParticleDataset):
         else:
             self.kernel_name = kernel_name
         self.kdtree_filename = kdtree_filename
-        super(SPHDataset, self).__init__(
+        super().__init__(
             filename,
             dataset_type=dataset_type,
             file_style=file_style,
@@ -86,7 +86,7 @@ class SPHParticleIndex(ParticleIndex):
         if hasattr(self.io, "_generate_smoothing_length"):
             self.io._generate_smoothing_length(self)
 
-        super(SPHParticleIndex, self)._initialize_index()
+        super()._initialize_index()
 
     def _generate_kdtree(self, fname):
         from yt.utilities.lib.cykdtree import PyKDTree

--- a/yt/frontends/sph/fields.py
+++ b/yt/frontends/sph/fields.py
@@ -27,7 +27,7 @@ class SPHFieldInfo(FieldInfoContainer):
     )
 
     def setup_particle_fields(self, ptype, *args, **kwargs):
-        super(SPHFieldInfo, self).setup_particle_fields(ptype, *args, **kwargs)
+        super().setup_particle_fields(ptype, *args, **kwargs)
         setup_species_fields(self, ptype)
 
     def setup_fluid_index_fields(self):

--- a/yt/frontends/sph/io.py
+++ b/yt/frontends/sph/io.py
@@ -19,7 +19,7 @@ class IOHandlerSPH(BaseIOHandler):
     def _count_particles_chunks(self, psize, chunks, ptf, selector):
         if getattr(selector, "is_all_data", False):
             chunks = list(chunks)
-            data_files = set([])
+            data_files = set()
             for chunk in chunks:
                 for obj in chunk.objs:
                     data_files.update(obj.data_files)

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -347,7 +347,7 @@ class StreamDataset(Dataset):
         return True
 
     def _find_particle_types(self):
-        particle_types = set([])
+        particle_types = set()
         for k, v in self.stream_handler.particle_types.items():
             if v:
                 particle_types.add(k[0])
@@ -370,7 +370,7 @@ class StreamDictFieldHandler(dict):
 class StreamParticleIndex(SPHParticleIndex):
     def __init__(self, ds, dataset_type=None):
         self.stream_handler = ds.stream_handler
-        super(StreamParticleIndex, self).__init__(ds, dataset_type)
+        super().__init__(ds, dataset_type)
 
     def _setup_data_io(self):
         if self.stream_handler.io is not None:
@@ -442,7 +442,7 @@ class StreamParticlesDataset(StreamDataset):
         geometry="cartesian",
         unit_system="cgs",
     ):
-        super(StreamParticlesDataset, self).__init__(
+        super().__init__(
             stream_handler,
             storage_filename=storage_filename,
             geometry=geometry,
@@ -617,7 +617,7 @@ class StreamHexahedralMesh(SemiStructuredMesh):
 class StreamHexahedralHierarchy(UnstructuredIndex):
     def __init__(self, ds, dataset_type=None):
         self.stream_handler = ds.stream_handler
-        super(StreamHexahedralHierarchy, self).__init__(ds, dataset_type)
+        super().__init__(ds, dataset_type)
 
     def _initialize_mesh(self):
         coords = self.stream_handler.fields.pop("coordinates")
@@ -740,7 +740,7 @@ class StreamOctreeHandler(OctreeIndex):
     def __init__(self, ds, dataset_type=None):
         self.stream_handler = ds.stream_handler
         self.dataset_type = dataset_type
-        super(StreamOctreeHandler, self).__init__(ds, dataset_type)
+        super().__init__(ds, dataset_type)
 
     def _setup_data_io(self):
         if self.stream_handler.io is not None:
@@ -796,7 +796,7 @@ class StreamOctreeHandler(OctreeIndex):
 
     def _setup_classes(self):
         dd = self._get_data_reader_dict()
-        super(StreamOctreeHandler, self)._setup_classes(dd)
+        super()._setup_classes(dd)
 
     def _detect_output_fields(self):
         # NOTE: Because particle unions add to the actual field list, without
@@ -821,9 +821,7 @@ class StreamOctreeDataset(StreamDataset):
         geometry="cartesian",
         unit_system="cgs",
     ):
-        super(StreamOctreeDataset, self).__init__(
-            stream_handler, storage_filename, geometry, unit_system
-        )
+        super().__init__(stream_handler, storage_filename, geometry, unit_system)
         # Set up levelmax
         self.max_level = stream_handler.levels.max()
         self.min_level = stream_handler.levels.min()
@@ -833,14 +831,14 @@ class StreamUnstructuredMesh(UnstructuredMesh):
     _index_offset = 0
 
     def __init__(self, *args, **kwargs):
-        super(StreamUnstructuredMesh, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._connectivity_length = self.connectivity_indices.shape[1]
 
 
 class StreamUnstructuredIndex(UnstructuredIndex):
     def __init__(self, ds, dataset_type=None):
         self.stream_handler = ds.stream_handler
-        super(StreamUnstructuredIndex, self).__init__(ds, dataset_type)
+        super().__init__(ds, dataset_type)
 
     def _initialize_mesh(self):
         coords = self.stream_handler.fields.pop("coordinates")
@@ -860,7 +858,7 @@ class StreamUnstructuredIndex(UnstructuredIndex):
 
     def _detect_output_fields(self):
         self.field_list = list(set(self.stream_handler.get_fields()))
-        fnames = list(set([fn for ft, fn in self.field_list]))
+        fnames = list({fn for ft, fn in self.field_list})
         self.field_list += [("all", fname) for fname in fnames]
 
 

--- a/yt/frontends/stream/fields.py
+++ b/yt/frontends/stream/fields.py
@@ -94,4 +94,4 @@ class StreamFieldInfo(FieldInfoContainer):
     def add_output_field(self, name, sampling_type, **kwargs):
         if name in self.ds.stream_handler.field_units:
             kwargs["units"] = self.ds.stream_handler.field_units[name]
-        super(StreamFieldInfo, self).add_output_field(name, sampling_type, **kwargs)
+        super().add_output_field(name, sampling_type, **kwargs)

--- a/yt/frontends/stream/io.py
+++ b/yt/frontends/stream/io.py
@@ -13,7 +13,7 @@ class IOHandlerStream(BaseIOHandler):
     def __init__(self, ds):
         self.fields = ds.stream_handler.fields
         self.field_units = ds.stream_handler.field_units
-        super(IOHandlerStream, self).__init__(ds)
+        super().__init__(ds)
 
     def _read_data_set(self, grid, field):
         # This is where we implement processor-locking
@@ -94,7 +94,7 @@ class StreamParticleIOHandler(BaseIOHandler):
 
     def __init__(self, ds):
         self.fields = ds.stream_handler.fields
-        super(StreamParticleIOHandler, self).__init__(ds)
+        super().__init__(ds)
 
     def _read_particle_coords(self, chunks, ptf):
         for data_file in sorted(
@@ -117,7 +117,7 @@ class StreamParticleIOHandler(BaseIOHandler):
             return f[ptype, "smoothing_length"]
 
     def _get_data_files(self, chunks):
-        data_files = set([])
+        data_files = set()
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
@@ -212,7 +212,7 @@ class IOHandlerStreamHexahedral(BaseIOHandler):
 
     def __init__(self, ds):
         self.fields = ds.stream_handler.fields
-        super(IOHandlerStreamHexahedral, self).__init__(ds)
+        super().__init__(ds)
 
     def _read_fluid_selection(self, chunks, selector, fields, size):
         chunks = list(chunks)
@@ -247,7 +247,7 @@ class IOHandlerStreamOctree(BaseIOHandler):
 
     def __init__(self, ds):
         self.fields = ds.stream_handler.fields
-        super(IOHandlerStreamOctree, self).__init__(ds)
+        super().__init__(ds)
 
     def _read_fluid_selection(self, chunks, selector, fields, size):
         rv = {}
@@ -271,7 +271,7 @@ class IOHandlerStreamUnstructured(BaseIOHandler):
 
     def __init__(self, ds):
         self.fields = ds.stream_handler.fields
-        super(IOHandlerStreamUnstructured, self).__init__(ds)
+        super().__init__(ds)
 
     def _read_fluid_selection(self, chunks, selector, fields, size):
         chunks = list(chunks)

--- a/yt/frontends/swift/data_structures.py
+++ b/yt/frontends/swift/data_structures.py
@@ -127,11 +127,9 @@ class SwiftDataset(SPHDataset):
                 self.hubble_constant = float(parameters["Cosmology:h"])
             except KeyError:
                 mylog.warning(
-                    (
-                        "Could not find cosmology information in Parameters, "
-                        "despite having ran with -c signifying a cosmological "
-                        "run."
-                    )
+                    "Could not find cosmology information in Parameters, "
+                    "despite having ran with -c signifying a cosmological "
+                    "run."
                 )
                 mylog.info("Setting up as a non-cosmological run. Check this!")
                 self.cosmological_simulation = 0
@@ -174,7 +172,7 @@ class SwiftDataset(SPHDataset):
             handle = h5py.File(filename, mode="r")
             valid = handle["Header"].attrs["Code"].decode("utf-8") == "SWIFT"
             handle.close()
-        except (IOError, KeyError, ImportError):
+        except (OSError, KeyError, ImportError):
             valid = False
 
         return valid

--- a/yt/frontends/swift/io.py
+++ b/yt/frontends/swift/io.py
@@ -8,7 +8,7 @@ class IOHandlerSwift(IOHandlerSPH):
     _dataset_type = "swift"
 
     def __init__(self, ds, *args, **kwargs):
-        super(IOHandlerSwift, self).__init__(ds, *args, **kwargs)
+        super().__init__(ds, *args, **kwargs)
 
     def _read_fluid_selection(self, chunks, selector, fields, size):
         raise NotImplementedError
@@ -22,7 +22,7 @@ class IOHandlerSwift(IOHandlerSPH):
         # yt has the concept of sub_files, i.e, we break up big files into
         # virtual sub_files to deal with the chunking system
         chunks = list(chunks)
-        sub_files = set([])
+        sub_files = set()
         for chunk in chunks:
             for obj in chunk.objs:
                 sub_files.update(obj.data_files)
@@ -77,7 +77,7 @@ class IOHandlerSwift(IOHandlerSPH):
 
     def _read_particle_fields(self, chunks, ptf, selector):
         # Now we have all the sizes, and we can allocate
-        sub_files = set([])
+        sub_files = set()
         for chunk in chunks:
             for obj in chunk.objs:
                 sub_files.update(obj.data_files)
@@ -120,7 +120,7 @@ class IOHandlerSwift(IOHandlerSPH):
         # defined by the subfile
         if None not in (si, ei):
             np.clip(pcount - si, 0, ei - si, out=pcount)
-        npart = dict((f"PartType{i}", v) for i, v in enumerate(pcount))
+        npart = {f"PartType{i}": v for i, v in enumerate(pcount)}
         return npart
 
     def _identify_fields(self, data_file):

--- a/yt/frontends/tipsy/data_structures.py
+++ b/yt/frontends/tipsy/data_structures.py
@@ -16,7 +16,7 @@ from .fields import TipsyFieldInfo
 
 class TipsyFile(ParticleFile):
     def __init__(self, ds, io, filename, file_id, range=None):
-        super(TipsyFile, self).__init__(ds, io, filename, file_id, range)
+        super().__init__(ds, io, filename, file_id, range)
         if not hasattr(io, "_field_list"):
             io._create_dtypes(self)
             # Check automatically what the domain size is
@@ -100,7 +100,7 @@ class TipsyDataset(SPHDataset):
                 "units_override is not supported for TipsyDataset. "
                 + "Use unit_base instead."
             )
-        super(TipsyDataset, self).__init__(
+        super().__init__(
             filename,
             dataset_type=dataset_type,
             unit_system=unit_system,
@@ -120,14 +120,12 @@ class TipsyDataset(SPHDataset):
 
         f = open(self.parameter_filename, "rb")
         hh = self.endian + "".join(["%s" % (b) for a, b in self._header_spec])
-        hvals = dict(
-            [
-                (a, c)
-                for (a, b), c in zip(
-                    self._header_spec, struct.unpack(hh, f.read(struct.calcsize(hh)))
-                )
-            ]
-        )
+        hvals = {
+            a: c
+            for (a, b), c in zip(
+                self._header_spec, struct.unpack(hh, f.read(struct.calcsize(hh)))
+            )
+        }
         self.parameters.update(hvals)
         self._header_offset = f.tell()
 
@@ -229,7 +227,7 @@ class TipsyDataset(SPHDataset):
             self.domain_left_edge = np.array([np.nan, np.nan, np.nan])
             self.domain_right_edge = np.array([np.nan, np.nan, np.nan])
             self.index
-        super(TipsyDataset, self)._set_derived_attrs()
+        super()._set_derived_attrs()
 
     def _set_code_unit_attributes(self):
         # First try to set units based on parameter file
@@ -309,7 +307,7 @@ class TipsyDataset(SPHDataset):
             f.seek(0, os.SEEK_SET)
             # Read in the header
             t, n, ndim, ng, nd, ns = struct.unpack("<diiiii", f.read(28))
-        except (IOError, struct.error):
+        except (OSError, struct.error):
             return False, 1
         endianswap = "<"
         # Check Endianness

--- a/yt/frontends/tipsy/fields.py
+++ b/yt/frontends/tipsy/fields.py
@@ -34,4 +34,4 @@ class TipsyFieldInfo(SPHFieldInfo):
                 and self.aux_particle_fields[field[1]] not in self.known_particle_fields
             ):
                 self.known_particle_fields += (self.aux_particle_fields[field[1]],)
-        super(TipsyFieldInfo, self).__init__(ds, field_list, slice_info)
+        super().__init__(ds, field_list, slice_info)

--- a/yt/frontends/tipsy/io.py
+++ b/yt/frontends/tipsy/io.py
@@ -48,7 +48,7 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
 
     def __init__(self, *args, **kwargs):
         self._aux_fields = []
-        super(IOHandlerTipsyBinary, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def _read_fluid_selection(self, chunks, selector, fields, size):
         raise NotImplementedError
@@ -88,7 +88,7 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
         return rv
 
     def _read_particle_coords(self, chunks, ptf):
-        data_files = set([])
+        data_files = set()
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
@@ -154,7 +154,7 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
 
     def _read_particle_fields(self, chunks, ptf, selector):
         chunks = list(chunks)
-        data_files = set([])
+        data_files = set()
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
@@ -323,7 +323,7 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
         if None not in (si, ei):
             np.clip(pcount - si, 0, ei - si, out=pcount)
         ptypes = ["Gas", "Stars", "DarkMatter"]
-        npart = dict((ptype, v) for ptype, v in zip(ptypes, pcount))
+        npart = {ptype: v for ptype, v in zip(ptypes, pcount)}
         return npart
 
     @classmethod

--- a/yt/frontends/tipsy/tests/test_outputs.py
+++ b/yt/frontends/tipsy/tests/test_outputs.py
@@ -33,8 +33,7 @@ pkdgrav_kwargs = dict(
 @requires_ds(pkdgrav, big_data=True, file_check=True)
 def test_pkdgrav():
     ds = data_dir_load(pkdgrav, TipsyDataset, (), kwargs=pkdgrav_kwargs)
-    for test in nbody_answer(ds, "halo1e11_run1.00400", 26847360, _fields):
-        yield test
+    yield from nbody_answer(ds, "halo1e11_run1.00400", 26847360, _fields)
     psc = ParticleSelectionComparison(ds)
     psc.run_defaults()
 
@@ -55,8 +54,7 @@ def test_gasoline_dmonly():
         unit_base={"length": (60.0, "Mpccm/h")},
     )
     ds = data_dir_load(gasoline_dmonly, TipsyDataset, (), kwargs)
-    for test in nbody_answer(ds, "agora_1e11.00400", 10550576, _fields):
-        yield test
+    yield from nbody_answer(ds, "agora_1e11.00400", 10550576, _fields)
     psc = ParticleSelectionComparison(ds)
     psc.run_defaults()
 

--- a/yt/frontends/ytdata/data_structures.py
+++ b/yt/frontends/ytdata/data_structures.py
@@ -118,7 +118,7 @@ class SavedDataset(Dataset):
             self._set_code_unit_attributes()
             del self.parameters["unit_registry_json"]
         else:
-            super(SavedDataset, self).set_units()
+            super().set_units()
 
     def _set_code_unit_attributes(self):
         attrs = (
@@ -173,13 +173,11 @@ class YTDataset(SavedDataset):
     )
 
     def _with_parameter_file_open(self, f):
-        self.num_particles = dict(
-            [
-                (group, parse_h5_attr(f[group], "num_elements"))
-                for group in f
-                if group != self.default_fluid_type
-            ]
-        )
+        self.num_particles = {
+            group: parse_h5_attr(f[group], "num_elements")
+            for group in f
+            if group != self.default_fluid_type
+        }
 
     def create_field_info(self):
         self.field_dependencies = {}
@@ -214,11 +212,9 @@ class YTDataset(SavedDataset):
 class YTDataHDF5File(ParticleFile):
     def __init__(self, ds, io, filename, file_id, range):
         with h5py.File(filename, mode="r") as f:
-            self.header = dict(
-                (field, parse_h5_attr(f, field)) for field in f.attrs.keys()
-            )
+            self.header = {field: parse_h5_attr(f, field) for field in f.attrs.keys()}
 
-        super(YTDataHDF5File, self).__init__(ds, io, filename, file_id, range)
+        super().__init__(ds, io, filename, file_id, range)
 
 
 class YTDataContainerDataset(YTDataset):
@@ -241,7 +237,7 @@ class YTDataContainerDataset(YTDataset):
     ):
         self.index_order = validate_index_order(index_order)
         self.index_filename = index_filename
-        super(YTDataContainerDataset, self).__init__(
+        super().__init__(
             filename,
             dataset_type,
             units_override=units_override,
@@ -249,7 +245,7 @@ class YTDataContainerDataset(YTDataset):
         )
 
     def _parse_parameter_file(self):
-        super(YTDataContainerDataset, self)._parse_parameter_file()
+        super()._parse_parameter_file()
         self.particle_types_raw = tuple(self.num_particles.keys())
         self.particle_types = self.particle_types_raw
         self.filename_template = self.parameter_filename
@@ -313,7 +309,7 @@ class YTDataLightRayDataset(YTDataContainerDataset):
     """Dataset for saved LightRay objects."""
 
     def _parse_parameter_file(self):
-        super(YTDataLightRayDataset, self)._parse_parameter_file()
+        super()._parse_parameter_file()
         self._restore_light_ray_solution()
 
     def _restore_light_ray_solution(self):
@@ -356,12 +352,10 @@ class YTSpatialPlotDataset(YTDataContainerDataset):
     _field_info_class = YTGridFieldInfo
 
     def __init__(self, *args, **kwargs):
-        super(YTSpatialPlotDataset, self).__init__(
-            *args, dataset_type="ytspatialplot_hdf5", **kwargs
-        )
+        super().__init__(*args, dataset_type="ytspatialplot_hdf5", **kwargs)
 
     def _parse_parameter_file(self):
-        super(YTSpatialPlotDataset, self)._parse_parameter_file()
+        super()._parse_parameter_file()
         if self.parameters["container_type"] == "proj":
             if (
                 isinstance(self.parameters["weight_field"], str)
@@ -425,7 +419,7 @@ class YTDataHierarchy(GridIndex):
         self.float_type = "float64"
         self.dataset = weakref.proxy(ds)
         self.directory = os.getcwd()
-        super(YTDataHierarchy, self).__init__(ds, dataset_type)
+        super().__init__(ds, dataset_type)
 
     def _count_grids(self):
         self.num_grids = 1
@@ -483,13 +477,11 @@ class YTGridDataset(YTDataset):
     fluid_types = ("grid", "gas", "deposit", "index")
 
     def __init__(self, filename, unit_system="cgs"):
-        super(YTGridDataset, self).__init__(
-            filename, self._dataset_type, unit_system=unit_system
-        )
+        super().__init__(filename, self._dataset_type, unit_system=unit_system)
         self.data = self.index.grids[0]
 
     def _parse_parameter_file(self):
-        super(YTGridDataset, self)._parse_parameter_file()
+        super()._parse_parameter_file()
         self.num_particles.pop(self.default_fluid_type, None)
         self.particle_types_raw = tuple(self.num_particles.keys())
         self.particle_types = self.particle_types_raw
@@ -564,7 +556,7 @@ class YTNonspatialGrid(AMRGridPatch):
     _id_offset = 0
 
     def __init__(self, gid, index, filename=None):
-        super(YTNonspatialGrid, self).__init__(gid, filename=filename, index=index)
+        super().__init__(gid, filename=filename, index=index)
         self._children_ids = []
         self._parent_id = -1
         self.Level = 0
@@ -782,7 +774,7 @@ class YTProfileDataset(YTNonspatialDataset):
     fluid_types = ("data", "gas", "standard_deviation")
 
     def __init__(self, filename, unit_system="cgs"):
-        super(YTProfileDataset, self).__init__(filename, unit_system=unit_system)
+        super().__init__(filename, unit_system=unit_system)
 
     _profile = None
 
@@ -857,7 +849,7 @@ class YTProfileDataset(YTNonspatialDataset):
                 self.field_info.alias(("gas", field), (ftype, field))
 
     def create_field_info(self):
-        super(YTProfileDataset, self).create_field_info()
+        super().create_field_info()
         if self.parameters["weight_field"] is not None:
             self.field_info.alias(
                 self.parameters["weight_field"], (self.default_fluid_type, "weight")
@@ -877,7 +869,7 @@ class YTProfileDataset(YTNonspatialDataset):
             ]:
                 v = getattr(self, a)
                 mylog.info("Parameters: %-25s = %s", a, v)
-        super(YTProfileDataset, self).print_key_parameters()
+        super().print_key_parameters()
 
     @classmethod
     def _is_valid(cls, filename, *args, **kwargs):
@@ -929,7 +921,7 @@ class YTClumpTreeDataset(YTNonspatialDataset):
     """Dataset for saved clump-finder data."""
 
     def __init__(self, filename, unit_system="cgs"):
-        super(YTClumpTreeDataset, self).__init__(filename, unit_system=unit_system)
+        super().__init__(filename, unit_system=unit_system)
         self._load_tree()
 
     def _load_tree(self):

--- a/yt/frontends/ytdata/fields.py
+++ b/yt/frontends/ytdata/fields.py
@@ -12,7 +12,7 @@ class YTDataContainerFieldInfo(FieldInfoContainer):
     known_particle_fields = ()
 
     def __init__(self, ds, field_list):
-        super(YTDataContainerFieldInfo, self).__init__(ds, field_list)
+        super().__init__(ds, field_list)
         self.add_fake_grid_fields()
 
     def add_fake_grid_fields(self):

--- a/yt/frontends/ytdata/io.py
+++ b/yt/frontends/ytdata/io.py
@@ -76,7 +76,7 @@ class IOHandlerYTGridHDF5(BaseIOHandler):
             f.close()
             return rv
         if size is None:
-            size = sum((g.count(selector) for chunk in chunks for g in chunk.objs))
+            size = sum(g.count(selector) for chunk in chunks for g in chunk.objs)
         for field in fields:
             ftype, fname = field
             fsize = size
@@ -194,7 +194,7 @@ class IOHandlerYTDataContainerHDF5(BaseIOHandler):
     def _read_particle_coords(self, chunks, ptf):
         # This will read chunks and yield the results.
         chunks = list(chunks)
-        data_files = set([])
+        data_files = set()
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
@@ -214,7 +214,7 @@ class IOHandlerYTDataContainerHDF5(BaseIOHandler):
     def _read_particle_fields(self, chunks, ptf, selector):
         # Now we have all the sizes, and we can allocate
         chunks = list(chunks)
-        data_files = set([])
+        data_files = set()
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
@@ -293,15 +293,10 @@ class IOHandlerYTDataContainerHDF5(BaseIOHandler):
             for ptype in f:
                 fields.extend([(ptype, str(field)) for field in f[ptype]])
                 units.update(
-                    dict(
-                        [
-                            (
-                                (ptype, str(field)),
-                                parse_h5_attr(f[ptype][field], "units"),
-                            )
-                            for field in f[ptype]
-                        ]
-                    )
+                    {
+                        (ptype, str(field)): parse_h5_attr(f[ptype][field], "units")
+                        for field in f[ptype]
+                    }
                 )
         return fields, units
 
@@ -312,7 +307,7 @@ class IOHandlerYTSpatialPlotHDF5(IOHandlerYTDataContainerHDF5):
     def _read_particle_coords(self, chunks, ptf):
         # This will read chunks and yield the results.
         chunks = list(chunks)
-        data_files = set([])
+        data_files = set()
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
@@ -333,7 +328,7 @@ class IOHandlerYTSpatialPlotHDF5(IOHandlerYTDataContainerHDF5):
     def _read_particle_fields(self, chunks, ptf, selector):
         # Now we have all the sizes, and we can allocate
         chunks = list(chunks)
-        data_files = set([])
+        data_files = set()
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)

--- a/yt/frontends/ytdata/tests/test_outputs.py
+++ b/yt/frontends/ytdata/tests/test_outputs.py
@@ -44,7 +44,7 @@ class YTDataFieldTest(AnswerTestingTest):
     _attrs = ("field_name",)
 
     def __init__(self, ds_fn, field, decimals=10, geometric=True):
-        super(YTDataFieldTest, self).__init__(ds_fn)
+        super().__init__(ds_fn)
         self.field = field
         if isinstance(field, tuple) and len(field) == 2:
             self.field_name = field[1]

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -1023,7 +1023,7 @@ def camelcase_to_underscore(name):
 
 def set_intersection(some_list):
     if len(some_list) == 0:
-        return set([])
+        return set()
     # This accepts a list of iterables, which we get the intersection of.
     s = set(some_list[0])
     for l in some_list[1:]:

--- a/yt/geometry/coordinates/cartesian_coordinates.py
+++ b/yt/geometry/coordinates/cartesian_coordinates.py
@@ -90,7 +90,7 @@ class CartesianCoordinateHandler(CoordinateHandler):
     name = "cartesian"
 
     def __init__(self, ds, ordering=("x", "y", "z")):
-        super(CartesianCoordinateHandler, self).__init__(ds, ordering)
+        super().__init__(ds, ordering)
 
     def setup_fields(self, registry):
         for axi, ax in enumerate(self.axis_order):

--- a/yt/geometry/coordinates/cylindrical_coordinates.py
+++ b/yt/geometry/coordinates/cylindrical_coordinates.py
@@ -19,7 +19,7 @@ class CylindricalCoordinateHandler(CoordinateHandler):
     name = "cylindrical"
 
     def __init__(self, ds, ordering=("r", "z", "theta")):
-        super(CylindricalCoordinateHandler, self).__init__(ds, ordering)
+        super().__init__(ds, ordering)
         self.image_units = {}
         self.image_units[self.axis_id["r"]] = ("rad", None)
         self.image_units[self.axis_id["theta"]] = (None, None)
@@ -248,9 +248,7 @@ class CylindricalCoordinateHandler(CoordinateHandler):
         return np.array([0.0, 0.0, 2.0 * np.pi])
 
     def sanitize_center(self, center, axis):
-        center, display_center = super(
-            CylindricalCoordinateHandler, self
-        ).sanitize_center(center, axis)
+        center, display_center = super().sanitize_center(center, axis)
         display_center = [
             0.0 * display_center[0],
             0.0 * display_center[1],
@@ -275,9 +273,7 @@ class CylindricalCoordinateHandler(CoordinateHandler):
             self.ds.coordinates.axis_id[ax] for ax in ("r", "theta", "z")
         )
         if width is not None:
-            width = super(CylindricalCoordinateHandler, self).sanitize_width(
-                axis, width, depth
-            )
+            width = super().sanitize_width(axis, width, depth)
         # Note: regardless of axes, these are set up to give consistent plots
         # when plotted, which is not strictly a "right hand rule" for axes.
         elif name == "r":  # soup can label

--- a/yt/geometry/coordinates/geographic_coordinates.py
+++ b/yt/geometry/coordinates/geographic_coordinates.py
@@ -12,7 +12,7 @@ class GeographicCoordinateHandler(CoordinateHandler):
     def __init__(self, ds, ordering=None):
         if not ordering:
             ordering = ("latitude", "longitude", self.radial_axis)
-        super(GeographicCoordinateHandler, self).__init__(ds, ordering)
+        super().__init__(ds, ordering)
         self.image_units = {}
         self.image_units[self.axis_id["latitude"]] = (None, None)
         self.image_units[self.axis_id["longitude"]] = (None, None)
@@ -354,8 +354,8 @@ class GeographicCoordinateHandler(CoordinateHandler):
         # Cartesian coordinates, since we transform them.
         rv = {
             self.axis_id["latitude"]: (
-                "x / \\sin(\mathrm{latitude})",
-                "y / \\sin(\mathrm{latitude})",
+                "x / \\sin(\\mathrm{latitude})",
+                "y / \\sin(\\mathrm{latitude})",
             ),
             self.axis_id["longitude"]: ("R", "z"),
             self.axis_id[self.radial_axis]: ("longitude", "latitude"),
@@ -413,9 +413,7 @@ class GeographicCoordinateHandler(CoordinateHandler):
         return self.ds.domain_width
 
     def sanitize_center(self, center, axis):
-        center, display_center = super(
-            GeographicCoordinateHandler, self
-        ).sanitize_center(center, axis)
+        center, display_center = super().sanitize_center(center, axis)
         name = self.axis_name[axis]
         if name == self.radial_axis:
             display_center = center
@@ -439,9 +437,7 @@ class GeographicCoordinateHandler(CoordinateHandler):
     def sanitize_width(self, axis, width, depth):
         name = self.axis_name[axis]
         if width is not None:
-            width = super(GeographicCoordinateHandler, self).sanitize_width(
-                axis, width, depth
-            )
+            width = super().sanitize_width(axis, width, depth)
         elif name == self.radial_axis:
             rax = self.radial_axis
             width = [

--- a/yt/geometry/coordinates/polar_coordinates.py
+++ b/yt/geometry/coordinates/polar_coordinates.py
@@ -5,5 +5,5 @@ class PolarCoordinateHandler(CylindricalCoordinateHandler):
     name = "polar"
 
     def __init__(self, ds, ordering=("r", "theta", "z")):
-        super(PolarCoordinateHandler, self).__init__(ds, ordering)
+        super().__init__(ds, ordering)
         # No need to set labels here

--- a/yt/geometry/coordinates/spec_cube_coordinates.py
+++ b/yt/geometry/coordinates/spec_cube_coordinates.py
@@ -9,13 +9,13 @@ class SpectralCubeCoordinateHandler(CartesianCoordinateHandler):
         ordering = tuple(
             "xyz"[axis] for axis in (ds.lon_axis, ds.lat_axis, ds.spec_axis)
         )
-        super(SpectralCubeCoordinateHandler, self).__init__(ds, ordering)
+        super().__init__(ds, ordering)
 
         self.default_unit_label = {}
         names = {}
         if ds.lon_name != "X" or ds.lat_name != "Y":
-            names["x"] = "Image\ x"
-            names["y"] = "Image\ y"
+            names["x"] = r"Image\ x"
+            names["y"] = r"Image\ y"
             # We can just use ds.lon_axis here
             self.default_unit_label[ds.lon_axis] = "pixel"
             self.default_unit_label[ds.lat_axis] = "pixel"
@@ -42,7 +42,7 @@ class SpectralCubeCoordinateHandler(CartesianCoordinateHandler):
 
     def setup_fields(self, registry):
         if not self.ds.no_cgs_equiv_length:
-            return super(SpectralCubeCoordinateHandler, self).setup_fields(registry)
+            return super().setup_fields(registry)
         for axi, ax in enumerate("xyz"):
             f1, f2 = _get_coord_fields(axi)
 

--- a/yt/geometry/coordinates/spherical_coordinates.py
+++ b/yt/geometry/coordinates/spherical_coordinates.py
@@ -9,7 +9,7 @@ class SphericalCoordinateHandler(CoordinateHandler):
     name = "spherical"
 
     def __init__(self, ds, ordering=("r", "theta", "phi")):
-        super(SphericalCoordinateHandler, self).__init__(ds, ordering)
+        super().__init__(ds, ordering)
         # Generate
         self.image_units = {}
         self.image_units[self.axis_id["r"]] = ("rad", "rad")
@@ -275,9 +275,7 @@ class SphericalCoordinateHandler(CoordinateHandler):
         return self.ds.domain_width
 
     def sanitize_center(self, center, axis):
-        center, display_center = super(
-            SphericalCoordinateHandler, self
-        ).sanitize_center(center, axis)
+        center, display_center = super().sanitize_center(center, axis)
         name = self.axis_name[axis]
         if name == "r":
             display_center = center
@@ -302,9 +300,7 @@ class SphericalCoordinateHandler(CoordinateHandler):
     def sanitize_width(self, axis, width, depth):
         name = self.axis_name[axis]
         if width is not None:
-            width = super(SphericalCoordinateHandler, self).sanitize_width(
-                axis, width, depth
-            )
+            width = super().sanitize_width(axis, width, depth)
         elif name == "r":
             width = [
                 self.ds.domain_width[self.x_axis["r"]],

--- a/yt/geometry/geometry_handler.py
+++ b/yt/geometry/geometry_handler.py
@@ -87,7 +87,7 @@ class Index(ParallelAnalysisInterface, abc.ABC):
                 if not exists:
                     self.__create_data_file(fn)
                 self._data_mode = "a"
-            except IOError:
+            except OSError:
                 self._data_mode = None
                 return
         else:

--- a/yt/geometry/grid_geometry_handler.py
+++ b/yt/geometry/grid_geometry_handler.py
@@ -199,7 +199,9 @@ class GridIndex(Index, abc.ABC):
         """
         Prints out (stdout) relevant information about the simulation
         """
-        header = "%3s\t%6s\t%14s\t%14s" % ("level", "# grids", "# cells", "# cells^3")
+        header = "{:>3}\t{:>6}\t{:>14}\t{:>14}".format(
+            "level", "# grids", "# cells", "# cells^3"
+        )
         print(header)
         print(f"{len(header.expandtabs()) * '-'}")
         for level in range(MAXLEVEL):
@@ -259,7 +261,7 @@ class GridIndex(Index, abc.ABC):
         out = []
         for field in fields:
             funit = self.ds._get_field_info(field).units
-            out.append(self.ds.arr(np.empty((len(coords))), funit))
+            out.append(self.ds.arr(np.empty(len(coords)), funit))
 
         for grid in grid_index:
             cellwidth = (grid.RightEdge - grid.LeftEdge) / grid.ActiveDimensions
@@ -357,7 +359,7 @@ class GridIndex(Index, abc.ABC):
             return fast_index.count(dobj.selector)
         if grids is None:
             grids = dobj._chunk_info
-        count = sum((g.count(dobj.selector) for g in grids))
+        count = sum(g.count(dobj.selector) for g in grids)
         return count
 
     def _chunk_all(self, dobj, cache=True, fast_index=None):

--- a/yt/geometry/particle_geometry_handler.py
+++ b/yt/geometry/particle_geometry_handler.py
@@ -23,7 +23,7 @@ class ParticleIndex(Index):
         self.dataset_type = dataset_type
         self.dataset = weakref.proxy(ds)
         self.float_type = np.float64
-        super(ParticleIndex, self).__init__(ds, dataset_type)
+        super().__init__(ds, dataset_type)
         self._initialize_index()
 
     def _setup_geometry(self):
@@ -273,7 +273,7 @@ class ParticleIndex(Index):
                     dsl.append(f)
         self.field_list = dsl
         ds = self.dataset
-        ds.particle_types = tuple(set(pt for pt, ds in dsl))
+        ds.particle_types = tuple({pt for pt, ds in dsl})
         # This is an attribute that means these particle types *actually*
         # exist.  As in, they are real, in the dataset.
         ds.field_units.update(units)

--- a/yt/geometry/unstructured_mesh_handler.py
+++ b/yt/geometry/unstructured_mesh_handler.py
@@ -19,7 +19,7 @@ class UnstructuredIndex(Index):
         self.index_filename = self.dataset.parameter_filename
         self.directory = os.path.dirname(self.index_filename)
         self.float_type = np.float64
-        super(UnstructuredIndex, self).__init__(ds, dataset_type)
+        super().__init__(ds, dataset_type)
 
     def _setup_geometry(self):
         mylog.debug("Initializing Unstructured Mesh Geometry Handler.")
@@ -53,7 +53,7 @@ class UnstructuredIndex(Index):
     def _count_selection(self, dobj, meshes=None):
         if meshes is None:
             meshes = dobj._chunk_info
-        count = sum((m.count(dobj.selector) for m in meshes))
+        count = sum(m.count(dobj.selector) for m in meshes)
         return count
 
     def _chunk_all(self, dobj, cache=True):

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -125,7 +125,7 @@ def amrspace(extent, levels=7, cells=8):
         levels = np.asarray(levels, dtype="int32")
         minlvl = levels.min()
         maxlvl = levels.max()
-        if minlvl != maxlvl and (minlvl != 0 or set([minlvl, maxlvl]) != set(levels)):
+        if minlvl != maxlvl and (minlvl != 0 or {minlvl, maxlvl} != set(levels)):
             raise ValueError("all levels must have the same value or zero.")
     dims_zero = levels == 0
     dims_nonzero = ~dims_zero
@@ -1197,7 +1197,7 @@ def assert_fname(fname):
 
     assert (
         image_type == extension
-    ), "Expected an image of type '%s' but '%s' is an image of type '%s'" % (
+    ), "Expected an image of type '{}' but '{}' is an image of type '{}'".format(
         extension,
         fname,
         image_type,

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -56,7 +56,7 @@ class AnswerTesting(Plugin):
     _my_version = None
 
     def options(self, parser, env=os.environ):
-        super(AnswerTesting, self).options(parser, env=env)
+        super().options(parser, env=env)
         parser.add_option(
             "--answer-name",
             dest="answer_name",
@@ -106,7 +106,7 @@ class AnswerTesting(Plugin):
         return self._my_version
 
     def configure(self, options, conf):
-        super(AnswerTesting, self).configure(options, conf)
+        super().configure(options, conf)
         if not self.enabled:
             return
         disable_stream_logging()
@@ -357,7 +357,7 @@ def data_dir_load(ds_fn, cls=None, args=None, kwargs=None):
 
 def sim_dir_load(sim_fn, path=None, sim_type="Enzo", find_outputs=False):
     if path is None and not os.path.exists(sim_fn):
-        raise IOError
+        raise OSError
     if os.path.exists(sim_fn) or not path:
         path = "."
     return load_simulation(
@@ -475,7 +475,7 @@ class AnswerTestingTest:
         if obj_type is None:
             oname = "all"
         else:
-            oname = "_".join((str(s) for s in obj_type))
+            oname = "_".join(str(s) for s in obj_type)
         args = [self._type_name, str(self.ds), oname]
         args += [str(getattr(self, an)) for an in self._attrs]
         suffix = getattr(self, "suffix", None)
@@ -489,7 +489,7 @@ class FieldValuesTest(AnswerTestingTest):
     _attrs = ("field",)
 
     def __init__(self, ds_fn, field, obj_type=None, particle_type=False, decimals=10):
-        super(FieldValuesTest, self).__init__(ds_fn)
+        super().__init__(ds_fn)
         self.obj_type = obj_type
         self.field = field
         self.particle_type = particle_type
@@ -539,7 +539,7 @@ class AllFieldValuesTest(AnswerTestingTest):
     _attrs = ("field",)
 
     def __init__(self, ds_fn, field, obj_type=None, decimals=None):
-        super(AllFieldValuesTest, self).__init__(ds_fn)
+        super().__init__(ds_fn)
         self.obj_type = obj_type
         self.field = field
         self.decimals = decimals
@@ -569,7 +569,7 @@ class ProjectionValuesTest(AnswerTestingTest):
     def __init__(
         self, ds_fn, axis, field, weight_field=None, obj_type=None, decimals=10
     ):
-        super(ProjectionValuesTest, self).__init__(ds_fn)
+        super().__init__(ds_fn)
         self.axis = axis
         self.field = field
         self.weight_field = weight_field
@@ -631,7 +631,7 @@ class PixelizedProjectionValuesTest(AnswerTestingTest):
     _attrs = ("field", "axis", "weight_field")
 
     def __init__(self, ds_fn, axis, field, weight_field=None, obj_type=None):
-        super(PixelizedProjectionValuesTest, self).__init__(ds_fn)
+        super().__init__(ds_fn)
         self.axis = axis
         self.field = field
         self.weight_field = weight_field
@@ -690,7 +690,7 @@ class GridValuesTest(AnswerTestingTest):
     _attrs = ("field",)
 
     def __init__(self, ds_fn, field):
-        super(GridValuesTest, self).__init__(ds_fn)
+        super().__init__(ds_fn)
         self.field = field
 
     def run(self):
@@ -836,7 +836,7 @@ class VRImageComparisonTest(AnswerTestingTest):
     _attrs = ("desc",)
 
     def __init__(self, scene, ds, desc, decimals):
-        super(VRImageComparisonTest, self).__init__(None)
+        super().__init__(None)
         self.obj_type = ("vr",)
         self.ds = ds
         self.scene = scene
@@ -878,7 +878,7 @@ class PlotWindowAttributeTest(AnswerTestingTest):
         callback_id="",
         callback_runners=None,
     ):
-        super(PlotWindowAttributeTest, self).__init__(ds_fn)
+        super().__init__(ds_fn)
         self.plot_type = plot_type
         self.plot_field = plot_field
         self.plot_axis = plot_axis
@@ -927,7 +927,7 @@ class PhasePlotAttributeTest(AnswerTestingTest):
         decimals,
         plot_type="PhasePlot",
     ):
-        super(PhasePlotAttributeTest, self).__init__(ds_fn)
+        super().__init__(ds_fn)
         self.data_source = self.ds.all_data()
         self.plot_type = plot_type
         self.x_field = x_field
@@ -978,7 +978,7 @@ class GenericArrayTest(AnswerTestingTest):
     _attrs = ("array_func_name", "args", "kwargs")
 
     def __init__(self, ds_fn, array_func, args=None, kwargs=None, decimals=None):
-        super(GenericArrayTest, self).__init__(ds_fn)
+        super().__init__(ds_fn)
         self.array_func = array_func
         self.array_func_name = array_func.__name__
         self.args = args
@@ -1025,7 +1025,7 @@ class GenericImageTest(AnswerTestingTest):
     _attrs = ("image_func_name", "args", "kwargs")
 
     def __init__(self, ds_fn, image_func, decimals, args=None, kwargs=None):
-        super(GenericImageTest, self).__init__(ds_fn)
+        super().__init__(ds_fn)
         self.image_func = image_func
         self.image_func_name = image_func.__name__
         self.args = args
@@ -1065,7 +1065,7 @@ class AxialPixelizationTest(AnswerTestingTest):
     _attrs = ("geometry",)
 
     def __init__(self, ds_fn, decimals=None):
-        super(AxialPixelizationTest, self).__init__(ds_fn)
+        super().__init__(ds_fn)
         self.decimals = decimals
         self.geometry = self.ds.coordinates.name
 

--- a/yt/utilities/answer_testing/level_sets_tests.py
+++ b/yt/utilities/answer_testing/level_sets_tests.py
@@ -9,7 +9,7 @@ class ExtractConnectedSetsTest(AnswerTestingTest):
     _attrs = ()
 
     def __init__(self, ds_fn, data_source, field, num_levels, min_val, max_val):
-        super(ExtractConnectedSetsTest, self).__init__(ds_fn)
+        super().__init__(ds_fn)
         self.data_source = data_source
         self.field = field
         self.num_levels = num_levels

--- a/yt/utilities/answer_testing/utils.py
+++ b/yt/utilities/answer_testing/utils.py
@@ -220,7 +220,7 @@ def _compare_result(data, outputFile):
         Name of file where answers are already saved.
     """
     # Load the saved data
-    with open(outputFile, "r") as f:
+    with open(outputFile) as f:
         savedData = yaml.safe_load(f)
     # Define the comparison function
     def _check_vals(newVals, oldVals):
@@ -427,7 +427,7 @@ def compare_unit_attributes(ds1, ds2):
 
 def fake_halo_catalog(data):
     filename = "catalog.0.h5"
-    ftypes = dict((field, ".") for field in data)
+    ftypes = {field: "." for field in data}
     extra_attrs = {"data_type": "halo_catalog", "num_halos": data["particle_mass"].size}
     ds = {
         "cosmological_simulation": 1,

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -1816,12 +1816,12 @@ class YTDownloadData(YTCommand):
             ensure_dir(data_dir)
         data_file = os.path.join(data_dir, args.filename)
         if os.path.exists(data_file) and not args.overwrite:
-            raise IOError(f"File '{data_file}' exists and overwrite=False!")
+            raise OSError(f"File '{data_file}' exists and overwrite=False!")
         print(f"Attempting to download file: {args.filename}")
         fn = download_file(data_url, data_file)
 
         if not os.path.exists(fn):
-            raise IOError(f"The file '{args.filename}' did not download!!")
+            raise OSError(f"The file '{args.filename}' did not download!!")
         print(f"File: {args.filename} downloaded successfully to {data_file}")
 
     def get_list(self):

--- a/yt/utilities/definitions.py
+++ b/yt/utilities/definitions.py
@@ -32,8 +32,8 @@ mpc_conversion = {
 # Nicely formatted versions of common length units
 formatted_length_unit_names = {
     "au": "AU",
-    "rsun": "R_\odot",
-    "code_length": "code\ length",
+    "rsun": r"R_\odot",
+    "code_length": r"code\ length",
 }
 
 # How many seconds are in each thing

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -336,7 +336,7 @@ class YTNoAPIKey(YTException):
         self.config_name = config_name
 
     def __str__(self):
-        return "You need to set an API key for %s in ~/.config/yt/ytrc as %s" % (
+        return "You need to set an API key for {} in ~/.config/yt/ytrc as {}".format(
             self.service,
             self.config_name,
         )
@@ -393,7 +393,7 @@ class YTDomainOverflow(YTException):
         self.dre = dre
 
     def __str__(self):
-        return "Particle bounds %s and %s exceed domain bounds %s and %s" % (
+        return "Particle bounds {} and {} exceed domain bounds {} and {}".format(
             self.mi,
             self.ma,
             self.dle,
@@ -417,7 +417,7 @@ class YTIllDefinedFilter(YTException):
         self.s2 = s2
 
     def __str__(self):
-        return "Filter '%s' ill-defined.  Applied to shape %s but is shape %s." % (
+        return "Filter '{}' ill-defined.  Applied to shape {} but is shape {}.".format(
             self.filter,
             self.s1,
             self.s2,
@@ -499,7 +499,7 @@ class YTElementTypeNotRecognized(YTException):
         self.num_nodes = num_nodes
 
     def __str__(self):
-        return "Element type not recognized - dim = %s, num_nodes = %s" % (
+        return "Element type not recognized - dim = {}, num_nodes = {}".format(
             self.dim,
             self.num_nodes,
         )
@@ -866,4 +866,4 @@ class YTArrayTooLargeToDisplay(YTException):
 class GenerationInProgress(Exception):
     def __init__(self, fields):
         self.fields = fields
-        super(GenerationInProgress, self).__init__()
+        super().__init__()

--- a/yt/utilities/fortran_utils.py
+++ b/yt/utilities/fortran_utils.py
@@ -69,7 +69,7 @@ def read_attrs(f, attrs, endian="="):
         s2 = vals.pop(0)
         if s1 != s2:
             size = struct.calcsize(endian + "I" + "".join(n * [t]) + "I")
-            raise IOError(
+            raise OSError(
                 "An error occured while reading a Fortran record. "
                 "Got a different size at the beginning and at the "
                 "end of the record: %s %s",
@@ -80,7 +80,7 @@ def read_attrs(f, attrs, endian="="):
             v = v[0]
         if isinstance(a, tuple):
             if len(a) != len(v):
-                raise IOError(
+                raise OSError(
                     "An error occured while reading a Fortran "
                     "record. Record length is not equal to expected "
                     "length: %s %s",
@@ -147,7 +147,7 @@ def read_cattrs(f, attrs, endian="="):
             v = v[0]
         if isinstance(a, tuple):
             if len(a) != len(v):
-                raise IOError(
+                raise OSError(
                     "An error occured while reading a Fortran "
                     "record. Record length is not equal to expected "
                     "length: %s %s",
@@ -192,7 +192,7 @@ def read_vector(f, d, endian="="):
     vec_fmt = f"{endian}{d}"
     vec_size = struct.calcsize(vec_fmt)
     if vec_len % vec_size != 0:
-        raise IOError(
+        raise OSError(
             "An error occured while reading a Fortran record. "
             "Vector length is not compatible with data type: %s %s",
             vec_len,
@@ -205,7 +205,7 @@ def read_vector(f, d, endian="="):
         tr = np.fromstring(f.read(vec_len), vec_fmt, count=vec_num)
     vec_len2 = struct.unpack(pad_fmt, f.read(pad_size))[0]
     if vec_len != vec_len2:
-        raise IOError(
+        raise OSError(
             "An error occured while reading a Fortran record. "
             "Got a different size at the beginning and at the "
             "end of the record: %s %s",
@@ -248,7 +248,7 @@ def skip(f, n=1, endian="="):
         f.seek(s1 + fmt_size, os.SEEK_CUR)
         s2 = struct.unpack(fmt, size)[0]
         if s1 != s2:
-            raise IOError(
+            raise OSError(
                 "An error occured while reading a Fortran record. "
                 "Got a different size at the beginning and at the "
                 "end of the record: %s %s",
@@ -323,7 +323,7 @@ def read_record(f, rspec, endian="="):
     vals = list(struct.unpack(net_format, f.read(size)))
     s1, s2 = vals.pop(0), vals.pop(-1)
     if s1 != s2:
-        raise IOError(
+        raise OSError(
             "An error occured while reading a Fortran record. Got "
             "a different size at the beginning and at the end of "
             "the record: %s %s",

--- a/yt/utilities/hierarchy_inspection.py
+++ b/yt/utilities/hierarchy_inspection.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import inspect
 from collections import Counter
 from functools import reduce

--- a/yt/utilities/io_handler.py
+++ b/yt/utilities/io_handler.py
@@ -46,7 +46,7 @@ class BaseIOHandler:
         # Make sure _vector_fields is a dict of fields and their dimension
         # and assume all non-specified vector fields are 3D
         if not isinstance(self._vector_fields, dict):
-            self._vector_fields = dict((field, 3) for field in self._vector_fields)
+            self._vector_fields = {field: 3 for field in self._vector_fields}
 
     # We need a function for reading a list of sets
     # and a function for *popping* from a queue all the appropriate sets

--- a/yt/utilities/lib/octree_raytracing.py
+++ b/yt/utilities/lib/octree_raytracing.py
@@ -6,7 +6,7 @@ from yt.funcs import mylog
 from yt.utilities.lib._octree_raytracing import _OctreeRayTracing
 
 
-class OctreeRayTracing(object):
+class OctreeRayTracing:
     octree = None
     data_source = None
     log_fields = None

--- a/yt/utilities/lib/tests/test_sample.py
+++ b/yt/utilities/lib/tests/test_sample.py
@@ -25,12 +25,12 @@ def test_sample():
     yp = np.random.uniform(low=1.0, high=63.0, size=num_particles)
     zp = np.random.uniform(low=1.0, high=63.0, size=num_particles)
 
-    xfield = np.zeros((num_particles))
-    yfield = np.zeros((num_particles))
-    zfield = np.zeros((num_particles))
+    xfield = np.zeros(num_particles)
+    yfield = np.zeros(num_particles)
+    zfield = np.zeros(num_particles)
 
     dx = 1.0
-    le = np.zeros((3))
+    le = np.zeros(3)
 
     CICSample_3(xp, yp, zp, xfield, num_particles, grid["x"], le, dims, dx)
     CICSample_3(xp, yp, zp, yfield, num_particles, grid["y"], le, dims, dx)

--- a/yt/utilities/lodgeit.py
+++ b/yt/utilities/lodgeit.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """
     LodgeIt!
     ~~~~~~~~
@@ -78,7 +77,7 @@ def load_default_settings():
                         else:
                             settings[key] = p[1].strip()
             f.close()
-        except IOError:
+        except OSError:
             pass
     settings["tags"] = []
     settings["title"] = None
@@ -194,7 +193,7 @@ def print_languages():
     languages.sort(lambda a, b: cmp(a[1].lower(), b[1].lower()))
     print("Supported Languages:")
     for alias, name in languages:
-        print("    %-30s%s" % (alias, name))
+        print(f"    {alias:<30}{name}")
 
 
 def download_paste(uid):

--- a/yt/utilities/mesh_code_generation.py
+++ b/yt/utilities/mesh_code_generation.py
@@ -145,7 +145,7 @@ class MeshCodeGenerator:
 
 if __name__ == "__main__":
 
-    with open("mesh_types.yaml", "r") as f:
+    with open("mesh_types.yaml") as f:
         lines = f.read()
 
     mesh_types = yaml.load(lines, Loader=yaml.FullLoader)

--- a/yt/utilities/minimal_representation.py
+++ b/yt/utilities/minimal_representation.py
@@ -99,7 +99,7 @@ class MinimalRepresentation(metaclass=abc.ABCMeta):
 
     @property
     def _attrs(self):
-        return dict(((attr, getattr(self, attr)) for attr in self._attr_list))
+        return {attr: getattr(self, attr) for attr in self._attr_list}
 
     @classmethod
     def _from_metadata(cls, metadata):
@@ -168,7 +168,7 @@ class MinimalDataset(MinimalRepresentation):
     type = "simulation_output"
 
     def __init__(self, obj):
-        super(MinimalDataset, self).__init__(obj)
+        super().__init__(obj)
         self.output_hash = obj._hash()
         self.name = str(obj)
 
@@ -288,7 +288,7 @@ class MinimalNotebook(MinimalRepresentation):
     def __init__(self, filename, title=None):
         # First we read in the data
         if not os.path.isfile(filename):
-            raise IOError(filename)
+            raise OSError(filename)
         self.data = open(filename).read()
         if title is None:
             title = json.loads(self.data)["metadata"]["name"]

--- a/yt/utilities/on_demand_imports.py
+++ b/yt/utilities/on_demand_imports.py
@@ -369,7 +369,7 @@ class h5py_imports:
                 )
         except ImportError:
             pass
-        super(h5py_imports, self).__init__()
+        super().__init__()
 
     _File = None
 
@@ -582,7 +582,7 @@ _yaml = yaml_imports()
 
 class NotMiniball(NotAModule):
     def __init__(self, pkg_name):
-        super(NotMiniball, self).__init__(pkg_name)
+        super().__init__(pkg_name)
         str = (
             "This functionality requires the %s package to be installed. "
             "Installation instructions can be found at "
@@ -610,7 +610,7 @@ class miniball_imports:
 _miniball = miniball_imports()
 
 
-class f90nml_imports(object):
+class f90nml_imports:
     _name = "f90nml"
     _module = None
 

--- a/yt/utilities/parallel_tools/io_runner.py
+++ b/yt/utilities/parallel_tools/io_runner.py
@@ -109,7 +109,7 @@ class IOHandlerRemote(BaseIOHandler):
         self.pool = pool
         self.comm = pool.comm
         self.proc_map = self.comm.comm.bcast(None, root=pool["io"].ranks[0])
-        super(IOHandlerRemote, self).__init__()
+        super().__init__()
 
     def _read_data_set(self, grid, field):
         dest = self.proc_map[grid.id]

--- a/yt/utilities/parallel_tools/parallel_analysis_interface.py
+++ b/yt/utilities/parallel_tools/parallel_analysis_interface.py
@@ -190,8 +190,7 @@ class ObjectIterator:
         self.just_list = just_list
 
     def __iter__(self):
-        for obj in self._objs:
-            yield obj
+        yield from self._objs
 
 
 class ParallelObjectIterator(ObjectIterator):
@@ -265,7 +264,7 @@ class ParallelDummy(type):
     """
 
     def __init__(cls, name, bases, d):
-        super(ParallelDummy, cls).__init__(name, bases, d)
+        super().__init__(name, bases, d)
         skip = d.pop("dont_wrap", [])
         extra = d.pop("extra_wrap", [])
         for attrname in d:
@@ -501,8 +500,7 @@ def parallel_objects(objects, njobs=0, storage=None, barrier=True, dynamic=False
     if dynamic:
         from .task_queue import dynamic_parallel_objects
 
-        for my_obj in dynamic_parallel_objects(objects, njobs=njobs, storage=storage):
-            yield my_obj
+        yield from dynamic_parallel_objects(objects, njobs=njobs, storage=storage)
         return
 
     if not parallel_capable:

--- a/yt/utilities/parameter_file_storage.py
+++ b/yt/utilities/parameter_file_storage.py
@@ -120,7 +120,7 @@ class ParameterFileStore:
         if os.path.exists(fn):
             ds = output_type_registry[class_name](os.path.join(fp, bn))
         else:
-            raise IOError
+            raise OSError
         # This next one is to ensure that we manually update the last_seen
         # record *now*, for during write_out.
         self._records[ds._hash()]["last_seen"] = ds._instantiated
@@ -187,7 +187,7 @@ class ParameterFileStore:
     @parallel_simple_proxy
     def read_db(self):
         """ This will read the storage device from disk. """
-        f = open(self._get_db_name(), "r")
+        f = open(self._get_db_name())
         vals = csv.DictReader(f, _field_names)
         db = {}
         for v in vals:

--- a/yt/utilities/particle_generator.py
+++ b/yt/utilities/particle_generator.py
@@ -21,9 +21,9 @@ class ParticleGenerator:
             (ptype, fd) if isinstance(fd, str) else fd for fd in field_list
         ]
         self.field_list.append((ptype, "particle_index"))
-        self.field_units = dict(
-            ((ptype, f"particle_position_{ax}"), "code_length") for ax in "xyz"
-        )
+        self.field_units = {
+            (ptype, f"particle_position_{ax}"): "code_length" for ax in "xyz"
+        }
         self.field_units[ptype, "particle_index"] = ""
         self.ptype = ptype
 
@@ -268,9 +268,7 @@ class FromListParticleGenerator(ParticleGenerator):
         if np.any(cond):
             raise ValueError("Some particles are outside of the domain!!!")
 
-        super(FromListParticleGenerator, self).__init__(
-            ds, num_particles, field_list, ptype=ptype
-        )
+        super().__init__(ds, num_particles, field_list, ptype=ptype)
         self._setup_particles(x, y, z, setup_fields=data)
 
 
@@ -333,9 +331,7 @@ class LatticeParticleGenerator(ParticleGenerator):
         if cond:
             raise ValueError("Proposed bounds for particles are outside domain!!!")
 
-        super(LatticeParticleGenerator, self).__init__(
-            ds, num_x * num_y * num_z, field_list, ptype=ptype
-        )
+        super().__init__(ds, num_x * num_y * num_z, field_list, ptype=ptype)
 
         dx = (xmax - xmin) / (num_x - 1)
         dy = (ymax - ymin) / (num_y - 1)
@@ -394,9 +390,7 @@ class WithDensityParticleGenerator(ParticleGenerator):
         ...             )
         """
 
-        super(WithDensityParticleGenerator, self).__init__(
-            ds, num_particles, field_list, ptype=ptype
-        )
+        super().__init__(ds, num_particles, field_list, ptype=ptype)
 
         num_cells = len(data_source["x"].flat)
         max_mass = (data_source[density_field] * data_source["cell_volume"]).max()

--- a/yt/utilities/rpdb.py
+++ b/yt/utilities/rpdb.py
@@ -1,7 +1,6 @@
 import cmd
 import pdb
 import signal
-import socket
 import sys
 import traceback
 from io import StringIO
@@ -120,7 +119,7 @@ def run_rpdb(task=None):
     sp = ServerProxy(f"http://localhost:{port}/")
     try:
         pp = rpdb_cmd(sp)
-    except socket.error:
+    except OSError:
         print("Connection refused.  Is the server running?")
         sys.exit(1)
     pp.cmdloop(__header % dict(task=port - 8010))

--- a/yt/utilities/sdf.py
+++ b/yt/utilities/sdf.py
@@ -413,8 +413,8 @@ class SDFRead(dict):
             for v in vnames:
                 str_types.append((v, vtype))
             l = ascfile.readline()
-        num = l.strip("}[]")
-        num = num.strip("\\;\\\n]")  # NOQA B005
+        spec_chars = r"{}[]\;\n\\"
+        num = l.strip(spec_chars)
         if len(num) == 0:
             # We need to compute the number of records.  The DataStruct will
             # handle this.

--- a/yt/utilities/sdf.py
+++ b/yt/utilities/sdf.py
@@ -230,7 +230,7 @@ class HTTPDataStruct(DataStruct):
     """docstring for HTTPDataStruct"""
 
     def __init__(self, *args, **kwargs):
-        super(HTTPDataStruct, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         HTTPArray, PageCacheURL = get_thingking_deps()
         self.HTTPArray = HTTPArray
         self.pcu = PageCacheURL(self.filename)
@@ -358,7 +358,7 @@ class SDFRead(dict):
     def parse_header(self):
         """docstring for parse_header"""
         # Pre-process
-        ascfile = open(self.header, "r")
+        ascfile = open(self.header)
         while True:
             l = ascfile.readline()
             if self._eof in l:
@@ -414,7 +414,7 @@ class SDFRead(dict):
                 str_types.append((v, vtype))
             l = ascfile.readline()
         num = l.strip("}[]")
-        num = num.strip("\;\\\n]")  # NOQA B005
+        num = num.strip("\\;\\\n]")  # NOQA B005
         if len(num) == 0:
             # We need to compute the number of records.  The DataStruct will
             # handle this.
@@ -479,7 +479,7 @@ class HTTPSDFRead(SDFRead):
     def __init__(self, *args, **kwargs):
         HTTPArray, _ = get_thingking_deps()
         self.HTTPArray = HTTPArray
-        super(HTTPSDFRead, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def parse_header(self):
         """docstring for parse_header"""
@@ -570,7 +570,7 @@ class SDFIndex:
     """
 
     def __init__(self, sdfdata, indexdata, level=None):
-        super(SDFIndex, self).__init__()
+        super().__init__()
         self.sdfdata = sdfdata
         self.indexdata = indexdata
         if level is None:
@@ -1117,8 +1117,7 @@ class SDFIndex:
         # right = right.astype('float32')
 
         # my_filter = bbox_filter(left, right, self.true_domain_width)
-        for dd in self.filter_bbox(left, right, self.iter_data(inds, fields)):
-            yield dd
+        yield from self.filter_bbox(left, right, self.iter_data(inds, fields))
         # for dd in self.filter_particles(
         #    self.iter_data(inds, fields),
         #    my_filter):
@@ -1133,8 +1132,7 @@ class SDFIndex:
         mylog.debug("MIDX Loading spherical region %s to %s", center, radius)
         inds = self.get_bbox(center - radius, center + radius)
 
-        for dd in self.filter_sphere(center, radius, self.iter_data(inds, fields)):
-            yield dd
+        yield from self.filter_sphere(center, radius, self.iter_data(inds, fields))
 
     def iter_ibbox_data(self, left, right, fields):
         mylog.debug("MIDX Loading region from %s to %s", left, right)
@@ -1407,8 +1405,7 @@ class SDFIndex:
 
         # Need to get all of these
         low_key, high_key = self.get_key_bounds(level, cell_iarr)
-        for k in range(low_key, high_key):
-            yield k
+        yield from range(low_key, high_key)
 
         # Bottom & Top
         pbox = bbox.copy()
@@ -1418,13 +1415,11 @@ class SDFIndex:
         pbox[1, 1] += pad[1]
         pbox[2, 0] -= pad[2]
         pbox[2, 1] = bbox[2, 0]
-        for k in self.get_bbox(pbox[:, 0], pbox[:, 1]):
-            yield k
+        yield from self.get_bbox(pbox[:, 0], pbox[:, 1])
 
         pbox[2, 0] = bbox[2, 1]
         pbox[2, 1] = pbox[2, 0] + pad[2]
-        for k in self.get_bbox(pbox[:, 0], pbox[:, 1]):
-            yield k
+        yield from self.get_bbox(pbox[:, 0], pbox[:, 1])
 
         # Front & Back
         pbox = bbox.copy()
@@ -1432,20 +1427,16 @@ class SDFIndex:
         pbox[0, 1] += pad[0]
         pbox[1, 0] -= pad[1]
         pbox[1, 1] = bbox[1, 0]
-        for k in self.get_bbox(pbox[:, 0], pbox[:, 1]):
-            yield k
+        yield from self.get_bbox(pbox[:, 0], pbox[:, 1])
         pbox[1, 0] = bbox[1, 1]
         pbox[1, 1] = pbox[1, 0] + pad[1]
-        for k in self.get_bbox(pbox[:, 0], pbox[:, 1]):
-            yield k
+        yield from self.get_bbox(pbox[:, 0], pbox[:, 1])
 
         # Left & Right
         pbox = bbox.copy()
         pbox[0, 0] -= pad[0]
         pbox[0, 1] = bbox[0, 0]
-        for k in self.get_bbox(pbox[:, 0], pbox[:, 1]):
-            yield k
+        yield from self.get_bbox(pbox[:, 0], pbox[:, 1])
         pbox[0, 0] = bbox[0, 1]
         pbox[0, 1] = pbox[0, 0] + pad[0]
-        for k in self.get_bbox(pbox[:, 0], pbox[:, 1]):
-            yield k
+        yield from self.get_bbox(pbox[:, 0], pbox[:, 1])

--- a/yt/utilities/tests/test_config.py
+++ b/yt/utilities/tests/test_config.py
@@ -170,6 +170,6 @@ class TestYTConfigMigration(TestYTConfig):
             os.path.exists(os.path.join(old_config_dir, _TEST_PLUGIN + ".bak"))
         )
 
-        with open(CURRENT_CONFIG_FILE, "r") as fh:
+        with open(CURRENT_CONFIG_FILE) as fh:
             new_cfg = "".join(fh.readlines())
         self.assertEqual(new_cfg.strip().split("\n"), _DUMMY_CFG)

--- a/yt/utilities/tests/test_cosmology.py
+++ b/yt/utilities/tests/test_cosmology.py
@@ -216,7 +216,7 @@ def test_cosmology_calculator_answers():
     """
 
     fn = os.path.join(local_dir, "cosmology_answers.yml")
-    data = yaml.load(open(fn, "r"), Loader=yaml.FullLoader)
+    data = yaml.load(open(fn), Loader=yaml.FullLoader)
 
     cosmologies = data["cosmologies"]
     functions = data["functions"]
@@ -240,11 +240,13 @@ def test_cosmology_calculator_answers():
                 val.convert_to_units(units)
             val = float(val)
 
-            err_msg = "%s answer has changed for %s cosmology, old: %f, new: %f." % (
-                fname,
-                cname,
-                finfo["answers"][cname],
-                val,
+            err_msg = (
+                "{} answer has changed for {} cosmology, old: {:f}, new: {:f}.".format(
+                    fname,
+                    cname,
+                    finfo["answers"][cname],
+                    val,
+                )
             )
             assert_almost_equal(val, finfo["answers"][cname], 10, err_msg=err_msg)
 

--- a/yt/utilities/tests/test_hierarchy_inspection.py
+++ b/yt/utilities/tests/test_hierarchy_inspection.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Created on Wed Feb 18 18:24:09 2015
 

--- a/yt/utilities/tests/test_interpolators.py
+++ b/yt/utilities/tests/test_interpolators.py
@@ -31,16 +31,14 @@ def test_linear_interpolator_1d():
 def test_linear_interpolator_2d():
     random_data = np.random.random((64, 64))
     # evenly spaced bins
-    fv = dict((ax, v) for ax, v in zip("xyz", np.mgrid[0.0:1.0:64j, 0.0:1.0:64j]))
+    fv = {ax: v for ax, v in zip("xyz", np.mgrid[0.0:1.0:64j, 0.0:1.0:64j])}
     bfi = lin.BilinearFieldInterpolator(random_data, (0.0, 1.0, 0.0, 1.0), "xy", True)
     assert_array_equal(bfi(fv), random_data)
 
     # randomly spaced bins
     size = 64
     bins = np.linspace(0.0, 1.0, size)
-    shifts = dict(
-        (ax, (1.0 / size) * np.random.random(size) - (0.5 / size)) for ax in "xy"
-    )
+    shifts = {ax: (1.0 / size) * np.random.random(size) - (0.5 / size) for ax in "xy"}
     fv["x"] += shifts["x"][:, np.newaxis]
     fv["y"] += shifts["y"]
     bfi = lin.BilinearFieldInterpolator(
@@ -52,9 +50,9 @@ def test_linear_interpolator_2d():
 def test_linear_interpolator_3d():
     random_data = np.random.random((64, 64, 64))
     # evenly spaced bins
-    fv = dict(
-        (ax, v) for ax, v in zip("xyz", np.mgrid[0.0:1.0:64j, 0.0:1.0:64j, 0.0:1.0:64j])
-    )
+    fv = {
+        ax: v for ax, v in zip("xyz", np.mgrid[0.0:1.0:64j, 0.0:1.0:64j, 0.0:1.0:64j])
+    }
     tfi = lin.TrilinearFieldInterpolator(
         random_data, (0.0, 1.0, 0.0, 1.0, 0.0, 1.0), "xyz", True
     )
@@ -63,9 +61,7 @@ def test_linear_interpolator_3d():
     # randomly spaced bins
     size = 64
     bins = np.linspace(0.0, 1.0, size)
-    shifts = dict(
-        (ax, (1.0 / size) * np.random.random(size) - (0.5 / size)) for ax in "xyz"
-    )
+    shifts = {ax: (1.0 / size) * np.random.random(size) - (0.5 / size) for ax in "xyz"}
     fv["x"] += shifts["x"][:, np.newaxis, np.newaxis]
     fv["y"] += shifts["y"][:, np.newaxis]
     fv["z"] += shifts["z"]

--- a/yt/utilities/tests/test_particle_generator.py
+++ b/yt/utilities/tests/test_particle_generator.py
@@ -52,7 +52,7 @@ def test_particle_generator():
 
     def new_indices():
         # We just add new indices onto the existing ones
-        return np.arange((np.product(pdims))) + num_particles
+        return np.arange(np.product(pdims)) + num_particles
 
     le = np.array([0.25, 0.25, 0.25])
     re = np.array([0.75, 0.75, 0.75])
@@ -93,7 +93,7 @@ def test_particle_generator():
     # Test the uniqueness of tags
     tags = np.concatenate([grid["particle_index"] for grid in ds.index.grids])
     tags.sort()
-    assert_equal(tags, np.arange((np.product(pdims) + num_particles)))
+    assert_equal(tags, np.arange(np.product(pdims) + num_particles))
 
     del tags
 

--- a/yt/utilities/tree_container.py
+++ b/yt/utilities/tree_container.py
@@ -14,5 +14,4 @@ class TreeContainer:
         if children is None:
             return
         for child in children:
-            for a_node in child:
-                yield a_node
+            yield from child

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -203,7 +203,7 @@ class ImagePlotMPL(PlotMPL):
 
     def __init__(self, fsize, axrect, caxrect, zlim, figure, axes, cax):
         """Initialize ImagePlotMPL class object"""
-        super(ImagePlotMPL, self).__init__(fsize, axrect, figure, axes)
+        super().__init__(fsize, axrect, figure, axes)
         self.zmin, self.zmax = zlim
         if cax is None:
             self.cax = self.figure.add_axes(caxrect)
@@ -456,7 +456,7 @@ class ImagePlotMPL(PlotMPL):
         self.figure.set_size_inches(*size)
 
     def _get_labels(self):
-        labels = super(ImagePlotMPL, self)._get_labels()
+        labels = super()._get_labels()
         cbax = self.cb.ax
         labels += cbax.yaxis.get_ticklabels()
         labels += [cbax.yaxis.label, cbax.yaxis.get_offset_text()]

--- a/yt/visualization/color_maps.py
+++ b/yt/visualization/color_maps.py
@@ -465,26 +465,22 @@ _turbo_colormap_data = np.array(
 )
 
 _tvals = np.linspace(0, 1, 256)
-_turbo_data = dict(
-    (
-        color,
-        np.transpose([_tvals, _turbo_colormap_data[:, i], _turbo_colormap_data[:, i]]),
+_turbo_data = {
+    color: np.transpose(
+        [_tvals, _turbo_colormap_data[:, i], _turbo_colormap_data[:, i]]
     )
     for i, color in enumerate(["red", "green", "blue"])
-)
+}
 
 add_colormap("turbo", _turbo_data)
 
 _turbo_r_colormap_data = np.flip(_turbo_colormap_data, axis=0)
-_turbo_r_data = dict(
-    (
-        color,
-        np.transpose(
-            [_tvals, _turbo_r_colormap_data[:, i], _turbo_r_colormap_data[:, i]]
-        ),
+_turbo_r_data = {
+    color: np.transpose(
+        [_tvals, _turbo_r_colormap_data[:, i], _turbo_r_colormap_data[:, i]]
     )
     for i, color in enumerate(["red", "green", "blue"])
-)
+}
 add_colormap("turbo_r", _turbo_r_data)
 
 # Add colormaps from cmocean, if it's installed

--- a/yt/visualization/eps_writer.py
+++ b/yt/visualization/eps_writer.py
@@ -882,7 +882,7 @@ class DualEPS:
             else:
                 _, _, z_title = plot._get_field_title(self.field, plot.profile)
                 _zlabel = pyxize_label(z_title)
-            _zlabel = _zlabel.replace("_", "\;")
+            _zlabel = _zlabel.replace("_", r"\;")
             _zlog = plot.get_log(self.field)[self.field]
             if plot.plots[self.field].zmin is None:
                 zmin = plot.plots[self.field].image._A.min()
@@ -894,7 +894,7 @@ class DualEPS:
                 zmax = plot.plots[self.field].zmax
             _zrange = (zmin, zmax)
         else:
-            _zlabel = plot._z_label.replace("_", "\;")
+            _zlabel = plot._z_label.replace("_", r"\;")
             _zlog = plot._log_z
             _zrange = (plot.norm.vmin, plot.norm.vmax)
         if cb_labels is not None:  # Overrides deduced labels
@@ -1520,15 +1520,15 @@ def multiplot_yt(ncol, nrow, plots, fields=None, **kwargs):
             fields = plots.fields
         if len(fields) < nrow * ncol:
             raise RuntimeError(
-                "Number of plots ({0}) is less "
-                "than nrow({1}) x ncol({2}).".format(len(fields), nrow, ncol)
+                "Number of plots ({}) is less "
+                "than nrow({}) x ncol({}).".format(len(fields), nrow, ncol)
             )
         figure = multiplot(ncol, nrow, yt_plots=plots, fields=fields, **kwargs)
     elif isinstance(plots, list) and isinstance(plots[0], (PlotWindow, PhasePlot)):
         if len(plots) < nrow * ncol:
             raise RuntimeError(
-                "Number of plots ({0}) is less "
-                "than nrow({1}) x ncol({2}).".format(len(fields), nrow, ncol)
+                "Number of plots ({}) is less "
+                "than nrow({}) x ncol({}).".format(len(fields), nrow, ncol)
             )
         figure = multiplot(ncol, nrow, yt_plots=plots, fields=fields, **kwargs)
     else:

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -236,7 +236,7 @@ class FITSImageData:
 
         # Sanity checking names
         s = set()
-        duplicates = set(f for f in self.fields if f in s or s.add(f))
+        duplicates = {f for f in self.fields if f in s or s.add(f)}
         if len(duplicates) > 0:
             for i, fd in enumerate(self.fields):
                 if fd in duplicates:
@@ -990,7 +990,7 @@ class FITSSlice(FITSImageData):
         w, frb, lunit = construct_image(
             ds, axis, slc, dcenter, image_res, width, length_unit
         )
-        super(FITSSlice, self).__init__(frb, fields=fields, length_unit=lunit, wcs=w)
+        super().__init__(frb, fields=fields, length_unit=lunit, wcs=w)
 
 
 class FITSProjection(FITSImageData):
@@ -1064,9 +1064,7 @@ class FITSProjection(FITSImageData):
         w, frb, lunit = construct_image(
             ds, axis, prj, dcenter, image_res, width, length_unit
         )
-        super(FITSProjection, self).__init__(
-            frb, fields=fields, length_unit=lunit, wcs=w
-        )
+        super().__init__(frb, fields=fields, length_unit=lunit, wcs=w)
 
 
 class FITSOffAxisSlice(FITSImageData):
@@ -1141,9 +1139,7 @@ class FITSOffAxisSlice(FITSImageData):
         w, frb, lunit = construct_image(
             ds, normal, cut, center, image_res, width, length_unit
         )
-        super(FITSOffAxisSlice, self).__init__(
-            frb, fields=fields, length_unit=lunit, wcs=w
-        )
+        super().__init__(frb, fields=fields, length_unit=lunit, wcs=w)
 
 
 class FITSOffAxisProjection(FITSImageData):
@@ -1267,6 +1263,4 @@ class FITSOffAxisProjection(FITSImageData):
         w, not_an_frb, lunit = construct_image(
             ds, normal, buf, center, image_res, width, length_unit
         )
-        super(FITSOffAxisProjection, self).__init__(
-            buf, fields=fields, wcs=w, length_unit=lunit, ds=ds
-        )
+        super().__init__(buf, fields=fields, wcs=w, length_unit=lunit, ds=ds)

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -524,13 +524,11 @@ class FixedResolutionBuffer:
         else:
             data.update(self.data)
 
-        ftypes = dict([(field, "grid") for field in data])
-        extra_attrs = dict(
-            [
-                (arg, getattr(self.data_source, arg, None))
-                for arg in self.data_source._con_args + self.data_source._tds_attrs
-            ]
-        )
+        ftypes = {field: "grid" for field in data}
+        extra_attrs = {
+            arg: getattr(self.data_source, arg, None)
+            for arg in self.data_source._con_args + self.data_source._tds_attrs
+        }
         extra_attrs["con_args"] = self.data_source._con_args
         extra_attrs["left_edge"] = self.ds.arr([self.bounds[0], self.bounds[2]])
         extra_attrs["right_edge"] = self.ds.arr([self.bounds[1], self.bounds[3]])
@@ -572,7 +570,7 @@ class FixedResolutionBuffer:
 class ObliqueFixedResolutionBuffer(FixedResolutionBuffer):
     @deprecate("FixedResolutionBuffer")
     def __init__(self, *args, **kwargs):
-        super(ObliqueFixedResolutionBuffer, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 
 class CylindricalFixedResolutionBuffer(FixedResolutionBuffer):

--- a/yt/visualization/line_plot.py
+++ b/yt/visualization/line_plot.py
@@ -76,7 +76,7 @@ class LineBuffer:
 
 class LinePlotDictionary(PlotDictionary):
     def __init__(self, data_source):
-        super(LinePlotDictionary, self).__init__(data_source)
+        super().__init__(data_source)
         self.known_dimensions = {}
 
     def _sanitize_dimensions(self, item):
@@ -94,15 +94,15 @@ class LinePlotDictionary(PlotDictionary):
 
     def __getitem__(self, item):
         ret_item = self._sanitize_dimensions(item)
-        return super(LinePlotDictionary, self).__getitem__(ret_item)
+        return super().__getitem__(ret_item)
 
     def __setitem__(self, item, value):
         ret_item = self._sanitize_dimensions(item)
-        super(LinePlotDictionary, self).__setitem__(ret_item, value)
+        super().__setitem__(ret_item, value)
 
     def __contains__(self, item):
         ret_item = self._sanitize_dimensions(item)
-        return super(LinePlotDictionary, self).__contains__(ret_item)
+        return super().__contains__(ret_item)
 
 
 class LinePlot(PlotContainer):

--- a/yt/visualization/mapserver/pannable_map.py
+++ b/yt/visualization/mapserver/pannable_map.py
@@ -129,7 +129,7 @@ class PannableMapServer:
         elif path[-3:].lower() == ".js":
             bottle.response.headers["Content-Type"] = "text/javascript"
         full_path = os.path.join(os.path.join(local_dir, "html"), path)
-        return open(full_path, "r").read()
+        return open(full_path).read()
 
     def list_fields(self):
         d = {}

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -329,7 +329,7 @@ class PlotContainer:
     def _switch_ds(self, new_ds, data_source=None):
         old_object = self.data_source
         name = old_object._type_name
-        kwargs = dict((n, getattr(old_object, n)) for n in old_object._con_args)
+        kwargs = {n: getattr(old_object, n) for n in old_object._con_args}
         kwargs["center"] = getattr(old_object, "center", None)
         if data_source is not None:
             if name != "proj":
@@ -583,7 +583,7 @@ class PlotContainer:
             img = base64.b64encode(self.plots[field]._repr_png_()).decode()
             ret += (
                 r'<img style="max-width:100%;max-height:100%;" '
-                r'src="data:image/png;base64,{0}"><br>'.format(img)
+                r'src="data:image/png;base64,{}"><br>'.format(img)
             )
         return ret
 
@@ -810,7 +810,7 @@ class ImagePlotContainer(PlotContainer):
     _colorbar_valid = False
 
     def __init__(self, data_source, figure_size, fontsize):
-        super(ImagePlotContainer, self).__init__(data_source, figure_size, fontsize)
+        super().__init__(data_source, figure_size, fontsize)
         self.plots = PlotDictionary(data_source)
         self._callbacks = []
         self._colormaps = defaultdict(lambda: ytcfg.get("yt", "default_colormap"))

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -1073,9 +1073,7 @@ class ImageLineCallback(LinePlotCallback):
     _supported_geometries = ("cartesian", "spectral_cube", "cylindrical")
 
     def __init__(self, p1, p2, data_coords=False, coord_system="axis", plot_args=None):
-        super(ImageLineCallback, self).__init__(
-            p1, p2, data_coords, coord_system, plot_args
-        )
+        super().__init__(p1, p2, data_coords, coord_system, plot_args)
         warnings.warn(
             "The ImageLineCallback (annotate_image_line()) is "
             "deprecated.  Please use the LinePlotCallback "
@@ -1083,7 +1081,7 @@ class ImageLineCallback(LinePlotCallback):
         )
 
     def __call__(self, plot):
-        super(ImageLineCallback, self).__call__(plot)
+        super().__call__(plot)
 
 
 class CuttingQuiverCallback(PlotCallback):
@@ -1749,7 +1747,7 @@ class PointAnnotateCallback(TextLabelCallback):
         text_args=None,
         inset_box_args=None,
     ):
-        super(PointAnnotateCallback, self).__init__(
+        super().__init__(
             pos, text, data_coords, coord_system, text_args, inset_box_args
         )
         warnings.warn(
@@ -1759,7 +1757,7 @@ class PointAnnotateCallback(TextLabelCallback):
         )
 
     def __call__(self, plot):
-        super(PointAnnotateCallback, self).__call__(plot)
+        super().__call__(plot)
 
 
 class HaloCatalogCallback(PlotCallback):
@@ -2194,7 +2192,7 @@ class MeshLinesCallback(PlotCallback):
     _supported_geometries = ("cartesian", "spectral_cube")
 
     def __init__(self, plot_args=None):
-        super(MeshLinesCallback, self).__init__()
+        super().__init__()
         self.plot_args = plot_args
 
     def promote_2d_to_3d(self, coords, indices, plot):
@@ -2261,7 +2259,7 @@ class TriangleFacetsCallback(PlotCallback):
     _supported_geometries = ("cartesian", "spectral_cube")
 
     def __init__(self, triangle_vertices, plot_args=None):
-        super(TriangleFacetsCallback, self).__init__()
+        super().__init__()
         self.plot_args = {} if plot_args is None else plot_args
         self.vertices = triangle_vertices
 
@@ -2516,7 +2514,7 @@ class TimestampCallback(PlotCallback):
             # Replace instances of -0.0* with 0.0* to avoid
             # negative null redshifts (e.g., "-0.00").
             self.text += self.redshift_format.format(redshift=float(z))
-            self.text = re.sub("-(0.0*)$", "\g<1>", self.text)
+            self.text = re.sub("-(0.0*)$", r"\g<1>", self.text)
 
         # This is just a fancy wrapper around the TextLabelCallback
         tcb = TextLabelCallback(

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -209,7 +209,7 @@ class PlotWindow(ImagePlotContainer):
         fields = list(iter_fields(fields))
         self.override_fields = list(set(fields).intersection(set(skip)))
         self.fields = [f for f in fields if f not in skip]
-        super(PlotWindow, self).__init__(data_source, window_size, fontsize)
+        super().__init__(data_source, window_size, fontsize)
 
         self._set_window(bounds)  # this automatically updates the data and plot
         self.origin = origin
@@ -818,10 +818,10 @@ class PWViewerMPL(PlotWindow):
             origin = tuple(origin.split("-"))[:3]
         if 1 == len(origin):
             origin = ("lower", "left") + origin
-        elif 2 == len(origin) and origin[0] in set(["left", "right", "center"]):
+        elif 2 == len(origin) and origin[0] in {"left", "right", "center"}:
             o0map = {"left": "lower", "right": "upper", "center": "center"}
             origin = (o0map[origin[0]],) + origin
-        elif 2 == len(origin) and origin[0] in set(["lower", "upper", "center"]):
+        elif 2 == len(origin) and origin[0] in {"lower", "upper", "center"}:
             origin = (origin[0], "center", origin[-1])
         elif 3 == len(origin) and isinstance(origin[0], (int, float)):
             xc = self.ds.quan(origin[0], "code_length")
@@ -847,7 +847,7 @@ class PWViewerMPL(PlotWindow):
         else:
             mylog.warning("origin = %s", origin)
             msg = (
-                'origin keyword "{0}" not recognized, must declare "domain" '
+                'origin keyword "{}" not recognized, must declare "domain" '
                 'or "center" as the last term in origin.'
             ).format(self.origin)
             raise RuntimeError(msg)
@@ -2175,9 +2175,7 @@ class WindowPlotMPL(ImagePlotMPL):
 
         size, axrect, caxrect = self._get_best_layout()
 
-        super(WindowPlotMPL, self).__init__(
-            size, axrect, caxrect, zlim, figure, axes, cax
-        )
+        super().__init__(size, axrect, caxrect, zlim, figure, axes, cax)
 
         self._init_image(data, cbname, cblinthresh, cmap, extent, aspect)
 

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -74,7 +74,7 @@ class PlotContainerDict(OrderedDict):
 class FigureContainer(OrderedDict):
     def __init__(self, plots):
         self.plots = plots
-        super(FigureContainer, self).__init__()
+        super().__init__()
 
     def __missing__(self, key):
         self[key] = self.plots[key].figure
@@ -89,14 +89,14 @@ class AxesContainer(OrderedDict):
         self.plots = plots
         self.ylim = {}
         self.xlim = (None, None)
-        super(AxesContainer, self).__init__()
+        super().__init__()
 
     def __missing__(self, key):
         self[key] = self.plots[key].axes
         return self[key]
 
     def __setitem__(self, key, value):
-        super(AxesContainer, self).__setitem__(key, value)
+        super().__setitem__(key, value)
         self.ylim[key] = (None, None)
 
 
@@ -380,7 +380,7 @@ class ProfilePlot:
             img = base64.b64encode(img).decode()
             ret += (
                 r'<img style="max-width:100%;max-height:100%;" '
-                r'src="data:image/png;base64,{0}"><br>'.format(img)
+                r'src="data:image/png;base64,{}"><br>'.format(img)
             )
         return ret
 
@@ -743,9 +743,9 @@ class ProfilePlot:
             field = field[1]
         if field_name is None:
             field_name = r"$\rm{" + field + r"}$"
-            field_name = r"$\rm{" + field.replace("_", "\ ").title() + r"}$"
+            field_name = r"$\rm{" + field.replace("_", r"\ ").title() + r"}$"
         elif field_name.find("$") == -1:
-            field_name = field_name.replace(" ", "\ ")
+            field_name = field_name.replace(" ", r"\ ")
             field_name = r"$\rm{" + field_name + r"}$"
         if fractional:
             label = field_name + r"$\rm{\ Probability\ Density}$"
@@ -1018,9 +1018,9 @@ class PhasePlot(ImagePlotContainer):
             field = field[1]
         if field_name is None:
             field_name = r"$\rm{" + field + r"}$"
-            field_name = r"$\rm{" + field.replace("_", "\ ").title() + r"}$"
+            field_name = r"$\rm{" + field.replace("_", r"\ ").title() + r"}$"
         elif field_name.find("$") == -1:
-            field_name = field_name.replace(" ", "\ ")
+            field_name = field_name.replace(" ", r"\ ")
             field_name = r"$\rm{" + field_name + r"}$"
         if fractional:
             label = field_name + r"$\rm{\ Probability\ Density}$"
@@ -1579,7 +1579,7 @@ class PhasePlot(ImagePlotContainer):
     def _recreate_profile(self):
         p = self._profile
         units = {p.x_field: str(p.x.units), p.y_field: str(p.y.units)}
-        zunits = dict((field, str(p.field_units[field])) for field in p.field_units)
+        zunits = {field: str(p.field_units[field]) for field in p.field_units}
         extrema = {p.x_field: self._xlim, p.y_field: self._ylim}
         if self.x_log is not None or self.y_log is not None:
             logs = {}
@@ -1651,9 +1651,7 @@ class PhasePlotMPL(ImagePlotMPL):
 
         size, axrect, caxrect = self._get_best_layout()
 
-        super(PhasePlotMPL, self).__init__(
-            size, axrect, caxrect, zlim, figure, axes, cax
-        )
+        super().__init__(size, axrect, caxrect, zlim, figure, axes, cax)
 
         self._init_image(x_data, y_data, data, x_scale, y_scale, z_scale, zlim, cmap)
 

--- a/yt/visualization/tests/test_line_plots.py
+++ b/yt/visualization/tests/test_line_plots.py
@@ -70,9 +70,9 @@ def test_line_buffer():
     assert_equal(lb["density"].size, 512)
     lb["density"] = 0
     assert_equal(lb["density"], 0)
-    assert_equal(set(lb.keys()), set(["density", "velocity_x"]))
+    assert_equal(set(lb.keys()), {"density", "velocity_x"})
     del lb["velocity_x"]
-    assert_equal(set(lb.keys()), set(["density"]))
+    assert_equal(set(lb.keys()), {"density"})
 
 
 def test_validate_point():

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import os
 import shutil
 import tempfile

--- a/yt/visualization/volume_rendering/camera.py
+++ b/yt/visualization/volume_rendering/camera.py
@@ -145,7 +145,7 @@ class Camera(Orientation):
         if auto:
             self.set_defaults_from_data_source(data_source)
 
-        super(Camera, self).__init__(
+        super().__init__(
             self.focus - self.position, self.north_vector, steady_north=False
         )
 
@@ -354,7 +354,7 @@ class Camera(Orientation):
         self._domain_center = data_source.ds.domain_center
         self._domain_width = data_source.ds.domain_width
 
-        super(Camera, self).__init__(
+        super().__init__(
             self.focus - self.position, self.north_vector, steady_north=False
         )
         self._moved = True

--- a/yt/visualization/volume_rendering/lens.py
+++ b/yt/visualization/volume_rendering/lens.py
@@ -14,7 +14,7 @@ class Lens(ParallelAnalysisInterface):
     """A Lens is used to define the set of rays for rendering."""
 
     def __init__(self):
-        super(Lens, self).__init__()
+        super().__init__()
         self.viewpoint = None
         self.sub_samples = 5
         self.num_threads = 0
@@ -79,7 +79,7 @@ class PlaneParallelLens(Lens):
     """
 
     def __init__(self):
-        super(PlaneParallelLens, self).__init__()
+        super().__init__()
 
     def _get_sampler_params(self, camera, render_source):
         if render_source.zbuffer is not None:
@@ -152,7 +152,7 @@ class PerspectiveLens(Lens):
     """
 
     def __init__(self):
-        super(PerspectiveLens, self).__init__()
+        super().__init__()
 
     def new_image(self, camera):
         self.current_image = ImageArray(
@@ -306,7 +306,7 @@ class StereoPerspectiveLens(Lens):
     """
 
     def __init__(self):
-        super(StereoPerspectiveLens, self).__init__()
+        super().__init__()
         self.disparity = None
 
     def new_image(self, camera):
@@ -534,7 +534,7 @@ class FisheyeLens(Lens):
     """
 
     def __init__(self):
-        super(FisheyeLens, self).__init__()
+        super().__init__()
         self.fov = 180.0
         self.radius = 1.0
         self.center = None
@@ -543,7 +543,7 @@ class FisheyeLens(Lens):
     def setup_box_properties(self, camera):
         """Set up the view and stage based on the properties of the camera."""
         self.radius = camera.width.max()
-        super(FisheyeLens, self).setup_box_properties(camera)
+        super().setup_box_properties(camera)
         self.set_viewpoint(camera)
 
     def new_image(self, camera):
@@ -645,7 +645,7 @@ class SphericalLens(Lens):
     """
 
     def __init__(self):
-        super(SphericalLens, self).__init__()
+        super().__init__()
         self.radius = 1.0
         self.center = None
         self.rotation_matrix = np.eye(3)
@@ -653,7 +653,7 @@ class SphericalLens(Lens):
     def setup_box_properties(self, camera):
         """Set up the view and stage based on the properties of the camera."""
         self.radius = camera.width.max()
-        super(SphericalLens, self).setup_box_properties(camera)
+        super().setup_box_properties(camera)
         self.set_viewpoint(camera)
 
     def _get_sampler_params(self, camera, render_source):
@@ -757,7 +757,7 @@ class StereoSphericalLens(Lens):
     """
 
     def __init__(self):
-        super(StereoSphericalLens, self).__init__()
+        super().__init__()
         self.radius = 1.0
         self.center = None
         self.disparity = None
@@ -765,7 +765,7 @@ class StereoSphericalLens(Lens):
 
     def setup_box_properties(self, camera):
         self.radius = camera.width.max()
-        super(StereoSphericalLens, self).setup_box_properties(camera)
+        super().setup_box_properties(camera)
         self.set_viewpoint(camera)
 
     def _get_sampler_params(self, camera, render_source):

--- a/yt/visualization/volume_rendering/render_source.py
+++ b/yt/visualization/volume_rendering/render_source.py
@@ -95,7 +95,7 @@ class RenderSource(ParallelAnalysisInterface):
     volume_method = None
 
     def __init__(self):
-        super(RenderSource, self).__init__()
+        super().__init__()
         self.opaque = False
         self.zbuffer = None
 
@@ -116,7 +116,7 @@ class OpaqueSource(RenderSource):
     """
 
     def __init__(self):
-        super(OpaqueSource, self).__init__()
+        super().__init__()
         self.opaque = True
 
     def set_zbuffer(self, zbuffer):
@@ -186,7 +186,7 @@ class VolumeSource(RenderSource, abc.ABC):
 
     def __init__(self, data_source, field):
         r"""Initialize a new volumetric source for rendering."""
-        super(VolumeSource, self).__init__()
+        super().__init__()
         self.data_source = data_source_or_all(data_source)
         field = self.data_source._determine_fields(field)[0]
         self.current_image = None
@@ -558,14 +558,14 @@ class KDTreeVolumeSource(VolumeSource):
         if self._volume is not None:
             image = self.volume.reduce_tree_images(image, camera.lens.viewpoint)
 
-        return super(KDTreeVolumeSource, self).finalize_image(camera, image)
+        return super().finalize_image(camera, image)
 
 
 class OctreeVolumeSource(VolumeSource):
     volume_method = "Octree"
 
     def __init__(self, *args, **kwa):
-        super(OctreeVolumeSource, self).__init__(*args, **kwa)
+        super().__init__(*args, **kwa)
         self.set_use_ghost_zones(True)
 
     def _get_volume(self):
@@ -666,7 +666,7 @@ class MeshSource(OpaqueSource):
 
     def __init__(self, data_source, field):
         r"""Initialize a new unstructured mesh source for rendering."""
-        super(MeshSource, self).__init__()
+        super().__init__()
         self.data_source = data_source_or_all(data_source)
         field = self.data_source._determine_fields(field)[0]
         self.field = field
@@ -1120,7 +1120,7 @@ class LineSource(OpaqueSource):
     data_source = None
 
     def __init__(self, positions, colors=None, color_stride=1):
-        super(LineSource, self).__init__()
+        super().__init__()
 
         assert positions.ndim == 3
         assert positions.shape[1] == 2
@@ -1264,7 +1264,7 @@ class BoxSource(LineSource):
             vertices[:, i] = corners[order, i, ...].ravel(order="F")
         vertices = vertices.reshape((12, 2, 3))
 
-        super(BoxSource, self).__init__(vertices, color, color_stride=24)
+        super().__init__(vertices, color, color_stride=24)
 
 
 class GridSource(LineSource):
@@ -1378,7 +1378,7 @@ class GridSource(LineSource):
             vertices[:, i] = corners[order, i, ...].ravel(order="F")
         vertices = vertices.reshape((corners.shape[2] * 12, 2, 3))
 
-        super(GridSource, self).__init__(vertices, colors, color_stride=24)
+        super().__init__(vertices, colors, color_stride=24)
 
 
 class CoordinateVectorSource(OpaqueSource):
@@ -1415,7 +1415,7 @@ class CoordinateVectorSource(OpaqueSource):
     """
 
     def __init__(self, colors=None, alpha=1.0):
-        super(CoordinateVectorSource, self).__init__()
+        super().__init__()
         # If colors aren't individually set, make black with full opacity
         if colors is None:
             colors = np.zeros((3, 4))

--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -77,7 +77,7 @@ class Scene:
 
     def __init__(self):
         r"""Create a new Scene instance"""
-        super(Scene, self).__init__()
+        super().__init__()
         self.sources = OrderedDict()
         self._last_render = None
         # A non-public attribute used to get around the fact that we can't

--- a/yt/visualization/volume_rendering/zbuffer_array.py
+++ b/yt/visualization/volume_rendering/zbuffer_array.py
@@ -34,7 +34,7 @@ class ZBuffer:
     """
 
     def __init__(self, rgba, z):
-        super(ZBuffer, self).__init__()
+        super().__init__()
         assert rgba.shape[: len(z.shape)] == z.shape
         self.rgba = rgba
         self.z = z


### PR DESCRIPTION
## PR Summary

[pyupgrade](https://github.com/asottile/pyupgrade) is a versatile tool that automatically replaces "old" python idioms with their modern equivalent.
In particular it does what flynt did for us (enforcing strings everywhere it can) and much more (dict comprehension, old-style classes, removes extraneous `# coding: ...` cookies to name a few).
Here's a non exhaustive list of my previous PRs that could have been at least partially automated by this tool:
- #2640
- #2641 (not sure about this one)
- #2990 


Here I'm using it to replace every idiom from Python < 3.6
In the future (#2917), it will be trivial to incrementally modernise the code base by replacing `--py36-plus` with `--py37-plus` then `--py38-plus` and so on...