### PR TITLE
[bugfix] Various SPH fixes

### DIFF
--- a/yt/frontends/arepo/data_structures.py
+++ b/yt/frontends/arepo/data_structures.py
@@ -77,6 +77,7 @@ class ArepoHDF5Dataset(GadgetHDF5Dataset):
 
     def _set_code_unit_attributes(self):
         self._unit_base = self._get_uvals()
+        self._unit_base["cmcm"] = 1.0 / self._unit_base["UnitLength_in_cm"]
         super()._set_code_unit_attributes()
         munit = np.sqrt(self.mass_unit / (self.time_unit ** 2 * self.length_unit)).to(
             "gauss"

--- a/yt/frontends/arepo/data_structures.py
+++ b/yt/frontends/arepo/data_structures.py
@@ -76,7 +76,7 @@ class ArepoHDF5Dataset(GadgetHDF5Dataset):
         else:
             # We assume this is comoving, because in the absence of comoving
             # integration the redshift will be zero.
-            self._unit_base["cmcm"] = 1.0 / self._unit_base["UnitLength_in_cm"]
+            uvals["cmcm"] = 1.0 / uvals["UnitLength_in_cm"]
         return uvals
 
     def _set_code_unit_attributes(self):

--- a/yt/frontends/arepo/data_structures.py
+++ b/yt/frontends/arepo/data_structures.py
@@ -77,7 +77,10 @@ class ArepoHDF5Dataset(GadgetHDF5Dataset):
 
     def _set_code_unit_attributes(self):
         self._unit_base = self._get_uvals()
-        self._unit_base["cmcm"] = 1.0 / self._unit_base["UnitLength_in_cm"]
+        if "UnitLength_in_cm" in self._unit_base:
+            # We assume this is comoving, because in the absence of comoving
+            # integration the redshift will be zero.
+            self._unit_base["cmcm"] = 1.0 / self._unit_base["UnitLength_in_cm"]
         super()._set_code_unit_attributes()
         munit = np.sqrt(self.mass_unit / (self.time_unit ** 2 * self.length_unit)).to(
             "gauss"

--- a/yt/frontends/arepo/data_structures.py
+++ b/yt/frontends/arepo/data_structures.py
@@ -77,7 +77,7 @@ class ArepoHDF5Dataset(GadgetHDF5Dataset):
 
     def _set_code_unit_attributes(self):
         self._unit_base = self._get_uvals()
-        if "UnitLength_in_cm" in self._unit_base:
+        if self._unit_base is not None and "UnitLength_in_cm" in self._unit_base:
             # We assume this is comoving, because in the absence of comoving
             # integration the redshift will be zero.
             self._unit_base["cmcm"] = 1.0 / self._unit_base["UnitLength_in_cm"]

--- a/yt/frontends/arepo/data_structures.py
+++ b/yt/frontends/arepo/data_structures.py
@@ -73,14 +73,14 @@ class ArepoHDF5Dataset(GadgetHDF5Dataset):
         handle.close()
         if missing:
             uvals = None
+        else:
+            # We assume this is comoving, because in the absence of comoving
+            # integration the redshift will be zero.
+            self._unit_base["cmcm"] = 1.0 / self._unit_base["UnitLength_in_cm"]
         return uvals
 
     def _set_code_unit_attributes(self):
         self._unit_base = self._get_uvals()
-        if self._unit_base is not None and "UnitLength_in_cm" in self._unit_base:
-            # We assume this is comoving, because in the absence of comoving
-            # integration the redshift will be zero.
-            self._unit_base["cmcm"] = 1.0 / self._unit_base["UnitLength_in_cm"]
         super()._set_code_unit_attributes()
         munit = np.sqrt(self.mass_unit / (self.time_unit ** 2 * self.length_unit)).to(
             "gauss"

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -361,6 +361,7 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
             f = open(data_file.filename, "rb")
             for ptype in ptf:
                 if tp[ptype] == 0:
+                    # skip if there are no particles
                     continue
                 f.seek(poff[ptype, "Coordinates"], os.SEEK_SET)
                 pos = self._read_field_from_file(f, tp[ptype], "Coordinates")

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -360,6 +360,8 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
             tp = data_file.total_particles
             f = open(data_file.filename, "rb")
             for ptype in ptf:
+                if tp[ptype] == 0:
+                    continue
                 f.seek(poff[ptype, "Coordinates"], os.SEEK_SET)
                 pos = self._read_field_from_file(f, tp[ptype], "Coordinates")
                 if ptype == self.ds._sph_ptypes[0]:

--- a/yt/geometry/particle_oct_container.pyx
+++ b/yt/geometry/particle_oct_container.pyx
@@ -571,8 +571,8 @@ cdef class ParticleBitmap:
                 continue
             if hsml[p] < 0:
                 raise RuntimeError(
-                    "Smoothing length for particle %s is negative with "
-                    "value \"%s\"" % p, hsml[p])
+                    f"Smoothing length for particle {p} is negative with "
+                    f"value {hsml[p]}")
             radius = hsml[p]
             # We first check if we're bounded within the domain; this follows the logic in the
             # pixelize_cartesian routine.  We assume that no smoothing
@@ -610,9 +610,9 @@ cdef class ParticleBitmap:
                                     particle_counts[miex] += 1
                                     if miex >= msize:
                                         raise IndexError(
-                                            "Index for a softening region " +
-                                            "({}) exceeds ".format(miex) +
-                                            "max ({})".format(msize))
+                                            "Index for a softening region "
+                                            f"({miex}) exceeds "
+                                            f"max ({msize})")
 
     @cython.boundscheck(False)
     @cython.wraparound(False)


### PR DESCRIPTION
This PR fixes a few issues related to SPH. 

* Arepo needed to have `"cmcm"` defined in its `_unit_base` but it did not.
* There was a string in the `particle_oct_container` code which didn't have enough format specifiers. I've fixed it and simply changed it to an f-string. 
* In `IOHandlerGadgetBinary`, we were not skipping a chunk/particle type combination in the `_read_particle_coords` method if it had no particles, which is what we should be doing (and what we do in `IOHandlerGadgetHDF5`). I've simply applied the same fix that is used in `IOHandlerGadgetHDF5`.