### PR TITLE
cleanup: remove yt.funcs.get_requests, use yt.utilities.on_demand_imports

### DIFF
--- a/yt/frontends/http_stream/data_structures.py
+++ b/yt/frontends/http_stream/data_structures.py
@@ -5,8 +5,8 @@ import numpy as np
 
 from yt.data_objects.static_output import ParticleDataset, ParticleFile
 from yt.frontends.sph.fields import SPHFieldInfo
-from yt.funcs import get_requests
 from yt.geometry.particle_geometry_handler import ParticleIndex
+from yt.utilities.on_demand_imports import _requests as requests
 
 
 class HTTPParticleFile(ParticleFile):
@@ -30,8 +30,6 @@ class HTTPStreamDataset(ParticleDataset):
         index_order=None,
         index_filename=None,
     ):
-        if get_requests() is None:
-            raise ImportError("This functionality depends on the requests package")
         self.base_url = base_url
         super().__init__(
             "",
@@ -50,7 +48,6 @@ class HTTPStreamDataset(ParticleDataset):
         self.parameters["HydroMethod"] = "sph"
 
         # Here's where we're going to grab the JSON index file
-        requests = get_requests()
         hreq = requests.get(self.base_url + "/yt_index.json")
         if hreq.status_code != 200:
             raise RuntimeError
@@ -97,10 +94,8 @@ class HTTPStreamDataset(ParticleDataset):
     def _is_valid(cls, filename, *args, **kwargs):
         if not filename.startswith("http://"):
             return False
-        requests = get_requests()
-        if requests is None:
+        try:
+            return requests.get(filename + "/yt_index.json").status_code == 200
+        except ImportError:
+            # requests is not installed
             return False
-        hreq = requests.get(filename + "/yt_index.json")
-        if hreq.status_code == 200:
-            return True
-        return False

--- a/yt/frontends/http_stream/io.py
+++ b/yt/frontends/http_stream/io.py
@@ -1,7 +1,8 @@
 import numpy as np
 
-from yt.funcs import get_requests, mylog
+from yt.funcs import mylog
 from yt.utilities.io_handler import BaseIOHandler
+from yt.utilities.on_demand_imports import _requests as requests
 
 
 class IOHandlerHTTPStream(BaseIOHandler):
@@ -9,8 +10,6 @@ class IOHandlerHTTPStream(BaseIOHandler):
     _vector_fields = ("Coordinates", "Velocity", "Velocities")
 
     def __init__(self, ds):
-        if get_requests() is None:
-            raise ImportError("This functionality depends on the requests package")
         self._url = ds.base_url
         # This should eventually manage the IO and cache it
         self.total_bytes = 0
@@ -21,7 +20,6 @@ class IOHandlerHTTPStream(BaseIOHandler):
         ftype, fname = field
         s = f"{self._url}/{data_file.file_id}/{ftype}/{fname}"
         mylog.info("Loading URL %s", s)
-        requests = get_requests()
         resp = requests.get(s)
         if resp.status_code != 200:
             raise RuntimeError

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -30,6 +30,7 @@ from tqdm import tqdm
 from yt.units import YTArray, YTQuantity
 from yt.utilities.exceptions import YTInvalidWidthError
 from yt.utilities.logger import ytLogger as mylog
+from yt.utilities.on_demand_imports import _requests as requests
 
 # Some functions for handling sequences and other types
 
@@ -617,11 +618,11 @@ def get_script_contents():
 
 
 def download_file(url, filename):
-    requests = get_requests()
-    if requests is None:
-        return simple_download_file(url, filename)
-    else:
+    try:
         return fancy_download_file(url, filename, requests)
+    except ImportError:
+        # fancy_download_file requires requests
+        return simple_download_file(url, filename)
 
 
 def fancy_download_file(url, filename, requests=None):
@@ -1042,14 +1043,6 @@ def get_brewer_cmap(cmap):
     else:
         raise RuntimeError("Please install palettable to use colorbrewer colormaps")
     return bmap.get_mpl_colormap(N=cmap[2])
-
-
-def get_requests():
-    try:
-        import requests
-    except ImportError:
-        requests = None
-    return requests
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
## PR Summary

This is a quick follow up to #3100, cleaning up a unique mechanism that was used to specify requests as an optional dep, which is not necessary any more.
