### PR TITLE
[bugfix] Fix log plots when using matplotilb 3.3.x if there are zeros in the plot

### DIFF
--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -970,7 +970,7 @@ class PWViewerMPL(PlotWindow):
                     # a fix is in -- see PR #3161 and linked issue.
                     cutoff_sigdigs = 15
                     if (
-                        np.log10(np.nanmax(image[np.isfinite(image)]]))
+                        np.log10(np.nanmax(image[np.isfinite(image)]))
                         - np.log10(np.nanmin(image[image > 0]))
                         > cutoff_sigdigs
                     ):

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -970,7 +970,7 @@ class PWViewerMPL(PlotWindow):
                     # a fix is in -- see PR #3161 and linked issue.
                     cutoff_sigdigs = 15
                     if (
-                        np.log10(np.nanmax(image))
+                        np.log10(np.nanmax(image[np.isfinite(image)]]))
                         - np.log10(np.nanmin(image[image > 0]))
                         > cutoff_sigdigs
                     ):

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -956,7 +956,7 @@ class PWViewerMPL(PlotWindow):
                 elif np.nanmax(image) > 0.0 and np.nanmin(image) <= 0:
                     msg = (
                         "Plot image for field %s has both positive "
-                        "and negative values. Min = %f, Max = %f."
+                        "and negative/zero values. Min = %f, Max = %f."
                         % (f, np.nanmin(image), np.nanmax(image))
                     )
                     use_symlog = True
@@ -964,8 +964,9 @@ class PWViewerMPL(PlotWindow):
                     mylog.warning(msg)
                     if use_symlog:
                         mylog.warning(
-                            "Switching to symlog colorbar scaling "
-                            "unless linear scaling is specified later"
+                            "Log-scaling specified: switching to symlog "
+                            "colorbar scaling unless linear scaling is "
+                            "specified later"
                         )
                         self._field_transform[f] = symlog_transform
                         self._field_transform[f].func = None

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -953,7 +953,7 @@ class PWViewerMPL(PlotWindow):
                     )
                 elif not np.any(np.isfinite(image)):
                     msg = f"Plot image for field {f} is filled with NaNs."
-                elif np.nanmax(image) > 0.0 and np.nanmin(image) < 0:
+                elif np.nanmax(image) > 0.0 and np.nanmin(image) <= 0:
                     msg = (
                         "Plot image for field %s has both positive "
                         "and negative values. Min = %f, Max = %f."


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

This PR fixes issue #2890, following a suggestion by @chrishavlin, which uses symlog scaling if there are zeros in the plot, avoiding a thrown exception by matplotlib if log-scaling is requested. 

I also updated the log messages to be more specific about why symlog scaling is being used.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
