### PR TITLE
Fix: loading DatasetSeries with broken arguments

### DIFF
--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -220,11 +220,9 @@ class DatasetSeries:
                 self._pre_outputs[key], parallel=self.parallel, **self.kwargs
             )
         o = self._pre_outputs[key]
-        try:
+        if isinstance(o, (str, os.PathLike)):
             o = self._load(o, **self.kwargs)
             self._setup_function(o)
-        except TypeError:
-            pass
         return o
 
     def __len__(self):

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -194,7 +194,7 @@ class DatasetSeries:
         pattern = outputs
         epattern = os.path.expanduser(pattern)
         data_dir = ytcfg.get("yt", "test_data_dir")
-        # if not match if found from the current work dir,
+        # if no match if found from the current work dir,
         # we try to match the pattern from the test data dir
         file_list = glob.glob(epattern) or glob.glob(os.path.join(data_dir, epattern))
         if not file_list:


### PR DESCRIPTION
## PR Summary

Currently, calling

```python
>>> series = yt.load(valid_series_regexp, invalid_kwarg="hello")
>>> ds = series[0]
>>> print(type(ds))
str
```

Because a type error is being wrongfully captured. These changes are required to free that error:
```python
TypeError: __init__() got an unexpected keyword argument 'invalid_kwarg'
```

~While I'm at it, I believe that our implementation `DatasetSeries__iter__` actually constitutes unnecessary code duplication so I'm removing it (if I'm wrong I hope our tests catch it).~
edit: I'll redo this experiment in an isolated PR

todo
- [x] add a test