### PR TITLE
make requests a first class dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -148,6 +148,7 @@ if __name__ == "__main__":
             "more_itertools>=8.4",
             "tqdm>=3.4.0",
             "toml>=0.10.2",
+            "requests>=2.20.0",
         ],
         extras_require={"hub": ["girder_client"], "mapserver": ["bottle"]},
         cmdclass={"sdist": sdist, "build_ext": build_ext},

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -10,7 +10,6 @@ nose-timer~=1.0.0
 nose~=1.3.7
 pandas~=1.1.2
 pytest~=5.2
-requests~=2.20.0
 scipy~=1.5.0
 sympy~=1.5
 pyqt5~=5.15.2

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -8,6 +8,7 @@ from re import finditer
 from tempfile import NamedTemporaryFile, TemporaryFile
 
 import numpy as np
+import requests
 from tqdm import tqdm
 
 from yt.config import ytcfg
@@ -2559,8 +2560,6 @@ class YTSurface(YTSelectionContainer3D):
 
     @parallel_root_only
     def _upload_to_sketchfab(self, data, files):
-        import requests
-
         SKETCHFAB_DOMAIN = "sketchfab.com"
         SKETCHFAB_API_URL = f"https://api.{SKETCHFAB_DOMAIN}/v2/models"
         SKETCHFAB_MODEL_URL = f"https://{SKETCHFAB_DOMAIN}/models/"

--- a/yt/frontends/http_stream/data_structures.py
+++ b/yt/frontends/http_stream/data_structures.py
@@ -2,10 +2,10 @@ import json
 import time
 
 import numpy as np
+import requests
 
 from yt.data_objects.static_output import ParticleDataset, ParticleFile
 from yt.frontends.sph.fields import SPHFieldInfo
-from yt.funcs import get_requests
 from yt.geometry.particle_geometry_handler import ParticleIndex
 
 
@@ -30,8 +30,6 @@ class HTTPStreamDataset(ParticleDataset):
         index_order=None,
         index_filename=None,
     ):
