### PR TITLE
hotfix: avoid a deprecation warning in enzo frontend (periodicity)

### DIFF
--- a/yt/frontends/enzo/data_structures.py
+++ b/yt/frontends/enzo/data_structures.py
@@ -852,7 +852,7 @@ class EnzoDataset(Dataset):
             else:
                 self.parameters[param] = vals
         self.refine_by = self.parameters["RefineBy"]
-        self._periodicity = tuple(
+        _periodicity = tuple(
             always_iterable(self.parameters["LeftFaceBoundaryCondition"] == 3)
         )
         self.dimensionality = self.parameters["TopGridRank"]
@@ -866,7 +866,7 @@ class EnzoDataset(Dataset):
                 tmp = self.domain_dimensions.tolist()
                 tmp.append(1)
                 self.domain_dimensions = np.array(tmp)
-                self.periodicity += (False,)
+                _periodicity += (False,)
             self.domain_left_edge = np.array(
                 self.parameters["DomainLeftEdge"], "float64"
             ).copy()
@@ -883,7 +883,9 @@ class EnzoDataset(Dataset):
             self.domain_dimensions = np.array(
                 [self.parameters["TopGridDimensions"], 1, 1]
             )
-            self.periodicity += (False, False)
+            _periodicity += (False, False)
+        assert len(_periodicity) == 3
+        self._periodicity = _periodicity
 
         self.gamma = self.parameters["Gamma"]
         if self.parameters["ComovingCoordinates"]:


### PR DESCRIPTION
## PR Summary

avoid raising the following warning
```
VisibleDeprecationWarning: Dataset.periodicity should not be overriden manually. In the future, this will become an error. Use `Dataset.force_periodicity` instead.
  Deprecated since v4.0.0 . This feature will be removed in v4.1.0
    self.periodicity += (False, False)
```