### PR TITLE
maint: pin matplotlib maximal supported version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ if __name__ == "__main__":
         packages=find_packages(),
         include_package_data=True,
         install_requires=[
-            "matplotlib>=2.0.2",
+            "matplotlib>=2.0.2,<3.4",
             "setuptools>=19.6",
             "sympy>=1.2",
             "numpy>=1.10.4",

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -5,7 +5,7 @@ fastcache~=1.0.2
 glueviz~=0.13.3
 h5py~=3.1.0
 ipython~=7.6.1
-matplotlib~=3.3
+matplotlib<3.4
 nose-timer~=1.0.0
 nose~=1.3.7
 pandas~=1.1.2


### PR DESCRIPTION
## PR Summary

This is a hot fix for failing answer-tests following the release of matplotlib 3.4.0
Obviously this boundary should be lifted in the near future.