### PR TITLE
doc: add badges for isort, precommit-ci, and minimal supported python

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
 # The yt Project
 
+![Supported Python Version](https://img.shields.io/badge/python%20version-≥%203.6-important)
+[![Latest Documentation](https://img.shields.io/badge/docs-latest-brightgreen.svg)](http://yt-project.org/docs/dev/)
 [![Users' Mailing List](https://img.shields.io/badge/Users-List-lightgrey.svg)](https://mail.python.org/archives/list/yt-users@python.org//)
 [![Devel Mailing List](https://img.shields.io/badge/Devel-List-lightgrey.svg)](https://mail.python.org/archives/list/yt-dev@python.org//)
-![Build and Test](https://github.com/yt-project/yt/workflows/Build%20and%20Test/badge.svg)
-[![Latest Documentation](https://img.shields.io/badge/docs-latest-brightgreen.svg)](http://yt-project.org/docs/dev/)
 [![Data Hub](https://img.shields.io/badge/data-hub-orange.svg)](https://hub.yt/)
 [![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](http://numfocus.org)
 [![Sponsor our Project](https://img.shields.io/badge/donate-to%20yt-blueviolet)](https://numfocus.salsalabs.org/donate-to-yt/index.html)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
-<!---
-[![codecov](https://codecov.io/gh/yt-project/yt/branch/main/graph/badge.svg)](https://codecov.io/gh/yt-project/yt)
---->
+<!--- Tests and style --->
+![Build and Test](https://github.com/yt-project/yt/workflows/Build%20and%20Test/badge.svg?branch=main)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/yt-project/yt/main.svg)](https://results.pre-commit.ci/latest/github/yt-project/yt/main)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
+<!--- [![codecov](https://codecov.io/gh/yt-project/yt/branch/main/graph/badge.svg)](https://codecov.io/gh/yt-project/yt) --->
+
 <a href="http://yt-project.org"><img src="doc/source/_static/yt_logo.png" width="300"></a>
 
 yt is an open-source, permissively-licensed python package for analyzing and


### PR DESCRIPTION
## PR Summary

And rearrange badges over two lines.
This is another attempt than #2976 to acknowledge our minimal supported Python version. This time with a custom static badge since pypi releases may often be out-of sync with the main branch, as is the case right now.

this also includes the change from #3057


Here's how it looks
## current state
![Screen Shot 2021-02-05 at 12 46 35](https://user-images.githubusercontent.com/14075922/107029980-3241a500-67b0-11eb-8648-5ba88f7700ac.png)
## this branch
![Screen Shot 2021-02-05 at 12 45 57](https://user-images.githubusercontent.com/14075922/107029912-1b9b4e00-67b0-11eb-8588-af6c10414609.png)
