### PR TITLE
ENH: rich progress bars (YTEP-0039)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ install_requires =
     numpy>=1.13.3
     packaging>=20.9
     pyyaml>=4.2b1
+    rich>=9.12.0
     setuptools>=19.6
     sympy>=1.2
     toml>=0.10.2

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -8,6 +8,7 @@ from re import finditer
 from tempfile import NamedTemporaryFile, TemporaryFile
 
 import numpy as np
+from more_itertools import always_iterable
 
 from yt.config import ytcfg
 from yt.data_objects.field_data import YTFieldData

--- a/yt/data_objects/level_sets/contour_finder.py
+++ b/yt/data_objects/level_sets/contour_finder.py
@@ -51,14 +51,14 @@ def identify_contours(data_source, field, min_val, max_val, cached_fields=None):
     # tree.add_joins(joins)
     joins = tree.export()
     contour_ids = defaultdict(list)
-    pbar = get_pbar("Updating joins ... ", len(contours))
+    pbar = get_pbar(title="Updating joins ... ", maxval=len(contours))
     final_joins = np.unique(joins[:, 1])
-    for i, nid in enumerate(sorted(contours)):
+    for nid in sorted(contours):
         level, node_ind, pg, sl = contours[nid]
         ff = pg.my_data[0].view("int64")
         update_joins(joins, ff, final_joins)
         contour_ids[pg.parent_grid_id].append((sl, ff))
-        pbar.update(i + 1)
+        pbar.update(advance=1)
     pbar.finish()
     rv = dict()
     rv.update(contour_ids)

--- a/yt/frontends/athena_pp/data_structures.py
+++ b/yt/frontends/athena_pp/data_structures.py
@@ -96,7 +96,7 @@ class AthenaPPLogarithmicIndex(UnstructuredIndex):
         num_meshes = len(bc)
 
         self.meshes = []
-        pbar = get_pbar("Constructing meshes", num_meshes)
+        pbar = get_pbar(title="Constructing meshes", maxval=num_meshes)
         for i in range(num_meshes):
             ob = bc[i][0]
             x = x1f[ob, :]
@@ -130,7 +130,7 @@ class AthenaPPLogarithmicIndex(UnstructuredIndex):
                 np.array([nxm - 1, nym - 1, nzm - 1]),
             )
             self.meshes.append(mesh)
-            pbar.update(i + 1)
+            pbar.update(advance=1)
         pbar.finish()
         mylog.debug("Done setting up meshes.")
 

--- a/yt/frontends/enzo/data_structures.py
+++ b/yt/frontends/enzo/data_structures.py
@@ -229,7 +229,7 @@ class EnzoHierarchy(GridIndex):
         self.grids = [self.grid(1, self)]
         self.grids[0].Level = 0
         si, ei, LE, RE, fn, npart = [], [], [], [], [], []
-        pbar = get_pbar("Parsing Hierarchy ", self.num_grids)
+        pbar = get_pbar(title="Parsing Hierarchy ", maxval=self.num_grids)
         version = self.dataset.parameters.get("VersionNumber", None)
         params = self.dataset.parameters
         if version is None and "Internal" in params:
@@ -251,8 +251,7 @@ class EnzoHierarchy(GridIndex):
             else:
                 nap = None
                 active_particles = False
-        for grid_id in range(self.num_grids):
-            pbar.update(grid_id + 1)
+        for _i in range(self.num_grids):
             # We will unroll this list
             si.append(_next_token_line("GridStartIndex", f))
             ei.append(_next_token_line("GridEndIndex", f))
@@ -281,6 +280,7 @@ class EnzoHierarchy(GridIndex):
                 if line.startswith("Pointer:"):
                     vv = patt.findall(line)[0]
                     self.__pointer_handler(vv)
+            pbar.update(advance=1)
         pbar.finish()
         self._fill_arrays(ei, si, LE, RE, npart, nap)
         temp_grids = np.empty(self.num_grids, dtype="object")

