### PR TITLE
add a pytest-compatible version of requires_module

### DIFF
--- a/yt/testing.py
+++ b/yt/testing.py
@@ -916,7 +916,7 @@ def requires_module_pytest(*module_names):
             if isinstance(mod, odi.NotAModule)
         ]
 
-        # note that order between these two decorators matter
+        # note that order between these two decorators matters
         @skipif(
             missing,
             reason=f"missing requirement(s): {', '.join(missing)}",


### PR DESCRIPTION
## PR Summary

This function is meant as a drop-in replacement for the existing `required_module` decorator.
The end goal is to provide a pytest-compatible alternative (and eventual replacement when nose is dropped).
While I'm at it, and since it's relevant in the context of #3089 (containing the initial implementation), I added support for
an arbitrary number of arguments as an alternative to decorator stacking.

It is under testing in #3089 at the time of writing, and I confirm that it works as intended locally.