### PR TITLE
Fix mistake in call to partial function

### DIFF
--- a/yt/frontends/art/io.py
+++ b/yt/frontends/art/io.py
@@ -121,7 +121,7 @@ class IOHandlerART(BaseIOHandler):
                 off = 1.0 / dd
                 tr[field] = rp(fields=[ax])[0] / dd - off
             if fname.startswith(f"particle_velocity_{ax}"):
-                (tr[field],) = rp(["v" + ax])
+                (tr[field],) = rp(fields=["v" + ax])
         if fname.startswith("particle_mass"):
             a = 0
             data = np.zeros(npa, dtype="f8")

--- a/yt/frontends/art/tests/test_outputs.py
+++ b/yt/frontends/art/tests/test_outputs.py
@@ -19,6 +19,7 @@ _fields = (
     ("gas", "temperature"),
     ("all", "particle_mass"),
     ("all", "particle_position_x"),
+    ("all", "particle_velocity_y"),
 )
 
 d9p = "D9p_500/10MpcBox_HartGal_csf_a0.500.d"


### PR DESCRIPTION
## PR Summary

Steps to reproduce:
```python
import yt
ds = yt.load_sample("D9p_500")
ad = ds.all_data()
ad["particle_velocity_x"]
```

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
