### PR TITLE
Deprecate WeightedVariance in favor of WeightedStandardDeviation

### DIFF
--- a/doc/source/analyzing/objects.rst
+++ b/doc/source/analyzing/objects.rst
@@ -731,12 +731,12 @@ Available Derived Quantities
       over an entire data object.  If you want an unweighted average,
       then set your weight to be the field: ``ones``.
 
-**Weighted Variance of a Field**
-    | Class :class:`~yt.data_objects.derived_quantities.WeightedVariance`
-    | Usage: ``weighted_variance(fields, weight)``
-    | The weighted variance of a field (or list of fields)
+**Weighted Standard Deviation of a Field**
+    | Class :class:`~yt.data_objects.derived_quantities.WeightedStandardDeviation`
+    | Usage: ``weighted_standard_deviation(fields, weight)``
+    | The weighted standard deviation of a field (or list of fields)
       over an entire data object and the weighted mean.
-      If you want an unweighted variance, then
+      If you want an unweighted standard deviation, then
       set your weight to be the field: ``ones``.
 
 .. _arbitrary-grid:

--- a/doc/source/cookbook/profile_with_standard_deviation.py
+++ b/doc/source/cookbook/profile_with_standard_deviation.py
@@ -30,7 +30,7 @@ std = prof.standard_deviation["gas", "velocity_magnitude"]
 
 # Plot the average velocity magnitude.
 plt.loglog(radius, mean, label="Mean")
-# Plot the variance of the velocity magnitude.
+# Plot the standard deviation of the velocity magnitude.
 plt.loglog(radius, std, label="Standard Deviation")
 plt.xlabel("r [kpc]")
 plt.ylabel("v [cm/s]")

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1049,25 +1049,25 @@ class YTDataContainer:
             raise NotImplementedError(f"Unknown axis {axis}")
 
     def std(self, field, weight=None):
-        """Compute the variance of a field.
+        """Compute the standard deviation of a field.
 
-        This will, in a parallel-ware fashion, compute the variance of
-        the given field.
+        This will, in a parallel-ware fashion, compute the standard
+        deviation of the given field.
 
         Parameters
         ----------
         field : string or tuple field name
-            The field to calculate the variance of
+            The field to calculate the standard deviation of
         weight : string or tuple field name
-            The field to weight the variance calculation by. Defaults to
-            unweighted if unset.
+            The field to weight the standard deviation calculation
+            by. Defaults to unweighted if unset.
 
         Returns
         -------
         Scalar
         """
         weight_field = sanitize_weight_field(self.ds, field, weight)
-        return self.quantities.weighted_variance(field, weight_field)[0]
+        return self.quantities.weighted_standard_deviation(field, weight_field)[0]
 
     def ptp(self, field):
         r"""Compute the range of values (maximum - minimum) of a field.

--- a/yt/data_objects/derived_quantities.py
+++ b/yt/data_objects/derived_quantities.py
@@ -464,8 +464,7 @@ class WeightedVariance(WeightedStandardDeviation):
             since="4.0.0",
             removal="4.1.0",
         )
-        rv = super().__call__(fields, weight)
-        return rv
+        return super().__call__(fields, weight)
 
 
 class AngularMomentumVector(DerivedQuantity):

--- a/yt/data_objects/derived_quantities.py
+++ b/yt/data_objects/derived_quantities.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.funcs import camelcase_to_underscore, iter_fields
 from yt.units.yt_array import array_like_field
 from yt.utilities.exceptions import YTParticleTypeNotFound
@@ -372,17 +373,17 @@ class BulkVelocity(DerivedQuantity):
         return self.data_source.ds.arr([v / w for v in [x, y, z]])
 
 
-class WeightedVariance(DerivedQuantity):
+class WeightedStandardDeviation(DerivedQuantity):
     r"""
-    Calculates the weighted variance and weighted mean for a field
+    Calculates the weighted standard deviation and weighted mean for a field
     or list of fields. Returns a YTArray for each field requested; if one,
     it returns a single YTArray, if many, it returns a list of YTArrays
     in order of the listed fields.  The first element of each YTArray is
-    the weighted variance, and the second element is the weighted mean.
+    the weighted standard deviation, and the second element is the weighted mean.
 
     Where f is the field, w is the weight, and <f_w> is the weighted mean,
-    the weighted variance is
-    Sum_i( (f_i - <f_w>)^2 \* w_i ) / Sum_i(w_i).
+    the weighted standard deviation is
+    sqrt( Sum_i( (f_i - <f_w>)^2 \* w_i ) / Sum_i(w_i) ).
 
     Parameters
     ----------
@@ -397,9 +398,9 @@ class WeightedVariance(DerivedQuantity):
 
     >>> ds = load("IsolatedGalaxy/galaxy0030/galaxy0030")
     >>> ad = ds.all_data()
-    >>> print(ad.quantities.weighted_variance([("gas", "density"),
-    ...                                        ("gas", "temperature")],
-    ...                                        ("gas", "cell_mass")))
+    >>> print(ad.quantities.weighted_standard_deviation([("gas", "density"),
+    ...                                                  ("gas", "temperature")],
+    ...                                                  ("gas", "cell_mass")))
 
     """
 
@@ -452,6 +453,19 @@ class WeightedVariance(DerivedQuantity):
             ]
             rvals.append(np.array(ret))
         return rvals
+
+
+class WeightedVariance(WeightedStandardDeviation):
+    def __call__(self, fields, weight):
+        issue_deprecation_warning(
+            "'weighted_variance' incorrectly returns the "
+            "standard deviation and has been deprecated. "
+            "Use 'weighted_standard_deviation' instead.",
+            since="4.0.0",
+            removal="4.1.0",
+        )
+        rv = super().__call__(fields, weight)
+        return rv
 
 
 class AngularMomentumVector(DerivedQuantity):

--- a/yt/data_objects/tests/test_derived_quantities.py
+++ b/yt/data_objects/tests/test_derived_quantities.py
@@ -54,16 +54,20 @@ def test_average():
             assert_rel_equal(my_mean, a_mean, 12)
 
 
-def test_variance():
+def test_standard_deviation():
     for nprocs in [1, 2, 4, 8]:
         ds = fake_random_ds(16, nprocs=nprocs, fields=("density",))
         for ad in [ds.all_data(), ds.r[0.5, :, :]]:
 
-            my_std, my_mean = ad.quantities["WeightedVariance"]("density", "ones")
+            my_std, my_mean = ad.quantities["WeightedStandardDeviation"](
+                "density", "ones"
+            )
             assert_rel_equal(my_mean, ad["density"].mean(), 12)
             assert_rel_equal(my_std, ad["density"].std(), 12)
 
-            my_std, my_mean = ad.quantities["WeightedVariance"]("density", "cell_mass")
+            my_std, my_mean = ad.quantities["WeightedStandardDeviation"](
+                "density", "cell_mass"
+            )
             a_mean = (ad["density"] * ad["cell_mass"]).sum() / ad["cell_mass"].sum()
             assert_rel_equal(my_mean, a_mean, 12)
             a_std = np.sqrt(


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

This PR deprecates the `DerivedQuantity` `WeightedVariance` and adds `WeightedStandardDeviation`, since what `WeightedVariance` returns is actually a standard deviation. This is exactly what we did for a similar situation with respect to profiles (PR #1372). 

`WeightedVariance` is now a subclass of `WeightedStandardDeviation` and a deprecation warning is flagged when it is used.

Closes issue #2713.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
