### PR TITLE
maint: replace numpy alias types with corresponding builtin types

### DIFF
--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -134,7 +134,7 @@ class YTStreamline(YTSelectionContainer1D):
             self.positions <= grid.RightEdge, axis=1
         )
         pids = np.where(points_in_grid)[0]
-        mask = np.zeros(points_in_grid.sum(), dtype="int")
+        mask = np.zeros(points_in_grid.sum(), dtype="int64")
         dts = np.zeros(points_in_grid.sum(), dtype="float64")
         ts = np.zeros(points_in_grid.sum(), dtype="float64")
         for mi, (i, pos) in enumerate(zip(pids, self.positions[points_in_grid])):

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -1120,7 +1120,7 @@ class YTCoveringGrid(YTSelectionContainer3D):
         bounds[3] = bounds[2] + dd[1].d * self.ActiveDimensions[1]
         bounds[4] = self.left_edge[2].in_base("code")
         bounds[5] = bounds[4] + dd[2].d * self.ActiveDimensions[2]
-        size = np.ones(3, dtype=int) * 2 ** self.level
+        size = np.ones(3, dtype="int64") * 2 ** self.level
 
         return bounds, size
 

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -1112,7 +1112,7 @@ class YTCoveringGrid(YTSelectionContainer3D):
 
     def _get_grid_bounds_size(self):
         dd = self.ds.domain_width / 2 ** self.level
-        bounds = np.zeros(6, dtype=float)
+        bounds = np.zeros(6, dtype="float64")
 
         bounds[0] = self.left_edge[0].in_base("code")
         bounds[1] = bounds[0] + dd[0].d * self.ActiveDimensions[0]
@@ -1224,7 +1224,7 @@ class YTArbitraryGrid(YTCoveringGrid):
             self[field] = self.ds.arr(dest, fi.units)
 
     def _get_grid_bounds_size(self):
-        bounds = np.empty(6, dtype=float)
+        bounds = np.empty(6, dtype="float64")
         bounds[0] = self.left_edge[0].in_base("code")
         bounds[2] = self.left_edge[1].in_base("code")
         bounds[4] = self.left_edge[2].in_base("code")

--- a/yt/data_objects/tests/test_particle_trajectories.py
+++ b/yt/data_objects/tests/test_particle_trajectories.py
@@ -62,7 +62,7 @@ def test_etc_traj():
 def test_uniqueness():
     n_particles = 2
     n_steps = 2
