### PR TITLE
Cleanup flake8 conf

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,14 +27,10 @@ exclude = doc,
           yt/visualization/_colormap_data.py,
 
 ignore = E203, # Whitespace before ':' (black compatibility)
-         E231, # Missing whitespace after ',', ';', or ':'
          E266, # Too many leading '#' for block comment
          E302, # Expected 2 blank lines, found 0
-         E306, # Expected 1 blank line before a nested definition
          E501, # Line too long (let Black deal with line-lenght)
          E741, # Do not use variables named 'I', 'O', or 'l'
          W503, # Line break occurred before a binary operator (black compatibility)
-         W605, # Invalid escape sequence 'x'
-         B302, # this is a python 3 compatibility warning, not relevant since don't support python 2 anymore
 
 jobs=8

--- a/yt/frontends/athena/fields.py
+++ b/yt/frontends/athena/fields.py
@@ -60,6 +60,7 @@ class AthenaFieldInfo(FieldInfoContainer):
                     function=velocity_field(comp),
                     units=unit_system["velocity"],
                 )
+
         # Add pressure, energy, and temperature fields
         def eint_from_etot(data):
             eint = data["athena", "total_energy"].copy()
@@ -133,6 +134,7 @@ class AthenaFieldInfo(FieldInfoContainer):
                 function=_total_energy,
                 units=unit_system["specific_energy"],
             )
+
         # Add temperature field
         def _temperature(field, data):
             return (

--- a/yt/frontends/athena_pp/fields.py
+++ b/yt/frontends/athena_pp/fields.py
@@ -94,6 +94,7 @@ class AthenaPPFieldInfo(FieldInfoContainer):
                 function=_thermal_energy,
                 units=unit_system["specific_energy"],
             )
+
         # Add temperature field
         def _temperature(field, data):
             return (

--- a/yt/frontends/enzo/fields.py
+++ b/yt/frontends/enzo/fields.py
@@ -250,6 +250,7 @@ class EnzoFieldInfo(FieldInfoContainer):
             self.add_output_field(
                 ("enzo", te_name), sampling_type="cell", units="code_velocity**2"
             )
+
             # Subtract off B-field energy
             def _sub_b(field, data):
                 ret = data[te_name] - 0.5 * data["velocity_x"] ** 2.0

--- a/yt/frontends/flash/fields.py
+++ b/yt/frontends/flash/fields.py
@@ -95,6 +95,7 @@ class FLASHFieldInfo(FieldInfoContainer):
                 units="",
                 display_name=f"Energy Group {i}",
             )
+
         # Add energy fields
         def ekin(data):
             ek = data["flash", "velx"] ** 2

--- a/yt/utilities/answer_testing/utils.py
+++ b/yt/utilities/answer_testing/utils.py
@@ -222,6 +222,7 @@ def _compare_result(data, outputFile):
     # Load the saved data
     with open(outputFile) as f:
         savedData = yaml.safe_load(f)
+
     # Define the comparison function
     def _check_vals(newVals, oldVals):
         for key, value in newVals.items():

--- a/yt/visualization/eps_writer.py
+++ b/yt/visualization/eps_writer.py
@@ -436,10 +436,10 @@ class DualEPS:
                 YTQuantity(xlimits[0], "m"),
                 YTQuantity(xlimits[1], "m"),
             )  # unit hardcoded but afaik it is not used anywhere so it doesn't matter
-            if list(plot.axes.ylim.viewvalues())[0][0] is None:
+            if list(plot.axes.ylim.values())[0][0] is None:
                 ylimits = subplot.get_ylim()
             else:
-                ylimits = list(plot.axes.ylim.viewvalues())[0]
+                ylimits = list(plot.axes.ylim.values())[0]
             _yrange = (
                 YTQuantity(ylimits[0], "m"),
                 YTQuantity(ylimits[1], "m"),


### PR DESCRIPTION
## PR Summary

With the recent adoption of pyupgrade, some flake8 rules can stopped being ignored because they are de-facto enforced already (E231 and W605)
Additionally, I manually fix E306 and B302 because there were only a couple of surviving errors.
