### PR TITLE
Fix/fake random ds

### DIFF
--- a/yt/data_objects/tests/test_center_squeeze.py
+++ b/yt/data_objects/tests/test_center_squeeze.py
@@ -6,7 +6,7 @@ def test_center_squeeze():
 
     # create and test amr, random and particle data
     check_single_ds(fake_amr_ds(fields=("Density",)))
-    check_single_ds(fake_random_ds(16, fields=("Density",)))
+    check_single_ds(fake_random_ds(16, fields=("Density",), units=("g/cm**3",)))
     check_single_ds(fake_particle_ds(npart=100))
 
 

--- a/yt/data_objects/tests/test_center_squeeze.py
+++ b/yt/data_objects/tests/test_center_squeeze.py
@@ -5,7 +5,7 @@ def test_center_squeeze():
     # checks that the center is reshaped correctly
 
     # create and test amr, random and particle data
-    check_single_ds(fake_amr_ds(fields=("Density",)))
+    check_single_ds(fake_amr_ds(fields=("Density",), units=("g/cm**3",)))
     check_single_ds(fake_random_ds(16, fields=("Density",), units=("g/cm**3",)))
     check_single_ds(fake_particle_ds(npart=100))
 

--- a/yt/data_objects/tests/test_clone.py
+++ b/yt/data_objects/tests/test_clone.py
@@ -4,11 +4,10 @@ from yt.testing import assert_array_equal, assert_equal, fake_random_ds
 def test_clone_sphere():
     # Now we test that we can get different radial velocities based on field
     # parameters.
-
+    fields = ("density", "velocity_x", "velocity_y", "velocity_z")
+    units = ("g/cm**3", "cm/s", "cm/s", "cm/s")
     # Get the first sphere
-    ds = fake_random_ds(
-        16, fields=("density", "velocity_x", "velocity_y", "velocity_z")
-    )
+    ds = fake_random_ds(16, fields=fields, units=units)
     sp0 = ds.sphere(ds.domain_center, 0.25)
 
     assert_equal(list(sp0.keys()), [])
@@ -24,7 +23,9 @@ def test_clone_sphere():
 
 
 def test_clone_cut_region():
-    ds = fake_random_ds(64, nprocs=4, fields=("density", "temperature"))
+    fields = ("density", "temperature")
+    units = ("g/cm**3", "K")
+    ds = fake_random_ds(64, nprocs=4, fields=fields, units=units)
     dd = ds.all_data()
     reg1 = dd.cut_region(["obj['temperature'] > 0.5", "obj['density'] < 0.75"])
     reg2 = reg1.clone()

--- a/yt/data_objects/tests/test_covering_grid.py
+++ b/yt/data_objects/tests/test_covering_grid.py
@@ -108,13 +108,9 @@ def test_xarray_export():
         assert_equal(xarr.y, cg["y"][0, :, 0])
         assert_equal(xarr.z, cg["z"][0, 0, :])
 
+    fields = ("density", "temperature", "specific_thermal_energy")
+    units = ("g/cm**3", "K", "dyn/cm**2")
     for level in [0, 1, 2]:
-        fields = [
-            ("gas", "density"),
-            ("gas", "temperature"),
-            ("gas", "specific_thermal_energy"),
-        ]
-        units = ["g/cm**3", "K", "erg/g"]
         ds = fake_random_ds(16, fields=fields, units=units)
         dn = ds.refine_by ** level
         rcg = ds.covering_grid(level, [0.0, 0.0, 0.0], dn * ds.domain_dimensions)

--- a/yt/data_objects/tests/test_covering_grid.py
+++ b/yt/data_objects/tests/test_covering_grid.py
@@ -109,7 +109,7 @@ def test_xarray_export():
         assert_equal(xarr.z, cg["z"][0, 0, :])
 
     fields = ("density", "temperature", "specific_thermal_energy")
-    units = ("g/cm**3", "K", "dyn/cm**2")
+    units = ("g/cm**3", "K", "erg/g")
     for level in [0, 1, 2]:
         ds = fake_random_ds(16, fields=fields, units=units)
         dn = ds.refine_by ** level

--- a/yt/data_objects/tests/test_data_containers.py
+++ b/yt/data_objects/tests/test_data_containers.py
@@ -106,7 +106,10 @@ class TestDataContainers(unittest.TestCase):
     def test_to_frb(self):
         # Test cylindrical geometry
         fields = ["density", "cell_mass"]
-        ds = fake_amr_ds(fields=fields, geometry="cylindrical", particles=16 ** 3)
+        units = ["g/cm**3", "g"]
+        ds = fake_amr_ds(
+            fields=fields, units=units, geometry="cylindrical", particles=16 ** 3
+        )
         dd = ds.all_data()
         proj = ds.proj("density", weight_field="cell_mass", axis=1, data_source=dd)
         frb = proj.to_frb((1.0, "unitary"), 64)
@@ -115,7 +118,9 @@ class TestDataContainers(unittest.TestCase):
 
     def test_extract_isocontours(self):
         # Test isocontour properties for AMRGridData
-        ds = fake_amr_ds(fields=["density", "cell_mass"], particles=16 ** 3)
+        fields = ["density", "cell_mass"]
+        units = ["g/cm**3", "g"]
+        ds = fake_amr_ds(fields=fields, units=units, particles=16 ** 3)
         dd = ds.all_data()
         q = dd.quantities["WeightedAverageQuantity"]
         rho = q("density", weight="cell_mass")

--- a/yt/data_objects/tests/test_dataset_access.py
+++ b/yt/data_objects/tests/test_dataset_access.py
@@ -37,7 +37,7 @@ def test_box_creation():
 
 
 def test_region_from_d():
-    ds = fake_amr_ds(fields=["density"])
+    ds = fake_amr_ds(fields=["density"], units=["g/cm**3"])
     # We'll do a couple here
 
     # First, no string units
@@ -81,7 +81,7 @@ def test_region_from_d():
 def test_accessing_all_data():
     # This will test first that we can access all_data, and next that we can
     # access it multiple times and get the *same object*.
-    ds = fake_amr_ds(fields=["density"])
+    ds = fake_amr_ds(fields=["density"], units=["g/cm**3"])
     dd = ds.all_data()
     assert_equal(ds.r["density"], dd["density"])
     # Now let's assert that it's the same object
