### PR TITLE
fix: don't copy unit registry if it is already the same thing

### DIFF
--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -759,6 +759,8 @@ class YTCoveringGrid(YTSelectionContainer3D):
                 "Length of edges must match the dimensionality of the " "dataset"
             )
         if hasattr(edge, "units"):
+            if edge.units.registry is self.ds.unit_registry:
+                return edge
             edge_units = edge.units.copy()
             edge_units.registry = self.ds.unit_registry
         else:
@@ -2765,6 +2767,8 @@ class YTOctree(YTSelectionContainer3D):
                 "Length of edges must match the dimensionality of the " "dataset"
             )
         if hasattr(edge, "units"):
+            if edge.units.registry is self.ds.unit_registry:
+                return edge
             edge_units = edge.units
         else:
             edge_units = "code_length"


### PR DESCRIPTION
I'll admit: I don't know what I'm doing. If this gets merged in, there is a chance some unnamed PhD student will probably lose a couple of weeks trying to debug a subtle issue of nonconforming units somewhere affecting their results. They'll `git bisect` and then `git blame` and learn my name. They won't know me, but they'll hate me. With passion. 
However, on a slim chance that what I'm suggesting doesn't break the Universe horribly, let's run a full testsuite on this PR. Afterwards, I'll provide a concrete example how this benefits a specific use case.