### PR TITLE
cleanup: remove dead config option

### DIFF
--- a/doc/source/reference/configuration.rst
+++ b/doc/source/reference/configuration.rst
@@ -108,8 +108,6 @@ used internally.
 * ``default_colormap`` (default: ``arbre``): What colormap should be used by
   default for yt-produced images?
 * ``plugin_filename``  (default ``my_plugins.py``) The name of our plugin file.
-* ``log_file`` (default: ``False``): Should we output to a log file in the
-  filesystem?
 * ``log_level`` (default: ``20``): What is the threshold (0 to 50) for
   outputting log files?
 * ``test_data_dir`` (default: ``/does/not/exist``): The default path the

--- a/yt/config.py
+++ b/yt/config.py
@@ -13,7 +13,6 @@ ytcfg_defaults["yt"] = dict(
     serialize=False,
     only_deserialize=False,
     time_functions=False,
-    log_file=False,
     colored_logs=False,
     suppress_stream_logging=False,
     stdout_stream_logging=False,

--- a/yt/utilities/parallel_tools/parallel_analysis_interface.py
+++ b/yt/utilities/parallel_tools/parallel_analysis_interface.py
@@ -112,10 +112,6 @@ def enable_parallelism(suppress_logging=False, communicator=None):
     ytcfg["yt", "internals", "parallel"] = True
     if exe_name == "embed_enzo" or ("_parallel" in dir(sys) and sys._parallel):
         ytcfg["yt", "inline"] = True
-    if communicator.rank > 0:
-        if ytcfg.get("yt", "log_file"):
-            ytcfg["yt", "log_file"] = False
-            yt.utilities.logger.disable_file_logging()
     yt.utilities.logger.uncolorize_logging()
     # Even though the uncolorize function already resets the format string,
     # we reset it again so that it includes the processor.


### PR DESCRIPTION
## PR Summary

I think the `log_file` config option isn't used or usable anymore. It looks like the one time we're checking this option in the code base is to force-disable it.

I discovered this while working on #3106