### PR TITLE
remove false api docstrings in frontends

### DIFF
--- a/yt/frontends/_skeleton/__init__.py
+++ b/yt/frontends/_skeleton/__init__.py
@@ -1,6 +1,0 @@
-"""
-API for yt.frontends._skeleton
-
-
-
-"""

--- a/yt/frontends/ahf/__init__.py
+++ b/yt/frontends/ahf/__init__.py
@@ -1,6 +1,0 @@
-"""
-API for yt.frontends.ahf
-
-
-
-"""

--- a/yt/frontends/art/__init__.py
+++ b/yt/frontends/art/__init__.py
@@ -1,6 +1,0 @@
-"""
-API for yt.frontends.art
-
-
-
-"""

--- a/yt/frontends/artio/__init__.py
+++ b/yt/frontends/artio/__init__.py
@@ -1,7 +1,0 @@
-"""
-API for yt.frontends.artio
-
-
-
-
-"""

--- a/yt/frontends/boxlib/__init__.py
+++ b/yt/frontends/boxlib/__init__.py
@@ -1,6 +1,0 @@
-"""
-API for yt.frontends.boxlib
-
-
-
-"""

--- a/yt/frontends/exodus_ii/__init__.py
+++ b/yt/frontends/exodus_ii/__init__.py
@@ -1,6 +1,0 @@
-"""
-API for yt.frontends.exodus_ii
-
-
-
-"""

--- a/yt/frontends/flash/__init__.py
+++ b/yt/frontends/flash/__init__.py
@@ -1,6 +1,0 @@
-"""
-API for yt.frontends.flash
-
-
-
-"""

--- a/yt/frontends/gamer/__init__.py
+++ b/yt/frontends/gamer/__init__.py
@@ -1,6 +1,0 @@
-"""
-API for yt.frontends.gamer
-
-
-
-"""

--- a/yt/frontends/nc4_cm1/__init__.py
+++ b/yt/frontends/nc4_cm1/__init__.py
@@ -1,6 +1,0 @@
-"""
-API for yt.frontends.nc4_cm1
-
-
-
-"""

--- a/yt/frontends/open_pmd/__init__.py
+++ b/yt/frontends/open_pmd/__init__.py
@@ -1,6 +1,0 @@
-"""
-API for yt.frontends.open_pmd
-
-
-
-"""

--- a/yt/frontends/ramses/__init__.py
+++ b/yt/frontends/ramses/__init__.py
@@ -1,6 +1,0 @@
-"""
-API for yt.frontends.ramses
-
-
-
-"""

--- a/yt/frontends/sph/__init__.py
+++ b/yt/frontends/sph/__init__.py
@@ -1,7 +1,0 @@
-"""
-API for yt.frontends.gadget
-
-
-
-
-"""


### PR DESCRIPTION
## PR Summary

I _think_ those docstrings predate the `yt/frontends/*/api.py` modules and are basically meaningless now, and confusing from a new-comer's perspective (which I got when I started writing the AMRVAC frontend). I propose to remove them. 