### PR TITLE
fix a string formatting error in yt.set_log_level

### DIFF
--- a/yt/utilities/logger.py
+++ b/yt/utilities/logger.py
@@ -54,7 +54,7 @@ def set_log_level(level):
     if level == "ALL":  # non-standard alias
         level = 1
     ytLogger.setLevel(level)
-    ytLogger.debug("Set log level to %d", level)
+    ytLogger.debug("Set log level to %s", level)
 
 
 ufstring = "%(name)-3s: [%(levelname)-9s] %(asctime)s %(message)s"


### PR DESCRIPTION
## PR Summary

Currently, the following scripts runs correctly _but_ prints out a error message
```python
import yt
yt.set_log_level("debug")
```

error:
```
...
TypeError: %d format: a number is required, not str
...
```

This fixes it; `%s` will also work with integers