### PR TITLE
Remove unused _initialize_index functions.

### DIFF
--- a/yt/frontends/adaptahop/io.py
+++ b/yt/frontends/adaptahop/io.py
@@ -118,38 +118,6 @@ class IOHandlerAdaptaHOPBinary(BaseIOHandler):
                 i = field_list.index(field)
                 yield (ptype, field), data[mask, i]
 
-    def _initialize_index(self, data_file, regions):
-        pcount = data_file.ds.parameters["nhalos"] + data_file.ds.parameters["nsubs"]
-        morton = np.empty(pcount, dtype="uint64")
-        mylog.debug(
-            "Initializing index % 5i (% 7i particles)", data_file.file_id, pcount
-        )
-        if pcount == 0:
-            return morton
-        ind = 0
-
-        pos = self._get_particle_positions()
-
-        if np.any(pos.min(axis=0) < self.ds.domain_left_edge) or np.any(
-            pos.max(axis=0) > self.ds.domain_right_edge
-        ):
-            raise YTDomainOverflow(
-                pos.min(axis=0),
-                pos.max(axis=0),
-                self.ds.domain_left_edge,
-                self.ds.domain_right_edge,
-            )
-        regions.add_data_file(pos, data_file.file_id)
-        morton[ind : ind + pos.shape[0]] = compute_morton(
-            pos[:, 0],
-            pos[:, 1],
-            pos[:, 2],
-            data_file.ds.domain_left_edge,
-            data_file.ds.domain_right_edge,
-        )
-
-        return morton
-
     def _count_particles(self, data_file):
         nhalos = data_file.ds.parameters["nhalos"] + data_file.ds.parameters["nsubs"]
         return {"halos": nhalos}

--- a/yt/frontends/adaptahop/io.py
+++ b/yt/frontends/adaptahop/io.py
@@ -11,11 +11,8 @@ from operator import attrgetter
 
 import numpy as np
 
-from yt.funcs import mylog
 from yt.utilities.cython_fortran_utils import FortranFile
-from yt.utilities.exceptions import YTDomainOverflow
 from yt.utilities.io_handler import BaseIOHandler
-from yt.utilities.lib.geometry_utils import compute_morton
 
 from .definitions import HALO_ATTRIBUTES, HEADER_ATTRIBUTES
 

--- a/yt/frontends/ahf/io.py
+++ b/yt/frontends/ahf/io.py
@@ -2,10 +2,7 @@ from operator import attrgetter
 
 import numpy as np
 
-from yt.funcs import mylog
-from yt.utilities.exceptions import YTDomainOverflow
 from yt.utilities.io_handler import BaseIOHandler
-from yt.utilities.lib.geometry_utils import compute_morton
 
 
 class IOHandlerAHFHalos(BaseIOHandler):

--- a/yt/frontends/ahf/io.py
+++ b/yt/frontends/ahf/io.py
@@ -56,28 +56,6 @@ class IOHandlerAHFHalos(BaseIOHandler):
                     data = halos[field][si:ei][mask].astype("float64")
                     yield (ptype, field), data
 
-    def _initialize_index(self, data_file, regions):
-        halos = data_file.read_data(usecols=["ID"])
-        pcount = len(halos["ID"])
-        morton = np.empty(pcount, dtype="uint64")
-        mylog.debug(
-            "Initializing index % 5i (% 7i particles)", data_file.file_id, pcount
-        )
-        if pcount == 0:
-            return morton
-        ind = 0
-        pos = data_file._get_particle_positions("halos")
-        pos = data_file.ds.arr(pos, "code_length")
-        dle = self.ds.domain_left_edge
-        dre = self.ds.domain_right_edge
-        if np.any(pos.min(axis=0) < dle) or np.any(pos.max(axis=0) > dre):
-            raise YTDomainOverflow(pos.min(axis=0), pos.max(axis=0), dle, dre)
-        regions.add_data_file(pos, data_file.file_id)
-        morton[ind : ind + pos.shape[0]] = compute_morton(
-            pos[:, 0], pos[:, 1], pos[:, 2], dle, dre
-        )
-        return morton
-
     def _count_particles(self, data_file):
         halos = data_file.read_data(usecols=["ID"])
         nhalos = len(halos["ID"])

--- a/yt/frontends/art/io.py
+++ b/yt/frontends/art/io.py
@@ -185,26 +185,6 @@ class IOHandlerDarkMatterART(IOHandlerART):
             for i, k in enumerate(self.ds.particle_types_raw)
         }
 
