### PR TITLE
Update filtering docs to reflect that particles should not be used with cut regions

### DIFF
--- a/doc/source/analyzing/filtering.rst
+++ b/doc/source/analyzing/filtering.rst
@@ -101,7 +101,7 @@ filtering out unwanted regions. Such wrapper functions are methods of
    overpressure_and_fast = overpressure_and_fast.include_above('velocity_magnitude', 1e2, 'km/s')
 
    print('Density of all data: ad["density"] = \n%s' % ad['density'])
-   print('Density of "overpressure and fast" data: overpressure_and_fast['density'] = \n%s' %
+   print('Density of "overpressure and fast" data: overpressure_and_fast["density"] = \n%s' %
           overpressure_and_fast['density'])
 
 The following exclude and include functions are supported:

--- a/doc/source/analyzing/filtering.rst
+++ b/doc/source/analyzing/filtering.rst
@@ -120,9 +120,12 @@ The following exclude and include functions are supported:
 
 .. warning::
 
-    Cut regions can have unexpected results with particle fields, or often not work
-    at all with some operations. If you want to filter particle fields, see the
-    next section :ref:`filtering-particles` instead.
+    Cut regions are unstable when used on particle fields. Though you can create
+    a cut region using a mesh field or fields as a filter and then obtain a
+    particle field within that region, you cannot create a cut region using
+    particle fields in the filter, as yt will currently raise an error. If
+    you want to filter particle fields, see the next section
+    :ref:`filtering-particles` instead.
 
 .. _filtering-particles:
 

--- a/doc/source/analyzing/filtering.rst
+++ b/doc/source/analyzing/filtering.rst
@@ -118,8 +118,11 @@ The following exclude and include functions are supported:
    - :func:`~yt.data_objects.data_containers.YTSelectionContainer3D.exclude_below` - Exclude values below given value
 
 
-Cut regions can also operate on particle fields, but a single cut region object
-cannot operate on both particle fields and mesh fields at the same time.
+.. warning::
+
+    Cut regions can have unexpected results with particle fields, or often not work
+    at all with some operations. If you want to filter particle fields, see the
+    next section :ref:`filtering-particles` instead.
 
 .. _filtering-particles:
 

--- a/yt/data_objects/selection_objects/cut_region.py
+++ b/yt/data_objects/selection_objects/cut_region.py
@@ -84,7 +84,7 @@ class YTCutRegion(YTSelectionContainer3D):
         for cond in self.conditionals:
             for field in re.findall(r"\[([A-Za-z0-9_,.'\"\(\)]+)\]", cond):
                 fd = field.replace('"', "").replace("'", "")
-                if "," in field:
+                if "," in fd:
                     fd = tuple(fd.strip("()").split(","))
                 fd = self.ds._get_field_info(fd)
                 if fd.sampling_type == "particle" or fd.is_sph_field:

--- a/yt/fields/particle_fields.py
+++ b/yt/fields/particle_fields.py
@@ -153,7 +153,7 @@ def particle_deposition_functions(ptype, coord_name, mass_name, registry):
             pos = data[ptype, "particle_position"]
             # Get back into density
             pden = data[ptype, "particle_mass"]
-            top = data.deposit(pos, [data[(ptype, fname)] * pden], method=method)
+            top = data.deposit(pos, [pden * data[(ptype, fname)]], method=method)
             bottom = data.deposit(pos, [pden], method=method)
             top[bottom == 0] = 0.0
             bnz = bottom.nonzero()


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

Cut regions fail for particle-based fields, as pointed out in issue #1976. 

Some work probably needs to be done to decide if we want to support them in cut regions at all, but @chummels made a good suggestion in that issue that we should update the docs to reflect the fact that particle filters should be used instead. This PR does that, and fixes an error on the same page. 

EDIT: We now provide a function that checks if the fields provided to filter a `YTCutRegion` object are mesh fields, and throws an error if not.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->
