### PR TITLE
doc: add a custom badge for downstream projects supported by yt

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,20 @@ We have some community and documentation resources available.
  * You can also join us on Slack at yt-project.slack.com ([request an
    invite](https://yt-project.org/slack.html))
 
+Is your code compatible with yt ? Great ! Please consider giving us a shoutout as a shiny badge in your README
+
+- markdown
+```markdown
+[![yt-project](https://img.shields.io/endpoint?url=https%3A%2F%2Fyt-support-badge-wuxbnksagnpg.runkit.sh)](https://yt-project.org)
+```
+- rst
+```reStructuredText
+|yt-project|
+
+.. |yt-project| image:: https://img.shields.io/endpoint?url=https%3A%2F%2Fyt-support-badge-wuxbnksagnpg.runkit.sh
+   :target: https://yt-project.org
+```
+
 ## Powered by NumFOCUS
 
 yt is a fiscally sponsored project of [NumFOCUS](https://numfocus.org/).

--- a/README.md
+++ b/README.md
@@ -166,13 +166,13 @@ Is your code compatible with yt ? Great ! Please consider giving us a shoutout a
 
 - markdown
 ```markdown
-[![yt-project](https://img.shields.io/endpoint?url=https%3A%2F%2Fyt-support-badge-wuxbnksagnpg.runkit.sh)](https://yt-project.org)
+[![yt-project](https://img.shields.io/static/v1?label="works%20with"&message="yt"&color="blueviolet")](https://yt-project.org)
 ```
 - rst
 ```reStructuredText
 |yt-project|
 
-.. |yt-project| image:: https://img.shields.io/endpoint?url=https%3A%2F%2Fyt-support-badge-wuxbnksagnpg.runkit.sh
+.. |yt-project| image:: https://img.shields.io/static/v1?label="works%20with"&message="yt"&color="blueviolet"
    :target: https://yt-project.org
 ```
 


### PR DESCRIPTION
## PR Summary

Following recent discussions on Twitter... here's a reusable custom badge for downstream projects to show off

~I'm opening this as a draft with two temporary files (one for markdown, the other for rst), because I wasn't able to check locally that the rst version is correct.~
edit: done. Removed the files in question.

Note that this is based on a custom json endpoint : https://runkit.com/neutrinoceros/yt-support-badge
and largely based off this blog post https://dev.to/milkers/how-to-make-custom-badges-to-improve-your-markdown-documents-460k

I wasn't able to make the actual logo work for now, but hopefully it can be fixed in the future, at which point it will auto update in any page that uses it.

Here's what I've got thus far (as previewed from VSCode)
![Screenshot 2021-03-24 at 20 16 36](https://user-images.githubusercontent.com/14075922/112370566-dab6b480-8cdd-11eb-9c90-fd99ba288270.png)

edit: current version
<img width="193" alt="Screenshot 2021-03-24 at 22 02 00" src="https://user-images.githubusercontent.com/14075922/112382907-badabd00-8cec-11eb-8bc7-b2fb6eb4dc52.png">


The badge is clickable and links to yt-project.org, though it could be argued that we want to link to the main repo instead, this is up for discussion !
