### PR TITLE
doc: fix missing `sampling_type` keyword argument in `add_field` examples

### DIFF
--- a/doc/source/developing/creating_derived_fields.rst
+++ b/doc/source/developing/creating_derived_fields.rst
@@ -50,7 +50,12 @@ look at the most basic ones needed for a simple scalar baryon field.
 
 .. code-block:: python
 
-   yt.add_field(("gas", "pressure"), function=_pressure, units="dyne/cm**2")
+    yt.add_field(
+        name=("gas", "pressure"),
+        function=_pressure,
+        sampling_type="cell",
+        units="dyne/cm**2",
+    )
 
 We feed it the name of the field, the name of the function, and the
 units.  Note that the units parameter is a "raw" string, in the format that yt
@@ -106,6 +111,7 @@ the dimensionality of the returned array and the field are the same:
     yt.add_field(
         ("gas", "pressure"),
         function=_pressure,
+        sampling_type="cell",
         units="auto",
         dimensions=dimensions.pressure,
     )
@@ -123,7 +129,7 @@ the previous example:
    from yt import derived_field
 
 
-   @derived_field(name="pressure", units="dyne/cm**2")
+   @derived_field(name="pressure", sampling_type="cell", units="dyne/cm**2")
    def _pressure(field, data):
        return (data.ds.gamma - 1.0) * data["density"] * data["thermal_energy"]
 
@@ -141,7 +147,9 @@ dataset objects. The calling syntax is the same:
 .. code-block:: python
 
    ds = yt.load("GasSloshing/sloshing_nomag2_hdf5_plt_cnt_0100")
-   ds.add_field(("gas", "pressure"), function=_pressure, units="dyne/cm**2")
+   ds.add_field(
+       ("gas", "pressure"), function=_pressure, sampling_type="cell", units="dyne/cm**2"
+   )
 
 If you specify fields in this way, you can take advantage of the dataset's
 :ref:`unit system <unit_systems>` to define the units for you, so that
@@ -149,7 +157,12 @@ the units will be returned in the units of that system:
 
 .. code-block:: python
 
-    ds.add_field(("gas", "pressure"), function=_pressure, units=ds.unit_system["pressure"])
+    ds.add_field(
+        ("gas", "pressure"),
+        function=_pressure,
+        sampling_type="cell",
+        units=ds.unit_system["pressure"],
+    )
 
 Since the :class:`yt.units.unit_systems.UnitSystem` object returns a :class:`yt.units.unit_object.Unit` object when
 queried, you're not limited to specifying units in terms of those already available. You can specify units for fields
@@ -160,6 +173,7 @@ using basic arithmetic if necessary:
     ds.add_field(
         ("gas", "my_acceleration"),
         function=_my_acceleration,
+        sampling_type="cell",
         units=ds.unit_system["length"] / ds.unit_system["time"] ** 2,
     )
 
@@ -204,6 +218,7 @@ transparent and simple example).
    yt.add_field(
        ("gas", "my_radial_velocity"),
        function=_my_radial_velocity,
+       sampling_type="cell",
        units="cm/s",
        take_log=False,
        validators=[ValidateParameter(["center", "bulk_velocity"])],

--- a/doc/source/developing/creating_derived_fields.rst
+++ b/doc/source/developing/creating_derived_fields.rst
@@ -64,7 +64,9 @@ is calculated. It can be set to "cell" for grid/mesh fields, "particle" for
 particle and SPH fields, or "local" to use the primary format of the loaded
 dataset. In most cases, "local" is sufficient, but "cell" and "particle"
 can be used to specify the source for datasets that have both grids and
-particles.
+particles. In a dataset with both grids and particles, using "cell" will
+ensure a field is created with a value for every grid cell, while using
+"particle" will result in a field with a value for every particle.
 
 The units parameter is a "raw" string, in the format that yt
 uses in its :ref:`symbolic units implementation <units>` (e.g., employing only

--- a/doc/source/developing/creating_derived_fields.rst
+++ b/doc/source/developing/creating_derived_fields.rst
@@ -58,10 +58,13 @@ look at the most basic ones needed for a simple scalar baryon field.
     )
 
 We feed it the name of the field, the name of the function, the sampling type,
-and the units. The ``sampling_type`` keyword controls how volume is sampled
-when calculating the field. It can be set to "cell" for grid/mesh fields,
-"particle" for particle and SPH fields, or "local" to use the primary format
-of the loaded dataset.
+and the units. The ``sampling_type`` keyword determines which elements are
+used to make the field (i.e., grid cell or particles) and controls how volume
+is calculated. It can be set to "cell" for grid/mesh fields, "particle" for
+particle and SPH fields, or "local" to use the primary format of the loaded
+dataset. In most cases, "local" is sufficient, but "cell" and "particle"
+can be used to specify the source for datasets that have both grids and
+particles.
 
 The units parameter is a "raw" string, in the format that yt
 uses in its :ref:`symbolic units implementation <units>` (e.g., employing only

--- a/doc/source/developing/creating_derived_fields.rst
+++ b/doc/source/developing/creating_derived_fields.rst
@@ -53,12 +53,17 @@ look at the most basic ones needed for a simple scalar baryon field.
     yt.add_field(
         name=("gas", "pressure"),
         function=_pressure,
-        sampling_type="cell",
+        sampling_type="local",
         units="dyne/cm**2",
     )
 
-We feed it the name of the field, the name of the function, and the
-units.  Note that the units parameter is a "raw" string, in the format that yt
+We feed it the name of the field, the name of the function, the sampling type,
+and the units. The ``sampling_type`` keyword controls how volume is sampled
+when calculating the field. It can be set to "cell" for grid/mesh fields,
+"particle" for particle and SPH fields, or "local" to use the primary format
+of the loaded dataset.
+
+The units parameter is a "raw" string, in the format that yt
 uses in its :ref:`symbolic units implementation <units>` (e.g., employing only
 unit names, numbers, and mathematical operators in the string, and using
 ``"**"`` for exponentiation). For cosmological datasets and fields, see
@@ -111,7 +116,7 @@ the dimensionality of the returned array and the field are the same:
     yt.add_field(
         ("gas", "pressure"),
         function=_pressure,
-        sampling_type="cell",
+        sampling_type="local",
         units="auto",
         dimensions=dimensions.pressure,
     )

--- a/doc/source/reference/configuration.rst
+++ b/doc/source/reference/configuration.rst
@@ -188,7 +188,13 @@ For example, if I created a plugin file containing:
        return np.random.random(data["density"].shape)
 
 
-   add_field("random", function=_myfunc, dimensions="dimensionless", units="auto")
+   add_field(
+       "random",
+       function=_myfunc,
+       sampling_type="cell",
+       dimensions="dimensionless",
+       units="auto",
+   )
 
 then all of my data objects would have access to the field ``random``.
 

--- a/doc/source/visualizing/sketchfab.rst
+++ b/doc/source/visualizing/sketchfab.rst
@@ -249,7 +249,7 @@ to output one more type of variable on your surfaces.  For example:
         return data["density"] * data["density"] * np.sqrt(data["temperature"])
 
 
-    add_field("emissivity", function=_Emissivity, units=r"g*K/cm**6")
+    add_field("emissivity", function=_Emissivity, sampling_type="cell", units=r"g*K/cm**6")
 
     sphere = ds.sphere("max", (1.0, "Mpc"))
     for i, r in enumerate(rho):


### PR DESCRIPTION
## PR Summary

fix #3108 
(hopefully I got all the broken examples)
