### PR TITLE
Fix and clean strings

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -69,7 +69,7 @@ def pytest_configure(config):
     # Register custom marks for answer tests and big data
     config.addinivalue_line("markers", "answer_test: Run the answer tests.")
     config.addinivalue_line(
-        "markers", "big_data: Run answer tests that require" " large data files."
+        "markers", "big_data: Run answer tests that require large data files."
     )
 
 

--- a/setupext.py
+++ b/setupext.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from textwrap import dedent
 from concurrent.futures import ThreadPoolExecutor
 from distutils import log
 from distutils.ccompiler import CCompiler, new_compiler
@@ -62,16 +63,16 @@ def check_for_openmp():
     tmp_dir = tempfile.mkdtemp()
     start_dir = os.path.abspath(".")
 
-    CCODE = """
-    #include <omp.h>
-    #include <stdio.h>
-    int main() {
-        omp_set_num_threads(2);
-        #pragma omp parallel
-        printf("nthreads=%d\\n", omp_get_num_threads());
-        return 0;
-    }
-    """
+    CCODE = dedent("""\
+        #include <omp.h>
+        #include <stdio.h>
+        int main() {
+            omp_set_num_threads(2);
+            #pragma omp parallel
+            printf("nthreads=%d\\n", omp_get_num_threads());
+            return 0;
+        }"""
+    )
 
     # TODO: test more known compilers:
     # MinGW, AppleClang with libomp, MSVC, ICC, XL, PGI, ...
@@ -156,18 +157,18 @@ def check_CPP14_flag(compile_flags):
     # Note: This code requires C++14 functionalities (also required to compile yt)
     # It compiles on gcc 4.7.4 (together with the entirety of yt) with the flag "-std=gnu++0x".
     # It does not compile on gcc 4.6.4 (neither does yt).
-    CPPCODE = """
-    #include <vector>
+    CPPCODE = dedent("""\
+        #include <vector>
 
-    struct node {
-        std::vector<int> vic;
-        bool visited = false;
-    };
+        struct node {
+            std::vector<int> vic;
+            bool visited = false;
+        };
 
-    int main() {
-        return 0;
-    }
-    """
+        int main() {
+            return 0;
+        }"""
+    )
 
     os.chdir(tmp_dir)
     try:
@@ -276,7 +277,13 @@ def read_embree_location():
         # Attempt to compile a test script.
         filename = r"test.cpp"
         file = open(filename, "wt", 1)
-        file.write('#include "embree2/rtcore.h"\n' "int main() {\nreturn 0;\n" "}")
+        CCODE = dedent("""\
+            #include "embree2/rtcore.h
+            int main() {
+                return 0;
+            }"""
+        )
+        file.write(CCODE)
         file.flush()
         p = Popen(
             compiler + ["-I%s/include/" % rd, filename],

--- a/setupext.py
+++ b/setupext.py
@@ -276,7 +276,7 @@ def read_embree_location():
         # Attempt to compile a test script.
         filename = r"test.cpp"
         file = open(filename, "wt", 1)
-        file.write('#include "embree2/rtcore.h"\n' "int main() {\n" "return 0;\n" "}")
+        file.write('#include "embree2/rtcore.h"\n' "int main() {\nreturn 0;\n" "}")
         file.flush()
         p = Popen(
             compiler + ["-I%s/include/" % rd, filename],
@@ -289,7 +289,7 @@ def read_embree_location():
 
         if exit_code != 0:
             log.warn(
-                "Pyembree is installed, but I could not compile Embree " "test code."
+                "Pyembree is installed, but I could not compile Embree test code."
             )
             log.warn("The error message was: ")
             log.warn(err)

--- a/tests/report_failed_answers.py
+++ b/tests/report_failed_answers.py
@@ -387,14 +387,14 @@ if __name__ == "__main__":
         "-m",
         "--upload-missing-answers",
         action="store_true",
-        help="Upload tests' answers that are not found in " "answer-store.",
+        help="Upload tests' answers that are not found in answer-store.",
     )
     parser.add_argument(
         "--xunit-file",
         action="store",
         dest="nosetest_xml",
         required=True,
-        help="Name of the nosetests xml file to parse for " "failed answer tests.",
+        help="Name of the nosetests xml file to parse for failed answer tests.",
     )
     args = parser.parse_args()
 

--- a/yt/analysis_modules/spectral_integrator/api.py
+++ b/yt/analysis_modules/spectral_integrator/api.py
@@ -1,5 +1,5 @@
 raise RuntimeError(
-    "The spectral_integrator module as been moved to yt.fields."
+    "The spectral_integrator module as been moved to yt.fields. "
     "'add_xray_emissivity_field' can now be imported "
     "from the yt module."
 )

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -395,9 +395,7 @@ class YTParticleProj(YTProj):
         )
 
     def _handle_chunk(self, chunk, fields, tree):
