### PR TITLE
update API docs for missing/moved classes

### DIFF
--- a/doc/source/reference/api/api.rst
+++ b/doc/source/reference/api/api.rst
@@ -79,11 +79,11 @@ These will almost never need to be instantiated on their own.
 .. autosummary::
 
    ~yt.data_objects.data_containers.YTDataContainer
-   ~yt.data_objects.data_containers.YTSelectionContainer
-   ~yt.data_objects.data_containers.YTSelectionContainer0D
-   ~yt.data_objects.data_containers.YTSelectionContainer1D
-   ~yt.data_objects.data_containers.YTSelectionContainer2D
-   ~yt.data_objects.data_containers.YTSelectionContainer3D
+   ~yt.data_objects.selection_objects.data_selection_objects.YTSelectionContainer
+   ~yt.data_objects.selection_objects.data_selection_objects.YTSelectionContainer0D
+   ~yt.data_objects.selection_objects.data_selection_objects.YTSelectionContainer1D
+   ~yt.data_objects.selection_objects.data_selection_objects.YTSelectionContainer2D
+   ~yt.data_objects.selection_objects.data_selection_objects.YTSelectionContainer3D
 
 Selection Objects
 +++++++++++++++++
@@ -93,18 +93,22 @@ geometric.
 
 .. autosummary::
 
-   ~yt.data_objects.selection_data_containers.YTPoint
-   ~yt.data_objects.selection_data_containers.YTOrthoRay
-   ~yt.data_objects.selection_data_containers.YTRay
-   ~yt.data_objects.selection_data_containers.YTSlice
-   ~yt.data_objects.selection_data_containers.YTCuttingPlane
-   ~yt.data_objects.selection_data_containers.YTDisk
-   ~yt.data_objects.selection_data_containers.YTRegion
-   ~yt.data_objects.selection_data_containers.YTDataCollection
-   ~yt.data_objects.selection_data_containers.YTSphere
-   ~yt.data_objects.selection_data_containers.YTEllipsoid
-   ~yt.data_objects.selection_data_containers.YTCutRegion
-   ~yt.data_objects.grid_patch.AMRGridPatch
+   ~yt.data_objects.selection_objects.point.YTPoint
+   ~yt.data_objects.selection_objects.ray.YTOrthoRay
+   ~yt.data_objects.selection_objects.ray.YTRay
+   ~yt.data_objects.selection_objects.slices.YTSlice
+   ~yt.data_objects.selection_objects.slices.YTCuttingPlane
+   ~yt.data_objects.selection_objects.disk.YTDisk
+   ~yt.data_objects.selection_objects.region.YTRegion
+   ~yt.data_objects.selection_objects.object_collection.YTDataCollection
+   ~yt.data_objects.selection_objects.spheroids.YTSphere
+   ~yt.data_objects.selection_objects.spheroids.YTEllipsoid
+   ~yt.data_objects.selection_objects.cur_region.YTCutRegion
+   ~yt.data_objects.index_subobjects.grid_patch.AMRGridPatch
+   ~yt.data_objects.index_subobjects.octree_subset.OctreeSubset
+   ~yt.data_objects.index_subobjects.particle_container.ParticleContainer
+   ~yt.data_objects.index_subobjects.unstructured_mesh.UnstructuredMesh
+   ~yt.data_objects.index_subobjects.unstructured_mesh.SemiStructuredMesh
 
 Construction Objects
 ++++++++++++++++++++
@@ -132,6 +136,7 @@ datasets.
 
    ~yt.data_objects.time_series.DatasetSeries
    ~yt.data_objects.time_series.DatasetSeriesObject
+   ~yt.data_objects.time_series.SimulationTimeSeries
    ~yt.data_objects.time_series.TimeSeriesQuantitiesContainer
    ~yt.data_objects.time_series.AnalysisTaskProxy
    ~yt.data_objects.particle_trajectories.ParticleTrajectories


### PR DESCRIPTION
A number of data container classes were moved in recent reorgs, breaking the api docs links. I also encountered some that were missing.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
