### PR TITLE
Upading cut_region docs and use tuples everywhere - fixes #3201

### DIFF
--- a/doc/source/analyzing/filtering.rst
+++ b/doc/source/analyzing/filtering.rst
@@ -54,11 +54,11 @@ set a simple mask based on the contents of one of our fields.
     import yt
     ds = yt.load('Enzo_64/DD0042/data0042')
     ad = ds.all_data()
-    hot = ad["temperature"].in_units('K') > 1e6
-    print('Temperature of all data: ad["temperature"] = \n%s' % ad["temperature"])
+    hot = ad[("gas", "temperature")].in_units('K') > 1e6
+    print('Temperature of all data: ad[("gas", "temperature")] = \n%s' % ad[("gas", "temperature")])
     print("Boolean Mask: hot = \n%s" % hot)
-    print('Temperature of "hot" data: ad["temperature"][hot] = \n%s' %
-          ad['temperature'][hot])
+    print('Temperature of "hot" data: ad[("gas", "temperature")][hot] = \n%s' %
+          ad[("gas", "temperature")][hot])
 
 This was a simple example, but one can make the conditionals that define
 a boolean mask have multiple parts, and one can stack masks together to
@@ -71,9 +71,9 @@ used if you simply need to access the NumPy arrays:
     ds = yt.load('Enzo_64/DD0042/data0042')
     ad = ds.all_data()
     overpressure_and_fast = (ad["pressure"] > 1e-14) & (ad["velocity_magnitude"].in_units('km/s') > 1e2)
-    print('Density of all data: ad["density"] = \n%s' % ad['density'])
-    print('Density of "overpressure and fast" data: overpressure_and_fast['density'] = \n%s' %
-          overpressure_and_fast['density'])
+    print('Density of all data: ad[("gas", "density")] = \n%s' % ad[("gas", "density")])
+    print('Density of "overpressure and fast" data: overpressure_and_fast[("gas", "density")] = \n%s' %
+          overpressure_and_fast[("gas", "density")])
 
 .. _cut-regions:
 
@@ -96,13 +96,13 @@ filtering out unwanted regions. Such wrapper functions are methods of
    import yt
    ds = yt.load('Enzo_64/DD0042/data0042')
    ad = ds.all_data()
-   overpressure_and_fast = ad.include_above('pressure', 1e-14)
+   overpressure_and_fast = ad.include_above(("gas", "pressure"), 1e-14)
    # You can chain include_xx and exclude_xx to produce the intersection of cut regions
-   overpressure_and_fast = overpressure_and_fast.include_above('velocity_magnitude', 1e2, 'km/s')
+   overpressure_and_fast = overpressure_and_fast.include_above(("gas", "velocity_magnitude"), 1e2, 'km/s')
 
