### PR TITLE
add pandas to yt.utilities.on_demand_imports

### DIFF
--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -512,7 +512,7 @@ class YTDataContainer:
         >>> dd = ds.all_data()
         >>> df = dd.to_dataframe(["density", "temperature"])
         """
-        import pandas as pd
+        from yt.utilities.on_demand_imports import _pandas as pd
 
         data = {}
         fields = self._determine_fields(fields)

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -582,7 +582,7 @@ class Profile1D(ProfileND):
         >>> df1 = p.to_dataframe()
         >>> df2 = p.to_dataframe(fields="density", only_used=True)
         """
-        import pandas as pd
+        from yt.utilities.on_demand_imports import _pandas as pd
 
         idxs, masked, fields = self._export_prep(fields, only_used)
         pdata = {self.x_field[-1]: self.x[idxs]}

--- a/yt/utilities/on_demand_imports.py
+++ b/yt/utilities/on_demand_imports.py
@@ -645,3 +645,22 @@ class requests_imports:
 
 
 _requests = requests_imports()
+
+
+class pandas_imports:
+    _name = "pandas"
+    _module = None
+
+    def __init__(self):
+        try:
+            import pandas as myself
+
+            self._module = myself
+        except ImportError:
+            self._module = NotAModule(self._name)
+
+    def __getattr__(self, attr):
+        return getattr(self._module, attr)
+
+
+_pandas = pandas_imports()


### PR DESCRIPTION
## PR Summary

As remarked by @munkm in https://github.com/yt-project/yt/pull/3089#discussion_r601793845
pandas is currently not part of our `on_demand_imports`, but the only places it's imported are clearly documented as fragile because it's _not_ a hard dependency.
