### PR TITLE
remove mccabe from linting specs (already a direct dependency of flake8)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,6 @@ repos:
     hooks:
     - id: flake8
       additional_dependencies: [
-        mccabe,
         flake8-bugbear>=20.3.2, # GH PR 2851
         flake8-logging-format
       ]


### PR DESCRIPTION
## PR Summary

See https://github.com/PyCQA/flake8/blob/e0116d8e77fb04acc62095734ec49e779f24ee54/setup.cfg#L43
