### PR TITLE
fix a missing loadname in sample dataset registry

### DIFF
--- a/yt/sample_data_registry.json
+++ b/yt/sample_data_registry.json
@@ -729,7 +729,7 @@
   "output_00080_halos.tar.gz": {
     "hash": "fb8f573ea7cb183e1531091b3fce91cf7015cfdf5ccbce9ef2742e3135b52d4c",
     "load_kwargs": {},
-    "load_name": null,
+    "load_name": "tree_bricks080",
     "url": "https://yt-project.org/data/output_00080_halos.tar.gz"
   },
   "output_00101.tar.gz": {


### PR DESCRIPTION
## PR Summary

I was able to discover this with my reworked version of `yt.load_sample` (https://github.com/yt-project/yt/pull/3089)

Note that this dataset in particular is a bit tricky to load as it really requires two steps
```python
import yt
ds_parent = yt.load_sample("output_00080")
ds = yt.load_sample("output_00080_halos", parent_ds=ds_parent)
```

Unfortunately, this can not be expressed in `load_kwargs`... and json files don't support comments. I don't know how it should be documented.