### PR TITLE
rewrite load tests with the pytest framework

### DIFF
--- a/nose_unit.cfg
+++ b/nose_unit.cfg
@@ -6,4 +6,5 @@ nologcapture=1
 verbosity=2
 where=yt
 with-timer=1
+ignore-files=test_load_errors.py
 exclude-test=yt.frontends.gdf.tests.test_outputs.TestGDF

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -175,6 +175,7 @@ other_tests:
   unittests:
      - '--exclude=test_mesh_slices'  # disable randomly failing test
      - '--ignore=test_outputs_pytest'
+     - '--ignore-files=test_load_errors.py'
      - '--exclude-test=yt.frontends.gdf.tests.test_outputs.TestGDF'
   cookbook:
      - 'doc/source/cookbook/tests/test_cookbook.py'

--- a/yt/tests/test_load_errors.py
+++ b/yt/tests/test_load_errors.py
@@ -1,10 +1,7 @@
-import os
-import tempfile
-from pathlib import Path
+import pytest
 
 from yt.data_objects.static_output import Dataset
 from yt.loaders import load, load_simulation
-from yt.testing import assert_raises
 from yt.utilities.exceptions import (
     YTAmbiguousDataType,
     YTSimulationNotIdentified,
@@ -13,49 +10,56 @@ from yt.utilities.exceptions import (
 from yt.utilities.object_registries import output_type_registry
 
 
-def test_load_nonexistent_data():
-    with tempfile.TemporaryDirectory() as tmpdir:
-        assert_raises(FileNotFoundError, load, os.path.join(tmpdir, "not_a_file"))
-        assert_raises(
-            FileNotFoundError,
-            load_simulation,
-            os.path.join(tmpdir, "not_a_file"),
-            "Enzo",
-        )
-
-        # this one is a design choice:
-        # it is preferable to report the most important problem in an error message
-        # (missing data is worse than a typo insimulation_type)
-        # so we make sure the error raised is not YTSimulationNotIdentified
-        assert_raises(
-            FileNotFoundError,
-            load_simulation,
-            os.path.join(tmpdir, "not_a_file"),
-            "unregistered_simulation_type",
-        )
+def test_load_not_a_file(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        load(tmp_path / "not_a_file")
 
 
-def test_load_unidentified_data():
-    with tempfile.TemporaryDirectory() as tmpdir:
-        empty_file_path = Path(tmpdir) / "empty_file"
-        empty_file_path.touch()
-        assert_raises(YTUnidentifiedDataType, load, tmpdir)
-        assert_raises(YTUnidentifiedDataType, load, empty_file_path)
-        assert_raises(
-            YTSimulationNotIdentified,
-            load_simulation,
-            tmpdir,
-            "unregistered_simulation_type",
-        )
-        assert_raises(
-            YTSimulationNotIdentified,
-            load_simulation,
+@pytest.mark.parametrize("simtype", ["Enzo", "unregistered_simulation_type"])
+def test_load_simulation_not_a_file(simtype, tmp_path):
+    # it is preferable to report the most important problem in an error message
+    # (missing data is worse than a typo insimulation_type)
+    # so we make sure the error raised is not YTSimulationNotIdentified,
+    # even with an absurd simulation type
+    with pytest.raises(FileNotFoundError):
+        load_simulation(tmp_path / "not_a_file", simtype)
+
+
+@pytest.fixture()
+def tmp_path_with_empty_file(tmp_path):
+    empty_file_path = tmp_path / "empty_file"
+    empty_file_path.touch()
+    return tmp_path, empty_file_path
+
+
+def test_load_unidentified_data_dir(tmp_path_with_empty_file):
+    tmp_path, empty_file_path = tmp_path_with_empty_file
+    with pytest.raises(YTUnidentifiedDataType):
+        load(tmp_path)
+
+
+def test_load_unidentified_data_file(tmp_path_with_empty_file):
+    tmp_path, empty_file_path = tmp_path_with_empty_file
+    with pytest.raises(YTUnidentifiedDataType):
+        load(empty_file_path)
+
+
+def test_load_simulation_unidentified_data_dir(tmp_path_with_empty_file):
+    tmp_path, empty_file_path = tmp_path_with_empty_file
+    with pytest.raises(YTSimulationNotIdentified):
+        load_simulation(tmp_path, "unregistered_simulation_type")
+
+
+def test_load_simulation_unidentified_data_file(tmp_path_with_empty_file):
+    tmp_path, empty_file_path = tmp_path_with_empty_file
+    with pytest.raises(YTSimulationNotIdentified):
+        load_simulation(
             empty_file_path,
             "unregistered_simulation_type",
         )
 
 
-def test_load_ambiguous_data():
+def test_load_ambiguous_data(tmp_path):
     # we deliberately setup a situation where two Dataset subclasses
     # that aren't parents are consisdered valid
     class FakeDataset(Dataset):
@@ -69,10 +73,8 @@ def test_load_ambiguous_data():
             return True
 
     try:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            assert_raises(YTAmbiguousDataType, load, tmpdir)
-    except Exception:
-        raise
+        with pytest.raises(YTAmbiguousDataType):
+            load(tmp_path)
     finally:
         # tear down to avoid possible breakage in following tests
         output_type_registry.pop("FakeDataset")


### PR DESCRIPTION
## PR Summary

I'm experiencing issues with these tests running on pytest in https://github.com/yt-project/yt/pull/3062, specifically:

https://tests.yt-project.org/job/yt_py38_unittests/18/testReport/junit/yt.tests/test_load_errors/test_load_nonexistent_data/

I originally wrote these tests for pytest but had to rewrite them to get them merged, so I'm rewriting them back in hopes that will help fixing the initial problem in #3062 

For reference I could not reproduce the issue locally but I assume pytest + Jenkins is less well behave with tests using a different framework.