-   print('Density of all data: ad["density"] = \n%s' % ad['density'])
-   print('Density of "overpressure and fast" data: overpressure_and_fast["density"] = \n%s' %
-          overpressure_and_fast['density'])
+   print('Density of all data: ad[("gas", "density")] = \n%s' % ad[("gas", density")])
+   print('Density of "overpressure and fast" data: overpressure_and_fast[("gas", "density")] = \n%s' %
+          overpressure_and_fast[("gas", "density")])
 
 The following exclude and include functions are supported:
    - :func:`~yt.data_objects.data_containers.YTSelectionContainer3D.include_equal` - Only include values equal to given value

--- a/yt/data_objects/selection_objects/cut_region.py
+++ b/yt/data_objects/selection_objects/cut_region.py
@@ -27,7 +27,7 @@ class YTCutRegion(YTSelectionContainer3D):
         A list of conditionals that will be evaluated.  In the namespace
         available, these conditionals will have access to 'obj' which is a data
         object of unknown shape, and they must generate a boolean array.  For
-        instance, conditionals = ["obj['gas', 'temperature'] < 1e3"]
+        instance, conditionals = ["obj[('gas', 'temperature')] < 1e3"]
 
     Examples
     --------
@@ -35,7 +35,7 @@ class YTCutRegion(YTSelectionContainer3D):
     >>> import yt
     >>> ds = yt.load("RedshiftOutput0005")
     >>> sp = ds.sphere("max", (1.0, 'Mpc'))
-    >>> cr = ds.cut_region(sp, ["obj['gas', 'temperature'] < 1e3"])
+    >>> cr = ds.cut_region(sp, ["obj[('gas', 'temperature')] < 1e3"])
     """
 
     _type_name = "cut_region"

--- a/yt/data_objects/selection_objects/data_selection_objects.py
+++ b/yt/data_objects/selection_objects/data_selection_objects.py
@@ -668,7 +668,7 @@ class YTSelectionContainer3D(YTSelectionContainer):
            A list of conditionals that will be evaluated. In the namespace
            available, these conditionals will have access to 'obj' which is a
            data object of unknown shape, and they must generate a boolean array.
-           For instance, conditionals = ["obj['gas', 'temperature'] < 1e3"]
+           For instance, conditionals = ["obj[('gas', 'temperature')] < 1e3"]
         field_parameters : dictionary
            A dictionary of field parameters to be used when applying the field
            cuts.
@@ -682,7 +682,7 @@ class YTSelectionContainer3D(YTSelectionContainer):
 
         >>> ds = yt.load("RedshiftOutput0005")
         >>> ad = ds.all_data()
-        >>> cr = ad.cut_region(["obj['gas', 'temperature'] > 1e6"])
+        >>> cr = ad.cut_region(["obj[('gas', 'temperature')] > 1e6"])
         >>> print(cr.quantities.total_quantity(("gas", "cell_mass")).in_units('Msun'))
         """
         if locals is None:
@@ -703,7 +703,7 @@ class YTSelectionContainer3D(YTSelectionContainer):
         -------
         >>> ds._build_operator_cut(">", ("gas", "density"), 1e-24)
         ... # is equivalent to
-        ... ds.cut_region(['obj["gas", "density"] > 1e-24'])
+        ... ds.cut_region(['obj[("gas", "density")] > 1e-24'])
         """
         ftype, fname = self._determine_fields(field)[0]
         if units is None:
@@ -725,7 +725,7 @@ class YTSelectionContainer3D(YTSelectionContainer):
         -------
         >>> ds._build_function_cut("np.isnan", ("gas", "density"), locals={"np": np})
         ... # is equivalent to
-        ... ds.cut_region(['np.isnan(obj["gas", "density"])'], locals={"np": np})
+        ... ds.cut_region(['np.isnan(obj[("gas", "density")])'], locals={"np": np})
         """
         ftype, fname = self._determine_fields(field)[0]
         if units is None:

--- a/yt/data_objects/tests/test_clone.py
+++ b/yt/data_objects/tests/test_clone.py
@@ -28,7 +28,7 @@ def test_clone_cut_region():
     ds = fake_random_ds(64, nprocs=4, fields=fields, units=units)
     dd = ds.all_data()
     reg1 = dd.cut_region(
-        ["obj['gas', 'temperature'] > 0.5", "obj['gas', 'density'] < 0.75"]
+        ["obj[('gas', 'temperature')] > 0.5", "obj[('gas', 'density')] < 0.75"]
     )
     reg2 = reg1.clone()
     assert_array_equal(reg1[("gas", "density")], reg2[("gas", "density")])

--- a/yt/data_objects/tests/test_covering_grid.py
+++ b/yt/data_objects/tests/test_covering_grid.py
@@ -86,7 +86,7 @@ def test_covering_grid():
     for fn in [cyl_2d, cyl_3d]:
         ds = load(fn)
         ad = ds.all_data()
-        upper_ad = ad.cut_region(["obj['index', 'z'] > 0"])
+        upper_ad = ad.cut_region(["obj[('index', 'z')] > 0"])
         sp = ds.sphere((0, 0, 0), 0.5 * ds.domain_width[0], data_source=upper_ad)
         sp.quantities.total_mass()
 
@@ -177,7 +177,7 @@ def test_arbitrary_grid():
                 volume = ds.quan(np.product(dds), "cm**3")
 
                 obj = ds.arbitrary_grid(LE, RE, dims)
-                deposited_mass = obj["deposit", "all_density"].sum() * volume
+                deposited_mass = obj[("deposit", "all_density")].sum() * volume
 
                 assert_equal(deposited_mass, ds.quan(1.0, "g"))
 
@@ -186,7 +186,7 @@ def test_arbitrary_grid():
 
                 obj = ds.arbitrary_grid(LE, RE, dims)
 
-                deposited_mass = obj["deposit", "all_density"].sum()
+                deposited_mass = obj[("deposit", "all_density")].sum()
 
                 assert_equal(deposited_mass, 0)
 

--- a/yt/data_objects/tests/test_extract_regions.py
+++ b/yt/data_objects/tests/test_extract_regions.py
@@ -29,9 +29,9 @@ def test_cut_region():
         dd = ds.all_data()
         r = dd.cut_region(
             [
-                "obj['gas', 'temperature'] > 0.5",
-                "obj['gas', 'density'] < 0.75",
-                "obj['gas', 'velocity_x'] > 0.25",
+                "obj[('gas', 'temperature')] > 0.5",
+                "obj[('gas', 'density')] < 0.75",
+                "obj[('gas', 'velocity_x')] > 0.25",
             ]
         )
         t = (
@@ -44,7 +44,7 @@ def test_cut_region():
         assert_equal(np.all(r[("gas", "velocity_x")] > 0.25), True)
         assert_equal(np.sort(dd[("gas", "density")][t]), np.sort(r[("gas", "density")]))
         assert_equal(np.sort(dd[("index", "x")][t]), np.sort(r[("index", "x")]))
-        r2 = r.cut_region(["obj['gas', 'temperature'] < 0.75"])
+        r2 = r.cut_region(["obj[('gas', 'temperature')] < 0.75"])
         t2 = r[("gas", "temperature")] < 0.75
         assert_equal(
             np.sort(r2[("gas", "temperature")]), np.sort(r[("gas", "temperature")][t2])
@@ -53,13 +53,13 @@ def test_cut_region():
 
         # Now we can test some projections
         dd = ds.all_data()
-        cr = dd.cut_region(["obj['index', 'ones'] > 0"])
+        cr = dd.cut_region(["obj[('index', 'ones')] > 0"])
         for weight in [None, ("gas", "density")]:
             p1 = ds.proj(("gas", "density"), 0, data_source=dd, weight_field=weight)
             p2 = ds.proj(("gas", "density"), 0, data_source=cr, weight_field=weight)
             for f in p1.field_data:
                 assert_almost_equal(p1[f], p2[f])
-        cr = dd.cut_region(["obj['gas', 'density'] > 0.25"])
+        cr = dd.cut_region(["obj[('gas', 'density')] > 0.25"])
         p2 = ds.proj(("gas", "density"), 2, data_source=cr)
         assert_equal(p2[("gas", "density")].max() > 0.25, True)
         p2 = ds.proj(
@@ -72,7 +72,7 @@ def test_region_and_particles():
     ds = fake_amr_ds(particles=10000)
 
     ad = ds.all_data()
-    reg = ad.cut_region('obj["index", "x"] < .5')
+    reg = ad.cut_region('[("index", "x")] < .5')
 
     mask = ad[("all", "particle_position_x")] < 0.5
     expected = np.sort(ad[("all", "particle_position_x")][mask].value)
@@ -91,7 +91,7 @@ def test_region_chunked_read():
     ds = load("IsolatedGalaxy/galaxy0030/galaxy0030")
 
     sp = ds.sphere((0.5, 0.5, 0.5), (2, "kpc"))
-    dense_sp = sp.cut_region(['obj["gas", "H_p0_number_density"]>= 1e-2'])
+    dense_sp = sp.cut_region(['obj[("gas", "H_p0_number_density")]>= 1e-2'])
     dense_sp.quantities.angular_momentum_vector()
 
 
@@ -100,8 +100,8 @@ def test_chained_cut_region():
     # see Issue #2233
     ds = load(ISOGAL)
     base = ds.disk([0.5, 0.5, 0.5], [0, 0, 1], (4, "kpc"), (10, "kpc"))
-    c1 = "(obj['index', 'cylindrical_r'].in_units('kpc') > 2.0)"
-    c2 = "(obj['gas', 'density'].to('g/cm**3') > 1e-26)"
+    c1 = "(obj[('index', 'cylindrical_r')].in_units('kpc') > 2.0)"
+    c2 = "(obj[('gas', 'density')].to('g/cm**3') > 1e-26)"
 
     cr12 = base.cut_region([c1, c2])
     cr1 = base.cut_region([c1])

--- a/yt/data_objects/tests/test_extract_regions.py
+++ b/yt/data_objects/tests/test_extract_regions.py
@@ -72,7 +72,7 @@ def test_region_and_particles():
     ds = fake_amr_ds(particles=10000)
 
     ad = ds.all_data()
-    reg = ad.cut_region('[("index", "x")] < .5')
+    reg = ad.cut_region('obj[("index", "x")] < .5')
 
     mask = ad[("all", "particle_position_x")] < 0.5
     expected = np.sort(ad[("all", "particle_position_x")][mask].value)

--- a/yt/frontends/adaptahop/data_structures.py
+++ b/yt/frontends/adaptahop/data_structures.py
@@ -303,7 +303,7 @@ class AdaptaHOPHaloContainer(YTSelectionContainer):
 
         # Build subregion that only contains halo particles
         reg = sph.cut_region(
-            ['np.in1d(obj["io", "particle_identity"].astype(int), members)'],
+            ['np.in1d(obj[("io", "particle_identity")].astype(int), members)'],
             locals=dict(members=members, np=np),
         )
 

--- a/yt/geometry/oct_geometry_handler.py
+++ b/yt/geometry/oct_geometry_handler.py
@@ -55,7 +55,7 @@ class OctreeIndex(Index):
                 if Nremaining == 0:
                     break
                 icell = (
-                    obj["index", "ones"].T.reshape(-1).astype(np.int64).cumsum().value
+                    obj[("index", "ones")].T.reshape(-1).astype(np.int64).cumsum().value
                     - 1
                 )
                 mesh_data = ((icell << Nbits) + i).astype(np.float64)

--- a/yt/visualization/tests/test_offaxisprojection.py
+++ b/yt/visualization/tests/test_offaxisprojection.py
@@ -85,7 +85,7 @@ class TestOffAxisProjection(unittest.TestCase):
 
 def test_field_cut_off_axis_octree():
     ds = fake_octree_ds()
-    cut = ds.all_data().cut_region('obj["gas", "density"]>0.5')
+    cut = ds.all_data().cut_region('obj[("gas", "density")]>0.5')
     p1 = OffAxisProjectionPlot(ds, [1, 0, 0], ("gas", "density"))
     p2 = OffAxisProjectionPlot(ds, [1, 0, 0], ("gas", "density"), data_source=cut)
     assert_equal(p2.frb[("gas", "density")].min() == 0.0, True)  # Lots of zeros


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

Updates a bunch of tuple access to always use the `data[("foo", "bar")]` syntax and update the cut_region doc to use tuples throughout.

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
