### PR TITLE
Update install doc

### DIFF
--- a/doc/source/installing.rst
+++ b/doc/source/installing.rst
@@ -386,7 +386,7 @@ which can be installed with ``pip``:
 
 .. code-block:: bash
 
-  $ pip install numpy cython
+  $ pip install --upgrade numpy cython
 
 You may also want to install some of yt's optional dependencies, including
 ``jupyter``, ``h5py`` (which in turn depends on the HDF5 library), ``scipy``,

--- a/doc/source/installing.rst
+++ b/doc/source/installing.rst
@@ -379,7 +379,7 @@ source include:
 
 - ``git``
 - A C compiler such as ``gcc`` or ``clang``
-- ``Python >= 3.5``
+- ``Python >= 3.6``
 
 In addition, building yt from source requires ``numpy`` and ``cython``
 which can be installed with ``pip``:


### PR DESCRIPTION
## PR Summary

- add an `--upgrade` flag to pip install instruction to mitigate the problem with users getting broken installations when compiling with a more recent numpy than the one they have installed.
- fix an out of date indication for minimal python version