### PR TITLE
fix config CLI

### DIFF
--- a/doc/source/developing/building_the_docs.rst
+++ b/doc/source/developing/building_the_docs.rst
@@ -198,7 +198,7 @@ and build it using Sphinx:
 If all of the dependencies are installed and all of the test data is in the
 testing directory, this should churn away for a while (several hours) and
 eventually generate a docs build.  We suggest setting
-:code:`suppress_stream_logging = True` in your yt configuration (See
+:code:`logging.stream = "none"` in your yt configuration (See
 :ref:`configuration-file`) to suppress large amounts of debug output from
 yt.
 

--- a/doc/source/reference/command-line.rst
+++ b/doc/source/reference/command-line.rst
@@ -366,23 +366,24 @@ Listing current content of the config file:
 
    $ yt config list
    [yt]
-   log_level = 50
+   logging.level = "CRITICAL"
 
 Obtaining a single config value by name:
 
 .. code-block:: bash
 
-   $ yt config get yt log_level
-   50
+   $ yt config get logging.level
+   "CRITICAL"
 
 Changing a single config value:
 
 .. code-block:: bash
 
-   $ yt config set yt log_level 10
+   $ yt config set logging.level DEBUG
+
 
 Removing a single config entry:
 
 .. code-block:: bash
 
-   $ yt config rm yt log_level
+   $ yt config rm logging.level

--- a/doc/source/reference/command-line.rst
+++ b/doc/source/reference/command-line.rst
@@ -381,7 +381,6 @@ Changing a single config value:
 
    $ yt config set logging.level DEBUG
 
-
 Removing a single config entry:
 
 .. code-block:: bash

--- a/doc/source/reference/configuration.rst
+++ b/doc/source/reference/configuration.rst
@@ -28,7 +28,7 @@ like:
 .. code-block:: none
 
    [yt]
-   log_level = 1
+   logging.level = "ALL"
    maximum_stored_datasets = 10000
 
 This configuration file would set the logging threshold much lower, enabling
@@ -41,7 +41,7 @@ options from the configuration file, e.g.:
 
    $ yt config -h
    $ yt config list
-   $ yt config set yt log_level 1
+   $ yt config set logging.level ALL
    $ yt config rm yt maximum_stored_datasets
 
 
@@ -60,8 +60,8 @@ options, and display the path to the local configuration file, e.g.:
 
    $ yt config -h
    $ yt config list --local
-   $ yt config set --local yt log_level 1
-   $ yt config rm --local yt maximum_stored_datasets
+   $ yt config set --local logging.level ALL
+   $ yt config rm --local maximum_stored_datasets
    $ yt config print-path --local
 
 If no local configuration file is present, these commands will create an (empty) one
@@ -93,7 +93,7 @@ Here is an example script, where we adjust the logging at startup:
    ds = yt.load("my_data0001")
    ds.print_stats()
 
-This has the same effect as setting ``log_level = 1`` in the configuration
+This has the same effect as setting ``logging.level = "ALL"`` in the configuration
 file. Note that a log level of 1 means that all log messages are printed to
 stdout.  To disable logging, set the log level to 50.
 
@@ -104,12 +104,9 @@ Available Configuration Options
 The following external parameters are available.  A number of parameters are
 used internally.
 
-* ``colored_logs`` (default: ``False``): Should logs be colored?
 * ``default_colormap`` (default: ``arbre``): What colormap should be used by
   default for yt-produced images?
 * ``plugin_filename``  (default ``my_plugins.py``) The name of our plugin file.
-* ``log_level`` (default: ``20``): What is the threshold (0 to 50) for
-  outputting log files?
 * ``test_data_dir`` (default: ``/does/not/exist``): The default path the
   ``load()`` function searches for datasets when it cannot find a dataset in the
   current directory.
@@ -131,14 +128,43 @@ used internally.
   :ref:`object serialization <object-serialization>`
 * ``sketchfab_api_key`` (default: empty): API key for https://sketchfab.com/ for
   uploading AMRSurface objects.
-* ``suppress_stream_logging`` (default: ``False``): If true, execution mode will be
-  quiet.
-* ``stdout_stream_logging`` (default: ``False``): If true, logging is directed
-  to stdout rather than stderr
 * ``skip_dataset_cache`` (default: ``False``): If true, automatic caching of datasets
   is turned off.
 * ``supp_data_dir`` (default: ``/does/not/exist``): The default path certain
   submodules of yt look in for supplemental data files.
+
+Logging-related arguments are gathered in a dedicated section
+* ``logging.use_color`` (default: ``False``). In a future version of yt, the default value will be changed to ``True``.
+* ``logging.stream`` (default: ``stderr``): select the stream where logs should be outputed
+(choices ``stderr``, ``stdout`` or ``none`` to suppress logs completely)
+* ``logging.handler`` (default: ``"legacy"``. This default value will be changed to ``"rich"``
+in a follow up release): select the logging handler. ``rich`` is the prefered option and future
+default value but is considered experimental for now. Use ``legacy`` if you need backwards compatibility
+in your logs' format.
+* ``logging.level`` (default: ``"INFO"``): select the minimal level of logs you want displayed (lower levels might be pretty verbose).
+Choices by increasing level of concern: ``"ALL"``,  ``"DEBUG"``,  ``"INFO"`` (default),  ``"WARNING"``,  ``"ERROR"``,  ``"CRITICAL"``.
+This option is case-insensitive.
+
+The options hereafter are only available with ``logging.handler = "rich"``
+* ``logging.format`` (default: ``"%(message)s"``): customize the log message format. For instance,
+if your application uses a separate logger, you might want to change this to ``"%(name)s: %(message)s``
+so that each log from yt will be signed (``"yt:  "``).
+* ``data_format`` (default: ``"[%m/%d/%Y %H:%M:%S]"``): customize the date format. Note that brackets
+in the default value are purely stylistic and are not required.
+* ``logging.custom_theme`` (default: ``""``): Specify a path to an arbitrary ``rich`` theme file to override the default.
+See `Rich's documentation<https://rich.readthedocs.io/en/stable/style.html#loading-themes>`_.
+* ``logging.width`` (default: ``-1``, meaning "automatic"): set the total width (in columns/characters)
+of logs, including timestamps, level, and source path. A realistic minimal value of ~80 is recommended.
+
+The following options are still usable for backward compatibility as of yt 4.0.0, but they
+will be removed in a following release
+* ``colored_logs`` (default: ``False``): Should logs be colored? (use ``logging.use_color`` instead)
+* ``log_level`` (default: ``20``): What is the threshold (0 to 50) for
+outputting log files? (use ``logging.level`` instead)
+* ``suppress_stream_logging`` (default: ``False``): If true, execution mode will be
+   quiet. (use ``logging.stream`` instead)
+* ``stdout_stream_logging`` (default: ``False``): If true, logging is directed
+   to stdout rather than stderr (use ``logging.stream`` instead)
 
 .. _plugin-file:
 

--- a/setup.py
+++ b/setup.py
@@ -138,6 +138,7 @@ if __name__ == "__main__":
         },
         packages=find_packages(),
         include_package_data=True,
