### PR TITLE
Add possibility to silence some warnings

### DIFF
--- a/yt/__init__.py
+++ b/yt/__init__.py
@@ -158,6 +158,7 @@ def _check_deprecated_parameters():
     if ytcfg.get("yt", "load_field_plugins"):
         issue_deprecation_warning(
             "Found deprecated parameter 'load_field_plugins' in yt's configuration file.",
+            deprecation_id="init:load_field_plugins",
             removal="4.1.0",
         )
 

--- a/yt/_maintenance/deprecation.py
+++ b/yt/_maintenance/deprecation.py
@@ -1,5 +1,7 @@
 import warnings
 
+from yt.config import ytcfg
+
 
 class VisibleDeprecationWarning(UserWarning):
     """Visible deprecation warning, adapted from NumPy
@@ -14,13 +16,19 @@ class VisibleDeprecationWarning(UserWarning):
     pass
 
 
-def issue_deprecation_warning(msg, *, removal, since=None, stacklevel=3):
+def issue_deprecation_warning(
+    msg, *, removal, since=None, stacklevel=3, deprecation_id=None
+):
     """
     Parameters
     ----------
     msg: str
         A text message explaining that the code surrounding the call to this function is
         deprecated, and what should be changed on the user side to avoid it.
+
+    deprecation_id: str
+        A unique id to identify the deprecation message. This can be used to silent
+        some warnings manually.
 
     since and removal: str version numbers, indicating the anticipated removal date
 
@@ -41,10 +49,15 @@ def issue_deprecation_warning(msg, *, removal, since=None, stacklevel=3):
     --------
     >>> issue_deprecation_warning(
             "This code is deprecated.",
+            deprecation_id="filename:key",
             since="4.0.0",
             removal="4.2.0"
         )
     """
+    warnings_to_ignore = ytcfg.get("yt", "developers", "ignore_warnings")
+    if deprecation_id in warnings_to_ignore:
+        return
+
     msg += "\n"
     if since is not None:
         msg += f"Deprecated since v{since} . "

--- a/yt/_maintenance/deprecation.py
+++ b/yt/_maintenance/deprecation.py
@@ -1,7 +1,5 @@
 import warnings
 
-from yt.config import ytcfg
-
 
 class VisibleDeprecationWarning(UserWarning):
     """Visible deprecation warning, adapted from NumPy
