### PR TITLE
make Scene.save less verbose

### DIFF
--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -1,6 +1,7 @@
 import builtins
 import functools
 from collections import OrderedDict
+from typing import Optional
 
 import numpy as np
 
@@ -274,7 +275,12 @@ class Scene:
         mylog.info("Saving rendered image to %s", fname)
         return fname
 
-    def save(self, fname=None, sigma_clip=None, render=True):
+    def save(
+        self,
+        fname: Optional[str] = None,
+        sigma_clip: Optional[float] = None,
+        render: bool = True,
+    ):
         r"""Saves a rendered image of the Scene to disk.
 
         Once you have created a scene, this saves an image array to disk with
@@ -358,12 +364,12 @@ class Scene:
 
     def save_annotated(
         self,
-        fname=None,
-        label_fmt=None,
-        text_annotate=None,
-        dpi=100,
-        sigma_clip=None,
-        render=True,
+        fname: Optional[str] = None,
+        label_fmt: Optional[str] = None,
+        text_annotate: Optional[str] = None,
+        dpi: int = 100,
+        sigma_clip: Optional[float] = None,
+        render: bool = True,
     ):
         r"""Saves the most recently rendered image of the Scene to disk,
         including an image of the transfer function and and user-defined

--- a/yt/visualization/volume_rendering/tests/test_scene.py
+++ b/yt/visualization/volume_rendering/tests/test_scene.py
@@ -75,7 +75,8 @@ class RotationTest(TestCase):
 
         fname = "test_rot.png"
         sc.camera.pitch(np.pi)
-        sc.save(fname, sigma_clip=6.0)
+        sc.render()
+        sc.save(fname, sigma_clip=6.0, render=False)
         assert_fname(fname)
 
 
@@ -97,7 +98,8 @@ def test_annotations():
         assert np.where((im == c).all(axis=-1))[0].shape[0] > 0
     sc[0].tfh.tf.add_layers(10, colormap="cubehelix")
     sc.save_annotated(
-        "test_scene_annotated.png", text_annotate=[[(0.1, 1.05), "test_string"]]
+        "test_scene_annotated.png",
+        text_annotate=[[(0.1, 1.05), "test_string"]],
     )
     image = imread("test_scene_annotated.png")
     assert image.shape == sc.camera.resolution + (4,)


### PR DESCRIPTION
## PR Summary
Currently the answer test build's log is polluted with these warnings:
```
VRImageComparison_UniformGridData_vr_yaw_plane-parallel_0001 ... WARNING:yt:Previously rendered image exists, but rendering anyway. Supply 'render=False' to save previously rendered image directly.
INFO:yt:Rendering scene (Can take a while).
INFO:yt:Saving rendered image to /tmp/tmp7ivhf93i.png
ok
VRImageComparison_UniformGridData_vr_pitch_plane-parallel_0002 ... WARNING:yt:Previously rendered image exists, but rendering anyway. Supply 'render=False' to save previously rendered image directly.
INFO:yt:Rendering scene (Can take a while).
INFO:yt:Saving rendered image to /tmp/tmp4tvkj13k.png
ok
VRImageComparison_UniformGridData_vr_roll_plane-parallel_0003 ... WARNING:yt:Previously rendered image exists, but rendering anyway. Supply 'render=False' to save previously rendered image directly.
INFO:yt:Rendering scene (Can take a while).
INFO:yt:Saving rendered image to /tmp/tmpyd_sw8nh.png
ok
VRImageComparison_UniformGridData_vr_perspective_0000 ... WARNING:yt:Previously rendered image exists, but rendering anyway. Supply 'render=False' to save previously rendered image directly.
```
This aims to solve this by properly controlling the `render` flag in `Scene.save...` calls
