### PR TITLE
Enable CI for pytest [02/NN]

### DIFF
--- a/.github/workflows/build-test-pytest.yaml
+++ b/.github/workflows/build-test-pytest.yaml
@@ -1,0 +1,52 @@
+name: Build and Test
+
+on: [push, pull_request]
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  HOMEBREW_NO_AUTO_UPDATE: 1
+
+jobs:
+
+  build:
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-18.04]
+        python-version: [3.9]
+        dependencies: [full]
+        tests-type: [unit]
+        include:
+          - os: ubuntu-18.04
+            python-version: 3.6
+            dependencies: minimal
+            tests-type: unit
+
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Install Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        fetch-depth: 0
+    - uses: s-weigand/setup-conda@v1
+      if: matrix.os == 'windows-latest'
+      with:
+        update-conda: true
+        conda-channels: conda-forge
+        activate-conda: true
+        python-version: ${{matrix.python-version}}
+    - name: Install dependencies and yt
+      shell: bash
+      env:
+        dependencies: ${{ matrix.dependencies }}
+      run: source ./tests/ci_install.sh
+    - name: Run Tests
+      env:
+        testsuite: ${{ matrix.tests-type }}
+      run: pytest

--- a/conftest.py
+++ b/conftest.py
@@ -205,7 +205,10 @@ def hashing(request):
             # As such, if we're comparing and the file of saved hashes isn't
             # found, we just skip the test. We do the skip before the test
             # is run to save time
-            pytest.skip("Answer file not found.")
+            needs_answer = f"{request.function.__module__.replace('.', '/')}.py::{request.cls.__name__}"
+            with open(f"generate_test_{os.getpid()}.txt", "a") as fp:
+                fp.write(needs_answer + "\n")
+            pytest.skip(f"Answer file not found.")
     request.cls.hashes = {}
     # Load the saved answers if we're comparing. We don't do this for the raw
     # answers because those are huge

--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,6 @@
 import os
 import shutil
 import tempfile
-import typing
 from pathlib import Path
 
 import pytest
@@ -265,11 +264,11 @@ def ds(request):
     # data_dir_load can take the cls, args, and kwargs. These optional
     # arguments, if present,  are given in a dictionary as the second
     # element of the list
-    if isinstance(request.param, typing.Sequence):
-        ds_fn, opts = request.param
-    else:
+    if isinstance(request.param, str):
         ds_fn = request.param
         opts = {}
