### PR TITLE
ci: restrain build-test workflow to pull request trigger

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1,6 +1,6 @@
 name: Build and Test
 
-on: [push, pull_request]
+on: [pull_request]
 
 defaults:
   run:


### PR DESCRIPTION
## PR Summary

This avoids having failures reported from both personal forks and the main repo.