### PR TITLE
maint: use matplotlib.pyplot in examples instead of matplotlib.pylab

### DIFF
--- a/doc/source/cookbook/streamlines.py
+++ b/doc/source/cookbook/streamlines.py
@@ -1,4 +1,4 @@
-import matplotlib.pylab as pl
+import matplotlib.pyplot as plt
 import numpy as np
 from mpl_toolkits.mplot3d import Axes3D
 
@@ -32,11 +32,11 @@ streamlines = Streamlines(
 streamlines.integrate_through_volume()
 
 # Create a 3D plot, trace the streamlines through the 3D volume of the plot
-fig = pl.figure()
+fig = plt.figure()
 ax = Axes3D(fig)
 for stream in streamlines.streamlines:
     stream = stream[np.all(stream != 0.0, axis=1)]
     ax.plot3D(stream[:, 0], stream[:, 1], stream[:, 2], alpha=0.1)
 
 # Save the plot to disk.
-pl.savefig("streamlines.png")
+plt.savefig("streamlines.png")

--- a/doc/source/cookbook/streamlines_isocontour.py
+++ b/doc/source/cookbook/streamlines_isocontour.py
@@ -1,4 +1,4 @@
-import matplotlib.pylab as pl
+import matplotlib.pyplot as plt
 import numpy as np
 from mpl_toolkits.mplot3d import Axes3D
 from mpl_toolkits.mplot3d.art3d import Poly3DCollection
@@ -24,7 +24,7 @@ streamlines = Streamlines(ds, pos, "velocity_x", "velocity_y", "velocity_z", len
 streamlines.integrate_through_volume()
 
 # Create a 3D matplotlib figure for visualizing the streamlines
-fig = pl.figure()
+fig = plt.figure()
 ax = Axes3D(fig)
 
 # Trace the streamlines through the volume of the 3D figure
@@ -61,4 +61,4 @@ p3dc.set_facecolors(colors)
 ax.add_collection(p3dc)
 
 # Save the figure
-pl.savefig("streamlines_isocontour.png")
+plt.savefig("streamlines_isocontour.png")

--- a/doc/source/visualizing/streamlines.rst
+++ b/doc/source/visualizing/streamlines.rst
@@ -55,7 +55,7 @@ Example Script
 
     import yt
     import numpy as np
-    import matplotlib.pylab as pl
+    import matplotlib.pyplot as plt
 
     from yt.visualization.api import Streamlines
     from yt.units import Mpc
@@ -80,14 +80,14 @@ Example Script
     streamlines.integrate_through_volume()
 
     # Create a 3D plot, trace the streamlines through the 3D volume of the plot
-    fig=pl.figure()
+    fig=plt.figure()
     ax = Axes3D(fig)
     for stream in streamlines.streamlines:
         stream = stream[np.all(stream != 0.0, axis=1)]
         ax.plot3D(stream[:,0], stream[:,1], stream[:,2], alpha=0.1)
 
     # Save the plot to disk.
-    pl.savefig('streamlines.png')
+    plt.savefig('streamlines.png')
 
 
 Data Access Along the Streamline

--- a/yt/data_objects/particle_trajectories.py
+++ b/yt/data_objects/particle_trajectories.py
@@ -316,11 +316,11 @@ class ParticleTrajectories:
         Examples
         --------
         >>> from yt.mods import *
-        >>> import matplotlib.pylab as pl
+        >>> import matplotlib.pyplot as plt
         >>> trajs = ParticleTrajectories(my_fns, indices)
         >>> traj = trajs.trajectory_from_index(indices[0])
-        >>> pl.plot(traj["particle_time"], traj["particle_position_x"], "-x")
-        >>> pl.savefig("orbit")
+        >>> plt.plot(traj["particle_time"], traj["particle_position_x"], "-x")
+        >>> plt.savefig("orbit")
         """
         mask = np.in1d(self.indices, (index,), assume_unique=True)
         if not np.any(mask):

--- a/yt/visualization/streamlines.py
+++ b/yt/visualization/streamlines.py
@@ -64,7 +64,7 @@ class Streamlines(ParallelAnalysisInterface):
     --------
     >>> import yt
     >>> import numpy as np
-    >>> import matplotlib.pylab as pl
+    >>> import matplotlib.pyplot as plt
     >>>
     >>> from yt.visualization.api import Streamlines
     >>> from mpl_toolkits.mplot3d import Axes3D
@@ -83,12 +83,12 @@ class Streamlines(ParallelAnalysisInterface):
     >>> streamlines.integrate_through_volume()
     >>>
     >>> # Make a 3D plot of the streamlines and save it to disk
-    >>> fig=pl.figure()
+    >>> fig = plt.figure()
     >>> ax = Axes3D(fig)
     >>> for stream in streamlines.streamlines:
     >>>     stream = stream[np.all(stream != 0.0, axis=1)]
     >>>     ax.plot3D(stream[:,0], stream[:,1], stream[:,2], alpha=0.1)
-    >>> pl.savefig('streamlines.png')
+    >>> plt.savefig('streamlines.png')
     """
 
     def __init__(


### PR DESCRIPTION
## PR Summary
See https://matplotlib.org/2.0.2/faq/usage_faq.html#matplotlib-pyplot-and-pylab-how-are-they-related
> pylab is a convenience module that bulk imports matplotlib.pyplot (for plotting) and numpy (for mathematics and working with arrays) in a single name space. Although many examples use pylab, it is no longer recommended.

TLDR:
`matplotlib.pylab` is a wrapper that contains `matplotlib.pyplot` and `numpy`. The reason it exists was to help people migrating from Matlab to Python, but its usage is discouraged, so I'm replacing it with direct calls to pyplot in our documentation and docstrings.