### PR TITLE
Special relativistic fields for GAMER

### DIFF
--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -1684,6 +1684,21 @@ functionality:
 Particle data are supported and are always stored in the same file as the grid
 data.
 
+For special relativistic simulations, both the gamma-law and Taub-Mathews EOSes
+are supported, and the following fields are defined:
+
+* ``("gas", "density")``: Comoving rest-mass density :math:`\rho`
+* ``("gas", "frame_density")``: Coordinate-frame density :math:`D = \gamma\rho`
+* ``("gas", "gamma")``: Ratio of specific heats :math:`\Gamma`
+* ``("gas", "four_velocity_[txyz]")``: Four-velocity fields :math:`U_t, U_x, U_y, U_z`
+* ``("gas", "lorentz_factor")``: Lorentz factor :math:`\gamma = \sqrt{1+U_iU^i/c^2}`
+  (where :math:`i` runs over the spatial indices)
+
+These, and other fields following them (3-velocity, energy densities, etc.) are
+computed in the same manner as in the
+`GAMER-SR paper <https://ui.adsabs.harvard.edu/abs/2021MNRAS.504.3298T/abstract>`_
+to avoid catastrophic cancellations.
+
 .. rubric:: Caveats
 
 * GAMER data in raw binary format (i.e., ``OPT__OUTPUT_TOTAL = "C-binary"``) is not

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -1679,9 +1679,6 @@ functionality:
    }
    ds = yt.load("InteractingJets/jet_000002", units_override=code_units)
 
-This means that the yt fields, e.g., ``("gas","density")``, will be in cgs units,
-but the GAMER fields, e.g., ``("gamer","Dens")``, will be in code units.
-
 Particle data are supported and are always stored in the same file as the grid
 data.
 

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -1655,8 +1655,10 @@ following:
 GAMER Data
 ----------
 
-GAMER HDF5 data is supported and cared for by Hsi-Yu Schive. You can load the
-data like this:
+GAMER HDF5 data is supported and cared for by Hsi-Yu Schive and John ZuHone.
+Datasets using hydrodynamics, particles, magnetohydrodynamics, wave dark matter,
+and special relativistic hydrodynamics are supported. You can load the data like
+this:
 
 .. code-block:: python
 

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -68,7 +68,7 @@ answer_tests:
     - yt/frontends/gadget/tests/test_outputs.py:test_bigendian_field_access
     - yt/frontends/gadget/tests/test_outputs.py:test_magneticum
 
-  local_gamer_008:
+  local_gamer_009:
     - yt/frontends/gamer/tests/test_outputs.py:test_jet
     - yt/frontends/gamer/tests/test_outputs.py:test_psiDM
     - yt/frontends/gamer/tests/test_outputs.py:test_plummer

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -73,6 +73,7 @@ answer_tests:
     - yt/frontends/gamer/tests/test_outputs.py:test_psiDM
     - yt/frontends/gamer/tests/test_outputs.py:test_plummer
     - yt/frontends/gamer/tests/test_outputs.py:test_mhdvortex
+    - yt/frontends/gamer/tests/test_outputs.py:test_jiw
 
   local_gdf_002:
     - yt/frontends/gdf/tests/test_outputs_nose.py:test_sedov_tunnel

--- a/yt/fields/astro_fields.py
+++ b/yt/fields/astro_fields.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from .derived_field import ValidateParameter
 from .field_plugin_registry import register_field_plugin
+from .vector_operations import create_magnitude_field
 
 
 @register_field_plugin
@@ -161,4 +162,11 @@ def setup_astro_fields(registry, ftype="gas", slice_info=None):
         sampling_type="local",
         function=_four_velocity_t,
         units=unit_system["velocity"],
+    )
+
+    create_magnitude_field(
+        registry,
+        "four_velocity",
+        unit_system["velocity"],
+        ftype=ftype,
     )

--- a/yt/fields/astro_fields.py
+++ b/yt/fields/astro_fields.py
@@ -125,24 +125,15 @@ def setup_astro_fields(registry, ftype="gas", slice_info=None):
         (ftype, "entropy"), sampling_type="local", units="keV*cm**2", function=_entropy
     )
 