+        package_data={"yt": ["utilities/monochrome_logger_theme.ini"]},
         install_requires=[
             "matplotlib>=1.5.3",
             "setuptools>=19.6",
@@ -148,6 +149,7 @@ if __name__ == "__main__":
             "more_itertools>=8.4",
             "tqdm>=3.4.0",
             "toml>=0.10.2",
+            "rich>=9.12.0",
         ],
         extras_require={"hub": ["girder_client"], "mapserver": ["bottle"]},
         cmdclass={"sdist": sdist, "build_ext": build_ext},

--- a/setup.py
+++ b/setup.py
@@ -149,6 +149,7 @@ if __name__ == "__main__":
             "more_itertools>=8.4",
             "tqdm>=3.4.0",
             "toml>=0.10.2",
+            "python-benedict>=0.23.2",
             "rich>=9.12.0",
         ],
         extras_require={"hub": ["girder_client"], "mapserver": ["bottle"]},

--- a/tests/ci_install.sh
+++ b/tests/ci_install.sh
@@ -22,7 +22,7 @@ esac
 # Disable excessive output
 mkdir -p $HOME/.config/yt
 echo "[yt]" > $HOME/.config/yt/yt.toml
-echo "suppress_stream_logging = true" >> $HOME/.config/yt/yt.toml
+echo 'logging.stream = "none"' >> $HOME/.config/yt/yt.toml
 cat $HOME/.config/yt/yt.toml
 # Sets default backend to Agg
 cp tests/matplotlibrc .

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -33,3 +33,4 @@ nose-exclude
 more_itertools>=8.4
 tqdm>=3.4.0
 toml>=0.10.2
+rich>=9.12.0

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -33,4 +33,5 @@ nose-exclude
 more_itertools>=8.4
 tqdm>=3.4.0
 toml>=0.10.2
+python-benedict>=0.23.2
 rich>=9.12.0

--- a/yt/config.py
+++ b/yt/config.py
@@ -3,6 +3,7 @@ import os
 import warnings
 
 import toml
+from benedict import benedict
 from more_itertools import always_iterable
 
 from yt._maintenance.deprecation import issue_deprecation_warning
@@ -25,7 +26,7 @@ def loglevel_str2int(level: str) -> int:
     return logging._nameToLevel[level]
 
 