@@ -92,7 +92,7 @@ def test_accessing_all_data():
 
 
 def test_slice_from_r():
-    ds = fake_amr_ds(fields=["density"])
+    ds = fake_amr_ds(fields=["density"], units=["g/cm**3"])
     sl1 = ds.r[0.5, :, :]
     sl2 = ds.slice("x", 0.5)
     assert_equal(sl1["density"], sl2["density"])
@@ -114,7 +114,7 @@ def test_slice_from_r():
 
 
 def test_point_from_r():
-    ds = fake_amr_ds(fields=["density"])
+    ds = fake_amr_ds(fields=["density"], units=["g/cm**3"])
     pt1 = ds.r[0.5, 0.3, 0.1]
     pt2 = ds.point([0.5, 0.3, 0.1])
     assert_equal(pt1["density"], pt2["density"])
@@ -126,7 +126,7 @@ def test_point_from_r():
 
 
 def test_ray_from_r():
-    ds = fake_amr_ds(fields=["density"])
+    ds = fake_amr_ds(fields=["density"], units=["g/cm**3"])
     ray1 = ds.r[(0.1, 0.2, 0.3):(0.4, 0.5, 0.6)]
     ray2 = ds.ray((0.1, 0.2, 0.3), (0.4, 0.5, 0.6))
     assert_equal(ray1["density"], ray2["density"])
@@ -149,7 +149,7 @@ def test_ray_from_r():
 
 
 def test_ortho_ray_from_r():
-    ds = fake_amr_ds(fields=["density"])
+    ds = fake_amr_ds(fields=["density"], units=["g/cm**3"])
     ray1 = ds.r[:, 0.3, 0.2]
     ray2 = ds.ortho_ray("x", [0.3, 0.2])
     assert_equal(ray1["density"], ray2["density"])

--- a/yt/data_objects/tests/test_derived_quantities.py
+++ b/yt/data_objects/tests/test_derived_quantities.py
@@ -25,6 +25,7 @@ def test_extrema():
             16,
             nprocs=nprocs,
             fields=("density", "velocity_x", "velocity_y", "velocity_z"),
+            units=("g/cm**3", "cm/s", "cm/s", "cm/s"),
         )
         for sp in [ds.sphere("c", (0.25, "unitary")), ds.r[0.5, :, :]]:
             mi, ma = sp.quantities["Extrema"]("density")
@@ -43,7 +44,7 @@ def test_extrema():
 
 def test_average():
     for nprocs in [1, 2, 4, 8]:
-        ds = fake_random_ds(16, nprocs=nprocs, fields=("density",))
+        ds = fake_random_ds(16, nprocs=nprocs, fields=("density",), units=("g/cm**3",))
         for ad in [ds.all_data(), ds.r[0.5, :, :]]:
 
             my_mean = ad.quantities["WeightedAverageQuantity"]("density", "ones")
@@ -56,7 +57,7 @@ def test_average():
 
 def test_variance():
     for nprocs in [1, 2, 4, 8]:
-        ds = fake_random_ds(16, nprocs=nprocs, fields=("density",))
+        ds = fake_random_ds(16, nprocs=nprocs, fields=("density",), units=("g/cm**3",))
         for ad in [ds.all_data(), ds.r[0.5, :, :]]:
 
             my_std, my_mean = ad.quantities["WeightedVariance"]("density", "ones")
@@ -75,7 +76,7 @@ def test_variance():
 
 def test_max_location():
     for nprocs in [1, 2, 4, 8]:
-        ds = fake_random_ds(16, nprocs=nprocs, fields=("density",))
+        ds = fake_random_ds(16, nprocs=nprocs, fields=("density",), units=("g/cm**3",))
         for ad in [ds.all_data(), ds.r[0.5, :, :]]:
 
             mv, x, y, z = ad.quantities.max_location(("gas", "density"))
@@ -91,7 +92,7 @@ def test_max_location():
 
 def test_min_location():
     for nprocs in [1, 2, 4, 8]:
-        ds = fake_random_ds(16, nprocs=nprocs, fields=("density",))
+        ds = fake_random_ds(16, nprocs=nprocs, fields=("density",), units=("g/cm**3",))
         for ad in [ds.all_data(), ds.r[0.5, :, :]]:
 
             mv, x, y, z = ad.quantities.min_location(("gas", "density"))
@@ -108,7 +109,10 @@ def test_min_location():
 def test_sample_at_min_field_values():
     for nprocs in [1, 2, 4, 8]:
         ds = fake_random_ds(
-            16, nprocs=nprocs, fields=("density", "temperature", "velocity_x")
+            16,
+            nprocs=nprocs,
+            fields=("density", "temperature", "velocity_x"),
+            units=("g/cm**3", "K", "cm/s"),
         )
         for ad in [ds.all_data(), ds.r[0.5, :, :]]:
 
@@ -127,7 +131,10 @@ def test_sample_at_min_field_values():
 def test_sample_at_max_field_values():
     for nprocs in [1, 2, 4, 8]:
         ds = fake_random_ds(
-            16, nprocs=nprocs, fields=("density", "temperature", "velocity_x")
+            16,
+            nprocs=nprocs,
+            fields=("density", "temperature", "velocity_x"),
+            units=("g/cm**3", "K", "cm/s"),
         )
         for ad in [ds.all_data(), ds.r[0.5, :, :]]:
 

--- a/yt/data_objects/tests/test_extract_regions.py
+++ b/yt/data_objects/tests/test_extract_regions.py
@@ -20,7 +20,10 @@ def test_cut_region():
     # We decompose in different ways
     for nprocs in [1, 2, 4, 8]:
         ds = fake_random_ds(
-            64, nprocs=nprocs, fields=("density", "temperature", "velocity_x")
+            64,
+            nprocs=nprocs,
+            fields=("density", "temperature", "velocity_x"),
+            units=("g/cm**3", "K", "cm/s"),
         )
         # We'll test two objects
         dd = ds.all_data()

