### PR TITLE
deprecate confusing alias "mylog"

### DIFF
--- a/yt/__init__.py
+++ b/yt/__init__.py
@@ -55,6 +55,7 @@ from yt.funcs import (
     is_root,
     is_sequence,
     memory_checker,
+    mylog,
     only_on_root,
     parallel_profile,
     print_tb,
@@ -78,7 +79,7 @@ from yt.units import (
     uvstack,
 )
 from yt.units.unit_object import define_unit
-from yt.utilities.logger import set_log_level, ytLogger
+from yt.utilities.logger import set_log_level
 
 frontends = _frontend_container()
 

--- a/yt/__init__.py
+++ b/yt/__init__.py
@@ -78,7 +78,7 @@ from yt.units import (
     uvstack,
 )
 from yt.units.unit_object import define_unit
-from yt.utilities.logger import set_log_level, ytLogger as mylog
+from yt.utilities.logger import set_log_level, ytLogger
 
 frontends = _frontend_container()
 

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -8,7 +8,7 @@ from yt.data_objects.field_data import YTFieldData
 from yt.data_objects.profiles import create_profile
 from yt.fields.field_exceptions import NeedsGridType
 from yt.frontends.ytdata.utilities import save_as_dataset
-from yt.funcs import get_output_filename, is_sequence, iter_fields, mylog
+from yt.funcs import get_output_filename, is_sequence, iter_fields, ytLogger
 from yt.units.yt_array import YTArray, YTQuantity, uconcatenate
 from yt.utilities.amr_kdtree.api import AMRKDTree
 from yt.utilities.exceptions import (
@@ -89,7 +89,7 @@ class YTDataContainer:
         self._current_particle_type = "all"
         self._current_fluid_type = self.ds.default_fluid_type
         self.ds.objects.append(weakref.proxy(self))
-        mylog.debug("Appending object to %s (type: %s)", self.ds, type(self))
+        ytLogger.debug("Appending object to %s (type: %s)", self.ds, type(self))
         self.field_data = YTFieldData()
         if self.ds.unit_system.has_current_mks:
             mag_unit = "T"
@@ -183,7 +183,7 @@ class YTDataContainer:
             self.center = self.ds.arr(center, "code_length", dtype="float64")
 
         if self.center.ndim > 1:
-            mylog.debug("Removing singleton dimensions from 'center'.")
+            ytLogger.debug("Removing singleton dimensions from 'center'.")
             self.center = np.squeeze(self.center)
             if self.center.ndim > 1:
                 msg = (
@@ -822,7 +822,7 @@ class YTDataContainer:
                 ## load the extra fields and print them
                 for field in this_ptype_fields:
                     if field not in fields_to_include:
-                        mylog.warning(
+                        ytLogger.warning(
                             "detected (but did not request) %s %s", ptype, field
                         )
 

--- a/yt/data_objects/index_subobjects/octree_subset.py
+++ b/yt/data_objects/index_subobjects/octree_subset.py
@@ -18,7 +18,7 @@ from yt.utilities.exceptions import (
     YTParticleDepositionNotImplemented,
 )
 from yt.utilities.lib.geometry_utils import compute_morton
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 
 
 def cell_count_cache(func):
@@ -182,7 +182,7 @@ class OctreeSubset(YTSelectionContainer):
         # We allocate number of zones, not number of octs
         op = cls(nvals, kernel_name)
         op.initialize()
-        mylog.debug(
+        ytLogger.debug(
             "Depositing %s (%s^3) particles into %s Octs",
             positions.shape[0],
             positions.shape[0] ** 0.3333333,
@@ -235,7 +235,7 @@ class OctreeSubset(YTSelectionContainer):
         # We allocate number of zones, not number of octs
         op = particle_deposit.CellIdentifier(npart, "none")
         op.initialize(npart)
-        mylog.debug(
+        ytLogger.debug(
             "Depositing %s Octs onto %s (%s^3) particles",
             nocts,
             positions.shape[0],
@@ -358,7 +358,7 @@ class OctreeSubset(YTSelectionContainer):
         nvals = (nz, nz, nz, (mdom_ind >= 0).sum())
         op = cls(nvals, len(fields), nneighbors, kernel_name)
         op.initialize()
-        mylog.debug(
+        ytLogger.debug(
             "Smoothing %s particles into %s Octs", positions.shape[0], nvals[-1]
         )
         # Pointer operations within 'process_octree' require arrays to be
@@ -459,7 +459,7 @@ class OctreeSubset(YTSelectionContainer):
         nvals = (nz, nz, nz, (mdom_ind >= 0).sum())
         op = cls(nvals, len(fields), nneighbors, kernel_name)
         op.initialize()
-        mylog.debug(
+        ytLogger.debug(
             "Smoothing %s particles into %s Octs", positions.shape[0], nvals[-1]
         )
         op.process_particles(

--- a/yt/data_objects/index_subobjects/unstructured_mesh.py
+++ b/yt/data_objects/index_subobjects/unstructured_mesh.py
@@ -3,7 +3,7 @@ import numpy as np
 from yt.data_objects.selection_objects.data_selection_objects import (
     YTSelectionContainer,
 )
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 from yt.utilities.lib.mesh_utilities import fill_fcoords, fill_fwidths
 
 
@@ -45,7 +45,7 @@ class UnstructuredMesh(YTSelectionContainer):
             coords = self.connectivity_coords[ind, :]
             for i in range(3):
                 assert np.unique(coords[:, i]).size == 2
-        mylog.debug("Connectivity is consistent.")
+        ytLogger.debug("Connectivity is consistent.")
 
     def __repr__(self):
         return "UnstructuredMesh_%04i" % (self.mesh_id)

--- a/yt/data_objects/level_sets/clump_handling.py
+++ b/yt/data_objects/level_sets/clump_handling.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from yt.fields.derived_field import ValidateSpatial
 from yt.frontends.ytdata.utilities import save_as_dataset
-from yt.funcs import get_output_filename, mylog
+from yt.funcs import get_output_filename, ytLogger
 from yt.utilities.tree_container import TreeContainer
 
 from .clump_info_items import clump_info_registry
@@ -145,7 +145,9 @@ class Clump(TreeContainer):
 
     def find_children(self, min_val, max_val=None):
         if self.children:
-            mylog.info("Wiping out existing children clumps: %d.", len(self.children))
+            ytLogger.info(
+                "Wiping out existing children clumps: %d.", len(self.children)
+            )
         self.children = []
         if max_val is None:
             max_val = self.max_val
@@ -408,7 +410,9 @@ class Clump(TreeContainer):
 
 
 def find_clumps(clump, min_val, max_val, d_clump):
-    mylog.info("Finding clumps: min: %e, max: %e, step: %f", min_val, max_val, d_clump)
+    ytLogger.info(
+        "Finding clumps: min: %e, max: %e, step: %f", min_val, max_val, d_clump
+    )
     if min_val >= max_val:
         return
     clump.find_children(min_val, max_val=max_val)
@@ -418,7 +422,7 @@ def find_clumps(clump, min_val, max_val, d_clump):
 
     elif len(clump.children) > 0:
         these_children = []
-        mylog.info("Investigating %d children.", len(clump.children))
+        ytLogger.info("Investigating %d children.", len(clump.children))
         for child in clump.children:
             find_clumps(child, min_val * d_clump, max_val, d_clump)
             if len(child.children) > 0:
@@ -426,17 +430,17 @@ def find_clumps(clump, min_val, max_val, d_clump):
             elif child._validate():
                 these_children.append(child)
             else:
-                mylog.info(
+                ytLogger.info(
                     "Eliminating invalid, childless clump with %d cells.",
                     len(child.data["ones"]),
                 )
         if len(these_children) > 1:
-            mylog.info(
+            ytLogger.info(
                 "%d of %d children survived.", len(these_children), len(clump.children)
             )
             clump.children = these_children
         elif len(these_children) == 1:
-            mylog.info(
+            ytLogger.info(
                 "%d of %d children survived, linking its children to parent.",
                 len(these_children),
                 len(clump.children),
@@ -446,7 +450,7 @@ def find_clumps(clump, min_val, max_val, d_clump):
                 child.parent = clump
                 child.data.parent = clump.data
         else:
-            mylog.info(
+            ytLogger.info(
                 "%d of %d children survived, erasing children.",
                 len(these_children),
                 len(clump.children),

--- a/yt/data_objects/level_sets/contour_finder.py
+++ b/yt/data_objects/level_sets/contour_finder.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 
 import numpy as np
 
-from yt.funcs import get_pbar, mylog
+from yt.funcs import get_pbar, ytLogger
 from yt.utilities.lib.contour_finding import (
     ContourTree,
     TileContourTree,
@@ -44,9 +44,9 @@ def identify_contours(data_source, field, min_val, max_val, cached_fields=None):
     if node_ids.size == 0:
         return 0, {}
     trunk = data_source.tiles.tree.trunk
-    mylog.info("Linking node (%s) contours.", len(contours))
+    ytLogger.info("Linking node (%s) contours.", len(contours))
     link_node_contours(trunk, contours, tree, node_ids)
-    mylog.info("Linked.")
+    ytLogger.info("Linked.")
     # joins = tree.cull_joins(bt)
     # tree.add_joins(joins)
     joins = tree.export()

--- a/yt/data_objects/particle_filters.py
+++ b/yt/data_objects/particle_filters.py
@@ -2,7 +2,7 @@ import copy
 from contextlib import contextmanager
 
 from yt.fields.field_info_container import NullFunc, TranslationFunc
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 from yt.utilities.exceptions import YTIllDefinedFilter
 
 # One to one mapping
@@ -120,7 +120,7 @@ def add_particle_filter(name, function, requires=None, filtered_type="all"):
         requires = []
     filter = ParticleFilter(name, function, requires, filtered_type)
     if filter_registry.get(name, None) is not None:
-        mylog.warning("The %s particle filter already exists. Overriding.", name)
+        ytLogger.warning("The %s particle filter already exists. Overriding.", name)
     filter_registry[name] = filter
 
 

--- a/yt/data_objects/particle_trajectories.py
+++ b/yt/data_objects/particle_trajectories.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from yt.config import ytcfg
 from yt.data_objects.field_data import YTFieldData
-from yt.funcs import get_pbar, mylog
+from yt.funcs import get_pbar, ytLogger
 from yt.units.yt_array import array_like_field
 from yt.utilities.exceptions import YTIllDefinedParticleData
 from yt.utilities.lib.particle_mesh_operations import CICSample_3
@@ -73,7 +73,7 @@ class ParticleTrajectories:
 
         if self.suppress_logging:
             old_level = int(ytcfg.get("yt", "log_level"))
-            mylog.setLevel(40)
+            ytLogger.setLevel(40)
         ds_first = self.data_series[0]
         dd_first = ds_first.all_data()
 
@@ -112,7 +112,7 @@ class ParticleTrajectories:
         pbar.finish()
 
         if self.suppress_logging:
-            mylog.setLevel(old_level)
+            ytLogger.setLevel(old_level)
 
         sorted_storage = sorted(my_storage.items())
         _fn, (time, *_) = sorted_storage[0]
@@ -220,7 +220,7 @@ class ParticleTrajectories:
 
         if self.suppress_logging:
             old_level = int(ytcfg.get("yt", "log_level"))
-            mylog.setLevel(40)
+            ytLogger.setLevel(40)
         ds_first = self.data_series[0]
         dd_first = ds_first.all_data()
 
@@ -298,7 +298,7 @@ class ParticleTrajectories:
             self.field_data[field] = array_like_field(dd_first, output_field.copy(), fd)
 
         if self.suppress_logging:
-            mylog.setLevel(old_level)
+            ytLogger.setLevel(old_level)
 
     def trajectory_from_index(self, index):
         """

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -3,7 +3,7 @@ import numpy as np
 from yt.data_objects.field_data import YTFieldData
 from yt.fields.derived_field import DerivedField
 from yt.frontends.ytdata.utilities import save_as_dataset
-from yt.funcs import get_output_filename, is_sequence, iter_fields, mylog
+from yt.funcs import get_output_filename, is_sequence, iter_fields, ytLogger
 from yt.units.unit_object import Unit
 from yt.units.yt_array import YTQuantity, array_like_field
 from yt.utilities.exceptions import (
@@ -880,7 +880,7 @@ class ParticleProfile(Profile2D):
         if deposition not in ["ngp", "cic"]:
             raise NotImplementedError(deposition)
         elif (x_log or y_log) and deposition != "ngp":
-            mylog.warning(
+            ytLogger.warning(
                 "cic deposition is only supported for linear axis "
                 "scales, falling back to ngp deposition"
             )

--- a/yt/data_objects/selection_objects/data_selection_objects.py
+++ b/yt/data_objects/selection_objects/data_selection_objects.py
@@ -25,7 +25,7 @@ from yt.utilities.exceptions import (
     YTFieldUnitParseError,
 )
 from yt.utilities.lib.marching_cubes import march_cubes_grid, march_cubes_grid_flux
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 from yt.utilities.parallel_tools.parallel_analysis_interface import (
     ParallelAnalysisInterface,
 )
@@ -251,7 +251,7 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface):
                             raise YTDimensionalityError(fi.dimensions, dimensions)
                         fi.units = units
                         self.field_data[field] = self.ds.arr(fd, units)
-                        mylog.warning(
+                        ytLogger.warning(
                             "Field %s was added without specifying units, "
                             "assuming units are %s",
                             fi.name,

--- a/yt/data_objects/selection_objects/ray.py
+++ b/yt/data_objects/selection_objects/ray.py
@@ -17,7 +17,7 @@ from yt.funcs import (
 )
 from yt.units import YTArray, YTQuantity
 from yt.utilities.lib.pixelization_routines import SPHKernelInterpolationTable
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 
 
 class YTOrthoRay(YTSelectionContainer1D):
@@ -176,7 +176,7 @@ class YTRay(YTSelectionContainer1D):
         if (self.start_point < self.ds.domain_left_edge).any() or (
             self.end_point > self.ds.domain_right_edge
         ).any():
-            mylog.warning(
+            ytLogger.warning(
                 "Ray start or end is outside the domain. "
                 + "Returned data will only be for the ray section inside the domain."
             )

--- a/yt/data_objects/selection_objects/spheroids.py
+++ b/yt/data_objects/selection_objects/spheroids.py
@@ -15,7 +15,7 @@ from yt.funcs import (
 )
 from yt.units import YTArray
 from yt.utilities.exceptions import YTEllipsoidOrdering, YTException, YTSphereTooSmall
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 from yt.utilities.math_utils import get_rotation_matrix
 from yt.utilities.on_demand_imports import _miniball
 
@@ -107,7 +107,7 @@ class YTMinimalSphere(YTSelectionContainer3D):
             raise YTException(
                 f"Not enough points. Expected at least 2, got {len(points)}"
             )
-        mylog.debug("Building minimal sphere around points.")
+        ytLogger.debug("Building minimal sphere around points.")
         mb = _miniball.Miniball(points)
         if not mb.is_valid():
             raise YTException("Could not build valid sphere around points.")

--- a/yt/data_objects/tests/test_particle_filter.py
+++ b/yt/data_objects/tests/test_particle_filter.py
@@ -54,7 +54,7 @@ def test_add_particle_filter():
 def test_add_particle_filter_overriding():
     """Test the add_particle_filter overriding"""
     from yt.data_objects.particle_filters import filter_registry
-    from yt.funcs import mylog
+    from yt.funcs import ytLogger
 
     def star_0(pfilter, data):
         pass
@@ -83,9 +83,9 @@ def test_add_particle_filter_overriding():
     ##         a warning is expected. We use the above closure to
     ##         check that.
     # Store the original warning function
-    warning = mylog.warning
+    warning = ytLogger.warning
     monkey_warning, monkey_patch_was_called = closure([False])
-    mylog.warning = monkey_warning
+    ytLogger.warning = monkey_warning
     add_particle_filter(
         "dummy", function=star_1, filtered_type="all", requires=["creation_time"]
     )
@@ -93,7 +93,7 @@ def test_add_particle_filter_overriding():
     assert_equal(monkey_patch_was_called(), True)
 
     # Restore the original warning function
-    mylog.warning = warning
+    ytLogger.warning = warning
 
 
 def test_particle_filter_decorator():

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -12,7 +12,7 @@ from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.config import ytcfg
 from yt.data_objects.analyzer_objects import AnalysisTask, create_quantity_proxy
 from yt.data_objects.particle_trajectories import ParticleTrajectories
-from yt.funcs import is_sequence, mylog
+from yt.funcs import is_sequence, ytLogger
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.exceptions import YTException
 from yt.utilities.object_registries import (
@@ -146,7 +146,7 @@ class DatasetSeries:
         code_name = cls.__name__[: cls.__name__.find("Simulation")]
         if code_name:
             simulation_time_series_registry[code_name] = cls
-            mylog.debug("Registering simulation: %s as %s", code_name, cls)
+            ytLogger.debug("Registering simulation: %s as %s", code_name, cls)
 
     def __new__(cls, outputs, *args, **kwargs):
         try:
@@ -617,17 +617,17 @@ class SimulationTimeSeries(DatasetSeries):
                 self._print_attr(a)
         for a in self.key_parameters:
             self._print_attr(a)
-        mylog.info("Total datasets: %d.", len(self.all_outputs))
+        ytLogger.info("Total datasets: %d.", len(self.all_outputs))
 
     def _print_attr(self, a):
         """
         Print the attribute or warn about it missing.
         """
         if not hasattr(self, a):
-            mylog.error("Missing %s in dataset definition!", a)
+            ytLogger.error("Missing %s in dataset definition!", a)
             return
         v = getattr(self, a)
-        mylog.info("Parameters: %-25s = %s", a, v)
+        ytLogger.info("Parameters: %-25s = %s", a, v)
 
     def _get_outputs_by_key(self, key, values, tolerance=None, outputs=None):
         r"""
@@ -675,7 +675,7 @@ class SimulationTimeSeries(DatasetSeries):
             ) and outputs[0] not in my_outputs:
                 my_outputs.append(outputs[0])
             else:
-                mylog.error("No dataset added for %s = %f.", key, value)
+                ytLogger.error("No dataset added for %s = %f.", key, value)
 
         outputs.sort(key=lambda obj: obj["time"])
         return my_outputs

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -3,7 +3,7 @@ from numbers import Number as numeric_type
 import numpy as np
 
 from yt._maintenance.deprecation import issue_deprecation_warning
-from yt.funcs import mylog, only_on_root
+from yt.funcs import only_on_root, ytLogger
 from yt.geometry.geometry_handler import is_curvilinear
 from yt.units.dimensions import dimensionless
 from yt.units.unit_object import Unit
@@ -223,7 +223,7 @@ class FieldInfoContainer(dict):
                 and args[0] == ""
                 and units != 1.0
             ):
-                mylog.warning(
+                ytLogger.warning(
                     "Cannot interpret units: %s * %s, setting to dimensionless.",
                     units,
                     args[0],
@@ -390,7 +390,7 @@ class FieldInfoContainer(dict):
         loaded = []
         for n in sorted(field_plugins):
             loaded += self.load_plugin(n, ftype)
-            only_on_root(mylog.debug, "Loaded %s (%s new fields)", n, len(loaded))
+            only_on_root(ytLogger.debug, "Loaded %s (%s new fields)", n, len(loaded))
         self.find_dependencies(loaded)
 
     def load_plugin(self, plugin_name, ftype="gas", skip_check=False):
@@ -490,7 +490,7 @@ class FieldInfoContainer(dict):
                     # see yt.fields.tests.test_fields
                     if hasattr(self.ds, "_field_test_dataset"):
                         raise
-                    mylog.debug(
+                    ytLogger.debug(
                         "Raises %s during field %s detection.", str(type(e)), field
                     )
                 self.pop(field)
@@ -504,7 +504,7 @@ class FieldInfoContainer(dict):
                 continue
             fd.requested = set(fd.requested)
             deps[field] = fd
-            mylog.debug("Succeeded with %s (needs %s)", field, fd.requested)
+            ytLogger.debug("Succeeded with %s (needs %s)", field, fd.requested)
 
         # now populate the derived field list with results
         # this violates isolation principles and should be refactored

--- a/yt/fields/fluid_fields.py
+++ b/yt/fields/fluid_fields.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 from yt.geometry.geometry_handler import is_curvilinear
 from yt.units.unit_object import Unit
 from yt.utilities.chemical_formulas import default_mu
@@ -220,7 +220,7 @@ def setup_gradient_fields(registry, grad_field, field_units, slice_info=None):
 
     geom = registry.ds.geometry
     if is_curvilinear(geom):
-        mylog.warning(
+        ytLogger.warning(
             "In %s geometry, gradient fields may contain "
             "artifacts near cartesian axes.",
             geom,

--- a/yt/fields/local_fields.py
+++ b/yt/fields/local_fields.py
@@ -1,5 +1,5 @@
 from yt.funcs import is_sequence
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 
 from .field_info_container import FieldInfoContainer
 from .field_plugin_registry import register_field_plugin
@@ -22,7 +22,7 @@ class LocalFieldInfoContainer(FieldInfoContainer):
         override = kwargs.get("force_override", False)
         # Handle the case where the field has already been added.
         if not override and name in self:
-            mylog.warning(
+            ytLogger.warning(
                 "Field %s already exists. To override use `force_override=True`.",
                 name,
             )

--- a/yt/fields/xray_emission_fields.py
+++ b/yt/fields/xray_emission_fields.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from yt.config import ytcfg
 from yt.fields.derived_field import DerivedField
-from yt.funcs import mylog, only_on_root, parse_h5_attr
+from yt.funcs import only_on_root, parse_h5_attr, ytLogger
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.cosmology import Cosmology
 from yt.utilities.exceptions import YTException, YTFieldNotFound
@@ -30,7 +30,7 @@ def _get_data_file(table_type, data_dir=None):
             data_file,
             data_url,
         )
-        mylog.error(msg)
+        ytLogger.error(msg)
         raise OSError(msg)
     return data_path
 
@@ -83,15 +83,15 @@ class XrayEmissivityIntegrator:
     def __init__(self, table_type, redshift=0.0, data_dir=None, use_metals=True):
 
         filename = _get_data_file(table_type, data_dir=data_dir)
-        only_on_root(mylog.info, "Loading emissivity data from %s", filename)
+        only_on_root(ytLogger.info, "Loading emissivity data from %s", filename)
         in_file = h5py.File(filename, mode="r")
         if "info" in in_file.attrs:
-            only_on_root(mylog.info, parse_h5_attr(in_file, "info"))
+            only_on_root(ytLogger.info, parse_h5_attr(in_file, "info"))
         if parse_h5_attr(in_file, "version") != data_version[table_type]:
             raise ObsoleteDataException(table_type)
         else:
             only_on_root(
-                mylog.info,
+                ytLogger.info,
                 "X-ray '%s' emissivity data version: %s."
                 % (table_type, parse_h5_attr(in_file, "version")),
             )
@@ -375,6 +375,6 @@ def add_xray_emissivity_field(
         fields += [ei_name, i_name]
 
     for field in fields:
-        mylog.info("Adding ('%s','%s') field.", field[0], field[1])
+        ytLogger.info("Adding ('%s','%s') field.", field[0], field[1])
 
     return fields

--- a/yt/frontends/adaptahop/io.py
+++ b/yt/frontends/adaptahop/io.py
@@ -11,7 +11,7 @@ from operator import attrgetter
 
 import numpy as np
 
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 from yt.utilities.cython_fortran_utils import FortranFile
 from yt.utilities.exceptions import YTDomainOverflow
 from yt.utilities.io_handler import BaseIOHandler
@@ -121,7 +121,7 @@ class IOHandlerAdaptaHOPBinary(BaseIOHandler):
     def _initialize_index(self, data_file, regions):
         pcount = data_file.ds.parameters["nhalos"] + data_file.ds.parameters["nsubs"]
         morton = np.empty(pcount, dtype="uint64")
-        mylog.debug(
+        ytLogger.debug(
             "Initializing index % 5i (% 7i particles)", data_file.file_id, pcount
         )
         if pcount == 0:

--- a/yt/frontends/ahf/io.py
+++ b/yt/frontends/ahf/io.py
@@ -2,7 +2,7 @@ from operator import attrgetter
 
 import numpy as np
 
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 from yt.utilities.exceptions import YTDomainOverflow
 from yt.utilities.io_handler import BaseIOHandler
 from yt.utilities.lib.geometry_utils import compute_morton
@@ -60,7 +60,7 @@ class IOHandlerAHFHalos(BaseIOHandler):
         halos = data_file.read_data(usecols=["ID"])
         pcount = len(halos["ID"])
         morton = np.empty(pcount, dtype="uint64")
-        mylog.debug(
+        ytLogger.debug(
             "Initializing index % 5i (% 7i particles)", data_file.file_id, pcount
         )
         if pcount == 0:

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -14,7 +14,7 @@ import numpy as np
 
 from yt.data_objects.index_subobjects.grid_patch import AMRGridPatch
 from yt.data_objects.static_output import Dataset
-from yt.funcs import mylog, setdefaultattr
+from yt.funcs import setdefaultattr, ytLogger
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.utilities.physical_constants import boltzmann_constant_cgs as kb_cgs
 
@@ -198,7 +198,7 @@ class AMRVACDataset(Dataset):
                 namelist_gamma = namelist["mhd_list"].get("mhd_gamma")
 
             if namelist_gamma is not None and self.gamma != namelist_gamma:
-                mylog.error(
+                ytLogger.error(
                     "Inconsistent values in gamma: datfile %s, parfiles %s",
                     self.gamma,
                     namelist_gamma,
@@ -299,7 +299,7 @@ class AMRVACDataset(Dataset):
         self.domain_dimensions = dd
 
         if self.parameters.get("staggered", False):
-            mylog.warning(
+            ytLogger.warning(
                 "'staggered' flag was found, but is currently ignored (unsupported)"
             )
 
@@ -314,7 +314,7 @@ class AMRVACDataset(Dataset):
             self.geometry = self._parse_geometry(amrvac_geom)
         elif self.parameters["datfile_version"] > 4:
             # py38: walrus here
-            mylog.error(
+            ytLogger.error(
                 "No 'geometry' flag found in datfile with version %d >4.",
                 self.parameters["datfile_version"],
             )
@@ -324,20 +324,22 @@ class AMRVACDataset(Dataset):
             try:
                 new_geometry = self._parse_geometry(self._geometry_override)
                 if new_geometry == self.geometry:
-                    mylog.info("geometry_override is identical to datfile parameter.")
+                    ytLogger.info(
+                        "geometry_override is identical to datfile parameter."
+                    )
                 else:
                     self.geometry = new_geometry
-                    mylog.warning(
+                    ytLogger.warning(
                         "Overriding geometry, this may lead to surprising results."
                     )
             except ValueError:
-                mylog.error(
+                ytLogger.error(
                     "Unable to parse geometry_override '%s' (will be ignored).",
                     self._geometry_override,
                 )
 
         if self.geometry is None:
-            mylog.warning(
+            ytLogger.warning(
                 "No geometry parameter supplied or found, defaulting to cartesian."
             )
             self.geometry = "cartesian"

--- a/yt/frontends/amrvac/fields.py
+++ b/yt/frontends/amrvac/fields.py
@@ -11,7 +11,7 @@ import numpy as np
 from yt.fields.field_info_container import FieldInfoContainer
 from yt.fields.magnetic_field import setup_magnetic_field_aliases
 from yt.units import dimensions
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 
 # We need to specify which fields we might have in our dataset.  The field info
 # container subclass here will define which fields it knows about.  There are
@@ -40,7 +40,7 @@ def _velocity(field, data, idir, prefix=None):
 
     mask1 = rho == 0
     if mask1.any():
-        mylog.info(
+        ytLogger.info(
             "zeros found in %sdensity, "
             "patching them to compute corresponding velocity field.",
             prefix,
@@ -124,7 +124,7 @@ class AMRVACFieldInfo(FieldInfoContainer):
         imax = self.__class__.MAXN_DUST_SPECIES
         while ("amrvac", "rhod%d" % idust) in self.field_list:
             if idust > imax:
-                mylog.error(
+                ytLogger.error(
                     "Only the first %d dust species are currently read by yt. "
                     "If you read this, please consider issuing a ticket. ",
                     imax,
@@ -243,17 +243,17 @@ class AMRVACFieldInfo(FieldInfoContainer):
         if ("amrvac", "e") in self.field_list:
             if self.ds._e_is_internal:
                 pressure_recipe = _polytropic_thermal_pressure
-                mylog.info("Using polytropic EoS for thermal pressure.")
+                ytLogger.info("Using polytropic EoS for thermal pressure.")
             elif ("amrvac", "b1") in self.field_list:
                 pressure_recipe = _full_thermal_pressure_MHD
-                mylog.info("Using full MHD energy for thermal pressure.")
+                ytLogger.info("Using full MHD energy for thermal pressure.")
             else:
                 pressure_recipe = _full_thermal_pressure_HD
-                mylog.info("Using full HD energy for thermal pressure.")
+                ytLogger.info("Using full HD energy for thermal pressure.")
         elif self.ds._c_adiab is not None:
             pressure_recipe = _adiabatic_thermal_pressure
-            mylog.info("Using adiabatic EoS for thermal pressure (isothermal).")
-            mylog.warning(
+            ytLogger.info("Using adiabatic EoS for thermal pressure (isothermal).")
+            ytLogger.warning(
                 "If you used usr_set_pthermal you should "
                 "redefine the thermal_pressure field."
             )
@@ -283,6 +283,6 @@ class AMRVACFieldInfo(FieldInfoContainer):
                 sampling_type="cell",
             )
         else:
-            mylog.warning(
+            ytLogger.warning(
                 "e not found and no parfile passed, can not set thermal_pressure."
             )

--- a/yt/frontends/arepo/data_structures.py
+++ b/yt/frontends/arepo/data_structures.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from yt.frontends.gadget.api import GadgetHDF5Dataset
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 from yt.utilities.on_demand_imports import _h5py as h5py
 
 from .fields import ArepoFieldInfo
@@ -68,7 +68,7 @@ class ArepoHDF5Dataset(GadgetHDF5Dataset):
             if unit in handle["/Header"].attrs:
                 uvals[unit] = handle["/Header"].attrs[unit]
             else:
-                mylog.warning("Arepo header is missing %s!", unit)
+                ytLogger.warning("Arepo header is missing %s!", unit)
                 missing = True
         handle.close()
         if missing:

--- a/yt/frontends/art/io.py
+++ b/yt/frontends/art/io.py
@@ -15,7 +15,7 @@ from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.fortran_utils import read_vector, skip
 from yt.utilities.io_handler import BaseIOHandler
 from yt.utilities.lib.geometry_utils import compute_morton
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 
 
 class IOHandlerART(BaseIOHandler):
@@ -50,7 +50,7 @@ class IOHandlerART(BaseIOHandler):
                 rv = subset.fill(f, fields, selector)
                 for ft, f in fields:
                     d = rv.pop(f)
-                    mylog.debug(
+                    ytLogger.debug(
                         "Filling %s with %s (%0.3e %0.3e) (%s:%s)",
                         f,
                         d.size,
@@ -104,9 +104,9 @@ class IOHandlerART(BaseIOHandler):
 
     def _get_field(self, field):
         if field in self.cache.keys() and self.caching:
-            mylog.debug("Cached %s", str(field))
+            ytLogger.debug("Cached %s", str(field))
             return self.cache[field]
-        mylog.debug("Reading %s", str(field))
+        ytLogger.debug("Reading %s", str(field))
         tr = {}
         ftype, fname = field
         ptmax = self.ws[-1]
@@ -216,9 +216,9 @@ class IOHandlerDarkMatterART(IOHandlerART):
 
     def _get_field(self, field):
         if field in self.cache.keys() and self.caching:
-            mylog.debug("Cached %s", str(field))
+            ytLogger.debug("Cached %s", str(field))
             return self.cache[field]
-        mylog.debug("Reading %s", str(field))
+        ytLogger.debug("Reading %s", str(field))
         tr = {}
         ftype, fname = field
         ptmax = self.ws[-1]
@@ -307,8 +307,8 @@ def interpolate_ages(
         if current_time:
             tdiff = YTQuantity(b2t(t_stars), "Gyr") - current_time.in_units("Gyr")
             if np.abs(tdiff) > 1e-4:
-                mylog.info("Timestamp mismatch in star particle header: %s", tdiff)
-        mylog.info("Interpolating ages")
+                ytLogger.info("Timestamp mismatch in star particle header: %s", tdiff)
+        ytLogger.info("Interpolating ages")
         interp_tb, interp_ages = b2t(data)
         interp_tb = YTArray(interp_tb, "Gyr")
         interp_ages = YTArray(interp_ages, "Gyr")

--- a/yt/frontends/artio/data_structures.py
+++ b/yt/frontends/artio/data_structures.py
@@ -15,7 +15,7 @@ from yt.frontends.artio._artio_caller import (
     artio_is_valid,
 )
 from yt.frontends.artio.fields import ARTIOFieldInfo
-from yt.funcs import mylog, setdefaultattr
+from yt.funcs import setdefaultattr, ytLogger
 from yt.geometry import particle_deposit as particle_deposit
 from yt.geometry.geometry_handler import Index, YTDataChunk
 from yt.utilities.exceptions import YTParticleDepositionNotImplemented
@@ -128,7 +128,7 @@ class ARTIORootMeshSubset(ARTIOOctreeSubset):
         # We allocate number of zones, not number of octs
         op = cls(nvals, kernel_name)
         op.initialize()
-        mylog.debug(
+        ytLogger.debug(
             "Depositing %s (%s^3) particles into %s Root Mesh",
             positions.shape[0],
             positions.shape[0] ** 0.3333333,
@@ -161,7 +161,7 @@ class ARTIOIndex(Index):
         return self.dataset.max_range
 
     def _setup_geometry(self):
-        mylog.debug("Initializing Geometry Handler empty for now.")
+        ytLogger.debug("Initializing Geometry Handler empty for now.")
 
     def get_smallest_dx(self):
         """
@@ -200,9 +200,9 @@ class ARTIOIndex(Index):
         source = self.all_data()
         if finest_levels is not False:
             source.min_level = self.max_level - finest_levels
-        mylog.debug("Searching for maximum value of %s", field)
+        ytLogger.debug("Searching for maximum value of %s", field)
         max_val, mx, my, mz = source.quantities["MaxLocation"](field)
-        mylog.info("Max Value is %0.5e at %0.16f %0.16f %0.16f", max_val, mx, my, mz)
+        ytLogger.info("Max Value is %0.5e at %0.16f %0.16f %0.16f", max_val, mx, my, mz)
         self.ds.parameters[f"Max{field}Value"] = max_val
         self.ds.parameters[f"Max{field}Pos"] = f"{mx, my, mz}"
         return max_val, np.array((mx, my, mz), dtype="float64")
@@ -211,7 +211,7 @@ class ARTIOIndex(Index):
         self.fluid_field_list = self._detect_fluid_fields()
         self.particle_field_list = self._detect_particle_fields()
         self.field_list = self.fluid_field_list + self.particle_field_list
-        mylog.debug("Detected fields: %s", (self.field_list,))
+        ytLogger.debug("Detected fields: %s", (self.field_list,))
 
     def _detect_fluid_fields(self):
         return [("artio", f) for f in self.ds.artio_parameters["grid_variable_labels"]]
@@ -238,15 +238,15 @@ class ARTIOIndex(Index):
             sfc_end = getattr(dobj, "sfc_end", None)
             nz = getattr(dobj, "_num_zones", 0)
             if all_data:
-                mylog.debug("Selecting entire artio domain")
+                ytLogger.debug("Selecting entire artio domain")
                 list_sfc_ranges = self.ds._handle.root_sfc_ranges_all(
                     max_range_size=self.max_range
                 )
             elif sfc_start is not None and sfc_end is not None:
-                mylog.debug("Restricting to %s .. %s", sfc_start, sfc_end)
+                ytLogger.debug("Restricting to %s .. %s", sfc_start, sfc_end)
                 list_sfc_ranges = [(sfc_start, sfc_end)]
             else:
-                mylog.debug("Running selector on artio base grid")
+                ytLogger.debug("Running selector on artio base grid")
                 list_sfc_ranges = self.ds._handle.root_sfc_ranges(
                     dobj.selector, max_range_size=self.max_range
                 )
@@ -289,7 +289,7 @@ class ARTIOIndex(Index):
                     )
             dobj._chunk_info = ci
             if len(list_sfc_ranges) > 1:
-                mylog.info("Created %d chunks for ARTIO", len(list_sfc_ranges))
+                ytLogger.info("Created %d chunks for ARTIO", len(list_sfc_ranges))
         dobj._current_chunk = list(self._chunk_all(dobj))[0]
 
     def _data_size(self, dobj, dobjs):
@@ -470,7 +470,7 @@ class ARTIODataset(Dataset):
             self.parameters["unit_l"] = self.artio_parameters["length_unit"][0] * abox
 
             if self.artio_parameters["DeltaDC"][0] != 0:
-                mylog.warning(
+                ytLogger.warning(
                     "DeltaDC != 0, which implies auni != abox. "
                     "Be sure you understand which expansion parameter "
                     "is appropriate for your use! (Gnedin, Kravtsov, & Rudd 2011)"

--- a/yt/frontends/athena/data_structures.py
+++ b/yt/frontends/athena/data_structures.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from yt.data_objects.index_subobjects.grid_patch import AMRGridPatch
 from yt.data_objects.static_output import Dataset
-from yt.funcs import mylog, sglob
+from yt.funcs import sglob, ytLogger
 from yt.geometry.geometry_handler import YTDataChunk
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.utilities.chemical_formulas import default_mu
@@ -157,7 +157,7 @@ class AthenaHierarchy(GridIndex):
                     grid_dims -= 1
                     grid_dims[grid_dims == 0] = 1
                 if np.prod(grid_dims) != grid_ncells:
-                    mylog.error(
+                    ytLogger.error(
                         "product of dimensions %i not equal to number of cells %i",
                         np.prod(grid_dims),
                         grid_ncells,
@@ -222,7 +222,7 @@ class AthenaHierarchy(GridIndex):
             grid["dimensions"] -= 1
             grid["dimensions"][grid["dimensions"] == 0] = 1
         if np.prod(grid["dimensions"]) != grid["ncells"]:
-            mylog.error(
+            ytLogger.error(
                 "product of dimensions %i not equal to number of cells %i",
                 np.prod(grid["dimensions"]),
                 grid["ncells"],
@@ -297,7 +297,7 @@ class AthenaHierarchy(GridIndex):
                 gridread["dimensions"] -= 1
                 gridread["dimensions"][gridread["dimensions"] == 0] = 1
             if np.prod(gridread["dimensions"]) != gridread["ncells"]:
-                mylog.error(
+                ytLogger.error(
                     "product of dimensions %i not equal to number of cells %i",
                     np.prod(gridread["dimensions"]),
                     gridread["ncells"],
@@ -429,7 +429,7 @@ class AthenaHierarchy(GridIndex):
 
     def _reconstruct_parent_child(self):
         mask = np.empty(len(self.grids), dtype="int32")
-        mylog.debug("First pass; identifying child grids")
+        ytLogger.debug("First pass; identifying child grids")
         for i, grid in enumerate(self.grids):
             get_box_grids_level(
                 self.grid_left_edge[i, :],
@@ -443,7 +443,7 @@ class AthenaHierarchy(GridIndex):
             grid.Children = [
                 g for g in self.grids[mask.astype("bool")] if g.Level == grid.Level + 1
             ]
-        mylog.debug("Second pass; identifying parents")
+        ytLogger.debug("Second pass; identifying parents")
         for grid in self.grids:  # Second pass
             for child in grid.Children:
                 child.Parent.append(grid)
@@ -512,7 +512,7 @@ class AthenaDataset(Dataset):
             # We set these to cgs for now, but they may have been overridden
             if getattr(self, unit + "_unit", None) is not None:
                 continue
-            mylog.warning("Assuming 1.0 = 1.0 %s", cgs)
+            ytLogger.warning("Assuming 1.0 = 1.0 %s", cgs)
             setattr(self, f"{unit}_unit", self.quan(1.0, cgs))
         self.magnetic_unit = np.sqrt(
             4 * np.pi * self.mass_unit / (self.time_unit ** 2 * self.length_unit)
@@ -548,7 +548,7 @@ class AthenaDataset(Dataset):
             line = self._handle.readline()
 
         self.domain_left_edge = grid["left_edge"]
-        mylog.info(
+        ytLogger.info(
             "Temporarily setting domain_right_edge = -domain_left_edge. "
             "This will be corrected automatically if it is not the case."
         )

--- a/yt/frontends/athena/io.py
+++ b/yt/frontends/athena/io.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 from yt.utilities.io_handler import BaseIOHandler
 
 from .data_structures import chk23
@@ -92,7 +92,7 @@ class IOHandlerAthena(BaseIOHandler):
         for field in fields:
             rv[field] = np.empty(size, dtype="float64")
         ng = sum(len(c.objs) for c in chunks)
-        mylog.debug(
+        ytLogger.debug(
             "Reading %s cells of %s fields in %s grids",
             size,
             [f2 for f1, f2 in fields],

--- a/yt/frontends/athena_pp/data_structures.py
+++ b/yt/frontends/athena_pp/data_structures.py
@@ -7,7 +7,7 @@ import numpy as np
 from yt.data_objects.index_subobjects.grid_patch import AMRGridPatch
 from yt.data_objects.index_subobjects.unstructured_mesh import SemiStructuredMesh
 from yt.data_objects.static_output import Dataset
-from yt.funcs import get_pbar, mylog
+from yt.funcs import get_pbar, ytLogger
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.geometry.unstructured_mesh_handler import UnstructuredIndex
 from yt.utilities.chemical_formulas import default_mu
@@ -61,7 +61,7 @@ class AthenaPPLogarithmicIndex(UnstructuredIndex):
         self.dataset_type = dataset_type
 
     def _initialize_mesh(self):
-        mylog.debug("Setting up meshes.")
+        ytLogger.debug("Setting up meshes.")
         num_blocks = self._handle.attrs["NumMeshBlocks"]
         log_loc = self._handle["LogicalLocations"]
         levels = self._handle["Levels"]
@@ -132,7 +132,7 @@ class AthenaPPLogarithmicIndex(UnstructuredIndex):
             self.meshes.append(mesh)
             pbar.update(i)
         pbar.finish()
-        mylog.debug("Done setting up meshes.")
+        ytLogger.debug("Done setting up meshes.")
 
     def _detect_output_fields(self):
         self.field_list = [("athena_pp", k) for k in self.ds._field_map]
@@ -286,7 +286,7 @@ class AthenaPPDataset(Dataset):
             # We set these to cgs for now, but they may have been overridden
             if getattr(self, unit + "_unit", None) is not None:
                 continue
-            mylog.warning("Assuming 1.0 = 1.0 %s", cgs)
+            ytLogger.warning("Assuming 1.0 = 1.0 %s", cgs)
             setattr(self, f"{unit}_unit", self.quan(1.0, cgs))
 
         self.magnetic_unit = np.sqrt(

--- a/yt/frontends/athena_pp/io.py
+++ b/yt/frontends/athena_pp/io.py
@@ -3,7 +3,7 @@ from itertools import groupby
 import numpy as np
 
 from yt.utilities.io_handler import BaseIOHandler
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 
 
 # http://stackoverflow.com/questions/2361945/detecting-consecutive-integers-in-a-list
@@ -42,7 +42,7 @@ class IOHandlerAthenaPP(BaseIOHandler):
             # Always use *native* 64-bit float.
             rv[field] = np.empty(size, dtype="=f8")
         ng = sum(len(c.objs) for c in chunks)
-        mylog.debug(
+        ytLogger.debug(
             "Reading %s cells of %s fields in %s blocks",
             size,
             [f2 for f1, f2 in fields],

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from yt.data_objects.index_subobjects.grid_patch import AMRGridPatch
 from yt.data_objects.static_output import Dataset
-from yt.funcs import mylog, setdefaultattr
+from yt.funcs import setdefaultattr, ytLogger
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.utilities.io_handler import io_registry
 from yt.utilities.lib.misc_utilities import get_box_grids_level
@@ -499,25 +499,25 @@ class BoxlibHierarchy(GridIndex):
                 "Perhaps the file is corrupt?"
             )
 
-        mylog.debug("FAB header suggests dtype of %s", dtype)
+        ytLogger.debug("FAB header suggests dtype of %s", dtype)
         self._dtype = np.dtype(dtype)
 
     def _populate_grid_objects(self):
-        mylog.debug("Creating grid objects")
+        ytLogger.debug("Creating grid objects")
         self.grids = np.array(self.grids, dtype="object")
         self._reconstruct_parent_child()
         for i, grid in enumerate(self.grids):
             if (i % 1e4) == 0:
-                mylog.debug("Prepared % 7i / % 7i grids", i, self.num_grids)
+                ytLogger.debug("Prepared % 7i / % 7i grids", i, self.num_grids)
             grid._prepare_grid()
             grid._setup_dx()
-        mylog.debug("Done creating grid objects")
+        ytLogger.debug("Done creating grid objects")
 
     def _reconstruct_parent_child(self):
         if self.max_level == 0:
             return
         mask = np.empty(len(self.grids), dtype="int32")
-        mylog.debug("First pass; identifying child grids")
+        ytLogger.debug("First pass; identifying child grids")
         for i, grid in enumerate(self.grids):
             get_box_grids_level(
                 self.grid_left_edge[i, :],
@@ -530,7 +530,7 @@ class BoxlibHierarchy(GridIndex):
             )
             ids = np.where(mask.astype("bool"))  # where is a tuple
             grid._children_ids = ids[0] + grid._id_offset
-        mylog.debug("Second pass; identifying parents")
+        ytLogger.debug("Second pass; identifying parents")
         for i, grid in enumerate(self.grids):  # Second pass
             for child in grid.Children:
                 child._parent_id.append(i + grid._id_offset)
@@ -922,10 +922,10 @@ class BoxlibDataset(Dataset):
             "domain_right_edge",
         ]:
             if not hasattr(self, a):
-                mylog.error("Missing %s in parameter file definition!", a)
+                ytLogger.error("Missing %s in parameter file definition!", a)
                 continue
             v = getattr(self, a)
-            mylog.info("Parameters: %-25s = %s", a, v)
+            ytLogger.info("Parameters: %-25s = %s", a, v)
 
     def relative_refinement(self, l0, l1):
         offset = self.level_offsets[l1] - self.level_offsets[l0]

--- a/yt/frontends/boxlib/io.py
+++ b/yt/frontends/boxlib/io.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 import numpy as np
 
 from yt.frontends.chombo.io import parse_orion_sinks
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 from yt.geometry.selection_routines import GridSelector
 from yt.utilities.io_handler import BaseIOHandler
 
@@ -39,7 +39,7 @@ class IOHandlerBoxlib(BaseIOHandler):
                 rv[field] = np.empty(size, dtype="float64")
         centered_fields = _remove_raw(fields, raw_fields)
         ng = sum(len(c.objs) for c in chunks)
-        mylog.debug(
+        ytLogger.debug(
             "Reading %s cells of %s fields in %s grids",
             size,
             [f2 for f1, f2 in fields],

--- a/yt/frontends/chombo/data_structures.py
+++ b/yt/frontends/chombo/data_structures.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from yt.data_objects.index_subobjects.grid_patch import AMRGridPatch
 from yt.data_objects.static_output import Dataset
-from yt.funcs import mylog, setdefaultattr
+from yt.funcs import setdefaultattr, ytLogger
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.utilities.file_handler import HDF5FileHandler, warn_h5py
 from yt.utilities.lib.misc_utilities import get_box_grids_level
@@ -215,7 +215,7 @@ class ChomboHierarchy(GridIndex):
 
     def _reconstruct_parent_child(self):
         mask = np.empty(len(self.grids), dtype="int32")
-        mylog.debug("First pass; identifying child grids")
+        ytLogger.debug("First pass; identifying child grids")
         for i, grid in enumerate(self.grids):
             get_box_grids_level(
                 self.grid_left_edge[i, :],
@@ -228,7 +228,7 @@ class ChomboHierarchy(GridIndex):
             )
             ids = np.where(mask.astype("bool"))  # where is a tuple
             grid._children_ids = ids[0] + grid._id_offset
-        mylog.debug("Second pass; identifying parents")
+        ytLogger.debug("Second pass; identifying parents")
         for i, grid in enumerate(self.grids):  # Second pass
             for child in grid.Children:
                 child._parent_id.append(i + grid._id_offset)
@@ -271,11 +271,11 @@ class ChomboDataset(Dataset):
 
     def _set_code_unit_attributes(self):
         if not hasattr(self, "length_unit"):
-            mylog.warning("Setting code length unit to be 1.0 cm")
+            ytLogger.warning("Setting code length unit to be 1.0 cm")
         if not hasattr(self, "mass_unit"):
-            mylog.warning("Setting code mass unit to be 1.0 g")
+            ytLogger.warning("Setting code mass unit to be 1.0 g")
         if not hasattr(self, "time_unit"):
-            mylog.warning("Setting code time unit to be 1.0 s")
+            ytLogger.warning("Setting code time unit to be 1.0 s")
         setdefaultattr(self, "length_unit", self.quan(1.0, "cm"))
         setdefaultattr(self, "mass_unit", self.quan(1.0, "g"))
         setdefaultattr(self, "time_unit", self.quan(1.0, "s"))
@@ -395,10 +395,10 @@ class ChomboDataset(Dataset):
             "domain_right_edge",
         ]:
             if not hasattr(self, a):
-                mylog.error("Missing %s in parameter file definition!", a)
+                ytLogger.error("Missing %s in parameter file definition!", a)
                 continue
             v = getattr(self, a)
-            mylog.info("Parameters: %-25s = %s", a, v)
+            ytLogger.info("Parameters: %-25s = %s", a, v)
 
 
 class PlutoHierarchy(ChomboHierarchy):
@@ -707,7 +707,7 @@ class Orion2Dataset(ChomboDataset):
                     except ValueError:
                         self.parameters[param] = vals
             except ValueError:
-                mylog.error("ValueError: '%s'", line)
+                ytLogger.error("ValueError: '%s'", line)
             if param == "GAMMA":
                 self.gamma = np.float64(vals)
 

--- a/yt/frontends/chombo/io.py
+++ b/yt/frontends/chombo/io.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from yt.geometry.selection_routines import GridSelector
 from yt.utilities.io_handler import BaseIOHandler
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 
 
 class IOHandlerChomboHDF5(BaseIOHandler):
@@ -123,7 +123,7 @@ class IOHandlerChomboHDF5(BaseIOHandler):
             fsize = size
             rv[field] = np.empty(fsize, dtype="float64")
         ng = sum(len(c.objs) for c in chunks)
-        mylog.debug(
+        ytLogger.debug(
             "Reading %s cells of %s fields in %s grids",
             size,
             [f2 for f1, f2 in fields],
@@ -253,8 +253,8 @@ def parse_orion_sinks(fn):
         index["particle_luminosity"] = 16
     else:
         # give a warning if none of the above apply:
-        mylog.warning("Warning - could not figure out particle output file")
-        mylog.warning("These results could be nonsense!")
+        ytLogger.warning("Warning - could not figure out particle output file")
+        ytLogger.warning("These results could be nonsense!")
 
     return index
 

--- a/yt/frontends/enzo/io.py
+++ b/yt/frontends/enzo/io.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from yt.geometry.selection_routines import GridSelector
 from yt.utilities.io_handler import BaseIOHandler
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 from yt.utilities.on_demand_imports import _h5py as h5py
 
 _convert_mass = ("particle_mass", "mass")
@@ -221,7 +221,7 @@ class IOHandlerInMemory(BaseIOHandler):
             fsize = size
             rv[field] = np.empty(fsize, dtype="float64")
         ng = sum(len(c.objs) for c in chunks)
-        mylog.debug(
+        ytLogger.debug(
             "Reading %s cells of %s fields in %s grids",
             size,
             [f2 for f1, f2 in fields],
@@ -317,7 +317,7 @@ class IOHandlerPacked2D(IOHandlerPackedHDF5):
             fsize = size
             rv[field] = np.empty(fsize, dtype="float64")
         ng = sum(len(c.objs) for c in chunks)
-        mylog.debug(
+        ytLogger.debug(
             "Reading %s cells of %s fields in %s grids",
             size,
             [f2 for f1, f2 in fields],

--- a/yt/frontends/enzo/simulation_handling.py
+++ b/yt/frontends/enzo/simulation_handling.py
@@ -15,7 +15,7 @@ from yt.utilities.exceptions import (
     NoStoppingCondition,
     YTUnidentifiedDataType,
 )
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 from yt.utilities.parallel_tools.parallel_analysis_interface import parallel_objects
 
 
@@ -237,7 +237,7 @@ class EnzoSimulation(SimulationTimeSeries):
 
         if not my_all_outputs:
             DatasetSeries.__init__(self, outputs=[], parallel=parallel)
-            mylog.info("0 outputs loaded into time series.")
+            ytLogger.info("0 outputs loaded into time series.")
             return
 
         # Apply selection criteria to the set.
@@ -315,7 +315,7 @@ class EnzoSimulation(SimulationTimeSeries):
         DatasetSeries.__init__(
             self, outputs=init_outputs, parallel=parallel, setup_function=setup_function
         )
-        mylog.info("%d outputs loaded into time series.", len(init_outputs))
+        ytLogger.info("%d outputs loaded into time series.", len(init_outputs))
 
     def _parse_parameter_file(self):
         """
@@ -470,7 +470,9 @@ class EnzoSimulation(SimulationTimeSeries):
         Calculate cycle outputs.
         """
 
-        mylog.warning("Calculating cycle outputs.  Dataset times will be unavailable.")
+        ytLogger.warning(
+            "Calculating cycle outputs.  Dataset times will be unavailable."
+        )
 
         if (
             self.stop_cycle is None
@@ -507,11 +509,11 @@ class EnzoSimulation(SimulationTimeSeries):
             self.parameters["dtDataDump"] > 0
             and self.parameters["CycleSkipDataDump"] > 0
         ):
-            mylog.info(
+            ytLogger.info(
                 "Simulation %s has both dtDataDump and CycleSkipDataDump set.",
                 self.parameter_filename,
             )
-            mylog.info(
+            ytLogger.info(
                 "    Unable to calculate datasets.  "
                 "Attempting to search in the current directory"
             )
@@ -565,7 +567,7 @@ class EnzoSimulation(SimulationTimeSeries):
             if not ("StopTime" in self.parameters or "StopCycle" in self.parameters):
                 raise NoStoppingCondition(self.parameter_filename)
             if self.final_time is None:
-                mylog.warning(
+                ytLogger.warning(
                     "Simulation %s has no stop time set, stopping condition "
                     "will be based only on cycles.",
                     self.parameter_filename,
@@ -620,7 +622,7 @@ class EnzoSimulation(SimulationTimeSeries):
 
         self.all_outputs = self.all_time_outputs + self.all_redshift_outputs
         self.all_outputs.sort(key=lambda obj: obj["time"])
-        only_on_root(mylog.info, "Located %d total outputs.", len(self.all_outputs))
+        only_on_root(ytLogger.info, "Located %d total outputs.", len(self.all_outputs))
 
         # manually set final time and redshift with last output
         if self.all_outputs:
@@ -634,14 +636,14 @@ class EnzoSimulation(SimulationTimeSeries):
         """
 
         only_on_root(
-            mylog.info, "Checking %d potential outputs.", len(potential_outputs)
+            ytLogger.info, "Checking %d potential outputs.", len(potential_outputs)
         )
 
         my_outputs = {}
-        llevel = mylog.level
+        llevel = ytLogger.level
         # suppress logging as we load every dataset, unless set to debug
         if llevel > 10 and llevel < 40:
-            mylog.setLevel(40)
+            ytLogger.setLevel(40)
         for my_storage, output in parallel_objects(
             potential_outputs, storage=my_outputs
         ):
@@ -660,7 +662,7 @@ class EnzoSimulation(SimulationTimeSeries):
             try:
                 ds = load(filename)
             except (FileNotFoundError, YTUnidentifiedDataType):
-                mylog.error("Failed to load %s", filename)
+                ytLogger.error("Failed to load %s", filename)
                 continue
             my_storage.result = {
                 "filename": filename,
@@ -668,7 +670,7 @@ class EnzoSimulation(SimulationTimeSeries):
             }
             if ds.cosmological_simulation:
                 my_storage.result["redshift"] = ds.current_redshift
-        mylog.setLevel(llevel)
+        ytLogger.setLevel(llevel)
         my_outputs = [
             my_output for my_output in my_outputs.values() if my_output is not None
         ]
@@ -680,7 +682,7 @@ class EnzoSimulation(SimulationTimeSeries):
         Write cosmology output parameters for a cosmology splice.
         """
 
-        mylog.info("Writing redshift output list to %s.", filename)
+        ytLogger.info("Writing redshift output list to %s.", filename)
         f = open(filename, "w")
         for q, output in enumerate(outputs):
             f.write(

--- a/yt/frontends/enzo_p/data_structures.py
+++ b/yt/frontends/enzo_p/data_structures.py
@@ -19,7 +19,7 @@ from yt.frontends.enzo_p.misc import (
 from yt.funcs import get_pbar, setdefaultattr
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.utilities.cosmology import Cosmology
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 from yt.utilities.on_demand_imports import _h5py as h5py, _libconf as libconf
 
 
@@ -274,7 +274,7 @@ class EnzoPHierarchy(GridIndex):
             # Just check the first grid.
             grid = self.grids[0]
             field_list, ptypes = self.io._read_field_names(grid)
-            mylog.debug("Grid %s has: %s", grid.id, field_list)
+            ytLogger.debug("Grid %s has: %s", grid.id, field_list)
         else:
             field_list = None
             ptypes = None

--- a/yt/frontends/exodus_ii/data_structures.py
+++ b/yt/frontends/exodus_ii/data_structures.py
@@ -6,7 +6,7 @@ from yt.data_objects.unions import MeshUnion
 from yt.funcs import setdefaultattr
 from yt.geometry.unstructured_mesh_handler import UnstructuredIndex
 from yt.utilities.file_handler import NetCDF4FileHandler, warn_netcdf
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 
 from .fields import ExodusIIFieldInfo
 from .util import get_num_pseudo_dims, load_info_records, sanitize_string
@@ -215,7 +215,7 @@ class ExodusIIDataset(Dataset):
             try:
                 return load_info_records(ds.variables["info_records"])
             except (KeyError, TypeError):
-                mylog.warning("No info_records found")
+                ytLogger.warning("No info_records found")
                 return []
 
     def _get_unique_identifier(self):
@@ -241,7 +241,7 @@ class ExodusIIDataset(Dataset):
 
         with self._handle.open_ds() as ds:
             if "name_glo_var" not in ds.variables:
-                mylog.warning("name_glo_var not found")
+                ytLogger.warning("name_glo_var not found")
                 return []
             else:
                 return [
@@ -257,7 +257,7 @@ class ExodusIIDataset(Dataset):
 
         with self._handle.open_ds() as ds:
             if "name_elem_var" not in ds.variables:
-                mylog.warning("name_elem_var not found")
+                ytLogger.warning("name_elem_var not found")
                 return []
             else:
                 return [
@@ -273,7 +273,7 @@ class ExodusIIDataset(Dataset):
 
         with self._handle.open_ds() as ds:
             if "name_nod_var" not in ds.variables:
-                mylog.warning("name_nod_var not found")
+                ytLogger.warning("name_nod_var not found")
                 return []
             else:
                 return [
@@ -289,7 +289,7 @@ class ExodusIIDataset(Dataset):
 
         coord_axes = "xyz"[: self.dimensionality]
 
-        mylog.info("Loading coordinates")
+        ytLogger.info("Loading coordinates")
         with self._handle.open_ds() as ds:
             if "coord" not in ds.variables:
                 coords = (
@@ -330,7 +330,7 @@ class ExodusIIDataset(Dataset):
         """
         Loads the connectivity data for the mesh
         """
-        mylog.info("Loading connectivity")
+        ytLogger.info("Loading connectivity")
         connectivity = []
         with self._handle.open_ds() as ds:
             for i in range(self.parameters["num_meshes"]):

--- a/yt/frontends/exodus_ii/simulation_handling.py
+++ b/yt/frontends/exodus_ii/simulation_handling.py
@@ -4,7 +4,7 @@ from yt.data_objects.time_series import DatasetSeries
 from yt.funcs import only_on_root
 from yt.loaders import load
 from yt.utilities.exceptions import YTUnidentifiedDataType
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 from yt.utilities.parallel_tools.parallel_analysis_interface import parallel_objects
 
 
@@ -80,7 +80,7 @@ class ExodusIISimulation(DatasetSeries):
         """
 
         only_on_root(
-            mylog.info, "Checking %d potential outputs.", len(potential_outputs)
+            ytLogger.info, "Checking %d potential outputs.", len(potential_outputs)
         )
 
         my_outputs = {}
@@ -90,7 +90,7 @@ class ExodusIISimulation(DatasetSeries):
             try:
                 ds = load(output)
             except (FileNotFoundError, YTUnidentifiedDataType):
-                mylog.error("Failed to load %s", output)
+                ytLogger.error("Failed to load %s", output)
                 continue
             my_storage.result = {"filename": output, "num_steps": ds.num_steps}
 

--- a/yt/frontends/fits/io.py
+++ b/yt/frontends/fits/io.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from yt.utilities.io_handler import BaseIOHandler
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 
 
 class IOHandlerFITS(BaseIOHandler):
@@ -58,7 +58,7 @@ class IOHandlerFITS(BaseIOHandler):
         for field in fields:
             rv[field] = np.empty(size, dtype=dt)
         ng = sum(len(c.objs) for c in chunks)
-        mylog.debug(
+        ytLogger.debug(
             "Reading %s cells of %s fields in %s grids",
             size,
             [f2 for f1, f2 in fields],

--- a/yt/frontends/fits/misc.py
+++ b/yt/frontends/fits/misc.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from yt.fields.derived_field import ValidateSpatial
 from yt.units.yt_array import YTArray, YTQuantity
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 from yt.utilities.on_demand_imports import _astropy
 
 
@@ -54,7 +54,7 @@ def setup_counts_fields(ds, ebounds, ftype="gas"):
     for (emin, emax) in ebounds:
         cfunc = _make_counts(emin, emax)
         fname = f"counts_{emin}-{emax}"
-        mylog.info("Creating counts field %s.", fname)
+        ytLogger.info("Creating counts field %s.", fname)
         ds.add_field(
             (ftype, fname),
             sampling_type="cell",
@@ -114,7 +114,9 @@ def create_spectral_slabs(filename, slab_centers, slab_width, **kwargs):
             slab_center = YTQuantity(v[0], v[1])
         else:
             slab_center = v
-        mylog.info("Adding slab field %s at %g %s", k, slab_center.v, slab_center.units)
+        ytLogger.info(
+            "Adding slab field %s at %g %s", k, slab_center.v, slab_center.units
+        )
         slab_lo = (slab_center - 0.5 * slab_width).to_astropy()
         slab_hi = (slab_center + 0.5 * slab_width).to_astropy()
         subcube = cube.spectral_slab(slab_lo, slab_hi)

--- a/yt/frontends/flash/data_structures.py
+++ b/yt/frontends/flash/data_structures.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from yt.data_objects.index_subobjects.grid_patch import AMRGridPatch
 from yt.data_objects.static_output import Dataset, ParticleFile, validate_index_order
-from yt.funcs import mylog, setdefaultattr
+from yt.funcs import setdefaultattr, ytLogger
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.geometry.particle_geometry_handler import ParticleIndex
 from yt.utilities.file_handler import HDF5FileHandler, warn_h5py
@@ -190,7 +190,7 @@ class FLASHDataset(Dataset):
                     filename.replace("plt_cnt", "part")
                 )
                 self.particle_filename = filename.replace("plt_cnt", "part")
-                mylog.info(
+                ytLogger.info(
                     "Particle file found: %s", self.particle_filename.split("/")[-1]
                 )
             except OSError:
@@ -205,7 +205,7 @@ class FLASHDataset(Dataset):
             plot_time = self._handle.handle.get("real scalars")[0][1]
             if not np.isclose(part_time, plot_time):
                 self._particle_handle = self._handle
-                mylog.warning(
+                ytLogger.warning(
                     "%s and %s are not at the same time. "
                     "This particle file will not be used.",
                     self.particle_filename,
@@ -312,7 +312,7 @@ class FLASHDataset(Dataset):
                     else:
                         pval = val
                     if vn in self.parameters and self.parameters[vn] != pval:
-                        mylog.info(
+                        ytLogger.info(
                             "%s %s overwrites a simulation scalar of the same name",
                             hn[:-1],
                             vn,
@@ -342,7 +342,7 @@ class FLASHDataset(Dataset):
                     else:
                         pval = val
                     if vn in self.parameters and self.parameters[vn] != pval:
-                        mylog.info(
+                        ytLogger.info(
                             "%s %s overwrites a simulation scalar of the same name",
                             hn[:-1],
                             vn,
@@ -371,7 +371,7 @@ class FLASHDataset(Dataset):
             if nyb == 1:
                 dimensionality = 1
             if dimensionality < 3:
-                mylog.warning("Guessing dimensionality as %s", dimensionality)
+                ytLogger.warning("Guessing dimensionality as %s", dimensionality)
 
         self.dimensionality = dimensionality
 
@@ -398,23 +398,23 @@ class FLASHDataset(Dataset):
         if self.dimensionality < 3:
             for d in [dimensionality] + list(range(3 - dimensionality)):
                 if dle[d] == dre[d]:
-                    mylog.warning(
+                    ytLogger.warning(
                         "Identical domain left edge and right edges "
                         "along dummy dimension (%i), attempting to read anyway",
                         d,
                     )
                     dre[d] = dle[d] + 1.0
         if self.dimensionality < 3 and self.geometry == "cylindrical":
-            mylog.warning("Extending theta dimension to 2PI + left edge.")
+            ytLogger.warning("Extending theta dimension to 2PI + left edge.")
             dre[2] = dle[2] + 2 * np.pi
         elif self.dimensionality < 3 and self.geometry == "polar":
-            mylog.warning("Extending theta dimension to 2PI + left edge.")
+            ytLogger.warning("Extending theta dimension to 2PI + left edge.")
             dre[1] = dle[1] + 2 * np.pi
         elif self.dimensionality < 3 and self.geometry == "spherical":
-            mylog.warning("Extending phi dimension to 2PI + left edge.")
+            ytLogger.warning("Extending phi dimension to 2PI + left edge.")
             dre[2] = dle[2] + 2 * np.pi
         if self.dimensionality == 1 and self.geometry == "spherical":
-            mylog.warning("Extending theta dimension to PI + left edge.")
+            ytLogger.warning("Extending theta dimension to PI + left edge.")
             dre[1] = dle[1] + np.pi
         self.domain_left_edge = dle
         self.domain_right_edge = dre
@@ -424,7 +424,7 @@ class FLASHDataset(Dataset):
         try:
             self.gamma = self.parameters["gamma"]
         except Exception:
-            mylog.info("Cannot find Gamma")
+            ytLogger.info("Cannot find Gamma")
             pass
 
         # Get the simulation time

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -10,7 +10,7 @@ from yt.funcs import only_on_root
 from yt.utilities.chemical_formulas import default_mu
 from yt.utilities.cosmology import Cosmology
 from yt.utilities.fortran_utils import read_record
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 from yt.utilities.on_demand_imports import _h5py as h5py
 
 from .definitions import (
@@ -260,7 +260,7 @@ class GadgetDataset(SPHDataset):
         header_size = self._header.size
         if header_size != [256]:
             only_on_root(
-                mylog.warn,
+                ytLogger.warn,
                 "Non-standard header size is detected! "
                 "Gadget-2 standard header is 256 bytes, but yours is %s. "
                 "Make sure a non-standard header is actually expected. "
@@ -368,7 +368,7 @@ class GadgetDataset(SPHDataset):
             # Probably not a cosmological dataset, we should just set
             # z = 0 and let the user know
             self.current_redshift = 0.0
-            only_on_root(mylog.info, "Redshift is not set in Header. Assuming z=0.")
+            only_on_root(ytLogger.info, "Redshift is not set in Header. Assuming z=0.")
 
         try:
             self.omega_lambda = hvals["OmegaLambda"]
@@ -388,7 +388,7 @@ class GadgetDataset(SPHDataset):
         # somehow, but opinions on this vary.
         if self.omega_lambda == 0.0:
             only_on_root(
-                mylog.info, "Omega Lambda is 0.0, so we are turning off Cosmology."
+                ytLogger.info, "Omega Lambda is 0.0, so we are turning off Cosmology."
             )
             self.hubble_constant = 1.0  # So that scaling comes out correct
             self.cosmological_simulation = 0
@@ -407,7 +407,7 @@ class GadgetDataset(SPHDataset):
             )
             self.current_time = cosmo.lookback_time(self.current_redshift, 1e6)
             only_on_root(
-                mylog.info,
+                ytLogger.info,
                 "Calculating time from %0.3e to be %0.3e seconds",
                 hvals["Time"],
                 self.current_time,
@@ -434,11 +434,13 @@ class GadgetDataset(SPHDataset):
         if self._unit_base is None:
             if self.cosmological_simulation == 1:
                 only_on_root(
-                    mylog.info, "Assuming length units are in kpc/h (comoving)"
+                    ytLogger.info, "Assuming length units are in kpc/h (comoving)"
                 )
                 self._unit_base = dict(length=(1.0, "kpccm/h"))
             else:
-                only_on_root(mylog.info, "Assuming length units are in kpc (physical)")
+                only_on_root(
+                    ytLogger.info, "Assuming length units are in kpc (physical)"
+                )
                 self._unit_base = dict(length=(1.0, "kpc"))
 
         # If units passed in by user, decide what to do about

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -6,7 +6,7 @@ import numpy as np
 from yt.frontends.sph.io import IOHandlerSPH
 from yt.units.yt_array import uconcatenate
 from yt.utilities.lib.particle_kdtree_tools import generate_smoothing_length
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 from yt.utilities.on_demand_imports import _h5py as h5py
 
 from .definitions import SNAP_FORMAT_2_OFFSET, gadget_hdf5_ptypes
@@ -96,7 +96,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
             with h5py.File(hsml_fn, mode="r") as f:
                 file_hash = f.attrs["q"]
             if file_hash != self.ds._file_hash:
-                mylog.warning("Replacing hsml files.")
+                ytLogger.warning("Replacing hsml files.")
                 for data_file in data_files:
                     hfn = data_file.filename.replace(".hdf5", ".hsml.hdf5")
                     os.remove(hfn)
@@ -122,7 +122,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
         hsml = generate_smoothing_length(positions, kdtree, self.ds._num_neighbors)
         dtype = positions.dtype
         hsml = hsml[np.argsort(kdtree.idx)].astype(dtype)
-        mylog.warning("Writing smoothing lengths to hsml files.")
+        ytLogger.warning("Writing smoothing lengths to hsml files.")
         for i, data_file in enumerate(data_files):
             si, ei = data_file.start, data_file.end
             fn = data_file.filename
@@ -538,7 +538,7 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
                         continue
                     if float(diff) / psize == int(float(diff) / psize):
                         possible.append(ptype)
-                mylog.warning(
+                ytLogger.warning(
                     "Your Gadget-2 file may have extra "
                     "columns or different precision! "
                     "(%s diff => %s?)",

--- a/yt/frontends/gadget/simulation_handling.py
+++ b/yt/frontends/gadget/simulation_handling.py
@@ -15,7 +15,7 @@ from yt.utilities.exceptions import (
     NoStoppingCondition,
     YTUnidentifiedDataType,
 )
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 from yt.utilities.parallel_tools.parallel_analysis_interface import parallel_objects
 
 
@@ -223,7 +223,7 @@ class GadgetSimulation(SimulationTimeSeries):
             DatasetSeries.__init__(
                 self, outputs=[], parallel=parallel, unit_base=self.unit_base
             )
-            mylog.info("0 outputs loaded into time series.")
+            ytLogger.info("0 outputs loaded into time series.")
             return
 
         # Apply selection criteria to the set.
@@ -282,7 +282,7 @@ class GadgetSimulation(SimulationTimeSeries):
             if os.path.exists(output["filename"]):
                 init_outputs.append(output["filename"])
         if len(init_outputs) == 0 and len(my_outputs) > 0:
-            mylog.warning(
+            ytLogger.warning(
                 "Could not find any datasets.  "
                 "Check the value of OutputDir in your parameter file."
             )
@@ -294,7 +294,7 @@ class GadgetSimulation(SimulationTimeSeries):
             setup_function=setup_function,
             unit_base=self.unit_base,
         )
-        mylog.info("%d outputs loaded into time series.", len(init_outputs))
+        ytLogger.info("%d outputs loaded into time series.", len(init_outputs))
 
     def _parse_parameter_file(self):
         """
@@ -383,7 +383,7 @@ class GadgetSimulation(SimulationTimeSeries):
         else:
             data_dir = os.path.join(self.directory, self.parameters["OutputDir"])
         if not os.path.exists(data_dir):
-            mylog.info(
+            ytLogger.info(
                 "OutputDir not found at %s, instead using %s.", data_dir, self.directory
             )
             data_dir = self.directory
@@ -498,7 +498,7 @@ class GadgetSimulation(SimulationTimeSeries):
         potential_outputs = glob.glob(self._snapshot_format())
         self.all_outputs = self._check_for_outputs(potential_outputs)
         self.all_outputs.sort(key=lambda obj: obj["time"])
-        only_on_root(mylog.info, "Located %d total outputs.", len(self.all_outputs))
+        only_on_root(ytLogger.info, "Located %d total outputs.", len(self.all_outputs))
 
         # manually set final time and redshift with last output
         if self.all_outputs:
@@ -512,7 +512,7 @@ class GadgetSimulation(SimulationTimeSeries):
         """
 
         only_on_root(
-            mylog.info, "Checking %d potential outputs.", len(potential_outputs)
+            ytLogger.info, "Checking %d potential outputs.", len(potential_outputs)
         )
 
         my_outputs = {}
@@ -522,7 +522,7 @@ class GadgetSimulation(SimulationTimeSeries):
             try:
                 ds = load(output)
             except (FileNotFoundError, YTUnidentifiedDataType):
-                mylog.error("Failed to load %s", output)
+                ytLogger.error("Failed to load %s", output)
                 continue
             my_storage.result = {
                 "filename": output,
@@ -541,7 +541,7 @@ class GadgetSimulation(SimulationTimeSeries):
         Write cosmology output parameters for a cosmology splice.
         """
 
-        mylog.info("Writing redshift output list to %s.", filename)
+        ytLogger.info("Writing redshift output list to %s.", filename)
         f = open(filename, "w")
         for output in outputs:
             f.write(f"{1.0 / (1.0 + output['redshift']):f}\n")

--- a/yt/frontends/gadget_fof/data_structures.py
+++ b/yt/frontends/gadget_fof/data_structures.py
@@ -15,7 +15,7 @@ from yt.frontends.halo_catalog.data_structures import HaloCatalogFile
 from yt.funcs import only_on_root, setdefaultattr
 from yt.geometry.particle_geometry_handler import ParticleIndex
 from yt.utilities.cosmology import Cosmology
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 from yt.utilities.on_demand_imports import _h5py as h5py
 
 
@@ -235,7 +235,7 @@ class GadgetFOFDataset(ParticleDataset):
     def _set_code_unit_attributes(self):
         # Set a sane default for cosmological simulations.
         if self._unit_base is None and self.cosmological_simulation == 1:
-            only_on_root(mylog.info, "Assuming length units are in Mpc/h (comoving)")
+            only_on_root(ytLogger.info, "Assuming length units are in Mpc/h (comoving)")
             self._unit_base = dict(length=(1.0, "Mpccm/h"))
         # The other same defaults we will use from the standard Gadget
         # defaults.
@@ -643,7 +643,7 @@ class GadgetFOFHaloContainer(YTSelectionContainer):
             )
             parent_subhalos = my_data["GroupNsubs"][0]
 
-            mylog.debug(
+            ytLogger.debug(
                 "Subhalo %d is subgroup %s of %d in group %d.",
                 self.particle_identifier,
                 self.subgroup_identifier,

--- a/yt/frontends/gadget_fof/io.py
+++ b/yt/frontends/gadget_fof/io.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 
 import numpy as np
 
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 from yt.utilities.exceptions import YTDomainOverflow
 from yt.utilities.io_handler import BaseIOHandler
 from yt.utilities.lib.geometry_utils import compute_morton
@@ -124,7 +124,7 @@ class IOHandlerGadgetFOFHDF5(BaseIOHandler):
         morton = np.empty(pcount, dtype="uint64")
         if pcount == 0:
             return morton
-        mylog.debug(
+        ytLogger.debug(
             "Initializing index % 5i (% 7i particles)", data_file.file_id, pcount
         )
         ind = 0
@@ -378,7 +378,7 @@ def subfind_field_list(fh, ptype, pcount):
                     fields.append(("Group", fname))
                 offset_fields.append(fname)
             else:
-                mylog.warning(
+                ytLogger.warning(
                     "Cannot add field (%s, %s) with size %d.",
                     ptype,
                     fh[field].name,

--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from yt.data_objects.index_subobjects.grid_patch import AMRGridPatch
 from yt.data_objects.static_output import Dataset
-from yt.funcs import mylog, setdefaultattr
+from yt.funcs import setdefaultattr, ytLogger
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.utilities.file_handler import HDF5FileHandler
 
@@ -137,7 +137,7 @@ class GAMERHierarchy(GridIndex):
 
     # for _debug mode only
     def _validate_parent_children_relationship(self):
-        mylog.info("Validating the parent-children relationship ...")
+        ytLogger.info("Validating the parent-children relationship ...")
 
         father_list = self._handle["Tree/Father"][()]
 
@@ -199,7 +199,7 @@ class GAMERHierarchy(GridIndex):
                     if not grid.RightEdge[d] >= c.RightEdge[d]:
                         raise ValueError(msgR)
 
-        mylog.info("Check passed")
+        ytLogger.info("Check passed")
 
 
 class GAMERDataset(Dataset):
@@ -269,7 +269,7 @@ class GAMERDataset(Dataset):
 
         else:
             if len(self.units_override) == 0:
-                mylog.warning(
+                ytLogger.warning(
                     "Cannot determine code units ==> "
                     "Use units_override to specify the units"
                 )
@@ -283,7 +283,7 @@ class GAMERDataset(Dataset):
                 setdefaultattr(self, f"{unit}_unit", self.quan(value, cgs))
 
                 if len(self.units_override) == 0:
-                    mylog.warning("Assuming %8s unit = %f %s", unit, value, cgs)
+                    ytLogger.warning("Assuming %8s unit = %f %s", unit, value, cgs)
 
     def _parse_parameter_file(self):
 

--- a/yt/frontends/gamer/io.py
+++ b/yt/frontends/gamer/io.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from yt.geometry.selection_routines import AlwaysSelector
 from yt.utilities.io_handler import BaseIOHandler
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 
 # -----------------------------------------------------------------------------
 # GAMER shares a similar HDF5 format, and thus io.py as well, with FLASH
@@ -102,7 +102,7 @@ class IOHandlerGAMER(BaseIOHandler):
             rv[field] = np.empty(size, dtype=self._field_dtype)
 
         ng = sum(len(c.objs) for c in chunks)  # c.objs is a list of grids
-        mylog.debug(
+        ytLogger.debug(
             "Reading %s cells of %s fields in %s grids",
             size,
             [f2 for f1, f2 in fields],

--- a/yt/frontends/gdf/data_structures.py
+++ b/yt/frontends/gdf/data_structures.py
@@ -12,7 +12,7 @@ from yt.units.unit_object import Unit
 from yt.units.unit_systems import unit_system_registry
 from yt.utilities.exceptions import YTGDFUnknownGeometry
 from yt.utilities.lib.misc_utilities import get_box_grids_level
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 from yt.utilities.on_demand_imports import _h5py as h5py
 
 from .fields import GDFFieldInfo
@@ -220,7 +220,7 @@ class GDFDataset(Dataset):
                 setdefaultattr(self, unit_name, self.quan(value, unit))
                 if unit_name in h5f["/field_types"]:
                     if unit_name in self.field_units:
-                        mylog.warning(
+                        ytLogger.warning(
                             "'field_units' was overridden by 'dataset_units/%s'",
                             unit_name,
                         )

--- a/yt/frontends/gdf/io.py
+++ b/yt/frontends/gdf/io.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 from yt.geometry.selection_routines import GridSelector
 from yt.utilities.io_handler import BaseIOHandler
 from yt.utilities.on_demand_imports import _h5py as h5py
@@ -51,7 +51,7 @@ class IOHandlerGDFHDF5(BaseIOHandler):
             # check the dtype instead
             rv[field] = np.empty(fsize, dtype="float64")
         ngrids = sum(len(chunk.objs) for chunk in chunks)
-        mylog.debug(
+        ytLogger.debug(
             "Reading %s cells of %s fields in %s blocks",
             size,
             [fn for ft, fn in fields],

--- a/yt/frontends/http_stream/io.py
+++ b/yt/frontends/http_stream/io.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from yt.funcs import get_requests, mylog
+from yt.funcs import get_requests, ytLogger
 from yt.utilities.io_handler import BaseIOHandler
 from yt.utilities.lib.geometry_utils import compute_morton
 
@@ -21,7 +21,7 @@ class IOHandlerHTTPStream(BaseIOHandler):
         # This does not actually stream yet!
         ftype, fname = field
         s = f"{self._url}/{data_file.file_id}/{ftype}/{fname}"
-        mylog.info("Loading URL %s", s)
+        ytLogger.info("Loading URL %s", s)
         requests = get_requests()
         resp = requests.get(s)
         if resp.status_code != 200:

--- a/yt/frontends/moab/io.py
+++ b/yt/frontends/moab/io.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 from yt.utilities.io_handler import BaseIOHandler
 
 
@@ -25,7 +25,7 @@ class IOHandlerMoabH5MHex8(BaseIOHandler):
             ftype, fname = field
             rv[field] = np.empty(size, dtype=fhandle[field_dname(fname)].dtype)
         ngrids = sum(len(chunk.objs) for chunk in chunks)
-        mylog.debug(
+        ytLogger.debug(
             "Reading %s cells of %s fields in %s blocks",
             size,
             [fname for ft, fn in fields],
@@ -52,7 +52,7 @@ class IOHandlerMoabPyneHex8(BaseIOHandler):
         for field in fields:
             rv[field] = np.empty(size, dtype="float64")
         ngrids = sum(len(chunk.objs) for chunk in chunks)
-        mylog.debug(
+        ytLogger.debug(
             "Reading %s cells of %s fields in %s blocks",
             size,
             [fname for ftype, fname in fields],

--- a/yt/frontends/nc4_cm1/data_structures.py
+++ b/yt/frontends/nc4_cm1/data_structures.py
@@ -9,7 +9,7 @@ from yt.data_objects.index_subobjects.grid_patch import AMRGridPatch
 from yt.data_objects.static_output import Dataset
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.utilities.file_handler import NetCDF4FileHandler, warn_netcdf
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 
 from .fields import CM1FieldInfo
 
@@ -193,7 +193,7 @@ class CM1Dataset(Dataset):
                         failed_vars.append(var)
 
                 if failed_vars:
-                    mylog.warning(
+                    ytLogger.warning(
                         "Trying to load a cm1_lofs netcdf file but the "
                         "coordinates of the following fields do not match the "
                         f"coordinates of the dataset: {failed_vars}"
@@ -202,7 +202,7 @@ class CM1Dataset(Dataset):
 
             if not is_cm1_lofs:
                 if is_cm1:
-                    mylog.warning(
+                    ytLogger.warning(
                         "It looks like you are trying to load a cm1 netcdf file, "
                         "but at present yt only supports cm1_lofs output. Until"
                         " support is added, you can likely use"

--- a/yt/frontends/open_pmd/data_structures.py
+++ b/yt/frontends/open_pmd/data_structures.py
@@ -14,7 +14,7 @@ from yt.frontends.open_pmd.misc import get_component, is_const_component
 from yt.funcs import setdefaultattr
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.utilities.file_handler import HDF5FileHandler, warn_h5py
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 from yt.utilities.on_demand_imports import _h5py as h5py
 
 ompd_known_versions = [
@@ -469,7 +469,7 @@ class OpenPMDDataset(Dataset):
             if len(particles) > 1:
                 # Only use on-disk particle names if there is more than one species
                 self.particle_types = particles
-            mylog.debug("self.particle_types: %s", self.particle_types)
+            ytLogger.debug("self.particle_types: %s", self.particle_types)
             self.particle_types_raw = self.particle_types
             self.particle_types = tuple(self.particle_types)
         except (KeyError, TypeError, AttributeError):
@@ -490,24 +490,24 @@ class OpenPMDDataset(Dataset):
         encoding = handle.attrs["iterationEncoding"].decode()
         if "groupBased" in encoding:
             iterations = list(handle["/data"].keys())
-            mylog.info("Found %s iterations in file", len(iterations))
+            ytLogger.info("Found %s iterations in file", len(iterations))
         elif "fileBased" in encoding:
             itformat = handle.attrs["iterationFormat"].decode().split("/")[-1]
             regex = "^" + itformat.replace("%T", "[0-9]+") + "$"
             if path == "":
-                mylog.warning(
+                ytLogger.warning(
                     "For file based iterations, please use absolute file paths!"
                 )
                 pass
             for filename in listdir(path):
                 if match(regex, filename):
                     iterations.append(filename)
-            mylog.info("Found %s iterations in directory", len(iterations))
+            ytLogger.info("Found %s iterations in directory", len(iterations))
 
         if len(iterations) == 0:
-            mylog.warning("No iterations found!")
+            ytLogger.warning("No iterations found!")
         if "groupBased" in encoding and len(iterations) > 1:
-            mylog.warning("Only chose to load one iteration (%s)", iteration)
+            ytLogger.warning("Only chose to load one iteration (%s)", iteration)
 
         self.base_path = f"/data/{iteration}/"
         try:
@@ -515,7 +515,7 @@ class OpenPMDDataset(Dataset):
             handle[self.base_path + self.meshes_path]
         except (KeyError):
             if self.standard_version <= StrictVersion("1.1.0"):
-                mylog.info(
+                ytLogger.info(
                     "meshesPath not present in file. "
                     "Assuming file contains no meshes and has a domain extent of 1m^3!"
                 )
@@ -527,7 +527,7 @@ class OpenPMDDataset(Dataset):
             handle[self.base_path + self.particles_path]
         except (KeyError):
             if self.standard_version <= StrictVersion("1.1.0"):
-                mylog.info(
+                ytLogger.info(
                     "particlesPath not present in file."
                     " Assuming file contains no particles!"
                 )

--- a/yt/frontends/open_pmd/fields.py
+++ b/yt/frontends/open_pmd/fields.py
@@ -4,7 +4,7 @@ from yt.fields.field_info_container import FieldInfoContainer
 from yt.fields.magnetic_field import setup_magnetic_field_aliases
 from yt.frontends.open_pmd.misc import is_const_component, parse_unit_dimension
 from yt.units.yt_array import YTQuantity
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 from yt.utilities.on_demand_imports import _h5py as h5py
 from yt.utilities.physical_constants import mu_0, speed_of_light
 
@@ -179,7 +179,7 @@ class OpenPMDFieldInfo(FieldInfoContainer):
                             self._mag_fields.append(ytname)
                         self.known_other_fields += ((ytname, (unit, aliases, None)),)
             for i in self.known_other_fields:
-                mylog.debug("open_pmd - known_other_fields - %s", i)
+                ytLogger.debug("open_pmd - known_other_fields - %s", i)
         except (KeyError, TypeError, AttributeError):
             pass
 
@@ -215,14 +215,14 @@ class OpenPMDFieldInfo(FieldInfoContainer):
                                 )
                     except (KeyError):
                         if recname != "particlePatches":
-                            mylog.info(
+                            ytLogger.info(
                                 "open_pmd - %s_%s does not seem to have "
                                 "unitDimension",
                                 pname,
                                 recname,
                             )
             for i in self.known_particle_fields:
-                mylog.debug("open_pmd - known_particle_fields - %s", i)
+                ytLogger.debug("open_pmd - known_particle_fields - %s", i)
         except (KeyError, TypeError, AttributeError):
             pass
 

--- a/yt/frontends/open_pmd/misc.py
+++ b/yt/frontends/open_pmd/misc.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 
 
 def parse_unit_dimension(unit_dimension):
@@ -41,7 +41,7 @@ def parse_unit_dimension(unit_dimension):
     'kg**1*s**-2*A**-1'
     """
     if len(unit_dimension) != 7:
-        mylog.error("SI must have 7 base dimensions!")
+        ytLogger.error("SI must have 7 base dimensions!")
     unit_dimension = np.asarray(unit_dimension, dtype=np.int)
     dim = []
     si = ["m", "kg", "s", "A", "C", "mol", "cd"]

--- a/yt/frontends/owls/fields.py
+++ b/yt/frontends/owls/fields.py
@@ -8,7 +8,7 @@ from yt.fields.species_fields import (
     add_species_field_by_fraction,
 )
 from yt.frontends.sph.fields import SPHFieldInfo
-from yt.funcs import download_file, mylog
+from yt.funcs import download_file, ytLogger
 
 from . import owls_ion_tables as oit
 
@@ -341,7 +341,7 @@ class OWLSFieldInfo(SPHFieldInfo):
         owls_ion_path = os.path.join(data_dir, "owls_ion_data")
 
         if not os.path.exists(owls_ion_path):
-            mylog.info(txt, data_url, data_dir)
+            ytLogger.info(txt, data_url, data_dir)
             fname = data_dir + "/" + data_file
             download_file(os.path.join(data_url, data_file), fname)
 

--- a/yt/frontends/owls_subfind/data_structures.py
+++ b/yt/frontends/owls_subfind/data_structures.py
@@ -9,7 +9,7 @@ from yt.frontends.gadget.data_structures import _fix_unit_ordering
 from yt.funcs import only_on_root, setdefaultattr
 from yt.geometry.particle_geometry_handler import ParticleIndex
 from yt.utilities.exceptions import YTException
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 from yt.utilities.on_demand_imports import _h5py as h5py
 
 from .fields import OWLSSubfindFieldInfo
@@ -146,7 +146,7 @@ class OWLSSubfindDataset(ParticleDataset):
     def _set_code_unit_attributes(self):
         # Set a sane default for cosmological simulations.
         if self._unit_base is None and self.cosmological_simulation == 1:
-            only_on_root(mylog.info, "Assuming length units are in Mpc/h (comoving)")
+            only_on_root(ytLogger.info, "Assuming length units are in Mpc/h (comoving)")
             self._unit_base = dict(length=(1.0, "Mpccm/h"))
         # The other same defaults we will use from the standard Gadget
         # defaults.

--- a/yt/frontends/owls_subfind/io.py
+++ b/yt/frontends/owls_subfind/io.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 from yt.utilities.exceptions import YTDomainOverflow
 from yt.utilities.io_handler import BaseIOHandler
 from yt.utilities.lib.geometry_utils import compute_morton
@@ -108,7 +108,7 @@ class IOHandlerOWLSSubfindHDF5(BaseIOHandler):
         morton = np.empty(pcount, dtype="uint64")
         if pcount == 0:
             return morton
-        mylog.debug(
+        ytLogger.debug(
             "Initializing index % 5i (% 7i particles)", data_file.file_id, pcount
         )
         ind = 0
@@ -220,7 +220,7 @@ def subfind_field_list(fh, ptype, pcount):
                     fields.append(("FOF", fname))
                 offset_fields.append(fname)
             else:
-                mylog.warning(
+                ytLogger.warning(
                     "Cannot add field (%s, %s) with size %d.",
                     ptype,
                     fh[field].name,

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -9,7 +9,7 @@ from yt.arraytypes import blankRecordArray
 from yt.data_objects.index_subobjects.octree_subset import OctreeSubset
 from yt.data_objects.particle_filters import add_particle_filter
 from yt.data_objects.static_output import Dataset
-from yt.funcs import mylog, setdefaultattr
+from yt.funcs import setdefaultattr, ytLogger
 from yt.geometry.geometry_handler import YTDataChunk
 from yt.geometry.oct_container import RAMSESOctreeContainer
 from yt.geometry.oct_geometry_handler import OctreeIndex
@@ -144,7 +144,9 @@ class RAMSESDomainFile:
         field_handlers = [FH(self) for FH in get_field_handlers() if FH.any_exist(ds)]
         self.field_handlers = field_handlers
         for fh in field_handlers:
-            mylog.debug("Detected fluid type %s in domain_id=%s", fh.ftype, domain_id)
+            ytLogger.debug(
+                "Detected fluid type %s in domain_id=%s", fh.ftype, domain_id
+            )
             fh.detect_fields(ds)
             # self._add_ftype(fh.ftype)
 
@@ -154,7 +156,7 @@ class RAMSESDomainFile:
         ]
         self.particle_handlers = particle_handlers
         for ph in particle_handlers:
-            mylog.debug(
+            ytLogger.debug(
                 "Detected particle type %s in domain_id=%s", ph.ptype, domain_id
             )
             ph.read_header()
@@ -245,7 +247,7 @@ class RAMSESDomainFile:
         )
         root_nodes = self.amr_header["numbl"][self.ds.min_level, :].sum()
         self.oct_handler.allocate_domains(self.total_oct_count, root_nodes)
-        mylog.debug(
+        ytLogger.debug(
             "Reading domain AMR % 4i (%0.3e, %0.3e)",
             self.domain_id,
             self.total_oct_count.sum(),
@@ -295,7 +297,7 @@ class RAMSESDomainSubset(OctreeSubset):
 
         if num_ghost_zones > 0:
             if not all(ds.periodicity):
-                mylog.warning(
+                ytLogger.warning(
                     "Ghost zones will wrongly assume the domain to be periodic."
                 )
             # Create a base domain *with no self._base_domain.fwidth
@@ -442,7 +444,7 @@ class RAMSESDomainSubset(OctreeSubset):
 
     def retrieve_ghost_zones(self, ngz, fields, smoothed=False):
         if smoothed:
-            mylog.warning(
+            ytLogger.warning(
                 f"{self}.retrieve_ghost_zones was called with the "
                 f"`smoothed` argument set to True. This is not supported, "
                 "ignoring it."
@@ -453,7 +455,7 @@ class RAMSESDomainSubset(OctreeSubset):
 
         try:
             new_subset = _subset_with_gz[ngz]
-            mylog.debug(
+            ytLogger.debug(
                 "Reusing previous subset with %s ghost zones for domain %s",
                 ngz,
                 self.domain_id,
@@ -532,7 +534,7 @@ class RAMSESIndex(OctreeIndex):
             domains = [dom for dom in self.domains if dom.included(dobj.selector)]
             base_region = getattr(dobj, "base_region", dobj)
             if len(domains) > 1:
-                mylog.debug("Identified %s intersecting domains", len(domains))
+                ytLogger.debug("Identified %s intersecting domains", len(domains))
             subsets = [
                 RAMSESDomainSubset(
                     base_region,
@@ -781,7 +783,7 @@ class RAMSESDataset(Dataset):
                 )
 
             for k in particle_families.keys():
-                mylog.info("Adding particle_type: %s", k)
+                ytLogger.info("Adding particle_type: %s", k)
                 self.add_particle_filter(f"{k}")
 
     def __repr__(self):
@@ -928,7 +930,7 @@ class RAMSESDataset(Dataset):
                     / self.parameters["unit_t"]
                 )
             except IndexError:
-                mylog.warning(
+                ytLogger.warning(
                     "Yt could not convert conformal time to physical time. "
                     "Yt will assume the simulation is *not* cosmological."
                 )
@@ -951,7 +953,7 @@ class RAMSESDataset(Dataset):
             except ImportError as e:
                 nml = f"An error occurred when reading the namelist: {str(e)}"
             except (ValueError, StopIteration) as e:
-                mylog.warning(
+                ytLogger.warning(
                     "Could not parse `namelist.txt` file as it was malformed: %s", e
                 )
                 return

--- a/yt/frontends/ramses/definitions.py
+++ b/yt/frontends/ramses/definitions.py
@@ -2,7 +2,7 @@
 import re
 
 from yt.config import ytcfg
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 
 
 def ramses_header(hvals):
@@ -73,7 +73,7 @@ if ytcfg.has_section("ramses-families"):
     for key in particle_families.keys():
         val = ytcfg.get("ramses-families", key, fallback=None)
         if val is not None:
-            mylog.info(
+            ytLogger.info(
                 "Changing family %s from %s to %s", key, particle_families[key], val
             )
             particle_families[key] = val

--- a/yt/frontends/ramses/field_handlers.py
+++ b/yt/frontends/ramses/field_handlers.py
@@ -3,7 +3,7 @@ import glob
 import os
 
 from yt.config import ytcfg
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 from yt.utilities.cython_fortran_utils import FortranFile
 
 from .io import _read_fluid_file_descriptor
@@ -310,7 +310,7 @@ class HydroFieldFileHandler(FieldFileHandler):
             ok = True
         elif os.path.exists(fname_desc):
             # Or there is an hydro file descriptor
-            mylog.debug("Reading hydro file descriptor.")
+            ytLogger.debug("Reading hydro file descriptor.")
             # For now, we can only read double precision fields
             fields = [e[0] for e in _read_fluid_file_descriptor(fname_desc)]
 
@@ -333,7 +333,7 @@ class HydroFieldFileHandler(FieldFileHandler):
             rt_flag = any(glob.glob(os.sep.join([foldername, "info_rt_*.txt"])))
             if rt_flag:  # rt run
                 if nvar < 10:
-                    mylog.info("Detected RAMSES-RT file WITHOUT IR trapping.")
+                    ytLogger.info("Detected RAMSES-RT file WITHOUT IR trapping.")
 
                     fields = [
                         "Density",
@@ -347,7 +347,7 @@ class HydroFieldFileHandler(FieldFileHandler):
                         "HeIII",
                     ]
                 else:
-                    mylog.info("Detected RAMSES-RT file WITH IR trapping.")
+                    ytLogger.info("Detected RAMSES-RT file WITH IR trapping.")
 
                     fields = [
                         "Density",
@@ -363,7 +363,7 @@ class HydroFieldFileHandler(FieldFileHandler):
                     ]
             else:
                 if nvar < 5:
-                    mylog.debug(
+                    ytLogger.debug(
                         "nvar=%s is too small! YT doesn't currently "
                         "support 1D/2D runs in RAMSES %s"
                     )
@@ -417,7 +417,7 @@ class HydroFieldFileHandler(FieldFileHandler):
                         "Pressure",
                         "Metallicity",
                     ]
-            mylog.debug(
+            ytLogger.debug(
                 "No fields specified by user; automatically setting fields array to %s",
                 fields,
             )
@@ -428,7 +428,7 @@ class HydroFieldFileHandler(FieldFileHandler):
             fields.append("var" + str(len(fields)))
             count_extra += 1
         if count_extra > 0:
-            mylog.debug("Detected %s extra fluid fields.", count_extra)
+            ytLogger.debug("Detected %s extra fluid fields.", count_extra)
         cls.field_list = [(cls.ftype, e) for e in fields]
 
         cls.set_detected_fields(ds, fields)
@@ -467,7 +467,7 @@ class GravFieldFileHandler(FieldFileHandler):
         ndetected = len(fields)
 
         if ndetected != nvar and not ds._warned_extra_fields["gravity"]:
-            mylog.warning("Detected %s extra gravity fields.", nvar - ndetected)
+            ytLogger.warning("Detected %s extra gravity fields.", nvar - ndetected)
             ds._warned_extra_fields["gravity"] = True
 
             for i in range(nvar - ndetected):
@@ -534,7 +534,7 @@ class RTFieldFileHandler(FieldFileHandler):
                 read_rhs(float)
 
             # Touchy part, we have to read the photon group properties
-            mylog.debug("Not reading photon group properties")
+            ytLogger.debug("Not reading photon group properties")
 
             cls.rt_parameters = rheader
 

--- a/yt/frontends/ramses/fields.py
+++ b/yt/frontends/ramses/fields.py
@@ -7,7 +7,7 @@ from yt.fields.field_info_container import FieldInfoContainer
 from yt.frontends.ramses.io import convert_ramses_ages
 from yt.utilities.cython_fortran_utils import FortranFile
 from yt.utilities.linear_interpolators import BilinearFieldInterpolator
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 from yt.utilities.physical_constants import (
     boltzmann_constant_cgs,
     mass_hydrogen_cgs,
@@ -307,7 +307,7 @@ class RAMSESFieldInfo(FieldInfoContainer):
         )
 
         if not os.path.exists(filename):
-            mylog.warning("This output has no cooling fields")
+            ytLogger.warning("This output has no cooling fields")
             return
 
         # Function to create the cooling fields
@@ -345,7 +345,7 @@ class RAMSESFieldInfo(FieldInfoContainer):
                 if var.size == n1 and i == 0:
                     # If this case occurs, the cooling files were produced pre-2010 in
                     # a format that is no longer supported
-                    mylog.warning(
+                    ytLogger.warning(
                         "This cooling file format is no longer supported. "
                         "Cooling field loading skipped."
                     )

--- a/yt/frontends/ramses/io.py
+++ b/yt/frontends/ramses/io.py
@@ -9,7 +9,7 @@ from yt.utilities.exceptions import (
     YTParticleOutputFormatNotImplemented,
 )
 from yt.utilities.io_handler import BaseIOHandler
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 from yt.utilities.physical_ratios import cm_per_km, cm_per_mpc
 
 from .definitions import VAR_DESC_RE, VERSION_RE
@@ -115,7 +115,7 @@ class IOHandlerRAMSES(BaseIOHandler):
                         rv = subset.fill(fd, field_subs, selector, file_handler)
                     for ft, f in field_subs:
                         d = rv.pop(f)
-                        mylog.debug(
+                        ytLogger.debug(
                             "Filling %s with %s (%0.3e %0.3e) (%s zones)",
                             f,
                             d.size,
@@ -234,7 +234,7 @@ def _read_part_file_descriptor(fname):
     with open(fname) as f:
         line = f.readline()
         tmp = VERSION_RE.match(line)
-        mylog.debug("Reading part file descriptor %s.", fname)
+        ytLogger.debug("Reading part file descriptor %s.", fname)
         if not tmp:
             raise YTParticleOutputFormatNotImplemented()
 
@@ -294,7 +294,7 @@ def _read_fluid_file_descriptor(fname):
     with open(fname) as f:
         line = f.readline()
         tmp = VERSION_RE.match(line)
-        mylog.debug("Reading fluid file descriptor %s.", fname)
+        ytLogger.debug("Reading fluid file descriptor %s.", fname)
         if not tmp:
             return []
 
@@ -320,7 +320,7 @@ def _read_fluid_file_descriptor(fname):
 
                 fields.append((varname, dtype))
         else:
-            mylog.error("Version %s", version)
+            ytLogger.error("Version %s", version)
             raise YTParticleOutputFormatNotImplemented()
 
     return fields

--- a/yt/frontends/ramses/particle_handlers.py
+++ b/yt/frontends/ramses/particle_handlers.py
@@ -2,7 +2,7 @@ import abc
 import os
 
 from yt.config import ytcfg
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 from yt.utilities.cython_fortran_utils import FortranFile
 
 from .field_handlers import HandlerMixin
@@ -179,7 +179,7 @@ class DefaultParticleFileHandler(ParticleFileHandler):
         fd.close()
 
         if iextra > 0 and not self.ds._warned_extra_fields["io"]:
-            mylog.warning(
+            ytLogger.warning(
                 "Detected %s extra particle fields assuming kind "
                 "`double`. Consider using the `extra_particle_fields` "
                 "keyword argument if you have unexpected behavior.",

--- a/yt/frontends/rockstar/io.py
+++ b/yt/frontends/rockstar/io.py
@@ -2,7 +2,7 @@ import os
 
 import numpy as np
 
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 from yt.utilities.exceptions import YTDomainOverflow
 from yt.utilities.io_handler import BaseIOHandler
 from yt.utilities.lib.geometry_utils import compute_morton
@@ -83,7 +83,7 @@ class IOHandlerRockstarBinary(BaseIOHandler):
     def _initialize_index(self, data_file, regions):
         pcount = data_file.header["num_halos"]
         morton = np.empty(pcount, dtype="uint64")
-        mylog.debug(
+        ytLogger.debug(
             "Initializing index % 5i (% 7i particles)", data_file.file_id, pcount
         )
         if pcount == 0:

--- a/yt/frontends/sdf/data_structures.py
+++ b/yt/frontends/sdf/data_structures.py
@@ -6,7 +6,7 @@ import numpy as np
 from yt.data_objects.static_output import ParticleDataset, ParticleFile
 from yt.funcs import get_requests, setdefaultattr
 from yt.geometry.particle_geometry_handler import ParticleIndex
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 from yt.utilities.sdf import HTTPSDFRead, SDFIndex, SDFRead
 
 from .fields import SDFFieldInfo
@@ -138,7 +138,7 @@ class SDFDataset(ParticleDataset):
             self.omega_matter += self.parameters["Omega0_r"]
         self.hubble_constant = self.parameters["h_100"]
         self.current_time = units_2HOT_v2_time * self.parameters.get("tpos", 0.0)
-        mylog.info("Calculating time to be %0.3e seconds", self.current_time)
+        ytLogger.info("Calculating time to be %0.3e seconds", self.current_time)
         self.filename_template = self.parameter_filename
         self.file_count = 1
 

--- a/yt/frontends/sdf/io.py
+++ b/yt/frontends/sdf/io.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 from yt.utilities.exceptions import YTDomainOverflow
 from yt.utilities.io_handler import BaseIOHandler
 from yt.utilities.lib.geometry_utils import compute_morton
@@ -89,7 +89,7 @@ class IOHandlerSDF(BaseIOHandler):
     def _count_particles(self, data_file):
         pcount = self._handle["x"].size
         if pcount > 1e9:
-            mylog.warning(
+            ytLogger.warning(
                 "About to load %i particles into memory. "
                 "You may want to consider a midx-enabled load",
                 pcount,
@@ -234,7 +234,7 @@ class IOHandlerSIndexSDF(IOHandlerSDF):
         dre = self.ds.domain_right_edge.in_units("code_length").d
         pcount_estimate = self.ds.midx.get_nparticles_bbox(dle, dre)
         if pcount_estimate > 1e9:
-            mylog.warning(
+            ytLogger.warning(
                 "Filtering %i particles to find total. "
                 "You may want to reconsider your bounding box.",
                 pcount_estimate,

--- a/yt/frontends/sph/data_structures.py
+++ b/yt/frontends/sph/data_structures.py
@@ -3,7 +3,7 @@ import os
 import numpy as np
 
 from yt.data_objects.static_output import ParticleDataset
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 from yt.geometry.particle_geometry_handler import ParticleIndex
 
 
@@ -93,10 +93,10 @@ class SPHParticleIndex(ParticleIndex):
 
         if fname is not None:
             if os.path.exists(fname):
-                mylog.info("Loading KDTree from %s", os.path.basename(fname))
+                ytLogger.info("Loading KDTree from %s", os.path.basename(fname))
                 kdtree = PyKDTree.from_file(fname)
                 if kdtree.data_version != self.ds._file_hash:
-                    mylog.info("Detected hash mismatch, regenerating KDTree")
+                    ytLogger.info("Detected hash mismatch, regenerating KDTree")
                 else:
                     self._kdtree = kdtree
                     return
@@ -110,7 +110,7 @@ class SPHParticleIndex(ParticleIndex):
             self._kdtree = None
             return
         positions = np.concatenate(positions)
-        mylog.info("Allocating KDTree for %s particles", positions.shape[0])
+        ytLogger.info("Allocating KDTree for %s particles", positions.shape[0])
         self._kdtree = PyKDTree(
             positions.astype("float64"),
             left_edge=self.ds.domain_left_edge,

--- a/yt/frontends/stream/definitions.py
+++ b/yt/frontends/stream/definitions.py
@@ -9,7 +9,7 @@ from yt.utilities.exceptions import (
     YTInconsistentGridFieldShapeGridDims,
     YTInconsistentParticleFieldShape,
 )
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 
 from .fields import StreamFieldInfo
 
@@ -30,7 +30,7 @@ def assign_particle_data(ds, pdata, bbox):
                     continue
                 if f == "number_of_particles":
                     continue
-                mylog.debug("Reassigning '%s' to ('%s','%s')", f, ptype, f)
+                ytLogger.debug("Reassigning '%s' to ('%s','%s')", f, ptype, f)
                 pdata_ftype[ptype, f] = pdata.pop(f)
             pdata_ftype.update(pdata)
             pdata = pdata_ftype
@@ -95,7 +95,7 @@ def assign_particle_data(ds, pdata, bbox):
                     [min(bbox[1, 0], s[1, 0]), max(bbox[1, 1], s[1, 1])],
                     [min(bbox[2, 0], s[2, 0]), max(bbox[2, 1], s[2, 1])],
                 ]
-                mylog.warning(
+                ytLogger.warning(
                     "Discarding %s particles (out of %s) that are outside "
                     "bounding box. Set bbox=%s to avoid this in the future.",
                     num_unassigned,

--- a/yt/frontends/stream/io.py
+++ b/yt/frontends/stream/io.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from yt.utilities.exceptions import YTDomainOverflow
 from yt.utilities.io_handler import BaseIOHandler
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 
 
 class IOHandlerStream(BaseIOHandler):
@@ -33,7 +33,7 @@ class IOHandlerStream(BaseIOHandler):
             rv[field] = self.ds.arr(np.empty(size, dtype="float64"))
 
         ng = sum(len(c.objs) for c in chunks)
-        mylog.debug(
+        ytLogger.debug(
             "Reading %s cells of %s fields in %s blocks",
             size,
             [f2 for f1, f2 in fields],
@@ -223,7 +223,7 @@ class IOHandlerStreamHexahedral(BaseIOHandler):
             ftype, fname = field
             rv[field] = np.empty(size, dtype="float64")
         ngrids = sum(len(chunk.objs) for chunk in chunks)
-        mylog.debug(
+        ytLogger.debug(
             "Reading %s cells of %s fields in %s blocks",
             size,
             [fn for ft, fn in fields],

--- a/yt/frontends/swift/data_structures.py
+++ b/yt/frontends/swift/data_structures.py
@@ -6,7 +6,7 @@ from yt.data_objects.static_output import ParticleFile
 from yt.frontends.sph.data_structures import SPHDataset, SPHParticleIndex
 from yt.frontends.sph.fields import SPHFieldInfo
 from yt.funcs import only_on_root
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 from yt.utilities.on_demand_imports import _h5py as h5py
 
 
@@ -42,13 +42,13 @@ class SwiftDataset(SPHDataset):
 
         if self.cosmological_simulation == 1:
             msg = "Assuming length units are in comoving centimetres"
-            only_on_root(mylog.info, msg)
+            only_on_root(ytLogger.info, msg)
             self.length_unit = self.quan(
                 float(units["Unit length in cgs (U_L)"]), "cmcm"
             )
         else:
             msg = "Assuming length units are in physical centimetres"
-            only_on_root(mylog.info, msg)
+            only_on_root(ytLogger.info, msg)
             self.length_unit = self.quan(float(units["Unit length in cgs (U_L)"]), "cm")
 
         self.mass_unit = self.quan(float(units["Unit mass in cgs (U_M)"]), "g")
@@ -126,12 +126,12 @@ class SwiftDataset(SPHDataset):
                 # This is "little h"
                 self.hubble_constant = float(parameters["Cosmology:h"])
             except KeyError:
-                mylog.warning(
+                ytLogger.warning(
                     "Could not find cosmology information in Parameters, "
                     "despite having ran with -c signifying a cosmological "
                     "run."
                 )
-                mylog.info("Setting up as a non-cosmological run. Check this!")
+                ytLogger.info("Setting up as a non-cosmological run. Check this!")
                 self.cosmological_simulation = 0
                 self.current_redshift = 0.0
                 self.omega_lambda = 0.0

--- a/yt/frontends/tipsy/io.py
+++ b/yt/frontends/tipsy/io.py
@@ -8,7 +8,7 @@ from numpy.lib.recfunctions import append_fields
 from yt.frontends.sph.io import IOHandlerSPH
 from yt.frontends.tipsy.definitions import npart_mapping
 from yt.utilities.lib.particle_kdtree_tools import generate_smoothing_length
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 
 
 class IOHandlerTipsyBinary(IOHandlerSPH):
@@ -60,7 +60,7 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
             size = mask.sum()
         rv = {}
         for field in fields:
-            mylog.debug("Allocating %s values for %s", size, field)
+            ytLogger.debug("Allocating %s values for %s", size, field)
             if field in self._vector_fields:
                 rv[field] = np.empty((size, 3), dtype="float64")
                 if size == 0:
@@ -312,7 +312,7 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
                 for axi, ax in enumerate("xyz"):
                     mi = pp["Coordinates"][ax].min()
                     ma = pp["Coordinates"][ax].max()
-                    mylog.debug("Spanning: %0.3e .. %0.3e in %s", mi, ma, ax)
+                    ytLogger.debug("Spanning: %0.3e .. %0.3e in %s", mi, ma, ax)
                     mis[axi] = mi
                     mas[axi] = ma
                 pos = np.empty((pp.size, 3), dtype="float64")

--- a/yt/frontends/ytdata/data_structures.py
+++ b/yt/frontends/ytdata/data_structures.py
@@ -21,7 +21,7 @@ from yt.units import dimensions
 from yt.units.unit_registry import UnitRegistry
 from yt.units.yt_array import YTQuantity, uconcatenate
 from yt.utilities.exceptions import GenerationInProgress, YTFieldTypeNotFound
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 from yt.utilities.on_demand_imports import _h5py as h5py
 from yt.utilities.parallel_tools.parallel_analysis_interface import parallel_root_only
 from yt.utilities.tree_container import TreeContainer
@@ -198,11 +198,11 @@ class YTDataset(SavedDataset):
         self.field_info.setup_fluid_index_fields()
 
         if "all" not in self.particle_types:
-            mylog.debug("Creating Particle Union 'all'")
+            ytLogger.debug("Creating Particle Union 'all'")
             pu = ParticleUnion("all", list(self.particle_types_raw))
             self.add_particle_union(pu)
         self.field_info.setup_extra_union_fields()
-        mylog.debug("Loading field plugins.")
+        ytLogger.debug("Loading field plugins.")
         self.field_info.load_all_plugins()
         deps, unloaded = self.field_info.check_derived_fields()
         self.field_dependencies.update(deps)
@@ -283,7 +283,7 @@ class YTDataContainerDataset(YTDataset):
             container_type = self.parameters.get("container_type")
             ex_container_type = ["cutting", "quad_proj", "ray", "slice", "cut_region"]
             if data_type == "yt_light_ray" or container_type in ex_container_type:
-                mylog.info("Returning an all_data data container.")
+                ytLogger.info("Returning an all_data data container.")
                 return self.all_data()
 
             my_obj = getattr(self, self.parameters["container_type"])
@@ -749,7 +749,7 @@ class YTNonspatialDataset(YTGridDataset):
         ]:
             v = getattr(self, a)
             if v is not None:
-                mylog.info("Parameters: %-25s = %s", a, v)
+                ytLogger.info("Parameters: %-25s = %s", a, v)
         if hasattr(self, "cosmological_simulation") and self.cosmological_simulation:
             for a in [
                 "current_redshift",
@@ -759,8 +759,10 @@ class YTNonspatialDataset(YTGridDataset):
             ]:
                 v = getattr(self, a)
                 if v is not None:
-                    mylog.info("Parameters: %-25s = %s", a, v)
-        mylog.warning("Geometric data selection not available for this dataset type.")
+                    ytLogger.info("Parameters: %-25s = %s", a, v)
+        ytLogger.warning(
+            "Geometric data selection not available for this dataset type."
+        )
 
     @classmethod
     def _is_valid(cls, filename, *args, **kwargs):
@@ -866,14 +868,14 @@ class YTProfileDataset(YTNonspatialDataset):
 
     def print_key_parameters(self):
         if is_root():
-            mylog.info("YTProfileDataset")
+            ytLogger.info("YTProfileDataset")
             for a in ["dimensionality", "profile_dimensions"] + [
                 f"{ax}_{attr}"
                 for ax in "xyz"[: self.dimensionality]
                 for attr in ["field", "range", "log"]
             ]:
                 v = getattr(self, a)
-                mylog.info("Parameters: %-25s = %s", a, v)
+                ytLogger.info("Parameters: %-25s = %s", a, v)
         super().print_key_parameters()
 
     @classmethod

--- a/yt/frontends/ytdata/io.py
+++ b/yt/frontends/ytdata/io.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from yt.funcs import mylog, parse_h5_attr
+from yt.funcs import parse_h5_attr, ytLogger
 from yt.geometry.selection_routines import GridSelector
 from yt.units.yt_array import uvstack
 from yt.utilities.exceptions import YTDomainOverflow
@@ -82,7 +82,7 @@ class IOHandlerYTGridHDF5(BaseIOHandler):
             fsize = size
             rv[field] = np.empty(fsize, dtype="float64")
         ng = sum(len(c.objs) for c in chunks)
-        mylog.debug(
+        ytLogger.debug(
             "Reading %s cells of %s fields in %s grids",
             size,
             [f2 for f1, f2 in fields],
@@ -238,7 +238,7 @@ class IOHandlerYTDataContainerHDF5(BaseIOHandler):
         all_count = self._count_particles(data_file)
         pcount = sum(all_count.values())
         morton = np.empty(pcount, dtype="uint64")
-        mylog.debug(
+        ytLogger.debug(
             "Initializing index % 5i (% 7i particles)", data_file.file_id, pcount
         )
         ind = 0
@@ -354,7 +354,7 @@ class IOHandlerYTSpatialPlotHDF5(IOHandlerYTDataContainerHDF5):
         all_count = self._count_particles(data_file)
         pcount = sum(all_count.values())
         morton = np.empty(pcount, dtype="uint64")
-        mylog.debug(
+        ytLogger.debug(
             "Initializing index % 5i (% 7i particles)", data_file.file_id, pcount
         )
         ind = 0

--- a/yt/frontends/ytdata/utilities.py
+++ b/yt/frontends/ytdata/utilities.py
@@ -1,5 +1,5 @@
 from yt.units.yt_array import YTArray
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 from yt.utilities.on_demand_imports import _h5py as h5py
 
 
@@ -65,7 +65,7 @@ def save_as_dataset(ds, filename, data, field_types=None, extra_attrs=None):
 
     """
 
-    mylog.info("Saving field data to yt dataset: %s.", filename)
+    ytLogger.info("Saving field data to yt dataset: %s.", filename)
 
     if extra_attrs is None:
         extra_attrs = {}

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -28,9 +28,23 @@ import numpy as np
 from more_itertools import always_iterable, collapse, first
 from tqdm import tqdm
 
+from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.units import YTArray, YTQuantity
 from yt.utilities.exceptions import YTInvalidWidthError
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
+
+
+def _mylog(*args):
+    issue_deprecation_warning(
+        "yt.funcs.mylog is a deprecated alias for yt.utilities.logger.ytLogger ."
+        "If you are looking to set yt's logger level, please use yt.set_log_level",
+        since="4.0.0",
+        removal="4.2.0",
+    )
+    ytLogger(*args)
+
+
+mylog = _mylog.__call__
 
 # Some functions for handling sequences and other types
 

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -195,7 +195,7 @@ def time_execution(func):
         t1 = time.time()
         res = func(*arg, **kw)
         t2 = time.time()
-        mylog.debug("%s took %0.3f s", func.__name__, (t2 - t1))
+        ytLogger.debug("%s took %0.3f s", func.__name__, (t2 - t1))
         return res
 
     from yt.config import ytcfg
@@ -355,13 +355,13 @@ class ParallelProgressBar:
     # that prints on start/stop
     def __init__(self, title, maxval):
         self.title = title
-        mylog.info("Starting '%s'", title)
+        ytLogger.info("Starting '%s'", title)
 
     def update(self, *args, **kwargs):
         return
 
     def finish(self):
-        mylog.info("Finishing '%s'", self.title)
+        ytLogger.info("Finishing '%s'", self.title)
 
 
 class GUIProgressBar:
@@ -899,7 +899,7 @@ def get_image_suffix(name):
     if suffix in supported_suffixes or suffix == "":
         return suffix
     else:
-        mylog.warning("Unsupported image suffix requested (%s)", suffix)
+        ytLogger.warning("Unsupported image suffix requested (%s)", suffix)
         return ""
 
 
@@ -1085,14 +1085,14 @@ def enable_plugins(plugin_filename=None):
             raise FileNotFoundError("Could not find a global system plugin file.")
 
         if _fn.startswith(old_config_dir):
-            mylog.warning(
+            ytLogger.warning(
                 "Your plugin file is located in a deprecated directory. "
                 "Please move it from %s to %s",
                 os.path.join(old_config_dir, my_plugin_name),
                 os.path.join(CONFIG_DIR, my_plugin_name),
             )
 
-    mylog.info("Loading plugins from %s", _fn)
+    ytLogger.info("Loading plugins from %s", _fn)
     ytdict = yt.__dict__
     execdict = ytdict.copy()
     execdict["add_field"] = my_plugins_fields.add_field

--- a/yt/geometry/coordinates/cartesian_coordinates.py
+++ b/yt/geometry/coordinates/cartesian_coordinates.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from yt.data_objects.index_subobjects.unstructured_mesh import SemiStructuredMesh
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 from yt.units.yt_array import YTArray, uconcatenate, uvstack
 from yt.utilities.lib.pixelization_routines import (
     interpolate_sph_grid_gather,
@@ -200,7 +200,7 @@ class CartesianCoordinateHandler(CoordinateHandler):
             # here, for now.
             elif field_data.shape[1] == 27:
                 # hexahedral
-                mylog.warning(
+                ytLogger.warning(
                     "High order elements not yet supported, dropping to 1st order."
                 )
                 field_data = field_data[:, 0:8]
@@ -262,7 +262,7 @@ class CartesianCoordinateHandler(CoordinateHandler):
             # here, for now.
             elif field_data.shape[1] == 27:
                 # hexahedral
-                mylog.warning(
+                ytLogger.warning(
                     "High order elements not yet supported, dropping to 1st order."
                 )
                 field_data = field_data[:, 0:8]
@@ -405,7 +405,7 @@ class CartesianCoordinateHandler(CoordinateHandler):
                             period=period,
                             weight_field=chunk[weight].in_units(wounits),
                         )
-                    mylog.info(
+                    ytLogger.info(
                         "Making a fixed resolution buffer of (%s) %d by %d",
                         weight,
                         size[0],

--- a/yt/geometry/geometry_handler.py
+++ b/yt/geometry/geometry_handler.py
@@ -8,7 +8,7 @@ from yt.config import ytcfg
 from yt.units.yt_array import YTArray, uconcatenate
 from yt.utilities.exceptions import YTFieldNotFound
 from yt.utilities.io_handler import io_registry
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 from yt.utilities.on_demand_imports import _h5py as h5py
 from yt.utilities.parallel_tools.parallel_analysis_interface import (
     ParallelAnalysisInterface,
@@ -29,18 +29,18 @@ class Index(ParallelAnalysisInterface, abc.ABC):
 
         self._initialize_state_variables()
 
-        mylog.debug("Initializing data storage.")
+        ytLogger.debug("Initializing data storage.")
         self._initialize_data_storage()
 
-        mylog.debug("Setting up domain geometry.")
+        ytLogger.debug("Setting up domain geometry.")
         self._setup_geometry()
 
-        mylog.debug("Initializing data grid data IO")
+        ytLogger.debug("Initializing data grid data IO")
         self._setup_data_io()
 
         # Note that this falls under the "geometry" object since it's
         # potentially quite expensive, and should be done with the indexing.
-        mylog.debug("Detecting fields.")
+        ytLogger.debug("Detecting fields.")
         self._detect_output_fields()
 
     @abc.abstractmethod
@@ -122,7 +122,7 @@ class Index(ParallelAnalysisInterface, abc.ABC):
         try:
             node_loc = self._data_file[node]
             if name in node_loc and force:
-                mylog.info("Overwriting node %s/%s", node, name)
+                ytLogger.info("Overwriting node %s/%s", node, name)
                 del self._data_file[node][name]
             elif name in node_loc and passthrough:
                 return

--- a/yt/geometry/grid_geometry_handler.py
+++ b/yt/geometry/grid_geometry_handler.py
@@ -11,7 +11,7 @@ from yt.fields.field_detector import FieldDetector
 from yt.funcs import ensure_numpy_array, iter_fields
 from yt.geometry.geometry_handler import ChunkDataCache, Index, YTDataChunk
 from yt.utilities.definitions import MAXLEVEL
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 
 from .grid_container import GridTree, MatchPointsToGrids
 
@@ -30,19 +30,19 @@ class GridIndex(Index, abc.ABC):
     )
 
     def _setup_geometry(self):
-        mylog.debug("Counting grids.")
+        ytLogger.debug("Counting grids.")
         self._count_grids()
 
-        mylog.debug("Initializing grid arrays.")
+        ytLogger.debug("Initializing grid arrays.")
         self._initialize_grid_arrays()
 
-        mylog.debug("Parsing index.")
+        ytLogger.debug("Parsing index.")
         self._parse_index()
 
-        mylog.debug("Constructing grid objects.")
+        ytLogger.debug("Constructing grid objects.")
         self._populate_grid_objects()
 
-        mylog.debug("Re-examining index")
+        ytLogger.debug("Re-examining index")
         self._initialize_level_stats()
 
     @abc.abstractmethod
@@ -84,7 +84,7 @@ class GridIndex(Index, abc.ABC):
             yield self.select_grids(level)
 
     def _initialize_grid_arrays(self):
-        mylog.debug("Allocating arrays for %s grids", self.num_grids)
+        ytLogger.debug("Allocating arrays for %s grids", self.num_grids)
         self.grid_dimensions = np.ones((self.num_grids, 3), "int32")
         self.grid_left_edge = self.ds.arr(
             np.zeros((self.num_grids, 3), self.float_type), "code_length"
@@ -187,7 +187,7 @@ class GridIndex(Index, abc.ABC):
         may be set slightly incorrectly, resulting in discontinuities in images
         and the like.
         """
-        mylog.info("Locking grids to parents.")
+        ytLogger.info("Locking grids to parents.")
         for i, g in enumerate(self.grids):
             si = g.get_global_startindex()
             g.LeftEdge = self.ds.domain_left_edge + g.dds * si

--- a/yt/geometry/oct_geometry_handler.py
+++ b/yt/geometry/oct_geometry_handler.py
@@ -2,14 +2,14 @@ import numpy as np
 
 from yt.fields.field_detector import FieldDetector
 from yt.geometry.geometry_handler import Index
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 
 
 class OctreeIndex(Index):
     """The Index subclass for oct AMR datasets"""
 
     def _setup_geometry(self):
-        mylog.debug("Initializing Octree Geometry Handler.")
+        ytLogger.debug("Initializing Octree Geometry Handler.")
         self._initialize_oct_handler()
 
     def get_smallest_dx(self):

--- a/yt/geometry/particle_geometry_handler.py
+++ b/yt/geometry/particle_geometry_handler.py
@@ -11,7 +11,7 @@ from yt.funcs import get_pbar, only_on_root
 from yt.geometry.geometry_handler import Index, YTDataChunk
 from yt.geometry.particle_oct_container import ParticleBitmap
 from yt.utilities.lib.fnv_hash import fnv_hash
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 
 
 class ParticleIndex(Index):
@@ -100,7 +100,7 @@ class ParticleIndex(Index):
     def _initialize_index(self):
         ds = self.dataset
         only_on_root(
-            mylog.info,
+            ytLogger.info,
             "Allocating for %0.3e particles",
             self.total_particles,
             global_rootonly=True,
@@ -114,7 +114,7 @@ class ParticleIndex(Index):
             max_ppos = np.empty(3, dtype="float64")
             max_ppos[:] = np.nan
             only_on_root(
-                mylog.info,
+                ytLogger.info,
                 "Bounding box cannot be inferred from metadata, reading "
                 "particle positions to infer bounding box",
             )
@@ -123,7 +123,7 @@ class ParticleIndex(Index):
                     min_ppos = np.nanmin(np.vstack([min_ppos, ppos]), axis=0)
                     max_ppos = np.nanmax(np.vstack([max_ppos, ppos]), axis=0)
             only_on_root(
-                mylog.info,
+                ytLogger.info,
                 "Load this dataset with bounding_box=[%s, %s] to avoid I/O "
                 "overhead from inferring bounding_box." % (min_ppos, max_ppos),
             )
@@ -218,7 +218,7 @@ class ParticleIndex(Index):
         pb = get_pbar("Initializing refined index", len(self.data_files))
         mask_threshold = getattr(self, "_index_mask_threshold", 2)
         count_threshold = getattr(self, "_index_count_threshold", 256)
-        mylog.debug(
+        ytLogger.debug(
             "Using estimated thresholds of %s and %s for refinement",
             mask_threshold,
             count_threshold,
@@ -227,7 +227,7 @@ class ParticleIndex(Index):
         total_coarse_refined = (
             (mask >= 2) & (self.regions.particle_counts > count_threshold)
         ).sum()
-        mylog.debug(
+        ytLogger.debug(
             "This should produce roughly %s zones, for %s of the domain",
             total_coarse_refined,
             100 * total_coarse_refined / mask.size,

--- a/yt/geometry/unstructured_mesh_handler.py
+++ b/yt/geometry/unstructured_mesh_handler.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from yt.geometry.geometry_handler import Index, YTDataChunk
 from yt.utilities.lib.mesh_utilities import smallest_fwidth
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 
 
 class UnstructuredIndex(Index):
@@ -22,7 +22,7 @@ class UnstructuredIndex(Index):
         super().__init__(ds, dataset_type)
 
     def _setup_geometry(self):
-        mylog.debug("Initializing Unstructured Mesh Geometry Handler.")
+        ytLogger.debug("Initializing Unstructured Mesh Geometry Handler.")
         self._initialize_mesh()
 
     def get_smallest_dx(self):

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -19,7 +19,7 @@ from yt.utilities.exceptions import (
 )
 from yt.utilities.hierarchy_inspection import find_lowest_subclasses
 from yt.utilities.lib.misc_utilities import get_box_grids_level
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 from yt.utilities.object_registries import (
     output_type_registry,
     simulation_time_series_registry,
@@ -278,7 +278,7 @@ def load_uniform_grid(
             if len(data[key].shape) == 1 or key[0] == "io":
                 if not isinstance(key, tuple):
                     field = ("io", key)
-                    mylog.debug("Reassigning '%s' to '%s'", key, field)
+                    ytLogger.debug("Reassigning '%s' to '%s'", key, field)
                 else:
                     field = key
                 sfh._additional_fields += (field,)
@@ -696,7 +696,7 @@ def load_particles(
     for key in data.keys():
         if not isinstance(key, tuple):
             field = ("io", key)
-            mylog.debug("Reassigning '%s' to '%s'", key, field)
+            ytLogger.debug("Reassigning '%s' to '%s'", key, field)
         else:
             field = key
         pdata[field] = data[key]
@@ -830,7 +830,7 @@ def load_hexahedral_mesh(
         fn = list(sorted(data))[0]
         array_values = data[fn]
         if array_values.size != connectivity.shape[0]:
-            mylog.error(
+            ytLogger.error(
                 "Dimensions of array must be one fewer than the coordinate set."
             )
             raise RuntimeError
@@ -1335,7 +1335,7 @@ def load_sample(fn=None, specific_file=None, pbar=True):
     # because in some cases the common path will overlap with the `load_name`
     # variable of the file.
     folder_path = os.path.commonprefix(storage_fname)
-    mylog.info("Files located at %s", folder_path)
+    ytLogger.info("Files located at %s", folder_path)
 
     # Location of the file to load automatically, registered in the Fido class
     info = fido[registered_fname]
@@ -1344,12 +1344,12 @@ def load_sample(fn=None, specific_file=None, pbar=True):
 
     if specific_file is None:
         # right now work on loading only untarred files. build out h5 later
-        mylog.info("Default to loading %s for %s dataset", file_lookup, name)
+        ytLogger.info("Default to loading %s for %s dataset", file_lookup, name)
         loaded_file = os.path.join(
             base_path, f"{registered_fname}.untar", name, file_lookup
         )
     else:
-        mylog.info("Loading %s for %s dataset", specific_file, name)
+        ytLogger.info("Loading %s for %s dataset", specific_file, name)
         loaded_file = os.path.join(
             base_path, f"{registered_fname}.untar", name, specific_file
         )

--- a/yt/mods.py
+++ b/yt/mods.py
@@ -19,7 +19,7 @@ unparsed_args = __startup_tasks.unparsed_args
 
 if _level >= int(ytcfg_defaults["yt"]["log_level"]):
     # This won't get displayed.
-    mylog.debug("Turning off NumPy error reporting")
+    ytLogger.debug("Turning off NumPy error reporting")
     np.seterr(all="ignore")
 
 # We load plugins.  Keep in mind, this can be fairly dangerous -

--- a/yt/startup_tasks.py
+++ b/yt/startup_tasks.py
@@ -7,11 +7,11 @@ import sys
 
 from yt.config import ytcfg
 from yt.funcs import (
-    mylog,
     paste_traceback,
     paste_traceback_detailed,
     signal_ipython,
     signal_print_traceback,
+    ytLogger,
 )
 from yt.utilities import rpdb
 
@@ -23,7 +23,7 @@ def turn_on_parallelism():
         # we import this to check if mpi4py is installed
         from mpi4py import MPI  # NOQA
     except ImportError as e:
-        mylog.error(
+        ytLogger.error(
             "Warning: Attempting to turn on parallelism, "
             "but mpi4py import failed. Try pip install mpi4py."
         )
@@ -46,9 +46,9 @@ def turn_on_parallelism():
 # and then examine the current stack.
 try:
     signal.signal(signal.SIGUSR1, signal_print_traceback)
-    mylog.debug("SIGUSR1 registered for traceback printing")
+    ytLogger.debug("SIGUSR1 registered for traceback printing")
     signal.signal(signal.SIGUSR2, signal_ipython)
-    mylog.debug("SIGUSR2 registered for IPython Insertion")
+    ytLogger.debug("SIGUSR2 registered for IPython Insertion")
 except (ValueError, RuntimeError, AttributeError):  # Not in main thread
     pass
 
@@ -61,27 +61,27 @@ class SetExceptionHandling(argparse.Action):
         #
         if self.dest == "paste":
             sys.excepthook = paste_traceback
-            mylog.debug("Enabling traceback pasting")
+            ytLogger.debug("Enabling traceback pasting")
         elif self.dest == "paste-detailed":
             sys.excepthook = paste_traceback_detailed
-            mylog.debug("Enabling detailed traceback pasting")
+            ytLogger.debug("Enabling detailed traceback pasting")
         elif self.dest == "detailed":
             import cgitb
 
             cgitb.enable(format="text")
-            mylog.debug("Enabling detailed traceback reporting")
+            ytLogger.debug("Enabling detailed traceback reporting")
         elif self.dest == "rpdb":
             sys.excepthook = rpdb.rpdb_excepthook
-            mylog.debug("Enabling remote debugging")
+            ytLogger.debug("Enabling remote debugging")
 
 
 class SetConfigOption(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         param, val = values.split("=")
-        mylog.debug("Overriding config: %s = %s", param, val)
+        ytLogger.debug("Overriding config: %s = %s", param, val)
         ytcfg["yt", param] = val
         if param == "log_level":  # special case
-            mylog.setLevel(int(val))
+            ytLogger.setLevel(int(val))
 
 
 class YTParser(argparse.ArgumentParser):

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -1064,11 +1064,11 @@ def run_nose(
 ):
     import sys
 
-    from yt.utilities.logger import ytLogger as mylog
+    from yt.utilities.logger import ytLogger
     from yt.utilities.on_demand_imports import _nose
 
-    orig_level = mylog.getEffectiveLevel()
-    mylog.setLevel(50)
+    orig_level = ytLogger.getEffectiveLevel()
+    ytLogger.setLevel(50)
     nose_argv = sys.argv
     nose_argv += ["--exclude=answer_testing", "--detailed-errors", "--exe"]
     if call_pdb:
@@ -1103,7 +1103,7 @@ def run_nose(
         _nose.run(argv=nose_argv)
     finally:
         os.chdir(initial_dir)
-        mylog.setLevel(orig_level)
+        ytLogger.setLevel(orig_level)
 
 
 def assert_allclose_units(actual, desired, rtol=1e-7, atol=0, **kwargs):

--- a/yt/utilities/amr_kdtree/amr_kdtools.py
+++ b/yt/utilities/amr_kdtree/amr_kdtools.py
@@ -1,11 +1,11 @@
 import numpy as np
 
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 
 
 def receive_and_reduce(comm, incoming_rank, image, add_to_front):
-    mylog.debug("Receiving image from %04i", incoming_rank)
-    # mylog.debug( '%04i receiving image from %04i'%(self.comm.rank,back.owner))
+    ytLogger.debug("Receiving image from %04i", incoming_rank)
+    # ytLogger.debug( '%04i receiving image from %04i'%(self.comm.rank,back.owner))
     arr2 = comm.recv_array(incoming_rank, incoming_rank).reshape(
         (image.shape[0], image.shape[1], image.shape[2])
     )
@@ -35,11 +35,11 @@ def receive_and_reduce(comm, incoming_rank, image, add_to_front):
 
 
 def send_to_parent(comm, outgoing_rank, image):
-    mylog.debug("Sending image to %04i", outgoing_rank)
+    ytLogger.debug("Sending image to %04i", outgoing_rank)
     comm.send_array(image, outgoing_rank, tag=comm.rank)
 
 
 def scatter_image(comm, root, image):
-    mylog.debug("Scattering from %04i", root)
+    ytLogger.debug("Scattering from %04i", root)
     image = comm.mpi_bcast(image, root=root)
     return image

--- a/yt/utilities/amr_kdtree/amr_kdtree.py
+++ b/yt/utilities/amr_kdtree/amr_kdtree.py
@@ -2,7 +2,7 @@ import operator
 
 import numpy as np
 
-from yt.funcs import is_sequence, mylog
+from yt.funcs import is_sequence, ytLogger
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.utilities.amr_kdtree.amr_kdtools import (
     receive_and_reduce,
@@ -137,7 +137,7 @@ class Tree:
 
         # Calculate the Volume
         vol = self.trunk.kd_sum_volume()
-        mylog.debug("AMRKDTree volume = %e", vol)
+        ytLogger.debug("AMRKDTree volume = %e", vol)
         self.trunk.kd_node_check()
 
     def sum_cells(self, all_cells=False):
@@ -196,7 +196,7 @@ class AMRKDTree(ParallelAnalysisInterface):
             data_source = self.ds.all_data()
         self.data_source = data_source
 
-        mylog.debug("Building AMRKDTree")
+        ytLogger.debug("Building AMRKDTree")
         self.tree = Tree(
             ds,
             self.comm.rank,
@@ -632,7 +632,7 @@ class AMRKDTree(ParallelAnalysisInterface):
             if splitdims[i] != -1:
                 n.create_split(splitdims[i], splitposs[i])
 
-        mylog.info(
+        ytLogger.info(
             "AMRKDTree rebuilt, Final Volume: %e", self.tree.trunk.kd_sum_volume()
         )
         return self.tree.trunk

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -43,7 +43,6 @@ from yt.visualization import (
     profile_plotter as profile_plotter,
 )
 
-mylog = logging.getLogger("nose.plugins.answer-testing")
 run_big_data = False
 
 # Set the latest gold and local standard filenames
@@ -269,7 +268,8 @@ class AnswerTestLocalStorage(AnswerTestStorage):
         for ds_name in result_storage:
             answer_name = f"{ds_name}"
             if answer_name in ds:
-                mylog.info("Overwriting %s", answer_name)
+                noseLogger = logging.getLogger("nose.plugins.answer-testing")
+                noseLogger.info("Overwriting %s", answer_name)
             ds[answer_name] = result_storage[ds_name]
         ds.close()
 

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -24,8 +24,8 @@ from yt.funcs import (
     ensure_dir_exists,
     get_hg_or_git_version,
     get_yt_version,
-    mylog,
     update_hg_or_git,
+    ytLogger,
 )
 from yt.loaders import load
 from yt.utilities.configure import set_config
@@ -1274,7 +1274,7 @@ class YTPlotCmd(YTCommand):
         ds = args.ds
         center = args.center
         if args.center == (-1, -1, -1):
-            mylog.info("No center fed in; seeking.")
+            ytLogger.info("No center fed in; seeking.")
             v, center = ds.find_max("density")
         if args.max:
             v, center = ds.find_max("density")
@@ -1298,7 +1298,7 @@ class YTPlotCmd(YTCommand):
             width = (args.width, args.unit)
 
         for ax in always_iterable(axes):
-            mylog.info("Adding plot for axis %i", ax)
+            ytLogger.info("Adding plot for axis %i", ax)
             if args.projection:
                 plt = ProjectionPlot(
                     ds,

--- a/yt/utilities/io_handler.py
+++ b/yt/utilities/io_handler.py
@@ -205,7 +205,7 @@ class BaseIOHandler:
             # Note that we now need to check the mappings
             for field_f in field_maps[field_r]:
                 my_ind = ind[field_f]
-                # mylog.debug("Filling %s from %s to %s with %s",
+                # ytLogger.debug("Filling %s from %s to %s with %s",
                 #    field_f, my_ind, my_ind+vals.shape[0], field_r)
                 rv[field_f][my_ind : my_ind + vals.shape[0], ...] = vals
                 ind[field_f] += vals.shape[0]

--- a/yt/utilities/lib/octree_raytracing.py
+++ b/yt/utilities/lib/octree_raytracing.py
@@ -2,7 +2,7 @@ from itertools import product
 
 import numpy as np
 
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 from yt.utilities.lib._octree_raytracing import _OctreeRayTracing
 
 
@@ -33,7 +33,7 @@ class OctreeRayTracing:
         lvl = data_source["grid_level"].astype(int).value + lvl_min
 
         ipos = np.floor(xyz * (1 << depth)).astype(int)
-        mylog.debug("Adding cells to volume")
+        ytLogger.debug("Adding cells to volume")
         self.octree.add_nodes(
             ipos.astype(np.int32),
             lvl.astype(np.int32),

--- a/yt/utilities/linear_interpolators.py
+++ b/yt/utilities/linear_interpolators.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 import yt.utilities.lib.interpolators as lib
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 
 
 class UnilinearFieldInterpolator:
@@ -37,7 +37,7 @@ class UnilinearFieldInterpolator:
         self.x_name = field_names
         if isinstance(boundaries, np.ndarray):
             if boundaries.size != table.shape[0]:
-                mylog.error("Bins array not the same length as the data.")
+                ytLogger.error("Bins array not the same length as the data.")
                 raise ValueError
             self.x_bins = boundaries
         else:
@@ -51,11 +51,11 @@ class UnilinearFieldInterpolator:
         x_i = (np.digitize(x_vals, self.x_bins) - 1).astype("int32")
         if np.any((x_i == -1) | (x_i == len(self.x_bins) - 1)):
             if not self.truncate:
-                mylog.error(
+                ytLogger.error(
                     "Sorry, but your values are outside "
                     "the table!  Dunno what to do, so dying."
                 )
-                mylog.error("Error was in: %s", data_object)
+                ytLogger.error("Error was in: %s", data_object)
                 raise ValueError
             else:
                 x_i = np.minimum(np.maximum(x_i, 0), len(self.x_bins) - 2)
@@ -103,15 +103,15 @@ class BilinearFieldInterpolator:
             self.y_bins = np.linspace(y0, y1, table.shape[1]).astype("float64")
         elif len(boundaries) == 2:
             if boundaries[0].size != table.shape[0]:
-                mylog.error("X bins array not the same length as the data.")
+                ytLogger.error("X bins array not the same length as the data.")
                 raise ValueError
             if boundaries[1].size != table.shape[1]:
-                mylog.error("Y bins array not the same length as the data.")
+                ytLogger.error("Y bins array not the same length as the data.")
                 raise ValueError
             self.x_bins = boundaries[0]
             self.y_bins = boundaries[1]
         else:
-            mylog.error(
+            ytLogger.error(
                 "Boundaries must be given as (x0, x1, y0, y1) or as (x_bins, y_bins)"
             )
             raise ValueError
@@ -127,11 +127,11 @@ class BilinearFieldInterpolator:
             (y_i == -1) | (y_i == len(self.y_bins) - 1)
         ):
             if not self.truncate:
-                mylog.error(
+                ytLogger.error(
                     "Sorry, but your values are outside "
                     "the table!  Dunno what to do, so dying."
                 )
-                mylog.error("Error was in: %s", data_object)
+                ytLogger.error("Error was in: %s", data_object)
                 raise ValueError
             else:
                 x_i = np.minimum(np.maximum(x_i, 0), len(self.x_bins) - 2)
@@ -184,19 +184,19 @@ class TrilinearFieldInterpolator:
             self.z_bins = np.linspace(z0, z1, table.shape[2]).astype("float64")
         elif len(boundaries) == 3:
             if boundaries[0].size != table.shape[0]:
-                mylog.error("X bins array not the same length as the data.")
+                ytLogger.error("X bins array not the same length as the data.")
                 raise ValueError
             if boundaries[1].size != table.shape[1]:
-                mylog.error("Y bins array not the same length as the data.")
+                ytLogger.error("Y bins array not the same length as the data.")
                 raise ValueError
             if boundaries[2].size != table.shape[2]:
-                mylog.error("Z bins array not the same length as the data.")
+                ytLogger.error("Z bins array not the same length as the data.")
                 raise ValueError
             self.x_bins = boundaries[0]
             self.y_bins = boundaries[1]
             self.z_bins = boundaries[2]
         else:
-            mylog.error(
+            ytLogger.error(
                 "Boundaries must be given as (x0, x1, y0, y1, z0, z1) "
                 "or as (x_bins, y_bins, z_bins)"
             )
@@ -217,11 +217,11 @@ class TrilinearFieldInterpolator:
             or np.any((z_i == -1) | (z_i == len(self.z_bins) - 1))
         ):
             if not self.truncate:
-                mylog.error(
+                ytLogger.error(
                     "Sorry, but your values are outside "
                     "the table!  Dunno what to do, so dying."
                 )
-                mylog.error("Error was in: %s", data_object)
+                ytLogger.error("Error was in: %s", data_object)
                 raise ValueError
             else:
                 x_i = np.minimum(np.maximum(x_i, 0), len(self.x_bins) - 2)

--- a/yt/utilities/orientation.py
+++ b/yt/utilities/orientation.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 from yt.units.yt_array import YTArray
 from yt.utilities.exceptions import YTException
 
@@ -62,7 +62,7 @@ class Orientation:
         normal_vector, north_vector = _validate_unit_vectors(
             normal_vector, north_vector
         )
-        mylog.debug("Setting normalized vectors %s %s", normal_vector, north_vector)
+        ytLogger.debug("Setting normalized vectors %s %s", normal_vector, north_vector)
         # Now we set up our various vectors
         normal_vector /= np.sqrt(np.dot(normal_vector, normal_vector))
         if north_vector is None:

--- a/yt/utilities/parallel_tools/task_queue.py
+++ b/yt/utilities/parallel_tools/task_queue.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 
 from .parallel_analysis_interface import (
     ResultsStorage,
@@ -38,7 +38,7 @@ class TaskQueueNonRoot:
             msg = self.comm.comm.recv(source=0, tag=2)
         msg = self.subcomm.bcast(msg, root=0)
         if msg["msg"] == messages["end"]["msg"]:
-            mylog.debug("Notified to end")
+            ytLogger.debug("Notified to end")
             raise StopIteration
         return msg["value"]
 
@@ -82,7 +82,7 @@ class TaskQueueRoot(TaskQueueNonRoot):
 
     def assign_task(self, source_id):
         if self._remaining == 0:
-            mylog.debug("Notifying %s to end", source_id)
+            ytLogger.debug("Notifying %s to end", source_id)
             msg = messages["end"].copy()
             self._notified += 1
         else:
@@ -102,7 +102,7 @@ class TaskQueueRoot(TaskQueueNonRoot):
         elif msg["msg"] == messages["task_req"]["msg"]:
             self.assign_task(status.source)
         else:
-            mylog.error("GOT AN UNKNOWN MESSAGE: %s", msg)
+            ytLogger.error("GOT AN UNKNOWN MESSAGE: %s", msg)
             raise RuntimeError
         if self._notified >= self.njobs:
             raise StopIteration
@@ -111,13 +111,13 @@ class TaskQueueRoot(TaskQueueNonRoot):
 def task_queue(func, tasks, njobs=0):
     comm = _get_comm(())
     if not parallel_capable:
-        mylog.error("Cannot create task queue for serial process.")
+        ytLogger.error("Cannot create task queue for serial process.")
         raise RuntimeError
     my_size = comm.comm.size
     if njobs <= 0:
         njobs = my_size - 1
     if njobs >= my_size:
-        mylog.error(
+        ytLogger.error(
             "You have asked for %s jobs, but only %s processors are available.",
             njobs,
             (my_size - 1),
@@ -143,13 +143,13 @@ def task_queue(func, tasks, njobs=0):
 def dynamic_parallel_objects(tasks, njobs=0, storage=None, broadcast=True):
     comm = _get_comm(())
     if not parallel_capable:
-        mylog.error("Cannot create task queue for serial process.")
+        ytLogger.error("Cannot create task queue for serial process.")
         raise RuntimeError
     my_size = comm.comm.size
     if njobs <= 0:
         njobs = my_size - 1
     if njobs >= my_size:
-        mylog.error(
+        ytLogger.error(
             "You have asked for %s jobs, but only %s processors are available.",
             njobs,
             (my_size - 1),

--- a/yt/utilities/parameter_file_storage.py
+++ b/yt/utilities/parameter_file_storage.py
@@ -3,7 +3,7 @@ import os.path
 from itertools import islice
 
 from yt.config import ytcfg
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 from yt.utilities.object_registries import output_type_registry
 from yt.utilities.parallel_tools.parallel_analysis_interface import (
     parallel_simple_proxy,
@@ -116,7 +116,7 @@ class ParameterFileStore:
         class_name = ds_dict["class_name"]
         if class_name not in output_type_registry:
             raise UnknownDatasetType(class_name)
-        mylog.info("Checking %s", fn)
+        ytLogger.info("Checking %s", fn)
         if os.path.exists(fn):
             ds = output_type_registry[class_name](os.path.join(fp, bn))
         else:

--- a/yt/utilities/performance_counters.py
+++ b/yt/utilities/performance_counters.py
@@ -6,7 +6,7 @@ from datetime import datetime as dt
 from functools import wraps
 
 from yt.config import ytcfg
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 
 
 class PerformanceCounters:
@@ -50,7 +50,7 @@ class PerformanceCounters:
         return func_wrapper
 
     def print_stats(self):
-        mylog.info("Current counter status:\n")
+        ytLogger.info("Current counter status:\n")
         times = []
         for i in self.counters:
             insort(times, [self.starttime[i], i, 1])  # 1 for 'on'
@@ -87,7 +87,7 @@ class PerformanceCounters:
                     i,
                     self.counters[i],
                 )
-        mylog.info("\n%s", line)
+        ytLogger.info("\n%s", line)
 
     def exit(self):
         if self._on:
@@ -132,5 +132,5 @@ class ProfilingController:
             pfn = f"{filename_prefix}"
         for n, p in sorted(self.profilers.items()):
             fn = f"{pfn}_{n}.cprof"
-            mylog.info("Dumping %s into %s", n, fn)
+            ytLogger.info("Dumping %s into %s", n, fn)
             p.dump_stats(fn)

--- a/yt/utilities/sample_data.py
+++ b/yt/utilities/sample_data.py
@@ -9,7 +9,7 @@ import os
 import pkg_resources
 
 from yt.config import ytcfg
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 from yt.utilities.on_demand_imports import _pooch as pooch
 
 ## The format of the data registry json:
@@ -79,7 +79,7 @@ class PoochHandle:
         """
 
         if not isinstance(name, str):
-            mylog.error(
+            ytLogger.error(
                 "The argument %s passed to load_sample() is not a string.", name
             )
 
@@ -101,7 +101,7 @@ class PoochHandle:
             basename = base
             extension = "h5"
         else:
-            mylog.info(
+            ytLogger.info(
                 """extension of %s for dataset %s is unexpected. the `load_data`
                 function  may not work as expected""",
                 ext,

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -10,7 +10,7 @@ from yt.funcs import (
     get_interactivity,
     is_sequence,
     matplotlib_style_context,
-    mylog,
+    ytLogger,
 )
 
 backend_dict = {
@@ -143,7 +143,7 @@ class PlotMPL:
             suffix = ".png"
             name = f"{name}{suffix}"
 
-        mylog.info("Saving plot %s", name)
+        ytLogger.info("Saving plot %s", name)
 
         if suffix in _AGG_FORMATS:
             canvas = FigureCanvasAgg(self.figure)
@@ -154,7 +154,7 @@ class PlotMPL:
         elif suffix in (".eps", ".ps"):
             canvas = FigureCanvasPS(self.figure)
         else:
-            mylog.warning("Unknown suffix %s, defaulting to Agg", suffix)
+            ytLogger.warning("Unknown suffix %s, defaulting to Agg", suffix)
             canvas = self.canvas
 
         with matplotlib_style_context():

--- a/yt/visualization/eps_writer.py
+++ b/yt/visualization/eps_writer.py
@@ -6,7 +6,7 @@ from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.config import ytcfg
 from yt.units.unit_object import Unit
 from yt.units.yt_array import YTQuantity
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 
 from .plot_window import PlotWindow
 from .profile_plotter import PhasePlot, ProfilePlot
@@ -605,7 +605,7 @@ class DualEPS:
         if isinstance(plot, (PlotWindow, PhasePlot)):
             if field is None:
                 self.field = list(plot.plots.keys())[0]
-                mylog.warning(
+                ytLogger.warning(
                     "No field specified.  Choosing first field (%s)", self.field
                 )
             else:
@@ -1272,7 +1272,7 @@ def multiplot(
     if yt_plots is None and images is None:
         raise RuntimeError("Must supply either yt_plots or image filenames.")
     if yt_plots is not None and images is not None:
-        mylog.warning("Given both images and yt plots.  Ignoring images.")
+        ytLogger.warning("Given both images and yt plots.  Ignoring images.")
     if yt_plots is not None:
         _yt = True
     else:
@@ -1441,7 +1441,7 @@ def multiplot(
                     ypos = bbox[3]
                     xpos = xpos0
                 else:
-                    mylog.warning(
+                    ytLogger.warning(
                         "Unknown colorbar location %s. No colorbar displayed.",
                         orientation,
                     )

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -8,7 +8,7 @@ from more_itertools import first, mark_ends
 from yt.data_objects.construction_data_containers import YTCoveringGrid
 from yt.data_objects.image_array import ImageArray
 from yt.fields.derived_field import DerivedField
-from yt.funcs import fix_axis, is_sequence, iter_fields, mylog
+from yt.funcs import fix_axis, is_sequence, iter_fields, ytLogger
 from yt.units import dimensions
 from yt.units.unit_object import Unit
 from yt.units.yt_array import YTArray, YTQuantity
@@ -202,7 +202,7 @@ class FITSImageData:
                 fields = list(img_data.keys())
         elif isinstance(data, np.ndarray):
             if fields is None:
-                mylog.warning(
+                ytLogger.warning(
                     "No field name given for this array. " "Calling it 'image_data'."
                 )
                 fn = "image_data"
@@ -242,7 +242,7 @@ class FITSImageData:
                 this_img = img_data[field]
                 if hasattr(img_data[field], "units"):
                     if this_img.units.is_code_unit:
-                        mylog.warning(
+                        ytLogger.warning(
                             "Cannot generate an image with code "
                             "units. Converting to units in CGS."
                         )
@@ -252,7 +252,7 @@ class FITSImageData:
                     self.field_units[name] = str(funits)
                 else:
                     self.field_units[name] = "dimensionless"
-                mylog.info("Making a FITS image of field %s", name)
+                ytLogger.info("Making a FITS image of field %s", name)
                 if isinstance(this_img, ImageArray):
                     if i == 0:
                         self.shape = this_img.shape[::-1]
@@ -386,7 +386,7 @@ class FITSImageData:
                 uq = None
 
             if uq is not None and uq.units.is_code_unit:
-                mylog.warning(
+                ytLogger.warning(
                     "Cannot use code units of '%s' "
                     "when creating a FITSImageData instance! "
                     "Converting to a cgs equivalent.",
@@ -395,7 +395,9 @@ class FITSImageData:
                 uq.convert_to_cgs()
 
             if attr == "length_unit" and uq.value != 1.0:
-                mylog.warning("Converting length units " "from %s to %s.", uq, uq.units)
+                ytLogger.warning(
+                    "Converting length units " "from %s to %s.", uq, uq.units
+                )
                 uq = YTQuantity(1.0, uq.units)
 
             setattr(self, attr, uq)
@@ -509,7 +511,7 @@ class FITSImageData:
             self.hdulist[idx].header[key] = value
 
     def update_all_headers(self, key, value):
-        mylog.warning(
+        ytLogger.warning(
             "update_all_headers is deprecated. "
             "Use update_header('all', key, value) instead."
         )
@@ -809,7 +811,7 @@ class FITSImageBuffer(FITSImageData):
 
 def sanitize_fits_unit(unit):
     if unit == "Mpc":
-        mylog.info("Changing FITS file length unit to kpc.")
+        ytLogger.info("Changing FITS file length unit to kpc.")
         unit = "kpc"
     elif unit == "au":
         unit = "AU"
@@ -823,7 +825,7 @@ def construct_image(ds, axis, data_source, center, image_res, width, length_unit
     if width is None:
         width = ds.domain_width[axis_wcs[axis]]
         unit = ds.get_smallest_appropriate_unit(width[0])
-        mylog.info(
+        ytLogger.info(
             "Making an image of the entire domain, "
             "so setting the center to the domain center."
         )

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from yt.data_objects.image_array import ImageArray
 from yt.frontends.ytdata.utilities import save_as_dataset
-from yt.funcs import get_output_filename, iter_fields, mylog
+from yt.funcs import get_output_filename, iter_fields, ytLogger
 from yt.loaders import load_uniform_grid
 from yt.utilities.lib.api import add_points_to_greyscale_image
 from yt.utilities.lib.pixelization_routines import pixelize_cylinder
@@ -125,7 +125,7 @@ class FixedResolutionBuffer:
     def __getitem__(self, item):
         if item in self.data:
             return self.data[item]
-        mylog.info(
+        ytLogger.info(
             "Making a fixed resolution buffer of (%s) %d by %d",
             item,
             self.buff_size[0],
@@ -563,7 +563,7 @@ class OffAxisProjectionFixedResolutionBuffer(FixedResolutionBuffer):
     def __getitem__(self, item):
         if item in self.data:
             return self.data[item]
-        mylog.info(
+        ytLogger.info(
             "Making a fixed resolution buffer of (%s) %d by %d",
             item,
             self.buff_size[0],
@@ -624,7 +624,7 @@ class ParticleImageBuffer(FixedResolutionBuffer):
         if item in self.data:
             return self.data[item]
 
-        mylog.info(
+        ytLogger.info(
             "Splatting (%s) onto a %d by %d mesh",
             item,
             self.buff_size[0],

--- a/yt/visualization/image_writer.py
+++ b/yt/visualization/image_writer.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.config import ytcfg
-from yt.funcs import get_brewer_cmap, get_image_suffix, mylog
+from yt.funcs import get_brewer_cmap, get_image_suffix, ytLogger
 from yt.units.yt_array import YTQuantity
 from yt.utilities import png_writer as pw
 from yt.utilities.exceptions import YTNotInsideNotebook
@@ -202,7 +202,7 @@ def write_image(image, filename, color_bounds=None, cmap_name=None, func=lambda 
     if cmap_name is None:
         cmap_name = ytcfg.get("yt", "default_colormap")
     if len(image.shape) == 3:
-        mylog.info("Using only channel 1 of supplied image")
+        ytLogger.info("Using only channel 1 of supplied image")
         image = image[:, :, 0]
     to_plot = apply_colormap(image, color_bounds=color_bounds, cmap_name=cmap_name)
     pw.write_png(to_plot, filename)
@@ -460,7 +460,7 @@ def write_projection(
     if suffix == "":
         suffix = ".png"
         filename = f"{filename}{suffix}"
-    mylog.info("Saving plot %s", filename)
+    ytLogger.info("Saving plot %s", filename)
     if suffix == ".pdf":
         canvas = FigureCanvasPdf(fig)
     elif suffix in (".eps", ".ps"):

--- a/yt/visualization/line_plot.py
+++ b/yt/visualization/line_plot.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 
 import numpy as np
 
-from yt.funcs import is_sequence, mylog
+from yt.funcs import is_sequence, ytLogger
 from yt.units.unit_object import Unit
 from yt.units.yt_array import YTArray
 from yt.visualization.base_plot_types import PlotMPL
@@ -63,7 +63,7 @@ class LineBuffer:
     def __getitem__(self, item):
         if item in self.data:
             return self.data[item]
-        mylog.info("Making a line buffer with %d points of %s", self.npoints, item)
+        ytLogger.info("Making a line buffer with %d points of %s", self.npoints, item)
         self.points, self.data[item] = self.ds.coordinates.pixelize_line(
             item, self.start_point, self.end_point, self.npoints
         )

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -10,7 +10,7 @@ import numpy as np
 from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.config import ytcfg
 from yt.data_objects.time_series import DatasetSeries
-from yt.funcs import ensure_dir, get_image_suffix, is_sequence, iter_fields, mylog
+from yt.funcs import ensure_dir, get_image_suffix, is_sequence, iter_fields, ytLogger
 from yt.units import YTQuantity
 from yt.units.unit_object import Unit
 from yt.utilities.definitions import formatted_length_unit_names
@@ -899,7 +899,7 @@ class ImagePlotContainer(PlotContainer):
                 except AttributeError:
                     # only certain subclasses have a frb attribute
                     # they can rely on for inspecting units
-                    mylog.warning(
+                    ytLogger.warning(
                         "%s class doesn't support zmin/zmax"
                         " as tuples or unyt_quantitiy",
                         self.__class__.__name__,

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -11,7 +11,7 @@ from yt.data_objects.level_sets.clump_handling import Clump
 from yt.data_objects.selection_objects.cut_region import YTCutRegion
 from yt.data_objects.static_output import Dataset
 from yt.frontends.ytdata.data_structures import YTClumpContainer
-from yt.funcs import is_sequence, mylog, validate_width_tuple
+from yt.funcs import is_sequence, validate_width_tuple, ytLogger
 from yt.geometry.geometry_handler import is_curvilinear
 from yt.geometry.unstructured_mesh_handler import UnstructuredIndex
 from yt.units import dimensions
@@ -744,7 +744,7 @@ class GridBoundaryCallback(PlotCallback):
         else:
             self.id_loc = id_loc.lower()  # Make case-insensitive
             if not self.draw_ids:
-                mylog.warning(
+                ytLogger.warning(
                     "Supplied id_loc but draw_ids is False. Not drawing grid ids"
                 )
         self.periodic = periodic
@@ -1216,7 +1216,7 @@ class ClumpContourCallback(PlotCallback):
         ny, nx = plot.image._A.shape
         buff = np.zeros((nx, ny), dtype="float64")
         for i, clump in enumerate(reversed(self.clumps)):
-            mylog.info("Pixelizing contour %s", i)
+            ytLogger.info("Pixelizing contour %s", i)
 
             if isinstance(clump, Clump):
                 ftype = "index"
@@ -2049,7 +2049,7 @@ class ParticleCallback(PlotCallback):
         x0, x1, y0, y1 = self._physical_bounds(plot)
         xx0, xx1, yy0, yy1 = self._plot_bounds(plot)
         if isinstance(self.data_source, YTCutRegion):
-            mylog.warning(
+            ytLogger.warning(
                 "Parameter 'width' is ignored in annotate_particles if the "
                 "data_source is a cut_region. "
                 "See https://github.com/yt-project/yt/issues/1933 for further details."

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -13,7 +13,14 @@ from unyt.exceptions import UnitConversionError
 from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.data_objects.image_array import ImageArray
 from yt.frontends.ytdata.data_structures import YTSpatialPlotDataset
-from yt.funcs import fix_axis, fix_unitary, is_sequence, iter_fields, mylog, obj_length
+from yt.funcs import (
+    fix_axis,
+    fix_unitary,
+    is_sequence,
+    iter_fields,
+    obj_length,
+    ytLogger,
+)
 from yt.units.unit_object import Unit
 from yt.units.unit_registry import UnitParseError
 from yt.units.yt_array import YTArray, YTQuantity
@@ -233,7 +240,7 @@ class PlotWindow(ImagePlotContainer):
 
     def __iter__(self):
         for ds in self.ts:
-            mylog.warning("Switching to %s", ds)
+            ytLogger.warning("Switching to %s", ds)
             self._switch_ds(ds)
             yield self
 
@@ -580,10 +587,10 @@ class PlotWindow(ImagePlotContainer):
             self.ylim = tuple(bounds[2:4])
             if len(bounds) == 6:
                 self.zlim = tuple(bounds[4:6])
-        mylog.info("xlim = %f %f", self.xlim[0], self.xlim[1])
-        mylog.info("ylim = %f %f", self.ylim[0], self.ylim[1])
+        ytLogger.info("xlim = %f %f", self.xlim[0], self.xlim[1])
+        ytLogger.info("ylim = %f %f", self.ylim[0], self.ylim[1])
         if hasattr(self, "zlim"):
-            mylog.info("zlim = %f %f", self.zlim[0], self.zlim[1])
+            ytLogger.info("zlim = %f %f", self.zlim[0], self.zlim[1])
 
     @invalidate_data
     def set_width(self, width, unit=None):
@@ -841,7 +848,7 @@ class PWViewerMPL(PlotWindow):
         elif origin[2] == "native":
             return (self.ds.quan(0.0, "code_length"), self.ds.quan(0.0, "code_length"))
         else:
-            mylog.warning("origin = %s", origin)
+            ytLogger.warning("origin = %s", origin)
             msg = (
                 'origin keyword "{}" not recognized, must declare "domain" '
                 'or "center" as the last term in origin.'
@@ -855,7 +862,7 @@ class PWViewerMPL(PlotWindow):
             elif origin[0] == "center":
                 yc = (yllim + yrlim) / 2.0
             else:
-                mylog.warning("origin = %s", origin)
+                ytLogger.warning("origin = %s", origin)
                 msg = (
                     'origin keyword "{0}" not recognized, must declare "lower" '
                     '"upper" or "center" as the first term in origin.'
@@ -870,7 +877,7 @@ class PWViewerMPL(PlotWindow):
             elif origin[1] == "center":
                 xc = (xllim + xrlim) / 2.0
             else:
-                mylog.warning("origin = %s", origin)
+                ytLogger.warning("origin = %s", origin)
                 msg = (
                     'origin keyword "{0}" not recognized, must declare "left" '
                     '"right" or "center" as the second term in origin.'
@@ -961,16 +968,16 @@ class PWViewerMPL(PlotWindow):
                     )
                     use_symlog = True
                 if msg is not None:
-                    mylog.warning(msg)
+                    ytLogger.warning(msg)
                     if use_symlog:
-                        mylog.warning(
+                        ytLogger.warning(
                             "Switching to symlog colorbar scaling "
                             "unless linear scaling is specified later"
                         )
                         self._field_transform[f] = symlog_transform
                         self._field_transform[f].func = None
                     else:
-                        mylog.warning("Switching to linear colorbar scaling.")
+                        ytLogger.warning("Switching to linear colorbar scaling.")
                         self._field_transform[f] = linear_transform
 
             font_size = self._font_properties.get_size()
@@ -1141,7 +1148,7 @@ class PWViewerMPL(PlotWindow):
                         self.plots[f].cax.yaxis.set_ticks(mticks, minor=True)
 
                 else:
-                    mylog.error(
+                    ytLogger.error(
                         "Unable to draw cbar minorticks for field "
                         "%s with transform %s ",
                         f,
@@ -1501,7 +1508,7 @@ class AxisAlignedSlicePlot(PWViewerMPL):
             "geographic",
             "internal_geographic",
         ):
-            mylog.info("Setting origin='native' for %s geometry.", ds.geometry)
+            ytLogger.info("Setting origin='native' for %s geometry.", ds.geometry)
             origin = "native"
 
         if isinstance(ds, YTSpatialPlotDataset):
@@ -1714,7 +1721,7 @@ class ProjectionPlot(PWViewerMPL):
             "geographic",
             "internal_geographic",
         ):
-            mylog.info("Setting origin='native' for %s geometry.", ds.geometry)
+            ytLogger.info("Setting origin='native' for %s geometry.", ds.geometry)
             origin = "native"
         if proj_style is not None:
             issue_deprecation_warning(
@@ -2372,7 +2379,7 @@ def SlicePlot(ds, normal=None, fields=None, axis=None, *args, **kwargs):
     if is_sequence(normal) and not isinstance(normal, str):
         # OffAxisSlicePlot has hardcoded origin; remove it if in kwargs
         if "origin" in kwargs:
-            mylog.warning(
+            ytLogger.warning(
                 "Ignoring 'origin' keyword as it is ill-defined for "
                 "an OffAxisSlicePlot object."
             )
@@ -2382,7 +2389,7 @@ def SlicePlot(ds, normal=None, fields=None, axis=None, *args, **kwargs):
     else:
         # north_vector not used in AxisAlignedSlicePlots; remove it if in kwargs
         if "north_vector" in kwargs:
-            mylog.warning(
+            ytLogger.warning(
                 "Ignoring 'north_vector' keyword as it is ill-defined for "
                 "an AxisAlignedSlicePlot object."
             )

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -19,7 +19,7 @@ from yt.funcs import (
     matplotlib_style_context,
 )
 from yt.utilities.exceptions import YTNotInsideNotebook
-from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.logger import ytLogger
 
 from ..data_objects.selection_objects.data_selection_objects import YTSelectionContainer
 from .base_plot_types import ImagePlotMPL, PlotMPL
@@ -49,7 +49,7 @@ def get_canvas(name):
     elif suffix in (".eps", ".ps"):
         canvas_cls = mpl.FigureCanvasPS
     else:
-        mylog.warning("Unknown suffix %s, defaulting to Agg", suffix)
+        ytLogger.warning("Unknown suffix %s, defaulting to Agg", suffix)
         canvas_cls = mpl.FigureCanvasAgg
     return canvas_cls
 
@@ -332,7 +332,7 @@ class ProfilePlot:
                 fns.append(f"{prefix}{suffix}")
             else:
                 fns.append(f"{prefix}_1d-Profile_{xfn}_{uid}{suffix}")
-            mylog.info("Saving %s", fns[-1])
+            ytLogger.info("Saving %s", fns[-1])
             with matplotlib_style_context():
                 plot.save(fns[-1], mpl_kwargs=mpl_kwargs)
         return fns
@@ -1089,12 +1089,12 @@ class PhasePlot(ImagePlotContainer):
                 if z_scale == "log":
                     positive_values = data[data > 0.0]
                     if len(positive_values) == 0:
-                        mylog.warning(
+                        ytLogger.warning(
                             "Profiled field %s has no positive " "values.  Max = %f.",
                             f,
                             np.nanmax(data),
                         )
-                        mylog.warning("Switching to linear colorbar scaling.")
+                        ytLogger.warning("Switching to linear colorbar scaling.")
                         zmin = np.nanmin(data)
                         z_scale = "linear"
                         self._field_transform[f] = linear_transform

--- a/yt/visualization/volume_rendering/image_handling.py
+++ b/yt/visualization/volume_rendering/image_handling.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 from yt.utilities.on_demand_imports import _h5py as h5py
 
 
@@ -50,7 +50,7 @@ def import_rgba(name, h5=True):
         a = f["A"].value
         f.close()
     else:
-        mylog.error("No support for fits import.")
+        ytLogger.error("No support for fits import.")
     return np.array([r, g, b, a]).swapaxes(0, 2).swapaxes(0, 1)
 
 

--- a/yt/visualization/volume_rendering/lens.py
+++ b/yt/visualization/volume_rendering/lens.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from yt.data_objects.image_array import ImageArray
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 from yt.units.yt_array import uhstack, unorm, uvstack
 from yt.utilities.lib.grid_traversal import arr_fisheye_vectors
 from yt.utilities.math_utils import get_rotation_matrix
@@ -233,8 +233,8 @@ class PerspectiveLens(Lens):
             lens_type="perspective",
         )
 
-        mylog.debug(positions)
-        mylog.debug(vectors)
+        ytLogger.debug(positions)
+        ytLogger.debug(vectors)
 
         return sampler_params
 
@@ -427,8 +427,8 @@ class StereoPerspectiveLens(Lens):
         # Here the east_vecs is non-rotated one
         positions = positions + east_vecs * disparity
 
-        mylog.debug(positions)
-        mylog.debug(vectors)
+        ytLogger.debug(positions)
+        ytLogger.debug(vectors)
 
         return vectors, positions
 

--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from yt.data_objects.api import ImageArray
-from yt.funcs import is_sequence, mylog
+from yt.funcs import is_sequence, ytLogger
 from yt.units.unit_object import Unit
 from yt.utilities.lib.partitioned_grid import PartitionedGrid
 from yt.utilities.lib.pixelization_routines import (
@@ -300,7 +300,7 @@ def off_axis_projection(
     data_source.ds.index
     if item is None:
         field = data_source.ds.field_list[0]
-        mylog.info("Setting default field to %s", field.__repr__())
+        ytLogger.info("Setting default field to %s", field.__repr__())
 
     funits = data_source.ds._get_field_info(item).units
 
@@ -367,7 +367,7 @@ def off_axis_projection(
     if vol.weight_field is not None:
         fields.append(vol.weight_field)
 
-    mylog.debug("Casting rays")
+    ytLogger.debug("Casting rays")
 
     for (grid, mask) in data_source.blocks:
         data = []

--- a/yt/visualization/volume_rendering/old_camera.py
+++ b/yt/visualization/volume_rendering/old_camera.py
@@ -5,7 +5,13 @@ import numpy as np
 
 from yt.config import ytcfg
 from yt.data_objects.api import ImageArray
-from yt.funcs import ensure_numpy_array, get_num_threads, get_pbar, is_sequence, mylog
+from yt.funcs import (
+    ensure_numpy_array,
+    get_num_threads,
+    get_pbar,
+    is_sequence,
+    ytLogger,
+)
 from yt.units.yt_array import YTArray
 from yt.utilities.amr_kdtree.api import AMRKDTree
 from yt.utilities.exceptions import YTNotInsideNotebook
@@ -213,7 +219,7 @@ class Camera(ParallelAnalysisInterface):
         self.light_dir = None
         self.light_rgba = None
         if self.no_ghost:
-            mylog.warning(
+            ytLogger.warning(
                 "no_ghost is currently True (default). "
                 "This may lead to artifacts at grid boundaries."
             )
@@ -1505,7 +1511,7 @@ class HEALpixCamera(Camera):
         use_light=False,
         inner_radius=10,
     ):
-        mylog.error("I am sorry, HEALpix Camera does not work yet in 3.0")
+        ytLogger.error("I am sorry, HEALpix Camera does not work yet in 3.0")
         raise NotImplementedError
 
     def new_image(self):
@@ -1865,7 +1871,7 @@ class MosaicCamera(Camera):
         # self._setup_box_properties(width, center, self.orienter.unit_vectors)
 
         if self.no_ghost:
-            mylog.warning(
+            ytLogger.warning(
                 "no_ghost is currently True (default). "
                 "This may lead to artifacts at grid boundaries."
             )
@@ -1913,7 +1919,7 @@ class MosaicCamera(Camera):
         dy = self.width[1]
         offi = self.imi + 0.5
         offj = self.imj + 0.5
-        mylog.info("Mosaic offset: %f %f", offi, offj)
+        ytLogger.info("Mosaic offset: %f %f", offi, offj)
         global_center = self.center
         self.center = self.origin
         self.center += offi * dx * self.orienter.unit_vectors[0]
@@ -1957,7 +1963,7 @@ class MosaicCamera(Camera):
             self.initialize_source()
 
             self.imi, self.imj = xy
-            mylog.debug("Working on: %i %i", self.imi, self.imj)
+            ytLogger.debug("Working on: %i %i", self.imi, self.imj)
             self._setup_box_properties(
                 self.width, self.center, self.orienter.unit_vectors
             )
@@ -2259,7 +2265,7 @@ class SphericalCamera(Camera):
     def __init__(self, *args, **kwargs):
         Camera.__init__(self, *args, **kwargs)
         if self.resolution[0] / self.resolution[1] != 2:
-            mylog.info("Warning: It's recommended to set the aspect ratio to 2:1")
+            ytLogger.info("Warning: It's recommended to set the aspect ratio to 2:1")
         self.resolution = np.asarray(self.resolution) + 2
 
     def get_sampler_args(self, image):
@@ -2342,11 +2348,11 @@ class StereoSphericalCamera(Camera):
         self.disparity = self.ds.arr(self.disparity, units="code_length")
         self.disparity_s = self.ds.arr(0.0, units="code_length")
         if self.resolution[0] / self.resolution[1] != 2:
-            mylog.info("Warning: It's recommended to set the aspect ratio to be 2:1")
+            ytLogger.info("Warning: It's recommended to set the aspect ratio to be 2:1")
         self.resolution = np.asarray(self.resolution) + 2
         if self.disparity <= 0.0:
             self.disparity = self.width[0] / 1000.0
-            mylog.info(
+            ytLogger.info(
                 "Warning: Invalid value of disparity; now reset it to %f",
                 self.disparity,
             )

--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 import numpy as np
 
 from yt.config import ytcfg
-from yt.funcs import get_image_suffix, mylog
+from yt.funcs import get_image_suffix, ytLogger
 from yt.units.dimensions import length
 from yt.units.unit_registry import UnitRegistry
 from yt.units.yt_array import YTArray, YTQuantity
@@ -219,7 +219,7 @@ class Scene:
         >>> sc.save(sigma_clip=4.0)
 
         """
-        mylog.info("Rendering scene (Can take a while).")
+        ytLogger.info("Rendering scene (Can take a while).")
         if camera is None:
             camera = self.camera
         assert camera is not None
@@ -234,15 +234,15 @@ class Scene:
         # desirable (e.g., if only changing sigma_clip or
         # saving after a call to sc.show()).
         if self._last_render is None:
-            mylog.warning("No previously rendered image found, rendering now.")
+            ytLogger.warning("No previously rendered image found, rendering now.")
             render = True
         elif render:
-            mylog.warning(
+            ytLogger.warning(
                 "Previously rendered image exists, but rendering anyway. "
                 "Supply 'render=False' to save previously rendered image directly."
             )
         else:
-            mylog.info("Found previously rendered image to save.")
+            ytLogger.info("Found previously rendered image to save.")
 
         return render
 
@@ -325,7 +325,7 @@ class Scene:
         render = self._sanitize_render(render)
         if render:
             self.render()
-        mylog.info("Saving rendered image to %s", fname)
+        ytLogger.info("Saving rendered image to %s", fname)
 
         # We can render pngs natively but for other formats we defer to
         # matplotlib.
@@ -456,7 +456,7 @@ class Scene:
         render = self._sanitize_render(render)
         if render:
             self.render()
-        mylog.info("Saving rendered image to %s", fname)
+        ytLogger.info("Saving rendered image to %s", fname)
 
         # which transfer function?
         rs = rensources[0]
@@ -494,7 +494,7 @@ class Scene:
         elif suffix in (".eps", ".ps"):
             canvas = FigureCanvasPS(self._render_figure)
         else:
-            mylog.warning("Unknown suffix %s, defaulting to Agg", suffix)
+            ytLogger.warning("Unknown suffix %s, defaulting to Agg", suffix)
             canvas = self.canvas
 
         self._render_figure.canvas = canvas

--- a/yt/visualization/volume_rendering/transfer_function_helper.py
+++ b/yt/visualization/volume_rendering/transfer_function_helper.py
@@ -5,7 +5,7 @@ import matplotlib
 import numpy as np
 
 from yt.data_objects.profiles import create_profile
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 from yt.visualization.volume_rendering.transfer_functions import ColorTransferFunction
 
 
@@ -103,7 +103,7 @@ class TransferFunctionHelper:
 
         """
         if self.bounds is None:
-            mylog.info(
+            ytLogger.info(
                 "Calculating data bounds. This may take a while. "
                 "Set the TransferFunctionHelper.bounds to avoid this."
             )

--- a/yt/visualization/volume_rendering/transfer_functions.py
+++ b/yt/visualization/volume_rendering/transfer_functions.py
@@ -2,7 +2,7 @@ import numpy as np
 from matplotlib.cm import get_cmap
 from more_itertools import always_iterable
 
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 from yt.utilities.physical_constants import clight, hcgs, kboltz
 
 
@@ -736,7 +736,7 @@ class ColorTransferFunction(MultiVariateTransferFunction):
         if alpha is None:
             alpha = a
         self.add_gaussian(v, w, [r, g, b, alpha])
-        mylog.debug(
+        ytLogger.debug(
             "Adding gaussian at %s with width %s and colors %s", v, w, (r, g, b, alpha)
         )
 
@@ -980,7 +980,7 @@ class PlanckTransferFunction(MultiVariateTransferFunction):
             # Now we set up the scattering
             scat = (johnson_filters[f]["Lchar"] ** -4 / mscat) * anorm
             tf = TransferFunction(rho_bounds)
-            mylog.debug("Adding: %s with relative scattering %s", f, scat)
+            ytLogger.debug("Adding: %s with relative scattering %s", f, scat)
             tf.y *= 0.0
             tf.y += scat
             self.add_field_table(tf, 1, weight_field_id=1)

--- a/yt/visualization/volume_rendering/volume_rendering.py
+++ b/yt/visualization/volume_rendering/volume_rendering.py
@@ -1,4 +1,4 @@
-from yt.funcs import mylog
+from yt.funcs import ytLogger
 from yt.utilities.exceptions import YTSceneFieldNotFound
 
 from .api import MeshSource, Scene, create_volume_source
@@ -57,7 +57,7 @@ def create_scene(data_source, field=None, lens_type="plane-parallel"):
                 f"""Could not find field '{field}' in {data_source.ds}.
                   Please specify a field in create_scene()"""
             )
-        mylog.info("Setting default field to %s", field.__repr__())
+        ytLogger.info("Setting default field to %s", field.__repr__())
 
     if hasattr(data_source.ds.index, "meshes"):
         source = MeshSource(data_source, field=field)


### PR DESCRIPTION
## PR Summary

`yt.funcs.mylog` is a widely spread alias for `yt.utilities.logger.ytLogger`. I find that the name is a bit confusing for it's not immediately clear who "my" refers to (the library ? the module ? a single function or class ?). Additionally, the code base is currently not harmonised and we have several co-existing ways to import the same object internally

```python
from yt.funcs import mylog
from yt.utilities.logger import ytLogger as mylog
from yt import mylog
```
This last one being mostly recommended from an external user's standpoint, so it needs to be dealt with accordingly with a proper deprecation process.

This PR proposes an internal harmonisation and a clean deprecation to avoid breaking downstream code in the next release.