### PR TITLE
Fix `print_stats` function for RAMSES datasets.

### DIFF
--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -566,7 +566,7 @@ class RAMSESIndex(OctreeIndex):
 
     def _initialize_level_stats(self):
         levels = sum([dom.level_count for dom in self.domains])
-        desc = {"names": ["numcells", "level"], "formats": ["Int64"] * 2}
+        desc = {"names": ["numcells", "level"], "formats": ["int64"] * 2}
         max_level = self.dataset.min_level + self.dataset.max_level + 2
         self.level_stats = blankRecordArray(desc, max_level)
         self.level_stats["level"] = [i for i in range(max_level)]

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -577,8 +577,8 @@ class RAMSESIndex(OctreeIndex):
             )
         for level in range(self.max_level + 1):
             self.level_stats[level + self.dataset.min_level + 1]["numcells"] = levels[
-                level
-            ]
+                :, level
+            ].sum()
 
     def _get_particle_type_counts(self):
         npart = 0

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -666,3 +666,5 @@ def test_print_stats():
 
     # Should work
     ds.print_stats()
+
+    # FIXME #3197: use `capsys` with pytest to make sure the print_stats function works as intended

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -638,7 +638,7 @@ def test_max_level():
         assert any(ds.r["index", "grid_level"] == 2)
 
 
-@requires_file(ramses_new_format)
+@requires_file(output_00080)
 def test_invalid_max_level():
     invalid_value_args = (
         (1, None),
@@ -658,3 +658,11 @@ def test_invalid_max_level():
     for lvl, convention in invalid_type_args:
         with assert_raises(TypeError):
             yt.load(output_00080, max_level=lvl, max_level_convention=convention)
+
+
+@requires_file(ramses_new_format)
+def test_print_stats():
+    ds = yt.load(ramses_new_format)
+
+    # Should work
+    ds.print_stats()


### PR DESCRIPTION
## PR Summary

The `print_stats` function is broken for RAMSES datasets.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
