### PR TITLE
[bugfix] Fix units of potential

### DIFF
--- a/yt/frontends/ramses/field_handlers.py
+++ b/yt/frontends/ramses/field_handlers.py
@@ -461,7 +461,7 @@ class GravFieldFileHandler(FieldFileHandler):
         ndim = ds.dimensionality
 
         if nvar == ndim + 1:
-            fields = ["potential"] + [f"{k}-acceleration" for k in "xyz"[:ndim]]
+            fields = ["Potential"] + [f"{k}-acceleration" for k in "xyz"[:ndim]]
         else:
             fields = [f"{k}-acceleration" for k in "xyz"[:ndim]]
         ndetected = len(fields)

--- a/yt/frontends/ramses/field_handlers.py
+++ b/yt/frontends/ramses/field_handlers.py
@@ -461,7 +461,9 @@ class GravFieldFileHandler(FieldFileHandler):
         ndim = ds.dimensionality
 
         if nvar == ndim + 1:
-            fields = ["Potential"] + [f"{k}-acceleration" for k in "xyz"[:ndim]]
+            fields = ["Specific-Potential"] + [
+                f"{k}-acceleration" for k in "xyz"[:ndim]
+            ]
         else:
             fields = [f"{k}-acceleration" for k in "xyz"[:ndim]]
         ndetected = len(fields)

--- a/yt/frontends/ramses/field_handlers.py
+++ b/yt/frontends/ramses/field_handlers.py
@@ -461,9 +461,7 @@ class GravFieldFileHandler(FieldFileHandler):
         ndim = ds.dimensionality
 
         if nvar == ndim + 1:
-            fields = ["Specific-Potential"] + [
-                f"{k}-acceleration" for k in "xyz"[:ndim]
-            ]
+            fields = ["Potential"] + [f"{k}-acceleration" for k in "xyz"[:ndim]]
         else:
             fields = [f"{k}-acceleration" for k in "xyz"[:ndim]]
         ndetected = len(fields)

--- a/yt/frontends/ramses/fields.py
+++ b/yt/frontends/ramses/fields.py
@@ -91,7 +91,7 @@ class RAMSESFieldInfo(FieldInfoContainer):
         ("x-acceleration", (ra_units, ["acceleration_x"], None)),
         ("y-acceleration", (ra_units, ["acceleration_y"], None)),
         ("z-acceleration", (ra_units, ["acceleration_z"], None)),
-        ("Potential", (specific_ener_units, ["potential"], None)),
+        ("Specific-Potential", (specific_ener_units, ["specific_potential"], None)),
         ("B_x_left", (b_units, ["magnetic_field_x_left"], None)),
         ("B_x_right", (b_units, ["magnetic_field_x_right"], None)),
         ("B_y_left", (b_units, ["magnetic_field_y_left"], None)),
@@ -181,6 +181,21 @@ class RAMSESFieldInfo(FieldInfoContainer):
         # Load magnetic fields
         if ("gas", "magnetic_field_x_left") in self:
             self.create_magnetic_fields()
+
+        # Potential field
+        if ("gravity", "Specific-Potential") in self:
+            self.create_gravity_fields()
+
+    def create_gravity_fields(self):
+        def potential(field, data):
+            return data["gas", "specific_potential"] * data["gas", "cell_mass"]
+
+        self.add_field(
+            ("gas", "potential"),
+            sampling_type="cell",
+            function=potential,
+            units=self.ds.unit_system["energy"],
+        )
 
     def create_magnetic_fields(self):
         # Calculate cell-centred magnetic fields from face-centred

--- a/yt/frontends/ramses/fields.py
+++ b/yt/frontends/ramses/fields.py
@@ -23,6 +23,7 @@ rho_units = "code_density"
 vel_units = "code_velocity"
 pressure_units = "code_pressure"
 ener_units = "code_mass * code_velocity**2"
+specific_ener_units = "code_velocity**2"
 ang_mom_units = "code_mass * code_velocity * code_length"
 cooling_function_units = " erg * cm**3 /s"
 cooling_function_prime_units = " erg * cm**3 /s/K"
@@ -90,7 +91,7 @@ class RAMSESFieldInfo(FieldInfoContainer):
         ("x-acceleration", (ra_units, ["acceleration_x"], None)),
         ("y-acceleration", (ra_units, ["acceleration_y"], None)),
         ("z-acceleration", (ra_units, ["acceleration_z"], None)),
-        ("Potential", (ener_units, ["potential"], None)),
+        ("Potential", (specific_ener_units, ["potential"], None)),
         ("B_x_left", (b_units, ["magnetic_field_x_left"], None)),
         ("B_x_right", (b_units, ["magnetic_field_x_right"], None)),
         ("B_y_left", (b_units, ["magnetic_field_y_left"], None)),