--- a/yt/data_objects/tests/test_io_geometry.py
+++ b/yt/data_objects/tests/test_io_geometry.py
@@ -13,7 +13,7 @@ from yt.units import YTQuantity
 @requires_module("h5py")
 def test_preserve_geometric_properties():
     for geom in ("cartesian", "cylindrical", "spherical"):
-        ds1 = fake_amr_ds(fields=[("gas", "density")], geometry=geom)
+        ds1 = fake_amr_ds(fields=[("gas", "density")], units=["g/cm**3"], geometry=geom)
         ad = ds1.all_data()
         with TemporaryDirectory() as tmpdir:
             tmpf = os.path.join(tmpdir, "savefile.h5")

--- a/yt/data_objects/tests/test_numpy_ops.py
+++ b/yt/data_objects/tests/test_numpy_ops.py
@@ -14,7 +14,9 @@ def test_mean_sum_integrate():
         if nprocs == -1:
             ds = fake_amr_ds(fields=("density",), particles=20)
         else:
-            ds = fake_random_ds(32, nprocs=nprocs, fields=("density",), particles=20)
+            ds = fake_random_ds(
+                32, nprocs=nprocs, fields=("density",), units=("g/cm**3",), particles=20
+            )
         ad = ds.all_data()
 
         # Sums
@@ -132,7 +134,12 @@ def test_argmin():
         if nprocs == -1:
             ds = fake_amr_ds(fields=("density", "temperature"))
         else:
-            ds = fake_random_ds(32, nprocs=nprocs, fields=("density", "temperature"))
+            ds = fake_random_ds(
+                32,
+                nprocs=nprocs,
+                fields=("density", "temperature"),
+                units=("g/cm**3", "K"),
+            )
 
         ad = ds.all_data()
 
@@ -156,7 +163,12 @@ def test_argmax():
         if nprocs == -1:
             ds = fake_amr_ds(fields=("density", "temperature"))
         else:
-            ds = fake_random_ds(32, nprocs=nprocs, fields=("density", "temperature"))
+            ds = fake_random_ds(
+                32,
+                nprocs=nprocs,
+                fields=("density", "temperature"),
+                units=("g/cm**3", "K"),
+            )
 
         ad = ds.all_data()
 

--- a/yt/data_objects/tests/test_numpy_ops.py
+++ b/yt/data_objects/tests/test_numpy_ops.py
@@ -12,7 +12,7 @@ def setup():
 def test_mean_sum_integrate():
     for nprocs in [-1, 1, 2, 16]:
         if nprocs == -1:
-            ds = fake_amr_ds(fields=("density",), units=("g/cm**3"), particles=20)
+            ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), particles=20)
         else:
             ds = fake_random_ds(
                 32, nprocs=nprocs, fields=("density",), units=("g/cm**3",), particles=20

--- a/yt/data_objects/tests/test_numpy_ops.py
+++ b/yt/data_objects/tests/test_numpy_ops.py
@@ -12,7 +12,7 @@ def setup():
 def test_mean_sum_integrate():
     for nprocs in [-1, 1, 2, 16]:
         if nprocs == -1:
-            ds = fake_amr_ds(fields=("density",), particles=20)
+            ds = fake_amr_ds(fields=("density",), units=("g/cm**3"), particles=20)
         else:
             ds = fake_random_ds(
                 32, nprocs=nprocs, fields=("density",), units=("g/cm**3",), particles=20
@@ -83,11 +83,13 @@ def test_mean_sum_integrate():
 
 def test_min_max():
     for nprocs in [-1, 1, 2, 16]:
+        fields = ["density", "temperature"]
+        units = ["g/cm**3", "K"]
         if nprocs == -1:
-            ds = fake_amr_ds(fields=("density", "temperature"), particles=20)
+            ds = fake_amr_ds(fields=fields, units=units, particles=20)
         else:
             ds = fake_random_ds(
-                32, nprocs=nprocs, fields=("density", "temperature"), particles=20
+                32, nprocs=nprocs, fields=fields, units=units, particles=20
             )
 
         ad = ds.all_data()
@@ -130,15 +132,17 @@ def test_min_max():
 
 
 def test_argmin():
+    fields = ["density", "temperature"]
+    units = ["g/cm**3", "K"]
     for nprocs in [-1, 1, 2, 16]:
         if nprocs == -1:
-            ds = fake_amr_ds(fields=("density", "temperature"))
+            ds = fake_amr_ds(fields=fields, units=units)
         else:
             ds = fake_random_ds(
                 32,
                 nprocs=nprocs,
-                fields=("density", "temperature"),
-                units=("g/cm**3", "K"),
+                fields=fields,
+                units=units,
             )
 
         ad = ds.all_data()
@@ -159,15 +163,17 @@ def test_argmin():
 
 
 def test_argmax():
+    fields = ["density", "temperature"]
+    units = ["g/cm**3", "K"]
     for nprocs in [-1, 1, 2, 16]:
         if nprocs == -1:
-            ds = fake_amr_ds(fields=("density", "temperature"))
+            ds = fake_amr_ds(fields=fields, units=units)
         else:
             ds = fake_random_ds(
                 32,
                 nprocs=nprocs,
-                fields=("density", "temperature"),
-                units=("g/cm**3", "K"),
+                fields=fields,
+                units=units,
             )
 
         ad = ds.all_data()

--- a/yt/data_objects/tests/test_slice.py
+++ b/yt/data_objects/tests/test_slice.py
@@ -75,7 +75,9 @@ def test_slice(pf):
 
 
 def test_slice_over_edges():
-    ds = fake_random_ds(64, nprocs=8, fields=["density"], negative=[False])
+    ds = fake_random_ds(
+        64, nprocs=8, fields=("density",), units=("g/cm**3",), negative=[False]
+    )
     slc = ds.slice(0, 0.0)
     slc["density"]
     slc = ds.slice(1, 0.5)
@@ -83,7 +85,9 @@ def test_slice_over_edges():
 
 
 def test_slice_over_outer_boundary():
-    ds = fake_random_ds(64, nprocs=8, fields=["density"], negative=[False])
+    ds = fake_random_ds(
+        64, nprocs=8, fields=("density",), units=("g/cm**3",), negative=[False]
+    )
     slc = ds.slice(2, 1.0)
     slc["density"]
     assert_equal(slc["density"].size, 0)

--- a/yt/data_objects/tests/test_spheres.py
+++ b/yt/data_objects/tests/test_spheres.py
@@ -34,7 +34,9 @@ def test_domain_sphere():
 
     # Get the first sphere
     ds = fake_random_ds(
-        16, fields=("density", "velocity_x", "velocity_y", "velocity_z")
+        16,
+        fields=("density", "velocity_x", "velocity_y", "velocity_z"),
+        units=("g/cm**3", "cm/s", "cm/s", "cm/s"),
     )
     sp0 = ds.sphere(ds.domain_center, 0.25)
 
@@ -91,7 +93,12 @@ def test_domain_sphere():
 
 
 def test_sphere_center():
-    ds = fake_random_ds(16, nprocs=8, fields=("density", "temperature", "velocity_x"))
+    ds = fake_random_ds(
+        16,
+        nprocs=8,
+        fields=("density", "temperature", "velocity_x"),
+        units=("g/cm**3", "K", "cm/s"),
+    )
 
     # Test if we obtain same center in different ways
     sp1 = ds.sphere("max", (0.25, "unitary"))

--- a/yt/fields/tests/test_angular_momentum.py
+++ b/yt/fields/tests/test_angular_momentum.py
@@ -5,7 +5,9 @@ from yt.testing import assert_allclose_units, fake_amr_ds
 
 def test_AM_value():
     ds = fake_amr_ds(
-        fields=("Density", "velocity_x", "velocity_y", "velocity_z"), length_unit=0.5
+        fields=("Density", "velocity_x", "velocity_y", "velocity_z"),
+        units=("g/cm**3", "cm/s", "cm/s", "cm/s"),
+        length_unit=0.5,
     )
 
     sp = ds.sphere([0.5] * 3, (0.1, "code_length"))

--- a/yt/fields/tests/test_fields.py
+++ b/yt/fields/tests/test_fields.py
@@ -239,7 +239,7 @@ def test_add_gradient_fields():
 
 
 def test_add_gradient_fields_by_fname():
-    ds = fake_amr_ds(fields=("density", "temperature"))
+    ds = fake_amr_ds(fields=("density", "temperature"), units=("g/cm**3", "K"))
     actual = ds.add_gradient_fields("density")
     expected = [
         ("gas", "density_gradient_x"),
@@ -251,7 +251,7 @@ def test_add_gradient_fields_by_fname():
 
 
 def test_add_gradient_multiple_fields():
-    ds = fake_amr_ds(fields=("density", "temperature"))
+    ds = fake_amr_ds(fields=("density", "temperature"), units=("g/cm**3", "K"))
     actual = ds.add_gradient_fields([("gas", "density"), ("gas", "temperature")])
     expected = [
         ("gas", "density_gradient_x"),
@@ -265,13 +265,13 @@ def test_add_gradient_multiple_fields():
     ]
     assert_equal(actual, expected)
 
-    ds = fake_amr_ds(fields=("density", "temperature"))
+    ds = fake_amr_ds(fields=("density", "temperature"), units=("g/cm**3", "K"))
     actual = ds.add_gradient_fields(["density", "temperature"])
     assert_equal(actual, expected)
 
 
 def test_add_gradient_fields_curvilinear():
-    ds = fake_amr_ds(fields=["density"], geometry="spherical")
+    ds = fake_amr_ds(fields=["density"], units=["g/cm**3"], geometry="spherical")
     gfields = ds.add_gradient_fields(("gas", "density"))
     gfields += ds.add_gradient_fields(("index", "ones"))
     field_list = [

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -370,7 +370,7 @@ def fake_particle_ds(
     from yt.loaders import load_particles
 
     prng = RandomState(0x4D3D3D3)
-    if not is_sequence(negative):
+    if negative is not None and not is_sequence(negative):
         negative = [negative for f in fields]
 
     fields, units, negative = _check_field_unit_args_helper(

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -328,8 +328,8 @@ def fake_amr_ds(
         gdata = dict(
             level=level, left_edge=left_edge, right_edge=right_edge, dimensions=dims
         )
-        for f in fields:
-            gdata[f] = prng.random_sample(dims)
+        for f, u in zip(fields, units):
+            gdata[f] = (prng.random_sample(dims), u)
         if particles:
             for i, f in enumerate(f"particle_position_{ax}" for ax in "xyz"):
                 pdata = prng.random_sample(particles)

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -234,7 +234,10 @@ def fake_random_ds(
     else:
         assert len(ndims) == 3
     if not is_sequence(negative):
-        negative = [negative for f in fields]
+        if fields:
+            negative = [negative for f in fields]
+        else:
+            negative = None
 
     fields, units, negative = _check_field_unit_args_helper(
         {

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -188,11 +188,15 @@ def amrspace(extent, levels=7, cells=8):
     return left, right, level
 
 
+_fake_random_ds_default_fields = ("density", "velocity_x", "velocity_y", "velocity_z")
+_fake_random_ds_default_units = ("g/cm**3", "cm/s", "cm/s", "cm/s")
+
+
 def fake_random_ds(
     ndims,
     peak_value=1.0,
-    fields=("density", "velocity_x", "velocity_y", "velocity_z"),
-    units=("g/cm**3", "cm/s", "cm/s", "cm/s"),
+    fields=None,
+    units=None,
     particle_fields=None,
     particle_field_units=None,
     negative=False,
@@ -203,6 +207,16 @@ def fake_random_ds(
     bbox=None,
 ):
     from yt.loaders import load_uniform_grid
+
+    if fields is not None and units is None:
+        raise RuntimeError(
+            "Error when creating a fake_random_ds:"
+            " passed a non-default `fields` without specifying `units`."
+        )
+    if fields is None:
+        fields = _fake_random_ds_default_fields
+    if units is None:
+        units = _fake_random_ds_default_units
 
     prng = RandomState(0x4D3D3D3)
     if not is_sequence(ndims):

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -188,8 +188,28 @@ def amrspace(extent, levels=7, cells=8):
     return left, right, level
 
 
+def _check_field_unit_args_helper(args: dict, default_args: dict):
+    values = list(args.values())
+    keys = list(args.keys())
+    if all(v is None for v in values):
+        for key in keys:
+            args[key] = default_args[key]
+    elif None in values:
+        raise ValueError(
+            "Error in creating a fake dataset:"
+            f" either all or none of the following arguments need to specified: {keys}."
+        )
+    elif any(len(v) != len(values[0]) for v in values):
+        raise ValueError(
+            "Error in creating a fake dataset:"
+            f" all the following arguments must have the same length: {keys}."
+        )
+    return list(args.values())
+
+
 _fake_random_ds_default_fields = ("density", "velocity_x", "velocity_y", "velocity_z")
 _fake_random_ds_default_units = ("g/cm**3", "cm/s", "cm/s", "cm/s")
+_fake_random_ds_default_negative = (False, False, False, False)
 
 
 def fake_random_ds(
@@ -208,19 +228,6 @@ def fake_random_ds(
 ):
     from yt.loaders import load_uniform_grid
 
-    if (fields, units) == (None, None):
-        fields = _fake_random_ds_default_fields
-        units = _fake_random_ds_default_units
-    elif None in (fields, units):
-        raise ValueError(
-            "Error in creating a fake_random_ds:"
-            " `fields` and `units` keyword arguments cannot be used separately."
-        )
-    elif len(fields) != len(units):
-        raise ValueError(
-            f"inconsistent sizes in `fields` ({len(fields)}) and `units` ({len(units)}) arguments."
-        )
-
     prng = RandomState(0x4D3D3D3)
     if not is_sequence(ndims):
         ndims = [ndims, ndims, ndims]
@@ -228,7 +235,20 @@ def fake_random_ds(
         assert len(ndims) == 3
     if not is_sequence(negative):
         negative = [negative for f in fields]
-    assert len(fields) == len(negative)
+
+    fields, units, negative = _check_field_unit_args_helper(
+        {
+            "fields": fields,
+            "units": units,
+            "negative": negative,
+        },
+        {
+            "fields": _fake_random_ds_default_fields,
+            "units": _fake_random_ds_default_units,
+            "negative": _fake_random_ds_default_negative,
+        },
+    )
+
     offsets = []
     for n in negative:
         if n:
@@ -276,10 +296,25 @@ _geom_transforms = {
 }
 
 
+_fake_amr_ds_default_fields = ("Density",)
+_fake_amr_ds_default_units = ("g/cm**3",)
+
+
 def fake_amr_ds(
-    fields=("Density",), geometry="cartesian", particles=0, length_unit=None
+    fields=None, units=None, geometry="cartesian", particles=0, length_unit=None
 ):
     from yt.loaders import load_amr_grids
+
+    fields, units = _check_field_unit_args_helper(
+        {
+            "fields": fields,
+            "units": units,
+        },
+        {
+            "fields": _fake_amr_ds_default_fields,
+            "units": _fake_amr_ds_default_units,
+        },
+    )
 
     prng = RandomState(0x4D3D3D3)
     LE, RE = _geom_transforms[geometry]
@@ -311,18 +346,23 @@ def fake_amr_ds(
     )
 
 
+_fake_particle_ds_default_fields = (
+    "particle_position_x",
+    "particle_position_y",
+    "particle_position_z",
+    "particle_mass",
+    "particle_velocity_x",
+    "particle_velocity_y",
+    "particle_velocity_z",
+)
+_fake_particle_ds_default_units = ("cm", "cm", "cm", "g", "cm/s", "cm/s", "cm/s")
+_fake_particle_ds_default_negative = (False, False, False, False, True, True, True)
+
+
 def fake_particle_ds(
-    fields=(
-        "particle_position_x",
-        "particle_position_y",
-        "particle_position_z",
-        "particle_mass",
-        "particle_velocity_x",
-        "particle_velocity_y",
-        "particle_velocity_z",
-    ),
-    units=("cm", "cm", "cm", "g", "cm/s", "cm/s", "cm/s"),
-    negative=(False, False, False, False, True, True, True),
+    fields=None,
+    units=None,
+    negative=None,
     npart=16 ** 3,
     length_unit=1.0,
     data=None,
@@ -332,7 +372,20 @@ def fake_particle_ds(
     prng = RandomState(0x4D3D3D3)
     if not is_sequence(negative):
         negative = [negative for f in fields]
-    assert len(fields) == len(negative)
+
+    fields, units, negative = _check_field_unit_args_helper(
+        {
+            "fields": fields,
+            "units": units,
+            "negative": negative,
+        },
+        {
+            "fields": _fake_particle_ds_default_fields,
+            "units": _fake_particle_ds_default_units,
+            "negative": _fake_particle_ds_default_negative,
+        },
+    )
+
     offsets = []
     for n in negative:
         if n:

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -208,15 +208,18 @@ def fake_random_ds(
 ):
     from yt.loaders import load_uniform_grid
 
-    if fields is not None and units is None:
-        raise RuntimeError(
-            "Error when creating a fake_random_ds:"
-            " passed a non-default `fields` without specifying `units`."
-        )
-    if fields is None:
+    if (fields, units) == (None, None):
         fields = _fake_random_ds_default_fields
-    if units is None:
         units = _fake_random_ds_default_units
+    elif None in (fields, units):
+        raise ValueError(
+            "Error in creating a fake_random_ds:"
+            " `fields` and `units` keyword arguments cannot be used separately."
+        )
+    elif len(fields) != len(units):
+        raise ValueError(
+            f"inconsistent sizes in `fields` ({len(fields)}) and `units` ({len(units)}) arguments."
+        )
 
     prng = RandomState(0x4D3D3D3)
     if not is_sequence(ndims):

--- a/yt/utilities/lib/tests/test_geometry_utils.py
+++ b/yt/utilities/lib/tests/test_geometry_utils.py
@@ -13,6 +13,7 @@ from yt.utilities.lib.misc_utilities import (
 )
 
 _fields = ("density", "velocity_x", "velocity_y", "velocity_z")
+_units = ("g/cm**3", "cm/s", "cm/s", "cm/s")
 
 # TODO: error compact/spread bits for incorrect size
 # TODO: test msdb for [0,0], [1,1], [2,2] etc.
@@ -954,7 +955,7 @@ def test_knn_direct(seed=1):
 
 def test_obtain_position_vector():
     ds = fake_random_ds(
-        64, nprocs=8, fields=_fields, negative=[False, True, True, True]
+        64, nprocs=8, fields=_fields, units=_units, negative=[False, True, True, True]
     )
 
     dd = ds.sphere((0.5, 0.5, 0.5), 0.2)
@@ -970,7 +971,7 @@ def test_obtain_position_vector():
 
 def test_obtain_relative_velocity_vector():
     ds = fake_random_ds(
-        64, nprocs=8, fields=_fields, negative=[False, True, True, True]
+        64, nprocs=8, fields=_fields, units=_units, negative=[False, True, True, True]
     )
 
     dd = ds.all_data()

--- a/yt/utilities/tests/test_amr_kdtree.py
+++ b/yt/utilities/tests/test_amr_kdtree.py
@@ -6,7 +6,7 @@ from yt.testing import assert_almost_equal, fake_amr_ds
 
 
 def test_amr_kdtree_set_fields():
-    ds = fake_amr_ds(fields=["density", "pressure"])
+    ds = fake_amr_ds(fields=["density", "pressure"], units=["g/cm**3", "dyn/cm**2"])
     dd = ds.all_data()
 
     fields = ds.field_list

--- a/yt/visualization/tests/test_callbacks.py
+++ b/yt/visualization/tests/test_callbacks.py
@@ -67,7 +67,7 @@ def test_timestamp_callback():
     with _cleanup_fname() as prefix:
         ax = "z"
         vector = [1.0, 1.0, 1.0]
-        ds = fake_amr_ds(fields=("density",))
+        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
         p = ProjectionPlot(ds, ax, "density")
         p.annotate_timestamp()
         assert_fname(p.save(prefix)[0])
@@ -83,7 +83,7 @@ def test_timestamp_callback():
         p.save(prefix)
 
     with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density",), geometry="spherical")
+        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
         p = ProjectionPlot(ds, "r", "density")
         p.annotate_timestamp(coord_system="data")
         assert_raises(YTDataTypeUnsupported, p.save, prefix)
@@ -96,7 +96,7 @@ def test_scale_callback():
     with _cleanup_fname() as prefix:
         ax = "z"
         vector = [1.0, 1.0, 1.0]
-        ds = fake_amr_ds(fields=("density",))
+        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
         p = ProjectionPlot(ds, ax, "density")
         p.annotate_scale()
         assert_fname(p.save(prefix)[0])
@@ -124,7 +124,7 @@ def test_scale_callback():
         assert_raises(YTPlotCallbackError)
 
     with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density",), geometry="spherical")
+        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
         p = ProjectionPlot(ds, "r", "density")
         p.annotate_scale()
         assert_raises(YTDataTypeUnsupported, p.save, prefix)
@@ -137,7 +137,7 @@ def test_line_callback():
     with _cleanup_fname() as prefix:
         ax = "z"
         vector = [1.0, 1.0, 1.0]
-        ds = fake_amr_ds(fields=("density",))
+        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
         p = ProjectionPlot(ds, ax, "density")
         p.annotate_line([0.1, 0.1, 0.1], [0.5, 0.5, 0.5])
         assert_fname(p.save(prefix)[0])
@@ -155,7 +155,7 @@ def test_line_callback():
         p.save(prefix)
 
     with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density",), geometry="spherical")
+        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
         p = ProjectionPlot(ds, "r", "density")
         p.annotate_line([0.1, 0.1, 0.1], [0.5, 0.5, 0.5])
         assert_raises(YTDataTypeUnsupported, p.save, prefix)
@@ -168,7 +168,7 @@ def test_ray_callback():
     with _cleanup_fname() as prefix:
         ax = "z"
         vector = [1.0, 1.0, 1.0]
-        ds = fake_amr_ds(fields=("density",))
+        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
         ray = ds.ray((0.1, 0.2, 0.3), (0.6, 0.8, 0.5))
         oray = ds.ortho_ray(0, (0.3, 0.4))
         p = ProjectionPlot(ds, ax, "density")
@@ -190,7 +190,7 @@ def test_ray_callback():
         p.save(prefix)
 
     with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density",), geometry="spherical")
+        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
         ray = ds.ray((0.1, 0.2, 0.3), (0.6, 0.8, 0.5))
         oray = ds.ortho_ray(0, (0.3, 0.4))
         p = ProjectionPlot(ds, "r", "density")
@@ -205,7 +205,7 @@ def test_arrow_callback():
     with _cleanup_fname() as prefix:
         ax = "z"
         vector = [1.0, 1.0, 1.0]
-        ds = fake_amr_ds(fields=("density",))
+        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
         p = ProjectionPlot(ds, ax, "density")
         p.annotate_arrow([0.5, 0.5, 0.5])
         assert_fname(p.save(prefix)[0])
@@ -238,7 +238,7 @@ def test_arrow_callback():
         p.save(prefix)
 
     with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density",), geometry="spherical")
+        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
         p = ProjectionPlot(ds, "r", "density")
         p.annotate_arrow([0.5, 0.5, 0.5])
         assert_raises(YTDataTypeUnsupported, p.save, prefix)
@@ -251,7 +251,7 @@ def test_marker_callback():
     with _cleanup_fname() as prefix:
         ax = "z"
         vector = [1.0, 1.0, 1.0]
-        ds = fake_amr_ds(fields=("density",))
+        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
         p = ProjectionPlot(ds, ax, "density")
         p.annotate_marker([0.5, 0.5, 0.5])
         assert_fname(p.save(prefix)[0])
@@ -277,7 +277,7 @@ def test_marker_callback():
         p.save(prefix)
 
     with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density",), geometry="spherical")
+        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
         p = ProjectionPlot(ds, "r", "density")
         p.annotate_marker([0.5, 0.5, 0.5])
         assert_raises(YTDataTypeUnsupported, p.save, prefix)
@@ -289,7 +289,7 @@ def test_marker_callback():
 def test_particles_callback():
     with _cleanup_fname() as prefix:
         ax = "z"
-        ds = fake_amr_ds(fields=("density",), particles=1)
+        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), particles=1)
         p = ProjectionPlot(ds, ax, "density")
         p.annotate_particles((10, "Mpc"))
         assert_fname(p.save(prefix)[0])
@@ -312,7 +312,7 @@ def test_particles_callback():
         p.save(prefix)
 
     with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density",), geometry="spherical")
+        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
         p = ProjectionPlot(ds, "r", "density")
         p.annotate_particles((10, "Mpc"))
         assert_raises(YTDataTypeUnsupported, p.save, prefix)
@@ -322,7 +322,7 @@ def test_sphere_callback():
     with _cleanup_fname() as prefix:
         ax = "z"
         vector = [1.0, 1.0, 1.0]
-        ds = fake_amr_ds(fields=("density",))
+        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
         p = ProjectionPlot(ds, ax, "density")
         p.annotate_sphere([0.5, 0.5, 0.5], 0.1)
         assert_fname(p.save(prefix)[0])
@@ -338,7 +338,7 @@ def test_sphere_callback():
         p.save(prefix)
 
     with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density",), geometry="spherical")
+        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
         p = ProjectionPlot(ds, "r", "density")
         p.annotate_sphere([0.5, 0.5, 0.5], 0.1)
         assert_raises(YTDataTypeUnsupported, p.save, prefix)
@@ -351,7 +351,7 @@ def test_text_callback():
     with _cleanup_fname() as prefix:
         ax = "z"
         vector = [1.0, 1.0, 1.0]
-        ds = fake_amr_ds(fields=("density",))
+        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
         p = ProjectionPlot(ds, ax, "density")
         p.annotate_text([0.5, 0.5, 0.5], "dinosaurs!")
         assert_fname(p.save(prefix)[0])
@@ -369,7 +369,7 @@ def test_text_callback():
         p.save(prefix)
 
     with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density",), geometry="spherical")
+        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
         p = ProjectionPlot(ds, "r", "density")
         p.annotate_text([0.5, 0.5, 0.5], "dinosaurs!")
         assert_raises(YTDataTypeUnsupported, p.save, prefix)
@@ -426,6 +426,7 @@ def test_velocity_callback():
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(
             fields=("density", "velocity_r", "velocity_theta", "velocity_phi"),
+            units=("g/cm**3", "cm/s", "cm/s", "cm/s"),
             geometry="spherical",
         )
         p = ProjectionPlot(ds, "r", "density")
@@ -443,7 +444,13 @@ def test_magnetic_callback():
                 "magnetic_field_x",
                 "magnetic_field_y",
                 "magnetic_field_z",
-            )
+            ),
+            units=(
+                "g/cm**3",
+                "G",
+                "G",
+                "G",
+            ),
         )
         for ax in "xyz":
             p = ProjectionPlot(ds, ax, "density", weight_field="density")
@@ -487,6 +494,12 @@ def test_magnetic_callback():
                 "magnetic_field_theta",
                 "magnetic_field_phi",
             ),
+            units=(
+                "g/cm**3",
+                "G",
+                "G",
+                "G",
+            ),
             geometry="spherical",
         )
         p = ProjectionPlot(ds, "r", "density")
@@ -500,7 +513,10 @@ def test_magnetic_callback():
 @requires_file(cyl_3d)
 def test_quiver_callback():
     with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density", "velocity_x", "velocity_y", "velocity_z"))
+        ds = fake_amr_ds(
+            fields=("density", "velocity_x", "velocity_y", "velocity_z"),
+            units=("g/cm**3", "cm/s", "cm/s", "cm/s"),
+        )
         for ax in "xyz":
             p = ProjectionPlot(ds, ax, "density")
             p.annotate_quiver("velocity_x", "velocity_y")
@@ -546,6 +562,7 @@ def test_quiver_callback():
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(
             fields=("density", "velocity_x", "velocity_theta", "velocity_phi"),
+            units=("g/cm**3", "cm/s", "cm/s", "cm/s"),
             geometry="spherical",
         )
         p = ProjectionPlot(ds, "r", "density")
@@ -565,7 +582,7 @@ def test_quiver_callback():
 @requires_file(cyl_2d)
 def test_contour_callback():
     with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density", "temperature"))
+        ds = fake_amr_ds(fields=("density", "temperature"), units=("g/cm**3", "K"))
         for ax in "xyz":
             p = ProjectionPlot(ds, ax, "density")
             p.annotate_contour("temperature")
@@ -621,7 +638,11 @@ def test_contour_callback():
         assert_fname(slc.save(prefix)[0])
 
     with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density", "temperature"), geometry="spherical")
+        ds = fake_amr_ds(
+            fields=("density", "temperature"),
+            units=("g/cm**3", "K"),
+            geometry="spherical",
+        )
         p = SlicePlot(ds, "r", "density")
         p.annotate_contour(
             "temperature",
@@ -639,7 +660,7 @@ def test_contour_callback():
 @requires_file(cyl_2d)
 def test_grids_callback():
     with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density",))
+        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
         for ax in "xyz":
             p = ProjectionPlot(ds, ax, "density")
             p.annotate_grids()
@@ -672,7 +693,7 @@ def test_grids_callback():
         assert_fname(slc.save(prefix)[0])
 
     with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density",), geometry="spherical")
+        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
         p = SlicePlot(ds, "r", "density")
         p.annotate_grids(
             alpha=0.7,
@@ -691,7 +712,7 @@ def test_grids_callback():
 @requires_file(cyl_2d)
 def test_cell_edges_callback():
     with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density",))
+        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
         for ax in "xyz":
             p = ProjectionPlot(ds, ax, "density")
             p.annotate_cell_edges()
@@ -714,7 +735,7 @@ def test_cell_edges_callback():
         assert_fname(slc.save(prefix)[0])
 
     with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density",), geometry="spherical")
+        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
         p = SlicePlot(ds, "r", "density")
         p.annotate_cell_edges()
         assert_raises(YTDataTypeUnsupported, p.save, prefix)
@@ -742,7 +763,10 @@ def test_streamline_callback():
 
     with _cleanup_fname() as prefix:
 
-        ds = fake_amr_ds(fields=("density", "velocity_x", "velocity_y", "magvel"))
+        ds = fake_amr_ds(
+            fields=("density", "velocity_x", "velocity_y", "magvel"),
+            units=("g/cm**3", "cm/s", "cm/s", "cm/s"),
+        )
 
         for ax in "xyz":
 
@@ -807,6 +831,7 @@ def test_streamline_callback():
 
         ds = fake_amr_ds(
             fields=("density", "velocity_r", "velocity_theta", "velocity_phi"),
+            units=("g/cm**3", "cm/s", "cm/s", "cm/s"),
             geometry="spherical",
         )
         p = SlicePlot(ds, "r", "density")
@@ -818,7 +843,10 @@ def test_streamline_callback():
 @requires_file(cyl_3d)
 def test_line_integral_convolution_callback():
     with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density", "velocity_x", "velocity_y", "velocity_z"))
+        ds = fake_amr_ds(
+            fields=("density", "velocity_x", "velocity_y", "velocity_z"),
+            units=("g/cm**3", "cm/s", "cm/s", "cm/s"),
+        )
         for ax in "xyz":
             p = ProjectionPlot(ds, ax, "density")
             p.annotate_line_integral_convolution("velocity_x", "velocity_y")
@@ -867,6 +895,7 @@ def test_line_integral_convolution_callback():
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(
             fields=("density", "velocity_r", "velocity_theta", "velocity_phi"),
+            units=("g/cm**3", "cm/s", "cm/s", "cm/s"),
             geometry="spherical",
         )
         p = SlicePlot(ds, "r", "density")

--- a/yt/visualization/tests/test_callbacks.py
+++ b/yt/visualization/tests/test_callbacks.py
@@ -876,7 +876,8 @@ def test_line_integral_convolution_callback():
 
 def test_accepts_all_fields_decorator():
     fields = ["density", "velocity_x", "pressure", "temperature"]
-    ds = fake_random_ds(16, fields=fields)
+    units = ["g/cm**3", "cm/s", "dyn/cm**2", "K"]
+    ds = fake_random_ds(16, fields=fields, units=units)
     plot = SlicePlot(ds, "z", fields=fields)
 
     # mocking a class method

--- a/yt/visualization/tests/test_callbacks.py
+++ b/yt/visualization/tests/test_callbacks.py
@@ -384,7 +384,10 @@ def test_text_callback():
 @requires_file(cyl_3d)
 def test_velocity_callback():
     with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density", "velocity_x", "velocity_y", "velocity_z"))
+        ds = fake_amr_ds(
+            fields=("density", "velocity_x", "velocity_y", "velocity_z"),
+            units=("g/cm**3", "cm/s", "cm/s", "cm/s"),
+        )
         for ax in "xyz":
             p = ProjectionPlot(ds, ax, "density", weight_field="density")
             p.annotate_velocity()

--- a/yt/visualization/tests/test_filters.py
+++ b/yt/visualization/tests/test_filters.py
@@ -8,7 +8,7 @@ from yt.testing import fake_amr_ds, requires_module
 
 @requires_module("scipy")
 def test_white_noise_filter():
-    ds = fake_amr_ds(fields=("density",))
+    ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
     p = ds.proj("density", "z")
     frb = p.to_frb((1, "unitary"), 64)
     frb.apply_white_noise()
@@ -18,7 +18,7 @@ def test_white_noise_filter():
 
 @requires_module("scipy")
 def test_gauss_beam_filter():
-    ds = fake_amr_ds(fields=("density",))
+    ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
     p = ds.proj("density", "z")
     frb = p.to_frb((1, "unitary"), 64)
     frb.apply_gauss_beam(nbeam=15, sigma=1.0)

--- a/yt/visualization/tests/test_profile_plots.py
+++ b/yt/visualization/tests/test_profile_plots.py
@@ -58,7 +58,7 @@ def test_phase_plot_attributes():
     y_field = "temperature"
     z_field = "cell_mass"
     decimals = 12
-    ds = fake_random_ds(16, fields=("density", "temperature"))
+    ds = fake_random_ds(16, fields=("density", "temperature"), units=("g/cm**3", "K"))
     for attr_name in ATTR_ARGS.keys():
         for args in ATTR_ARGS[attr_name]:
             test = PhasePlotAttributeTest(
@@ -153,7 +153,8 @@ def test_phase_plot():
 @attr(ANSWER_TEST_TAG)
 def test_profile_plot_multiple_field_multiple_plot():
     fields = ("density", "temperature", "dark_matter_density")
-    ds = fake_random_ds(16, fields=fields)
+    units = ("g/cm**3", "K", "g/cm**3")
+    ds = fake_random_ds(16, fields=fields, units=units)
     sphere = ds.sphere("max", (1.0, "Mpc"))
     profiles = []
     profiles.append(

--- a/yt/visualization/volume_rendering/tests/test_lenses.py
+++ b/yt/visualization/volume_rendering/tests/test_lenses.py
@@ -30,7 +30,7 @@ class LensTest(TestCase):
             self.curdir, self.tmpdir = None, None
 
         self.field = ("gas", "density")
-        self.ds = fake_random_ds(32, fields=self.field)
+        self.ds = fake_random_ds(32, fields=(self.field,), units=("g/cm**3",))
         self.ds.index
 
     def tearDown(self):


### PR DESCRIPTION
## PR Summary

`fake_random_ds` does not check that units are passed when it receives custom fields. This implicitly assumes that the units of the four first fields are `("g/cm**3", "cm/s", "cm/s", "cm/s")`).

This PR changes the behaviour by raising an exception when the some fields are passed by no units are passed.

```ipython
In [1]: from yt.testing import fake_random_ds
   ...: ds = fake_random_ds(16, fields=["density", "velocity_x", "pressure", "te
   ...: mperature"])
   ...: print(ds.r["density"].units)
   ...: print(ds.r["temperature"].units)
g/cm**3   # this is fine
cm/s      # this is not fine
```

[EDIT]: This PR allowed me to realise that some answer tests are plain wrong, see e.g the one attached (temperatures in cm/s ?!)
![image](https://user-images.githubusercontent.com/5411875/108888886-088bd900-760c-11eb-91b8-8f688a22a662.png)
After this PR, I obtain:
![image](https://user-images.githubusercontent.com/5411875/108888975-19d4e580-760c-11eb-9fca-49d63a5dc1f7.png)



