### PR TITLE
docs: fix missing inclusions

### DIFF
--- a/doc/source/developing/index.rst
+++ b/doc/source/developing/index.rst
@@ -27,3 +27,4 @@ and contributing code!
    creating_derived_quantities
    creating_frontend
    external_analysis
+   deprecating_features

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -33,7 +33,7 @@ Table of Contents
       <tr valign="top">
        <td width="25%">
          <p>
-           <a href="yt4differences.html">yt 3.0</a>
+           <a href="yt4differences.html">yt 4.0</a>
          </p>
        </td>
        <td width="75%">

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -33,6 +33,16 @@ Table of Contents
       <tr valign="top">
        <td width="25%">
          <p>
+           <a href="yt4differences.html">yt 3.0</a>
+         </p>
+       </td>
+       <td width="75%">
+         <p class="linkdescr">How yt-4.0 differs from past versions</p>
+       </td>
+     </tr>
+     <tr valign="top">
+       <td width="25%">
+         <p>
            <a href="yt3differences.html">yt 3.0</a>
          </p>
        </td>

--- a/doc/source/reference/api/api.rst
+++ b/doc/source/reference/api/api.rst
@@ -721,7 +721,6 @@ Function List
 
 .. autosummary::
 
-   ~yt.convenience.load
    ~yt.frontends.ytdata.utilities.save_as_dataset
    ~yt.data_objects.static_output.Dataset.all_data
    ~yt.data_objects.static_output.Dataset.box


### PR DESCRIPTION
## PR Summary

this fixes part of #3029

I'd like some feedback (@brittonsmith ?) for the following, currently unincluded pages
```
doc/source/analyzing/domain_analysis/index.rst
doc/source/analyzing/domain_analysis/xray_data_README.rst
```
Are they still relevant to the main project ? If so, where should they be referenced ?