### PR TITLE
maint: drop compatibility layers for matplotlib 1.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,7 @@ if __name__ == "__main__":
         packages=find_packages(),
         include_package_data=True,
         install_requires=[
-            "matplotlib>=1.5.3",
+            "matplotlib>=2.0.2",
             "setuptools>=19.6",
             "sympy>=1.2",
             "numpy>=1.10.4",

--- a/tests/test_minimal_requirements.txt
+++ b/tests/test_minimal_requirements.txt
@@ -1,5 +1,5 @@
 ipython~=1.0.0
-matplotlib~=1.5.3
+matplotlib==2.0.2  # 2.0.0 is the first version that came out after Python 3.6, using the most recent patch in this branch as minimal
 sympy~=1.2
 nose~=1.3.7
 nose-timer~=0.7.3

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -276,11 +276,7 @@ class ImagePlotMPL(PlotMPL):
             transform=transform,
         )
         if cbnorm == "symlog":
-            if LooseVersion(matplotlib.__version__) < LooseVersion("2.0.0"):
-                formatter_kwargs = {}
-            else:
-                formatter_kwargs = dict(linthresh=cblinthresh)
-            formatter = matplotlib.ticker.LogFormatterMathtext(**formatter_kwargs)
+            formatter = matplotlib.ticker.LogFormatterMathtext(linthresh=cblinthresh)
             self.cb = self.figure.colorbar(self.image, self.cax, format=formatter)
             if np.nanmin(data) >= 0.0:
                 yticks = [np.nanmin(data).v] + list(
@@ -414,10 +410,6 @@ class ImagePlotMPL(PlotMPL):
             draw_frame = choice
         self._draw_axes = choice
         self._draw_frame = draw_frame
-        if LooseVersion(matplotlib.__version__) < LooseVersion("2.0.0"):
-            fc = self.axes.get_axis_bgcolor()
-        else:
-            fc = self.axes.get_facecolor()
         self.axes.set_frame_on(draw_frame)
         self.axes.get_xaxis().set_visible(choice)
         self.axes.get_yaxis().set_visible(choice)
@@ -425,10 +417,6 @@ class ImagePlotMPL(PlotMPL):
         self.axes.set_position(axrect)
         self.cax.set_position(caxrect)
         self.figure.set_size_inches(*size)
-        if LooseVersion(matplotlib.__version__) < LooseVersion("2.0.0"):
-            self.axes.set_axis_bgcolor(fc)
-        else:
-            self.axes.set_facecolor(fc)
 
     def _toggle_colorbar(self, choice):
         """

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1076,10 +1076,7 @@ class PWViewerMPL(PlotWindow):
 
             color = self._background_color[f]
 
-            if LooseVersion(matplotlib.__version__) < LooseVersion("2.0.0"):
-                self.plots[f].axes.set_axis_bgcolor(color)
-            else:
-                self.plots[f].axes.set_facecolor(color)
+            self.plots[f].axes.set_facecolor(color)
 
             # Determine the units of the data
             units = Unit(self.frb[f].units, registry=self.ds.unit_registry)

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -1114,10 +1114,7 @@ class PhasePlot(ImagePlotContainer):
 
             color = self._background_color[f]
 
-            if MPL_VERSION < LooseVersion("2.0.0"):
-                self.plots[f].axes.set_axis_bgcolor(color)
-            else:
-                self.plots[f].axes.set_facecolor(color)
+            self.plots[f].axes.set_facecolor(color)
 
             if f in self._plot_text:
                 self.plots[f].axes.text(

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -4,9 +4,7 @@ import shutil
 import tempfile
 import unittest
 from collections import OrderedDict
-from distutils.version import LooseVersion
 
-import matplotlib
 import numpy as np
 from nose.tools import assert_true
 
@@ -545,10 +543,7 @@ def test_set_background_color():
         plot.set_background_color(field, "red")
         plot._setup_plots()
         ax = plot.plots[field].axes
-        if LooseVersion(matplotlib.__version__) < LooseVersion("2.0.0"):
-            assert_equal(ax.get_axis_bgcolor(), "red")
-        else:
-            assert_equal(ax.get_facecolor(), (1.0, 0.0, 0.0, 1.0))
+        assert_equal(ax.get_facecolor(), (1.0, 0.0, 0.0, 1.0))
 
 
 def test_set_unit():

--- a/yt/visualization/volume_rendering/transfer_function_helper.py
+++ b/yt/visualization/volume_rendering/transfer_function_helper.py
@@ -1,7 +1,5 @@
-from distutils.version import LooseVersion
 from io import BytesIO
 
-import matplotlib
 import numpy as np
 
 from yt.data_objects.profiles import create_profile
@@ -127,11 +125,7 @@ class TransferFunctionHelper:
         transfer function to produce a natural contrast ratio.
 
         """
-        if LooseVersion(matplotlib.__version__) < LooseVersion("2.0.0"):
-            colormap_name = "spectral"
-        else:
-            colormap_name = "nipy_spectral"
-        self.tf.add_layers(10, colormap=colormap_name)
+        self.tf.add_layers(10, colormap="nipy_spectral")
         factor = self.tf.funcs[-1].y.size / self.tf.funcs[-1].y.sum()
         self.tf.funcs[-1].y *= 2 * factor
 


### PR DESCRIPTION
## PR Summary

Rationale:
matplotlib doesn't document their supported Python versions very well, which makes it a bit hard to guess which version should be considered minimal for us.

Here's what I got out of my research:
Python 3.6 (our current earliest supported Python version) came out on December 23, 2016
[Matplotlib 2.0.0](https://github.com/matplotlib/matplotlib/releases/tag/v2.0.0) was the very first release after that (January 17, 2017), and came out only a few months after [1.5.3](https://github.com/matplotlib/matplotlib/releases/tag/v1.5.3) (September 6, 2016), which is our  _currently_ earliest tested matplotlib version.

Because we have acquired a small but noticeable amount of technical debt in the form of compatibility layers as we attempt to support the broadest range of versions possible, and since most of it only supports a short lived version from over 4 years ago (1.5.3) that didn't explicitly support Python 3.6, I think it's reasonable to bump this.

For closure, this isn't a _necessary_ change at the time of writing, but I'm hoping it's a small enough breakage that it can be considered for inclusion soon, since it's part of an effort I'm doing to clarify dependency specifications.