### PR TITLE
ci: deactivate pre-commit-ci autofixing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,9 @@ yt/extern\
 |yt/visualization/_colormap_data.py\
 )"
 
+ci:
+    autofix_prs: false
+
 repos:
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -726,8 +726,9 @@ It is recommended (though not required) that you install ``pre-commit`` on your 
 
 So that our hooks will run and update your changes on every commit.
 If you do not want to/are unable to configure ``pre-commit`` on your machine, note that
-after opening a pull request, a bot will run the hooks and validate your contribution by
-appending commits to your branch.
+after opening a pull request, it will still be run as a static checker as part of our CI.
+Some hooks also come with auto-fixing capabilities, which you can trigger manually in a
+PR by commenting ``pre-commit.ci run`` (see ` <https://pre-commit.ci/#features>`_).
 
 Here's a list of the main automated formatters we use along with a short description
 
@@ -738,9 +739,21 @@ Here's a list of the main automated formatters we use along with a short descrip
 
 The complete configuration is located in ``.pre-commit-config.yaml``.
 
-.. note:: It is not recommended to run formatters directly on the command line because
-    versions available in your system may conflict with the ones we run through
-    ``pre-commit`` hooks (which are updated periodically).
+Note that formatters should not be run directly on the command line as, for instance
+
+.. code-block:: bash
+
+    $ black yt
+
+But it can still be done as
+
+.. code-block:: bash
+
+    $ pre-commit run black --all-files
+
+The reason is that you may have a specific version of ``black`` installed which can
+produce different results, while the one that's installed with pre-commit is guaranteed
+to be in sync with the rest of contributors.
 
 Below are a list of additional guidelines for coding in yt, that are not automatically
 enforced.


### PR DESCRIPTION
## PR Summary

Anthony Sottile just implemented a switch to deactivate the auto-fixing feature from pre-commit-ci:
https://groups.google.com/u/0/g/pre-commit-ci/c/OdKCckDrv0A?pli=1
https://pre-commit.ci/#configuration

Given that it's the one feature that was deemed hurtful by the steering council (https://mail.python.org/archives/list/yt-dev@python.org/thread/EOEK3SOQJXOZY463UX6KPD5GAIWO7YWU/), I propose we take the opportunity to switch it off, and I hope we can continue using the rest of the service (static checking for PRs and auto-updates for .pre-commit-config.yaml).


hopefully fix #3122 

## TODO:

- [x] deactivate auto-fixing
- [x] edit documentation