### PR TITLE
rephrase comment in README to avoid pinning a specific minimal python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Alternatively, you can install yt in a
 ```shell
 # It is conventional to create virtualenvs at ~/.virtualenv/
 $ mkdir -p ~/.virtualenv
-# Assuming your version of Python 3 is 3.4 or higher,
+# Assuming your version of Python 3 meets the minimal requirement
 # create a virtualenv named yt-git
 $ python3 -m venv ~/.virtualenv/yt-git
 # Activate it


### PR DESCRIPTION
## PR Summary

If this has been falling off my radar for months, I assume it is reasonable to say that we are collectively prone to forget about it when we bump our minimal supported python version in the future, so I rephrased it to a permanent truth.