+    else:
+        ds_fn, opts = request.param
     try:
         return data_dir_load(
             ds_fn, cls=opts.get("cls"), args=opts.get("args"), kwargs=opts.get("kwargs")

--- a/conftest.py
+++ b/conftest.py
@@ -198,17 +198,10 @@ def hashing(request):
             with open(request.cls.answer_file) as fd:
                 request.cls.saved_hashes = yaml.safe_load(fd)
         except FileNotFoundError:
-            # On travis and appveyor only a minimal set of answer tests are
-            # run, which means that, for most answer tests, there won't be
-            # an existing answer file when comparing. There is currently no
-            # list of the minimal answer tests, so they can't be marked.
-            # As such, if we're comparing and the file of saved hashes isn't
-            # found, we just skip the test. We do the skip before the test
-            # is run to save time
             needs_answer = f"{request.function.__module__.replace('.', '/')}.py::{request.cls.__name__}"
             with open(f"generate_test_{os.getpid()}.txt", "a") as fp:
                 fp.write(needs_answer + "\n")
-            pytest.skip(f"Answer file not found.")
+            pytest.fail(msg="Answer file not found.", pytrace=False)
     request.cls.hashes = {}
     # Load the saved answers if we're comparing. We don't do this for the raw
     # answers because those are huge

--- a/conftest.py
+++ b/conftest.py
@@ -225,7 +225,9 @@ def hashing(request):
     # Compare hashes
     elif not no_hash and not store_hash:
         try:
-            assert hashes == request.cls.saved_hashes
+            for test_name, test_hash in hashes.items():
+                assert test_name in request.cls.saved_hashes
+                assert test_hash == request.cls.saved_hashes[test_name]
         except AssertionError:
             pytest.fail(f"Comparison failure: {request.node.name}", pytrace=False)
     # Save raw data

--- a/conftest.py
+++ b/conftest.py
@@ -198,9 +198,9 @@ def hashing(request):
             with open(request.cls.answer_file) as fd:
                 request.cls.saved_hashes = yaml.safe_load(fd)
         except FileNotFoundError:
-            needs_answer = f"{request.function.__module__.replace('.', '/')}.py::{request.cls.__name__}"
+            module_filename = f"{request.function.__module__.replace('.', os.sep)}.py"
             with open(f"generate_test_{os.getpid()}.txt", "a") as fp:
-                fp.write(needs_answer + "\n")
+                fp.write(f"{module_filename}::{request.cls.__name__}\n")
             pytest.fail(msg="Answer file not found.", pytrace=False)
     request.cls.hashes = {}
     # Load the saved answers if we're comparing. We don't do this for the raw

--- a/tests/pytest_runner.py
+++ b/tests/pytest_runner.py
@@ -1,3 +1,12 @@
+"""This is a helper script for running answer tests on CI services.
+
+It's currently used on:
+  * Jenkins
+  * GHA
+for executing answer tests and optionally generating new answers.
+"""
+
+
 import glob
 import os
 
@@ -8,7 +17,7 @@ if __name__ == "__main__":
     pytest_args = [
         "-s",
         "-v",
-        "-rsfE",
+        "-rsfE",  # it means -r "sfE" (show skiped, failed, errors), no -r -s -f -E
         "--with-answer-testing",
         "-m answer_test",
         f"-n {int(os.environ.get('NUM_WORKERS', 1))}",

--- a/tests/pytest_runner.py
+++ b/tests/pytest_runner.py
@@ -1,17 +1,29 @@
+import glob
 import os
 
 import pytest
 
-from yt.config import ytcfg
-
 if __name__ == "__main__":
     os.environ["OMP_NUM_THREADS"] = "1"
     pytest_args = [
-        f"--local-dir={os.path.join(ytcfg.get('yt', 'test_data_dir'), 'answers')}",
-        "-c=pytest_answer.ini",
-        "--junitxml=unittests.xml",
-        "--answer-big-data",
-        f"-n {int(os.environ.get('NUM_WORKERS', 6))}",
+        "-s",
+        "-v",
+        "-rsfE",
+        "--with-answer-testing",
+        "-m answer_test",
+        f"-n {int(os.environ.get('NUM_WORKERS', 1))}",
         "--dist=loadscope",
     ]
-    pytest.main(pytest_args)
+    pytest.main(pytest_args + ["--local-dir=answer-store", "--junitxml=answers.xml"])
+
+    if (files := glob.glob("generate_test*.txt")) :
+        tests = set()
+        for fname in files:
+            with open(fname) as fp:
+                tests |= set(fp.read().splitlines())
+        output_dir = "artifacts"
+        if not os.path.isdir(output_dir):
+            os.mkdir(output_dir)
+        pytest.main(
+            pytest_args + [f"--local-dir={output_dir}", "--answer-store"] + list(tests)
+        )


### PR DESCRIPTION
## PR Summary

Enable CI for tests that were merged with https://github.com/yt-project/yt/pull/3102. There are three additional jobs being enabled with this PR: unittest on GHA, unit and answer tests on Jenkins called *py38_unittests* and *py38_answertests* respectively. The latter will fail due to missing answers. The proposed way to deal with answer generation is:
1. pytest run @ Jenkins uses https://github.com/yt-project/answer-store to look for answers
2. if answers are not found, test are marked as failed for proper reporting (this is a change: before they were marked as skipped)
3. After the main run is finished, all tests that failed due to lack of answers are re-run with `--answer-store`
4. Resulting artifacts are published as Jenkins job artifacts (see e.g. https://tests.yt-project.org/job/yt_py38_answertests/4/ Build Artifacts > TestGDF_000.yaml)
5. Contributor creating a PR that needs new answers to be generated is expected to manually download required yaml files and issue a separate PR to https://github.com/yt-project/answer-store (for now).

### NOTE
Jenkins jobs will only run on PRs that have label `infrastructure` set for now.

### TODO

- [x] merge https://github.com/yt-project/answer-store/pull/14
- [x] update `answer-store` to point to the merge commit from previous step