-    def _relativistic_beta(field, data):
-        return data[ftype, "velocity_magnitude"].to_value("c")
-    
-    registry.add_field(
-        (ftype, "relativistic_beta"),
-        sampling_type="local",
-        units="",
-        function=_relativistic_beta,
-    )
-
-    def _relativistic_gamma(field, data):
-        b2 = data[ftype, "relativistic_beta"]
+    def _lorentz_factor(field, data):
+        b2 = data[ftype, "velocity_magnitude"].to_value("c")
         b2 *= b2
         return 1.0/np.sqrt(1.0-b2)
 
     registry.add_field(
-        (ftype, "relativistic_gamma"), 
+        (ftype, "lorentz_factor"),
         sampling_type="local",
-        units="", 
-        function=_relativistic_gamma,
+        units="",
+        function=_lorentz_factor,
     )
+

--- a/yt/fields/astro_fields.py
+++ b/yt/fields/astro_fields.py
@@ -125,9 +125,19 @@ def setup_astro_fields(registry, ftype="gas", slice_info=None):
         (ftype, "entropy"), sampling_type="local", units="keV*cm**2", function=_entropy
     )
 
+    def _relativistic_beta(field, data):
+        return data[ftype, "velocity_magnitude"].to_value("c")
+    
+    registry.add_field(
+        (ftype, "relativistic_beta"),
+        sampling_type="local",
+        units="",
+        function=_relativistic_beta,
+    )
+
     def _relativistic_gamma(field, data):
