### PR TITLE
Set _periodicity to avoid deprecated setter.

### DIFF
--- a/yt/frontends/ytdata/data_structures.py
+++ b/yt/frontends/ytdata/data_structures.py
@@ -29,6 +29,7 @@ from yt.utilities.tree_container import TreeContainer
 from .fields import YTDataContainerFieldInfo, YTGridFieldInfo
 
 _grid_data_containers = ["arbitrary_grid", "covering_grid", "smoothed_covering_grid"]
+_set_attrs = {"periodicity": "_periodicity"}
 
 
 class SavedDataset(Dataset):
@@ -104,7 +105,8 @@ class SavedDataset(Dataset):
 
         for attr in self._con_attrs:
             try:
-                setattr(self, attr, self.parameters.get(attr))
+                sattr = _set_attrs.get(attr, attr)
+                setattr(self, sattr, self.parameters.get(attr))
             except TypeError:
                 # some Dataset attributes are properties with setters
                 # which may not accept None as an input
@@ -516,12 +518,13 @@ class YTGridDataset(YTDataset):
                     self.domain_right_edge - self.domain_left_edge
                 ) / self.domain_dimensions
 
-            self._periodicity = (
+            periodicity = (
                 np.abs(self.domain_left_edge - self.base_domain_left_edge) < 0.5 * dx
             )
-            self.periodicity &= (
+            periodicity &= (
                 np.abs(self.domain_right_edge - self.base_domain_right_edge) < 0.5 * dx
             )
+            self._periodicity = periodicity
 
         elif self.data_type == "yt_frb":
             dle = self.domain_left_edge
@@ -728,7 +731,7 @@ class YTNonspatialDataset(YTGridDataset):
             "domain_dimensions": np.ones(3, dtype="int"),
             "domain_left_edge": np.zeros(3),
             "domain_right_edge": np.ones(3),
-            "periodicity": np.ones(3, dtype="bool"),
+            "_periodicity": np.ones(3, dtype="bool"),
         }
         for att, val in default_attrs.items():
             if getattr(self, att, None) is None:


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

This fixes the `ytdata` frontend to set `self._periodicity` instead of `self.periodicity`, for which the setter function is deprecated.

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
