### PR TITLE
fix for velocity_annotation with unstructured grids

### DIFF
--- a/yt/frontends/stream/tests/test_stream_unstructured.py
+++ b/yt/frontends/stream/tests/test_stream_unstructured.py
@@ -66,6 +66,7 @@ def test_multi_field():
     )
 
     ds = load_unstructured_mesh(connect, coords, data)
+
     sl = SlicePlot(ds, "z", "test")
     sl.annotate_mesh_lines()
 

--- a/yt/frontends/stream/tests/test_stream_unstructured.py
+++ b/yt/frontends/stream/tests/test_stream_unstructured.py
@@ -66,7 +66,6 @@ def test_multi_field():
     )
 
     ds = load_unstructured_mesh(connect, coords, data)
-
     sl = SlicePlot(ds, "z", "test")
     sl.annotate_mesh_lines()
 

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -1263,7 +1263,7 @@ def load_unstructured_mesh(
     sds._node_fields = flatten([[f[1] for f in m] for m in node_data if m])
     sds._elem_fields = flatten([[f[1] for f in m] for m in elem_data if m])
     sds.default_field = [f for f in sds.field_list if f[0] == "connect1"][-1]
-
+    sds.default_fluid_type = sds.default_field[0]
     return sds
 
 

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -360,7 +360,7 @@ def fake_tetrahedral_ds():
     return ds
 
 
-def fake_hexahedral_ds():
+def fake_hexahedral_ds(fields=()):
     from yt.frontends.stream.sample_data.hexahedral_mesh import (
         _connectivity,
         _coordinates,
@@ -372,6 +372,9 @@ def fake_hexahedral_ds():
     node_data = {}
     dist = np.sum(_coordinates ** 2, 1)
     node_data[("connect1", "test")] = dist[_connectivity - 1]
+
+    for field in fields:
+        node_data[("connect1", field)] = dist[_connectivity - 1]
 
     # each element gets a random number
     elem_data = {}

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -373,7 +373,7 @@ def fake_hexahedral_ds(fields=None):
     dist = np.sum(_coordinates ** 2, 1)
     node_data[("connect1", "test")] = dist[_connectivity - 1]
 
-    for field in fields:
+    for field in always_iterable(fields):
         node_data[("connect1", field)] = dist[_connectivity - 1]
 
     # each element gets a random number

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -10,6 +10,7 @@ import unittest
 
 import matplotlib
 import numpy as np
+from more_itertools import always_iterable
 from numpy.random import RandomState
 from unyt.exceptions import UnitOperationError
 

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -360,7 +360,7 @@ def fake_tetrahedral_ds():
     return ds
 
 
-def fake_hexahedral_ds(fields=()):
+def fake_hexahedral_ds(fields=None):
     from yt.frontends.stream.sample_data.hexahedral_mesh import (
         _connectivity,
         _coordinates,

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -361,6 +361,10 @@ class VelocityCallback(PlotCallback):
                 xv = f"velocity_{axis_names[xax]}"
                 yv = f"velocity_{axis_names[yax]}"
 
+            # determine the full fields including field type
+            xv = plot.data._determine_fields(xv)[0]
+            yv = plot.data._determine_fields(yv)[0]
+
             qcb = QuiverCallback(
                 xv,
                 yv,

--- a/yt/visualization/tests/test_callbacks.py
+++ b/yt/visualization/tests/test_callbacks.py
@@ -402,6 +402,12 @@ def test_velocity_callback():
         assert_fname(p.save(prefix)[0])
 
     with _cleanup_fname() as prefix:
+        ds = fake_hexahedral_ds(fields=(f"velocity_{ax}" for ax in ["x", "y", "z"]))
+        sl = SlicePlot(ds, 1, "test")
+        sl.annotate_velocity()
+        assert_fname(sl.save(prefix)[0])
+
+    with _cleanup_fname() as prefix:
         ds = load(cyl_2d)
         slc = SlicePlot(ds, "theta", "velocity_magnitude")
         slc.annotate_velocity()


### PR DESCRIPTION
## PR Summary

This fixes several related issues that were causing `velocity_annotation` to fail for unstructured grids and improves some of the Stream frontend's unstructured mesh testing. 

The following reproduces the error on `main`:

```python

import yt

# test dataset, similar to yt.testing.fake_hexahedral_ds but with velocity fields
import numpy as np
from yt.frontends.stream.sample_data import hexahedral_mesh
coords = hexahedral_mesh._coordinates
cons =  hexahedral_mesh._connectivity
node_data = {}
dist = np.sum(coords ** 2, 1) # distance from origin
node_data[("connect1", "test")] = dist[cons - 1]
for dim in ['x','y','z']:
    node_data[("connect1", f"velocity_{dim}")] = dist[cons - 1]
ds =  yt.load_unstructured_mesh(cons - 1, coords, node_data=node_data)

# slice and annotate it
sl = yt.SlicePlot(ds, "z", "test")
sl.annotate_velocity()
sl.save("/tmp/stream_z")
```
resulting in 

```
Traceback (most recent call last):
  File "/home/chavlin/src/yt/yt/visualization/plot_window.py", line 1263, in run_callbacks
    callback(cbw)
  File "/home/chavlin/src/yt/yt/visualization/plot_modifications.py", line 42, in _check_geometry
    return func(self, plot)
  File "/home/chavlin/src/yt/yt/visualization/plot_modifications.py", line 375, in __call__
    return qcb(plot)
  File "/home/chavlin/src/yt/yt/visualization/plot_modifications.py", line 42, in _check_geometry
    return func(self, plot)
  File "/home/chavlin/src/yt/yt/visualization/plot_modifications.py", line 526, in __call__
    pixX = plot.data.ds.coordinates.pixelize(
  File "/home/chavlin/src/yt/yt/geometry/coordinates/cartesian_coordinates.py", line 170, in pixelize
    ftype, fname = field
ValueError: too many values to unpack (expected 2)
```
The issue here is similar to other issues (https://github.com/yt-project/yt/issues/2256 and https://github.com/yt-project/yt/issues/1717), arising because the `VelocityCallback` makes some assumptions about the fields (noted here https://github.com/yt-project/yt/issues/2256#issuecomment-490531376). Those issues seem to be fixed now because `geometry.cartesian_coordinates.pixelize` behaves differently for the mesh/particle types referenced in those issues, but the unstructured mesh still hits that troublesome line 170 in `pixelize`. 

With the fixes here, the above code results in the following image:

![stream_z_Slice_z_test](https://user-images.githubusercontent.com/22038879/110188304-cf5c2180-7de0-11eb-9900-61d16fad9f08.png)

The fix:
1. adds a `determine_field` in `VelocityCallback` immediately after the fields are set (so that we get a full `(fieldtype, fieldname)` tuple
2. sets the `default_fluid_type` to be the same field type as the `default_field` in `load_unstructured_mesh`  (otherwise, the `default_fluid_type` is `gas`, which does not exist...)
3. adds an unstructured mesh test to the existing `visualization.tests.test_callbacks.test_velocity_callback()` function (I could add this as a new test but it seemed appropriate to add there?)

## PR Checklist
- [x] Adds a test for any bugs fixed. Adds tests for new features.