-    ids = np.arange(n_particles, dtype=int) % (n_particles // 2)
+    ids = np.arange(n_particles, dtype="int64") % (n_particles // 2)
     data = {"particle_index": ids}
     fields = [
         "particle_position_x",

--- a/yt/frontends/adaptahop/io.py
+++ b/yt/frontends/adaptahop/io.py
@@ -186,7 +186,7 @@ class IOHandlerAdaptaHOPBinary(BaseIOHandler):
 
             nhalos = params["nhalos"] + params["nsubs"]
             data = np.zeros((nhalos, 3))
-            offset_map = np.zeros((nhalos, 2), dtype=int)
+            offset_map = np.zeros((nhalos, 2), dtype="int64")
             for ihalo in range(nhalos):
                 ipos = fpu.tell()
                 for it in todo:

--- a/yt/frontends/art/io.py
+++ b/yt/frontends/art/io.py
@@ -135,7 +135,7 @@ class IOHandlerART(BaseIOHandler):
             tr[field] = np.arange(idxa, idxb)
         elif fname == "particle_type":
             a = 0
-            data = np.zeros(npa, dtype="int")
+            data = np.zeros(npa, dtype="int64")
             for i, (ptb, size) in enumerate(zip(pbool, sizes)):
                 if ptb:
                     data[a : a + size] = i
@@ -248,7 +248,7 @@ class IOHandlerDarkMatterART(IOHandlerART):
             tr[field] = np.arange(idxa, idxb)
         elif fname == "particle_type":
             a = 0
-            data = np.zeros(npa, dtype="int")
+            data = np.zeros(npa, dtype="int64")
             for i, (ptb, size) in enumerate(zip(pbool, sizes)):
                 if ptb:
                     data[a : a + size] = i

--- a/yt/frontends/artio/_artio_caller.pyx
+++ b/yt/frontends/artio/_artio_caller.pyx
@@ -459,7 +459,7 @@ cdef class artio_fileset :
         if not self.has_particles: return
 
         data = {}
-        accessed_species = np.zeros( self.num_species, dtype="int")
+        accessed_species = np.zeros( self.num_species, dtype="int64")
         selected_mass = [ None for i in range(self.num_species)]
         selected_pid = [ None for i in range(self.num_species)]
         selected_species = [ None for i in range(self.num_species)]

--- a/yt/frontends/athena/data_structures.py
+++ b/yt/frontends/athena/data_structures.py
@@ -371,7 +371,7 @@ class AthenaHierarchy(GridIndex):
                     [slc[0].start, slc[1].start, slc[2].start] for slc in slices
                 ]
                 read_dims += [
-                    np.array([gdims[i][0], gdims[i][1], shape[2]], dtype="int")
+                    np.array([gdims[i][0], gdims[i][1], shape[2]], dtype="int64")
                     for shape in shapes
                 ]
             self.num_grids *= self.dataset.nprocs

--- a/yt/frontends/athena_pp/data_structures.py
+++ b/yt/frontends/athena_pp/data_structures.py
@@ -71,8 +71,8 @@ class AthenaPPLogarithmicIndex(UnstructuredIndex):
         nbx, nby, nbz = tuple(np.max(log_loc, axis=0) + 1)
         nlevel = self._handle.attrs["MaxLevel"] + 1
 
-        nb = np.array([nbx, nby, nbz], dtype="int")
-        self.mesh_factors = np.ones(3, dtype="int") * ((nb > 1).astype("int") + 1)
+        nb = np.array([nbx, nby, nbz], dtype="int64")
+        self.mesh_factors = np.ones(3, dtype="int64") * ((nb > 1).astype("int") + 1)
 
         block_grid = -np.ones((nbx, nby, nbz, nlevel), dtype=np.int)
         block_grid[log_loc[:, 0], log_loc[:, 1], log_loc[:, 2], levels[:]] = np.arange(

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -1407,7 +1407,7 @@ def _read_header(raw_file, field):
             except ValueError:
                 # nghost_line[0] is (#,#,#)
                 nghost_list = nghost_line[0].strip("()").split(",")
-                nghost = np.array(nghost_list, dtype=int)
+                nghost = np.array(nghost_list, dtype="int64")
 
             # read the file and offset position for the corresponding box
             file_names = []

--- a/yt/frontends/boxlib/io.py
+++ b/yt/frontends/boxlib/io.py
@@ -251,7 +251,7 @@ class IOHandlerOrion(IOHandlerBoxlib):
 
         def read(line, field):
             entry = line.strip().split(" ")[self.particle_field_index[field]]
-            return np.float(entry)
+            return float(entry)
 
         try:
             lines = self._cached_lines

--- a/yt/frontends/chombo/io.py
+++ b/yt/frontends/chombo/io.py
@@ -287,7 +287,7 @@ class IOHandlerOrion2HDF5(IOHandlerChomboHDF5):
 
         def read(line, field):
             entry = line.strip().split(" ")[self.particle_field_index[field]]
-            return np.float(entry)
+            return float(entry)
 
         try:
             lines = self._cached_lines

--- a/yt/frontends/enzo_p/misc.py
+++ b/yt/frontends/enzo_p/misc.py
@@ -65,7 +65,7 @@ def get_block_info(block, min_dim=3):
 
 def get_root_blocks(block, min_dim=3):
     mybs, dim = get_block_string_and_dim(block, min_dim=min_dim)
-    nb = np.ones(dim, dtype=int)
+    nb = np.ones(dim, dtype="int64")
     for i, myb in enumerate(mybs):
         if myb == "":
             continue
@@ -76,7 +76,7 @@ def get_root_blocks(block, min_dim=3):
 
 def get_root_block_id(block, min_dim=3):
     mybs, dim = get_block_string_and_dim(block, min_dim=min_dim)
-    rbid = np.zeros(dim, dtype=int)
+    rbid = np.zeros(dim, dtype="int64")
     for i, myb in enumerate(mybs):
         if myb == "":
             continue

--- a/yt/frontends/open_pmd/data_structures.py
+++ b/yt/frontends/open_pmd/data_structures.py
@@ -316,9 +316,7 @@ class OpenPMDHierarchy(GridIndex):
                 0, domain_dimension[0], num_grids + 1, dtype=np.int32
             )
             grid_edge_offset = (
-                grid_dim_offset
-                * np.float(domain_dimension[0]) ** -1
-                * (gre[0] - gle[0])
+                grid_dim_offset * float(domain_dimension[0]) ** -1 * (gre[0] - gle[0])
                 + gle[0]
             )
             mesh_names = []
@@ -556,7 +554,7 @@ class OpenPMDDataset(Dataset):
 
         self.unique_identifier = 0
         self.parameters = 0
-        self._periodicity = np.zeros(3, dtype=np.bool)
+        self._periodicity = np.zeros(3, dtype=bool)
         self.refine_by = 1
         self.cosmological_simulation = 0
 
@@ -642,7 +640,7 @@ class OpenPMDDatasetSeries(DatasetSeries):
         self.handle = h5py.File(filename, mode="r")
         self.filename = filename
         self._pre_outputs = sorted(
-            np.asarray(list(self.handle["/data"].keys()), dtype=np.int)
+            np.asarray(list(self.handle["/data"].keys()), dtype=int)
         )
 
     def __iter__(self):

--- a/yt/frontends/open_pmd/data_structures.py
+++ b/yt/frontends/open_pmd/data_structures.py
@@ -640,7 +640,7 @@ class OpenPMDDatasetSeries(DatasetSeries):
         self.handle = h5py.File(filename, mode="r")
         self.filename = filename
         self._pre_outputs = sorted(
-            np.asarray(list(self.handle["/data"].keys()), dtype="int")
+            np.asarray(list(self.handle["/data"].keys()), dtype="int64")
         )
 
     def __iter__(self):

--- a/yt/frontends/open_pmd/data_structures.py
+++ b/yt/frontends/open_pmd/data_structures.py
@@ -554,7 +554,7 @@ class OpenPMDDataset(Dataset):
 
         self.unique_identifier = 0
         self.parameters = 0
-        self._periodicity = np.zeros(3, dtype=bool)
+        self._periodicity = np.zeros(3, dtype="bool")
         self.refine_by = 1
         self.cosmological_simulation = 0
 
@@ -640,7 +640,7 @@ class OpenPMDDatasetSeries(DatasetSeries):
         self.handle = h5py.File(filename, mode="r")
         self.filename = filename
         self._pre_outputs = sorted(
-            np.asarray(list(self.handle["/data"].keys()), dtype=int)
+            np.asarray(list(self.handle["/data"].keys()), dtype="int")
         )
 
     def __iter__(self):

--- a/yt/frontends/open_pmd/fields.py
+++ b/yt/frontends/open_pmd/fields.py
@@ -156,7 +156,7 @@ class OpenPMDFieldInfo(FieldInfoContainer):
                     # This appears to be a vector field of single dimensionality
                     ytname = str("_".join([fname.replace("_", "-")]))
                     parsed = parse_unit_dimension(
-                        np.asarray(field.attrs["unitDimension"], dtype=int)
+                        np.asarray(field.attrs["unitDimension"], dtype="int")
                     )
                     unit = str(YTQuantity(1, parsed).units)
                     aliases = []
@@ -169,7 +169,7 @@ class OpenPMDFieldInfo(FieldInfoContainer):
                     for axis in field.keys():
                         ytname = str("_".join([fname.replace("_", "-"), axis]))
                         parsed = parse_unit_dimension(
-                            np.asarray(field.attrs["unitDimension"], dtype=int)
+                            np.asarray(field.attrs["unitDimension"], dtype="int")
                         )
                         unit = str(YTQuantity(1, parsed).units)
                         aliases = []

--- a/yt/frontends/open_pmd/fields.py
+++ b/yt/frontends/open_pmd/fields.py
@@ -156,7 +156,7 @@ class OpenPMDFieldInfo(FieldInfoContainer):
                     # This appears to be a vector field of single dimensionality
                     ytname = str("_".join([fname.replace("_", "-")]))
                     parsed = parse_unit_dimension(
-                        np.asarray(field.attrs["unitDimension"], dtype=np.int)
+                        np.asarray(field.attrs["unitDimension"], dtype=int)
                     )
                     unit = str(YTQuantity(1, parsed).units)
                     aliases = []
@@ -169,7 +169,7 @@ class OpenPMDFieldInfo(FieldInfoContainer):
                     for axis in field.keys():
                         ytname = str("_".join([fname.replace("_", "-"), axis]))
                         parsed = parse_unit_dimension(
-                            np.asarray(field.attrs["unitDimension"], dtype=np.int)
+                            np.asarray(field.attrs["unitDimension"], dtype=int)
                         )
                         unit = str(YTQuantity(1, parsed).units)
                         aliases = []

--- a/yt/frontends/open_pmd/fields.py
+++ b/yt/frontends/open_pmd/fields.py
@@ -156,7 +156,7 @@ class OpenPMDFieldInfo(FieldInfoContainer):
                     # This appears to be a vector field of single dimensionality
                     ytname = str("_".join([fname.replace("_", "-")]))
                     parsed = parse_unit_dimension(
-                        np.asarray(field.attrs["unitDimension"], dtype="int")
+                        np.asarray(field.attrs["unitDimension"], dtype="int64")
                     )
                     unit = str(YTQuantity(1, parsed).units)
                     aliases = []
@@ -169,7 +169,7 @@ class OpenPMDFieldInfo(FieldInfoContainer):
                     for axis in field.keys():
                         ytname = str("_".join([fname.replace("_", "-"), axis]))
                         parsed = parse_unit_dimension(
-                            np.asarray(field.attrs["unitDimension"], dtype="int")
+                            np.asarray(field.attrs["unitDimension"], dtype="int64")
                         )
                         unit = str(YTQuantity(1, parsed).units)
                         aliases = []

--- a/yt/frontends/open_pmd/misc.py
+++ b/yt/frontends/open_pmd/misc.py
@@ -42,7 +42,7 @@ def parse_unit_dimension(unit_dimension):
     """
     if len(unit_dimension) != 7:
         mylog.error("SI must have 7 base dimensions!")
-    unit_dimension = np.asarray(unit_dimension, dtype="int")
+    unit_dimension = np.asarray(unit_dimension, dtype="int64")
     dim = []
     si = ["m", "kg", "s", "A", "C", "mol", "cd"]
     for i in np.arange(7):

--- a/yt/frontends/open_pmd/misc.py
+++ b/yt/frontends/open_pmd/misc.py
@@ -42,7 +42,7 @@ def parse_unit_dimension(unit_dimension):
     """
     if len(unit_dimension) != 7:
         mylog.error("SI must have 7 base dimensions!")
-    unit_dimension = np.asarray(unit_dimension, dtype=np.int)
+    unit_dimension = np.asarray(unit_dimension, dtype=int)
     dim = []
     si = ["m", "kg", "s", "A", "C", "mol", "cd"]
     for i in np.arange(7):

--- a/yt/frontends/open_pmd/misc.py
+++ b/yt/frontends/open_pmd/misc.py
@@ -42,7 +42,7 @@ def parse_unit_dimension(unit_dimension):
     """
     if len(unit_dimension) != 7:
         mylog.error("SI must have 7 base dimensions!")
-    unit_dimension = np.asarray(unit_dimension, dtype=int)
+    unit_dimension = np.asarray(unit_dimension, dtype="int")
     dim = []
     si = ["m", "kg", "s", "A", "C", "mol", "cd"]
     for i in np.arange(7):

--- a/yt/frontends/ramses/hilbert.py
+++ b/yt/frontends/ramses/hilbert.py
@@ -338,7 +338,7 @@ def get_cpu_list(ds, X):
     for icpu in range(1, ncpu + 1):
         bound_key[icpu - 1], bound_key[icpu] = ds.hilbert_indices[icpu]
 
-    cpu_min, cpu_max = [np.zeros(ncpu + 1, dtype=np.int) for _ in range(2)]
+    cpu_min, cpu_max = [np.zeros(ncpu + 1, dtype=int) for _ in range(2)]
     for icpu in range(1, ncpu + 1):
         for i in range(ndom):
             if (
@@ -354,7 +354,7 @@ def get_cpu_list(ds, X):
 
     ncpu_read = 0
     cpu_list = []
-    cpu_read = np.zeros(ncpu, dtype=np.bool)
+    cpu_read = np.zeros(ncpu, dtype=bool)
     for i in range(ndom):
         for j in range(cpu_min[i], cpu_max[i]):
             if not cpu_read[j]:

--- a/yt/frontends/ramses/hilbert.py
+++ b/yt/frontends/ramses/hilbert.py
@@ -338,7 +338,7 @@ def get_cpu_list(ds, X):
     for icpu in range(1, ncpu + 1):
         bound_key[icpu - 1], bound_key[icpu] = ds.hilbert_indices[icpu]
 
-    cpu_min, cpu_max = [np.zeros(ncpu + 1, dtype=int) for _ in range(2)]
+    cpu_min, cpu_max = [np.zeros(ncpu + 1, dtype="int") for _ in range(2)]
     for icpu in range(1, ncpu + 1):
         for i in range(ndom):
             if (
@@ -354,7 +354,7 @@ def get_cpu_list(ds, X):
 
     ncpu_read = 0
     cpu_list = []
-    cpu_read = np.zeros(ncpu, dtype=bool)
+    cpu_read = np.zeros(ncpu, dtype="bool")
     for i in range(ndom):
         for j in range(cpu_min[i], cpu_max[i]):
             if not cpu_read[j]:

--- a/yt/frontends/ramses/hilbert.py
+++ b/yt/frontends/ramses/hilbert.py
@@ -308,7 +308,7 @@ def get_cpu_list(ds, X):
     if bit_length > 0:
         ndom = 8
 
-    idom, jdom, kdom = [np.zeros(8, dtype=int) for _ in range(3)]
+    idom, jdom, kdom = [np.zeros(8, dtype="int64") for _ in range(3)]
 
     idom[0], idom[1] = imin, imax
     idom[2], idom[3] = imin, imax

--- a/yt/frontends/ramses/hilbert.py
+++ b/yt/frontends/ramses/hilbert.py
@@ -338,7 +338,7 @@ def get_cpu_list(ds, X):
     for icpu in range(1, ncpu + 1):
         bound_key[icpu - 1], bound_key[icpu] = ds.hilbert_indices[icpu]
 
-    cpu_min, cpu_max = [np.zeros(ncpu + 1, dtype="int") for _ in range(2)]
+    cpu_min, cpu_max = [np.zeros(ncpu + 1, dtype="int64") for _ in range(2)]
     for icpu in range(1, ncpu + 1):
         for i in range(ndom):
             if (

--- a/yt/frontends/stream/tests/test_stream_octree.py
+++ b/yt/frontends/stream/tests/test_stream_octree.py
@@ -36,7 +36,7 @@ def test_octree():
     octree_mask = np.array(OCT_MASK_LIST, dtype=np.uint8)
 
     quantities = {}
-    quantities[("gas", "density")] = np.ones((22, 1), dtype=float)
+    quantities[("gas", "density")] = np.ones((22, 1), dtype="float64")
 
     bbox = np.array([[-10.0, 10.0], [-10.0, 10.0], [-10.0, 10.0]])
 

--- a/yt/frontends/ytdata/data_structures.py
+++ b/yt/frontends/ytdata/data_structures.py
@@ -728,7 +728,7 @@ class YTNonspatialDataset(YTGridDataset):
         # set some defaults just to make things go
         default_attrs = {
             "dimensionality": 3,
-            "domain_dimensions": np.ones(3, dtype="int"),
+            "domain_dimensions": np.ones(3, dtype="int64"),
             "domain_left_edge": np.zeros(3),
             "domain_right_edge": np.ones(3),
             "_periodicity": np.ones(3, dtype="bool"),
@@ -822,7 +822,7 @@ class YTProfileDataset(YTNonspatialDataset):
         self.base_domain_right_edge = self.domain_right_edge
         self.base_domain_dimensions = self.domain_dimensions
 
-        domain_dimensions = np.ones(3, dtype="int")
+        domain_dimensions = np.ones(3, dtype="int64")
         domain_dimensions[: self.dimensionality] = self.profile_dimensions
         self.domain_dimensions = domain_dimensions
         domain_left_edge = np.zeros(3)

--- a/yt/geometry/grid_geometry_handler.py
+++ b/yt/geometry/grid_geometry_handler.py
@@ -248,7 +248,7 @@ class GridIndex(Index, abc.ABC):
         coords = self.ds.arr(ensure_numpy_array(coords), "code_length")
         grids = self._find_points(coords[:, 0], coords[:, 1], coords[:, 2])[0]
         fields = list(iter_fields(fields))
-        mark = np.zeros(3, dtype=int)
+        mark = np.zeros(3, dtype="int64")
         out = []
 
         # create point -> grid mapping

--- a/yt/geometry/grid_geometry_handler.py
+++ b/yt/geometry/grid_geometry_handler.py
@@ -418,7 +418,7 @@ class GridIndex(Index, abc.ABC):
         if chunk_sizing == "auto":
             chunk_ngrids = len(gobjs)
             if chunk_ngrids > 0:
-                nproc = float(ytcfg.get("yt", "internals", "global_parallel_size"))
+                nproc = int(ytcfg.get("yt", "internals", "global_parallel_size"))
                 chunking_factor = np.ceil(
                     self._grid_chunksize * nproc / chunk_ngrids
                 ).astype("int")

--- a/yt/geometry/grid_geometry_handler.py
+++ b/yt/geometry/grid_geometry_handler.py
@@ -248,7 +248,7 @@ class GridIndex(Index, abc.ABC):
         coords = self.ds.arr(ensure_numpy_array(coords), "code_length")
         grids = self._find_points(coords[:, 0], coords[:, 1], coords[:, 2])[0]
         fields = list(iter_fields(fields))
-        mark = np.zeros(3, dtype=np.int)
+        mark = np.zeros(3, dtype=int)
         out = []
 
         # create point -> grid mapping
@@ -418,7 +418,7 @@ class GridIndex(Index, abc.ABC):
         if chunk_sizing == "auto":
             chunk_ngrids = len(gobjs)
             if chunk_ngrids > 0:
-                nproc = np.float(ytcfg.get("yt", "internals", "global_parallel_size"))
+                nproc = float(ytcfg.get("yt", "internals", "global_parallel_size"))
                 chunking_factor = np.ceil(
                     self._grid_chunksize * nproc / chunk_ngrids
                 ).astype("int")

--- a/yt/geometry/tests/test_particle_octree.py
+++ b/yt/geometry/tests/test_particle_octree.py
@@ -544,7 +544,7 @@ def fake_decomp_hilbert_gaussian(
     hpos = get_hilbert_points(order, hlist)
     iLE = np.empty((len(hlist), 3), dtype="float")
     iRE = np.empty((len(hlist), 3), dtype="float")
-    count = np.zeros(3, dtype="int")
+    count = np.zeros(3, dtype="int64")
     pos = np.empty((npart, 3), dtype="float")
     for k in range(3):
         iLE[:, k] = DLE[k] + hdiv[k] * hpos[:, k]

--- a/yt/utilities/math_utils.py
+++ b/yt/utilities/math_utils.py
@@ -5,7 +5,7 @@ import numpy as np
 from yt.units.yt_array import YTArray
 
 prec_accum = {
-    np.int: np.int64,
+    int: np.int64,
     np.int8: np.int64,
     np.int16: np.int64,
     np.int32: np.int64,
@@ -14,11 +14,11 @@ prec_accum = {
     np.uint16: np.uint64,
     np.uint32: np.uint64,
     np.uint64: np.uint64,
-    np.float: np.float64,
+    float: np.float64,
     np.float16: np.float64,
     np.float32: np.float64,
     np.float64: np.float64,
-    np.complex: np.complex128,
+    complex: np.complex128,
     np.complex64: np.complex128,
     np.complex128: np.complex128,
     np.dtype("int"): np.int64,

--- a/yt/utilities/parallel_tools/parallel_analysis_interface.py
+++ b/yt/utilities/parallel_tools/parallel_analysis_interface.py
@@ -872,7 +872,7 @@ class Communicator:
     @parallel_passthrough
     def mpi_allreduce(self, data, dtype=None, op="sum"):
         op = op_names[op]
-        if isinstance(data, np.ndarray) and data.dtype != np.bool:
+        if isinstance(data, np.ndarray) and data.dtype != bool:
             if dtype is None:
                 dtype = data.dtype
             if dtype != data.dtype:

--- a/yt/utilities/sdf.py
+++ b/yt/utilities/sdf.py
@@ -186,7 +186,7 @@ class DataStruct:
 
     def __getitem__(self, key):
         mask = None
-        if isinstance(key, (int, np.int, np.integer)):
+        if isinstance(key, (int, np.integer)):
             if key == -1:
                 key = slice(-1, None)
             else:

--- a/yt/visualization/volume_rendering/render_source.py
+++ b/yt/visualization/volume_rendering/render_source.py
@@ -621,7 +621,7 @@ class OctreeVolumeSource(VolumeSource):
             1, len(dx), 14, 1
         )
         mask = np.full(dt.shape[1:], 1, dtype=np.uint8)
-        dims = np.array([1, 1, 1], dtype=int)
+        dims = np.array([1, 1, 1], dtype="int64")
         pg = PartitionedGrid(0, dt, mask, LE.flatten(), RE.flatten(), dims, n_fields=1)
 
         mylog.debug("Casting rays")


### PR DESCRIPTION
## PR Summary

Following their deprecation with the release of numpy 1.20.0, replace long-standing type aliases with their corresponding builtin types.
See release notes https://github.com/numpy/numpy/releases/tag/v1.20.0

This should not cause any change in behaviour but will prevent some deprecation warnings to pop up.