@@ -54,6 +52,9 @@ def issue_deprecation_warning(
             removal="4.2.0"
         )
     """
+    # We need to import this here to prevent import cycles
+    from yt.config import ytcfg
+
     warnings_to_ignore = ytcfg.get("yt", "developers", "ignore_warnings")
     if deprecation_id in warnings_to_ignore:
         return

--- a/yt/config.py
+++ b/yt/config.py
@@ -64,6 +64,11 @@ ytcfg_defaults["yt"] = dict(
         topcomm_parallel_size=1,
         command_line=False,
     ),
+    # Options for developers
+    developers=dict(
+        # List of warnings to ignore
+        ignore_warnings=[]
+    ),
 )
 
 
@@ -179,17 +184,9 @@ OLD_CONFIG_FILE = os.path.join(CONFIG_DIR, "ytrc")
 _global_config_file = YTConfig.get_global_config_file()
 _local_config_file = YTConfig.get_local_config_file()
 
+warn_about_both_config_present = False
 if os.path.exists(OLD_CONFIG_FILE):
-    if os.path.exists(_global_config_file):
-        issue_deprecation_warning(
-            f"The configuration file {OLD_CONFIG_FILE} is deprecated in "
-            f"favor of {_global_config_file}. Currently, both are present. "
-            "Please manually remove the deprecated one to silence "
-            "this warning.",
-            since="4.0.0",
-            removal="4.1.0",
-        )
-    else:
+    if not os.path.exists(_global_config_file):
         # We have an issue here: when calling from the command line,
         # we do not want this to exit, as it would prevent `yt config migrate`
         # from running. The issue is that yt.config (this file) is imported
@@ -206,10 +203,15 @@ if os.path.exists(OLD_CONFIG_FILE):
                 f"The configuration file {OLD_CONFIG_FILE} is deprecated. "
                 f"Please migrate your config to {_global_config_file} by running: "
                 "'yt config migrate'",
+                deprecation_id="config:migration",
                 since="4.0.0",
                 removal="4.1.0",
             )
             raise SystemExit
+    else:
+        # We keep the information both files are present and warn afterwards,
+        # unless the config explicitely asks for it to be turned off
+        warn_about_both_config_present = True
 
 
 if not os.path.exists(_global_config_file):
@@ -230,3 +232,16 @@ if os.path.exists(_local_config_file):
     ytcfg.read(_local_config_file)
 elif os.path.exists(_global_config_file):
     ytcfg.read(_global_config_file)
+
+# We need to do this *after* the config was read so that devs may
+# deactivate the warnings
+if warn_about_both_config_present:
+    issue_deprecation_warning(
+        f"The configuration file {OLD_CONFIG_FILE} is deprecated in "
+        f"favor of {_global_config_file}. Currently, both are present. "
+        "Please manually remove the deprecated one to silence "
+        "this warning.",
+        deprecation_id="config:both_file_present",
+        since="4.0.0",
+        removal="4.1.0",
+    )

--- a/yt/data_objects/index_subobjects/octree_subset.py
+++ b/yt/data_objects/index_subobjects/octree_subset.py
@@ -532,7 +532,12 @@ class OctreeSubset(YTSelectionContainer):
                 "get_vertex_centered_data() requires list of fields, rather than "
                 "a single field as an argument."
             )
-            issue_deprecation_warning(message, since="4.0.0", removal="4.1.0")
+            issue_deprecation_warning(
+                message,
+                deprecation_id="octree_subset:get_vertex_centered_data-old_api",
+                since="4.0.0",
+                removal="4.1.0",
+            )
             fields = [fields]
 
         # Make sure the field list has only unique entries

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -261,6 +261,7 @@ class Dataset(abc.ABC):
             "Dataset.periodicity should not be overriden manually. "
             "In the future, this will become an error. "
             "Use `Dataset.force_periodicity` instead.",
+            deprecation_id="static_output:manual-set-periodicity",
             since="4.0.0",
             removal="4.1.0",
         )
@@ -1682,6 +1683,7 @@ class Dataset(abc.ABC):
             "visualization machinery now treats SPH fields properly by smoothing onto "
             "pixel locations. See this page to learn more: "
             "https://yt-project.org/doc/yt4differences.html",
+            deprecation_id="static_output:add_smoothed_particle_field",
             since="4.0.0",
             removal="4.1.0",
         )
@@ -1731,6 +1733,7 @@ class Dataset(abc.ABC):
             issue_deprecation_warning(
                 "keyword argument 'input_field' is deprecated in favor of 'fields' "
                 "and will be removed in a future version of yt.",
+                deprecation_id="static_output:input_field",
                 since="4.0.0",
                 removal="4.1.0",
             )

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -409,6 +409,7 @@ class DatasetSeries:
         issue_deprecation_warning(
             "DatasetSeries.from_filenames() is deprecated and will be removed "
             "in a future version of yt. Use DatasetSeries() directly.",
+            deprecation_id="time_series:from_filenames",
             since="4.0.0",
             removal="4.1.0",
         )

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -296,6 +296,7 @@ class FieldInfoContainer(dict):
             issue_deprecation_warning(
                 "'particle_type' keyword argument is deprecated in favour "
                 "of the positional argument 'sampling_type'.",
+                deprecation_id="field_info_container:particle_type_keyword",
                 since="4.0.0",
                 removal="4.1.0",
             )

--- a/yt/fields/particle_fields.py
+++ b/yt/fields/particle_fields.py
@@ -869,6 +869,7 @@ def add_volume_weighted_smoothed_field(
         "visualization machinery now treats SPH fields properly by smoothing onto "
         "pixel locations. See this page to learn more: "
         "https://yt-project.org/doc/yt4differences.html",
+        deprecation_id="particle_fields:add_volume_weighted_smoothed_field",
         since="4.0.0",
         removal="4.1.0",
     )

--- a/yt/fields/species_fields.py
+++ b/yt/fields/species_fields.py
@@ -182,6 +182,7 @@ def add_deprecated_species_alias(registry, ftype, alias_species, species, suffix
             issue_deprecation_warning(
                 ('The "%s_%s" field is deprecated. ' + 'Please use "%s_%s" instead.')
                 % (alias_species, suffix, species, suffix),
+                deprecation_id="species_field:deprecated_alias_fields",
                 since="4.0.0",
                 removal="4.1.0",
             )

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -145,6 +145,7 @@ def simulation(fn, simulation_type, find_outputs=False):
     issue_deprecation_warning(
         "yt.simulation is a deprecated alias for yt.load_simulation"
         "and will be removed in a future version of yt.",
+        deprecation_id="loaders:yt.simulation",
         since="4.0.0",
         removal="4.1.0",
     )
@@ -258,6 +259,7 @@ def load_uniform_grid(
             "dict. The number of particles is "
             "determined from the sizes of the "
             "particle fields.",
+            deprecation_id="loaders:number_of_particles",
             since="4.0.0",
             removal="4.1.0",
         )
@@ -486,6 +488,7 @@ def load_amr_grids(
                 "dict. The number of particles is "
                 "determined from the sizes of the "
                 "particle fields.",
+                deprecation_id="loaders:number_of_particles",
                 since="4.0.0",
                 removal="4.1.0",
             )

--- a/yt/utilities/amr_kdtree/amr_kdtree.py
+++ b/yt/utilities/amr_kdtree/amr_kdtree.py
@@ -377,6 +377,7 @@ class AMRKDTree(ParallelAnalysisInterface):
         issue_deprecation_warning(
             "`AMRKDTree.locate_brick` is a deprecated alias "
             "for `AMRKDTree.locate_node`.",
+            deprecation_id="amr_kdtree:locate_brick",
             removal="4.1.0",
         )
         return self.locate_node(position)

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -320,6 +320,7 @@ def can_run_sim(sim_fn, sim_type, file_check=False):
         "This function is no longer used in the "
         "yt project testing framework and is "
         "targeted for deprecation.",
+        deprecation_id="framework:can_run_sim",
         since="4.0.0",
         removal="4.1.0",
     )
@@ -1116,6 +1117,7 @@ def requires_sim(sim_fn, sim_type, big_data=False, file_check=False):
         "This function is no longer used in the "
         "yt project testing framework and is "
         "targeted for deprecation.",
+        deprecation_id="framework:requires_sim",
         since="4.0.0",
         removal="4.1.0",
     )

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -37,6 +37,7 @@ class YTOutputNotIdentified(YTUnidentifiedDataType):
 
         issue_deprecation_warning(
             "YTOutputNotIdentified is a deprecated alias for YTUnidentifiedDataType",
+            deprecation_id="exceptions:YTOutputNotIdentified",
             since="4.0.0",
             removal="4.1.0",
         )

--- a/yt/visualization/color_maps.py
+++ b/yt/visualization/color_maps.py
@@ -30,6 +30,7 @@ def add_cmap(name, cdict):
 
     issue_deprecation_warning(
         "`add_cmap` is a deprecated alias for `add_colormap`",
+        deprecation_id="color_maps:add_cmap",
         since="4.0.0",
         removal="4.1.0",
     )

--- a/yt/visualization/eps_writer.py
+++ b/yt/visualization/eps_writer.py
@@ -1590,7 +1590,9 @@ def single_plot(
 # =============================================================================
 def return_cmap(cmap=None, label="", range=(0, 1), log=False):
     issue_deprecation_warning(
-        "Deprecated alias. Use return_colormap instead.", removal="4.1.0"
+        "Deprecated alias. Use return_colormap instead.",
+        deprecation_id="eps_writer:return_cmap",
+        removal="4.1.0",
     )
     return return_colormap(cmap=cmap, label=label, crange=range, log=log)
 

--- a/yt/visualization/image_writer.py
+++ b/yt/visualization/image_writer.py
@@ -413,6 +413,7 @@ def write_projection(
         issue_deprecation_warning(
             "The `limits` keyword argument is deprecated and will "
             "be removed in a future version of yt. Use `vmin` and `vmax` instead.",
+            deprecation_id="image_writer:limits_keyword",
             since="4.0.0",
             removal="4.1.0",
         )

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -304,6 +304,7 @@ class PlotContainer:
             issue_deprecation_warning(
                 "Deprecated api, use bools for *state*.",
                 deprecation_id="plot_container:bools_for_state",
+                since="4.0.0",
                 removal="4.1.0",
             )
             state = {"on": True, "off": False}[state.lower()]

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -302,7 +302,9 @@ class PlotContainer:
         """
         if isinstance(state, str):
             issue_deprecation_warning(
-                "Deprecated api, use bools for *state*.", removal="4.1.0"
+                "Deprecated api, use bools for *state*.",
+                deprecation_id="plot_container:bools_for_state",
+                removal="4.1.0",
             )
             state = {"on": True, "off": False}[state.lower()]
 
