### PR TITLE
fix a FutureWarning from numpy

### DIFF
--- a/doc/source/analyzing/units.rst
+++ b/doc/source/analyzing/units.rst
@@ -210,8 +210,8 @@ Using parsec as an example,
   * ``pc/h``
     Proper parsecs, normalized by the scaled hubble constant, :math:`\rm{pc}/h`.
 
-Overriding Code Unit Defintions
--------------------------------
+Overriding Code Unit Definitions
+--------------------------------
 
 On occasion, you might have a dataset for a supported frontend that does not
 have the conversions to code units accessible or you may want to change them

--- a/yt/visualization/volume_rendering/render_source.py
+++ b/yt/visualization/volume_rendering/render_source.py
@@ -901,7 +901,7 @@ class MeshSource(OpaqueSource):
         if color is None:
             color = np.array([0, 0, 0, alpha])
 
-        locs = [self.sampler.amesh_lines == 1]
+        locs = (self.sampler.amesh_lines == 1,)
 
         self.current_image[:, :, 0][locs] = color[0]
         self.current_image[:, :, 1][locs] = color[1]


### PR DESCRIPTION
## PR Summary

Here's the warning as it pops up on Jenkins 
```
/var/jenkins_home/workspace/yt_docs_new/yt/visualization/volume_rendering/render_source.py:906: FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.
  self.current_image[:, :, 0][locs] = color[0]
```
this is not exactly a bug for now but it will be in the future so I'm using the bug label.
