### PR TITLE
blacklist RecursionError to reveal failing tests

### DIFF
--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -489,7 +489,7 @@ class FieldInfoContainer(dict):
         # - a greylist (exceptions that may be covering bugs but should be checked)
         # See https://github.com/yt-project/yt/issues/2853
         # in the long run, the greylist should be removed
-        blacklist = ()
+        blacklist = (RecursionError,)
         whitelist = (NotImplementedError,)
         greylist = (
             YTFieldNotFound,
@@ -503,9 +503,6 @@ class FieldInfoContainer(dict):
             KeyError,
             # code smells -> those are very likely bugs
             UnitConversionError,  # solved in GH PR 2897 ?
-            # RecursionError is clearly a bug, and was already solved once
-            # in GH PR 2851
-            RecursionError,
         )
 
         deps = {}


### PR DESCRIPTION
## PR Summary
Attempt to solve a recursion errors that are currently caught in tests.
First things first: stop catching them and see how bad the situation is (how many tests fall).