-    def _initialize_index(self, data_file, regions):
-        totcount = 4096 ** 2  # file is always this size
-        count = data_file.ds.parameters["lspecies"][-1]
-        DLE = data_file.ds.domain_left_edge
-        DRE = data_file.ds.domain_right_edge
-        with open(data_file.filename, "rb") as f:
-            # The first total_particles * 3 values are positions
-            pp = np.fromfile(f, dtype=">f4", count=totcount * 3)
-            pp.shape = (3, totcount)
-            pp = pp[:, :count]  # remove zeros
-            pp = np.transpose(pp).astype(
-                np.float32
-            )  # cast as float32 for compute_morton
-            pp = (pp - 1.0) / data_file.ds.parameters[
-                "ng"
-            ]  # correct the dm particle units
-        regions.add_data_file(pp, data_file.file_id)
-        morton = compute_morton(pp[:, 0], pp[:, 1], pp[:, 2], DLE, DRE)
-        return morton
-
     def _identify_fields(self, domain):
         field_list = []
         self.particle_field_list = [f for f in particle_fields]

--- a/yt/frontends/art/io.py
+++ b/yt/frontends/art/io.py
@@ -14,7 +14,6 @@ from yt.frontends.art.definitions import (
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.fortran_utils import read_vector, skip
 from yt.utilities.io_handler import BaseIOHandler
-from yt.utilities.lib.geometry_utils import compute_morton
 from yt.utilities.logger import ytLogger as mylog
 
 

--- a/yt/frontends/flash/io.py
+++ b/yt/frontends/flash/io.py
@@ -218,29 +218,6 @@ class IOHandlerFLASHParticle(BaseIOHandler):
                     data = p_fields[si:ei, fi]
                     yield (ptype, field), data[mask]
 
-    def _initialize_index(self, data_file, regions):
-        p_fields = self._handle["/tracer particles"]
-        px, py, pz = self._position_fields
-        pcount = self._count_particles(data_file)["io"]
-        morton = np.empty(pcount, dtype="uint64")
-        ind = 0
-        while ind < pcount:
-            npart = min(self.chunksize, pcount - ind)
-            pos = np.empty((npart, 3), dtype="=f8")
-            pos[:, 0] = p_fields[ind : ind + npart, px]
-            pos[:, 1] = p_fields[ind : ind + npart, py]
-            pos[:, 2] = p_fields[ind : ind + npart, pz]
-            regions.add_data_file(pos, data_file.file_id)
-            morton[ind : ind + npart] = compute_morton(
-                pos[:, 0],
-                pos[:, 1],
-                pos[:, 2],
-                data_file.ds.domain_left_edge,
-                data_file.ds.domain_right_edge,
-            )
-            ind += self.chunksize
-        return morton
-
     _pcount = None
 
     def _count_particles(self, data_file):

--- a/yt/frontends/flash/io.py
+++ b/yt/frontends/flash/io.py
@@ -4,7 +4,6 @@ import numpy as np
 
 from yt.geometry.selection_routines import AlwaysSelector
 from yt.utilities.io_handler import BaseIOHandler
-from yt.utilities.lib.geometry_utils import compute_morton
 
 
 # http://stackoverflow.com/questions/2361945/detecting-consecutive-integers-in-a-list

--- a/yt/frontends/gadget_fof/io.py
+++ b/yt/frontends/gadget_fof/io.py
@@ -3,9 +3,7 @@ from collections import defaultdict
 import numpy as np
 
 from yt.funcs import mylog
-from yt.utilities.exceptions import YTDomainOverflow
 from yt.utilities.io_handler import BaseIOHandler
-from yt.utilities.lib.geometry_utils import compute_morton
 from yt.utilities.on_demand_imports import _h5py as h5py
 
 

--- a/yt/frontends/gadget_fof/io.py
+++ b/yt/frontends/gadget_fof/io.py
@@ -114,52 +114,6 @@ class IOHandlerGadgetFOFHDF5(BaseIOHandler):
                         data = field_data[si:ei][mask]
                         yield (ptype, field), data
 
-    def _initialize_index(self, data_file, regions):
-        if self.index_ptype == "all":
-            ptypes = self.ds.particle_types_raw
-            pcount = sum(data_file.total_particles.values())
-        else:
-            ptypes = [self.index_ptype]
-            pcount = data_file.total_particles[self.index_ptype]
-        morton = np.empty(pcount, dtype="uint64")
-        if pcount == 0:
-            return morton
-        mylog.debug(
-            "Initializing index % 5i (% 7i particles)", data_file.file_id, pcount
-        )
-        ind = 0
-        with h5py.File(data_file.filename, mode="r") as f:
-            if not f.keys():
-                return None
-            dx = np.finfo(f["Group"]["GroupPos"].dtype).eps
-            dx = 2.0 * self.ds.quan(dx, "code_length")
-
-            for ptype in ptypes:
-                if data_file.total_particles[ptype] == 0:
-                    continue
-                pos = data_file._get_particle_positions(ptype, f=f)
-                pos = self.ds.arr(pos, "code_length")
-
-                if np.any(pos.min(axis=0) < self.ds.domain_left_edge) or np.any(
-                    pos.max(axis=0) > self.ds.domain_right_edge
-                ):
-                    raise YTDomainOverflow(
-                        pos.min(axis=0),
-                        pos.max(axis=0),
-                        self.ds.domain_left_edge,
-                        self.ds.domain_right_edge,
-                    )
-                regions.add_data_file(pos, data_file.file_id)
-                morton[ind : ind + pos.shape[0]] = compute_morton(
-                    pos[:, 0],
-                    pos[:, 1],
-                    pos[:, 2],
-                    self.ds.domain_left_edge,
-                    self.ds.domain_right_edge,
-                )
-                ind += pos.shape[0]
-        return morton
-
     def _count_particles(self, data_file):
         si, ei = data_file.start, data_file.end
         pcount = {

--- a/yt/frontends/http_stream/io.py
+++ b/yt/frontends/http_stream/io.py
@@ -71,27 +71,5 @@ class IOHandlerHTTPStream(BaseIOHandler):
                     data = c[mask, ...]
                     yield (ptype, field), data
 
-    def _initialize_index(self, data_file, regions):
-        header = self.ds.parameters
-        ptypes = header["particle_count"][data_file.file_id].keys()
-        pcount = sum(header["particle_count"][data_file.file_id].values())
-        morton = np.empty(pcount, dtype="uint64")
-        ind = 0
-        for ptype in ptypes:
-            s = self._open_stream(data_file, (ptype, "Coordinates"))
-            c = np.frombuffer(s, dtype="float64")
-            c.shape = (c.shape[0] / 3.0, 3)
-            regions.add_data_file(c, data_file.file_id, data_file.ds.filter_bbox)
-            morton[ind : ind + c.shape[0]] = compute_morton(
-                c[:, 0],
-                c[:, 1],
-                c[:, 2],
-                data_file.ds.domain_left_edge,
-                data_file.ds.domain_right_edge,
-                data_file.ds.filter_bbox,
-            )
-            ind += c.shape[0]
-        return morton
-
     def _count_particles(self, data_file):
         return self.ds.parameters["particle_count"][data_file.file_id]

--- a/yt/frontends/http_stream/io.py
+++ b/yt/frontends/http_stream/io.py
@@ -2,7 +2,6 @@ import numpy as np
 
 from yt.funcs import get_requests, mylog
 from yt.utilities.io_handler import BaseIOHandler
-from yt.utilities.lib.geometry_utils import compute_morton
 
 
 class IOHandlerHTTPStream(BaseIOHandler):

--- a/yt/frontends/owls_subfind/io.py
+++ b/yt/frontends/owls_subfind/io.py
@@ -4,6 +4,7 @@ from yt.funcs import mylog
 from yt.utilities.io_handler import BaseIOHandler
 from yt.utilities.on_demand_imports import _h5py as h5py
 
+
 class IOHandlerOWLSSubfindHDF5(BaseIOHandler):
     _dataset_type = "subfind_hdf5"
 

--- a/yt/frontends/owls_subfind/io.py
+++ b/yt/frontends/owls_subfind/io.py
@@ -103,57 +103,6 @@ class IOHandlerOWLSSubfindHDF5(BaseIOHandler):
                         data = field_data[mask]
                         yield (ptype, field), data
 
-    def _initialize_index(self, data_file, regions):
-        pcount = sum(data_file.total_particles.values())
-        morton = np.empty(pcount, dtype="uint64")
-        if pcount == 0:
-            return morton
-        mylog.debug(
-            "Initializing index % 5i (% 7i particles)", data_file.file_id, pcount
-        )
-        ind = 0
-        with h5py.File(data_file.filename, mode="r") as f:
-            if not f.keys():
-                return None
-            dx = np.finfo(f["FOF"]["CenterOfMass"].dtype).eps
-            dx = 2.0 * self.ds.quan(dx, "code_length")
-
-            for ptype in data_file.ds.particle_types_raw:
-                if data_file.total_particles[ptype] == 0:
-                    continue
-                pos = f[ptype]["CenterOfMass"][()].astype("float64")
-                pos = np.resize(pos, (data_file.total_particles[ptype], 3))
-                pos = data_file.ds.arr(pos, "code_length")
-
-                # These are 32 bit numbers, so we give a little lee-way.
-                # Otherwise, for big sets of particles, we often will bump into the
-                # domain edges.  This helps alleviate that.
-                np.clip(
-                    pos,
-                    self.ds.domain_left_edge + dx,
-                    self.ds.domain_right_edge - dx,
-                    pos,
-                )
-                if np.any(pos.min(axis=0) < self.ds.domain_left_edge) or np.any(
-                    pos.max(axis=0) > self.ds.domain_right_edge
-                ):
-                    raise YTDomainOverflow(
-                        pos.min(axis=0),
-                        pos.max(axis=0),
-                        self.ds.domain_left_edge,
-                        self.ds.domain_right_edge,
-                    )
-                regions.add_data_file(pos, data_file.file_id)
-                morton[ind : ind + pos.shape[0]] = compute_morton(
-                    pos[:, 0],
-                    pos[:, 1],
-                    pos[:, 2],
-                    data_file.ds.domain_left_edge,
-                    data_file.ds.domain_right_edge,
-                )
-                ind += pos.shape[0]
-        return morton
-
     def _count_particles(self, data_file):
         with h5py.File(data_file.filename, mode="r") as f:
             pcount = {"FOF": f["FOF"].attrs["Number_of_groups"]}

--- a/yt/frontends/owls_subfind/io.py
+++ b/yt/frontends/owls_subfind/io.py
@@ -1,11 +1,8 @@
 import numpy as np
 
 from yt.funcs import mylog
-from yt.utilities.exceptions import YTDomainOverflow
 from yt.utilities.io_handler import BaseIOHandler
-from yt.utilities.lib.geometry_utils import compute_morton
 from yt.utilities.on_demand_imports import _h5py as h5py
-
 
 class IOHandlerOWLSSubfindHDF5(BaseIOHandler):
     _dataset_type = "subfind_hdf5"

--- a/yt/frontends/rockstar/io.py
+++ b/yt/frontends/rockstar/io.py
@@ -2,10 +2,7 @@ import os
 
 import numpy as np
 
-from yt.funcs import mylog
-from yt.utilities.exceptions import YTDomainOverflow
 from yt.utilities.io_handler import BaseIOHandler
-from yt.utilities.lib.geometry_utils import compute_morton
 
 from .definitions import halo_dts
 

--- a/yt/frontends/rockstar/io.py
+++ b/yt/frontends/rockstar/io.py
@@ -80,38 +80,6 @@ class IOHandlerRockstarBinary(BaseIOHandler):
             pos[:, 2] = halos["particle_position_z"]
             yield "halos", pos
 
-    def _initialize_index(self, data_file, regions):
-        pcount = data_file.header["num_halos"]
-        morton = np.empty(pcount, dtype="uint64")
-        mylog.debug(
-            "Initializing index % 5i (% 7i particles)", data_file.file_id, pcount
-        )
-        if pcount == 0:
-            return morton
-        ind = 0
-        ptype = "halos"
-        with open(data_file.filename, "rb") as f:
-            pos = data_file._get_particle_positions(ptype, f=f)
-            pos = data_file.ds.arr(pos, "code_length")
-            if np.any(pos.min(axis=0) < self.ds.domain_left_edge) or np.any(
-                pos.max(axis=0) > self.ds.domain_right_edge
-            ):
-                raise YTDomainOverflow(
-                    pos.min(axis=0),
-                    pos.max(axis=0),
-                    self.ds.domain_left_edge,
-                    self.ds.domain_right_edge,
-                )
-            regions.add_data_file(pos, data_file.file_id)
-            morton[ind : ind + pos.shape[0]] = compute_morton(
-                pos[:, 0],
-                pos[:, 1],
-                pos[:, 2],
-                data_file.ds.domain_left_edge,
-                data_file.ds.domain_right_edge,
-            )
-        return morton
-
     def _count_particles(self, data_file):
         nhalos = data_file.header["num_halos"]
         si, ei = data_file.start, data_file.end

--- a/yt/frontends/sdf/io.py
+++ b/yt/frontends/sdf/io.py
@@ -1,9 +1,7 @@
 import numpy as np
 
 from yt.funcs import mylog
-from yt.utilities.exceptions import YTDomainOverflow
 from yt.utilities.io_handler import BaseIOHandler
-from yt.utilities.lib.geometry_utils import compute_morton
 
 
 class IOHandlerSDF(BaseIOHandler):

--- a/yt/frontends/sdf/io.py
+++ b/yt/frontends/sdf/io.py
@@ -58,29 +58,6 @@ class IOHandlerSDF(BaseIOHandler):
                         data = self._handle[field][mask]
                     yield (ptype, field), data
 
-    def _initialize_index(self, data_file, regions):
-        x, y, z = (self._handle[ax] for ax in "xyz")
-        pcount = x.size
-
-        morton = np.empty(pcount, dtype="uint64")
-        ind = 0
-        while ind < pcount:
-            npart = min(self.ds.index.chunksize, pcount - ind)
-            pos = np.empty((npart, 3), dtype=x.dtype)
-            pos[:, 0] = x[ind : ind + npart]
-            pos[:, 1] = y[ind : ind + npart]
-            pos[:, 2] = z[ind : ind + npart]
-            regions.add_data_file(pos, data_file.file_id)
-            morton[ind : ind + npart] = compute_morton(
-                pos[:, 0],
-                pos[:, 1],
-                pos[:, 2],
-                data_file.ds.domain_left_edge,
-                data_file.ds.domain_right_edge,
-            )
-            ind += self.ds.index.chunksize
-        return morton
-
     def _identify_fields(self, data_file):
         fields = [("dark_matter", v) for v in self._handle.keys()]
         fields.append(("dark_matter", "mass"))
@@ -191,43 +168,6 @@ class IOHandlerSIndexSDF(IOHandlerSDF):
                     else:
                         data = dd[field][mask]
                     yield (ptype, field), data
-
-    def _initialize_index(self, data_file, regions):
-        dle = self.ds.domain_left_edge.in_units("code_length").d
-        dre = self.ds.domain_right_edge.in_units("code_length").d
-        pcount = 0
-        for dd in self.ds.midx.iter_bbox_data(dle, dre, ["x"]):
-            pcount += dd["x"].size
-
-        morton = np.empty(pcount, dtype="uint64")
-        ind = 0
-
-        chunk_id = 0
-        for dd in self.ds.midx.iter_bbox_data(dle, dre, ["x", "y", "z"]):
-            npart = dd["x"].size
-            pos = np.empty((npart, 3), dtype=dd["x"].dtype)
-            pos[:, 0] = dd["x"]
-            pos[:, 1] = dd["y"]
-            pos[:, 2] = dd["z"]
-            if np.any(pos.min(axis=0) < self.ds.domain_left_edge) or np.any(
-                pos.max(axis=0) > self.ds.domain_right_edge
-            ):
-                raise YTDomainOverflow(
-                    pos.min(axis=0),
-                    pos.max(axis=0),
-                    self.ds.domain_left_edge,
-                    self.ds.domain_right_edge,
-                )
-            regions.add_data_file(pos, chunk_id)
-            morton[ind : ind + npart] = compute_morton(
-                pos[:, 0],
-                pos[:, 1],
-                pos[:, 2],
-                data_file.ds.domain_left_edge,
-                data_file.ds.domain_right_edge,
-            )
-            ind += npart
-        return morton
 
     def _count_particles(self, data_file):
         dle = self.ds.domain_left_edge.in_units("code_length").d

--- a/yt/frontends/ytdata/io.py
+++ b/yt/frontends/ytdata/io.py
@@ -3,9 +3,7 @@ import numpy as np
 from yt.funcs import mylog, parse_h5_attr
 from yt.geometry.selection_routines import GridSelector
 from yt.units.yt_array import uvstack
-from yt.utilities.exceptions import YTDomainOverflow
 from yt.utilities.io_handler import BaseIOHandler
-from yt.utilities.lib.geometry_utils import compute_morton
 from yt.utilities.on_demand_imports import _h5py as h5py
 
 


### PR DESCRIPTION
This removes the `_initialize_index` function from the frontend-specific io handler classes. These are no longer used after yt-3.x.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
