### PR TITLE
[BUGFIX] Support old gcc versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ import pkg_resources
 from setuptools import Distribution, find_packages, setup
 
 from setupext import (
+    check_CPP14_flags,
     check_for_openmp,
     check_for_pyembree,
     create_build_ext,
@@ -38,11 +39,10 @@ with open("README.md") as file:
     long_description = file.read()
 
 CPP14_CONFIG = defaultdict(
-    lambda: ["-std=c++14"], {"unix": ["-std=c++14"], "msvc": ["/std:c++14"]}
+    lambda: check_CPP14_flags(["-std=c++14", "-std=c++1y"]),
+    {"msvc": ["/std:c++14"]},
 )
-CPP03_CONFIG = defaultdict(
-    lambda: ["-std=c++03"], {"unix": ["-std=c++03"], "msvc": ["/std:c++03"]}
-)
+CPP03_CONFIG = defaultdict(lambda: ["-std=c++03"], {"msvc": ["/std:c++03"]})
 
 _COMPILER = get_default_compiler()
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ with open("README.md") as file:
     long_description = file.read()
 
 CPP14_CONFIG = defaultdict(
-    lambda: check_CPP14_flags(["-std=c++14", "-std=c++1y"]),
+    lambda: check_CPP14_flags(["-std=c++14", "-std=c++1y", "-std=gnu++0x"]),
     {"msvc": ["/std:c++14"]},
 )
 CPP03_CONFIG = defaultdict(lambda: ["-std=c++03"], {"msvc": ["/std:c++03"]})

--- a/setupext.py
+++ b/setupext.py
@@ -30,6 +30,9 @@ int main() {
 }
 """
 
+# Note: This code requires C++14 functionalities (also required to compile yt)
+# It compiles on gcc 4.7.4 (together with the entirety of yt) with the flag "-std=gnu++0x".
+# It does not compile on gcc 4.6.4 (neither does yt).
 CPPCODE = """
 #include <vector>
 

--- a/setupext.py
+++ b/setupext.py
@@ -31,8 +31,15 @@ int main() {
 """
 
 CPPCODE = """
+#include <vector>
+
+struct node {
+    std::vector<int> vic;
+    bool visited = false;
+};
+
 int main() {
-    auto lambda = [](auto x, auto y) {return x + y;};
+    return 0;
 }
 """
 
@@ -164,7 +171,7 @@ def check_CPP14_flag(compile_flags):
         os.chdir(tmp_dir)
 
         with open("test_cpp14.cpp", "w") as f:
-            f.write("")
+            f.write(CPPCODE)
 
         os.mkdir("objects")
 

--- a/setupext.py
+++ b/setupext.py
@@ -169,9 +169,8 @@ def check_CPP14_flag(compile_flags):
     tmp_dir = tempfile.mkdtemp()
     start_dir = os.path.abspath(".")
 
-    ok = True
+    os.chdir(tmp_dir)
     try:
-        os.chdir(tmp_dir)
 
         with open("test_cpp14.cpp", "w") as f:
             f.write(CPPCODE)
@@ -183,11 +182,11 @@ def check_CPP14_flag(compile_flags):
             ccompiler.compile(
                 ["test_cpp14.cpp"], output_dir="objects", extra_postargs=compile_flags
             )
+           return True
     except CompileError:
-        ok = False
+        return False
     finally:
         os.chdir(start_dir)
-    return ok
 
 
 def check_CPP14_flags(possible_compile_flags):

--- a/setupext.py
+++ b/setupext.py
@@ -181,7 +181,7 @@ def check_CPP14_flag(compile_flags):
             ccompiler.compile(
                 ["test_cpp14.cpp"], output_dir="objects", extra_postargs=compile_flags
             )
-           return True
+        return True
     except CompileError:
         return False
     finally:

--- a/setupext.py
+++ b/setupext.py
@@ -197,7 +197,7 @@ def check_CPP14_flags(possible_compile_flags):
 
     log.warn(
         "Your compiler seems to be too old to support C++14. "
-        "yt may not be able to be compiled. Please use a newer version."
+        "yt may not be able to compile. Please use a newer version."
     )
     return []
 

--- a/setupext.py
+++ b/setupext.py
@@ -19,33 +19,6 @@ from pkg_resources import resource_filename
 from setuptools.command.build_ext import build_ext as _build_ext
 from setuptools.command.sdist import sdist as _sdist
 
-CCODE = """
-#include <omp.h>
-#include <stdio.h>
-int main() {
-  omp_set_num_threads(2);
-  #pragma omp parallel
-  printf("nthreads=%d\\n", omp_get_num_threads());
-  return 0;
-}
-"""
-
-# Note: This code requires C++14 functionalities (also required to compile yt)
-# It compiles on gcc 4.7.4 (together with the entirety of yt) with the flag "-std=gnu++0x".
-# It does not compile on gcc 4.6.4 (neither does yt).
-CPPCODE = """
-#include <vector>
-
-struct node {
-    std::vector<int> vic;
-    bool visited = false;
-};
-
-int main() {
-    return 0;
-}
-"""
-
 
 @contextlib.contextmanager
 def stdchannel_redirected(stdchannel, dest_filename):
@@ -88,6 +61,17 @@ def check_for_openmp():
 
     tmp_dir = tempfile.mkdtemp()
     start_dir = os.path.abspath(".")
+
+    CCODE = """
+    #include <omp.h>
+    #include <stdio.h>
+    int main() {
+        omp_set_num_threads(2);
+        #pragma omp parallel
+        printf("nthreads=%d\\n", omp_get_num_threads());
+        return 0;
+    }
+    """
 
     # TODO: test more known compilers:
     # MinGW, AppleClang with libomp, MSVC, ICC, XL, PGI, ...
@@ -169,9 +153,24 @@ def check_CPP14_flag(compile_flags):
     tmp_dir = tempfile.mkdtemp()
     start_dir = os.path.abspath(".")
 
+    # Note: This code requires C++14 functionalities (also required to compile yt)
+    # It compiles on gcc 4.7.4 (together with the entirety of yt) with the flag "-std=gnu++0x".
+    # It does not compile on gcc 4.6.4 (neither does yt).
+    CPPCODE = """
+    #include <vector>
+
+    struct node {
+        std::vector<int> vic;
+        bool visited = false;
+    };
+
+    int main() {
+        return 0;
+    }
+    """
+
     os.chdir(tmp_dir)
     try:
-
         with open("test_cpp14.cpp", "w") as f:
             f.write(CPPCODE)
 


### PR DESCRIPTION
Some files require some C++14 features which aren't supported on old versions of GCC. This PR tries to find the most suitable compiler flags to supports these features (though it does not capture all cases).

I tested this PR with GCC 4.7.4 (can now compile yt, could not before). With GCC 4.6.4 and older versions, the compilation fails as the support for C++14 is unsufficient to compile yt.

Fixes #3071.