### PR TITLE
ci: deactivate a randomly failing answer test

### DIFF
--- a/yt/visualization/volume_rendering/tests/test_vr_orientation.py
+++ b/yt/visualization/volume_rendering/tests/test_vr_orientation.py
@@ -37,7 +37,12 @@ def test_orientation():
     decimals = 12
     test_name = "vr_orientation"
 
-    for lens_type in ["plane-parallel", "perspective"]:
+    for lens_type in [
+        "perspective",
+        # final name VRImageComparison_UniformGridData_vr_pitch_plane-parallel_0002
+        # deactivated because of a random failure since numpy 0.20.0 and 0.20.1
+        # "plane-parallel"
+    ]:
         frame = 0
 
         cam = sc.add_camera(ds, lens_type=lens_type)


### PR DESCRIPTION
## PR Summary

This one answer test has been randomly failing in all PRs since the release of numpy 0.20.0 a week ago.
I suggest to deactivate it at least temporarily (I added a comment to explain the situation).