-        if get_requests() is None:
-            raise ImportError("This functionality depends on the requests package")
         self.base_url = base_url
         super().__init__(
             "",
@@ -50,7 +48,6 @@ class HTTPStreamDataset(ParticleDataset):
         self.parameters["HydroMethod"] = "sph"
 
         # Here's where we're going to grab the JSON index file
-        requests = get_requests()
         hreq = requests.get(self.base_url + "/yt_index.json")
         if hreq.status_code != 200:
             raise RuntimeError
@@ -97,9 +94,7 @@ class HTTPStreamDataset(ParticleDataset):
     def _is_valid(cls, filename, *args, **kwargs):
         if not filename.startswith("http://"):
             return False
-        requests = get_requests()
-        if requests is None:
-            return False
+
         hreq = requests.get(filename + "/yt_index.json")
         if hreq.status_code == 200:
             return True

--- a/yt/frontends/http_stream/io.py
+++ b/yt/frontends/http_stream/io.py
@@ -1,6 +1,7 @@
 import numpy as np
+import requests
 
-from yt.funcs import get_requests, mylog
+from yt.funcs import mylog
 from yt.utilities.io_handler import BaseIOHandler
 
 
@@ -9,8 +10,6 @@ class IOHandlerHTTPStream(BaseIOHandler):
     _vector_fields = ("Coordinates", "Velocity", "Velocities")
 
     def __init__(self, ds):
-        if get_requests() is None:
-            raise ImportError("This functionality depends on the requests package")
         self._url = ds.base_url
         # This should eventually manage the IO and cache it
         self.total_bytes = 0
@@ -21,7 +20,6 @@ class IOHandlerHTTPStream(BaseIOHandler):
         ftype, fname = field
         s = f"{self._url}/{data_file.file_id}/{ftype}/{fname}"
         mylog.info("Loading URL %s", s)
-        requests = get_requests()
         resp = requests.get(s)
         if resp.status_code != 200:
             raise RuntimeError

--- a/yt/frontends/sdf/data_structures.py
+++ b/yt/frontends/sdf/data_structures.py
@@ -2,9 +2,10 @@ import contextlib
 import os
 
 import numpy as np
+import requests
 
 from yt.data_objects.static_output import ParticleDataset, ParticleFile
-from yt.funcs import get_requests, setdefaultattr
+from yt.funcs import setdefaultattr
 from yt.geometry.particle_geometry_handler import ParticleIndex
 from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.sdf import HTTPSDFRead, SDFIndex, SDFRead
@@ -185,9 +186,6 @@ class SDFDataset(ParticleDataset):
     def _is_valid(cls, filename, *args, **kwargs):
         sdf_header = kwargs.get("sdf_header", filename)
         if sdf_header.startswith("http"):
-            requests = get_requests()
-            if requests is None:
-                return False
             hreq = requests.get(sdf_header, stream=True)
             if hreq.status_code != 200:
                 return False

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -25,6 +25,7 @@ from numbers import Number as numeric_type
 
 import matplotlib
 import numpy as np
+import requests
 from more_itertools import always_iterable, collapse, first
 from tqdm import tqdm
 
@@ -644,14 +645,6 @@ def get_script_contents():
 
 
 def download_file(url, filename):
-    requests = get_requests()
-    if requests is None:
-        return simple_download_file(url, filename)
-    else:
-        return fancy_download_file(url, filename, requests)
-
-
-def fancy_download_file(url, filename, requests=None):
     response = requests.get(url, stream=True)
     total_length = response.headers.get("content-length")
 
@@ -674,16 +667,15 @@ def fancy_download_file(url, filename, requests=None):
     return filename
 
 
-def simple_download_file(url, filename):
-    class MyURLopener(urllib.request.FancyURLopener):
-        def http_error_default(self, url, fp, errcode, errmsg, headers):
-            raise RuntimeError(
-                "Attempt to download file from %s failed with error %s: %s."
-                % (url, errcode, errmsg)
-            )
+def fancy_download_file(url, filename):
+    from yt._maintenance.deprecation import issue_deprecation_warning
 
-    fn, h = MyURLopener().retrieve(url, filename)
-    return fn
+    issue_deprecation_warning(
+        "`yt.funcs.fancy_downwload_file` is now an alias of `yt.funcs.download_file`.",
+        since="4.0.0",
+        removal="4.1.0",
+    )
+    return download_file(url, filename)
 
 
 # This code snippet is modified from Georg Brandl
@@ -1080,14 +1072,6 @@ def get_brewer_cmap(cmap):
     else:
         raise RuntimeError("Please install palettable to use colorbrewer colormaps")
     return bmap.get_mpl_colormap(N=cmap[2])
-
-
-def get_requests():
-    try:
-        import requests
-    except ImportError:
-        requests = None
-    return requests
 
 
 @contextlib.contextmanager

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -13,6 +13,7 @@ import urllib.request
 from urllib.parse import urlparse
 
 import numpy as np
+import requests
 from more_itertools import always_iterable
 from tqdm import tqdm
 
@@ -802,10 +803,6 @@ class YTHubRegisterCmd(YTCommand):
         """
 
     def __call__(self, args):
-        try:
-            import requests
-        except ImportError as e:
-            raise YTCommandRequiresModule("requests") from e
         hub_api_key, config_file = ytcfg.get(
             "yt",
             "hub_api_key",
@@ -1617,11 +1614,6 @@ class YTUploadFileCmd(YTCommand):
     name = "upload"
 
     def __call__(self, args):
-        try:
-            import requests
-        except ImportError as e:
-            raise YTCommandRequiresModule("requests") from e
-
         fs = iter(FileStreamer(open(args.file, "rb")))
         upload_url = ytcfg.get("yt", "curldrop_upload_url")
         r = requests.put(upload_url + "/" + os.path.basename(args.file), data=fs)


### PR DESCRIPTION
## PR Summary

It seems that we in a bunch of places the code base dances around importing requests because it's not a mandatory dependency. The ways in which we avoid making it mandatory are however pretty inconsistent with each other, creating a small but noticeable amount of technical debt. Additionally, I'm suspecting that the reason it wasn't made a first class dependency originally was that the project was young and unstable. I think it is reasonable now to make it a direct and mandatory dependency, especially taking into account the fact that it is now a dependency of many other projects in the ecosystem, I'm fairly convinced almost everyone installs it already by virtue of transitive dependencies.

alternatively, if we decide not to make it a mandatory dependency, we should at least uniformise the "dancing". Here I'm just going with the easy (and easy to maintain) option.