### PR TITLE
ENH: (optional) rich-based logging (YTEP-0039)

### DIFF
--- a/doc/source/developing/building_the_docs.rst
+++ b/doc/source/developing/building_the_docs.rst
@@ -189,7 +189,7 @@ and build it using Sphinx:
 If all of the dependencies are installed and all of the test data is in the
 testing directory, this should churn away for a while (several hours) and
 eventually generate a docs build.  We suggest setting
-:code:`suppress_stream_logging = True` in your yt configuration (See
+:code:`logging.stream = "none"` in your yt configuration (See
 :ref:`configuration-file`) to suppress large amounts of debug output from
 yt.
 

--- a/doc/source/reference/command-line.rst
+++ b/doc/source/reference/command-line.rst
@@ -331,24 +331,25 @@ Listing current content of the config file:
 .. code-block:: bash
 
    $ yt config list
-   [yt]
-   log_level = 50
+   [logging]
+   level = "CRITICAL"
 
 Obtaining a single config value by name:
 
 .. code-block:: bash
 
-   $ yt config get yt log_level
-   50
+   $ yt config get logging.level
+   "CRITICAL"
 
 Changing a single config value:
 
 .. code-block:: bash
 
-   $ yt config set yt log_level 10
+   $ yt config set logging.level DEBUG
+
 
 Removing a single config entry:
 
 .. code-block:: bash
 
-   $ yt config rm yt log_level
+   $ yt config rm logging.level

--- a/doc/source/reference/configuration.rst
+++ b/doc/source/reference/configuration.rst
@@ -30,7 +30,7 @@ like:
 .. code-block:: none
 
    [yt]
-   log_level = 1
+   logging.level = "ALL"
    maximum_stored_datasets = 10000
 
 This configuration file would set the logging threshold much lower, enabling
@@ -43,7 +43,7 @@ options from the configuration file, e.g.:
 
    $ yt config -h
    $ yt config list
-   $ yt config set yt log_level 1
+   $ yt config set logging.level ALL
    $ yt config rm yt maximum_stored_datasets
 
 
@@ -64,7 +64,7 @@ options, and display the path to the local configuration file, e.g.:
 
    $ yt config -h
    $ yt config list --local
-   $ yt config set --local yt log_level 1
+   $ yt config set --local logging.level ALL
    $ yt config rm --local yt maximum_stored_datasets
    $ yt config print-path --local
 
@@ -97,7 +97,7 @@ Here is an example script, where we adjust the logging at startup:
    ds = yt.load("my_data0001")
    ds.print_stats()
 
-This has the same effect as setting ``log_level = 1`` in the configuration
+This has the same effect as setting ``logging.level = "ALL"`` in the configuration
 file. Note that a log level of 1 means that all log messages are printed to
 stdout.  To disable logging, set the log level to 50.
 
@@ -110,12 +110,9 @@ Available Configuration Options
 The following external parameters are available.  A number of parameters are
 used internally.
 
-* ``colored_logs`` (default: ``False``): Should logs be colored?
 * ``default_colormap`` (default: ``arbre``): What colormap should be used by
   default for yt-produced images?
 * ``plugin_filename``  (default ``my_plugins.py``) The name of our plugin file.
-* ``log_level`` (default: ``20``): What is the threshold (0 to 50) for
-  outputting log files?
 * ``test_data_dir`` (default: ``/does/not/exist``): The default path the
   ``load()`` function searches for datasets when it cannot find a dataset in the
   current directory.
@@ -137,10 +134,6 @@ used internally.
   :ref:`object serialization <object-serialization>`
 * ``sketchfab_api_key`` (default: empty): API key for https://sketchfab.com/ for
   uploading AMRSurface objects.
-* ``suppress_stream_logging`` (default: ``False``): If true, execution mode will be
-  quiet.
-* ``stdout_stream_logging`` (default: ``False``): If true, logging is directed
-  to stdout rather than stderr
 * ``skip_dataset_cache`` (default: ``False``): If true, automatic caching of datasets
   is turned off.
 * ``supp_data_dir`` (default: ``/does/not/exist``): The default path certain
@@ -183,6 +176,52 @@ as illustrated below in the deposit block.
 
   [plot.deposit]
   path_length_units = "kpc"  # use kpc for deposition projections
+
+
+
+  .. _logging-config:
+
+Logging Configuration Options
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Logging-related arguments are gathered in a dedicated section
+* ``logging.use_color`` (default: ``False``). In a future version of yt, the default value
+   will be changed to ``True``.
+* ``logging.stream`` (default: ``stderr``): select the stream where logs should be outputed
+  (choices ``stderr``, ``stdout`` or ``none`` to suppress logs completely)
+* ``logging.handler`` (default: ``"legacy"``. This default value will be changed to 
+  ``"rich"`` in a follow up release): select the logging handler. ``rich`` is the prefered
+  option and future default value but is considered experimental for now. Use ``legacy`` if
+  you need backwards compatibility in your logs' format.
+* ``logging.level`` (default: ``"INFO"``): select the minimal level of logs you
+   want displayed (lower levels might be pretty verbose). Choices by increasing
+   level of severity:
+   ``"ALL"``,  ``"DEBUG"``,  ``"INFO"``,  ``"WARNING"``,  ``"ERROR"``,  ``"CRITICAL"``.
+   This option is case-insensitive, and defaults to ``"INFO"``.
+
+The options hereafter are only available with ``logging.handler = "rich"``
+* ``logging.format`` (default: ``"%(message)s"``): customize the log message format. For
+  instance, if your application uses a separate logger, you might want to change this to
+  ``"%(name)s: %(message)s`` so that each log from yt will be signed (``"yt:  "``).
+* ``data_format`` (default: ``"[%m/%d/%Y %H:%M:%S]"``): customize the date format.
+  Note that brackets in the default value are purely stylistic and are not required.
+* ``logging.custom_theme`` (default: ``""``): Specify a path to an arbitrary ``rich`` theme
+  file to override the default. 
+  See `Rich's documentation<https://rich.readthedocs.io/en/stable/style.html#loading-themes>`_.
+* ``logging.width`` (default: ``-1``, meaning "automatic"): set the total width (in
+  columns/characters) of logs, including timestamps, level, and source path. A realistic
+  minimal value of ~80 is recommended.
+
+The following options are still usable for backward compatibility as of yt 4.0.0, but they
+will be removed in a following release
+* ``colored_logs`` (default: ``False``): Should logs be colored? (use ``logging.use_color``
+  instead)
+* ``log_level`` (default: ``20``): What is the threshold (0 to 50) for outputting log files?
+  (use ``logging.level`` instead)
+* ``suppress_stream_logging`` (default: ``False``): If true, execution mode will be
+   quiet. (use ``logging.stream`` instead)
+* ``stdout_stream_logging`` (default: ``False``): If true, logging is directed
+   to stdout rather than stderr (use ``logging.stream`` instead).
 
 
 .. _plugin-file:

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ install_requires =
     numpy>=1.13.3
     packaging>=20.9
     pyyaml>=4.2b1
+    rich>=9.12.0
     setuptools>=19.6
     sympy>=1.2,<1.9
     toml>=0.10.2

--- a/tests/ci_install.sh
+++ b/tests/ci_install.sh
@@ -29,7 +29,7 @@ esac
 # Disable excessive output
 mkdir -p $HOME/.config/yt
 echo "[yt]" > $HOME/.config/yt/yt.toml
-echo "suppress_stream_logging = true" >> $HOME/.config/yt/yt.toml
+echo 'logging.stream = "none"' >> $HOME/.config/yt/yt.toml
 cat $HOME/.config/yt/yt.toml
 # Sets default backend to Agg
 cp tests/matplotlibrc .

--- a/yt/config.py
+++ b/yt/config.py
@@ -227,7 +227,10 @@ class YTConfig:
         if "colored_logs" in self["yt"]:
             self["logging", "use_color"] = self["yt", "colored_logs"]
 
-        if "stdout_stream_logging" in self["yt"] and self["yt", "std_stream_logging"]:
+        if (
+            "stdout_stream_logging" in self["yt"]
+            and self["yt", "stdout_stream_logging"]
+        ):
             self["logging", "stream"] = "stdout"
 
         if (

--- a/yt/data_objects/particle_trajectories.py
+++ b/yt/data_objects/particle_trajectories.py
@@ -2,10 +2,11 @@ import numpy as np
 
 from yt.config import ytcfg
 from yt.data_objects.field_data import YTFieldData
-from yt.funcs import get_pbar, mylog
+from yt.funcs import get_pbar
 from yt.units.yt_array import array_like_field
 from yt.utilities.exceptions import YTIllDefinedParticleData
 from yt.utilities.lib.particle_mesh_operations import CICSample_3
+from yt.utilities.logger import set_log_level
 from yt.utilities.on_demand_imports import _h5py as h5py
 from yt.utilities.parallel_tools.parallel_analysis_interface import parallel_root_only
 
@@ -77,8 +78,8 @@ class ParticleTrajectories:
             fields = []
 
         if self.suppress_logging:
-            old_level = int(ytcfg.get("yt", "log_level"))
-            mylog.setLevel(40)
+            old_level = ytcfg.get("logging", "level")
+            set_log_level("ERROR")
         ds_first = self.data_series[0]
         dd_first = ds_first.all_data()
 
@@ -117,7 +118,7 @@ class ParticleTrajectories:
         pbar.finish()
 
         if self.suppress_logging:
-            mylog.setLevel(old_level)
+            set_log_level(old_level)
 
         sorted_storage = sorted(my_storage.items())
         _fn, (time, *_) = sorted_storage[0]
@@ -224,8 +225,8 @@ class ParticleTrajectories:
             return
 
         if self.suppress_logging:
-            old_level = int(ytcfg.get("yt", "log_level"))
-            mylog.setLevel(40)
+            old_level = ytcfg.get("logging", "level")
+            set_log_level("ERROR")
         ds_first = self.data_series[0]
         dd_first = ds_first.all_data()
 
@@ -304,7 +305,7 @@ class ParticleTrajectories:
             self.field_data[field] = array_like_field(dd_first, output_field.copy(), fd)
 
         if self.suppress_logging:
-            mylog.setLevel(old_level)
+            set_log_level(old_level)
 
     def trajectory_from_index(self, index):
         """

--- a/yt/data_objects/tests/test_ellipsoid.py
+++ b/yt/data_objects/tests/test_ellipsoid.py
@@ -5,8 +5,9 @@ from yt.testing import assert_array_less, fake_random_ds
 
 def setup():
     from yt.config import ytcfg
+    from yt.utilities.logger import set_log_level
 
-    ytcfg["yt", "log_level"] = 50
+    set_log_level("CRITICAL")
     ytcfg["yt", "internals", "within_testing"] = True
 
 

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -347,7 +347,7 @@ def get_pbar(title, maxval):
     from yt.config import ytcfg
 
     if (
-        ytcfg.get("yt", "suppress_stream_logging")
+        ytcfg.get("logging", "stream") == "none"
         or ytcfg.get("yt", "internals", "within_testing")
         or maxval == 1
         or not is_root()

--- a/yt/startup_tasks.py
+++ b/yt/startup_tasks.py
@@ -14,6 +14,7 @@ from yt.funcs import (
     signal_print_traceback,
 )
 from yt.utilities import rpdb
+from yt.utilities.logger import set_log_level
 
 exe_name = os.path.basename(sys.executable)
 # At import time, we determined whether or not we're being run in parallel.
@@ -80,8 +81,10 @@ class SetConfigOption(argparse.Action):
         param, val = values.split("=")
         mylog.debug("Overriding config: %s = %s", param, val)
         ytcfg["yt", param] = val
-        if param == "log_level":  # special case
-            mylog.setLevel(int(val))
+
+        # TODO: check this
+        if param == "logging.level":  # special case
+            set_log_level(val)
 
 
 class YTParser(argparse.ArgumentParser):

--- a/yt/utilities/configure.py
+++ b/yt/utilities/configure.py
@@ -49,7 +49,8 @@ def write_config(config_file):
 
 def migrate_config():
     if not os.path.exists(old_config_file()):
-        print("Old config not found.")
+    from yt.utilities.logger import ytLogger as mylog
+        print("Old config not found.", file=sys.stderr)
         sys.exit(1)
 
     old_config = configparser.RawConfigParser()
@@ -81,10 +82,13 @@ def migrate_config():
             cast_value = _cast_value_helper(value)
 
             # Normalize the key (if present in the defaults)
-            if normalize_key(key) in old_keys_to_new and section == "yt":
-                new_key = old_keys_to_new[normalize_key(key)]
-            else:
+            if not (normalize_key(key) in old_keys_to_new and section == "yt"):
+                mylog.warning(
+                    "Found unknown option `%s` while migrating. Conserving it.", key
+                )
                 new_key = key
+            else:
+                new_key = old_keys_to_new[normalize_key(key)]
 
             config_as_dict[section][new_key] = cast_value
 

--- a/yt/utilities/configure.py
+++ b/yt/utilities/configure.py
@@ -48,8 +48,9 @@ def write_config(config_file):
 
 
 def migrate_config():
-    if not os.path.exists(old_config_file()):
     from yt.utilities.logger import ytLogger as mylog
+
+    if not os.path.exists(old_config_file()):
         print("Old config not found.", file=sys.stderr)
         sys.exit(1)
 
@@ -72,6 +73,18 @@ def migrate_config():
 
     old_keys_to_new = {normalize_key(k): k for k in ytcfg_defaults["yt"].keys()}
 
+    # YTEP-0039: special cases
+    # colored_logs is directly converted to a new but perfectly equivalent option
+    # while other deprecated options are kept for backwards compatibility
+    # (will migrate them properly later, but they require more fine tuning)
+    old_keys_to_new.update(
+        {
+            "loglevel": "log_level",
+            "stdoutStreamLogging": "stdout_stream_logging",
+            "suppressstreamlogging": "suppress_stream_logging",
+            "colored_logs": "logging.use_color",
+        }
+    )
     config_as_dict = {}
     for section in old_config:
         if section == "DEFAULT":

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -1,7 +1,10 @@
 # We don't need to import 'exceptions'
 import os.path
+from typing import Any, Optional, Sequence
 
 from unyt.exceptions import UnitOperationError
+
+from yt.config import ytcfg
 
 
 class YTException(Exception):
@@ -927,6 +930,20 @@ class YTArrayTooLargeToDisplay(YTException):
         msg = f"The requested array is of size {self.size}.\n"
         msg += "We do not support displaying arrays larger\n"
         msg += f"than size {self.max_size}."
+        return msg
+
+
+class YTConfigError(YTException):
+    def __init__(self, key: str, choices: Optional[Sequence[Any]] = None) -> None:
+        self.key = key
+        self.value = ytcfg.get(*(key.split(".")))
+        self.choices = choices
+
+    def __str__(self) -> str:
+        msg = f"Unrecognised value for {self.key} in config file '{self.value}'."
+        if self.choices is not None:
+            choices_repr = "\n".join(self.choices)
+            msg += f" Possible values are\n{choices_repr}"
         return msg
 
 

--- a/yt/utilities/monochrome_logger_theme.ini
+++ b/yt/utilities/monochrome_logger_theme.ini
@@ -1,0 +1,12 @@
+[styles]
+log.level = none
+log.message = none
+log.path =
+log.time =
+logging.keyword =
+logging.level.critical =
+logging.level.debug =
+logging.level.error =
+logging.level.info =
+logging.level.notset =
+logging.level.warning =

--- a/yt/utilities/parallel_tools/parallel_analysis_interface.py
+++ b/yt/utilities/parallel_tools/parallel_analysis_interface.py
@@ -10,7 +10,7 @@ import numpy as np
 from more_itertools import always_iterable
 
 import yt.utilities.logger
-from yt.config import ytcfg
+from yt.config import loglevel_str2int, ytcfg
 from yt.data_objects.image_array import ImageArray
 from yt.funcs import is_sequence
 from yt.units.unit_registry import UnitRegistry
@@ -112,7 +112,10 @@ def enable_parallelism(suppress_logging=False, communicator=None):
     ytcfg["yt", "internals", "parallel"] = True
     if exe_name == "embed_enzo" or ("_parallel" in dir(sys) and sys._parallel):
         ytcfg["yt", "inline"] = True
-    yt.utilities.logger.uncolorize_logging()
+
+    if ytcfg.get("logging", "handler") == "legacy":
+        yt.utilities.logger.uncolorize_logging()
+
     # Even though the uncolorize function already resets the format string,
     # we reset it again so that it includes the processor.
     f = logging.Formatter(
@@ -126,7 +129,7 @@ def enable_parallelism(suppress_logging=False, communicator=None):
     else:
         sys.excepthook = default_mpi_excepthook
 
-    if ytcfg.get("yt", "log_level") < 20:
+    if loglevel_str2int(ytcfg.get("logging", "level")) < logging.INFO:
         yt.utilities.logger.ytLogger.warning(
             "Log Level is set low -- this could affect parallel performance!"
         )

--- a/yt/utilities/tests/test_set_log_level.py
+++ b/yt/utilities/tests/test_set_log_level.py
@@ -7,7 +7,7 @@ def test_valid_level():
     # - case-insensitivity
     # - integer values
     # - "all" alias, which isn't standard
-    for lvl in ("all", "ALL", 10, 42, "info", "warning", "ERROR", "CRITICAL"):
+    for lvl in ("all", "ALL", 10, "info", "warning", "ERROR", "CRITICAL"):
         set_log_level(lvl)
 
 
@@ -16,4 +16,4 @@ def test_invalid_level():
     # since they are perfectly clear and readable, we check that nothing else
     # happens in the wrapper
     assert_raises(TypeError, set_log_level, 1.5)
-    assert_raises(ValueError, set_log_level, "invalid_level")
+    assert_raises(KeyError, set_log_level, "invalid_level")


### PR DESCRIPTION
## PR Summary

This is the first PR in support to [YTEP-0039](https://github.com/yt-project/ytep/pull/18)
This is also the first PR that's _enabled_ by @cphyc's work with the new config file (#2981)
A side effect of modernising the log-related configuration is that this PR actually fixes some bugs here and there.
In particular, this improve the setter `yt.utilities.logger.set_log_level` to enforce a consistent state between the shared configuration object `ytcfg` and the logger's current log level. Using this setter everywhere instead of `mylog.setLevel` is then more robust.

I've also found some bugs in the command line configuration tool `yt config`, so I'm fixing them as well (tests are only at the draft stage).

## PR Checklist

- [x] New features are documented, with docstrings and narrative docs
- [x] complete implementation of the YTEP specification for a yt.logging config file section
- [x] Add default values for this section
- [x] add documentation

Proposed release cycle:
- targeting yt 4.0: offer rich logging as an experimental option (opt-in) and don't change anything with the legacy log style.
- next minor/major release after 4.0: consider the feature stable, keep "legacy" as the default handler but raise visible deprecation warnings (offer an automated migration script at this point).
- next one after that: make rich logging the default.

Hopefully the feature will be well received and tested in its experimental phase. If not, we can keep it experimental for longer or even not make it the default ever.

Notes for documentation and reviewers 
- `use_color=False` won't play nicely with `custom_theme = "my/awesome/rich/theme.ini"` because deactivating colors requires using a theme file already and there's no trivial way to patch them. It may not look like it's worth exposing the `custom_theme` argument but I don't want to undermine colorblind folks out there so I want all users to have the option of setting colors themeselves. This is the easiest and most permissive way to do so.
- I'm keeping changes to the config file migration script (`yt config migrate`) minimal here. It's already complicated enough and I don't think this change is worth taking the risk to break it. It may however become necessary to provide a separate migration script when/if the rich logger is promoted to default in the future.
- converting the legacy logging related parameters in place proved necessary because they were called in many different parts of the code. Doing this means that in case legacy parameters and their replacement collide, the legacy ones win.
- This PR updates the documentation for the CLI configuration tool but it doesn't actually make it work as documented (note that it's actually broken even with the main branch's examples). To keep the present PR focused, I opened a separate followup branch to address this issue #3112
- in a effort to minimise the difficulty of lifting any additional technical debt generated by this change without using deprecation warnings, code bits due for eventual removal receive a comment starting with `# YTEP-0039`
- I don't want to add any new test for now. It will be much easier to write tests for this when we have a pytest-based CI, at least partially, so hopefully soon. Given how hard it was to not break existing tests I figure the basics are already covered anyway.