-        v = data[ftype, "velocity_magnitude"].to_value("c")
-        return 1.0/np.sqrt(1.0-v*v)
+        b2 = data[ftype, "relativistic_beta"]
+        return 1.0/np.sqrt(1.0-b2)
 
     registry.add_field(
         (ftype, "relativistic_gamma"), 

--- a/yt/fields/astro_fields.py
+++ b/yt/fields/astro_fields.py
@@ -137,6 +137,7 @@ def setup_astro_fields(registry, ftype="gas", slice_info=None):
 
     def _relativistic_gamma(field, data):
         b2 = data[ftype, "relativistic_beta"]
+        b2 *= b2
         return 1.0/np.sqrt(1.0-b2)
 
     registry.add_field(

--- a/yt/fields/astro_fields.py
+++ b/yt/fields/astro_fields.py
@@ -124,3 +124,14 @@ def setup_astro_fields(registry, ftype="gas", slice_info=None):
     registry.add_field(
         (ftype, "entropy"), sampling_type="local", units="keV*cm**2", function=_entropy
     )
+
+    def _relativistic_gamma(field, data):
+        v = data[ftype, "velocity_magnitude"].to_value("c")
+        return 1.0/np.sqrt(1.0-v*v)
+
+    registry.add_field(
+        (ftype, "relativistic_gamma"), 
+        sampling_type="local",
+        units="", 
+        function=_relativistic_gamma,
+    )

--- a/yt/fields/astro_fields.py
+++ b/yt/fields/astro_fields.py
@@ -128,7 +128,7 @@ def setup_astro_fields(registry, ftype="gas", slice_info=None):
     def _lorentz_factor(field, data):
         b2 = data[ftype, "velocity_magnitude"].to_value("c")
         b2 *= b2
-        return 1.0/np.sqrt(1.0-b2)
+        return 1.0 / np.sqrt(1.0 - b2)
 
     registry.add_field(
         (ftype, "lorentz_factor"),
@@ -140,7 +140,8 @@ def setup_astro_fields(registry, ftype="gas", slice_info=None):
     # 4-velocity spatial components
     def four_velocity_xyz(u):
         def _four_velocity(field, data):
-            return data["gas", f"velocity_{u}"]*data["gas", "lorentz_factor"]
+            return data["gas", f"velocity_{u}"] * data["gas", "lorentz_factor"]
+
         return _four_velocity
 
     for u in "xyz":
@@ -153,11 +154,11 @@ def setup_astro_fields(registry, ftype="gas", slice_info=None):
 
     # 4-velocity t-component
     def _four_velocity_t(field, data):
-        return data["gas", "lorentz_factor"]*pc.clight
+        return data["gas", "lorentz_factor"] * pc.clight
 
     registry.add_field(
         ("gas", "four_velocity_t"),
         sampling_type="local",
         function=_four_velocity_t,
-        units=unit_system["velocity"]
+        units=unit_system["velocity"],
     )

--- a/yt/fields/astro_fields.py
+++ b/yt/fields/astro_fields.py
@@ -137,3 +137,27 @@ def setup_astro_fields(registry, ftype="gas", slice_info=None):
         function=_lorentz_factor,
     )
 
+    # 4-velocity spatial components
+    def four_velocity_xyz(u):
+        def _four_velocity(field, data):
+            return data["gas", f"velocity_{u}"]*data["gas", "lorentz_factor"]
+        return _four_velocity
+
+    for u in "xyz":
+        registry.add_field(
+            ("gas", f"four_velocity_{u}"),
+            sampling_type="local",
+            function=four_velocity_xyz(u),
+            units=unit_system["velocity"],
+        )
+
+    # 4-velocity t-component
+    def _four_velocity_t(field, data):
+        return data["gas", "lorentz_factor"]*pc.clight
+
+    registry.add_field(
+        ("gas", "four_velocity_t"),
+        sampling_type="local",
+        function=_four_velocity_t,
+        units=unit_system["velocity"]
+    )

--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -347,11 +347,14 @@ class GAMERDataset(Dataset):
         # make aliases to some frequently used variables
         if parameters["Model"] == "Hydro":
             self.gamma = parameters["Gamma"]
+            self.eos = parameters["EoS"]
             # default to 0.6 for old data format
             self.mu = parameters.get("MolecularWeight", 0.6)
             self.mhd = parameters.get("Magnetohydrodynamics", 0)
+            self.srhd = parameters.get("SRHydrodynamics", 0)
         else:
             self.mhd = 0
+            self.srhd = 0
 
         # old data format (version < 2210) did not contain any information of code units
         self.parameters.setdefault("Opt__Unit", 0)

--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -347,9 +347,11 @@ class GAMERDataset(Dataset):
         # make aliases to some frequently used variables
         if parameters["Model"] == "Hydro":
             self.gamma = parameters["Gamma"]
-            self.eos = parameters["EoS"]
+            self.eos = parameters.get("EoS", 1)  # Assume gamma-law by default
             # default to 0.6 for old data format
-            self.mu = parameters.get("MolecularWeight", 0.6)
+            self.mu = parameters.get(
+                "MolecularWeight", 0.6
+            )  # Assume ionized primordial by default
             self.mhd = parameters.get("Magnetohydrodynamics", 0)
             self.srhd = parameters.get("SRHydrodynamics", 0)
         else:

--- a/yt/frontends/gamer/tests/test_outputs.py
+++ b/yt/frontends/gamer/tests/test_outputs.py
@@ -79,3 +79,21 @@ def test_GAMERDataset():
 @requires_file(jet)
 def test_units_override():
     units_override_check(jet)
+
+
+jiw = "JetICMWall/Data_000060"
+_fields_jiw = (
+    ("gas", "four_velocity_magnitude"),
+    ("gas", "density"),
+    ("gas", "gamma"),
+    ("gas", "temperature"),
+)
+
+
+@requires_ds(jiw, big_data=True)
+def test_jiw():
+    ds = data_dir_load(jiw)
+    assert_equal(str(ds), "Data_000060")
+    for test in small_patch_amr(ds, _fields_jiw):
+        test_jiw.__name__ = test.description
+        yield test

--- a/yt/sample_data_registry.json
+++ b/yt/sample_data_registry.json
@@ -229,6 +229,12 @@
     "load_name": "data.0000.3d.hdf5",
     "url": "https://yt-project.org/data/IsothermalSphere.tar.gz"
   },
+  "JetICMWall.tar.gz": {
+    "hash": "d0f75569c743836a2d9d140e4bc88f039d6788d3dc53284e8a081cf76b2edbd9",
+    "load_kwargs": {},
+    "load_name": "Data_000060",
+    "url": "https://yt-project.org/data/JetICMWall.tar.gz"
+  },
   "KelvinHelmholtz.tar.gz": {
     "hash": "a70ccdab287e6b24553881d24a08a4025079b0e40eea9097c7ef686166ce571d",
     "load_kwargs": {},


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

This PR adds field definitions for special relativistic simulations to the GAMER frontend. This is a work in progress.

It uses the equations from https://arxiv.org/abs/2012.11130.

See also https://github.com/gamer-project/gamer/pull/41.

It also adds the general derived fields `lorentz_factor` and `four_velocity_[xyzt]` components for any frontend. 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Need to add field definitions for thermal and kinetic energies in the case of SR. 
 
<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
