### PR TITLE
fix a NameError in yt.mods

### DIFF
--- a/yt/mods.py
+++ b/yt/mods.py
@@ -4,6 +4,8 @@
 
 import os
 
+import numpy as np
+
 # This next item will handle most of the actual startup procedures, but it will
 # also attempt to parse the command line and set up the global state of various
 # operations.  The variable unparsed_args is not used internally but is


### PR DESCRIPTION
## PR Summary

I'm not actually convinced that the file should be kept (dead code ?) but it's easy enough to fix the NameError one gets with `import yt.mods` atm
