### PR TITLE
Consistent return statements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,8 @@ repos:
     - id: flake8
       additional_dependencies: [
         flake8-bugbear>=20.3.2, # GH PR 2851
-        flake8-logging-format
+        flake8-logging-format,
+        flake8-return,
       ]
 -   repo: https://github.com/asottile/blacken-docs
     rev: v1.10.0

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -784,8 +784,6 @@ Source code style guide
    imports should happen at the top of the file.
  * If you are comparing with a numpy boolean array, just refer to the array.
    Ex: do ``np.all(array)`` instead of ``np.all(array == True)``.
- * Only declare local variables if they will be used later. If you do not use the
-   return value of a function, do not store it in a variable.
 
 API Style Guide
 ---------------

--- a/conftest.py
+++ b/conftest.py
@@ -133,8 +133,7 @@ def _param_list(request):
     # Convert python-specific data objects (such as tuples) to a more
     # io-friendly format (in order to not have python-specific anchors
     # in the answer yaml file)
-    test_params = _streamline_for_io(test_params)
-    return test_params
+    return _streamline_for_io(test_params)
 
 
 def _get_answer_files(request):

--- a/doc/extensions/config_help.py
+++ b/doc/extensions/config_help.py
@@ -11,9 +11,7 @@ def setup(app):
     setup.config = app.config
     setup.confdir = app.confdir
 
-    retdict = dict(version="1.0", parallel_read_safe=True, parallel_write_safe=True)
-
-    return retdict
+    return dict(version="1.0", parallel_read_safe=True, parallel_write_safe=True)
 
 
 class GetConfigHelp(Directive):

--- a/doc/extensions/pythonscript_sphinxext.py
+++ b/doc/extensions/pythonscript_sphinxext.py
@@ -74,9 +74,7 @@ def setup(app):
     setup.config = app.config
     setup.confdir = app.confdir
 
-    retdict = dict(version="0.1", parallel_read_safe=True, parallel_write_safe=True)
-
-    return retdict
+    return dict(version="0.1", parallel_read_safe=True, parallel_write_safe=True)
 
 
 def get_image_tag(filename, image_dir, image_rel_dir):

--- a/doc/extensions/yt_colormaps.py
+++ b/doc/extensions/yt_colormaps.py
@@ -18,9 +18,7 @@ def setup(app):
     setup.config = app.config
     setup.confdir = app.confdir
 
-    retdict = dict(version="0.1", parallel_read_safe=True, parallel_write_safe=True)
-
-    return retdict
+    return dict(version="0.1", parallel_read_safe=True, parallel_write_safe=True)
 
 
 class ColormapScript(Directive):

--- a/doc/extensions/yt_cookbook.py
+++ b/doc/extensions/yt_cookbook.py
@@ -18,9 +18,7 @@ def setup(app):
     setup.config = app.config
     setup.confdir = app.confdir
 
-    retdict = dict(version="0.1", parallel_read_safe=True, parallel_write_safe=True)
-
-    return retdict
+    return dict(version="0.1", parallel_read_safe=True, parallel_write_safe=True)
 
 
 data_patterns = ["*.h5", "*.out", "*.dat", "*.mp4"]

--- a/doc/extensions/yt_showfields.py
+++ b/doc/extensions/yt_showfields.py
@@ -10,9 +10,7 @@ def setup(app):
     setup.config = app.config
     setup.confdir = app.confdir
 
-    retdict = dict(version="1.0", parallel_read_safe=True, parallel_write_safe=True)
-
-    return retdict
+    return dict(version="1.0", parallel_read_safe=True, parallel_write_safe=True)
 
 
 class ShowFields(Directive):

--- a/doc/source/cookbook/hse_field.py
+++ b/doc/source/cookbook/hse_field.py
@@ -23,8 +23,7 @@ def _hse(field, data):
     hx = data[("gas", "pressure_gradient_x")] - gx
     hy = data[("gas", "pressure_gradient_y")] - gy
     hz = data[("gas", "pressure_gradient_z")] - gz
-    h = np.sqrt((hx * hx + hy * hy + hz * hz) / (gx * gx + gy * gy + gz * gz))
-    return h
+    return np.sqrt((hx * hx + hy * hy + hz * hz) / (gx * gx + gy * gy + gz * gz))
 
 
 ds.add_field(

--- a/doc/source/cookbook/particle_filter.py
+++ b/doc/source/cookbook/particle_filter.py
@@ -10,20 +10,17 @@ from yt.data_objects.particle_filters import add_particle_filter
 # in the old stars filter.
 def stars_10Myr(pfilter, data):
     age = data.ds.current_time - data["Stars", "creation_time"]
-    filter = np.logical_and(age >= 0, age.in_units("Myr") < 10)
-    return filter
+    return np.logical_and(age >= 0, age.in_units("Myr") < 10)
 
 
 def stars_100Myr(pfilter, data):
     age = (data.ds.current_time - data["Stars", "creation_time"]).in_units("Myr")
-    filter = np.logical_and(age >= 10, age < 100)
-    return filter
+    return np.logical_and(age >= 10, age < 100)
 
 
 def stars_old(pfilter, data):
     age = data.ds.current_time - data["Stars", "creation_time"]
-    filter = np.logical_or(age < 0, age.in_units("Myr") >= 100)
-    return filter
+    return np.logical_or(age < 0, age.in_units("Myr") >= 100)
 
 
 # Create the particle filters

--- a/doc/source/cookbook/particle_filter_sfr.py
+++ b/doc/source/cookbook/particle_filter_sfr.py
@@ -6,8 +6,7 @@ from yt.data_objects.particle_filters import add_particle_filter
 
 
 def formed_star(pfilter, data):
-    filter = data["all", "creation_time"] > 0
-    return filter
+    return data["all", "creation_time"] > 0
 
 
 add_particle_filter(

--- a/tests/report_failed_answers.py
+++ b/tests/report_failed_answers.py
@@ -106,8 +106,7 @@ def generate_failed_answers_html(failed_answers):
             )
             rows.append(formatted_row)
 
-    html = html_template.format(rows="\n".join(rows))
-    return html
+    return html_template.format(rows="\n".join(rows))
 
 
 def upload_to_curldrop(data, filename):
@@ -138,8 +137,7 @@ def upload_to_curldrop(data, filename):
 
     base_url = ytcfg.get("yt", "curldrop_upload_url")
     upload_url = base_url + "/" + os.path.basename(filename)
-    response = requests.put(upload_url, data=data)
-    return response
+    return requests.put(upload_url, data=data)
 
 
 def upload_failed_answers(failed_answers):
@@ -163,9 +161,7 @@ def upload_failed_answers(failed_answers):
     html = generate_failed_answers_html(failed_answers)
     # convert html str to bytes
     html = html.encode()
-    response = upload_to_curldrop(data=html, filename="failed_answers_{}.html")
-
-    return response
+    return upload_to_curldrop(data=html, filename="failed_answers_{}.html")
 
 
 def generate_answers(answer_dir, answers):
@@ -247,7 +243,7 @@ def upload_answers(answers):
         data = iter(FileStreamer(open(zip_file, "rb")))
         response = upload_to_curldrop(data=data, filename="new_answers_{}.zip")
         shutil.rmtree(tmpdir)
-        return response
+        return response  # noqa R504
     return None
 
 

--- a/yt/config.py
+++ b/yt/config.py
@@ -108,15 +108,12 @@ class YTConfig:
         return node_or_leaf
 
     def get_most_specific(self, section, *keys, **kwargs):
-        use_fallback = "fallback" in kwargs
-        fallback = kwargs.pop("fallback", None)
         try:
             return self.config_root.get_deepest_leaf(section, *keys)
         except KeyError as err:
-            if use_fallback:
-                return fallback
-            else:
-                raise err
+            if "fallback" in kwargs:
+                return kwargs["fallback"]
+            raise err
 
     def update(self, new_values, metadata=None):
         if metadata is None:

--- a/yt/data_objects/analyzer_objects.py
+++ b/yt/data_objects/analyzer_objects.py
@@ -29,16 +29,14 @@ def analysis_task(params=None):
         params = tuple()
 
     def create_new_class(func):
-        cls = type(func.__name__, (AnalysisTask,), dict(eval=func, _params=params))
-        return cls
+        return type(func.__name__, (AnalysisTask,), dict(eval=func, _params=params))
 
     return create_new_class
 
 
 @analysis_task(("field",))
 def MaximumValue(params, data_object):
-    v = data_object.quantities["MaxLocation"](params.field)[0]
-    return v
+    return data_object.quantities["MaxLocation"](params.field)[0]
 
 
 @analysis_task()
@@ -76,8 +74,7 @@ class QuantityProxy(AnalysisTask):
         self.kwargs = kwargs
 
     def eval(self, data_object):
-        rv = data_object.quantities[self.quantity_name](*self.args, **self.kwargs)
-        return rv
+        return data_object.quantities[self.quantity_name](*self.args, **self.kwargs)
 
 
 class ParameterValue(AnalysisTask):
@@ -104,5 +101,4 @@ def create_quantity_proxy(quantity_object):
     if kwargs is not None:
         params += kwargs
     dd = dict(_params=params, quantity_name=quantity_object[0])
-    cls = type(quantity_object[0], (QuantityProxy,), dd)
-    return cls
+    return type(quantity_object[0], (QuantityProxy,), dd)

--- a/yt/data_objects/derived_quantities.py
+++ b/yt/data_objects/derived_quantities.py
@@ -22,11 +22,9 @@ def get_position_fields(field, data):
             ftype = finfo.alias_name[0]
         else:
             ftype = finfo.name[0]
-        position_fields = [(ftype, f"particle_position_{d}") for d in axis_names]
+        return [(ftype, f"particle_position_{d}") for d in axis_names]
     else:
-        position_fields = [("index", ax_name) for ax_name in axis_names]
-
-    return position_fields
+        return [("index", ax_name) for ax_name in axis_names]
 
 
 class DerivedQuantity(ParallelAnalysisInterface):
@@ -63,8 +61,7 @@ class DerivedQuantity(ParallelAnalysisInterface):
                 values[i].append(storage[key][i])
         # These will be YTArrays
         values = [self.data_source.ds.arr(values[i]) for i in range(self.num_vals)]
-        values = self.reduce_intermediate(values)
-        return values
+        return self.reduce_intermediate(values)
 
     def process_chunk(self, data, *args, **kwargs):
         raise NotImplementedError
@@ -132,7 +129,7 @@ class WeightedAverageQuantity(DerivedQuantity):
         fields = list(iter_fields(fields))
         rv = super().__call__(fields, weight)
         if len(rv) == 1:
-            rv = rv[0]
+            return rv[0]
         return rv
 
     def process_chunk(self, data, fields, weight):
@@ -171,12 +168,11 @@ class TotalQuantity(DerivedQuantity):
         fields = list(iter_fields(fields))
         rv = super().__call__(fields)
         if len(rv) == 1:
-            rv = rv[0]
+            return rv[0]
         return rv
 
     def process_chunk(self, data, fields):
-        vals = [data[field].sum(dtype=np.float64) for field in fields]
-        return vals
+        return [data[field].sum(dtype=np.float64) for field in fields]
 
     def reduce_intermediate(self, values):
         return [v.sum(dtype=np.float64) for v in values]
@@ -418,7 +414,7 @@ class WeightedStandardDeviation(DerivedQuantity):
         rv = super().__call__(fields, weight)
         rv = [self.data_source.ds.arr(v, u) for v, u in zip(rv, units)]
         if len(rv) == 1:
-            rv = rv[0]
+            return rv[0]
         return rv
 
     def process_chunk(self, data, fields, weight):
@@ -607,7 +603,7 @@ class Extrema(DerivedQuantity):
         fields = list(iter_fields(fields))
         rv = super().__call__(fields, non_zero)
         if len(rv) == 1:
-            rv = rv[0]
+            return rv[0]
         return rv
 
     def process_chunk(self, data, fields, non_zero):
@@ -664,7 +660,7 @@ class SampleAtMaxFieldValues(DerivedQuantity):
     def __call__(self, field, sample_fields):
         rv = super().__call__(field, sample_fields)
         if len(rv) == 1:
-            rv = rv[0]
+            return rv[0]
         return rv
 
     def process_chunk(self, data, field, sample_fields):
@@ -711,7 +707,7 @@ class MaxLocation(SampleAtMaxFieldValues):
         sample_fields = get_position_fields(field, self.data_source)
         rv = super().__call__(field, sample_fields)
         if len(rv) == 1:
-            rv = rv[0]
+            return rv[0]
         return rv
 
 
@@ -767,7 +763,7 @@ class MinLocation(SampleAtMinFieldValues):
         sample_fields = get_position_fields(field, self.data_source)
         rv = super().__call__(field, sample_fields)
         if len(rv) == 1:
-            rv = rv[0]
+            return rv[0]
         return rv
 
 

--- a/yt/data_objects/index_subobjects/grid_patch.py
+++ b/yt/data_objects/index_subobjects/grid_patch.py
@@ -186,8 +186,7 @@ class AMRGridPatch(YTSelectionContainer):
 
     def get_position(self, index):
         """Returns center position of an *index*."""
-        pos = (index + 0.5) * self.dds + self.LeftEdge
-        return pos
+        return (index + 0.5) * self.dds + self.LeftEdge
 
     def _fill_child_mask(self, child, mask, tofill, dlevel=1):
         rf = self.ds.refine_by
@@ -380,7 +379,7 @@ class AMRGridPatch(YTSelectionContainer):
         op.process_grid(self, positions, fields)
         vals = op.finalize()
         if vals is None:
-            return
+            return None
         # Fortran-ordered, so transpose.
         vals = vals.transpose()
         # squeeze dummy dimension we appended above
@@ -427,9 +426,7 @@ class AMRGridPatch(YTSelectionContainer):
 
     def count_particles(self, selector, x, y, z):
         # We don't cache the selector results
-        count = selector.count_points(x, y, z, 0.0)
-        return count
+        return selector.count_points(x, y, z, 0.0)
 
     def select_particles(self, selector, x, y, z):
-        mask = selector.select_points(x, y, z, 0.0)
-        return mask
+        return selector.select_points(x, y, z, 0.0)

--- a/yt/data_objects/index_subobjects/octree_subset.py
+++ b/yt/data_objects/index_subobjects/octree_subset.py
@@ -97,14 +97,12 @@ class OctreeSubset(YTSelectionContainer):
         # data.  But, it might.  However, I can't seem to figure out how to
         # make the assignment to .shape, which *won't* copy the data, make the
         # resultant array viewed in Fortran order.
-        arr = arr.reshape(new_shape, order="F")
-        return arr
+        return arr.reshape(new_shape, order="F")
 
     _domain_ind = None
 
     def mask_refinement(self, selector):
-        mask = self.oct_handler.mask(selector, domain_id=self.domain_id)
-        return mask
+        return self.oct_handler.mask(selector, domain_id=self.domain_id)
 
     def select_blocks(self, selector):
         mask = self.oct_handler.mask(selector, domain_id=self.domain_id)
@@ -203,7 +201,7 @@ class OctreeSubset(YTSelectionContainer):
         )
         vals = op.finalize()
         if vals is None:
-            return
+            return None
         return np.asfortranarray(vals)
 
     def mesh_sampling_particle_field(self, positions, mesh_field, lvlmax=None):
@@ -385,10 +383,9 @@ class OctreeSubset(YTSelectionContainer):
         with np.errstate(invalid="ignore"):
             vals = op.finalize()
         if isinstance(vals, list):
-            vals = [np.asfortranarray(v) for v in vals]
+            return [np.asfortranarray(v) for v in vals]
         else:
-            vals = np.asfortranarray(vals)
-        return vals
+            return np.asfortranarray(vals)
 
     def particle_operation(
         self, positions, fields=None, method=None, nneighbors=64, kernel_name="cubic"
@@ -474,12 +471,11 @@ class OctreeSubset(YTSelectionContainer):
         )
         vals = op.finalize()
         if vals is None:
-            return
+            return None
         if isinstance(vals, list):
-            vals = [np.asfortranarray(v) for v in vals]
+            return [np.asfortranarray(v) for v in vals]
         else:
-            vals = np.asfortranarray(vals)
-        return vals
+            return np.asfortranarray(vals)
 
     @cell_count_cache
     def select_icoords(self, dobj):
@@ -508,22 +504,19 @@ class OctreeSubset(YTSelectionContainer):
         )
 
     def select(self, selector, source, dest, offset):