--- a/yt/frontends/ramses/fields.py
+++ b/yt/frontends/ramses/fields.py
@@ -91,7 +91,7 @@ class RAMSESFieldInfo(FieldInfoContainer):
         ("x-acceleration", (ra_units, ["acceleration_x"], None)),
         ("y-acceleration", (ra_units, ["acceleration_y"], None)),
         ("z-acceleration", (ra_units, ["acceleration_z"], None)),
-        ("Specific-Potential", (specific_ener_units, ["specific_potential"], None)),
+        ("Potential", (specific_ener_units, ["potential"], None)),
         ("B_x_left", (b_units, ["magnetic_field_x_left"], None)),
         ("B_x_right", (b_units, ["magnetic_field_x_right"], None)),
         ("B_y_left", (b_units, ["magnetic_field_y_left"], None)),
@@ -183,17 +183,17 @@ class RAMSESFieldInfo(FieldInfoContainer):
             self.create_magnetic_fields()
 
         # Potential field
-        if ("gravity", "Specific-Potential") in self:
+        if ("gravity", "Potential") in self:
             self.create_gravity_fields()
 
     def create_gravity_fields(self):
-        def potential(field, data):
-            return data["gas", "specific_potential"] * data["gas", "cell_mass"]
+        def potential_energy(field, data):
+            return data["gas", "potential"] * data["gas", "cell_mass"]
 
         self.add_field(
-            ("gas", "potential"),
+            ("gas", "potential_energy"),
             sampling_type="cell",
-            function=potential,
+            function=potential_energy,
             units=self.ds.unit_system["energy"],
         )
 

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -380,14 +380,17 @@ def test_grav_detection():
             assert ("gas", f"acceleration_{k}") in ds.derived_field_list
 
         if has_potential:
-            assert ("gravity", "Potential") in ds.field_list
+            assert ("gravity", "Specific-Potential") in ds.field_list
+            assert ("gas", "specific_potential") in ds.derived_field_list
             assert ("gas", "potential") in ds.derived_field_list
 
         # Test access
         for k in "xyz":
             ds.r["gas", f"acceleration_{k}"].to("m/s**2")
+
         if has_potential:
-            ds.r["gas", "potential"].to("m**2/s**2")
+            ds.r["gas", "specific_potential"].to("m**2/s**2")
+            ds.r["gas", "potential"].to("kg*m**2/s**2")
 
 
 @requires_file(ramses_sink)

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -369,17 +369,25 @@ def test_custom_hydro_def():
 
 
 @requires_file(output_00080)
+@requires_file(ramses_sink)
 def test_grav_detection():
-    ds = yt.load(output_00080)
+    for path, has_potential in ((output_00080, False), (ramses_sink, True)):
+        ds = yt.load(path)
 
-    # Test detection
-    for k in "xyz":
-        assert ("gravity", f"{k}-acceleration") in ds.field_list
-        assert ("gas", f"acceleration_{k}") in ds.derived_field_list
+        # Test detection
+        for k in "xyz":
+            assert ("gravity", f"{k}-acceleration") in ds.field_list
+            assert ("gas", f"acceleration_{k}") in ds.derived_field_list
 
-    # Test access
-    for k in "xyz":
-        ds.r["gas", f"acceleration_{k}"]
+        if has_potential:
+            assert ("gravity", "Potential") in ds.field_list
+            assert ("gas", "potential") in ds.derived_field_list
+
+        # Test access
+        for k in "xyz":
+            ds.r["gas", f"acceleration_{k}"].to("m/s**2")
+        if has_potential:
+            ds.r["gas", "potential"].to("m**2/s**2")
 
 
 @requires_file(ramses_sink)

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -380,17 +380,17 @@ def test_grav_detection():
             assert ("gas", f"acceleration_{k}") in ds.derived_field_list
 
         if has_potential:
-            assert ("gravity", "Specific-Potential") in ds.field_list
-            assert ("gas", "specific_potential") in ds.derived_field_list
+            assert ("gravity", "Potential") in ds.field_list
             assert ("gas", "potential") in ds.derived_field_list
+            assert ("gas", "potential_energy") in ds.derived_field_list
 
         # Test access
         for k in "xyz":
             ds.r["gas", f"acceleration_{k}"].to("m/s**2")
 
         if has_potential:
-            ds.r["gas", "specific_potential"].to("m**2/s**2")
-            ds.r["gas", "potential"].to("kg*m**2/s**2")
+            ds.r["gas", "potential"].to("m**2/s**2")
+            ds.r["gas", "potential_energy"].to("kg*m**2/s**2")
 
 
 @requires_file(ramses_sink)


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

Until recently, the potential dumped by RAMSES was assumed to be in energy units, whereas it should be in specific energy units.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