--- a/yt/frontends/enzo_e/data_structures.py
+++ b/yt/frontends/enzo_e/data_structures.py
@@ -154,8 +154,7 @@ class EnzoEHierarchy(GridIndex):
     def _parse_index(self):
         self.grids = np.empty(self.num_grids, dtype="object")
 
-        c = 1
-        pbar = get_pbar("Parsing Hierarchy", self.num_grids)
+        pbar = get_pbar(title="Parsing Hierarchy", maxval=self.num_grids)
         f = open(self.ds.parameter_filename)
         fblock_size = 32768
         f.seek(0, 2)
@@ -234,8 +233,7 @@ class EnzoEHierarchy(GridIndex):
                     self.grids[parent_id].add_child(my_grid)
 
                 bnl = nnl + 1
-                pbar.update(c)
-                c += 1
+                pbar.update(advance=1)
             lstr = buff[bnl:]
             offset += fblock
 

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -22,6 +22,7 @@ from functools import lru_cache, wraps
 from numbers import Number as numeric_type
 from typing import Any, Callable, Type, Optional, Sequence, Union
 
+
 import matplotlib
 import numpy as np
 from more_itertools import always_iterable, collapse, first

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -20,8 +20,7 @@ import urllib.request
 import warnings
 from functools import lru_cache, wraps
 from numbers import Number as numeric_type
-from typing import Any, Callable, Type, Optional, Sequence, Union
-
+from typing import Any, Callable, Optional, Sequence, Type, Union
 
 import matplotlib
 import numpy as np

--- a/yt/geometry/particle_oct_container.pyx
+++ b/yt/geometry/particle_oct_container.pyx
@@ -1079,14 +1079,14 @@ cdef class ParticleBitmap:
                     "Number of bitmasks ({}) conflicts with number of files "
                     "({})".format(nfiles, self.nfiles))
         # Read bitmap for each file
-        pb = get_pbar("Loading particle index", nfiles)
+        pbar = get_pbar(title="Loading particle index", maxval=nfiles)
         for ifile in range(nfiles):
-            pb.update(ifile+1)
             size_serial, = struct.unpack('Q', f.read(struct.calcsize('Q')))
             irflag = self.bitmasks._loads(ifile, f.read(size_serial))
             if irflag == 0:
                 read_flag = 0
