### PR TITLE
Migration script: migrate with user input

### DIFF
--- a/yt/config.py
+++ b/yt/config.py
@@ -6,7 +6,6 @@ from more_itertools import always_iterable
 
 from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.utilities.configuration_tree import ConfigNode
-from yt.utilities.configure import interactive_migrate_config
 
 ytcfg_defaults = {}
 
@@ -210,6 +209,8 @@ if os.path.exists(OLD_CONFIG_FILE):
                 since="4.0.0",
                 removal="4.1.0",
             )
+            from yt.utilities.configure import interactive_migrate_config
+
             interactive_migrate_config()
 
 

--- a/yt/config.py
+++ b/yt/config.py
@@ -6,6 +6,7 @@ from more_itertools import always_iterable
 
 from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.utilities.configuration_tree import ConfigNode
+from yt.utilities.configure import interactive_migrate_config
 
 ytcfg_defaults = {}
 
@@ -209,7 +210,7 @@ if os.path.exists(OLD_CONFIG_FILE):
                 since="4.0.0",
                 removal="4.1.0",
             )
-            raise SystemExit
+            interactive_migrate_config()
 
 
 if not os.path.exists(_global_config_file):

--- a/yt/utilities/configure.py
+++ b/yt/utilities/configure.py
@@ -47,6 +47,19 @@ def write_config(config_file):
     CONFIG.write(config_file)
 
 
+def interactive_migrate_config():
+    prompt = "Perform the migration now [yn]? "
+    user_input = input(prompt).lower()
+    while user_input not in ("y", "yes", "n", "no"):
+        print(f"Did not understand your input '{user_input}'. Please enter 'y' or 'n'.")
+        user_input = input(prompt).lower()
+
+    if user_input in ("y", "yes"):
+        migrate_config()
+    else:
+        raise SystemExit("Migration not performed: exiting.")
+
+
 def migrate_config():
     if not os.path.exists(OLD_CONFIG_FILE):
         print("Old config not found.")


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

At the moment, if a user has `~/.config/yt/ytrc` but no `~/.config/yt/yt.toml`, a hard-exit happens which prevent yt from being used. Though we display an explicit message advising the user on how to fix the issue, we may give the user a chance to interactively perform the migration immediately to lower the friction of this transition.