@@ -944,6 +946,7 @@ class ImagePlotContainer(PlotContainer):
         issue_deprecation_warning(
             "`ImagePlotContainer.set_cbar_minorticks` is a deprecated alias "
             "for `ImagePlotContainer.set_colorbar_minorticks`.",
+            deprecation_id="plot_container:cbar_minorticks",
             removal="4.1.0",
         )
 

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -2346,7 +2346,7 @@ def SlicePlot(ds, normal=None, fields=None, axis=None, *args, **kwargs):
         issue_deprecation_warning(
             "SlicePlot's argument 'axis' is a deprecated alias for 'normal', it "
             "will be removed in a future version of yt.",
-            deprecation_id="plot_window:slice_plot:axis",
+            deprecation_id="plot_window:slice_plot-axis",
             since="4.0.0",
             removal="4.1.0",
         )

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -715,6 +715,7 @@ class PlotWindow(ImagePlotContainer):
         issue_deprecation_warning(
             "`PlotWindow.set_window_size` is a deprecated alias "
             "for `PlotWindow.set_figure_size`.",
+            deprecation_id="plot_window:set_window_size",
             removal="4.1.0",
         )
         self.set_figure_size(size)
@@ -1217,6 +1218,7 @@ class PWViewerMPL(PlotWindow):
         issue_deprecation_warning(
             "`annotate_clear` has been deprecated "
             "in favor of `clear_annotations`. Using `clear_annotations`.",
+            deprecation_id="plot_window:annotate_clear",
             since="4.0.0",
             removal="4.1.0",
         )
