### PR TITLE
cleanup: remove cubehelix colormap

### DIFF
--- a/yt/visualization/color_maps.py
+++ b/yt/visualization/color_maps.py
@@ -173,38 +173,6 @@ cdict = {
 
 add_colormap("purple_mm", cdict)
 
-# This one comes from
-# http://permalink.gmane.org/gmane.comp.python.matplotlib.devel/10518
-# and is an implementation of http://arxiv.org/abs/1108.5083
-#
-
-# cubehelix parameters
-_gamma_cubehelix = 1.0
-_s_cubehelix = 0.5
-_r_cubehelix = -1.5
-_h_cubehelix = 1.0
-
-_cubehelix_data = {
-    "red": lambda x: x ** _gamma_cubehelix
-    + (_h_cubehelix * x ** _gamma_cubehelix * (1 - x ** _gamma_cubehelix) / 2)
-    * (
-        -0.14861 * np.cos(2 * np.pi * (_s_cubehelix / 3 + _r_cubehelix * x))
-        + 1.78277 * np.sin(2 * np.pi * (_s_cubehelix / 3 + _r_cubehelix * x))
-    ),
-    "green": lambda x: x ** _gamma_cubehelix
-    + (_h_cubehelix * x ** _gamma_cubehelix * (1 - x ** _gamma_cubehelix) / 2)
-    * (
-        -0.29227 * np.cos(2 * np.pi * (_s_cubehelix / 3 + _r_cubehelix * x))
-        - 0.90649 * np.sin(2 * np.pi * (_s_cubehelix / 3 + _r_cubehelix * x))
-    ),
-    "blue": lambda x: x ** _gamma_cubehelix
-    + (_h_cubehelix * x ** _gamma_cubehelix * (1 - x ** _gamma_cubehelix) / 2)
-    * (1.97294 * np.cos(2 * np.pi * (_s_cubehelix / 3 + _r_cubehelix * x))),
-}
-
-add_colormap("cubehelix", _cubehelix_data)
-
-
 # Add colormaps from cmocean, if it's installed
 if cmocean is not None:
     cmo_cmapnames = cmocean.cm.cmapnames

--- a/yt/visualization/color_maps.py
+++ b/yt/visualization/color_maps.py
@@ -43,10 +43,7 @@ def add_colormap(name, cdict):
     yt_colormaps[name] = cc.LinearSegmentedColormap(name, cdict, 256)
     mcm.datad[name] = cdict
     mcm.__dict__[name] = cdict
-    try:  # API compatibility
-        mcm.register_cmap(name, yt_colormaps[name])
-    except AttributeError:
-        pass
+    mcm.register_cmap(name, yt_colormaps[name])
 
 
 # The format is as follows:
@@ -184,12 +181,7 @@ if cmocean is not None:
         if cmname in yt_colormaps:
             cmname = cmname + "_cmocean"
         yt_colormaps[cmname] = cm
-        try:
-            mcm.register_cmap(cmname, yt_colormaps[cmname])
-        except AttributeError:
-            # for old versions of matplotlib this won't work, so we avoid
-            # erroring out but don't worry about registering with matplotlib
-            pass
+        mcm.register_cmap(cmname, yt_colormaps[cmname])
 
 # Add colormaps in _colormap_data.py that weren't defined here
 _vs = np.linspace(0, 1, 256)


### PR DESCRIPTION
## PR Summary

followup to #3143 and fix for a failing workflow in #3078 with the following error message
```
ValueError: Trying to re-register the builtin cmap 'cubehelix'.
```

Indeed we don't need to vendor this colormap anymore since it was already present in matplotlib 2.0.2
See https://matplotlib.org/2.0.2/users/colormaps.html?highlight=cubehelix

Note that registering an existing cmap name actually causes an error in matplotlib 3.4
