### PR TITLE
switch internal instances of collections.OrderedDict to regular dict

### DIFF
--- a/doc/source/cookbook/simulation_analysis.py
+++ b/doc/source/cookbook/simulation_analysis.py
@@ -1,5 +1,3 @@
-import collections
-
 import yt
 
 yt.enable_parallelism()
@@ -27,13 +25,13 @@ for ds in ts.piter():
     # Fill the dictionary with extrema and redshift information for each dataset
     data[ds.basename] = (extrema, ds.current_redshift)
 
-# Convert dictionary to ordered dictionary to get the right order
-od = collections.OrderedDict(sorted(data.items()))
+# Sort dict by keys
+data = {k: v for k, v in sorted(data.items())}
 
 # Print out all the values we calculated.
 print("Dataset      Redshift        Density Min      Density Max")
 print("---------------------------------------------------------")
-for key, val in od.items():
+for key, val in data.items():
     print(
         "%s       %05.3f          %5.3g g/cm^3   %5.3g g/cm^3"
         % (key, val[1], val[0][0], val[0][1])

--- a/yt/data_objects/particle_trajectories.py
+++ b/yt/data_objects/particle_trajectories.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 import numpy as np
 
 from yt.config import ytcfg
@@ -69,7 +67,6 @@ class ParticleTrajectories:
 
         if fields is None:
             fields = []
-        fields = list(OrderedDict.fromkeys(fields))
 
         if self.suppress_logging:
             old_level = int(ytcfg.get("yt", "loglevel"))

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -597,12 +597,10 @@ class Profile1D(ProfileND):
         >>> df1 = p.to_dataframe()
         >>> df2 = p.to_dataframe(fields="density", only_used=True)
         """
-        from collections import OrderedDict
-
         import pandas as pd
 
         idxs, masked, fields = self._export_prep(fields, only_used)
-        pdata = OrderedDict([(self.x_field[-1], self.x[idxs])])
+        pdata = {self.x_field[-1]: self.x[idxs]}
         for field in fields:
             pdata[field[-1]] = self[field][idxs]
         df = pd.DataFrame(pdata)


### PR DESCRIPTION
## PR Summary

…when the differences do not matter any more: starting from Python 3.6, normal dict objects preserve insertion order.
I was originally aiming at replacing _all_ ordereddict by normal dict but I left every user-facing one untouched because _comparison_ is still different between the two classes, so I don't mean to cause bugs downwards where OrderedDict is possibly still relevant.
