### PR TITLE
Allow `brew` to update to fix hdf5 installation issues

### DIFF
--- a/tests/ci_install.sh
+++ b/tests/ci_install.sh
@@ -15,6 +15,7 @@ linux|Linux)
 osx|macOS)
     sudo mkdir -p /usr/local/man
     sudo chown -R "${USER}:admin" /usr/local/man
+    brew update
     HOMEBREW_NO_AUTO_UPDATE=1 brew install hdf5 proj geos open-mpi netcdf ccache
     ;;
 esac


### PR DESCRIPTION
## PR Summary

Tries to make the OSx test run again by allowing brew to update itself.

The origin of the bug is due to:
1. hdf5 requires a library called szip
2. szip depends on a compiled binary that was hosted on bintray
3. which depends on jfrog.com, who announced recently they were dropping support for bintray (https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/).

This has been fixed quite a while ago (see the file history of https://github.com/Homebrew/homebrew-core/blob/master/Formula/szip.rb), but we still need to have brew update its recipe cache for it to take into account.

