### PR TITLE
doc: replace dead travis badge with corresponding GH workflow build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Users' Mailing List](https://img.shields.io/badge/Users-List-lightgrey.svg)](https://mail.python.org/archives/list/yt-users@python.org//)
 [![Devel Mailing List](https://img.shields.io/badge/Devel-List-lightgrey.svg)](https://mail.python.org/archives/list/yt-dev@python.org//)
-[![Build Status](https://img.shields.io/travis/yt-project/yt.svg?branch=main)](https://travis-ci.org/yt-project/yt)
+![Build and Test](https://github.com/yt-project/yt/workflows/Build%20and%20Test/badge.svg)
 [![Latest Documentation](https://img.shields.io/badge/docs-latest-brightgreen.svg)](http://yt-project.org/docs/dev/)
 [![Data Hub](https://img.shields.io/badge/data-hub-orange.svg)](https://hub.yt/)
 [![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](http://numfocus.org)


### PR DESCRIPTION
This will fail test for the same reason I discovered it was necessary: the main branch is currently broken against our test suite but the build badge reports that it's all good... because it hasn't been updated since we dropped travis.