### PR TITLE
Migration script: warn and do not migrate

### DIFF
--- a/yt/config.py
+++ b/yt/config.py
@@ -209,7 +209,6 @@ if os.path.exists(OLD_CONFIG_FILE):
                 since="4.0.0",
                 removal="4.1.0",
             )
-            raise SystemExit
 
 
 if not os.path.exists(_global_config_file):

--- a/yt/config.py
+++ b/yt/config.py
@@ -190,25 +190,13 @@ if os.path.exists(OLD_CONFIG_FILE):
             removal="4.1.0",
         )
     else:
-        # We have an issue here: when calling from the command line,
-        # we do not want this to exit, as it would prevent `yt config migrate`
-        # from running. The issue is that yt.config (this file) is imported
-        # from yt.__init__, which is imported *before* yt.utilities.configure
-        # is executed, so the latter cannot set some internal variable before
-        # we arrive here.
-        # The workaround here relies on inspecting the call stack and hopefully
-        # detect we were called from the CLI.
-        import inspect
-
-        stack = inspect.stack()
-        if len(stack) < 2 or stack[-2].function != "importlib_load_entry_point":
-            issue_deprecation_warning(
-                f"The configuration file {OLD_CONFIG_FILE} is deprecated. "
-                f"Please migrate your config to {_global_config_file} by running: "
-                "'yt config migrate'",
-                since="4.0.0",
-                removal="4.1.0",
-            )
+        issue_deprecation_warning(
+            f"The configuration file {OLD_CONFIG_FILE} is deprecated. "
+            f"Please migrate your config to {_global_config_file} by running: "
+            "'yt config migrate'",
+            since="4.0.0",
+            removal="4.1.0",
+        )
 
 
 if not os.path.exists(_global_config_file):


### PR DESCRIPTION
Related to #3044.

Here is the behaviour
- on yt 4, `yt.toml` and `ytcfg` are present: raise a warning
- on yt 4, `yt.toml` does not exist, `ytcfg` exists: raise another warning and **do not migrate**
- in any case, a `yt.toml` will be created (see #3045)