### PR TITLE
Bugfix #3155 + improvement in config handler

### DIFF
--- a/yt/config.py
+++ b/yt/config.py
@@ -149,11 +149,11 @@ class YTConfig:
         )
 
     def __setitem__(self, args, value):
-        section, *keys = args
+        section, *keys = always_iterable(args)
         self.set(section, *keys, value, metadata=None)
 
     def __getitem__(self, key):
-        section, *keys = key
+        section, *keys = always_iterable(key)
         return self.get(section, *keys)
 
     def remove(self, *args):

--- a/yt/config.py
+++ b/yt/config.py
@@ -195,6 +195,8 @@ class YTConfig:
     def __contains__(self, item):
         return item in self.config_root
 
+    # Add support for IPython rich display
+    # see https://ipython.readthedocs.io/en/stable/config/integrating.html
     def _repr_json_(self):
         return self.config_root._repr_json_()
 

--- a/yt/config.py
+++ b/yt/config.py
@@ -195,6 +195,9 @@ class YTConfig:
     def __contains__(self, item):
         return item in self.config_root
 
+    def _repr_json_(self):
+        return self.config_root._repr_json_()
+
 
 _global_config_file = YTConfig.get_global_config_file()
 _local_config_file = YTConfig.get_local_config_file()

--- a/yt/config.py
+++ b/yt/config.py
@@ -5,7 +5,7 @@ import toml
 from more_itertools import always_iterable
 
 from yt._maintenance.deprecation import issue_deprecation_warning
-from yt.utilities.configuration_tree import ConfigNode
+from yt.utilities.configuration_tree import ConfigLeaf, ConfigNode
 
 ytcfg_defaults = {}
 
@@ -99,13 +99,15 @@ class YTConfig:
             defaults = {}
         self.config_root = ConfigNode(None)
 
-    def get(self, section, *keys, callback=None, **kwargs):
-        if callback is None:
-
-            def callback(leaf):
-                return leaf.value
-
-        return self.config_root.get_leaf(section, *keys, callback=callback)
+    def get(self, section, *keys, callback=None):
+        node_or_leaf = self.config_root.get(section, *keys)
+        if isinstance(node_or_leaf, ConfigLeaf):
+            if callback is None:
+                return node_or_leaf.value
+            else:
+                return callback(node_or_leaf)
+        else:
+            return node_or_leaf
 
     def get_most_specific(self, section, *keys, **kwargs):
         use_fallback = "fallback" in kwargs
@@ -148,14 +150,6 @@ class YTConfig:
             [section] + list(keys), value, extra_data=metadata
         )
 
-    def __setitem__(self, args, value):
-        section, *keys = always_iterable(args)
-        self.set(section, *keys, value, metadata=None)
-
-    def __getitem__(self, key):
-        section, *keys = always_iterable(key)
-        return self.get(section, *keys)
-
     def remove(self, *args):
         self.config_root.pop_leaf(args)
 
@@ -189,6 +183,17 @@ class YTConfig:
     @staticmethod
     def get_local_config_file():
         return os.path.join(os.path.abspath(os.curdir), "yt.toml")
+
+    def __setitem__(self, args, value):
+        section, *keys = always_iterable(args)
+        self.set(section, *keys, value, metadata=None)
+
+    def __getitem__(self, key):
+        section, *keys = always_iterable(key)
+        return self.get(section, *keys)
+
+    def __contains__(self, item):
+        return item in self.config_root
 
 
 _global_config_file = YTConfig.get_global_config_file()

--- a/yt/config.py
+++ b/yt/config.py
@@ -102,12 +102,10 @@ class YTConfig:
     def get(self, section, *keys, callback=None):
         node_or_leaf = self.config_root.get(section, *keys)
         if isinstance(node_or_leaf, ConfigLeaf):
-            if callback is None:
-                return node_or_leaf.value
-            else:
+            if callback is not None:
                 return callback(node_or_leaf)
-        else:
-            return node_or_leaf
+            return node_or_leaf.value
+        return node_or_leaf
 
     def get_most_specific(self, section, *keys, **kwargs):
         use_fallback = "fallback" in kwargs

--- a/yt/utilities/configuration_tree.py
+++ b/yt/utilities/configuration_tree.py
@@ -137,6 +137,9 @@ class ConfigNode:
     def __repr__(self):
         return f"<Node {self.key}>"
 
+    def _repr_json_(self):
+        return self.as_dict()
+
     def __contains__(self, item):
         return item in self.children
 

--- a/yt/utilities/configuration_tree.py
+++ b/yt/utilities/configuration_tree.py
@@ -105,9 +105,6 @@ class ConfigNode:
             retval[key] = child.serialize()
         return retval
 
-    def __repr__(self):
-        return f"<Node {self.key}>"
-
     @staticmethod
     def from_dict(other, parent=None, **kwa):
         me = ConfigNode(None, parent=parent)
@@ -136,6 +133,12 @@ class ConfigNode:
     def as_dict(self, callback=lambda child: child.value):
         data, _ = self._as_dict_with_count(callback)
         return data
+
+    def __repr__(self):
+        return f"<Node {self.key}>"
+
+    def __contains__(self, item):
+        return item in self.children
 
 
 class ConfigLeaf:

--- a/yt/utilities/configuration_tree.py
+++ b/yt/utilities/configuration_tree.py
@@ -137,11 +137,13 @@ class ConfigNode:
     def __repr__(self):
         return f"<Node {self.key}>"
 
-    def _repr_json_(self):
-        return self.as_dict()
-
     def __contains__(self, item):
         return item in self.children
+
+    # Add support for IPython rich display
+    # see https://ipython.readthedocs.io/en/stable/config/integrating.html
+    def _repr_json_(self):
+        return self.as_dict()
 
 
 class ConfigLeaf:


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

This fixes #3155 and improves support for inclusion statement (i.e. you can now use `"thing" in ytcfg`).

As a nice addition, this also adds rich display in the notebook (almost) for free
![image](https://user-images.githubusercontent.com/5411875/112822622-7783a400-9088-11eb-8b8b-9c23d4914730.png)