### PR TITLE
Migration script: migrate automatically

### DIFF
--- a/yt/config.py
+++ b/yt/config.py
@@ -209,7 +209,6 @@ if os.path.exists(OLD_CONFIG_FILE):
                 since="4.0.0",
                 removal="4.1.0",
             )
-            raise SystemExit
 
 
 if not os.path.exists(_global_config_file):

--- a/yt/config.py
+++ b/yt/config.py
@@ -204,11 +204,15 @@ if os.path.exists(OLD_CONFIG_FILE):
         if len(stack) < 2 or stack[-2].function != "importlib_load_entry_point":
             issue_deprecation_warning(
                 f"The configuration file {OLD_CONFIG_FILE} is deprecated. "
-                f"Please migrate your config to {_global_config_file} by running: "
-                "'yt config migrate'",
+                f"Migrating your config to {_global_config_file} automatically. "
+                "You can also migrate manually by running: "
+                "'yt config migrate'.",
                 since="4.0.0",
                 removal="4.1.0",
             )
+            from yt.utilities.configure import migrate_config
+
+            migrate_config()
 
 
 if not os.path.exists(_global_config_file):


### PR DESCRIPTION
Related to #3044.

Here is the behaviour
- on yt 4, `yt.toml` and `ytcfg` are present: raise a warning
- on yt 4, `yt.toml` does not exist, `ytcfg` exists: raise another warning and **do the migration automatically** without confirmation
- in any case, a `yt.toml` will be created (see #3045)