### PR TITLE
TYP: add a yt._typing module and start annotating yt.loaders

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,7 @@ repos:
         flake8-bugbear>=20.3.2, # GH PR 2851
         flake8-logging-format,
         flake8-2020==1.6.0,
+        flake8-typing-imports==1.10.1,
       ]
 -   repo: https://github.com/asottile/blacken-docs
     rev: v1.11.0

--- a/yt/_typing.py
+++ b/yt/_typing.py
@@ -1,4 +1,42 @@
 import os
-from typing import Union
+from typing import Tuple, TypeVar, Union
 
-PathType = Union[str, bytes, "os.PathLike[str]", int]
+from matplotlib.colors import ListedColormap
+from unyt.unit_object import Unit
+
+# this defines a useful generic type to maintain type information
+# across generic functions and parametrization
+# It is close to the concept of templates in C++
+# see https://docs.python.org/3/library/typing.html#generics
+T = TypeVar("T")
+
+FileLike = Union[str, bytes, "os.PathLike[str]", int]
+
+# Note that Tuple is currently the only Sequence-like type
+# that support specifying the size
+# In most places where a field-like input is expected,
+# List[str] should be acceptable as long as the size is exactly 2.
+#
+# here's a proto adapter function in python>=3.10
+# def unpack_field(field:FieldLike) -> Tuple[str, str]:
+#     match field:
+#         case ftype, fname:
+#             pass
+#         case str():
+#             ftype = "auto"
+#             fname = field
+#         case _:
+#             raise TypeError
+#     return ftype, fname
+
+# and in python>=3.6 (only type hints are incompatible with earlier versions of Python 3)
+# def unpack_field(field:FieldLike) -> Tuple[str, str]:
+#     from yt.funcs import is_sequence
+#     if is_sequence(field) and len(field) == 2:
+#         return field
+#     elif isinstance(field, str):
+#         return "auto", field
+#     raise TypeError
+FieldLike = Union[Tuple[str, str], str]
+UnitLike = Union[Unit, str]
+CmapLike = Union[ListedColormap, str]

--- a/yt/_typing.py
+++ b/yt/_typing.py
@@ -1,0 +1,4 @@
+import os
+from typing import Union
+
+PathType = Union[str, bytes, "os.PathLike[str]", int]

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -6,13 +6,17 @@ import os
 import sys
 import tarfile
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 from urllib.parse import urlsplit
 
 import numpy as np
 from more_itertools import always_iterable
 
 from yt._maintenance.deprecation import issue_deprecation_warning
+from yt._typing import FileLike
+from yt.config import ytcfg
+from yt.data_objects.static_output import Dataset
+from yt.data_objects.time_series import DatasetSeries
 from yt.funcs import levenshtein_distance
 from yt.sample_data.api import lookup_on_disk_data
 from yt.utilities.decompose import decompose_array, get_psize
@@ -34,7 +38,7 @@ from yt.utilities.on_demand_imports import _pooch as pooch
 # --- Loaders for known data formats ---
 
 
-def load(fn, *args, **kwargs):
+def load(fn: FileLike, *args, **kwargs) -> Union[DatasetSeries, Dataset]:
     """
     Load a Dataset or DatasetSeries object.
     The data format is automatically discovered, and the exact return type is the
@@ -72,8 +76,6 @@ def load(fn, *args, **kwargs):
     fn = os.path.expanduser(fn)
 
     if any(wildcard in fn for wildcard in "[]?!*"):
-        from yt.data_objects.time_series import DatasetSeries
-
         return DatasetSeries(fn, *args, **kwargs)
 
     # This will raise FileNotFoundError if the path isn't matched
@@ -98,7 +100,9 @@ def load(fn, *args, **kwargs):
     raise YTUnidentifiedDataType(fn, *args, **kwargs)
 
 
-def load_simulation(fn, simulation_type, find_outputs=False):
+def load_simulation(
+    fn: FileLike, simulation_type: str, find_outputs: bool = False
+) -> DatasetSeries:
     """
     Load a simulation time series object of the specified simulation type.
 


### PR DESCRIPTION
## PR Summary

This is small step in the direction of #2864
- add a yt._typing module (a place to define custom/complex type definitions (imitating pandas)
- start annotating fonctions in yt.loaders (experimental, it's dauntingly simple to create circular imports by accident here)

also add a flake8 plugin (flake8-typing-imports) to enforce safe guarding of typing imports from day one.