@@ -1719,6 +1721,7 @@ class ProjectionPlot(PWViewerMPL):
         if proj_style is not None:
             issue_deprecation_warning(
                 "`proj_style` parameter is deprecated, use `method` instead.",
+                deprecation_id="plot_window:proj_style",
                 removal="4.1.0",
             )
             method = proj_style
@@ -2343,6 +2346,7 @@ def SlicePlot(ds, normal=None, fields=None, axis=None, *args, **kwargs):
         issue_deprecation_warning(
             "SlicePlot's argument 'axis' is a deprecated alias for 'normal', it "
             "will be removed in a future version of yt.",
+            deprecation_id="plot_window:slice_plot:axis",
             since="4.0.0",
             removal="4.1.0",
         )


### PR DESCRIPTION
## PR Summary

As devs, we may want to silence some warnings when developing. For example, we may want to ignore the warning that both `~/.config/yt/ytrc` and `~/.config/yt/yt.toml` exist when working on both yt 3 and yt 4.

This PR adds supports for adding a list of warnings to simply ignore for devs convenience. I did *not* write any doc for this, as it is intended for devs only (otherwise users may simply ignore all warnings).

To use it, find the warning that is getting on your nerve, and save it in your config using
```toml
[yt.developers]
ignore_warnings = ["config:both_file_present"]
```