-        pb.finish()
+            pbar.update(advance=1)
+        pbar.finish()
         # Collisions
         size_serial, = struct.unpack('Q',f.read(struct.calcsize('Q')))
         irflag = self.collisions._loads(f.read(size_serial))

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -1352,6 +1352,12 @@ def load_sample(
     - Corresponding sample data live at https://yt-project.org/data
 
     """
+    if pbar:
+        try:
+            import tqdm  # noqa F401
+        except ImportError:
+            mylog.warning("`pbar=True` requires tqdm to be installed. Turning it off.")
+            pbar = False
 
     if fn is None:
         print(

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -1352,12 +1352,14 @@ def load_sample(
     - Corresponding sample data live at https://yt-project.org/data
 
     """
-    if pbar:
+    if progressbar:
         try:
             import tqdm  # noqa F401
         except ImportError:
-            mylog.warning("`pbar=True` requires tqdm to be installed. Turning it off.")
-            pbar = False
+            mylog.warning(
+                "`progressbar=True` requires tqdm to be installed. Turning it off."
+            )
+            progressbar = False
 
     if fn is None:
         print(

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -242,15 +242,15 @@ class AnswerTestCloudStorage(AnswerTestStorage):
         pyrax.set_credential_file(credentials)
         cf = pyrax.cloudfiles
         c = cf.get_container("yt-answer-tests")
-        pb = get_pbar("Storing results ", len(result_storage))
-        for i, ds_name in enumerate(result_storage):
-            pb.update(i + 1)
+        pb = get_pbar(title="Storing results ", maxval=len(result_storage))
+        for ds_name in result_storage:
             rs = pickle.dumps(result_storage[ds_name])
             object_name = f"{self.answer_name}_{ds_name}"
             if object_name in c.get_object_names():
                 obj = c.get_object(object_name)
                 c.delete_object(obj)
             c.store_object(object_name, rs)
+            pb.update(advance=1)
         pb.finish()
 
 

--- a/yt/utilities/lib/misc_utilities.pyx
+++ b/yt/utilities/lib/misc_utilities.pyx
@@ -981,8 +981,10 @@ def gravitational_binding_energy(
     cdef np.float64_t this_potential
 
     n_q = mass.size
-    pbar = get_pbar("Calculating potential for %d cells with %d thread(s)" % (n_q,num_threads),
-        n_q)
+    pbar = get_pbar(
+            title="Calculating potential for %d cells with %d thread(s)" % (n_q,num_threads),
+            maxval=n_q,
+           )
 
     # using reversed iterator in order to make use of guided scheduling
     # (inner loop is getting more and more expensive)
@@ -1010,7 +1012,7 @@ def gravitational_binding_energy(
         with gil:
             PyErr_CheckSignals()
             # this call is not thread safe, but it gives a reasonable approximation
-            pbar.update()
+            pbar.update(advance=1)
 
     pbar.finish()
     return total_potential

--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -1267,7 +1267,7 @@ def interpolate_sph_grid_gather(np.float64_t[:, :, :] buff,
                     if prog % 10000 == 0:
                         with gil:
                             PyErr_CheckSignals()
-                            pbar.update(prog)
+                            pbar.update(completed=prog)
 
                     queue.size = 0
 
@@ -1303,6 +1303,7 @@ def interpolate_sph_grid_gather(np.float64_t[:, :, :] buff,
                         if use_normalization:
                             buff_den[i, j, k] += prefactor_j * kernel_func(q_ij)
 
+    pbar.finish()
     if use_normalization:
         normalization_3d_utility(buff, buff_den)
 
@@ -1505,7 +1506,7 @@ def pixelize_sph_kernel_arbitrary_grid(np.float64_t[:, :, :] buff,
             if j % 50000 == 0:
                 with gil:
                     if(pbar is not None):
-                        pbar.update(50000)
+                        pbar.update(advance=50000)
                     PyErr_CheckSignals()
 
             xiter[1] = yiter[1] = ziter[1] = 999

--- a/yt/utilities/particle_generator.py
+++ b/yt/utilities/particle_generator.py
@@ -155,9 +155,8 @@ class ParticleGenerator:
         ... }
         >>> particles.map_grid_fields_to_particles(field_map)
         """
-        pbar = get_pbar("Mapping fields to particles", self.num_grids)
+        pbar = get_pbar(title="Mapping fields to particles", maxval=self.num_grids)
         for i, grid in enumerate(self.ds.index.grids):
-            pbar.update(i + 1)
             if self.NumberOfParticles[i] > 0:
                 start = self.ParticleGridIndices[i]
                 end = self.ParticleGridIndices[i + 1]
@@ -179,6 +178,7 @@ class ParticleGenerator:
                         dims,
                         grid.dds[0],
                     )
+            pbar.update(advance=1)
         pbar.finish()
 
     def apply_to_stream(self, overwrite=False, **kwargs):
@@ -403,8 +403,7 @@ class WithDensityParticleGenerator(ParticleGenerator):
         all_y = []
         all_z = []
 
-        pbar = get_pbar("Generating Particles", num_particles)
-        tot_num_accepted = int(0)
+        pbar = get_pbar(title="Generating Particles", maxval=num_particles)
 
         while num_particles_left > 0:
 
@@ -438,8 +437,7 @@ class WithDensityParticleGenerator(ParticleGenerator):
             all_z.append(zpos)
 
             num_particles_left -= num_accepted
-            tot_num_accepted += num_accepted
-            pbar.update(tot_num_accepted)
+            pbar.update(advance=num_accepted)
 
         pbar.finish()
 

--- a/yt/visualization/streamlines.py
+++ b/yt/visualization/streamlines.py
@@ -142,7 +142,7 @@ class Streamlines(ParallelAnalysisInterface):
         my_rank = self.comm.rank
         self.streamlines[my_rank::nprocs, 0, :] = self.start_positions[my_rank::nprocs]
 
-        pbar = get_pbar("Streamlining", self.N)
+        pbar = get_pbar(title="Streamlining", maxval=self.N)
         for i, stream in enumerate(self.streamlines[my_rank::nprocs]):
             thismag = None
             if self.get_magnitude:
@@ -153,7 +153,7 @@ class Streamlines(ParallelAnalysisInterface):
                 step = self._integrate_through_brick(
                     this_node, stream, step, mag=thismag
                 )
-            pbar.update(i + 1)
+            pbar.update(advance=1)
         pbar.finish()
 
         self._finalize_parallel(None)


### PR DESCRIPTION
## PR Summary

This is the second PR in support to [YTEP-0039](https://github.com/yt-project/ytep/pull/18)
The branch is currently based on #3115


Fortunately we already have a `get_pbar` function that's used everywhere in the code base to create progress bars, so the change is very straightforward.

Rich progress bars are supposed to work well in all sorts of contexts (terminal with various levels of support for colors, as well as notebooks), so I don't expect any complication with CI but life, box, chocolates...
See rich's doc for details on how progress bar should behave in limited environments (or when writing to a file)
https://rich.readthedocs.io/en/stable/console.html?highlight=environment#terminal-detection

I took advantage of rich's api to force the distinction between two ways pbars can be updated using `pbar.update()`:
`yt.func.RichProgressBar.update` now takes keyword arguments only (and should be provided exactly one), which will be either `completed` (state the current completion) or `advance` (increment completion).
In most places where bars are used in yt we implicitly want `completed`, but there are one or two cases where `advance` would be more suited, which allows me to simplify the surrounding code.

Overall I normalised the way pbars are used in the code base and I believe I also fixed some bugs here and there (including the one reported in #3116)

TODO:
- [x] make sure that I'm replacing every usage of `tqdm`
- [x] remove tqdm from required deps
- [x] either deprecate or remove `TqdmProgressBar` and cleanup `RichProgressBar`'s docstring accordingly

Here's a minimal demo script you can use to try this out for yourself

```python
# pbar_demo.py
from yt.funcs import get_pbar
from time import sleep

def main(title, ntasks=100):
    p = get_pbar(title=title, maxval=ntasks)
    for i in range(ntasks):
        sleep(0.05)
        try:
            p.update(i+1) # this syntax only works with the main branch
        except TypeError:
            # this is one correct way to do it with this branch
            p.update(completed=i+1)
            # and within this context, the following line is also equivalent
            # p.update(advance=1)
    p.finish()

if __name__ == "__main__":
    main(title="Loading...")
```
And here's a short video showing how this looks on the main branch (with tqdm), then with this one (with, then without color)

https://user-images.githubusercontent.com/14075922/110307343-16276280-7fff-11eb-8488-2133244dbbd9.mp4

In a few cases we had "progress bars" (no bars really) generated by calling tqdm directly instead of using `yt.funcs.get_pbar`. The reason for that was that the total number of iterations was hard to predict. I added support for such a case, in line with was tqdm was getting us

```python
# tqdm2rich.py
from tqdm import tqdm
from time import sleep

with tqdm(
    desc="pbar without a max (tqdm)"
) as pbar:
    for i in range(100):
        sleep(0.02)
        pbar.update(1)

from yt.funcs import get_pbar

pbar = get_pbar(title="pbar without a max (yt+rich)")
for i in range(100):
    sleep(0.02)
    pbar.update(advance=1)
pbar.finish()
```


https://user-images.githubusercontent.com/14075922/110336401-1f2b2a80-8025-11eb-8936-29ed2774d2a1.mp4

update:
Regarding perfs, this benchmark just came out and shows that rich and tqdm are extremely comparable
https://tqdm.github.io/tqdm/#benchmarks.track_alternatives

## Follow ups

This work will gain support from other PRs, and can be adapted if then get in first, or will know smaller follow up PRs otherwise. Namely

- The present PR has very little actual overlap with #3106 but there's one thing that will need to be addressed as a follow up:  the new proposed parameter `logging.use_color` currently has no effect on progress bars (it should).
- I wrote a patch upstream for pooch in support of this work https://github.com/fatiando/pooch/pull/228.