### PR TITLE
supporting MPL 3.4 : stop registering colormaps from cmocean

### DIFF
--- a/doc/source/visualizing/colormaps/index.rst
+++ b/doc/source/visualizing/colormaps/index.rst
@@ -50,24 +50,6 @@ not be interpolated, and can be useful for creating
 colorblind/printer/grayscale-friendly plots. For more information, visit
 `http://colorbrewer2.org <http://colorbrewer2.org>`_.
 
-.. _cmocean-cmaps:
-
-Colormaps from cmocean
-~~~~~~~~~~~~~~~~~~~~~~
-
-In addition to ``palettable``, yt will also import colormaps defined in the
-`cmocean <https://matplotlib.org/cmocean>`_ package. These colormaps are
-`perceptually uniform <http://bids.github.io/colormap/>`_ and were originally
-designed for oceanography applications, but can be used for any kind of plots.
-
-Since ``cmocean`` is not installed as a dependency of yt by default, it must be
-installed separately to access the ``cmocean`` colormaps with yt. The easiest
-way to install ``cmocean`` is via ``pip``: ``pip install cmocean``.  To access
-the colormaps in yt, simply specify the name of the ``cmocean`` colormap in any
-context where you would specify a colormap. One caveat is the ``cmocean``
-colormap ``algae``. Since yt already defines a colormap named ``algae``, the
-``cmocean`` version of ``algae`` must be specified with the name
-``algae_cmocean``.
 
 .. _custom-colormaps:
 

--- a/yt/visualization/color_maps.py
+++ b/yt/visualization/color_maps.py
@@ -3,11 +3,6 @@ from matplotlib import cm as mcm, colors as cc
 
 from . import _colormap_data as _cm
 
-try:
-    import cmocean
-except ImportError:
-    cmocean = None
-
 
 def is_colormap(cmap):
     return isinstance(cmap, cc.Colormap)
@@ -170,18 +165,6 @@ cdict = {
 
 add_colormap("purple_mm", cdict)
 
-# Add colormaps from cmocean, if it's installed
-if cmocean is not None:
-    cmo_cmapnames = cmocean.cm.cmapnames
-    cmo_cmapnames += [f"{name}_r" for name in cmo_cmapnames]
-    for cmname in cmo_cmapnames:
-        cm = getattr(cmocean.cm, cmname)
-        # cmocean has a colormap named 'algae', so let's avoid overwriting
-        # yt's algae or any other colormap we've already added
-        if cmname in yt_colormaps:
-            cmname = cmname + "_cmocean"
-        yt_colormaps[cmname] = cm
-        mcm.register_cmap(cmname, yt_colormaps[cmname])
 
 # Add colormaps in _colormap_data.py that weren't defined here
 _vs = np.linspace(0, 1, 256)


### PR DESCRIPTION
## PR Summary

The problem is discussed in #3165
Right now, using an env with yt's bleeding edge and
```
cmocean
matplotlib==3.4
```
breaks everything because of a naming collision that matplotlib used to tolerate but doesn't any more
```shell
$ python -c "import yt"
...
ValueError: Trying to re-register the builtin cmap 'gray'.
```

The solution is to stop registering cmocean's colormaps unprefixed.
Sadly this is a backward breaking change but it's necessary in order to make yt compatible with matplotlib 3.4, so I believe it's worth the cost.

Note that yt can still be used in combination with cmocean or similar projects (such as cmasher), at the discretion of the user.


This used to work (with cmocean installed)
```python
import matplotlib
import yt

ds = yt.testing.fake_amr_ds()
p = yt.SlicePlot(ds, "z", "Density")
p.set_cmap("all", "balance")
```

This is how it should work instead
```python
import matplotlib
import yt
import cmocean

ds = yt.testing.fake_amr_ds()
p = yt.SlicePlot(ds, "z", "Density")
p.set_cmap("all", "cmo.balance")
```
note that this second version works with any existing version of yt.