-ytcfg_defaults = {}
+ytcfg_defaults = benedict()
 
 ytcfg_defaults["yt"] = dict(
     serialize=False,
@@ -101,10 +102,11 @@ if not os.path.exists(CONFIG_DIR):
 
 
 class YTConfig:
-    def __init__(self, defaults=None):
+    def __init__(self, defaults=None, metadata=None):
         if defaults is None:
             defaults = {}
-        self.config_root = ConfigNode(None)
+        self.config_root = ConfigNode(key=None, parent=None, metadata=metadata)
+        self.update(defaults, metadata=metadata)
 
     def get(self, section, *keys, callback=None, **kwargs):
         if callback is None:
@@ -259,8 +261,9 @@ if not os.path.exists(_global_config_file):
 
 
 # Load the config
-ytcfg = YTConfig()
-ytcfg.update(ytcfg_defaults, metadata={"source": "defaults"})
+# ytcfg = YTConfig()
+# ytcfg.update(ytcfg_defaults, metadata={"source": "defaults"})
+ytcfg = YTConfig(ytcfg_defaults, metadata={"source": "defaults"})
 
 # Try loading the local config first, otherwise fall back to global config
 if os.path.exists(_local_config_file):
@@ -268,4 +271,4 @@ if os.path.exists(_local_config_file):
 elif os.path.exists(_global_config_file):
     ytcfg.read(_global_config_file)
 
-ytcfg._convert_legacy_logging_parameters()
+# ytcfg._convert_legacy_logging_parameters()

--- a/yt/data_objects/particle_trajectories.py
+++ b/yt/data_objects/particle_trajectories.py
@@ -2,10 +2,11 @@ import numpy as np
 
 from yt.config import ytcfg
 from yt.data_objects.field_data import YTFieldData
-from yt.funcs import get_pbar, mylog
+from yt.funcs import get_pbar
 from yt.units.yt_array import array_like_field
 from yt.utilities.exceptions import YTIllDefinedParticleData
 from yt.utilities.lib.particle_mesh_operations import CICSample_3
+from yt.utilities.logger import set_log_level
 from yt.utilities.on_demand_imports import _h5py as h5py
 from yt.utilities.parallel_tools.parallel_analysis_interface import parallel_root_only
 
@@ -69,8 +70,8 @@ class ParticleTrajectories:
             fields = []
 
         if self.suppress_logging:
-            old_level = int(ytcfg.get("yt", "log_level"))
-            mylog.setLevel(40)
+            old_level = ytcfg.get("yt", "logging", "level")
+            set_log_level("ERROR")
         ds_first = self.data_series[0]
         dd_first = ds_first.all_data()
 
@@ -109,7 +110,7 @@ class ParticleTrajectories:
         pbar.finish()
 
         if self.suppress_logging:
-            mylog.setLevel(old_level)
+            set_log_level(old_level)
 
         sorted_storage = sorted(my_storage.items())
         _fn, (time, *_) = sorted_storage[0]
@@ -216,8 +217,8 @@ class ParticleTrajectories:
             return
 
         if self.suppress_logging:
-            old_level = int(ytcfg.get("yt", "log_level"))
-            mylog.setLevel(40)
+            old_level = ytcfg.get("yt", "logging", "level")
+            set_log_level("ERROR")
         ds_first = self.data_series[0]
         dd_first = ds_first.all_data()
 
@@ -295,7 +296,7 @@ class ParticleTrajectories:
             self.field_data[field] = array_like_field(dd_first, output_field.copy(), fd)
 
         if self.suppress_logging:
-            mylog.setLevel(old_level)
+            set_log_level(old_level)
 
     def trajectory_from_index(self, index):
         """

--- a/yt/data_objects/tests/test_ellipsoid.py
+++ b/yt/data_objects/tests/test_ellipsoid.py
@@ -5,8 +5,9 @@ from yt.testing import assert_array_less, fake_random_ds
 
 def setup():
     from yt.config import ytcfg
+    from yt.utilities.logger import set_log_level
 
-    ytcfg["yt", "log_level"] = 50
+    set_log_level("CRITICAL")
     ytcfg["yt", "internals", "within_testing"] = True
 
 

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -387,7 +387,7 @@ def get_pbar(title, maxval, parallel=False):
     from yt.config import ytcfg
 
     if (
-        ytcfg.get("yt", "suppress_stream_logging")
+        ytcfg.get("yt", "logging", "stream") == "none"
         or ytcfg.get("yt", "internals", "within_testing")
         or maxval == 1
     ):

--- a/yt/mods.py
+++ b/yt/mods.py
@@ -13,13 +13,13 @@ import numpy as np
 # https://mail.python.org/archives/list/yt-dev@python.org/thread/L6AQPJ3OIMJC5SNKVM7CJG32YVQZRJWA/
 import yt.startup_tasks as __startup_tasks
 from yt import *
-from yt.config import ytcfg, ytcfg_defaults
+from yt.config import loglevel_str2int, ytcfg, ytcfg_defaults
 from yt.utilities.logger import _level
 
 unparsed_args = __startup_tasks.unparsed_args
 
-
-if _level >= int(ytcfg_defaults["yt"]["log_level"]):
+default_level = loglevel_str2int(ytcfg_defaults["yt"]["logging"]["level"])
+if _level >= default_level:
     # This won't get displayed.
     mylog.debug("Turning off NumPy error reporting")
     np.seterr(all="ignore")

--- a/yt/startup_tasks.py
+++ b/yt/startup_tasks.py
@@ -95,7 +95,11 @@ class YTParser(argparse.ArgumentParser):
         and then exits.
         """
         self.print_help(sys.stderr)
-        self.exit(2, f"{self.prog}: error: {message}\n")
+
+        # raise an error that can be caught in the main CLI function
+        # to keep it testable
+        raise RuntimeError(f"{self.prog}: error: {message}\n")
+        # self.exit(2, f"{self.prog}: error: {message}\n")
 
 
 parser = YTParser(description="yt command line arguments")

--- a/yt/startup_tasks.py
+++ b/yt/startup_tasks.py
@@ -14,7 +14,6 @@ from yt.funcs import (
     signal_print_traceback,
 )
 from yt.utilities import rpdb
-from yt.utilities.logger import set_log_level
 
 exe_name = os.path.basename(sys.executable)
 # At import time, we determined whether or not we're being run in parallel.
@@ -76,17 +75,6 @@ class SetExceptionHandling(argparse.Action):
             mylog.debug("Enabling remote debugging")
 
 
-class SetConfigOption(argparse.Action):
-    def __call__(self, parser, namespace, values, option_string=None):
-        param, val = values.split("=")
-        mylog.debug("Overriding config: %s = %s", param, val)
-        ytcfg["yt", param] = val
-
-        # TODO: check this
-        if param == "logging.level":  # special case
-            set_log_level(val)
-
-
 class YTParser(argparse.ArgumentParser):
     def error(self, message):
         """error(message: string)
@@ -103,11 +91,6 @@ class YTParser(argparse.ArgumentParser):
 
 
 parser = YTParser(description="yt command line arguments")
-parser.add_argument(
-    "--config",
-    action=SetConfigOption,
-    help="Set configuration option, in the form param=value",
-)
 parser.add_argument(
     "--paste",
     action=SetExceptionHandling,
@@ -147,8 +130,6 @@ unparsed_args = []
 parallel_capable = False
 if not ytcfg.get("yt", "internals", "command_line"):
     opts, unparsed_args = parser.parse_known_args()
-    # THIS IS NOT SUCH A GOOD IDEA:
-    # sys.argv = [a for a in unparsed_args]
     if opts.parallel:
         parallel_capable = turn_on_parallelism()
     subparsers = parser.add_subparsers(

--- a/yt/startup_tasks.py
+++ b/yt/startup_tasks.py
@@ -14,6 +14,7 @@ from yt.funcs import (
     signal_print_traceback,
 )
 from yt.utilities import rpdb
+from yt.utilities.logger import set_log_level
 
 exe_name = os.path.basename(sys.executable)
 # At import time, we determined whether or not we're being run in parallel.
@@ -80,8 +81,10 @@ class SetConfigOption(argparse.Action):
         param, val = values.split("=")
         mylog.debug("Overriding config: %s = %s", param, val)
         ytcfg["yt", param] = val
-        if param == "log_level":  # special case
-            mylog.setLevel(int(val))
+
+        # TODO: check this
+        if param == "logging.level":  # special case
+            set_log_level(val)
 
 
 class YTParser(argparse.ArgumentParser):

--- a/yt/utilities/configure.py
+++ b/yt/utilities/configure.py
@@ -71,6 +71,18 @@ def migrate_config():
 
     old_keys_to_new = {normalize_key(k): k for k in ytcfg_defaults["yt"].keys()}
 
+    # YTEP-0039: special cases
+    # colored_logs is directly converted to a new but perfectly equivalent option
+    # while other deprecated options are kept for backwards compatibility
+    # (will migrate them properly later, but they require more fine tuning)
+    old_keys_to_new.update(
+        {
+            "loglevel": "log_level",
+            "stdoutStreamLogging": "stdout_stream_logging",
+            "suppressstreamlogging": "suppress_stream_logging",
+            "colored_logs": "logging.use_color",
+        }
+    )
     config_as_dict = {}
     for section in old_config:
         if section == "DEFAULT":

--- a/yt/utilities/configure.py
+++ b/yt/utilities/configure.py
@@ -48,6 +48,8 @@ def write_config(config_file):
 
 
 def migrate_config():
+    from yt.utilities.logger import ytLogger as mylog
+
     if not os.path.exists(OLD_CONFIG_FILE):
         print("Old config not found.")
         sys.exit(1)
@@ -93,10 +95,13 @@ def migrate_config():
             cast_value = _cast_value_helper(value)
 
             # Normalize the key (if present in the defaults)
-            if normalize_key(key) in old_keys_to_new and section == "yt":
-                new_key = old_keys_to_new[normalize_key(key)]
-            else:
+            if not (normalize_key(key) in old_keys_to_new and section == "yt"):
+                mylog.warning(
+                    "Found unknown option `%s` while migrating. Conserving it.", key
+                )
                 new_key = key
+            else:
+                new_key = old_keys_to_new[normalize_key(key)]
 
             config_as_dict[section][new_key] = cast_value
 

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -1,7 +1,10 @@
 # We don't need to import 'exceptions'
 import os.path
+from typing import Any, Optional
 
 from unyt.exceptions import UnitOperationError
+
+from yt.config import ytcfg
 
 
 class YTException(Exception):
@@ -861,6 +864,19 @@ class YTArrayTooLargeToDisplay(YTException):
         msg = f"The requested array is of size {self.size}.\n"
         msg += "We do not support displaying arrays larger\n"
         msg += f"than size {self.max_size}."
+        return msg
+
+
+class YTConfigError(YTException):
+    def __init__(self, key: str, choices: Optional[Any] = None) -> None:
+        self.key = key
+        self.value = ytcfg.get(*(key.split(".")))
+        self.choices = choices
+
+    def __str__(self) -> str:
+        msg = f"Unrecognised value for {self.key} in config file '{self.value}'."
+        if self.choices is not None:
+            msg += f" Possible values are\n{self.choices}"
         return msg
 
 

--- a/yt/utilities/logger.py
+++ b/yt/utilities/logger.py
@@ -1,13 +1,28 @@
 import logging
 import sys
+from typing import Union
 
-from yt.config import ytcfg
+import pkg_resources
+from rich.console import Console
+from rich.logging import RichHandler
+from rich.theme import Theme
+
+from yt.config import loglevel_int2str, loglevel_str2int, ytcfg
+from yt.utilities.exceptions import YTConfigError
+
+# YTEP-0039: legacy helper functions to (de)activate color logging
+# and suppress logging. They should be removed at some point.
+# (see the YTEP)
+
+ufstring = "%(name)-3s: [%(levelname)-9s] %(asctime)s %(message)s"
+cfstring = "%(name)-3s: [%(levelname)-18s] %(asctime)s %(message)s"
 
 # This next bit is grabbed from:
 # http://stackoverflow.com/questions/384076/how-can-i-make-the-python-logging-output-to-be-colored
 
 
 def add_coloring_to_emit_ansi(fn):
+    # YTEP-0039: legacy only
     # add methods we need to the class
     def new(*args):
         levelno = args[0].levelno
@@ -30,7 +45,38 @@ def add_coloring_to_emit_ansi(fn):
     return new
 
 
-def set_log_level(level):
+def disable_stream_logging():
+    # YTEP-0039: legacy only
+    if len(ytLogger.handlers) > 0:
+        ytLogger.removeHandler(ytLogger.handlers[0])
+    h = logging.NullHandler()
+    ytLogger.addHandler(h)
+
+
+def colorize_logging():
+    # YTEP-0039: legacy only
+    f = logging.Formatter(cfstring)
+    ytLogger.handlers[0].setFormatter(f)
+    handler.emit = add_coloring_to_emit_ansi(handler.emit)
+
+
+def uncolorize_logging():
+    # YTEP-0039: legacy only
+    try:
+        f = logging.Formatter(ufstring)
+        ytLogger.handlers[0].setFormatter(f)
+        handler.emit = original_emitter
+    except NameError:
+        # `handler` and `original_emitter` are not defined because
+        # ytcfg["yt", "logging", "stream"] == "none"
+        # so we continue since there is nothing to uncolorize.
+        pass
+
+
+### end legacy-only definitions (YTEP-0039)
+
+
+def set_log_level(level: Union[int, str]) -> None:
     """
     Select which minimal logging level should be displayed.
 
@@ -48,24 +94,18 @@ def set_log_level(level):
     """
     # this is a user-facing interface to avoid importing from yt.utilities in user code.
 
-    if isinstance(level, str):
-        level = level.upper()
+    if isinstance(level, int):
+        ytcfg["yt", "logging", "level"] = loglevel_int2str(level)
+    elif isinstance(level, str):
+        ytcfg["yt", "logging", "level"] = level.upper()
+        level = loglevel_str2int(level)
+    else:
+        raise TypeError(
+            f"Expected an int or an str, got `{level}` with type `{type(level)}`."
+        )
 
-    if level == "ALL":  # non-standard alias
-        level = 1
     ytLogger.setLevel(level)
-    ytLogger.debug("Set log level to %s", level)
-
-
-ufstring = "%(name)-3s: [%(levelname)-9s] %(asctime)s %(message)s"
-cfstring = "%(name)-3s: [%(levelname)-18s] %(asctime)s %(message)s"
-
-if ytcfg.get("yt", "stdout_stream_logging"):
-    stream = sys.stdout
-else:
-    stream = sys.stderr
-
-ytLogger = logging.getLogger("yt")
+    ytLogger.debug("log level to %s", level)
 
 
 class DuplicateFilter(logging.Filter):
@@ -81,49 +121,68 @@ class DuplicateFilter(logging.Filter):
         return False
 
 
+ytLogger = logging.getLogger("yt")
 ytLogger.addFilter(DuplicateFilter())
 
+# normalize logging level string to all caps
+ytcfg["yt", "logging", "level"] = ytcfg.get("yt", "logging", "level").upper()
 
-def disable_stream_logging():
-    if len(ytLogger.handlers) > 0:
-        ytLogger.removeHandler(ytLogger.handlers[0])
-    h = logging.NullHandler()
-    ytLogger.addHandler(h)
-
-
-def colorize_logging():
-    f = logging.Formatter(cfstring)
-    ytLogger.handlers[0].setFormatter(f)
-    yt_sh.emit = add_coloring_to_emit_ansi(yt_sh.emit)
-
-
-def uncolorize_logging():
-    try:
-        f = logging.Formatter(ufstring)
-        ytLogger.handlers[0].setFormatter(f)
-        yt_sh.emit = original_emitter
-    except NameError:
-        # yt_sh and original_emitter are not defined because
-        # suppress_stream_logging is True, so we continue since there is nothing
-        # to uncolorize
-        pass
-
-
-_level = min(max(ytcfg.get("yt", "log_level"), 0), 50)
-
-if ytcfg.get("yt", "suppress_stream_logging"):
+_stream = ytcfg.get("yt", "logging", "stream").lower()
+if _stream == "stdout":
+    stream = sys.stdout
+elif _stream == "stderr":
+    stream = sys.stderr
+elif _stream == "none":
     disable_stream_logging()
 else:
-    yt_sh = logging.StreamHandler(stream=stream)
-    # create formatter and add it to the handlers
-    formatter = logging.Formatter(ufstring)
-    yt_sh.setFormatter(formatter)
+    raise YTConfigError("yt.logging.stream", choices=["stdout", "stderr", "none"])
+
+if _stream != "none":
+    _handler = ytcfg.get("yt", "logging", "handler")
+
+    if _handler == "legacy":
+        handler = logging.StreamHandler(stream=stream)
+        _fmt = ufstring
+        _datefmt = None  # unspecified
+    elif _handler == "rich":
+        _width = ytcfg.get("yt", "logging", "width")
+        width = None if _width <= 0 else _width
+
+        theme_file = None
+        no_color = not ytcfg.get("yt", "logging", "use_color")
+        if no_color:
+            # note that the monochrome theme doesn't deactivate rich markup (bold, italic, dim)
+            theme_file = pkg_resources.resource_filename(
+                "yt", "utilities/monochrome_logger_theme.ini"
+            )
+
+        _custom_theme = ytcfg.get("yt", "logging", "custom_theme")
+        if _custom_theme:
+            theme_file = _custom_theme
+
+        if theme_file is None:
+            theme = None
+        else:
+            theme = Theme.read(theme_file)
+
+        console = Console(file=stream, width=width, theme=theme, no_color=no_color)
+        handler = RichHandler(console=console)
+        _fmt = ytcfg.get("yt", "logging", "format")
+        _datefmt = ytcfg.get("yt", "logging", "date_format")
+    else:
+        raise YTConfigError("yt.logging.handler", choices=["legacy", "rich"])
+
+    handler.setFormatter(logging.Formatter(fmt=_fmt, datefmt=_datefmt))
+
     # add the handler to the logger
-    ytLogger.addHandler(yt_sh)
-    set_log_level(_level)
+    ytLogger.addHandler(handler)
+
+    set_log_level(ytcfg.get("yt", "logging", "level"))
     ytLogger.propagate = False
 
-    original_emitter = yt_sh.emit
-
-    if ytcfg.get("yt", "colored_logs"):
+    original_emitter = handler.emit
+    if _handler == "legacy" and ytcfg.get("yt", "logging", "use_color"):
         colorize_logging()
+
+# this exists only to support yt.mods
+_level = loglevel_str2int(ytcfg.get("yt", "logging", "level"))

--- a/yt/utilities/monochrome_logger_theme.ini
+++ b/yt/utilities/monochrome_logger_theme.ini
@@ -1,0 +1,12 @@
+[styles]
+log.level = none
+log.message = none
+log.path =
+log.time =
+logging.keyword =
+logging.level.critical =
+logging.level.debug =
+logging.level.error =
+logging.level.info =
+logging.level.notset =
+logging.level.warning =

--- a/yt/utilities/parallel_tools/parallel_analysis_interface.py
+++ b/yt/utilities/parallel_tools/parallel_analysis_interface.py
@@ -10,7 +10,7 @@ import numpy as np
 from more_itertools import always_iterable
 
 import yt.utilities.logger
-from yt.config import ytcfg
+from yt.config import loglevel_str2int, ytcfg
 from yt.data_objects.image_array import ImageArray
 from yt.funcs import is_sequence
 from yt.units.unit_registry import UnitRegistry
@@ -112,7 +112,10 @@ def enable_parallelism(suppress_logging=False, communicator=None):
     ytcfg["yt", "internals", "parallel"] = True
     if exe_name == "embed_enzo" or ("_parallel" in dir(sys) and sys._parallel):
         ytcfg["yt", "inline"] = True
-    yt.utilities.logger.uncolorize_logging()
+
+    if ytcfg.get("yt", "logging", "handler") == "legacy":
+        yt.utilities.logger.uncolorize_logging()
+
     # Even though the uncolorize function already resets the format string,
     # we reset it again so that it includes the processor.
     f = logging.Formatter(
@@ -126,7 +129,7 @@ def enable_parallelism(suppress_logging=False, communicator=None):
     else:
         sys.excepthook = default_mpi_excepthook
 
-    if ytcfg.get("yt", "log_level") < 20:
+    if loglevel_str2int(ytcfg.get("yt", "logging", "level")) < logging.INFO:
         yt.utilities.logger.ytLogger.warning(
             "Log Level is set low -- this could affect parallel performance!"
         )

--- a/yt/utilities/tests/test_cli_config.py
+++ b/yt/utilities/tests/test_cli_config.py
@@ -1,0 +1,129 @@
+import pytest
+
+from yt.config import ytcfg_defaults
+from yt.utilities.command_line import run_main
+
+
+# todo: maybe set this fixture to auto use with a module scope
+@pytest.fixture
+def tmp_config_file(tmp_path, monkeypatch):
+    config_file = tmp_path / "yt.toml"
+    config_file.touch()
+    monkeypatch.setattr("yt.config.YTConfig.get_local_config_file", lambda: config_file)
+    monkeypatch.setattr("yt.config.YTConfig.get_global_config_file", lambda: "")
+    return config_file
+
+
+CONFIG_SET_HELP_MESSAGE = """
+usage: yt config set [-h] [--local | --global] option value
+
+set a config value
+
+positional arguments:
+  option      The option to set.
+  value       The value to set the option to.
+
+optional arguments:
+  -h, --help  show this help message and exit
+  --local     Store the configuration in the global configuration file.
+  --global    Store the configuration in the global configuration file.
+"""
+
+
+@pytest.mark.parametrize("key", ["test_data_dir", "unknown_param"])
+def test_set_missing_value(tmp_config_file, capsys, key):
+    retval = run_main(["config", "set", key])
+    out, err = capsys.readouterr()
+    assert type(retval) is int
+    assert retval != 0
+    assert out == ""
+    # skipping the first line because it differs between macos and linux
+    assert err.splitlines()[1:] == CONFIG_SET_HELP_MESSAGE.splitlines()[2:]
+    assert tmp_config_file.read_text() == ""
+
+
+@pytest.mark.skip(reason="no time for this now")
+def test_set_wrong_type_value(tmp_config_file, capsys):
+    retval = run_main(["config", "set", "logging.level", "10"])
+    out, err = capsys.readouterr()
+
+    assert type(retval) is int
+    assert retval != 0
+    assert out == ""
+    err = err.splitlines()
+    assert "INFO" in err[0]
+    assert str(tmp_config_file) in err[0]
+    assert (
+        err[1]
+        == "Error: tried to assign a value with type `<class 'int'>`' to `yt.logging.level`. Excepted type `<class 'str'>`."
+    )
+    assert err[2] == "This entry was last set in defaults."
+    assert len(err) == 3
+    assert tmp_config_file.read_text() == ""
+
+
+# @pytest.mark.skip(reason="still in the shop")
+def test_set_unknown_param_with_value(tmp_config_file, capsys):
+    retval = run_main(["config", "set", "log_level", "0"])
+    out, err = capsys.readouterr()
+    assert type(retval) is int
+    assert retval != 0
+    assert out == ""
+
+    err = err.splitlines()
+    assert "INFO" in err[0]
+    assert str(tmp_config_file) in err[0]
+    assert err[1] == "Error: unknown parameter `log_level`."
+    assert len(err) == 2
+    assert tmp_config_file.read_text() == ""
+
+
+def test_set_nested_param(tmp_config_file, capsys):
+    assert tmp_config_file.read_text() == ""
+    retval = run_main(["config", "set", "logging.level", "CRITICAL"])
+    out, err = capsys.readouterr()
+
+    assert retval == 0  # this fails, I need to fix it
+    assert out == ""
+    err = err.splitlines()
+    assert "INFO" in err[0]
+    assert str(tmp_config_file) in err[0]
+    assert len(err) == 1
+    assert tmp_config_file.read_text() == '[yt.logging]\nlevel = "CRITICAL"\n'
+
+
+# Getter tests
+@pytest.mark.parametrize("key", ("test_data_dir", "logging.level"))
+def test_get_default_params(tmp_config_file, capsys, key):
+    assert tmp_config_file.read_text() == ""
+    retval = run_main(["config", "get", key])
+    out, err = capsys.readouterr()
+
+    assert retval == 0  # this fails, I need to fix it
+    err = err.splitlines()
+    assert "INFO" in err[0]
+    assert str(tmp_config_file) in err[0]
+    assert (
+        err[1]
+        == f"`{key}` not found in configuration file. Falling back to default value."
+    )
+    assert out == f"{ytcfg_defaults['yt', key]}\n"
+    assert tmp_config_file.read_text() == ""
+
+
+def test_get_unknown_parameter(tmp_config_file, capsys):
+    assert tmp_config_file.read_text() == ""
+    retval = run_main(["config", "get", "unknown_parameter"])
+    out, err = capsys.readouterr()
+
+    assert type(retval) is int
+    assert retval != 0
+    err = err.splitlines()
+    assert "INFO" in err[0]
+    assert str(tmp_config_file) in err[0]
+    assert err[1] == "Error: unknown parameter `unknown_parameter`."
+    assert out == ""
+    assert tmp_config_file.read_text() == ""
+
+
+# TODO: yt config rm tests...

--- a/yt/utilities/tests/test_config.py
+++ b/yt/utilities/tests/test_config.py
@@ -164,6 +164,7 @@ class TestYTConfigGlobalLocal(TestYTConfig):
 
 class TestYTConfigMigration(TestYTConfig):
     def setUp(self):
+        # TODO: rewrite this with pytest fixtures monkeypatching and tmp_path
         if not os.path.exists(os.path.dirname(OLD_CONFIG_FILE)):
             os.makedirs(os.path.dirname(OLD_CONFIG_FILE))
 
@@ -174,6 +175,7 @@ class TestYTConfigMigration(TestYTConfig):
             os.remove(GLOBAL_CONFIG_FILE)
 
     def tearDown(self):
+        # TODO: rewrite this with pytest fixtures monkeypatching and tmp_path
         if os.path.exists(GLOBAL_CONFIG_FILE):
             os.remove(GLOBAL_CONFIG_FILE)
         if os.path.exists(OLD_CONFIG_FILE + ".bak"):

--- a/yt/utilities/tests/test_set_log_level.py
+++ b/yt/utilities/tests/test_set_log_level.py
@@ -7,7 +7,7 @@ def test_valid_level():
     # - case-insensitivity
     # - integer values
     # - "all" alias, which isn't standard
-    for lvl in ("all", "ALL", 10, 42, "info", "warning", "ERROR", "CRITICAL"):
+    for lvl in ("all", "ALL", 10, "info", "warning", "ERROR", "CRITICAL"):
         set_log_level(lvl)
 
 
@@ -16,4 +16,4 @@ def test_invalid_level():
     # since they are perfectly clear and readable, we check that nothing else
     # happens in the wrapper
     assert_raises(TypeError, set_log_level, 1.5)
-    assert_raises(ValueError, set_log_level, "invalid_level")
+    assert_raises(KeyError, set_log_level, "invalid_level")


### PR DESCRIPTION
## PR Summary

The command line interface is all kinds of broken. In particular, not all documented examples for `yt config set/rm/get` currently work. It's actually to be expected because we don't have proper testing for the CLI.
I am adding some some and am fixing them as I go.

⚠️ 
- This branch is based on #3106 (first usage of toml files nested sectioning)
- requires pytest (YTEP-0035)
- I'm using `benedict` (https://pypi.org/project/python-benedict/) make accessing nested values a little easier. I do think it's worth adding such a nice little dependency in support of the new configuration file format (toml), but I will need to clean up a bit my usage for it after I get all tests to pass.

❗ I did a mistake in drafting this. I assumed every parameter would live it the `[yt]` root section, so this part could be ommited in the api to retrieve any which parameter.