-        raise NotImplementedError(
-            "Particle projections have not yet been " "implemented"
-        )
+        raise NotImplementedError("Particle projections have not yet been implemented")
 
 
 class YTQuadTreeProj(YTProj):
@@ -756,7 +754,7 @@ class YTCoveringGrid(YTSelectionContainer3D):
             edge = [edge] * len(self.ds.domain_left_edge)
         if len(edge) != len(self.ds.domain_left_edge):
             raise RuntimeError(
-                "Length of edges must match the dimensionality of the " "dataset"
+                "Length of edges must match the dimensionality of the dataset"
             )
         if hasattr(edge, "units"):
             edge_units = edge.units.copy()
@@ -2762,7 +2760,7 @@ class YTOctree(YTSelectionContainer3D):
             edge = [edge] * len(self.ds.domain_left_edge)
         if len(edge) != len(self.ds.domain_left_edge):
             raise RuntimeError(
-                "Length of edges must match the dimensionality of the " "dataset"
+                "Length of edges must match the dimensionality of the dataset"
             )
         if hasattr(edge, "units"):
             edge_units = edge.units

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -1993,7 +1993,7 @@ class YTSurface(YTSelectionContainer3D):
             fobj.write("# yt OBJ file\n")
             fobj.write("# www.yt-project.org\n")
             fobj.write(
-                "mtllib " + filename + ".mtl\n\n"
+                f"mtllib {filename}.mtl\n\n"
             )  # use this material file for the faces
             fmtl.write("# yt MLT file\n")
             fmtl.write("# www.yt-project.org\n\n")
@@ -2053,11 +2053,9 @@ class YTSurface(YTSelectionContainer3D):
                 v[ax][:] = tmp
         # (1) write all colors per surface to mtl file
         for i in range(0, lut[0].shape[0]):