-        n = self.oct_handler.selector_fill(
+        return self.oct_handler.selector_fill(
             selector, source, dest, offset, domain_id=self.domain_id
         )
-        return n
 
     def count(self, selector):
         return -1
 
     def count_particles(self, selector, x, y, z):
         # We don't cache the selector results
-        count = selector.count_points(x, y, z, 0.0)
-        return count
+        return selector.count_points(x, y, z, 0.0)
 
     def select_particles(self, selector, x, y, z):
-        mask = selector.select_points(x, y, z, 0.0)
-        return mask
+        return selector.select_points(x, y, z, 0.0)
 
     def get_vertex_centered_data(self, fields):
         _old_api = isinstance(fields, (str, tuple))
@@ -565,11 +558,10 @@ class OctreeSubsetBlockSlicePosition:
 
     def __getitem__(self, key):
         bs = self.block_slice
-        rv = np.require(
+        return np.require(
             bs.octree_subset[key][:, :, :, self.ind].T,
             requirements=bs.octree_subset._block_order,
         )
-        return rv
 
     @property
     def id(self):
@@ -679,8 +671,7 @@ class YTPositionArray(YTArray):
         LE -= np.abs(LE) * eps
         RE = self.max(axis=0)
         RE += np.abs(RE) * eps
-        morton = compute_morton(self[:, 0], self[:, 1], self[:, 2], LE, RE)
-        return morton
+        return compute_morton(self[:, 0], self[:, 1], self[:, 2], LE, RE)
 
     def to_octree(self, over_refine_factor=1, dims=(1, 1, 1), n_ref=64):
         mi = self.morton

--- a/yt/data_objects/index_subobjects/particle_container.py
+++ b/yt/data_objects/index_subobjects/particle_container.py
@@ -61,8 +61,7 @@ class ParticleContainer(YTSelectionContainer):
         raise YTDataSelectorNotImplemented(self.oc_type_name)
 
     def select_particles(self, selector, x, y, z):
-        mask = selector.select_points(x, y, z)
-        return mask
+        return selector.select_points(x, y, z)
 
     @contextlib.contextmanager
     def _expand_data_files(self):

--- a/yt/data_objects/index_subobjects/unstructured_mesh.py
+++ b/yt/data_objects/index_subobjects/unstructured_mesh.py
@@ -118,12 +118,10 @@ class UnstructuredMesh(YTSelectionContainer):
 
     def count_particles(self, selector, x, y, z):
         # We don't cache the selector results
-        count = selector.count_points(x, y, z, 0.0)
-        return count
+        return selector.count_points(x, y, z, 0.0)
 
     def select_particles(self, selector, x, y, z):
-        mask = selector.select_points(x, y, z, 0.0)
-        return mask
+        return selector.select_points(x, y, z, 0.0)
 
     def _get_selector_mask(self, selector):
         if hash(selector) == self._last_selector_id:
@@ -162,6 +160,7 @@ class SemiStructuredMesh(UnstructuredMesh):
             return self._current_chunk.fwidth[:, 1]
         elif field == "dz":
             return self._current_chunk.fwidth[:, 2]
+        raise ValueError
 
     def select_fwidth(self, dobj):
         mask = self._get_selector_mask(dobj.selector)

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -40,24 +40,6 @@ def _sanitize_min_max_units(amin, amax, finfo, registry):
     return rmin, rmax
 
 
-def preserve_source_parameters(func):
-    def save_state(*args, **kwargs):
-        # Temporarily replace the 'field_parameters' for a
-        # grid with the 'field_parameters' for the data source
-        prof = args[0]
-        source = args[1]
-        if hasattr(source, "field_parameters"):
-            old_params = source.field_parameters
-            source.field_parameters = prof._data_source.field_parameters
-            tr = func(*args, **kwargs)
-            source.field_parameters = old_params
-        else:
-            tr = func(*args, **kwargs)
-        return tr
-
-    return save_state
-
-
 class ProfileFieldAccumulator:
     def __init__(self, n_fields, size):
         shape = size + (n_fields,)

--- a/yt/data_objects/region_expression.py
+++ b/yt/data_objects/region_expression.py
@@ -84,12 +84,11 @@ class RegionExpression:
 
     def _spec_to_value(self, input):
         if isinstance(input, tuple):
-            v = self.ds.quan(input[0], input[1]).to("code_length")
+            return self.ds.quan(input[0], input[1]).to("code_length")
         elif isinstance(input, YTQuantity):
-            v = self.ds.quan(input).to("code_length")
+            return self.ds.quan(input).to("code_length")
         else:
-            v = self.ds.quan(input, "code_length")
-        return v
+            return self.ds.quan(input, "code_length")
 
     def _create_slice(self, slice_tuple):
         # This is somewhat more complex because we want to allow for slicing
@@ -133,7 +132,7 @@ class RegionExpression:
             height = source.right_edge[yax] - source.left_edge[yax]
             # Make a resolution tuple with
             resolution = (int(new_slice[xax].step.imag), int(new_slice[yax].step.imag))
-            sl = sl.to_frb(width=width, resolution=resolution, height=height)
+            return sl.to_frb(width=width, resolution=resolution, height=height)
         return sl
 
     def _slice_to_edges(self, ax, val):
@@ -203,10 +202,9 @@ class RegionExpression:
                     axis = ax
                     new_slice.append(v)
         if npoints > 0:
-            ray = LineBuffer(self.ds, start_point, end_point, npoints)
+            return LineBuffer(self.ds, start_point, end_point, npoints)
         else:
             if axis == 1:
                 coord = [coord[1], coord[0]]
             source = self._create_region(new_slice)
-            ray = self.ds.ortho_ray(axis, coord, data_source=source)
-        return ray
+            return self.ds.ortho_ray(axis, coord, data_source=source)

--- a/yt/data_objects/selection_objects/cut_region.py
+++ b/yt/data_objects/selection_objects/cut_region.py
@@ -219,7 +219,7 @@ class YTCutRegion(YTSelectionContainer3D):
     def _part_ind_brute_force(self, ptype):
         parent = getattr(self, "parent", self.base_object)
         units = "code_length"
-        mask = points_in_cells(
+        return points_in_cells(
             self[("index", "x")].to(units),
             self[("index", "y")].to(units),
             self[("index", "z")].to(units),
@@ -230,8 +230,6 @@ class YTCutRegion(YTSelectionContainer3D):
             parent[(ptype, "particle_position_y")].to(units),
             parent[(ptype, "particle_position_z")].to(units),
         )
-
-        return mask
 
     def _part_ind(self, ptype):
         # If scipy is installed, use the fast KD tree

--- a/yt/data_objects/selection_objects/data_selection_objects.py
+++ b/yt/data_objects/selection_objects/data_selection_objects.py
@@ -596,8 +596,7 @@ class YTSelectionContainer2D(YTSelectionContainer):
             validate_width_tuple(width)
             if is_sequence(resolution):
                 resolution = max(resolution)
-            frb = CylindricalFixedResolutionBuffer(self, width, resolution)
-            return frb
+            return CylindricalFixedResolutionBuffer(self, width, resolution)
 
         if center is None:
             center = self.center
@@ -632,8 +631,7 @@ class YTSelectionContainer2D(YTSelectionContainer):
             center[yax] - height * 0.5,
             center[yax] + height * 0.5,
         )
-        frb = FixedResolutionBuffer(self, bounds, resolution, periodic=periodic)
-        return frb
+        return FixedResolutionBuffer(self, bounds, resolution, periodic=periodic)
 
 
 class YTSelectionContainer3D(YTSelectionContainer):
@@ -687,10 +685,9 @@ class YTSelectionContainer3D(YTSelectionContainer):
         """
         if locals is None:
             locals = {}
-        cr = self.ds.cut_region(
+        return self.ds.cut_region(
             self, field_cuts, field_parameters=field_parameters, locals=locals
         )
-        return cr
 
     def _build_operator_cut(self, operation, field, value, units=None):
         """
@@ -902,8 +899,7 @@ class YTSelectionContainer3D(YTSelectionContainer):
                 f'(obj["{ftype}", "{fname}"].in_units("{units}") <= {min_value}) | '
                 f'(obj["{ftype}", "{fname}"].in_units("{units}") >= {max_value})'
             )
-        cr = self.cut_region(field_cuts)
-        return cr
+        return self.cut_region(field_cuts)
 
     def include_inside(self, field, min_value, max_value, units=None):
         """
@@ -946,8 +942,7 @@ class YTSelectionContainer3D(YTSelectionContainer):
                 f'(obj["{ftype}", "{fname}"].in_units("{units}") > {min_value}) & '
                 f'(obj["{ftype}", "{fname}"].in_units("{units}") < {max_value})'
             )
-        cr = self.cut_region(field_cuts)
-        return cr
+        return self.cut_region(field_cuts)
 
     def exclude_outside(self, field, min_value, max_value, units=None):
         """
@@ -979,8 +974,7 @@ class YTSelectionContainer3D(YTSelectionContainer):
         >>> print(cr.quantities.total_quantity(("gas", "cell_mass")).in_units("Msun"))
         """
         cr = self.exclude_below(field, min_value, units)
-        cr = cr.exclude_above(field, max_value, units)
-        return cr
+        return cr.exclude_above(field, max_value, units)
 
     def include_outside(self, field, min_value, max_value, units=None):
         """
@@ -1012,8 +1006,7 @@ class YTSelectionContainer3D(YTSelectionContainer):
         >>> cr = ad.exclude_outside(("gas", "temperature"), 1e5, 1e6)
         >>> print(cr.quantities.total_quantity(("gas", "cell_mass")).in_units("Msun"))
         """
-        cr = self.exclude_inside(field, min_value, max_value, units)
-        return cr
+        return self.exclude_inside(field, min_value, max_value, units)
 
     def exclude_below(self, field, value, units=None):
         """
@@ -1211,10 +1204,9 @@ class YTSelectionContainer3D(YTSelectionContainer):
         except KeyError:
             svals = None
 
-        my_verts = march_cubes_grid(
+        return march_cubes_grid(
             value, vc_data[field], mask, grid.LeftEdge, grid.dds, svals
         )
-        return my_verts
 
     def calculate_isocontour_flux(
         self, field, value, field_x, field_y, field_z, fluxing_field=None
@@ -1289,8 +1281,7 @@ class YTSelectionContainer3D(YTSelectionContainer):
             flux += self._calculate_flux_in_grid(
                 block, mask, field, value, field_x, field_y, field_z, fluxing_field
             )
-        flux = self.comm.mpi_allreduce(flux, op="sum")
-        return flux
+        return self.comm.mpi_allreduce(flux, op="sum")
 
     def _calculate_flux_in_grid(
         self, grid, mask, field, value, field_x, field_y, field_z, fluxing_field=None

--- a/yt/data_objects/selection_objects/slices.py
+++ b/yt/data_objects/selection_objects/slices.py
@@ -112,8 +112,7 @@ class YTSlice(YTSelectionContainer2D):
         object, which can then be moved around, zoomed, and on and on.  All
         behavior of the plot window is relegated to that routine.
         """
-        pw = self._get_pw(fields, center, width, origin, "Slice")
-        return pw
+        return self._get_pw(fields, center, width, origin, "Slice")
 
     def plot(self, fields=None):
         if hasattr(self._data_source, "left_edge") and hasattr(
@@ -366,5 +365,4 @@ class YTCuttingPlane(YTSelectionContainer2D):
         from yt.visualization.fixed_resolution import FixedResolutionBuffer
 
         bounds = (-width / 2.0, width / 2.0, -height / 2.0, height / 2.0)
-        frb = FixedResolutionBuffer(self, bounds, resolution, periodic=periodic)
-        return frb
+        return FixedResolutionBuffer(self, bounds, resolution, periodic=periodic)

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -97,8 +97,7 @@ def requires_index(attr_name):
     def ireq(self):
         self.index
         # By now it should have been set
-        attr = self.__dict__[attr_name]
-        return attr
+        return self.__dict__[attr_name]
 
     @ireq.setter
     def ireq(self, value):
@@ -155,14 +154,14 @@ class Dataset(abc.ABC):
         apath = os.path.abspath(filename)
         cache_key = (apath, pickle.dumps(args), pickle.dumps(kwargs))
         if ytcfg.get("yt", "skip_dataset_cache"):
-            obj = object.__new__(cls)
+            return object.__new__(cls)
         elif cache_key not in _cached_datasets:
             obj = object.__new__(cls)
             if not obj._skip_cache:
                 _cached_datasets[cache_key] = obj
+            return obj
         else:
-            obj = _cached_datasets[cache_key]
-        return obj
+            return _cached_datasets[cache_key]
 
     def __init_subclass__(cls, *args, **kwargs):
         super().__init_subclass__(*args, **kwargs)
@@ -505,6 +504,7 @@ class Dataset(abc.ABC):
                 uq = self.quan(j, good_u)
                 if uq <= v:
                     return uq
+            raise RuntimeError
         else:
             return good_u
 
@@ -1238,8 +1238,7 @@ class Dataset(abc.ABC):
             string that we can parse for a sympy Expr.
 
         """
-        new_unit = Unit(unit_str, registry=self.unit_registry)
-        return new_unit
+        return Unit(unit_str, registry=self.unit_registry)
 
     def set_code_units(self):
         # here we override units, if overrides have been provided.
@@ -1860,8 +1859,7 @@ class Dataset(abc.ABC):
 
 def _reconstruct_ds(*args, **kwargs):
     datasets = ParameterFileStore()
-    ds = datasets.get_ds_hash(*args)
-    return ds
+    return datasets.get_ds_hash(*args)
 
 
 @functools.total_ordering
@@ -1934,9 +1932,9 @@ class ParticleDataset(Dataset):
 
 def validate_index_order(index_order):
     if index_order is None:
-        index_order = (7, 5)
+        return (7, 5)
     elif not is_sequence(index_order):
-        index_order = (int(index_order), 1)
+        return (int(index_order), 1)
     else:
         if len(index_order) != 2:
             raise RuntimeError(
@@ -1944,5 +1942,4 @@ def validate_index_order(index_order):
                 "index_order\nmust be an integer or a two-element tuple of "
                 "integers.".format(index_order)
             )
-        index_order = tuple(int(o) for o in index_order)
-    return index_order
+        return tuple(int(o) for o in index_order)

--- a/yt/data_objects/tests/test_chunking.py
+++ b/yt/data_objects/tests/test_chunking.py
@@ -3,7 +3,7 @@ from yt.units.yt_array import uconcatenate
 
 
 def _get_dobjs(c):
-    dobjs = [
+    return [
         ("sphere", ("center", (1.0, "unitary"))),
         ("sphere", ("center", (0.1, "unitary"))),
         ("ortho_ray", (0, (c[1], c[2]))),
@@ -13,7 +13,6 @@ def _get_dobjs(c):
         ("cutting", ([0.1, 0.3, 0.6], "center")),
         ("all_data", ()),
     ]
-    return dobjs
 
 
 def test_chunking():

--- a/yt/data_objects/tests/test_compose.py
+++ b/yt/data_objects/tests/test_compose.py
@@ -22,8 +22,7 @@ def _IDFIELD(field, data):
     xi = x / min_dx
     yi = y / min_dx
     zi = z / min_dx
-    index = xi + delta[0] * (yi + delta[1] * zi)
-    return index
+    return xi + delta[0] * (yi + delta[1] * zi)
 
 
 def test_compose_no_overlap():

--- a/yt/data_objects/tests/test_profiles.py
+++ b/yt/data_objects/tests/test_profiles.py
@@ -481,8 +481,7 @@ def test_particle_profile_negative_field():
 
 def test_profile_zero_weight():
     def DMparticles(pfilter, data):
-        filter = data[(pfilter.filtered_type, "particle_type")] == 1
-        return filter
+        return data[(pfilter.filtered_type, "particle_type")] == 1
 
     def DM_in_cell_mass(field, data):
         return data["deposit", "DM_density"] * data["index", "cell_volume"]

--- a/yt/data_objects/tests/test_refinement.py
+++ b/yt/data_objects/tests/test_refinement.py
@@ -30,7 +30,7 @@ def setup_fake_refby():
         g["density"] = (np.random.random(g["dimensions"].astype("i8")), "g/cm**3")
     bbox = np.array([[0.0, 1.0], [0.0, np.pi], [0.0, np.pi * 2]])
 
-    ds = yt.load_amr_grids(
+    return yt.load_amr_grids(
         grid_data,
         top_grid_dim,
         bbox=bbox,
@@ -38,7 +38,6 @@ def setup_fake_refby():
         refine_by=refine_by,
         length_unit="kpc",
     )
-    return ds
 
 
 def test_refine_by():

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -53,8 +53,7 @@ def get_ds_prop(propname):
     def _eval(params, ds):
         return getattr(ds, propname)
 
-    cls = type(propname, (AnalysisTask,), dict(eval=_eval, _params=tuple()))
-    return cls
+    return type(propname, (AnalysisTask,), dict(eval=_eval, _params=tuple()))
 
 
 attrs = (
@@ -401,8 +400,9 @@ class DatasetSeries:
             since="4.0.0",
             removal="4.1.0",
         )
-        obj = cls(filenames, parallel=parallel, setup_function=setup_function, **kwargs)
-        return obj
+        return cls(
+            filenames, parallel=parallel, setup_function=setup_function, **kwargs
+        )
 
     @classmethod
     def from_output_log(cls, output_log, line_prefix="DATASET WRITTEN", parallel=True):
@@ -413,8 +413,7 @@ class DatasetSeries:
             cut_line = line[len(line_prefix) :].strip()
             fn = cut_line.split()[0]
             filenames.append(fn)
-        obj = cls(filenames, parallel=parallel)
-        return obj
+        return cls(filenames, parallel=parallel)
 
     _dataset_cls = None
 

--- a/yt/exthook.py
+++ b/yt/exthook.py
@@ -52,6 +52,7 @@ class ExtensionImporter:
     def find_module(self, fullname, path=None):
         if fullname.startswith(self.prefix):
             return self
+        return None  # checkme: this should probably be a raise statement
 
     def load_module(self, fullname):
         if fullname in sys.modules:

--- a/yt/fields/astro_fields.py
+++ b/yt/fields/astro_fields.py
@@ -39,7 +39,7 @@ def setup_astro_fields(registry, ftype="gas", slice_info=None):
         MJ_constant = (((5.0 * pc.kboltz) / (pc.G * pc.mh)) ** 1.5) * (
             3.0 / (4.0 * np.pi)
         ) ** 0.5
-        u = (
+        return (
             MJ_constant
             * (
                 (data[ftype, "temperature"] / data[ftype, "mean_molecular_weight"])
@@ -47,7 +47,6 @@ def setup_astro_fields(registry, ftype="gas", slice_info=None):
             )
             * (data[ftype, "density"] ** (-0.5))
         )
-        return u
 
     registry.add_field(
         (ftype, "jeans_mass"),

--- a/yt/fields/cosmology_fields.py
+++ b/yt/fields/cosmology_fields.py
@@ -111,10 +111,9 @@ def setup_cosmology_fields(registry, ftype="gas", slice_info=None):
     def _virial_radius_fraction(field, data):
         virial_radius = data.get_field_parameter("virial_radius")
         if virial_radius == 0.0:
-            ret = 0.0
+            return 0.0
         else:
-            ret = data[("index", "radius")] / virial_radius
-        return ret
+            return data[("index", "radius")] / virial_radius
 
     registry.add_field(
         ("index", "virial_radius_fraction"),

--- a/yt/fields/derived_field.py
+++ b/yt/fields/derived_field.py
@@ -298,7 +298,7 @@ class DerivedField:
         for field_name in data.keys():
             if field_name not in original_fields:
                 del data[field_name]
-        return dd
+        return dd  # noqa R504
 
     def get_source(self):
         """
@@ -367,10 +367,7 @@ class DerivedField:
 
     def _is_ion(self):
         p = re.compile("_p[0-9]+_")
-        result = False
-        if p.search(self.name[1]) is not None:
-            result = True
-        return result
+        return p.search(self.name[1]) is not None
 
     def _ion_to_label(self):
         # check to see if the output format has changed
@@ -437,7 +434,7 @@ class DerivedField:
 
             if self._ionization_label_format == "roman_numeral":
                 roman = pnum2rom[pstr[1:]]
-                label = (
+                return (
                     species_label
                     + r"\ "
                     + roman
@@ -448,7 +445,7 @@ class DerivedField:
             # use +/- for ionization
             else:
                 sign = "+" * int(pstr[1:])
-                label = (
+                return (
                     "{"
                     + species_label
                     + "}"
@@ -460,8 +457,7 @@ class DerivedField:
                 )
 
         else:
-            label = self.name[1]
-        return label
+            return self.name[1]
 
     def get_latex_display_name(self):
         label = self.display_name
@@ -469,13 +465,14 @@ class DerivedField:
             if self._is_ion():
                 fname = self._ion_to_label()
                 label = r"$\rm{" + fname.replace("_", r"\ ") + r"}$"
-                label = label.replace("latexsub", "_")
+                return label.replace("latexsub", "_")
             else:
-                label = r"$\rm{" + self.name[1].replace("_", r"\ ").title() + r"}$"
+                return r"$\rm{" + self.name[1].replace("_", r"\ ").title() + r"}$"
         elif label.find("$") == -1:
             label = label.replace(" ", r"\ ")
-            label = r"$\rm{" + label + r"}$"
-        return label
+            return r"$\rm{" + label + r"}$"
+        else:
+            return label
 
 
 class FieldValidator:

--- a/yt/fields/field_detector.py
+++ b/yt/fields/field_detector.py
@@ -289,10 +289,9 @@ class FieldDetector(defaultdict):
             0 : self.nd - 1 : self.nd * 1j,
         ]
         if self.flat:
-            ic.shape = (self.nd * self.nd * self.nd, 3)
+            return np.reshape(ic, (self.nd ** 3, 3))
         else:
-            ic = ic.transpose()
-        return ic
+            return ic.transpose()
 
     @property
     def ires(self):

--- a/yt/fields/field_functions.py
+++ b/yt/fields/field_functions.py
@@ -33,11 +33,9 @@ def get_radius(data, field_prefix, ftype):
         np.add(radius2, r, radius2)
         if data.ds.dimensionality < i + 1:
             break
-    # Now it's cm.
-    np.sqrt(radius2, radius2)
-    # Alias it, just for clarity.
-    radius = radius2
-    return radius
+
+    np.sqrt(radius2, r)
+    return r
 
 
 def get_periodic_rvec(data):

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -357,7 +357,7 @@ class FieldInfoContainer(dict):
                     return f
 
                 return create_function
-            return
+            return None
         # add_field can be used in two different ways: it can be called
         # directly, or used as a decorator (as yt.derived_field). If called directly,
         # the function will be passed in as an argument, and we simply create
@@ -375,7 +375,7 @@ class FieldInfoContainer(dict):
 
         if isinstance(name, tuple):
             self[name] = DerivedField(name, sampling_type, function, **kwargs)
-            return
+            return None
 
         sampling_type = self._sanitize_sampling_type(
             sampling_type, particle_type=kwargs.get("particle_type")
@@ -394,6 +394,7 @@ class FieldInfoContainer(dict):
             self.alias(name, tuple_name)
         else:
             self[name] = DerivedField(name, sampling_type, function, **kwargs)
+        return None
 
     def load_all_plugins(self, ftype="gas"):
         loaded = []
@@ -409,8 +410,7 @@ class FieldInfoContainer(dict):
             f = field_plugins[plugin_name]
         orig = set(self.items())
         f(self, ftype, slice_info=self.slice_info)
-        loaded = [n for n, v in set(self.items()).difference(orig)]
-        return loaded
+        return [n for n, v in set(self.items()).difference(orig)]
 
     def find_dependencies(self, loaded):
         deps, unavailable = self.check_derived_fields(loaded)

--- a/yt/fields/field_type_container.py
+++ b/yt/fields/field_type_container.py
@@ -10,7 +10,7 @@ from yt.fields.derived_field import DerivedField
 
 
 def _fill_values(values):
-    value = (
+    return (
         '<div class="rendered_html jp-RenderedHTMLCommon">'
         + "<table><thead><tr><th>Name</th><th>Type</th>"
         + "<th>Value</th></tr></thead><tr><td>"
@@ -22,7 +22,6 @@ def _fill_values(values):
         )
         + "</td></tr></table></div>"
     )
-    return value
 
 
 class FieldTypeContainer:

--- a/yt/fields/fluid_fields.py
+++ b/yt/fields/fluid_fields.py
@@ -145,8 +145,7 @@ def setup_fluid_fields(registry, ftype="gas", slice_info=None):
         t3 = data[ftype, "dz"] / (
             data[ftype, "sound_speed"] + np.abs(data[ftype, "velocity_z"])
         )
-        tr = np.minimum(np.minimum(t1, t2), t3)
-        return tr
+        return np.minimum(np.minimum(t1, t2), t3)
 
     registry.add_field(
         (ftype, "courant_time_step"),
@@ -157,10 +156,9 @@ def setup_fluid_fields(registry, ftype="gas", slice_info=None):
 
     def _pressure(field, data):
         """M{(Gamma-1.0)*rho*E}"""
-        tr = (data.ds.gamma - 1.0) * (
+        return (data.ds.gamma - 1.0) * (
             data[ftype, "density"] * data[ftype, "specific_thermal_energy"]
         )
-        return tr
 
     registry.add_field(
         (ftype, "pressure"),
@@ -288,7 +286,7 @@ def setup_gradient_fields(registry, grad_field, field_units, slice_info=None):
             new_field[slice_3d] = f
 
             if block_order == "F":
-                new_field = new_field.swapaxes(0, 2)
+                return new_field.swapaxes(0, 2)
 
             return new_field
 

--- a/yt/fields/fluid_vector_fields.py
+++ b/yt/fields/fluid_vector_fields.py
@@ -209,8 +209,7 @@ def setup_fluid_vector_fields(registry, ftype="gas", slice_info=None):
             dot += (
                 data[ftype, f"vorticity_{ax}"] * data[ftype, f"vorticity_growth_{ax}"]
             ).to_ndarray()
-        result = np.sign(dot) * result
-        return result
+        return np.sign(dot) * result
 
     registry.add_field(
         (ftype, "vorticity_growth_magnitude"),
@@ -350,8 +349,7 @@ def setup_fluid_vector_fields(registry, ftype="gas", slice_info=None):
             dot += (
                 data[ftype, f"vorticity_{ax}"] * data[ftype, f"vorticity_growth_{ax}"]
             ).to_ndarray()
-        result = np.sign(dot) * result
-        return result
+        return np.sign(dot) * result
 
     registry.add_field(
         (ftype, "vorticity_radiation_pressure_growth_magnitude"),

--- a/yt/fields/magnetic_field.py
+++ b/yt/fields/magnetic_field.py
@@ -27,6 +27,7 @@ def setup_magnetic_field_fields(registry, ftype="gas", slice_info=None):
             return 4.0 * np.pi
         elif dims == dimensions.magnetic_field_mks:
             return ds.units.physical_constants.mu_0
+        raise ValueError
 
     def _magnetic_field_strength(field, data):
         xm = f"relative_magnetic_field_{axis_names[0]}"

--- a/yt/fields/particle_fields.py
+++ b/yt/fields/particle_fields.py
@@ -54,8 +54,7 @@ def _field_concat(fname):
             if ptype == "all" or ptype in data.ds.known_filters:
                 continue
             v.append(data[ptype, fname].copy())
-        rv = uconcatenate(v, axis=0)
-        return rv
+        return uconcatenate(v, axis=0)
 
     return _AllFields
 
@@ -68,8 +67,7 @@ def _field_concat_slice(fname, axi):
             if ptype == "all" or ptype in data.ds.known_filters:
                 continue
             v.append(data[ptype, fname][:, axi])
-        rv = uconcatenate(v, axis=0)
-        return rv
+        return uconcatenate(v, axis=0)
 
     return _AllFields
 
@@ -158,8 +156,7 @@ def particle_deposition_functions(ptype, coord_name, mass_name, registry):
             top[bottom == 0] = 0.0
             bnz = bottom.nonzero()
             top[bnz] /= bottom[bnz]
-            d = data.ds.arr(top, units=units)
-            return d
+            return data.ds.arr(top, units=units)
 
         return _deposit_field
 
@@ -557,8 +554,7 @@ def standard_particle_fields(
         vel = data[(ptype, "relative_particle_velocity")].T
         theta = get_sph_theta(pos, normal)
         phi = get_sph_phi(pos, normal)
-        sphr = get_sph_r_component(vel, theta, phi, normal)
-        return sphr
+        return get_sph_r_component(vel, theta, phi, normal)
 
     registry.add_field(
         (ptype, "particle_velocity_spherical_radius"),
@@ -591,8 +587,7 @@ def standard_particle_fields(
         vel = data[(ptype, "relative_particle_velocity")].T
         theta = get_sph_theta(pos, normal)
         phi = get_sph_phi(pos, normal)
-        spht = get_sph_theta_component(vel, theta, phi, normal)
-        return spht
+        return get_sph_theta_component(vel, theta, phi, normal)
 
     registry.add_field(
         (ptype, "particle_velocity_spherical_theta"),
@@ -618,8 +613,7 @@ def standard_particle_fields(
         pos = data[(ptype, "relative_particle_position")].T
         vel = data[(ptype, "relative_particle_velocity")].T
         phi = get_sph_phi(pos, normal)
-        sphp = get_sph_phi_component(vel, phi, normal)
-        return sphp
+        return get_sph_phi_component(vel, phi, normal)
 
     registry.add_field(
         (ptype, "particle_velocity_spherical_phi"),
@@ -701,8 +695,7 @@ def standard_particle_fields(
         pos = data[(ptype, "relative_particle_position")].T
         vel = data[(ptype, "relative_particle_velocity")].T
         theta = get_cyl_theta(pos, normal)
-        cylr = get_cyl_r_component(vel, theta, normal)
-        return cylr
+        return get_cyl_r_component(vel, theta, normal)
 
     registry.add_field(
         (ptype, "particle_velocity_cylindrical_radius"),
@@ -722,8 +715,7 @@ def standard_particle_fields(
         pos = data[(ptype, "relative_particle_position")].T
         vel = data[(ptype, "relative_particle_velocity")].T
         theta = get_cyl_theta(pos, normal)
-        cylt = get_cyl_theta_component(vel, theta, normal)
-        return cylt
+        return get_cyl_theta_component(vel, theta, normal)
 
     registry.add_field(
         (ptype, "particle_velocity_cylindrical_theta"),
@@ -747,8 +739,7 @@ def standard_particle_fields(
         """
         normal = data.get_field_parameter("normal")
         vel = data[(ptype, "relative_particle_velocity")].T
-        cylz = get_cyl_z_component(vel, normal)
-        return cylz
+        return get_cyl_z_component(vel, normal)
 
     registry.add_field(
         (ptype, "particle_velocity_cylindrical_z"),
@@ -861,8 +852,7 @@ def add_nearest_neighbor_value_field(ptype, coord_name, sampled_field, registry)
         rv = data.smooth(
             pos, [value], method="nearest", create_octree=True, nneighbors=1
         )
-        rv = data.apply_units(rv, field_units)
-        return rv
+        return data.apply_units(rv, field_units)
 
     registry.add_field(
         field_name,

--- a/yt/fields/xray_emission_fields.py
+++ b/yt/fields/xray_emission_fields.py
@@ -129,21 +129,19 @@ class XrayEmissivityIntegrator:
 
         interp_data = (data[..., e_is:e_ie] * my_dE).sum(axis=-1)
         if data.ndim == 2:
-            emiss = UnilinearFieldInterpolator(
+            return UnilinearFieldInterpolator(
                 np.log10(interp_data),
                 [self.log_T[0], self.log_T[-1]],
                 "log_T",
                 truncate=True,
             )
         else:
-            emiss = BilinearFieldInterpolator(
+            return BilinearFieldInterpolator(
                 np.log10(interp_data),
                 [self.log_nH[0], self.log_nH[-1], self.log_T[0], self.log_T[-1]],
                 ["log_nH", "log_T"],
                 truncate=True,
             )
-
-        return emiss
 
 
 def add_xray_emissivity_field(

--- a/yt/frontends/adaptahop/io.py
+++ b/yt/frontends/adaptahop/io.py
@@ -168,15 +168,16 @@ class IOHandlerAdaptaHOPBinary(BaseIOHandler):
                         halo_id = fpu.read_int()
                         offset_map[ihalo, 0] = halo_id
                         offset_map[ihalo, 1] = ipos
-        data = self.ds.arr(data, "code_length") + self.ds.domain_width / 2
 
         # Make sure halos are loaded in increasing halo_id order
         assert np.all(np.diff(offset_map[:, 0]) > 0)
 
         # Cache particle positions as one do not expect a large number of halos anyway
-        self._particle_positions = data
+        self._particle_positions = (
+            self.ds.arr(data, "code_length") + self.ds.domain_width / 2
+        )
         self._offsets = offset_map
-        return data
+        return self._particle_positions
 
     def members(self, ihalo):
         offset = self._offsets[ihalo, 1]
@@ -185,8 +186,7 @@ class IOHandlerAdaptaHOPBinary(BaseIOHandler):
             fpu.seek(offset)
             if isinstance(todo[0], int):
                 fpu.skip(todo.pop(0))
-            members = fpu.read_attrs(todo.pop(0))["particle_identities"]
-        return members
+            return fpu.read_attrs(todo.pop(0))["particle_identities"]
 
 
 def _todo_from_attributes(attributes):

--- a/yt/frontends/ahf/data_structures.py
+++ b/yt/frontends/ahf/data_structures.py
@@ -33,8 +33,7 @@ class AHFHalosFile(HaloCatalogFile):
             line = line[1:]
             names = line.split()
             # Remove trailing '()'
-            names = [name.split("(")[0] for name in names]
-            return names
+            return [name.split("(")[0] for name in names]
 
     def _read_particle_positions(self, ptype, f=None):
         """

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -229,27 +229,31 @@ class AMRVACDataset(Dataset):
     @classmethod
     def _is_valid(cls, filename, *args, **kwargs):
         """At load time, check whether data is recognized as AMRVAC formatted."""
-        validation = False
-        if filename.endswith(".dat"):
-            try:
-                with open(filename, mode="rb") as istream:
-                    fmt = "=i"
-                    [datfile_version] = struct.unpack(
+        if not filename.endswith(".dat"):
+            return False
+        try:
+            with open(filename, mode="rb") as istream:
+                fmt = "=i"
+                [datfile_version] = struct.unpack(
+                    fmt, istream.read(struct.calcsize(fmt))
+                )
+                if 3 <= datfile_version < 6:
+                    fmt = "=ii"
+                    offset_tree, offset_blocks = struct.unpack(
                         fmt, istream.read(struct.calcsize(fmt))
                     )
-                    if 3 <= datfile_version < 6:
-                        fmt = "=ii"
-                        offset_tree, offset_blocks = struct.unpack(
-                            fmt, istream.read(struct.calcsize(fmt))
-                        )
-                        istream.seek(0, 2)
-                        file_size = istream.tell()
-                        validation = (
-                            offset_tree < file_size and offset_blocks < file_size
-                        )
-            except Exception:
-                pass
-        return validation
+                    istream.seek(0, 2)
+                    file_size = istream.tell()
+                    return offset_tree < file_size and offset_blocks < file_size
+                elif datfile_version < 15:
+                    mylog.warning(
+                        "This may be a amrvac output, "
+                        "but this format version (%s) is not supported yet.",
+                        datfile_version,
+                    )
+                return False
+        except Exception:
+            return False
 
     def _parse_geometry(self, geometry_tag):
         """Translate AMRVAC's geometry tag to yt's format.

--- a/yt/frontends/amrvac/datfile_utils.py
+++ b/yt/frontends/amrvac/datfile_utils.py
@@ -145,8 +145,7 @@ def get_single_block_data(istream, byte_offset, block_shape):
     fmt = ALIGN + np.prod(block_shape) * "d"
     d = struct.unpack(fmt, istream.read(struct.calcsize(fmt)))
     # Fortran ordering
-    block_data = np.reshape(d, block_shape, order="F")
-    return block_data
+    return np.reshape(d, block_shape, order="F")
 
 
 def get_single_block_field_data(istream, byte_offset, block_shape, field_idx):
@@ -163,5 +162,4 @@ def get_single_block_field_data(istream, byte_offset, block_shape, field_idx):
     d = struct.unpack(fmt, istream.read(struct.calcsize(fmt)))
 
     # Fortran ordering
-    block_field_data = np.reshape(d, field_shape, order="F")
-    return block_field_data
+    return np.reshape(d, field_shape, order="F")

--- a/yt/frontends/amrvac/fields.py
+++ b/yt/frontends/amrvac/fields.py
@@ -222,17 +222,15 @@ class AMRVACFieldInfo(FieldInfoContainer):
 
         def _full_thermal_pressure_HD(field, data):
             # energy density and pressure are actually expressed in the same unit
-            pthermal = (data.ds.gamma - 1) * (
+            return (data.ds.gamma - 1) * (
                 data["gas", "energy_density"] - data["gas", "kinetic_energy_density"]
             )
-            return pthermal
 
         def _full_thermal_pressure_MHD(field, data):
-            pthermal = (
+            return (
                 _full_thermal_pressure_HD(field, data)
                 - (data.ds.gamma - 1) * data["gas", "magnetic_energy_density"]
             )
-            return pthermal
 
         def _polytropic_thermal_pressure(field, data):
             return (data.ds.gamma - 1) * data["gas", "energy_density"]

--- a/yt/frontends/art/fields.py
+++ b/yt/frontends/art/fields.py
@@ -128,8 +128,7 @@ class ARTFieldInfo(FieldInfoContainer):
         )
 
         def _H_mass_fraction(field, data):
-            tr = 1.0 - data.ds.parameters["Y_p"] - data["gas", "metal_mass_fraction"]
-            return tr
+            return 1.0 - data.ds.parameters["Y_p"] - data["gas", "metal_mass_fraction"]
 
         self.add_field(
             ("gas", "H_mass_fraction"),

--- a/yt/frontends/art/io.py
+++ b/yt/frontends/art/io.py
@@ -74,9 +74,7 @@ class IOHandlerART(BaseIOHandler):
         mask = selector.select_points(x, y, z, 0.0)
         if self.caching:
             self.masks[key] = mask
-            return self.masks[key]
-        else:
-            return mask
+        return mask  # noqa R504
 
     def _read_particle_coords(self, chunks, ptf):
         chunks = list(chunks)
@@ -352,8 +350,7 @@ def _read_art_level_info(
     # try to find the root_level first
     def cfc(root_level, level, le):
         d_x = 1.0 / (2.0 ** (root_level - level + 1))
-        fc = (d_x * le) - 2 ** (level - 1)
-        return fc
+        return (d_x * le) - 2 ** (level - 1)
 
     if root_level is None:
         root_level = np.floor(np.log2(le.max() * 1.0 / coarse_grid))
@@ -559,8 +556,7 @@ def _read_root_level(f, level_offsets, level_info, nhydro_vars=10):
     var = read_vector(f, "f", ">")
     hvar = hvar.reshape((nhydro_vars, nocts * 8), order="F")
     var = var.reshape((2, nocts * 8), order="F")
-    arr = np.concatenate((hvar, var))
-    return arr
+    return np.concatenate((hvar, var))
 
 
 # All of these functions are to convert from hydro time var to
@@ -586,8 +582,7 @@ def find_root(f, a, b, tol=1e-6):
 def quad(fintegrand, xmin, xmax, n=1e4):
     spacings = np.logspace(np.log10(xmin), np.log10(xmax), num=int(n))
     integrand_arr = fintegrand(spacings)
-    val = np.trapz(integrand_arr, dx=np.diff(spacings))
-    return val
+    return np.trapz(integrand_arr, dx=np.diff(spacings))
 
 
 def a2b(at, Om0=0.27, Oml0=0.73, h=0.700):
@@ -596,9 +591,7 @@ def a2b(at, Om0=0.27, Oml0=0.73, h=0.700):
         val /= sqrt(Om0 / x ** 3.0 + Oml0 + (1.0 - Om0 - Oml0) / x ** 2.0)
         return val
 
-    # val, err = si.quad(f_a2b,1,at)
-    val = quad(f_a2b, 1, at)
-    return val
+    return quad(f_a2b, 1, at)
 
 
 def b2a(bt, **kwargs):

--- a/yt/frontends/artio/data_structures.py
+++ b/yt/frontends/artio/data_structures.py
@@ -67,8 +67,7 @@ class ARTIOOctreeSubset(OctreeSubset):
         self.oct_handler.fill_sfc(
             levels, cell_inds, file_inds, domain_counts, field_indices, tr
         )
-        tr = {field: v for field, v in zip(fields, tr)}
-        return tr
+        return {field: v for field, v in zip(fields, tr)}
 
     def fill_particles(self, fields):
         if len(fields) == 0:
@@ -113,8 +112,7 @@ class ARTIORootMeshSubset(ARTIOOctreeSubset):
         ]
         tr = self.oct_handler.fill_sfc(selector, field_indices)
         self.data_size = tr[0].size
-        tr = {field: v for field, v in zip(fields, tr)}
-        return tr
+        return {field: v for field, v in zip(fields, tr)}
 
     def deposit(self, positions, fields=None, method=None, kernel_name="cubic"):
         # Here we perform our particle deposition.
@@ -139,7 +137,7 @@ class ARTIORootMeshSubset(ARTIOOctreeSubset):
         self.oct_handler.deposit(op, self.base_selector, pos, f64)
         vals = op.finalize()
         if vals is None:
-            return
+            return None
         return np.asfortranarray(vals)
 
 

--- a/yt/frontends/artio/fields.py
+++ b/yt/frontends/artio/fields.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from yt.fields.field_info_container import FieldInfoContainer
 from yt.units.yt_array import YTArray
 from yt.utilities.physical_constants import amu_cgs, boltzmann_constant_cgs
@@ -107,21 +105,20 @@ class ARTIOFieldInfo(FieldInfoContainer):
             if flag1 and flag2:
 
                 def _metal_density(field, data):
-                    tr = data[("gas", "metal_ia_density")].copy()
-                    np.add(tr, data[("gas", "metal_ii_density")], out=tr)
-                    return tr
+                    return (
+                        data[("gas", "metal_ia_density")]
+                        + data[("gas", "metal_ii_density")]
+                    )
 
             elif flag1 and not flag2:
 
                 def _metal_density(field, data):
-                    tr = data["metal_ia_density"]
-                    return tr
+                    return data["metal_ia_density"]
 
             else:
 
                 def _metal_density(field, data):
-                    tr = data["metal_ii_density"]
-                    return tr
+                    return data["metal_ii_density"]
 
             self.add_field(
                 ("gas", "metal_density"),

--- a/yt/frontends/athena/data_structures.py
+++ b/yt/frontends/athena/data_structures.py
@@ -33,16 +33,16 @@ def check_readline(fl):
         line = line[line.find(chk) :]
     chk = chk23("VECTORS")
     if chk in line and not line.startswith(chk):
-        line = line[line.find(chk) :]
+        return line[line.find(chk) :]
     return line
 
 
 def check_break(line):
     splitup = line.strip().split()
     do_break = chk23("SCALAR") in splitup
-    do_break = (chk23("VECTOR") in splitup) & do_break
-    do_break = (chk23("TABLE") in splitup) & do_break
-    do_break = (len(line) == 0) & do_break
+    do_break &= chk23("VECTOR") in splitup
+    do_break &= chk23("TABLE") in splitup
+    do_break &= len(line) == 0
     return do_break
 
 

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -978,7 +978,7 @@ class OrionHierarchy(BoxlibHierarchy):
     def _read_particle_file(self, fn):
         """actually reads the orion particle data file itself."""
         if not os.path.exists(fn):
-            return
+            return None
         with open(fn) as f:
             lines = f.readlines()
             self.num_stars = int(lines[0].strip()[0])
@@ -1354,7 +1354,7 @@ def _guess_pcast(vals):
     else:
         vals = [pcast(value) for value in vals.split()]
     if len(vals) == 1:
-        vals = vals[0]
+        return vals[0]
     return vals
 
 
@@ -1518,15 +1518,8 @@ class WarpXHierarchy(BoxlibHierarchy):
             self.ds.nodal_flags[field_name] = np.array(boxes[0][2])
 
 
-def _skip_line(line):
-    if len(line) == 0:
-        return True
-    if line[0] == "\n":
-        return True
-    if line[0] == "=":
-        return True
-    if line[0] == " ":
-        return True
+def _skip_line(line: str) -> bool:
+    return not line or line.startswith(("\n", "=", " "))
 
 
 class WarpXDataset(BoxlibDataset):

--- a/yt/frontends/chombo/io.py
+++ b/yt/frontends/chombo/io.py
@@ -211,8 +211,7 @@ def parse_orion_sinks(fn):
     except IndexError:
         # a particle file exists, but there is only one line,
         # so no sinks have been created yet.
-        index = {}
-        return index
+        return {}
 
     # The basic fields that all sink particles have
     index = {

--- a/yt/frontends/eagle/data_structures.py
+++ b/yt/frontends/eagle/data_structures.py
@@ -51,20 +51,17 @@ class EagleDataset(GadgetHDF5Dataset):
             "PartType0/ChemistryAbundances",
             "PartType0/ChemicalAbundances",
         ]
-        valid = True
         try:
-            fileh = h5py.File(filename, mode="r")
-            for ng in need_groups:
-                if ng not in fileh["/"]:
-                    valid = False
-            for vg in veto_groups:
-                if vg in fileh["/"]:
-                    valid = False
-            fileh.close()
+            with h5py.File(filename, mode="r") as fileh:
+                for ng in need_groups:
+                    if ng not in fileh["/"]:
+                        return False
+                for vg in veto_groups:
+                    if vg in fileh["/"]:
+                        return False
+            return True
         except Exception:
-            valid = False
-            pass
-        return valid
+            return False
 
 
 class EagleNetworkDataset(EagleDataset):

--- a/yt/frontends/enzo/data_structures.py
+++ b/yt/frontends/enzo/data_structures.py
@@ -72,11 +72,10 @@ class EnzoGrid(AMRGridPatch):
         if not hasattr(self.index, "grid_active_particle_count"):
             return {}
         id = self.id - self._id_offset
-        nap = {
+        return {
             ptype: self.index.grid_active_particle_count[ptype][id]
             for ptype in self.index.grid_active_particle_count
         }
-        return nap
 
 
 class EnzoGridInMemory(EnzoGrid):
@@ -222,6 +221,7 @@ class EnzoHierarchy(GridIndex):
             for line in f:
                 if line.startswith(token):
                     return line.split()[2:]
+            raise ValueError
 
         pattern = r"Pointer: Grid\[(\d*)\]->NextGrid(Next|This)Level = (\d*)\s+$"
         patt = re.compile(pattern)

--- a/yt/frontends/enzo/simulation_handling.py
+++ b/yt/frontends/enzo/simulation_handling.py
@@ -478,7 +478,7 @@ class EnzoSimulation(SimulationTimeSeries):
             or "CycleSkipDataDump" not in self.parameters
             or self.parameters["CycleSkipDataDump"] <= 0.0
         ):
-            return []
+            return
 
         self.all_time_outputs = []
         index = 0

--- a/yt/frontends/enzo_e/io.py
+++ b/yt/frontends/enzo_e/io.py
@@ -172,5 +172,5 @@ class EnzoEIOHandler(BaseIOHandler):
         data = rdata[self._base].T
         if self.ds.dimensionality < 3:
             nshape = data.shape + (1,) * (3 - self.ds.dimensionality)
-            data = np.reshape(data, nshape)
+            return np.reshape(data, nshape)
         return data

--- a/yt/frontends/enzo_e/misc.py
+++ b/yt/frontends/enzo_e/misc.py
@@ -32,10 +32,9 @@ def get_block_string_and_dim(block, min_dim=3):
 
 def get_block_level(block):
     if ":" in block:
-        l = block.find(":")
+        return block.find(":")
     else:
-        l = len(block)
-    return l
+        return len(block)
 
 
 def get_block_info(block, min_dim=3):
@@ -91,8 +90,7 @@ def get_child_index(anc_id, desc_id):
     cid = ""
     for aind, dind in zip(anc_id.split("_"), desc_id.split("_")):
         cid += dind[len(aind)]
-    cid = int(cid, 2)
-    return cid
+    return int(cid, 2)
 
 
 def is_parent(anc_block, desc_block):

--- a/yt/frontends/exodus_ii/data_structures.py
+++ b/yt/frontends/exodus_ii/data_structures.py
@@ -303,25 +303,22 @@ class ExodusIIDataset(Dataset):
         mylog.info("Loading coordinates")
         with self._handle.open_ds() as ds:
             if "coord" not in ds.variables:
-                coords = (
+                return (
                     np.array([ds.variables[f"coord{ax}"][:] for ax in coord_axes])
                     .transpose()
                     .astype("f8")
                 )
-            else:
-                coords = (
-                    np.array([coord for coord in ds.variables["coord"][:]])
-                    .transpose()
-                    .astype("f8")
-                )
-            return coords
+            return (
+                np.array([coord for coord in ds.variables["coord"][:]])
+                .transpose()
+                .astype("f8")
+            )
 
     def _apply_displacement(self, coords, mesh_id):
 
         mesh_name = "connect%d" % (mesh_id + 1)
         if mesh_name not in self.displacements:
-            new_coords = coords.copy()
-            return new_coords
+            return coords.copy()
 
         new_coords = np.zeros_like(coords)
         fac = self.displacements[mesh_name][0]

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -630,13 +630,16 @@ class YTFITSDataset(FITSDataset):
         fileh = check_fits_valid(filename)
         if fileh is None:
             return False
-        else:
-            if "WCSNAME" in fileh[0].header:
-                isyt = fileh[0].header["WCSNAME"].strip() == "yt"
-            else:
-                isyt = False
+
+        try:
+            return (
+                "WCSNAME" in fileh[0].header
+                and fileh[0].header["WCSNAME"].strip() == "yt"
+            )
+        except Exception:
+            return False
+        finally:
             fileh.close()
-            return isyt
 
 
 class SkyDataFITSDataset(FITSDataset):
@@ -910,11 +913,12 @@ class EventsFITSDataset(SkyDataFITSDataset):
     @classmethod
     def _is_valid(cls, filename, *args, **kwargs):
         fileh = check_fits_valid(filename)
-        if fileh is not None:
-            try:
-                valid = fileh[1].name == "EVENTS"
-                fileh.close()
-                return valid
-            except Exception:
-                pass
-        return False
+        if fileh is None:
+            return False
+
+        try:
+            return fileh[1].name == "EVENTS"
+        except Exception:
+            return False
+        finally:
+            fileh.close()

--- a/yt/frontends/fits/misc.py
+++ b/yt/frontends/fits/misc.py
@@ -129,8 +129,7 @@ def create_spectral_slabs(filename, slab_centers, slab_width, **kwargs):
     for hdu in fid:
         hdu.header.pop("RESTFREQ", None)
         hdu.header.pop("RESTFRQ", None)
-    ds = FITSDataset(fid, **kwargs)
-    return ds
+    return FITSDataset(fid, **kwargs)
 
 
 def ds9_region(ds, reg, obj=None, field_parameters=None):
@@ -257,6 +256,7 @@ class PlotWindowWCS:
         for k in self.keys():
             if k[1] == key:
                 return self.plots[k]
+        raise KeyError(key)
 
     def show(self):
         return self

--- a/yt/frontends/flash/io.py
+++ b/yt/frontends/flash/io.py
@@ -26,10 +26,9 @@ def determine_particle_fields(handle):
         particle_fields = [
             s[0].decode("ascii", "ignore").strip() for s in handle["/particle names"][:]
         ]
-        _particle_fields = {"particle_" + s: i for i, s in enumerate(particle_fields)}
+        return {"particle_" + s: i for i, s in enumerate(particle_fields)}
     except KeyError:
-        _particle_fields = {}
-    return _particle_fields
+        return {}
 
 
 class IOHandlerFLASH(BaseIOHandler):

--- a/yt/frontends/gadget_fof/data_structures.py
+++ b/yt/frontends/gadget_fof/data_structures.py
@@ -133,7 +133,7 @@ class GadgetFOFHDF5File(HaloCatalogFile):
         if close:
             f.close()
 
-        return pos
+        return pos  # noqa R504
 
 
 class GadgetFOFDataset(ParticleDataset):
@@ -298,17 +298,13 @@ class GadgetFOFDataset(ParticleDataset):
     def _is_valid(cls, filename, *args, **kwargs):
         need_groups = ["Group", "Header", "Subhalo"]
         veto_groups = ["FOF"]
-        valid = True
         try:
-            fh = h5py.File(filename, mode="r")
-            valid = all(ng in fh["/"] for ng in need_groups) and not any(
-                vg in fh["/"] for vg in veto_groups
-            )
-            fh.close()
+            with h5py.File(filename, mode="r") as fh:
+                return all(ng in fh["/"] for ng in need_groups) and not any(
+                    vg in fh["/"] for vg in veto_groups
+                )
         except Exception:
-            valid = False
-            pass
-        return valid
+            return False
 
 
 class GadgetFOFHaloParticleIndex(GadgetFOFParticleIndex):
@@ -380,8 +376,7 @@ class GadgetFOFHaloParticleIndex(GadgetFOFParticleIndex):
 
     def _get_halo_scalar_index(self, ptype, identifier):
         i_scalar = self._get_halo_file_indices(ptype, [identifier])[0]
-        scalar_index = identifier - self._halo_index_start[ptype][i_scalar]
-        return scalar_index
+        return identifier - self._halo_index_start[ptype][i_scalar]
 
     def _get_halo_values(self, ptype, identifiers, fields, f=None):
         """

--- a/yt/frontends/gizmo/fields.py
+++ b/yt/frontends/gizmo/fields.py
@@ -149,11 +149,10 @@ class GizmoFieldInfo(GadgetFieldInfo):
             if data.ds.cosmological_simulation:
                 a_form = data[(ptype, "StellarFormationTime")]
                 z_form = 1 / a_form - 1
-                creation_time = data.ds.cosmology.t_from_z(z_form)
+                return data.ds.cosmology.t_from_z(z_form)
             else:
                 t_form = data[(ptype, "StellarFormationTime")]
-                creation_time = data.ds.arr(t_form, "code_time")
-            return creation_time
+                return data.ds.arr(t_form, "code_time")
 
         self.add_field(
             (ptype, "creation_time"),

--- a/yt/frontends/halo_catalog/data_structures.py
+++ b/yt/frontends/halo_catalog/data_structures.py
@@ -250,8 +250,7 @@ class YTHaloParticleIndex(ParticleIndex):
 
     def _get_halo_scalar_index(self, ptype, identifier):
         i_scalar = self._get_halo_file_indices(ptype, [identifier])[0]
-        scalar_index = identifier - self._halo_index_start[ptype][i_scalar]
-        return scalar_index
+        return identifier - self._halo_index_start[ptype][i_scalar]
 
     def _get_halo_values(self, ptype, identifiers, fields, f=None):
         """

--- a/yt/frontends/open_pmd/fields.py
+++ b/yt/frontends/open_pmd/fields.py
@@ -28,6 +28,7 @@ def setup_poynting_vector(self):
                     data[("openPMD", "E_x")] * data[("gas", "magnetic_field_y")]
                     - data[("openPMD", "E_y")] * data[("gas", "magnetic_field_x")]
                 )
+            raise ValueError
 
         return poynting
 

--- a/yt/frontends/owls/data_structures.py
+++ b/yt/frontends/owls/data_structures.py
@@ -41,7 +41,6 @@ class OWLSDataset(GadgetHDF5Dataset):
             "RuntimePars",
             "HashTable",
         ]
-        valid = True
         valid_fname = filename
         # If passed arg is a directory, look for the .0 file in that dir
         if os.path.isdir(filename):
@@ -55,22 +54,17 @@ class OWLSDataset(GadgetHDF5Dataset):
                     and os.path.isfile(fname)
                 ):
                     valid_files.append(fname)
-            if len(valid_files) == 0:
-                valid = False
-            elif len(valid_files) > 1:
-                valid = False
-            else:
-                valid_fname = valid_files[0]
+            if len(valid_files) != 1:
+                return False
+            valid_fname = valid_files[0]
         try:
-            fileh = h5py.File(valid_fname, mode="r")
-            for ng in need_groups:
-                if ng not in fileh["/"]:
-                    valid = False
-            for vg in veto_groups:
-                if vg in fileh["/"]:
-                    valid = False
-            fileh.close()
+            with h5py.File(valid_fname, mode="r") as fileh:
+                for ng in need_groups:
+                    if ng not in fileh["/"]:
+                        return False
+                for vg in veto_groups:
+                    if vg in fileh["/"]:
+                        return False
+            return True
         except Exception:
-            valid = False
-            pass
-        return valid
+            return False

--- a/yt/frontends/owls/owls_ion_tables.py
+++ b/yt/frontends/owls/owls_ion_tables.py
@@ -56,9 +56,7 @@ class IonTableSpectrum:
         dlog_GH1 = logGH1_all[i_zhi] - logGH1_all[i_zlo]
 
         logGH1_table = logGH1_all[i_zlo] + z_frac * dlog_GH1
-        GH1_table = 10.0 ** logGH1_table
-
-        return GH1_table
+        return 10.0 ** logGH1_table
 
 
 class IonTableOWLS:
@@ -137,8 +135,7 @@ class IonTableOWLS:
         # in that case we simply return 1.0
 
         if nH.size == 1 and T.size == 1:
-            ionfrac = 1.0
-            return ionfrac
+            return 1.0
 
         # find inH and fnH
         # -----------------------------------------------------

--- a/yt/frontends/owls/tests/test_outputs.py
+++ b/yt/frontends/owls/tests/test_outputs.py
@@ -41,8 +41,7 @@ def test_OWLS_particlefilter():
 
     def cold_gas(pfilter, data):
         temperature = data[pfilter.filtered_type, "Temperature"]
-        filter = temperature.in_units("K") <= 1e5
-        return filter
+        return temperature.in_units("K") <= 1e5
 
     add_particle_filter(
         "gas_cold",

--- a/yt/frontends/owls_subfind/data_structures.py
+++ b/yt/frontends/owls_subfind/data_structures.py
@@ -204,14 +204,10 @@ class OWLSSubfindDataset(ParticleDataset):
     def _is_valid(cls, filename, *args, **kwargs):
         need_groups = ["Constants", "Header", "Parameters", "Units", "FOF"]
         veto_groups = []
-        valid = True
         try:
-            fh = h5py.File(filename, mode="r")
-            valid = all(ng in fh["/"] for ng in need_groups) and not any(
-                vg in fh["/"] for vg in veto_groups
-            )
-            fh.close()
+            with h5py.File(filename, mode="r") as fh:
+                return all(ng in fh["/"] for ng in need_groups) and not any(
+                    vg in fh["/"] for vg in veto_groups
+                )
         except Exception:
-            valid = False
-            pass
-        return valid
+            return False

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -399,14 +399,15 @@ class RAMSESDomainSubset(OctreeSubset):
     def fwidth(self):
         fwidth = super().fwidth
         if self._num_ghost_zones > 0:
-            fwidth = fwidth.reshape(-1, 8, 3)
+            fwidth.shape = (-1, 8, 3)
             n_oct = fwidth.shape[0]
             # new_fwidth contains the fwidth of the oct+ghost zones
             # this is a constant array in each oct, so we simply copy
             # the oct value using numpy fancy-indexing
             new_fwidth = np.zeros((n_oct, self.nz ** 3, 3), dtype=fwidth.dtype)
             new_fwidth[:, :, :] = fwidth[:, 0:1, :]
-            fwidth = new_fwidth.reshape(-1, 3)
+            new_fwidth.shape = (-1, 3)
+            return new_fwidth
         return fwidth
 
     @property
@@ -428,9 +429,7 @@ class RAMSESDomainSubset(OctreeSubset):
 
         inds = indices[oct_inds, cell_inds]
 
-        fcoords = self.ds.arr(oh.fcoords(self.selector)[inds].reshape(-1, 3), "unitary")
-
-        return fcoords
+        return self.ds.arr(oh.fcoords(self.selector)[inds].reshape(-1, 3), "unitary")
 
     def fill(self, fd, fields, selector, file_handler):
         if self._num_ghost_zones == 0:

--- a/yt/frontends/ramses/field_handlers.py
+++ b/yt/frontends/ramses/field_handlers.py
@@ -121,10 +121,8 @@ class HandlerMixin:
         fname = os.path.join(
             os.path.split(ds.parameter_filename)[0], cls.fname.format(iout=iout, icpu=1)
         )
-        exists = os.path.exists(fname)
-        cls._unique_registry[ds.unique_identifier] = exists
-
-        return exists
+        cls._unique_registry[ds.unique_identifier] = os.path.exists(fname)
+        return cls._unique_registry[ds.unique_identifier]
 
 
 class FieldFileHandler(abc.ABC, HandlerMixin):

--- a/yt/frontends/ramses/fields.py
+++ b/yt/frontends/ramses/fields.py
@@ -302,8 +302,7 @@ class RAMSESFieldInfo(FieldInfoContainer):
         # Adding the fields in the rt_ files
         def gen_pdens(igroup):
             def _photon_density(field, data):
-                rv = data["ramses-rt", f"Photon_density_{igroup + 1}"] * dens_conv
-                return rv
+                return data["ramses-rt", f"Photon_density_{igroup + 1}"] * dens_conv
 
             return _photon_density
 
@@ -319,8 +318,7 @@ class RAMSESFieldInfo(FieldInfoContainer):
 
         def gen_flux(key, igroup):
             def _photon_flux(field, data):
-                rv = data["ramses-rt", f"Photon_flux_{key}_{igroup + 1}"] * flux_conv
-                return rv
+                return data["ramses-rt", f"Photon_flux_{key}_{igroup + 1}"] * flux_conv
 
             return _photon_flux
 

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -370,8 +370,7 @@ class StreamDictFieldHandler(dict):
         self_fields = chain.from_iterable(s.keys() for s in self.values())
         self_fields = list(set(self_fields))
         fields = list(self._additional_fields) + self_fields
-        fields = list(set(fields))
-        return fields
+        return list(set(fields))
 
 
 class StreamParticleIndex(SPHParticleIndex):
@@ -685,19 +684,17 @@ class StreamOctreeSubset(OctreeSubset):
 
     def retrieve_ghost_zones(self, ngz, fields, smoothed=False):
         try:
-            new_subset = self._subset_with_gz
             mylog.debug("Reusing previous subset with ghost zone.")
+            return self._subset_with_gz
         except AttributeError:
-            new_subset = StreamOctreeSubset(
+            self._subset_with_gz = StreamOctreeSubset(
                 self.base_region,
                 self.ds,
                 self.oct_handler,
                 self._over_refine_factor,
                 num_ghost_zones=ngz,
             )
-            self._subset_with_gz = new_subset
-
-        return new_subset
+            return self._subset_with_gz
 
     def _fill_no_ghostzones(self, content, dest, selector, offset):
         # Here we get a copy of the file, which we skip through and read the
@@ -710,10 +707,9 @@ class StreamOctreeSubset(OctreeSubset):
         levels[:] = 0
         dest.update((field, np.empty(cell_count, dtype="float64")) for field in content)
         # Make references ...
-        count = oct_handler.fill_level(
+        return oct_handler.fill_level(
             0, levels, cell_inds, file_inds, dest, content, offset
         )
-        return count
 
     def _fill_with_ghostzones(self, content, dest, selector, offset):
         oct_handler = self.oct_handler

--- a/yt/frontends/stream/io.py
+++ b/yt/frontends/stream/io.py
@@ -110,11 +110,10 @@ class StreamParticleIOHandler(BaseIOHandler):
                 )
 
     def _read_smoothing_length(self, chunks, ptf, ptype):
-        for data_file in sorted(
+        data_file = sorted(
             self._get_data_files(chunks), key=lambda x: (x.filename, x.start)
-        ):
-            f = self.fields[data_file.filename]
-            return f[ptype, "smoothing_length"]
+        )[0]
+        return self.fields[data_file.filename][ptype, "smoothing_length"]
 
     def _get_data_files(self, chunks):
         data_files = set()

--- a/yt/frontends/stream/tests/test_stream_amrgrids.py
+++ b/yt/frontends/stream/tests/test_stream_amrgrids.py
@@ -24,8 +24,9 @@ def test_qt_overflow():
     spf = load_amr_grids(grid_data, domain_dimensions)
 
     def make_proj():
-        p = ProjectionPlot(spf, "x", [("gas", "density")], center="c", origin="native")
-        return p
+        return ProjectionPlot(
+            spf, "x", [("gas", "density")], center="c", origin="native"
+        )
 
     assert_raises(YTIntDomainOverflow, make_proj)
 

--- a/yt/frontends/swift/data_structures.py
+++ b/yt/frontends/swift/data_structures.py
@@ -81,9 +81,7 @@ class SwiftDataset(SPHDataset):
         """
 
         with h5py.File(self.filename, mode="r") as handle:
-            header = dict(handle[dataset].attrs)
-
-        return header
+            return dict(handle[dataset].attrs)
 
     def _parse_parameter_file(self):
         """
@@ -178,13 +176,9 @@ class SwiftDataset(SPHDataset):
         This requires the file to have the Code attribute set in the
         Header dataset to "SWIFT".
         """
-        valid = True
         # Attempt to open the file, if it's not a hdf5 then this will fail:
         try:
-            handle = h5py.File(filename, mode="r")
-            valid = handle["Header"].attrs["Code"].decode("utf-8") == "SWIFT"
-            handle.close()
+            with h5py.File(filename, mode="r") as handle:
+                return handle["Header"].attrs["Code"].decode("utf-8") == "SWIFT"
         except (OSError, KeyError, ImportError):
-            valid = False
-
-        return valid
+            return False

--- a/yt/frontends/swift/io.py
+++ b/yt/frontends/swift/io.py
@@ -72,8 +72,7 @@ class IOHandlerSwift(IOHandlerSPH):
             pcount = np.clip(pcount - si, 0, ei - si)
             # we upscale to float64
             hsml = f[ptype]["SmoothingLength"][si:ei, ...]
-            hsml = hsml.astype("float64", copy=False)
-            return hsml
+            return hsml.astype("float64", copy=False)
 
     def _read_particle_fields(self, chunks, ptf, selector):
         # Now we have all the sizes, and we can allocate
@@ -120,8 +119,7 @@ class IOHandlerSwift(IOHandlerSPH):
         # defined by the subfile
         if None not in (si, ei):
             np.clip(pcount - si, 0, ei - si, out=pcount)
-        npart = {f"PartType{i}": v for i, v in enumerate(pcount)}
-        return npart
+        return {f"PartType{i}": v for i, v in enumerate(pcount)}
 
     def _identify_fields(self, data_file):
         f = h5py.File(data_file.filename, mode="r")

--- a/yt/frontends/tipsy/io.py
+++ b/yt/frontends/tipsy/io.py
@@ -332,8 +332,7 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
         if None not in (si, ei):
             np.clip(pcount - si, 0, ei - si, out=pcount)
         ptypes = ["Gas", "Stars", "DarkMatter"]
-        npart = {ptype: v for ptype, v in zip(ptypes, pcount)}
-        return npart
+        return {ptype: v for ptype, v in zip(ptypes, pcount)}
 
     @classmethod
     def _compute_dtypes(cls, field_dtypes, endian="<"):

--- a/yt/frontends/ytdata/io.py
+++ b/yt/frontends/ytdata/io.py
@@ -235,12 +235,12 @@ class IOHandlerYTDataContainerHDF5(BaseIOHandler):
     def _count_particles(self, data_file):
         si, ei = data_file.start, data_file.end
         if None not in (si, ei):
-            pcount = {}
-            for ptype, npart in self.ds.num_particles.items():
-                pcount[ptype] = np.clip(npart - si, 0, ei - si)
+            return {
+                ptype: np.clip(npart - si, 0, ei - si)
+                for ptype, npart in self.ds.num_particles.items()
+            }
         else:
-            pcount = self.ds.num_particles
-        return pcount
+            return self.ds.num_particles
 
     def _identify_fields(self, data_file):
         fields = []

--- a/yt/geometry/coordinates/coordinate_handler.py
+++ b/yt/geometry/coordinates/coordinate_handler.py
@@ -26,8 +26,7 @@ def _get_coord_fields(axi, units="code_length"):
 
 def _get_vert_fields(axi, units="code_length"):
     def _vert(field, data):
-        rv = data.ds.arr(data.fcoords_vertex[..., axi].copy(), units)
-        return rv
+        return data.ds.arr(data.fcoords_vertex[..., axi].copy(), units)
 
     return _vert
 

--- a/yt/geometry/coordinates/cylindrical_coordinates.py
+++ b/yt/geometry/coordinates/cylindrical_coordinates.py
@@ -273,16 +273,16 @@ class CylindricalCoordinateHandler(CoordinateHandler):
             self.ds.coordinates.axis_id[ax] for ax in ("r", "theta", "z")
         )
         if width is not None:
-            width = super().sanitize_width(axis, width, depth)
+            return super().sanitize_width(axis, width, depth)
         # Note: regardless of axes, these are set up to give consistent plots
         # when plotted, which is not strictly a "right hand rule" for axes.
         elif name == "r":  # soup can label
-            width = [2.0 * np.pi * self.ds.domain_width.uq, self.ds.domain_width[z_ax]]
+            return [2.0 * np.pi * self.ds.domain_width.uq, self.ds.domain_width[z_ax]]
         elif name == "theta":
-            width = [self.ds.domain_width[r_ax], self.ds.domain_width[z_ax]]
+            return [self.ds.domain_width[r_ax], self.ds.domain_width[z_ax]]
         elif name == "z":
-            width = [
+            return [
                 2.0 * self.ds.domain_right_edge[r_ax],
                 2.0 * self.ds.domain_right_edge[r_ax],
             ]
-        return width
+        raise ValueError

--- a/yt/geometry/coordinates/geographic_coordinates.py
+++ b/yt/geometry/coordinates/geographic_coordinates.py
@@ -319,17 +319,17 @@ class GeographicCoordinateHandler(CoordinateHandler):
             nc[:, lat] = np.cos(phi) * np.sin(theta) * r
             nc[:, lon] = np.sin(phi) * np.sin(theta) * r
             nc[:, rad] = np.cos(theta) * r
+            return nc
         else:
             a, b, c = coord
             theta = b * np.pi / 180
             phi = a * np.pi / 180
             r = factor * c + offset
-            nc = (
+            return (
                 np.cos(phi) * np.sin(theta) * r,
                 np.sin(phi) * np.sin(theta) * r,
                 np.cos(theta) * r,
             )
-        return nc
 
     def convert_to_cylindrical(self, coord):
         raise NotImplementedError
@@ -437,10 +437,10 @@ class GeographicCoordinateHandler(CoordinateHandler):
     def sanitize_width(self, axis, width, depth):
         name = self.axis_name[axis]
         if width is not None:
-            width = super().sanitize_width(axis, width, depth)
+            return super().sanitize_width(axis, width, depth)
         elif name == self.radial_axis:
             rax = self.radial_axis
-            width = [
+            return [
                 self.ds.domain_width[self.x_axis[rax]],
                 self.ds.domain_width[self.y_axis[rax]],
             ]
@@ -448,11 +448,12 @@ class GeographicCoordinateHandler(CoordinateHandler):
             ri = self.axis_id[self.radial_axis]
             # Remember, in spherical coordinates when we cut in theta,
             # we create a conic section
-            width = [2.0 * self.ds.domain_width[ri], 2.0 * self.ds.domain_width[ri]]
+            return [2.0 * self.ds.domain_width[ri], 2.0 * self.ds.domain_width[ri]]
         elif name == "longitude":
             ri = self.axis_id[self.radial_axis]
-            width = [self.ds.domain_width[ri], 2.0 * self.ds.domain_width[ri]]
-        return width
+            return [self.ds.domain_width[ri], 2.0 * self.ds.domain_width[ri]]
+
+        raise ValueError
 
 
 class InternalGeographicCoordinateHandler(GeographicCoordinateHandler):
@@ -533,12 +534,12 @@ class InternalGeographicCoordinateHandler(GeographicCoordinateHandler):
     def sanitize_width(self, axis, width, depth):
         name = self.axis_name[axis]
         if width is not None:
-            width = super(GeographicCoordinateHandler, self).sanitize_width(
+            return super(GeographicCoordinateHandler, self).sanitize_width(
                 axis, width, depth
             )
         elif name == self.radial_axis:
             rax = self.radial_axis
-            width = [
+            return [
                 self.ds.domain_width[self.x_axis[rax]],
                 self.ds.domain_width[self.y_axis[rax]],
             ]
@@ -548,10 +549,11 @@ class InternalGeographicCoordinateHandler(GeographicCoordinateHandler):
             # we create a conic section
             offset, factor = self._retrieve_radial_offset()
             outermost = factor * self.ds.domain_left_edge[ri] + offset
-            width = [2.0 * outermost, 2.0 * outermost]
+            return [2.0 * outermost, 2.0 * outermost]
         elif name == "longitude":
             ri = self.axis_id[self.radial_axis]
             offset, factor = self._retrieve_radial_offset()
             outermost = factor * self.ds.domain_left_edge[ri] + offset
-            width = [outermost, 2.0 * outermost]
-        return width
+            return [outermost, 2.0 * outermost]
+        else:
+            raise ValueError

--- a/yt/geometry/coordinates/spec_cube_coordinates.py
+++ b/yt/geometry/coordinates/spec_cube_coordinates.py
@@ -42,7 +42,8 @@ class SpectralCubeCoordinateHandler(CartesianCoordinateHandler):
 
     def setup_fields(self, registry):
         if not self.ds.no_cgs_equiv_length:
-            return super().setup_fields(registry)
+            super().setup_fields(registry)
+            return
         for axi, ax in enumerate("xyz"):
             f1, f2 = _get_coord_fields(axi)
 

--- a/yt/geometry/coordinates/spherical_coordinates.py
+++ b/yt/geometry/coordinates/spherical_coordinates.py
@@ -167,7 +167,7 @@ class SphericalCoordinateHandler(CoordinateHandler):
     def _ortho_pixelize(
         self, data_source, field, bounds, size, antialias, dim, periodic
     ):
-        buff = pixelize_aitoff(
+        return pixelize_aitoff(
             data_source["py"],
             data_source["pdy"],
             data_source["px"],
@@ -179,7 +179,6 @@ class SphericalCoordinateHandler(CoordinateHandler):
             theta_offset=0,
             phi_offset=0,
         ).transpose()
-        return buff
 
     def _cyl_pixelize(self, data_source, field, bounds, size, antialias, dimension):
         name = self.axis_name[dimension]
@@ -226,14 +225,14 @@ class SphericalCoordinateHandler(CoordinateHandler):
             nc[:, ri] = np.cos(phi) * np.sin(theta) * r
             nc[:, thetai] = np.sin(phi) * np.sin(theta) * r
             nc[:, phii] = np.cos(theta) * r
+            return nc
         else:
             r, theta, phi = coord
-            nc = (
+            return (
                 np.cos(phi) * np.sin(theta) * r,
                 np.sin(phi) * np.sin(theta) * r,
                 np.cos(theta) * r,
             )
-        return nc
 
     def convert_to_cylindrical(self, coord):
         raise NotImplementedError
@@ -300,9 +299,9 @@ class SphericalCoordinateHandler(CoordinateHandler):
     def sanitize_width(self, axis, width, depth):
         name = self.axis_name[axis]
         if width is not None:
-            width = super().sanitize_width(axis, width, depth)
+            return super().sanitize_width(axis, width, depth)
         elif name == "r":
-            width = [
+            return [
                 self.ds.domain_width[self.x_axis["r"]],
                 self.ds.domain_width[self.y_axis["r"]],
             ]
@@ -310,11 +309,11 @@ class SphericalCoordinateHandler(CoordinateHandler):
             ri = self.axis_id["r"]
             # Remember, in spherical coordinates when we cut in theta,
             # we create a conic section
-            width = [2.0 * self.ds.domain_width[ri], 2.0 * self.ds.domain_width[ri]]
+            return [2.0 * self.ds.domain_width[ri], 2.0 * self.ds.domain_width[ri]]
         elif name == "phi":
             ri = self.axis_id["r"]
-            width = [self.ds.domain_right_edge[ri], 2.0 * self.ds.domain_width[ri]]
-        return width
+            return [self.ds.domain_right_edge[ri], 2.0 * self.ds.domain_width[ri]]
+        raise ValueError
 
     def _sanity_check(self):
         """This prints out a handful of diagnostics that help verify the

--- a/yt/geometry/geometry_handler.py
+++ b/yt/geometry/geometry_handler.py
@@ -302,8 +302,7 @@ class YTDataChunk:
     def fcoords(self):
         if self._fast_index is not None:
             ci = self._fast_index.select_fcoords(self.dobj.selector, self.data_size)
-            ci = YTArray(ci, units="code_length", registry=self.dobj.ds.unit_registry)
-            return ci
+            return YTArray(ci, units="code_length", registry=self.dobj.ds.unit_registry)
         ci = np.empty((self.data_size, 3), dtype="float64")
         ci = YTArray(ci, units="code_length", registry=self.dobj.ds.unit_registry)
         if self.data_size == 0:
@@ -320,8 +319,7 @@ class YTDataChunk:
     @cached_property
     def icoords(self):
         if self._fast_index is not None:
-            ci = self._fast_index.select_icoords(self.dobj.selector, self.data_size)
-            return ci
+            return self._fast_index.select_icoords(self.dobj.selector, self.data_size)
         ci = np.empty((self.data_size, 3), dtype="int64")
         if self.data_size == 0:
             return ci
@@ -338,8 +336,7 @@ class YTDataChunk:
     def fwidth(self):
         if self._fast_index is not None:
             ci = self._fast_index.select_fwidth(self.dobj.selector, self.data_size)
-            ci = YTArray(ci, units="code_length", registry=self.dobj.ds.unit_registry)
-            return ci
+            return YTArray(ci, units="code_length", registry=self.dobj.ds.unit_registry)
         ci = np.empty((self.data_size, 3), dtype="float64")
         ci = YTArray(ci, units="code_length", registry=self.dobj.ds.unit_registry)
         if self.data_size == 0:
@@ -356,8 +353,7 @@ class YTDataChunk:
     @cached_property
     def ires(self):
         if self._fast_index is not None:
-            ci = self._fast_index.select_ires(self.dobj.selector, self.data_size)
-            return ci
+            return self._fast_index.select_ires(self.dobj.selector, self.data_size)
         ci = np.empty(self.data_size, dtype="int64")
         if self.data_size == 0:
             return ci

--- a/yt/geometry/grid_geometry_handler.py
+++ b/yt/geometry/grid_geometry_handler.py
@@ -359,8 +359,7 @@ class GridIndex(Index, abc.ABC):
             return fast_index.count(dobj.selector)
         if grids is None:
             grids = dobj._chunk_info
-        count = sum(g.count(dobj.selector) for g in grids)
-        return count
+        return sum(g.count(dobj.selector) for g in grids)
 
     def _chunk_all(self, dobj, cache=True, fast_index=None):
         gobjs = getattr(dobj._current_chunk, "objs", dobj._chunk_info)

--- a/yt/geometry/particle_geometry_handler.py
+++ b/yt/geometry/particle_geometry_handler.py
@@ -382,6 +382,7 @@ class ParticleIndex(Index):
                 data = fh.read(size)
                 ret.extend(data)
             return fnv_hash(ret)
+        raise RuntimeError
 
     def _initialize_frontend_specific(self):
         """This is for frontend-specific initialization code

--- a/yt/geometry/tests/test_particle_octree.py
+++ b/yt/geometry/tests/test_particle_octree.py
@@ -471,12 +471,10 @@ def makeall_decomp_hilbert_gaussian(
     def load_pos(file_id):
         filename = fname_base + f"file{file_id}"
         if os.path.isfile(filename):
-            fd = open(filename, "rb")
-            positions = pickle.load(fd)
-            fd.close()
+            with open(filename, "rb") as fd:
+                return pickle.load(fd)
         else:
-            positions = np.empty((0, 3), dtype="float64")
-        return positions
+            return np.empty((0, 3), dtype="float64")
 
     def save_pos(file_id, positions):
         filename = fname_base + f"file{file_id}"
@@ -656,8 +654,7 @@ def fake_decomp_grid(npart, nfiles, ifile, DLE, DRE, buff=0.0, verbose=False):
         DLE[2] + 0.1 * div[2] : DRE[2] - 0.1 * div[2] : nYZ * 1j,
     ]
     X = 0.5 * div[0] * np.ones(Y.shape, dtype="float64") + div[0] * ifile
-    pos = np.array([X.ravel(), Y.ravel(), Z.ravel()], dtype="float64").transpose()
-    return pos
+    return np.array([X.ravel(), Y.ravel(), Z.ravel()], dtype="float64").transpose()
 
 
 def yield_fake_decomp(decomp, npart, nfiles, DLE, DRE, **kws):
@@ -674,10 +671,8 @@ def fake_decomp(
     if fname is None and distrib == "gaussian":
         fname = f"{decomp}6_{distrib}_np{npart}_nf{nfiles}_file{ifile}"
     if fname is not None and os.path.isfile(fname):
-        fd = open(fname, "rb")
-        pos = pickle.load(fd)
-        fd.close()
-        return pos
+        with open(fname, "rb") as fd:
+            return pickle.load(fd)
     if decomp.startswith("zoom_"):
         zoom_factor = 5
         decomp_zoom = decomp.split("zoom_")[-1]

--- a/yt/geometry/unstructured_mesh_handler.py
+++ b/yt/geometry/unstructured_mesh_handler.py
@@ -29,13 +29,12 @@ class UnstructuredIndex(Index):
         """
         Returns (in code units) the smallest cell size in the simulation.
         """
-        dx = min(
+        return min(
             smallest_fwidth(
                 mesh.connectivity_coords, mesh.connectivity_indices, mesh._index_offset
             )
             for mesh in self.meshes
         )
-        return dx
 
     def convert(self, unit):
         return self.dataset.conversion_factors[unit]
@@ -53,8 +52,7 @@ class UnstructuredIndex(Index):
     def _count_selection(self, dobj, meshes=None):
         if meshes is None:
             meshes = dobj._chunk_info
-        count = sum(m.count(dobj.selector) for m in meshes)
-        return count
+        return sum(m.count(dobj.selector) for m in meshes)
 
     def _chunk_all(self, dobj, cache=True):
         oobjs = getattr(dobj._current_chunk, "objs", dobj._chunk_info)

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -579,13 +579,12 @@ def load_amr_grids(
     handler.simulation_time = sim_time
     handler.cosmology_simulation = 0
 
-    sds = StreamDataset(
+    return StreamDataset(
         handler,
         geometry=geometry,
         unit_system=unit_system,
         default_species_fields=default_species_fields,
     )
-    return sds
 
 
 def load_particles(
@@ -699,7 +698,7 @@ def load_particles(
         if unit is None:
             unit = "code_" + dimension
             if data_source is not None:
-                unit = getattr(data_source.ds, dimension + "_unit", unit)
+                return getattr(data_source.ds, dimension + "_unit", unit)
         return unit
 
     length_unit = parse_unit(length_unit, "length")
@@ -753,14 +752,12 @@ def load_particles(
     handler.simulation_time = sim_time
     handler.cosmology_simulation = 0
 
-    sds = StreamParticlesDataset(
+    return StreamParticlesDataset(
         handler,
         geometry=geometry,
         unit_system=unit_system,
         default_species_fields=default_species_fields,
     )
-
-    return sds
 
 
 def load_hexahedral_mesh(
@@ -899,9 +896,7 @@ def load_hexahedral_mesh(
     handler.simulation_time = sim_time
     handler.cosmology_simulation = 0
 
-    sds = StreamHexahedralDataset(handler, geometry=geometry, unit_system=unit_system)
-
-    return sds
+    return StreamHexahedralDataset(handler, geometry=geometry, unit_system=unit_system)
 
 
 def load_octree(

--- a/yt/startup_tasks.py
+++ b/yt/startup_tasks.py
@@ -18,7 +18,6 @@ from yt.utilities import rpdb
 exe_name = os.path.basename(sys.executable)
 # At import time, we determined whether or not we're being run in parallel.
 def turn_on_parallelism():
-    parallel_capable = False
     try:
         # we import this to check if mpi4py is installed
         from mpi4py import MPI  # NOQA
@@ -34,8 +33,7 @@ def turn_on_parallelism():
         enable_parallelism,
     )
 
-    parallel_capable = enable_parallelism()
-    return parallel_capable
+    return enable_parallelism()
 
 
 # This fallback is for Paraview:

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -274,7 +274,7 @@ def fake_random_ds(
             for f in (f"particle_velocity_{ax}" for ax in "xyz"):
                 data["io", f] = (prng.random_sample(size=particles) - 0.5, "cm/s")
             data["io", "particle_mass"] = (prng.random_sample(particles), "g")
-    ug = load_uniform_grid(
+    return load_uniform_grid(
         data,
         ndims,
         length_unit=length_unit,
@@ -283,7 +283,6 @@ def fake_random_ds(
         bbox=bbox,
         default_species_fields=default_species_fields,
     )
-    return ug
 
 
 _geom_transforms = {
@@ -404,8 +403,7 @@ def fake_particle_ds(
         v = prng.random_sample(npart) - offset
         data[field] = (v, u)
     bbox = np.array([[0.0, 1.0], [0.0, 1.0], [0.0, 1.0]])
-    ds = load_particles(data, 1.0, bbox=bbox)
-    return ds
+    return load_particles(data, 1.0, bbox=bbox)
 
 
 def fake_tetrahedral_ds():
@@ -426,10 +424,9 @@ def fake_tetrahedral_ds():
     elem_data = {}
     elem_data[("connect1", "elem")] = prng.rand(_connectivity.shape[0])
 
-    ds = load_unstructured_mesh(
+    return load_unstructured_mesh(
         _connectivity, _coordinates, node_data=node_data, elem_data=elem_data
     )
-    return ds
 
 
 def fake_hexahedral_ds(fields=None):
@@ -452,10 +449,9 @@ def fake_hexahedral_ds(fields=None):
     elem_data = {}
     elem_data[("connect1", "elem")] = prng.rand(_connectivity.shape[0])
 
-    ds = load_unstructured_mesh(
+    return load_unstructured_mesh(
         _connectivity - 1, _coordinates, node_data=node_data, elem_data=elem_data
     )
-    return ds
 
 
 def small_fake_hexahedral_ds():
@@ -480,8 +476,7 @@ def small_fake_hexahedral_ds():
     dist = np.sum(_coordinates ** 2, 1)
     node_data[("connect1", "test")] = dist[_connectivity - 1]
 
-    ds = load_unstructured_mesh(_connectivity - 1, _coordinates, node_data=node_data)
-    return ds
+    return load_unstructured_mesh(_connectivity - 1, _coordinates, node_data=node_data)
 
 
 def fake_vr_orientation_test_ds(N=96, scale=1):
@@ -568,8 +563,7 @@ def fake_vr_orientation_test_ds(N=96, scale=1):
         arr[idx] = 0.6
 
     data = dict(density=(arr, "g/cm**3"))
-    ds = load_uniform_grid(data, arr.shape, bbox=bbox)
-    return ds
+    return load_uniform_grid(data, arr.shape, bbox=bbox)
 
 
 def fake_sph_orientation_ds():
@@ -703,7 +697,7 @@ def fake_octree_ds(
         quantities[("gas", "velocity_y")] = prng.random_sample((particles, 1))
         quantities[("gas", "velocity_z")] = prng.random_sample((particles, 1))
 
-    ds = load_octree(
+    return load_octree(
         octree_mask=octree_mask,
         data=quantities,
         bbox=bbox,
@@ -718,7 +712,6 @@ def fake_octree_ds(
         over_refine_factor=over_refine_factor,
         unit_system=unit_system,
     )
-    return ds
 
 
 def add_noise_fields(ds):
@@ -966,7 +959,7 @@ def disable_dataset_cache(func):
         rv = func(*args, **kwargs)
         if restore_cfg_state:
             ytcfg["yt", "skip_dataset_cache"] = False
-        return rv
+        return rv  # noqa R504
 
     return newfunc
 

--- a/yt/utilities/amr_kdtree/amr_kdtools.py
+++ b/yt/utilities/amr_kdtree/amr_kdtools.py
@@ -41,5 +41,4 @@ def send_to_parent(comm, outgoing_rank, image):
 
 def scatter_image(comm, root, image):
     mylog.debug("Scattering from %04i", root)
-    image = comm.mpi_bcast(image, root=root)
-    return image
+    return comm.mpi_bcast(image, root=root)

--- a/yt/utilities/amr_kdtree/amr_kdtree.py
+++ b/yt/utilities/amr_kdtree/amr_kdtree.py
@@ -368,7 +368,7 @@ class AMRKDTree(ParallelAnalysisInterface):
         node.dirty = False
         if not self._initialized:
             self.brick_dimensions.append(dims)
-        return brick
+        return brick  # noqa R504
 
     def locate_brick(self, position):
         """Given a position, find the node that contains it."""

--- a/yt/utilities/answer_testing/answer_tests.py
+++ b/yt/utilities/answer_testing/answer_tests.py
@@ -39,8 +39,7 @@ def parentage_relationships(ds):
         else:
             parents = parents + [pg.id for pg in p]
         children = children + [c.id for c in g.Children]
-    result = np.array(parents + children)
-    return result
+    return np.array(parents + children)
 
 
 def grid_values(ds, field):
@@ -232,7 +231,7 @@ def plot_window_attribute(
     plot.save(name=tmpname)
     image = mpimg.imread(tmpname)
     os.remove(tmpname)
-    return image
+    return image  # noqa R504
 
 
 def phase_plot_attribute(
@@ -258,12 +257,11 @@ def phase_plot_attribute(
     plot.save(name=tmpname)
     image = mpimg.imread(tmpname)
     os.remove(tmpname)
-    return image
+    return image  # noqa R504
 
 
 def generic_image(img_fname):
-    img_data = mpimg.imread(img_fname)
-    return img_data
+    return mpimg.imread(img_fname)
 
 
 def axial_pixelization(ds):
@@ -302,8 +300,7 @@ def extract_connected_sets(ds_fn, data_source, field, num_levels, min_val, max_v
                     all_sets[level][set_id]["cell_mass"].sum(),
                 ]
             )
-    result = np.array(result)
-    return result
+    return np.array(result)
 
 
 def VR_image_comparison(scene):
@@ -312,4 +309,4 @@ def VR_image_comparison(scene):
     scene.save(tmpname, sigma_clip=1.0)
     image = mpimg.imread(tmpname)
     os.remove(tmpname)
-    return image
+    return image  # noqa R504

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -227,7 +227,7 @@ class AnswerTestCloudStorage(AnswerTestStorage):
             # This is dangerous, but we have a controlled S3 environment
             rv = pickle.loads(data)
         self.cache[ds_name] = rv
-        return rv
+        return self.cache[ds_name]
 
     def progress_callback(self, current, total):
         self.pbar.update(current)
@@ -280,11 +280,11 @@ class AnswerTestLocalStorage(AnswerTestStorage):
         answer_name = f"{ds_name}"
         ds = shelve.open(self.reference_name, protocol=-1)
         try:
-            result = ds[answer_name]
+            return ds[answer_name]
         except KeyError:
-            result = default
-        ds.close()
-        return result
+            return default
+        finally:
+            ds.close()
 
 
 @contextlib.contextmanager
@@ -447,8 +447,7 @@ class AnswerTestingTest:
         cls = getattr(pw, plot_type, None)
         if cls is None:
             cls = getattr(particle_plots, plot_type)
-        plot = cls(*(ds, plot_axis, plot_field), **plot_kwargs)
-        return plot
+        return cls(*(ds, plot_axis, plot_field), **plot_kwargs)
 
     @property
     def sim_center(self):
@@ -723,8 +722,7 @@ class VerifySimulationSameTest(AnswerTestingTest):
         self.ds = simulation_obj
 
     def run(self):
-        result = [ds.current_time for ds in self.ds]
-        return result
+        return [ds.current_time for ds in self.ds]
 
     def compare(self, new_result, old_result):
         assert_equal(
@@ -951,8 +949,7 @@ class PhasePlotAttributeTest(AnswerTestingTest):
         cls = getattr(profile_plotter, plot_type, None)
         if cls is None:
             cls = getattr(particle_plots, plot_type)
-        plot = cls(*(data_source, x_field, y_field, z_field), **plot_kwargs)
-        return plot
+        return cls(*(data_source, x_field, y_field, z_field), **plot_kwargs)
 
     def run(self):
         plot = self.create_plot(
@@ -1270,5 +1267,4 @@ def create_obj(ds, obj_type):
     if obj_type is None:
         return ds.all_data()
     cls = getattr(ds, obj_type[0])
-    obj = cls(*obj_type[1])
-    return obj
+    return cls(*obj_type[1])

--- a/yt/utilities/answer_testing/level_sets_tests.py
+++ b/yt/utilities/answer_testing/level_sets_tests.py
@@ -29,8 +29,7 @@ class ExtractConnectedSetsTest(AnswerTestingTest):
                         all_sets[level][set_id]["cell_mass"].sum(),
                     ]
                 )
-        result = np.array(result)
-        return result
+        return np.array(result)
 
     def compare(self, new_result, old_result):
         err_msg = f"Size and/or mass of connected sets do not agree for {self.ds_fn}."

--- a/yt/utilities/answer_testing/testing_utilities.py
+++ b/yt/utilities/answer_testing/testing_utilities.py
@@ -189,19 +189,17 @@ def generate_hash(data):
     # Try to hash. Some tests return hashable types (like ndarrays) and
     # others don't (such as dictionaries)
     try:
-        hd = hashlib.md5(data).hexdigest()
+        return hashlib.md5(data).hexdigest()
         # Handle those tests that return non-hashable types. This is done
         # here instead of in the tests themselves to try and reduce boilerplate
         # and provide a central location where all of this is done in case it needs
         # to be changed
     except TypeError:
         if isinstance(data, dict):
-            hd = _hash_dict(data)
+            return _hash_dict(data)
         elif data is None:
-            hd = hashlib.md5(bytes(str(-1).encode("utf-8"))).hexdigest()
-        else:
-            raise
-    return hd
+            return hashlib.md5(bytes(str(-1).encode("utf-8"))).hexdigest()
+        raise
 
 
 def _save_result(data, output_file):
@@ -421,8 +419,7 @@ def create_obj(ds, obj_type):
     if obj_type is None:
         return ds.all_data()
     cls = getattr(ds, obj_type[0])
-    obj = cls(*obj_type[1])
-    return obj
+    return cls(*obj_type[1])
 
 
 def compare_unit_attributes(ds1, ds2):
@@ -481,8 +478,7 @@ def _create_plot_window_attribute_plot(ds, plot_type, field, axis, pkwargs=None)
     cls = getattr(pw, plot_type, None)
     if cls is None:
         cls = getattr(particle_plots, plot_type)
-    plot = cls(ds, axis, field, **pkwargs)
-    return plot
+    return cls(ds, axis, field, **pkwargs)
 
 
 def _create_phase_plot_attribute_plot(
@@ -516,8 +512,7 @@ def _create_phase_plot_attribute_plot(
     cls = getattr(profile_plotter, plot_type, None)
     if cls is None:
         cls = getattr(particle_plots, plot_type)
-    plot = cls(*(data_source, x_field, y_field, z_field), **plot_kwargs)
-    return plot
+    return cls(*(data_source, x_field, y_field, z_field), **plot_kwargs)
 
 
 def get_parameterization(fname):

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -58,14 +58,13 @@ _arg_groups = {}
 
 def _fix_ds(arg, *args, **kwargs):
     if os.path.isdir(f"{arg}") and os.path.exists(f"{arg}/{arg}"):
-        ds = load(f"{arg}/{arg}", *args, **kwargs)
+        return load(f"{arg}/{arg}", *args, **kwargs)
     elif os.path.isdir(f"{arg}.dir") and os.path.exists(f"{arg}.dir/{arg}"):
-        ds = load(f"{arg}.dir/{arg}", *args, **kwargs)
+        return load(f"{arg}.dir/{arg}", *args, **kwargs)
     elif arg.endswith(".index"):
-        ds = load(arg[:-10], *args, **kwargs)
+        return load(arg[:-10], *args, **kwargs)
     else:
-        ds = load(arg, *args, **kwargs)
-    return ds
+        return load(arg, *args, **kwargs)
 
 
 def _add_arg(sc, arg):
@@ -1557,6 +1556,7 @@ class YTDeleteImageCmd(YTCommand):
             print("Something has gone wrong!  Here is the server response:")
             print()
             pprint.pprint(rv)
+        return None
 
 
 class YTUploadImageCmd(YTCommand):
@@ -1604,6 +1604,7 @@ class YTUploadImageCmd(YTCommand):
             print("Something has gone wrong!  Here is the server response:")
             print()
             pprint.pprint(rv)
+        return None
 
 
 class YTUploadFileCmd(YTCommand):

--- a/yt/utilities/configuration_tree.py
+++ b/yt/utilities/configuration_tree.py
@@ -21,12 +21,12 @@ class ConfigNode:
 
     def get_child(self, key, constructor=None):
         if key in self.children:
-            child = self.children[key]
+            return self.children[key]
         elif constructor is not None:
-            child = self.children[key] = constructor()
+            self.children[key] = constructor()
+            return self.children[key]
         else:
             raise KeyError(f"Cannot get key {key}")
-        return child
 
     def add_child(self, key):
         self.get_child(key, lambda: ConfigNode(key, parent=self))

--- a/yt/utilities/configure.py
+++ b/yt/utilities/configure.py
@@ -23,10 +23,10 @@ def _expand_all(s):
 def _cast_value_helper(value, types=(_cast_bool_helper, int, float, _expand_all)):
     for t in types:
         try:
-            retval = t(value)
-            return retval
+            return t(value)
         except ValueError:
             pass
+    raise ValueError
 
 
 def get_config(section, option):

--- a/yt/utilities/cosmology.py
+++ b/yt/utilities/cosmology.py
@@ -554,8 +554,7 @@ class Cosmology:
             if iter > 10:
                 raise RuntimeError("a_from_t calculation did not converge!")
 
-        a = np.power(10, table(lt))
-        return a
+        return np.power(10, table(lt))
 
     def z_from_t(self, t):
         """
@@ -600,11 +599,9 @@ class Cosmology:
         scale_factor = 1.0 / (1.0 + z)
 
         # Evaluate exponential using Linder02 parameterization
-        dark_factor = np.power(
-            scale_factor, -3.0 * (1.0 + self.w_0 + self.w_a)
-        ) * np.exp(-3.0 * self.w_a * (1.0 - scale_factor))
-
-        return dark_factor
+        return np.power(scale_factor, -3.0 * (1.0 + self.w_0 + self.w_a)) * np.exp(
+            -3.0 * self.w_a * (1.0 - scale_factor)
+        )
 
     _arr = None
 

--- a/yt/utilities/decompose.py
+++ b/yt/utilities/decompose.py
@@ -37,14 +37,14 @@ def evaluate_domain_decomposition(n_d, pieces, ldom):
         float(pieces) * np.product((n_d - 1) // ldom + 1)
     )
 
+    if np.any(ldom > n_d):
+        return 0
     # 0.25 is magic number
     quality = load_balance / (1 + 0.25 * (bsize / ideal_bsize - 1.0))
     # \todo add a factor that estimates lower cost when x-direction is
     # not chopped too much
     # \deprecated estimate these magic numbers
     quality *= 1.0 - (0.001 * ldom[0] + 0.0001 * ldom[1]) / pieces
-    if np.any(ldom > n_d):
-        quality = 0
 
     return quality
 

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -25,8 +25,7 @@ class YTUnidentifiedDataType(YTException):
             msg.append(", ".join(str(a) for a in self.args))
         if self.kwargs:
             msg.append(", ".join(f"{k}={v}" for k, v in self.kwargs.items()))
-        msg = ", ".join(msg) + "`."
-        return msg
+        return ", ".join(msg) + "`."
 
 
 class YTOutputNotIdentified(YTUnidentifiedDataType):
@@ -571,11 +570,10 @@ class YTDuplicateFieldInProfile(Exception):
         self.old_spec = old_spec
 
     def __str__(self):
-        r = f"""Field {self.field} already exists with field spec:
+        return f"""Field {self.field} already exists with field spec:
                {self.old_spec}
                But being asked to add it with:
                {self.new_spec}"""
-        return r
 
 
 class YTInvalidPositionArray(Exception):
@@ -584,9 +582,8 @@ class YTInvalidPositionArray(Exception):
         self.dimensions = dimensions
 
     def __str__(self):
-        r = f"""Position arrays must be length and shape (N,3).
+        return f"""Position arrays must be length and shape (N,3).
                But this one has {self.dimensions} and {self.shape}."""
-        return r
 
 
 class YTIllDefinedCutRegion(Exception):
@@ -697,7 +694,7 @@ class YTInvalidFieldType(YTException):
         self.fields = fields
 
     def __str__(self):
-        msg = (
+        return (
             "\nSlicePlot, ProjectionPlot, and OffAxisProjectionPlot can "
             "only plot fields that\n"
             "are defined on a mesh or for SPH particles, but received the "
@@ -707,7 +704,6 @@ class YTInvalidFieldType(YTException):
             "Did you mean to use ParticlePlot or plot a deposited particle "
             "field instead?" % self.fields
         )
-        return msg
 
 
 class YTUnknownUniformKind(YTException):
@@ -830,11 +826,10 @@ class YTIllDefinedAMR(YTException):
         self.axis = axis
 
     def __str__(self):
-        msg = (
+        return (
             "Grids on the level {} are not properly aligned with cell edges "
             "on the parent level ({} axis)"
         ).format(self.level, self.axis)
-        return msg
 
 
 class YTIllDefinedParticleData(YTException):

--- a/yt/utilities/fortran_utils.py
+++ b/yt/utilities/fortran_utils.py
@@ -212,7 +212,7 @@ def read_vector(f, d, endian="="):
             vec_len,
             vec_len2,
         )
-    return tr
+    return tr  # noqa R504
 
 
 def skip(f, n=1, endian="="):

--- a/yt/utilities/lib/tests/test_bounding_volume_hierarchy.py
+++ b/yt/utilities/lib/tests/test_bounding_volume_hierarchy.py
@@ -44,5 +44,5 @@ def test_bounding_volume_hierarchy():
 
     image = np.empty(800 * 800, np.float64)
     test_ray_trace(image, origins, direction, bvh)
-    image = image.reshape((800, 800))
+    image.shape = (800, 800)
     return image

--- a/yt/utilities/math_utils.py
+++ b/yt/utilities/math_utils.py
@@ -261,10 +261,10 @@ def euclidean_dist(a, b):
     c = c.sum(axis=0)
     if isinstance(c, np.ndarray):
         np.sqrt(c, c)
+        return c
     else:
         # This happens if a and b only have one entry.
-        c = math.sqrt(c)
-    return c
+        return math.sqrt(c)
 
 
 def rotate_vector_3D(a, dim, angle):
@@ -1184,7 +1184,7 @@ def get_rotation_matrix(theta, rot_vector):
     cost = np.cos(theta)
     sint = np.sin(theta)
 
-    R = np.array(
+    return np.array(
         [
             [
                 cost + ux ** 2 * (1 - cost),
@@ -1203,8 +1203,6 @@ def get_rotation_matrix(theta, rot_vector):
             ],
         ]
     )
-
-    return R
 
 
 def quaternion_mult(q1, q2):
@@ -1328,10 +1326,9 @@ def get_sph_r(coords):
 
 def resize_vector(vector, vector_array):
     if len(vector_array.shape) == 4:
-        res_vector = np.resize(vector, (3, 1, 1, 1))
+        return np.resize(vector, (3, 1, 1, 1))
     else:
-        res_vector = np.resize(vector, (3, 1))
-    return res_vector
+        return np.resize(vector, (3, 1))
 
 
 def normalize_vector(vector):
@@ -1340,8 +1337,7 @@ def normalize_vector(vector):
 
     L2 = np.atleast_1d(np.linalg.norm(vector))
     L2[L2 == 0] = 1.0
-    vector = vector / L2
-    return vector
+    return vector / L2
 
 
 def get_sph_theta(coords, normal):

--- a/yt/utilities/parallel_tools/io_runner.py
+++ b/yt/utilities/parallel_tools/io_runner.py
@@ -71,13 +71,11 @@ class IOCommunicator(BaseIOHandler):
             # because this gets upcast to float
             return np.array([], dtype="float64")
         try:
-            temp = self.ds.index.io._read_data_set(g, f)
+            return self.ds.index.io._read_data_set(g, f)
         except Exception:  # self.ds.index.io._read_exception as exc:
             if fi.not_in_all:
-                temp = np.zeros(g.ActiveDimensions, dtype="float64")
-            else:
-                raise
-        return temp
+                return np.zeros(g.ActiveDimensions, dtype="float64")
+            raise
 
     def wait(self):
         status = MPI.Status()

--- a/yt/utilities/parameter_file_storage.py
+++ b/yt/utilities/parameter_file_storage.py
@@ -96,6 +96,7 @@ class ParameterFileStore:
         for h in self._records:
             if self._records[h]["ctid"] == ctid:
                 return self._convert_ds(self._records[h])
+        raise ValueError(f"Unknown value received for `ctid` = {ctid}")
 
     def _adapt_ds(self, ds):
         """This turns a dataset into a CSV entry."""
@@ -165,8 +166,7 @@ class ParameterFileStore:
         self.read_db()
 
     def get_recent(self, n=10):
-        recs = sorted(self._records.values(), key=lambda a: -a["last_seen"])[:n]
-        return recs
+        return sorted(self._records.values(), key=lambda a: -a["last_seen"])[:n]
 
     @parallel_simple_proxy
     def _write_out(self):

--- a/yt/utilities/png_writer.py
+++ b/yt/utilities/png_writer.py
@@ -22,8 +22,6 @@ def write_png(buffer, filename, dpi=100):
 
 
 def write_png_to_string(buffer, dpi=100):
-    fileobj = BytesIO()
-    call_png_write_png(buffer, fileobj, dpi)
-    png_str = fileobj.getvalue()
-    fileobj.close()
-    return png_str
+    with BytesIO() as fileobj:
+        call_png_write_png(buffer, fileobj, dpi)
+        return fileobj.getvalue()

--- a/yt/utilities/sdf.py
+++ b/yt/utilities/sdf.py
@@ -47,12 +47,11 @@ def _get_type(vtype, tlen=None):
     try:
         t = _types[vtype]
         if tlen is not None:
-            t = np.dtype((t, tlen))
+            return np.dtype((t, tlen))
         else:
-            t = np.dtype(t)
+            return np.dtype(t)
     except KeyError:
-        t = eval("np." + vtype)
-    return t
+        return eval("np." + vtype)
 
 
 def _lstrip(text_list):
@@ -537,10 +536,9 @@ def load_sdf(filename, header=None):
 
     """
     if "http" in filename:
-        sdf = HTTPSDFRead(filename, header=header)
+        return HTTPSDFRead(filename, header=header)
     else:
-        sdf = SDFRead(filename, header=header)
-    return sdf
+        return SDFRead(filename, header=header)
 
 
 def _shift_periodic(pos, left, right, domain_width):
@@ -856,10 +854,9 @@ class SDFIndex:
         # indices = np.array([self.get_key_ijk(x, y, z) for x, y, z in zip(X, Y, Z)])
         # Here we sort the indices to batch consecutive reads together.
         if self.wandering_particles:
-            indices = np.sort(np.append(indices, dinds))
+            return np.sort(np.append(indices, dinds))
         else:
-            indices = np.sort(indices)
-        return indices
+            return np.sort(indices)
 
     def get_bbox(self, left, right):
         """
@@ -1219,16 +1216,14 @@ class SDFIndex:
         return lmax_lk, lmax_rk
 
     def find_max_cell(self):
-        max_cell = np.argmax(self.indexdata["len"][:])
-        return max_cell
+        return np.argmax(self.indexdata["len"][:])
 
     def find_max_cell_center(self):
         max_cell = self.find_max_cell()
         cell_ijk = np.array(
             self.get_ind_from_key(self.indexdata["index"][max_cell]), dtype="int64"
         )
-        position = (cell_ijk + 0.5) * (self.domain_width / self.domain_dims) + self.rmin
-        return position
+        return (cell_ijk + 0.5) * (self.domain_width / self.domain_dims) + self.rmin
 
     def get_cell_data(self, level, cell_iarr, fields):
         """

--- a/yt/utilities/tests/test_cosmology.py
+++ b/yt/utilities/tests/test_cosmology.py
@@ -83,9 +83,7 @@ def z_from_t_analytic(my_time, hubble_constant=0.7, omega_matter=0.3, omega_lamb
     else:
         raise NotImplementedError
 
-    redshift = (1.0 / a) - 1.0
-
-    return redshift
+    return (1.0 / a) - 1.0
 
 
 def t_from_z_analytic(z, hubble_constant=0.7, omega_matter=0.3, omega_lambda=0.7):
@@ -130,9 +128,7 @@ def t_from_z_analytic(z, hubble_constant=0.7, omega_matter=0.3, omega_lambda=0.7
 
     # Now convert from Time * H0 to time.
 
-    my_time = t0 / hubble_constant
-
-    return my_time
+    return t0 / hubble_constant
 
 
 def test_z_t_roundtrip():

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -110,7 +110,7 @@ class PlotMPL:
         try:
             module, fig_canvas, fig_manager = BACKEND_SPECS[key]
         except KeyError:
-            return
+            return None
 
         mod = __import__(
             "matplotlib.backends",

--- a/yt/visualization/eps_writer.py
+++ b/yt/visualization/eps_writer.py
@@ -33,8 +33,7 @@ def convert_frac_to_tex(string):
         + r"}$"
         + result[end_pos:]
     )
-    result = result.replace(r"\ ", r"\;")
-    return result
+    return result.replace(r"\ ", r"\;")
 
 
 def pyxize_label(string):
@@ -45,8 +44,7 @@ def pyxize_label(string):
     else:
         result = string
     result = result.replace("$", "")
-    result = r"$" + result + r"$"
-    return result
+    return r"$" + result + r"$"
 
 
 class DualEPS:
@@ -1538,17 +1536,16 @@ def multiplot_yt(ncol, nrow, plots, fields=None, **kwargs):
                 "Number of plots ({}) is less "
                 "than nrow({}) x ncol({}).".format(len(fields), nrow, ncol)
             )
-        figure = multiplot(ncol, nrow, yt_plots=plots, fields=fields, **kwargs)
+        return multiplot(ncol, nrow, yt_plots=plots, fields=fields, **kwargs)
     elif isinstance(plots, list) and isinstance(plots[0], (PlotWindow, PhasePlot)):
         if len(plots) < nrow * ncol:
             raise RuntimeError(
                 "Number of plots ({}) is less "
                 "than nrow({}) x ncol({}).".format(len(fields), nrow, ncol)
             )
-        figure = multiplot(ncol, nrow, yt_plots=plots, fields=fields, **kwargs)
-    else:
-        raise RuntimeError("Unknown plot type in multiplot_yt")
-    return figure
+        return multiplot(ncol, nrow, yt_plots=plots, fields=fields, **kwargs)
+
+    raise RuntimeError("Unknown plot type in multiplot_yt")
 
 
 # =============================================================================

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -601,8 +601,9 @@ class FITSImageData:
             output.write("\n".join(results))
             output.write("\n")
             output.flush()
-        else:
-            return results[2:]
+            return None
+
+        return results[2:]
 
     @parallel_root_only
     def writeto(self, fileobj, fields=None, overwrite=False, **kwargs):
@@ -839,9 +840,9 @@ class FITSImageBuffer(FITSImageData):
 def sanitize_fits_unit(unit):
     if unit == "Mpc":
         mylog.info("Changing FITS file length unit to kpc.")
-        unit = "kpc"
+        return "kpc"
     elif unit == "au":
-        unit = "AU"
+        return "AU"
     return unit
 
 

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -613,9 +613,8 @@ class OffAxisProjectionFixedResolutionBuffer(FixedResolutionBuffer):
             north_vector=dd.north_vector,
             method=dd.method,
         )
-        ia = ImageArray(buff.swapaxes(0, 1), info=self._get_info(item))
-        self[item] = ia
-        return ia
+        self[item] = ImageArray(buff.swapaxes(0, 1), info=self._get_info(item))
+        return self[item]
 
 
 class ParticleImageBuffer(FixedResolutionBuffer):

--- a/yt/visualization/geo_plot_utils.py
+++ b/yt/visualization/geo_plot_utils.py
@@ -104,5 +104,5 @@ def get_mpl_transform(mpl_proj):
     # build in a check that if none of the above options are satisfied by what
     # the user passes that None is returned for the instantiated function
     if key is None:
-        instantiated_func = None
-    return instantiated_func
+        return None
+    return instantiated_func  # noqa R504

--- a/yt/visualization/image_writer.py
+++ b/yt/visualization/image_writer.py
@@ -38,8 +38,7 @@ def scale_image(image, mi=None, ma=None):
         mi = image.min()
     if ma is None:
         ma = image.max()
-    image = (np.clip((image - mi) / (ma - mi) * 255, 0, 255)).astype("uint8")
-    return image
+    return (np.clip((image - mi) / (ma - mi) * 255, 0, 255)).astype("uint8")
 
 
 def multi_image_composite(
@@ -248,8 +247,7 @@ def apply_colormap(image, color_bounds=None, cmap_name=None, func=lambda x: x):
         color_bounds = [YTQuantity(func(c), image.units) for c in color_bounds]
     image = (image - color_bounds[0]) / (color_bounds[1] - color_bounds[0])
     to_plot = map_to_colors(image, cmap_name)
-    to_plot = np.clip(to_plot, 0, 255)
-    return to_plot
+    return np.clip(to_plot, 0, 255)
 
 
 def map_to_colors(buff, cmap_name):

--- a/yt/visualization/line_plot.py
+++ b/yt/visualization/line_plot.py
@@ -87,10 +87,9 @@ class LinePlotDictionary(PlotDictionary):
         ).dimensions
         if dimensions not in self.known_dimensions:
             self.known_dimensions[dimensions] = item
-            ret_item = item
+            return item
         else:
-            ret_item = self.known_dimensions[dimensions]
-        return ret_item
+            return self.known_dimensions[dimensions]
 
     def __getitem__(self, item):
         ret_item = self._sanitize_dimensions(item)
@@ -280,12 +279,9 @@ class LinePlot(PlotContainer):
             y_frac_widths[1],
         )
 
-        try:
-            plot = self.plots[field]
-        except KeyError:
-            plot = PlotMPL(self.figure_size, axrect, None, None)
-            self.plots[field] = plot
-        return plot
+        if field not in self.plots:
+            self.plots[field] = PlotMPL(self.figure_size, axrect, None, None)
+        return self.plots[field]
 
     def _setup_plots(self):
         if self._plot_valid:
@@ -450,5 +446,5 @@ def _validate_point(point, ds, start=False):
             val = 0
         else:
             val = 1
-        point = np.append(point.d, [val] * (3 - ds.dimensionality)) * point.uq
+        return np.append(point.d, [val] * (3 - ds.dimensionality)) * point.uq
     return point

--- a/yt/visualization/mapserver/pannable_map.py
+++ b/yt/visualization/mapserver/pannable_map.py
@@ -18,8 +18,7 @@ def exc_writeout(f):
     @wraps(f)
     def func(*args, **kwargs):
         try:
-            rv = f(*args, **kwargs)
-            return rv
+            return f(*args, **kwargs)
         except Exception:
             traceback.print_exc(None, open("temp.exc", "w"))
             raise
@@ -111,8 +110,7 @@ class PannableMapServer:
                 frb[field], color_bounds=(cmi, cma), cmap_name=cmap
             )
 
-        rv = write_png_to_string(to_plot)
-        return rv
+        return write_png_to_string(to_plot)
 
     def index(self, field=None):
         if field is not None:

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -75,40 +75,36 @@ class PlotCallback:
         code_length units.  Projected data units are 2D versions of the
         simulation data units relative to the axes of the final plot.
         """
-        if len(coord) == 3:
-            if not isinstance(coord, YTArray):
-                coord = plot.data.ds.arr(coord, "code_length")
-            coord.convert_to_units("code_length")
-            ax = plot.data.axis
-            # if this is an on-axis projection or slice, then
-            # just grab the appropriate 2 coords for the on-axis view
-            if ax >= 0 and ax <= 2:
-                (xi, yi) = (
-                    plot.data.ds.coordinates.x_axis[ax],
-                    plot.data.ds.coordinates.y_axis[ax],
-                )
-                coord = (coord[xi], coord[yi])
-
-            # if this is an off-axis project or slice (ie cutting plane)
-            # we have to calculate where the data coords fall in the projected
-            # plane
-            elif ax == 4:
-                # transpose is just to get [[x1,x2,...],[y1,y2,...],[z1,z2,...]]
-                # in the same order as plot.data.center for array arithmetic
-                coord_vectors = coord.transpose() - plot.data.center
-                x = np.dot(coord_vectors, plot.data.orienter.unit_vectors[1])
-                y = np.dot(coord_vectors, plot.data.orienter.unit_vectors[0])
-                # Transpose into image coords. Due to VR being not a
-                # right-handed coord system
-                coord = (y, x)
-            else:
-                raise ValueError("Object being plot must have a `data.axis` defined")
-
-        # if the position is already two-coords, it is expected to be
-        # in the proper projected orientation
-        else:
+        if len(coord) != 3:
+            # if the position is already two-coords, it is expected to be
+            # in the proper projected orientation
             raise ValueError("'data' coordinates must be 3 dimensions")
-        return coord
+        if not isinstance(coord, YTArray):
+            coord = plot.data.ds.arr(coord, "code_length")
+        coord.convert_to_units("code_length")
+        ax = plot.data.axis
+        # if this is an on-axis projection or slice, then
+        # just grab the appropriate 2 coords for the on-axis view
+        if ax >= 0 and ax <= 2:
+            (xi, yi) = (
+                plot.data.ds.coordinates.x_axis[ax],
+                plot.data.ds.coordinates.y_axis[ax],
+            )
+            return (coord[xi], coord[yi])
+
+        # if this is an off-axis project or slice (ie cutting plane)
+        # we have to calculate where the data coords fall in the projected
+        # plane
+        elif ax == 4:
+            # transpose is just to get [[x1,x2,...],[y1,y2,...],[z1,z2,...]]
+            # in the same order as plot.data.center for array arithmetic
+            coord_vectors = coord.transpose() - plot.data.center
+            x = np.dot(coord_vectors, plot.data.orienter.unit_vectors[1])
+            y = np.dot(coord_vectors, plot.data.orienter.unit_vectors[0])
+            # Transpose into image coords. Due to VR being not a
+            # right-handed coord system
+            return (y, x)
+        raise ValueError("Object being plot must have a `data.axis` defined")
 
     def _convert_to_plot(self, plot, coord, offset=True):
         """

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -97,19 +97,15 @@ def get_axes_unit(width, ds):
         return ("code_length",) * 2
     if is_sequence(width):
         if isinstance(width[1], str):
-            axes_unit = (width[1], width[1])
+            return (width[1], width[1])
         elif is_sequence(width[1]):
-            axes_unit = (width[0][1], width[1][1])
+            return (width[0][1], width[1][1])
         elif isinstance(width[0], YTArray):
-            axes_unit = (str(width[0].units), str(width[1].units))
-        else:
-            axes_unit = None
-    else:
-        if isinstance(width, YTArray):
-            axes_unit = (str(width.units), str(width.units))
-        else:
-            axes_unit = None
-    return axes_unit
+            return (str(width[0].units), str(width[1].units))
+        return None
+    if isinstance(width, YTArray):
+        return (str(width.units), str(width.units))
+    return None
 
 
 def validate_mesh_fields(data_source, fields):

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -36,7 +36,7 @@ def invalidate_profile(f):
     def newfunc(*args, **kwargs):
         rv = f(*args, **kwargs)
         args[0]._profile_valid = False
-        return rv
+        return rv  # noqa 504
 
     return newfunc
 
@@ -735,12 +735,11 @@ class ProfilePlot:
             field_name = field_name.replace(" ", r"\ ")
             field_name = r"$\rm{" + field_name + r"}$"
         if fractional:
-            label = field_name + r"$\rm{\ Probability\ Density}$"
+            return field_name + r"$\rm{\ Probability\ Density}$"
         elif field_unit is None or field_unit == "":
-            label = field_name
+            return field_name
         else:
-            label = field_name + r"$\ \ (" + field_unit + r")$"
-        return label
+            return field_name + r"$\ \ (" + field_unit + r")$"
 
     def _get_field_title(self, field_y, profile):
         field_x = profile.x_field
@@ -1023,12 +1022,11 @@ class PhasePlot(ImagePlotContainer):
             field_name = field_name.replace(" ", r"\ ")
             field_name = r"$\rm{" + field_name + r"}$"
         if fractional:
-            label = field_name + r"$\rm{\ Probability\ Density}$"
+            return field_name + r"$\rm{\ Probability\ Density}$"
         elif field_unit is None or field_unit == "":
-            label = field_name
+            return field_name
         else:
-            label = field_name + r"$\ \ (" + field_unit + r")$"
-        return label
+            return field_name + r"$\ \ (" + field_unit + r")$"
 
     def _get_field_log(self, field_z, profile):
         zfi = profile.field_info[field_z]

--- a/yt/visualization/tests/test_geo_projections.py
+++ b/yt/visualization/tests/test_geo_projections.py
@@ -25,8 +25,7 @@ def compare(
             sl._setup_plots()
             sl.annotate_mesh_lines()
         sl.set_log("all", False)
-        image_file = sl.save(filename_prefix)
-        return image_file
+        return sl.save(filename_prefix)
 
     slice_image.__name__ = f"slice_{test_prefix}"
     test = GenericImageTest(ds, slice_image, decimals)

--- a/yt/visualization/tests/test_mesh_slices.py
+++ b/yt/visualization/tests/test_mesh_slices.py
@@ -27,8 +27,7 @@ def compare(ds, field, idir, test_prefix, test_name, decimals=12, annotate=False
         if annotate:
             sl.annotate_mesh_lines()
         sl.set_log("all", False)
-        image_file = sl.save(filename_prefix)
-        return image_file
+        return sl.save(filename_prefix)
 
     slice_image.__name__ = f"slice_{test_prefix}"
     test = GenericImageTest(ds, slice_image, decimals)

--- a/yt/visualization/tests/test_particle_plot.py
+++ b/yt/visualization/tests/test_particle_plot.py
@@ -133,8 +133,7 @@ def test_particle_projection_filter():
     """
 
     def formed_star(pfilter, data):
-        filter = data["all", "creation_time"] > 0
-        return filter
+        return data["all", "creation_time"] > 0
 
     add_particle_filter(
         "formed_star",

--- a/yt/visualization/tests/test_raw_field_slices.py
+++ b/yt/visualization/tests/test_raw_field_slices.py
@@ -17,8 +17,7 @@ def compare(ds, field, test_prefix, decimals=12):
     def slice_image(filename_prefix):
         sl = yt.SlicePlot(ds, "z", field)
         sl.set_log("all", False)
-        image_file = sl.save(filename_prefix)
-        return image_file
+        return sl.save(filename_prefix)
 
     slice_image.__name__ = f"slice_{test_prefix}"
     test = GenericImageTest(ds, slice_image, decimals)

--- a/yt/visualization/volume_rendering/lens.py
+++ b/yt/visualization/volume_rendering/lens.py
@@ -94,7 +94,7 @@ class PlaneParallelLens(Lens):
             ]
         )
 
-        sampler_params = dict(
+        return dict(
             vp_pos=vp_pos,
             vp_dir=self.box_vectors[2],  # All the same
             center=self.back_center,
@@ -110,7 +110,6 @@ class PlaneParallelLens(Lens):
             image=image,
             lens_type="plane-parallel",
         )
-        return sampler_params
 
     def set_viewpoint(self, camera):
         """Set the viewpoint based on the camera"""
@@ -138,10 +137,9 @@ class PlaneParallelLens(Lens):
         return px, py, dz
 
     def __repr__(self):
-        disp = "<Lens Object>:\n\tlens_type:plane-parallel\n\tviewpoint:%s" % (
+        return "<Lens Object>:\n\tlens_type:plane-parallel\n\tviewpoint:%s" % (
             self.viewpoint
         )
-        return disp
 
 
 class PerspectiveLens(Lens):
@@ -221,7 +219,10 @@ class PerspectiveLens(Lens):
 
         image = self.new_image(camera)
 
-        sampler_params = dict(
+        mylog.debug(positions)
+        mylog.debug(vectors)
+
+        return dict(
             vp_pos=positions,
             vp_dir=vectors,
             center=self.back_center,
@@ -232,11 +233,6 @@ class PerspectiveLens(Lens):
             image=image,
             lens_type="perspective",
         )
-
-        mylog.debug(positions)
-        mylog.debug(vectors)
-
-        return sampler_params
 
     def set_viewpoint(self, camera):
         """
@@ -293,8 +289,7 @@ class PerspectiveLens(Lens):
         return px, py, dz
 
     def __repr__(self):
-        disp = f"<Lens Object>:\n\tlens_type:perspective\n\tviewpoint:{self.viewpoint}"
-        return disp
+        return f"<Lens Object>:\n\tlens_type:perspective\n\tviewpoint:{self.viewpoint}"
 
 
 class StereoPerspectiveLens(Lens):
@@ -354,7 +349,7 @@ class StereoPerspectiveLens(Lens):
         vectors_comb.shape = (camera.resolution[0], camera.resolution[1], 3)
         positions_comb.shape = (camera.resolution[0], camera.resolution[1], 3)
 
-        sampler_params = dict(
+        return dict(
             vp_pos=positions_comb,
             vp_dir=vectors_comb,
             center=self.back_center,
@@ -365,8 +360,6 @@ class StereoPerspectiveLens(Lens):
             image=image,
             lens_type="stereo-perspective",
         )
-
-        return sampler_params
 
     def _get_positions_vectors(self, camera, disparity):
 
@@ -518,8 +511,7 @@ class StereoPerspectiveLens(Lens):
         self.viewpoint = self.front_center
 
     def __repr__(self):
-        disp = f"<Lens Object>:\n\tlens_type:perspective\n\tviewpoint:{self.viewpoint}"
-        return disp
+        return f"<Lens Object>:\n\tlens_type:perspective\n\tviewpoint:{self.viewpoint}"
 
 
 class FisheyeLens(Lens):
@@ -574,7 +566,7 @@ class FisheyeLens(Lens):
         else:
             image = self.new_image(camera)
 
-        sampler_params = dict(
+        return dict(
             vp_pos=positions,
             vp_dir=vp,
             center=self.center,
@@ -586,18 +578,15 @@ class FisheyeLens(Lens):
             lens_type="fisheye",
         )
 
-        return sampler_params
-
     def set_viewpoint(self, camera):
         """For a FisheyeLens, the viewpoint is the camera's position"""
         self.viewpoint = camera.position
 
     def __repr__(self):
-        disp = (
+        return (
             "<Lens Object>:\n\tlens_type:fisheye\n\tviewpoint:%s"
             "\nt\tfov:%s\n\tradius:%s" % (self.viewpoint, self.fov, self.radius)
         )
-        return disp
 
     def project_to_plane(self, camera, pos, res=None):
         if res is None:
@@ -698,7 +687,7 @@ class SphericalLens(Lens):
         vectors.shape = (camera.resolution[0], camera.resolution[1], 3)
         positions.shape = (camera.resolution[0], camera.resolution[1], 3)
 
-        sampler_params = dict(
+        return dict(
             vp_pos=positions,
             vp_dir=vectors,
             center=self.back_center,
@@ -709,7 +698,6 @@ class SphericalLens(Lens):
             image=image,
             lens_type="spherical",
         )
-        return sampler_params
 
     def set_viewpoint(self, camera):
         """For a SphericalLens, the viewpoint is the camera's position"""
@@ -835,7 +823,7 @@ class StereoSphericalLens(Lens):
         vectors_comb.shape = (camera.resolution[0], camera.resolution[1], 3)
         positions_comb.shape = (camera.resolution[0], camera.resolution[1], 3)
 
-        sampler_params = dict(
+        return dict(
             vp_pos=positions_comb,
             vp_dir=vectors_comb,
             center=self.back_center,
@@ -846,7 +834,6 @@ class StereoSphericalLens(Lens):
             image=image,
             lens_type="stereo-spherical",
         )
-        return sampler_params
 
     def set_viewpoint(self, camera):
         """

--- a/yt/visualization/volume_rendering/old_camera.py
+++ b/yt/visualization/volume_rendering/old_camera.py
@@ -642,10 +642,9 @@ class Camera(ParallelAnalysisInterface):
         self._setup_box_properties(width, self.center, self.orienter.unit_vectors)
 
     def new_image(self):
-        image = np.zeros(
+        return np.zeros(
             (self.resolution[0], self.resolution[1], 4), dtype="float64", order="C"
         )
-        return image
 
     def get_sampler_args(self, image):
         rotp = np.concatenate(
@@ -686,12 +685,11 @@ class Camera(ParallelAnalysisInterface):
             )
             if self.light_rgba is None:
                 self.set_default_light_rgba()
-            sampler = LightSourceRenderSampler(
+            return LightSourceRenderSampler(
                 *args, light_dir=temp_dir, light_rgba=self.light_rgba, **kwargs
             )
-        else:
-            sampler = self._sampler_object(*args, **kwargs)
-        return sampler
+
+        return self._sampler_object(*args, **kwargs)
 
     def finalize_image(self, image):
         view_pos = (
@@ -722,8 +720,7 @@ class Camera(ParallelAnalysisInterface):
 
         pbar.finish()
         image = sampler.aimage
-        image = self.finalize_image(image)
-        return image
+        return self.finalize_image(image)
 
     @cached_property
     def _pyplot(self):
@@ -764,8 +761,7 @@ class Camera(ParallelAnalysisInterface):
             del nz
         else:
             nim = im
-        ax = self._pyplot.imshow(nim[:, :, :3] / nim[:, :, :3].max(), origin="upper")
-        return ax
+        return self._pyplot.imshow(nim[:, :, :3] / nim[:, :, :3].max(), origin="upper")
 
     def draw(self):
         self._pyplot.draw()
@@ -817,7 +813,7 @@ class Camera(ParallelAnalysisInterface):
         )
 
     def get_information(self):
-        info_dict = {
+        return {
             "fields": self.fields,
             "type": self.__class__.__name__,
             "east_vector": self.orienter.unit_vectors[0],
@@ -826,7 +822,6 @@ class Camera(ParallelAnalysisInterface):
             "width": self.width,
             "dataset": self.ds.fullpath,
         }
-        return info_dict
 
     def snapshot(
         self,
@@ -1381,8 +1376,7 @@ class PerspectiveCamera(Camera):
             pbar.update(total_cells)
 
         pbar.finish()
-        image = self.finalize_image(sampler.aimage)
-        return image
+        return self.finalize_image(sampler.aimage)
 
     def finalize_image(self, image):
         view_pos = self.front_center
@@ -1502,8 +1496,7 @@ class HEALpixCamera(Camera):
         raise NotImplementedError
 
     def new_image(self):
-        image = np.zeros((12 * self.nside ** 2, 1, 4), dtype="float64", order="C")
-        return image
+        return np.zeros((12 * self.nside ** 2, 1, 4), dtype="float64", order="C")
 
     def get_sampler_args(self, image):
         nv = 12 * self.nside ** 2
@@ -1558,18 +1551,16 @@ class HEALpixCamera(Camera):
 
     def finalize_image(self, image):
         view_pos = self.center
-        image = self.volume.reduce_tree_images(image, view_pos)
-        return image
+        return self.volume.reduce_tree_images(image, view_pos)
 
     def get_information(self):
-        info_dict = {
+        return {
             "fields": self.fields,
             "type": self.__class__.__name__,
             "center": self.center,
             "radius": self.radius,
             "dataset": self.ds.fullpath,
         }
-        return info_dict
 
     def snapshot(
         self,
@@ -1723,8 +1714,7 @@ class FisheyeCamera(Camera):
         return {}
 
     def new_image(self):
-        image = np.zeros((self.resolution ** 2, 1, 4), dtype="float64", order="C")
-        return image
+        return np.zeros((self.resolution ** 2, 1, 4), dtype="float64", order="C")
 
     def get_sampler_args(self, image):
         vp = arr_fisheye_vectors(self.resolution, self.fov)
@@ -1888,10 +1878,9 @@ class MosaicCamera(Camera):
         return volume
 
     def new_image(self):
-        image = np.zeros(
+        return np.zeros(
             (self.resolution[0], self.resolution[1], 4), dtype="float64", order="C"
         )
-        return image
 
     def _setup_box_properties(self, width, center, unit_vectors):
         owidth = deepcopy(width)
@@ -2113,10 +2102,8 @@ class ProjectionCamera(Camera):
 
     def get_sampler(self, args, kwargs):
         if self.interpolated:
-            sampler = InterpolatedProjectionSampler(*args, **kwargs)
-        else:
-            sampler = ProjectionSampler(*args, **kwargs)
-        return sampler
+            return InterpolatedProjectionSampler(*args, **kwargs)
+        return ProjectionSampler(*args, **kwargs)
 
     def initialize_source(self):
         if self.interpolated:
@@ -2203,8 +2190,7 @@ class ProjectionCamera(Camera):
             grid.clear_data()
             sampler(pg, num_threads=num_threads)
 
-        image = self.finalize_image(sampler.aimage)
-        return image
+        return self.finalize_image(sampler.aimage)
 
     def save_image(self, image, fn=None, clip_ratio=None):
         dd = self.ds.all_data()
@@ -2312,8 +2298,7 @@ class SphericalCamera(Camera):
             pbar.update(total_cells)
 
         pbar.finish()
-        image = self.finalize_image(sampler.aimage)
-        return image
+        return self.finalize_image(sampler.aimage)
 
     def finalize_image(self, image):
         view_pos = self.front_center
@@ -2321,8 +2306,7 @@ class SphericalCamera(Camera):
         image = self.volume.reduce_tree_images(image, view_pos)
         if not self.transfer_function.grey_opacity:
             image[:, :, 3] = 1.0
-        image = image[1:-1, 1:-1, :]
-        return image
+        return image[1:-1, 1:-1, :]
 
 
 data_object_registry["spherical_camera"] = SphericalCamera
@@ -2446,8 +2430,7 @@ class StereoSphericalCamera(Camera):
         image.shape = self.resolution[0], self.resolution[1], 4
         if not self.transfer_function.grey_opacity:
             image[:, :, 3] = 1.0
-        image = image[1:-1, 1:-1, :]
-        return image
+        return image[1:-1, 1:-1, :]
 
 
 data_object_registry["stereospherical_camera"] = StereoSphericalCamera

--- a/yt/visualization/volume_rendering/render_source.py
+++ b/yt/visualization/volume_rendering/render_source.py
@@ -60,7 +60,7 @@ def invalidate_volume(f):
             obj._use_ghost_zones = False
         del obj.volume
         obj._volume_valid = False
-        return ret
+        return ret  # noqa R504
 
     return wrapper
 
@@ -935,8 +935,7 @@ class MeshSource(OpaqueSource):
         return image
 
     def __repr__(self):
-        disp = f"<Mesh Source>:{str(self.data_source)} "
-        return disp
+        return f"<Mesh Source>:{str(self.data_source)} "
 
 
 class PointSource(OpaqueSource):
@@ -1049,8 +1048,7 @@ class PointSource(OpaqueSource):
         return zbuffer
 
     def __repr__(self):
-        disp = "<Point Source>"
-        return disp
+        return "<Point Source>"
 
 
 class LineSource(OpaqueSource):
@@ -1197,8 +1195,7 @@ class LineSource(OpaqueSource):
         return zbuffer
 
     def __repr__(self):
-        disp = "<Line Source>"
-        return disp
+        return "<Line Source>"
 
 
 class BoxSource(LineSource):
@@ -1513,5 +1510,4 @@ class CoordinateVectorSource(OpaqueSource):
         return zbuffer
 
     def __repr__(self):
-        disp = "<Coordinates Source>"
-        return disp
+        return "<Coordinates Source>"

--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -221,9 +221,8 @@ class Scene:
             camera = self.camera
         assert camera is not None
         self._validate()
-        bmp = self.composite(camera=camera)
-        self._last_render = bmp
-        return bmp
+        self._last_render = self.composite(camera=camera)
+        return self._last_render
 
     def _render_on_demand(self, render):
         # checks for existing render before rendering, in most cases we want to
@@ -478,9 +477,7 @@ class Scene:
             del nz
         else:
             nim = im
-        axim = ax.imshow(nim[:, :, :3] / nim[:, :, :3].max(), interpolation="bilinear")
-
-        return axim
+        return ax.imshow(nim[:, :, :3] / nim[:, :, :3].max(), interpolation="bilinear")
 
     def _annotate(self, ax, tf, source, label="", label_fmt=None):
         ax.get_xaxis().set_visible(False)
@@ -943,7 +940,7 @@ class Scene:
             filename=None, sigma_clip=self._sigma_clip, background="black"
         )
         self._sigma_clip = None
-        return png
+        return png  # noqa 504
 
     def __repr__(self):
         disp = "<Scene Object>:"

--- a/yt/visualization/volume_rendering/tests/test_vr_cameras.py
+++ b/yt/visualization/volume_rendering/tests/test_vr_cameras.py
@@ -60,8 +60,7 @@ class CameraTest(TestCase):
             return tf
         elif camera_type in ["healpix"]:
             return ProjectionTransferFunction()
-        else:
-            pass
+        raise ValueError(f"Unknown `camera_type` value received '{camera_type}'.")
 
     def test_camera(self):
         tf = self.setup_transfer_function("camera")

--- a/yt/visualization/volume_rendering/transfer_function_helper.py
+++ b/yt/visualization/volume_rendering/transfer_function_helper.py
@@ -207,13 +207,13 @@ class TransferFunctionHelper:
         if fn is None:
             from IPython.core.display import Image
 
-            f = BytesIO()
-            canvas.print_figure(f)
-            f.seek(0)
-            img = f.read()
-            return Image(img)
-        else:
-            fig.savefig(fn)
+            with BytesIO() as f:
+                canvas.print_figure(f)
+                f.seek(0)
+                return Image(f.read())
+
+        fig.savefig(fn)
+        return None
 
     def setup_profile(self, profile_field=None, profile_weight=None):
         if profile_field is None:

--- a/yt/visualization/volume_rendering/transfer_functions.py
+++ b/yt/visualization/volume_rendering/transfer_functions.py
@@ -237,12 +237,11 @@ class TransferFunction:
         self.features = []
 
     def __repr__(self):
-        disp = (
+        return (
             "<Transfer Function Object>: "
             "x_bounds:(%3.2g, %3.2g) nbins:%3.2g features:%s"
             % (self.x_bounds[0], self.x_bounds[1], self.nbins, self.features)
         )
-        return disp
 
 
 class MultiVariateTransferFunction:
@@ -598,8 +597,7 @@ class ColorTransferFunction(MultiVariateTransferFunction):
         ax.yaxis.set_ticks(yticks)
 
         def y_format(y, pos):
-            s = f"{y:0.2f}"
-            return s
+            return f"{y:0.2f}"
 
         ax.yaxis.set_major_formatter(FuncFormatter(y_format))
         ax.set_ylabel("Opacity")
@@ -680,8 +678,7 @@ class ColorTransferFunction(MultiVariateTransferFunction):
         ax.xaxis.set_ticks(yticks)
 
         def y_format(y, pos):
-            s = f"{y:0.2f}"
-            return s
+            return f"{y:0.2f}"
 
         ax.xaxis.set_major_formatter(FuncFormatter(y_format))
         ax.set_xlim(0.0, max_alpha)
@@ -888,8 +885,7 @@ class ColorTransferFunction(MultiVariateTransferFunction):
         for i, f in enumerate(self.funcs[:3]):
             vals = np.interp(hvals, f.x, f.y)
             image[:, :, i] = (vals[:, None] * 255).astype("uint8")
-        image = image[::-1, :, :]
-        return image
+        return image[::-1, :, :]
 
     def clear(self):
         for f in self.funcs:

--- a/yt/visualization/volume_rendering/utils.py
+++ b/yt/visualization/volume_rendering/utils.py
@@ -46,10 +46,10 @@ def new_mesh_sampler(camera, render_source, engine):
     )
     kwargs = {"lens_type": params["lens_type"]}
     if engine == "embree":
-        sampler = mesh_traversal.EmbreeMeshSampler(*args, **kwargs)
+        return mesh_traversal.EmbreeMeshSampler(*args, **kwargs)
     elif engine == "yt":
-        sampler = bounding_volume_hierarchy.BVHMeshSampler(*args, **kwargs)
-    return sampler
+        return bounding_volume_hierarchy.BVHMeshSampler(*args, **kwargs)
+    raise ValueError(f"Unknown value passed for `engine` ({engine}).")
 
 
 def new_volume_render_sampler(camera, render_source):
@@ -83,8 +83,7 @@ def new_volume_render_sampler(camera, render_source):
         )
     else:
         kwargs["zbuffer"] = np.ones(params["image"].shape[:2], "float64")
-    sampler = VolumeRenderSampler(*args, **kwargs)
-    return sampler
+    return VolumeRenderSampler(*args, **kwargs)
 
 
 def new_interpolated_projection_sampler(camera, render_source):
@@ -108,8 +107,7 @@ def new_interpolated_projection_sampler(camera, render_source):
         kwargs["zbuffer"] = render_source.zbuffer.z
     else:
         kwargs["zbuffer"] = np.ones(params["image"].shape[:2], "float64")
-    sampler = InterpolatedProjectionSampler(*args, **kwargs)
-    return sampler
+    return InterpolatedProjectionSampler(*args, **kwargs)
 
 
 def new_projection_sampler(camera, render_source):
@@ -135,8 +133,7 @@ def new_projection_sampler(camera, render_source):
         kwargs["zbuffer"] = render_source.zbuffer.z
     else:
         kwargs["zbuffer"] = np.ones(params["image"].shape[:2], "float64")
-    sampler = ProjectionSampler(*args, **kwargs)
-    return sampler
+    return ProjectionSampler(*args, **kwargs)
 
 
 def get_corners(le, re):


### PR DESCRIPTION
## PR Summary

Our style guide contains the following rule

> Only declare local variables if they will be used later. If you do not use the		
   return value of a function, do not store it in a variable.

Unfortunately this rule is not automatically enforced _yet_, and the code base currently contains 363 violations of it.
The good news is that [flake8-return](https://github.com/afonasev/flake8-return) defines this as rule `R504`. This plugin also defines a couple of other rules for which we have a cumulated number of violations of 55.

Here I fix all of those, and I add a handful of noqas specifically in cases that can't really be refactored straightforwardly.
(mostly places where `tmpdir` is used without context managers, I might fix those later)
 
Happy side effects:
- in most cases, fixing these errors produces more concise and clearer code
- R503 helps discovering branches of code where errors should be raised
- coincidently, fixing R502 and R503 violations will be helpful later to add type hints to the code base (#2864)

## todo

- [x] New features are documented, with docstrings and narrative docs
- [x] finish up cleaning existing errors
- [x] review myself (in particular see the resulting consistency of _is_valid methods)
- [x] check that nothing breaks
- [x] rebase and squash commits