### PR TITLE
fix: correct more-itertools package name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ if __name__ == "__main__":
             "numpy>=1.10.4",
             "IPython>=1.0",
             "unyt>=2.7.2",
-            "more_itertools>=8.4",
+            "more-itertools>=8.4",
             "tqdm>=3.4.0",
             "toml>=0.10.2",
         ],

--- a/tests/test_minimal_requirements.txt
+++ b/tests/test_minimal_requirements.txt
@@ -7,6 +7,6 @@ pyyaml>=4.2b1
 coverage~=4.5.1
 codecov~=2.0.15
 unyt~=2.8.0
-more_itertools==8.4
+more-itertools==8.4
 pytest~=6.1
 nose-exclude

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -29,7 +29,7 @@ MiniballCpp>=0.2.1
 pooch>=0.7.0
 pykdtree~=1.3.1
 nose-exclude
-more_itertools>=8.4
+more-itertools>=8.4
 tqdm>=3.4.0
 toml>=0.10.2
 pytest-xdist~=2.1.0


### PR DESCRIPTION
I don't know if they renamed the package, but there's no such thing as `more_itertools` package, only `more-itertools`. I'm surprised only py38_latest was failing due to this...