-            omname = (
-                "material_" + str(i) + "_" + str(plot_index)
-            )  # name of the material
+            omname = f"material_{i}_{plot_index}"  # name of the material
             fmtl.write(
-                "newmtl " + omname + "\n"
+                f"newmtl {omname}\n"
             )  # the specific material (color) for this face
             fmtl.write(f"Ka {0.0:.6f} {0.0:.6f} {0.0:.6f}\n")  # ambient color, keep off
             fmtl.write(
@@ -2069,22 +2067,18 @@ class YTSurface(YTSelectionContainer3D):
             fmtl.write(f"d {transparency:.6f}\n")  # transparency
             fmtl.write(f"em {emiss[i]:.6f}\n")  # emissivity per color
             fmtl.write("illum 2\n")  # not relevant, 2 means highlights on?
-            fmtl.write("Ns %.6f\n\n" % (0.0))  # keep off, some other specular thing
+            fmtl.write(f"Ns {0:.6f}\n\n")  # keep off, some other specular thing
         # (2) write vertices
         for i in range(0, self.vertices.shape[1]):
             fobj.write(f"v {v['x'][i]:.6f} {v['y'][i]:.6f} {v['z'][i]:.6f}\n")
         fobj.write("#done defining vertices\n\n")
         # (3) define faces and materials for each face
         for i in range(0, self.triangles.shape[0]):
-            omname = (
-                "material_" + str(f["cind"][i]) + "_" + str(plot_index)
-            )  # which color to use
+            omname = f"material_{f['cind'][i]}_{plot_index}"  # which color to use
             fobj.write(
-                "usemtl " + omname + "\n"
+                f"usemtl {omname}\n"
             )  # which material to use for this face (color)
-            fobj.write(
-                "f " + str(cc) + " " + str(cc + 1) + " " + str(cc + 2) + "\n\n"
-            )  # vertices to color
+            fobj.write(f"f {cc} {cc+1} {cc+2}\n\n")  # vertices to color
             cc = cc + 3
         fmtl.close()
         fobj.close()

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -784,9 +784,9 @@ class YTDataContainer:
             from firefly_api.reader import Reader
         except ImportError as e:
             raise ImportError(
-                "Can't find firefly_api, ensure it"
-                "is in your python path or install it with"
-                "'$ pip install firefly_api'. It is also available"
+                "Can't find firefly_api, ensure it "
+                "is in your python path or install it with "
+                "'$ pip install firefly_api'. It is also available "
                 "on github at github.com/agurvich/firefly_api"
             ) from e
 

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1042,9 +1042,7 @@ class YTDataContainer:
                 return rv[0]
             return rv
         elif axis in self.ds.coordinates.axis_name:
-            raise NotImplementedError(
-                "Minimum intensity projection not" " implemented."
-            )
+            raise NotImplementedError("Minimum intensity projection not implemented.")
         else:
             raise NotImplementedError(f"Unknown axis {axis}")
 

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -1296,7 +1296,7 @@ def create_profile(
                     bin_fields[1] in logs and logs[bin_fields[1]]
                 ):
                     raise RuntimeError(
-                        "CIC deposition is only implemented for linear-scaled " "axes"
+                        "CIC deposition is only implemented for linear-scaled axes"
                     )
             else:
                 logs = {bin_fields[0]: False, bin_fields[1]: False}

--- a/yt/data_objects/selection_objects/data_selection_objects.py
+++ b/yt/data_objects/selection_objects/data_selection_objects.py
@@ -1414,7 +1414,7 @@ class YTSelectionContainer3D(YTSelectionContainer):
         """
         if self.ds.geometry != "cartesian":
             raise NotImplementedError(
-                "get_bbox is currently only implemented " "for cartesian geometries!"
+                "get_bbox is currently only implemented for cartesian geometries!"
             )
         le, re = self._get_bbox()
         le.convert_to_units("code_length")

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -628,7 +628,7 @@ class Dataset(abc.ABC):
                 )
         else:
             raise ValueError(
-                "{} not a recognized format_property. Available"
+                "{} not a recognized format_property. Available "
                 "properties are: {}".format(
                     format_property, list(available_formats.keys())
                 )
@@ -1681,7 +1681,7 @@ class Dataset(abc.ABC):
         The field name tuple for the newly created field.
         """
         issue_deprecation_warning(
-            "This method is deprecated."
+            "This method is deprecated. "
             "Since yt-4.0, it's no longer necessary to add a field specifically for "
             "smoothing, because the global octree is removed. The old behavior of "
             "interpolating onto a grid structure can be recovered through data objects "

--- a/yt/data_objects/tests/test_disks.py
+++ b/yt/data_objects/tests/test_disks.py
@@ -42,7 +42,7 @@ def test_bad_disk_input():
             (20, "kpc"),
             fields=YTQuantity(1, "kpc"),
         )
-    desired = "Expected an iterable object, received" " 'unyt.array.unyt_quantity'"
+    desired = "Expected an iterable object, received 'unyt.array.unyt_quantity'"
     assert_equal(str(ex.exception), desired)
 
     # Test invalid object

--- a/yt/data_objects/tests/test_image_array.py
+++ b/yt/data_objects/tests/test_image_array.py
@@ -118,7 +118,7 @@ class TestImageArray(unittest.TestCase):
             # Trigger a warning.
             im_arr.write_png("clipped.png", clip_ratio=0.5)
             assert str(w[0].message) == (
-                "'clip_ratio' keyword is deprecated." " Use 'sigma_clip' instead"
+                "'clip_ratio' keyword is deprecated. Use 'sigma_clip' instead"
             )
 
     def test_image_array_background(self):

--- a/yt/fields/derived_field.py
+++ b/yt/fields/derived_field.py
@@ -179,7 +179,7 @@ class DerivedField:
             self.units = units.decode("utf-8")
         else:
             raise FieldUnitsError(
-                "Cannot handle units '%s' (type %s)."
+                "Cannot handle units '%s' (type %s). "
                 "Please provide a string or Unit "
                 "object." % (units, type(units))
             )

--- a/yt/fields/xray_emission_fields.py
+++ b/yt/fields/xray_emission_fields.py
@@ -335,7 +335,7 @@ def add_xray_emissivity_field(
                     dist = ds.quan(*dist)
                 except (RuntimeError, TypeError):
                     raise TypeError(
-                        "dist should be a YTQuantity " "or a (value, unit) tuple!"
+                        "dist should be a YTQuantity or a (value, unit) tuple!"
                     ) from e
 
             angular_scale = dist / ds.quan(1.0, "radian")

--- a/yt/frontends/art/io.py
+++ b/yt/frontends/art/io.py
@@ -499,7 +499,7 @@ def _read_child_mask_level(f, level_child_offsets, level, nLevel, nhydro_vars):
 
 
 nchem = 8 + 2
-dtyp = np.dtype(">i4,>i8,>i8" + f",>{nchem}f4" + ",>%sf4" % (2) + ",>i4")
+dtyp = np.dtype(f">i4,>i8,>i8,>{nchem}f4,>2f4,>i4")
 
 
 def _read_child_level(

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -142,7 +142,7 @@ class BoxLibParticleHeader:
                 self.real_type = known_real_types[particle_real_type]
             except KeyError:
                 warnings.warn(
-                    f"yt did not recognize particle real type {particle_real_type}"
+                    f"yt did not recognize particle real type {particle_real_type} "
                     "assuming double",
                     category=RuntimeWarning,
                 )

--- a/yt/frontends/enzo/simulation_handling.py
+++ b/yt/frontends/enzo/simulation_handling.py
@@ -684,7 +684,7 @@ class EnzoSimulation(SimulationTimeSeries):
         f = open(filename, "w")
         for q, output in enumerate(outputs):
             f.write(
-                ("CosmologyOutputRedshift[%d] = %." + str(decimals) + "f\n")
+                (f"CosmologyOutputRedshift[%d] = %.{decimals}f\n")
                 % ((q + start_index), output["redshift"])
             )
         f.close()

--- a/yt/frontends/enzo_p/tests/test_misc.py
+++ b/yt/frontends/enzo_p/tests/test_misc.py
@@ -20,7 +20,7 @@ def get_random_block_string(max_n=64, random_state=None, level=None):
         random_state = np.random.RandomState()
 
     max_l = int(np.log2(max_n))
-    form = "%0" + str(max_l) + "d"
+    form = f"%0{max_l}d"
     num10 = random_state.randint(0, high=max_n)
     num2 = form % int(bin(num10)[2:])  # the slice clips the '0b' prefix
 

--- a/yt/frontends/moab/data_structures.py
+++ b/yt/frontends/moab/data_structures.py
@@ -159,7 +159,7 @@ class PyneMoabHex8Dataset(Dataset):
         unit_system="cgs",
     ):
         self.fluid_types += ("pyne",)
-        filename = "pyne_mesh_" + str(id(pyne_mesh))
+        filename = f"pyne_mesh_{id(pyne_mesh)}"
         self.pyne_mesh = pyne_mesh
         Dataset.__init__(
             self,

--- a/yt/frontends/open_pmd/data_structures.py
+++ b/yt/frontends/open_pmd/data_structures.py
@@ -236,7 +236,7 @@ class OpenPMDHierarchy(GridIndex):
                     for (patch, size) in enumerate(
                         species["/particlePatches/numParticles"]
                     ):
-                        self.numparts[pname + "#" + str(patch)] = size
+                        self.numparts[f"{pname}#{patch}"] = size
                 else:
                     axis = list(species["/position"].keys())[0]
                     if is_const_component(species["/position/" + axis]):

--- a/yt/frontends/owls/fields.py
+++ b/yt/frontends/owls/fields.py
@@ -175,7 +175,7 @@ class OWLSFieldInfo(SPHFieldInfo):
                 if (ptype, symbol + "_fraction") not in self.field_aliases:
                     continue
 
-                pstr = "_p" + str(roman - 1)
+                pstr = f"_p{roman - 1}"
                 yt_ion = symbol + pstr
 
                 # add particle field
@@ -226,7 +226,7 @@ class OWLSFieldInfo(SPHFieldInfo):
                 if (ptype, symbol + "_fraction") not in self.field_aliases:
                     continue
 
-                pstr = "_p" + str(roman - 1)
+                pstr = f"_p{roman - 1}"
                 yt_ion = symbol + pstr
 
                 for sfx in smoothed_suffixes:
@@ -252,7 +252,7 @@ class OWLSFieldInfo(SPHFieldInfo):
             if (ptype, symbol + "_fraction") not in self.field_aliases:
                 continue
 
-            pstr = "_p" + str(roman - 1)
+            pstr = f"_p{roman - 1}"
             yt_ion = symbol + pstr
             ftype = ptype
 
@@ -345,7 +345,7 @@ class OWLSFieldInfo(SPHFieldInfo):
             fname = data_dir + "/" + data_file
             download_file(os.path.join(data_url, data_file), fname)
 
-            cmnd = "cd " + data_dir + "; " + "tar xf " + data_file
+            cmnd = f"cd {data_dir}; tar xf {data_file}"
             os.system(cmnd)
 
         if not os.path.exists(owls_ion_path):

--- a/yt/frontends/ramses/field_handlers.py
+++ b/yt/frontends/ramses/field_handlers.py
@@ -425,7 +425,7 @@ class HydroFieldFileHandler(FieldFileHandler):
         # Allow some wiggle room for users to add too many variables
         count_extra = 0
         while len(fields) < nvar:
-            fields.append("var" + str(len(fields)))
+            fields.append(f"var_{len(fields)}")
             count_extra += 1
         if count_extra > 0:
             mylog.debug("Detected %s extra fluid fields.", count_extra)

--- a/yt/geometry/coordinates/cartesian_coordinates.py
+++ b/yt/geometry/coordinates/cartesian_coordinates.py
@@ -228,7 +228,7 @@ class CartesianCoordinateHandler(CoordinateHandler):
         """
         if npoints < 2:
             raise ValueError(
-                "Must have at least two sample points in order " "to draw a line plot."
+                "Must have at least two sample points in order to draw a line plot."
             )
         index = self.ds.index
         if hasattr(index, "meshes") and not isinstance(

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -327,7 +327,7 @@ _common_options = dict(
         type=str,
         dest="field",
         default="density",
-        help=("Field to color by, " "use a comma to separate field tuple values"),
+        help=("Field to color by, use a comma to separate field tuple values"),
     ),
     weight=dict(
         short="-g",
@@ -1906,7 +1906,7 @@ class YTDownloadData(YTCommand):
             )
         elif not args.location:
             raise RuntimeError(
-                "You need to specify download location. See " "--help for details."
+                "You need to specify download location. See --help for details."
             )
         data_url = f"http://yt-project.org/data/{args.filename}"
         if args.location in ["test_data_dir", "supp_data_dir"]:

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -276,8 +276,8 @@ _common_options = dict(
         default=False,
         action="store_true",
         help=(
-            "Reinstall the full yt stack in the current location."
-            "This option has been deprecated and will not have any"
+            "Reinstall the full yt stack in the current location. "
+            "This option has been deprecated and will not have any "
             "effect."
         ),
     ),

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -911,7 +911,7 @@ class YTInstInfoCmd(YTCommand):
             action="store",
             default=None,
             dest="outputfile",
-            help="File into which the current revision number will be" + "stored",
+            help="File into which the current revision number will be stored",
         ),
     )
     description = """

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -271,7 +271,7 @@ class YTNoFilenamesMatchPattern(YTException):
         self.pattern = pattern
 
     def __str__(self):
-        return "No filenames were found to match the pattern: " + f"'{self.pattern}'"
+        return f"No filenames were found to match the pattern: '{self.pattern}'"
 
 
 class YTNoOldAnswer(YTException):
@@ -279,7 +279,7 @@ class YTNoOldAnswer(YTException):
         self.path = path
 
     def __str__(self):
-        return "There is no old answer available.\n" + str(self.path)
+        return f"There is no old answer available.\n{self.path}"
 
 
 class YTNoAnswerNameSpecified(YTException):

--- a/yt/utilities/file_handler.py
+++ b/yt/utilities/file_handler.py
@@ -17,7 +17,7 @@ def warn_h5py(fn):
     needs_h5py = valid_hdf5_signature(fn)
     if needs_h5py and isinstance(h5py.File, NotAModule):
         raise RuntimeError(
-            "This appears to be an HDF5 file, " "but h5py is not installed."
+            "This appears to be an HDF5 file, but h5py is not installed."
         )
 
 

--- a/yt/utilities/lib/cykdtree/tests/__init__.py
+++ b/yt/utilities/lib/cykdtree/tests/__init__.py
@@ -39,9 +39,9 @@ def call_subprocess(np, func, args, kwargs):
     # Create string with arguments & kwargs
     args_str = ""
     for a in args:
-        args_str += str(a) + ","
+        args_str += f"{a},"
     for k, v in kwargs.items():
-        args_str += k + "=" + str(v) + ","
+        args_str += f"{k}={v},"
     if args_str.endswith(","):
         args_str = args_str[:-1]
     cmd = [

--- a/yt/utilities/lodgeit.py
+++ b/yt/utilities/lodgeit.py
@@ -211,7 +211,7 @@ def create_paste(code, language, filename, mimetype, private):
     xmlrpc = get_xmlrpc_service()
     rv = xmlrpc.pastes.newPaste(language, code, None, filename, mimetype, private)
     if not rv:
-        fail("Could not create paste. Something went wrong " "on the server side.", 4)
+        fail("Could not create paste. Something went wrong on the server side.", 4)
     return rv
 
 

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -794,7 +794,7 @@ class FITSImageData:
             scaleq = YTQuantity(sky_scale[0], sky_scale[1])
         if scaleq.units.dimensions != dimensions.angle / dimensions.length:
             raise RuntimeError(
-                f"sky_scale {sky_scale} not in correct " + "dimensions of angle/length!"
+                f"sky_scale {sky_scale} not in correct dimensions of angle/length!"
             )
         deltas = old_wcs.wcs.cdelt
         units = [str(unit) for unit in old_wcs.wcs.cunit]

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -203,7 +203,7 @@ class FITSImageData:
         elif isinstance(data, np.ndarray):
             if fields is None:
                 mylog.warning(
-                    "No field name given for this array. " "Calling it 'image_data'."
+                    "No field name given for this array. Calling it 'image_data'."
                 )
                 fn = "image_data"
                 fields = [fn]
@@ -408,7 +408,7 @@ class FITSImageData:
                 uq.convert_to_cgs()
 
             if attr == "length_unit" and uq.value != 1.0:
-                mylog.warning("Converting length units " "from %s to %s.", uq, uq.units)
+                mylog.warning("Converting length units from %s to %s.", uq, uq.units)
                 uq = YTQuantity(1.0, uq.units)
 
             setattr(self, attr, uq)

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -2487,7 +2487,7 @@ class TimestampCallback(PlotCallback):
                     toffset = plot.ds.quan(self.time_offset, self.time_unit)
                 elif not isinstance(self.time_offset, YTQuantity):
                     raise RuntimeError(
-                        "'time_offset' must be a float, tuple, or" "YTQuantity!"
+                        "'time_offset' must be a float, tuple, orYTQuantity!"
                     )
                 t -= toffset.in_units(self.time_unit)
             try:
@@ -2512,7 +2512,7 @@ class TimestampCallback(PlotCallback):
                 z = plot.data.ds.current_redshift
             except AttributeError:
                 raise AttributeError(
-                    "Dataset does not have current_redshift. " "Set redshift=False."
+                    "Dataset does not have current_redshift. Set redshift=False."
                 )
             # Replace instances of -0.0* with 0.0* to avoid
             # negative null redshifts (e.g., "-0.00").

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -2487,7 +2487,7 @@ class TimestampCallback(PlotCallback):
                     toffset = plot.ds.quan(self.time_offset, self.time_unit)
                 elif not isinstance(self.time_offset, YTQuantity):
                     raise RuntimeError(
-                        "'time_offset' must be a float, tuple, orYTQuantity!"
+                        "'time_offset' must be a float, tuple, or YTQuantity!"
                     )
                 t -= toffset.in_units(self.time_unit)
             try:

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -932,7 +932,7 @@ class PWViewerMPL(PlotWindow):
         y_in_bounds = yc >= yllim and yc <= yrlim
 
         if not x_in_bounds and not y_in_bounds:
-            msg = "origin inputs not in bounds of specified coordinate sytemdomain."
+            msg = "origin inputs not in bounds of specified coordinate system domain."
             msg = msg.format(self.origin)
             raise RuntimeError(msg)
 

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -932,9 +932,7 @@ class PWViewerMPL(PlotWindow):
         y_in_bounds = yc >= yllim and yc <= yrlim
 
         if not x_in_bounds and not y_in_bounds:
-            msg = (
-                "origin inputs not in bounds of specified coordinate sytem" + "domain."
-            )
+            msg = "origin inputs not in bounds of specified coordinate sytemdomain."
             msg = msg.format(self.origin)
             raise RuntimeError(msg)
 

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -1058,7 +1058,7 @@ class PhasePlot(ImagePlotContainer):
                     positive_values = data[data > 0.0]
                     if len(positive_values) == 0:
                         mylog.warning(
-                            "Profiled field %s has no positive " "values.  Max = %f.",
+                            "Profiled field %s has no positive values. Max = %f.",
                             f,
                             np.nanmax(data),
                         )

--- a/yt/visualization/tests/test_image_writer.py
+++ b/yt/visualization/tests/test_image_writer.py
@@ -65,9 +65,7 @@ class TestImageWriter(unittest.TestCase):
 
         with assert_raises(RuntimeError) as ex:
             write_bitmap(np.ones([16, 16]), None)
-        desired = (
-            "Expecting image array of shape (N,M,3) " "or (N,M,4), received (16, 16)"
-        )
+        desired = "Expecting image array of shape (N,M,3) or (N,M,4), received (16, 16)"
         assert_equal(str(ex.exception)[:50], desired[:50])
 
     def test_strip_colormap_data(self):

--- a/yt/visualization/volume_rendering/render_source.py
+++ b/yt/visualization/volume_rendering/render_source.py
@@ -688,7 +688,7 @@ class MeshSource(OpaqueSource):
         assert self.data_source is not None
         if self.field[0] == "all":
             raise NotImplementedError(
-                "Mesh unions are not implemented " "for 3D rendering"
+                "Mesh unions are not implemented for 3D rendering"
             )
 
         if self.engine == "embree":
@@ -698,7 +698,7 @@ class MeshSource(OpaqueSource):
             self.build_volume_bvh()
         else:
             raise NotImplementedError(
-                "Invalid ray-tracing engine selected. " "Choices are 'embree' and 'yt'."
+                "Invalid ray-tracing engine selected. Choices are 'embree' and 'yt'."
             )
 
     def cmap():


### PR DESCRIPTION
This removes all occurrences of `x = "foo"  "bar"` by `x = "foobar"` and applies other cosmetic changes. In particular, some of our messages are missing a space at the joint between string parts, e.g.
```
x = "Houston, we have" "a problem"  # == "Houston, we havea problem"
# should be
x = "Houston, we have a problem"
```
These aren't "bugs" _per se_ as they shouldn't prevent yt from functioning properly on the machine side, but should be corrected nonetheless.