### PR TITLE
ci: install wheel as part of our gh build workflows

### DIFF
--- a/tests/test_prerequirements.txt
+++ b/tests/test_prerequirements.txt
@@ -1,3 +1,7 @@
 # We need this file mostly because of Cartopy..
 numpy>=1.19.4
 cython>=0.29.21
+
+# this is sometimes useful to avoid CI breakage when a dependency release comes out
+# but some wheels (typically windows) are missing for a few hours/days
+wheel


### PR DESCRIPTION
## PR Summary

Attempt to circumvent breakage from just-released dependencies with no wheels available. Currently `cftime` 1.4.0 is breaking our CI because they don't have windows wheels yet.
