### PR TITLE
fix a broken load_name in data sample metadata

### DIFF
--- a/yt/sample_data_registry.json
+++ b/yt/sample_data_registry.json
@@ -38,7 +38,7 @@
   "CfRadialGrid.tar.gz": {
     "hash": "22a45b322773d4b2864ccab93c521d8e3d637d81c8d8c0852e1a67c7fa883e0c",
     "load_kwargs": {},
-    "load_name": "CfRadialGrid/grid1.nc",
+    "load_name": "grid1.nc",
     "url": "https://yt-project.org/data/CfRadialGrid.tar.gz"
   },
   "ClusterMerger.tar.gz": {


### PR DESCRIPTION
## PR Summary

```python
import yt
yt.load_sample("CfRadialGrid")
```
fails with 
```
FileNotFoundError
```

This fixes it.
Note that this particular dataset still doesn't load (`YTUnidentifiedDataType`). I believe it was added in support to #1990 which is still in the shop. 

I except this will fail the same way #3118 does: the hash probably needs to be updated as well.
edit: nope. Must be a problem with changing the type (from null to str) of the field, which is not a concern here.