### PR TITLE
making ParticleContainers pickleable

### DIFF
--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1336,7 +1336,7 @@ class YTDataContainer:
         []
         """
         args = self.__reduce__()
-        return args[0](self.ds, *args[1][1:])[1]
+        return args[0](self.ds, *args[1][1:])
 
     def __repr__(self):
         # We'll do this the slow way to be clear what's going on
@@ -1483,29 +1483,16 @@ class YTDataContainer:
                 o.field_parameters = cache_fp
 
 
-# Many of these items are set up specifically to ensure that
-# we are not breaking old pickle files.  This means we must only call the
-# _reconstruct_object and that we cannot mandate any additional arguments to
-# the reconstruction function.
+# PR3124: Given that save_as_dataset is now the recommended method for saving
+# objects (see Issue 2021 and references therein), the following has been re-written.
+#
+# Original comments (still true):
 #
 # In the future, this would be better off being set up to more directly
 # reference objects or retain state, perhaps with a context manager.
 #
 # One final detail: time series or multiple datasets in a single pickle
 # seems problematic.
-
-
-class ReconstructedObject(tuple):
-    pass
-
-
-def _check_nested_args(arg, ref_ds):
-    if not isinstance(arg, (tuple, list, ReconstructedObject)):
-        return arg
-    elif isinstance(arg, ReconstructedObject) and ref_ds == arg[0]:
-        return arg[1]
-    narg = [_check_nested_args(a, ref_ds) for a in arg]
-    return narg
 
 
 def _get_ds_by_hash(hash):
@@ -1522,17 +1509,31 @@ def _get_ds_by_hash(hash):
 
 
 def _reconstruct_object(*args, **kwargs):
-    dsid = args[0]
-    dtype = args[1]
+    # returns a reconstructed YTDataContainer. As of PR 3124, we now return
+    # the actual YTDataContainer rather than a (ds, YTDataContainer) tuple.
+
+    # pull out some arguments
+    dsid = args[0]  # the hash id
+    dtype = args[1]  # DataContainer type (e.g., 'region')
+    field_parameters = args[-1]  # the field parameters
+
+    # re-instantiate the base dataset from the hash and ParameterFileStore
     ds = _get_ds_by_hash(dsid)
+    override_weakref = False
     if not ds:
+        override_weakref = True
         datasets = ParameterFileStore()
         ds = datasets.get_ds_hash(dsid)
-    field_parameters = args[-1]
-    # will be much nicer when we can do dsid, *a, fp = args
-    args = args[2:-1]
-    new_args = [_check_nested_args(a, ds) for a in args]
+
+    # instantiate the class with remainder of the args and adjust the state
     cls = getattr(ds, dtype)
-    obj = cls(*new_args)
+    obj = cls(*args[2:-1])
     obj.field_parameters.update(field_parameters)
-    return ReconstructedObject((ds, obj))
+
+    # any nested ds references are weakref.proxy(ds), so need to ensure the ds
+    # we just loaded persists when we leave this function (nosetests fail without
+    # this) if we did not have an actual dataset as an argument.
+    if hasattr(obj, "ds") and override_weakref:
+        obj.ds = ds
+
+    return obj

--- a/yt/data_objects/index_subobjects/particle_container.py
+++ b/yt/data_objects/index_subobjects/particle_container.py
@@ -23,11 +23,14 @@ class ParticleContainer(YTSelectionContainer):
     _spatial = False
     _type_name = "particle_container"
     _skip_add = True
-    _con_args = ("base_region", "data_files", "overlap_files")
+    _con_args = ("base_region", "base_selector", "data_files", "overlap_files")
 
-    def __init__(self, base_region, data_files, overlap_files=None, domain_id=-1):
+    def __init__(
+        self, base_region, base_selector, data_files, overlap_files=None, domain_id=-1
+    ):
         if overlap_files is None:
             overlap_files = []
+        # print("hello pc init")
         self.field_data = YTFieldData()
         self.field_parameters = {}
         self.data_files = list(always_iterable(data_files))
@@ -37,12 +40,13 @@ class ParticleContainer(YTSelectionContainer):
         self._last_selector_id = None
         self._current_particle_type = "all"
         # self._current_fluid_type = self.ds.default_fluid_type
-        if hasattr(base_region, "base_selector"):
-            self.base_selector = base_region.base_selector
-            self.base_region = base_region.base_region
-        else:
-            self.base_region = base_region
-            self.base_selector = base_region.selector
+
+        if isinstance(base_region, tuple):
+            # when unpickling, base_region comes in as tuple.
+            base_region = base_region[-1]
+
+        self.base_region = base_region
+        self.base_selector = base_selector
         self._octree = None
         self._temp_spatial = False
         if isinstance(base_region, ParticleContainer):
@@ -50,6 +54,12 @@ class ParticleContainer(YTSelectionContainer):
             self._octree = base_region._octree
         # To ensure there are not domains if global octree not used
         self.domain_id = -1
+
+    def __reduce__(self):
+        # we need to override the __reduce__ from data_containers as this method is not
+        # a registered dataset method (i.e., ds.particle_container does not exist)
+        arg_tuple = tuple(getattr(self, attr) for attr in self._con_args)
+        return (self.__class__, arg_tuple)
 
     @property
     def selector(self):
@@ -74,6 +84,7 @@ class ParticleContainer(YTSelectionContainer):
         gz_oct = self.octree.retrieve_ghost_zones(ngz, coarse_ghosts=coarse_ghosts)
         gz = ParticleContainer(
             gz_oct.base_region,
+            gz_oct.base_selector,
             gz_oct.data_files,
             overlap_files=gz_oct.overlap_files,
             selector_mask=gz_oct.selector_mask,

--- a/yt/data_objects/index_subobjects/particle_container.py
+++ b/yt/data_objects/index_subobjects/particle_container.py
@@ -30,7 +30,6 @@ class ParticleContainer(YTSelectionContainer):
     ):
         if overlap_files is None:
             overlap_files = []
-        # print("hello pc init")
         self.field_data = YTFieldData()
         self.field_parameters = {}
         self.data_files = list(always_iterable(data_files))

--- a/yt/data_objects/index_subobjects/particle_container.py
+++ b/yt/data_objects/index_subobjects/particle_container.py
@@ -40,10 +40,6 @@ class ParticleContainer(YTSelectionContainer):
         self._current_particle_type = "all"
         # self._current_fluid_type = self.ds.default_fluid_type
 
-        if isinstance(base_region, tuple):
-            # when unpickling, base_region comes in as tuple.
-            base_region = base_region[-1]
-
         self.base_region = base_region
         self.base_selector = base_selector
         self._octree = None

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -226,17 +226,16 @@ class Dataset(abc.ABC):
         self.setup_cosmology()
         self._assign_unit_system(unit_system)
         self._setup_coordinate_handler()
-
+        self.print_key_parameters()
+        self._set_derived_attrs()
         # Because we need an instantiated class to check the ds's existence in
         # the cache, we move that check to here from __new__.  This avoids
         # double-instantiation.
+        # PR 3124: _set_derived_attrs() can change the hash, check store here
         try:
             _ds_store.check_ds(self)
         except NoParameterShelf:
             pass
-        self.print_key_parameters()
-
-        self._set_derived_attrs()
         self._setup_classes()
 
     @property

--- a/yt/data_objects/tests/test_pickling.py
+++ b/yt/data_objects/tests/test_pickling.py
@@ -1,0 +1,27 @@
+import pickle
+
+from yt.testing import assert_equal, requires_file
+from yt.utilities.answer_testing.framework import data_dir_load
+
+tipsy_ds = "TipsyGalaxy/galaxy.00300"
+enzo_ds = "enzo_tiny_cosmology/DD0000/DD0000"
+
+
+@requires_file(enzo_ds)
+def test_grid_pickles():
+    ds = data_dir_load(enzo_ds)
+    ad = ds.all_data()
+    # just test ad since there is a nested ds that will get (un)pickled
+    ad_pickle = pickle.loads(pickle.dumps(ad))
+    assert_equal(ad.ds.basename, ad_pickle.ds.basename)
+
+
+@requires_file(tipsy_ds)
+def test_particle_pickles():
+    ds = data_dir_load(tipsy_ds)
+    ad = ds.all_data()
+    ds.index._identify_base_chunk(ad)
+    ch0 = list(ds.index._chunk_io(ad, cache=False))[0]
+    # just test one chunk since there is a nested ds that will get (un)pickled
+    ch_pickle = pickle.loads(pickle.dumps(ch0))
+    assert_equal(ch0.dobj.ds.basename, ch_pickle.dobj.ds.basename)

--- a/yt/geometry/particle_geometry_handler.py
+++ b/yt/geometry/particle_geometry_handler.py
@@ -304,6 +304,10 @@ class ParticleIndex(Index):
                     nfiles = len(file_masks)
                 dobj._chunk_info = [None for _ in range(nfiles)]
 
+                # The following was moved here from ParticleContainer in order
+                # to make the ParticleContainer object pickleable. By having
+                # the base_selector as its own argument, we avoid having to
+                # rebuild the index on unpickling a ParticleContainer.
                 if hasattr(dobj, "base_selector"):
                     base_selector = dobj.base_selector
                     base_region = dobj.base_region

--- a/yt/geometry/particle_geometry_handler.py
+++ b/yt/geometry/particle_geometry_handler.py
@@ -303,10 +303,21 @@ class ParticleIndex(Index):
                     )
                     nfiles = len(file_masks)
                 dobj._chunk_info = [None for _ in range(nfiles)]
+
+                if hasattr(dobj, "base_selector"):
+                    base_selector = dobj.base_selector
+                    base_region = dobj.base_region
+                else:
+                    base_region = dobj
+                    base_selector = dobj.selector
+
                 for i in range(nfiles):
                     domain_id = i + 1
                     dobj._chunk_info[i] = ParticleContainer(
-                        dobj, [self.data_files[dfi[i]]], domain_id=domain_id
+                        base_region,
+                        base_selector,
+                        [self.data_files[dfi[i]]],
+                        domain_id=domain_id,
                     )
                 # NOTE: One fun thing about the way IO works is that it
                 # consolidates things quite nicely.  So we should feel free to


### PR DESCRIPTION
## PR Summary

Update: this PR has broadened a bit to include some wider pickle and `ParameterFileStore` fixes. Happy to split into separate PRs if warranted. 

The main update that may be worth some discussion is that I'm modifying the base `__reduce__` used by `YTDataContainer`. Since `save_as_dataset` is now the recommended method for long term dataset storage and the pickling seems to have been broken for some time, I assumed this was OK. But it does mean that if there happened to be any legacy pickled datasets out there for which the reload was NOT broken, this change will definitely break them. 


Original: 

I'm not sure this qualifies as a bug per se as this isn't something that you would do accidentally (feel free to remove the bug tag).... but currently on main, if you try to pickle a chunk of a particle data container, the pickling fails:

```python
import yt
import pickle
ds = yt.load("snapshot_033")
ad = ds.all_data()
ds.index._identify_base_chunk(ad)
chunks = list(ds.index._chunk_io(ad, cache=False))
chu_p = pickle.loads(pickle.dumps(chunks[0]))
```

results in 

```
Traceback (most recent call last):
  File "/home/chavlin/.pyenv/versions/yt_dev/lib/python3.8/site-packages/IPython/core/interactiveshell.py", line 3427, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-2-69d3e1f050db>", line 7, in <module>
    chu_p = pickle.loads(pickle.dumps(chunks[0]))
  File "/home/chavlin/src/yt/yt/data_objects/data_containers.py", line 1535, in _reconstruct_object
    cls = getattr(ds, dtype)
AttributeError: 'OWLSDataset' object has no attribute 'particle_container'
```

**Why would you do this?** This came up during some Daskening  (related PR to the Daskening branch to follow soon...), in which I distribute chunks of a particle dataset to dask. 

**The fix** The issue comes from the fact that the `ParticleContainer` objects embedded in the `index` chunks are not pickleable. The `ParticleContainer` inherits a `__reduce__` method from the general `YTDataContainer`, which was designed for unpickling datasets. The fix (1) overrides the `__reduce__` method in `ParticleContainer`  and (2) adds the `base_selector` as an explicit argument to `ParticleContainer.__init__`. The reason for thing (2) is that having the `base_selector` as an argument avoids the need to rebuild the index on unpickling a chunk. 

I'm open to other approaches -- I think this behavior indicates a wider refactoring of the indexing/chunking might be warranted, but not sure where to start? and I think adding a unit test might make sense here? 