### PR TITLE
DOC: Misc numpydoc syntax fixing.

### DIFF
--- a/yt/_maintenance/deprecation.py
+++ b/yt/_maintenance/deprecation.py
@@ -18,7 +18,7 @@ def issue_deprecation_warning(msg, *, removal, since=None, stacklevel=3):
     """
     Parameters
     ----------
-    msg: str
+    msg : str
         A text message explaining that the code surrounding the call to this function is
         deprecated, and what should be changed on the user side to avoid it.
 

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -2112,10 +2112,6 @@ class YTSurface(YTSelectionContainer3D):
 
         Parameters
         ----------
-        filename : string
-            The file this will be exported to.  This cannot be a file-like object.
-            Note - there are no file extentions included - both obj & mtl files
-            are created.
         transparency : float
             This gives the transparency of the output surface plot.  Values
             from 0.0 (invisible) to 1.0 (opaque).

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -743,16 +743,13 @@ class YTDataContainer:
         velocity_units : string
             The units that the velocity should be converted to in order to
             show streamlines in Firefly. Defaults to km/s.
-
-        coordinate_units: string
+        coordinate_units : string
             The units that the coordinates should be converted to. Defaults to
             kpc.
-
-        show_unused_fields: boolean
+        show_unused_fields : boolean
             A flag to optionally print the fields that are available, in the
             dataset but were not explicitly requested to be tracked.
-
-        dataset_name: string
+        dataset_name : string
             The name of the subdirectory the JSON files will be stored in
             (and the name that will appear in startup.json and in the dropdown
             menu at startup). e.g. `yt` -> json files will appear in
@@ -1273,7 +1270,7 @@ class YTDataContainer:
         ----------
         field : string or tuple field name
             The field to project.
-        weight: string or tuple field name
+        weight : string or tuple field name
             The field to weight the projection by
         axis : string
             The axis to project along.

--- a/yt/data_objects/image_array.py
+++ b/yt/data_objects/image_array.py
@@ -94,10 +94,9 @@ class ImageArray(YTArray):
 
         Parameters
         ----------
-        filename: string
+        filename : string
         The filename to create and write a dataset to
-
-        dataset_name: string
+        dataset_name : string
             The name of the dataset to create in the file.
 
         Examples
@@ -144,7 +143,8 @@ class ImageArray(YTArray):
                * 4-element array [r,g,b,a]: arbitrary rgba setting.
 
             Default: 'black'
-        inline: boolean, optional
+
+        inline : boolean, optional
             If True, original ImageArray is modified. If False, a copy is first
             created, then modified. Default: True
 
@@ -193,13 +193,13 @@ class ImageArray(YTArray):
 
         Parameters
         ----------
-        cmax: float, optional
+        cmax : float, optional
             Normalization value to use for rgb channels. Defaults to None,
             corresponding to using the maximum value in the rgb channels.
-        amax: float, optional
+        amax : float, optional
             Normalization value to use for alpha channel. Defaults to None,
             corresponding to using the maximum value in the alpha channel.
-        inline: boolean, optional
+        inline : boolean, optional
             Specifies whether or not the rescaling is done inline. If false,
             a new copy of the ImageArray will be created, returned.
             Default:True.
@@ -261,10 +261,11 @@ class ImageArray(YTArray):
 
         Parameters
         ----------
-        filename: string
+        filename : string
             Filename to save to.  If None, PNG contents will be returned as a
             string.
-        sigma_clip: float, optional
+
+        sigma_clip : float, optional
             Image will be clipped before saving to the standard deviation
             of the image multiplied by this value.  Useful for enhancing
             images. Default: None
@@ -278,7 +279,8 @@ class ImageArray(YTArray):
                * 4-element array [r,g,b,a]: arbitrary rgba setting.
 
             Default: 'black'
-        rescale: boolean, optional
+
+        rescale : boolean, optional
             If True, will write out a rescaled image (without modifying the
             original image). Default: True
 
@@ -337,7 +339,7 @@ class ImageArray(YTArray):
 
         Parameters
         ----------
-        filename: string
+        filename : string
             Note filename not be modified.
 
         Other Parameters

--- a/yt/data_objects/particle_filters.py
+++ b/yt/data_objects/particle_filters.py
@@ -97,9 +97,8 @@ def add_particle_filter(name, function, requires=None, filtered_type="all"):
     filtered_type : string
         The name of the particle type to be filtered.
 
-    Example
-    -------
-
+    Examples
+    --------
     >>> import yt
 
     >>> def _stars(pfilter, data):
@@ -144,18 +143,13 @@ def particle_filter(name=None, requires=None, filtered_type="all"):
         set by this name will be added to any dataset that enables this particle
         filter.  If not set, the name will be inferred from the name of the
         filter function.
-    function : reference to a function
-        The function that defines the particle filter.  The function should
-        accept two arguments: a reference to a particle filter object and a
-        reference to an abstract yt data object.  See the example below.
     requires : a list of field names
         A list of field names required by the particle filter definition.
     filtered_type : string
         The name of the particle type to be filtered.
 
-    Example
-    -------
-
+    Examples
+    --------
     >>> import yt
 
     >>> # define a filter named "stars"

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -516,10 +516,10 @@ class Profile1D(ProfileND):
     def set_x_unit(self, new_unit):
         """Sets a new unit for the x field
 
-        parameters
+        Parameters
         ----------
         new_unit : string or Unit object
-           The name of the new unit.
+            The name of the new unit.
         """
         self.x_bins.convert_to_units(new_unit)
         self.x = 0.5 * (self.x_bins[1:] + self.x_bins[:-1])
@@ -769,10 +769,10 @@ class Profile2D(ProfileND):
     def set_x_unit(self, new_unit):
         """Sets a new unit for the x field
 
-        parameters
+        Parameters
         ----------
         new_unit : string or Unit object
-           The name of the new unit.
+            The name of the new unit.
         """
         self.x_bins.convert_to_units(new_unit)
         self.x = 0.5 * (self.x_bins[1:] + self.x_bins[:-1])
@@ -780,10 +780,10 @@ class Profile2D(ProfileND):
     def set_y_unit(self, new_unit):
         """Sets a new unit for the y field
 
-        parameters
+        Parameters
         ----------
         new_unit : string or Unit object
-           The name of the new unit.
+            The name of the new unit.
         """
         self.y_bins.convert_to_units(new_unit)
         self.y = 0.5 * (self.y_bins[1:] + self.y_bins[:-1])
@@ -1117,10 +1117,10 @@ class Profile3D(ProfileND):
     def set_x_unit(self, new_unit):
         """Sets a new unit for the x field
 
-        parameters
+        Parameters
         ----------
         new_unit : string or Unit object
-           The name of the new unit.
+            The name of the new unit.
         """
         self.x_bins.convert_to_units(new_unit)
         self.x = 0.5 * (self.x_bins[1:] + self.x_bins[:-1])
@@ -1128,10 +1128,10 @@ class Profile3D(ProfileND):
     def set_y_unit(self, new_unit):
         """Sets a new unit for the y field
 
-        parameters
+        Parameters
         ----------
         new_unit : string or Unit object
-           The name of the new unit.
+            The name of the new unit.
         """
         self.y_bins.convert_to_units(new_unit)
         self.y = 0.5 * (self.y_bins[1:] + self.y_bins[:-1])
@@ -1139,10 +1139,10 @@ class Profile3D(ProfileND):
     def set_z_unit(self, new_unit):
         """Sets a new unit for the z field
 
-        parameters
+        Parameters
         ----------
         new_unit : string or Unit object
-           The name of the new unit.
+            The name of the new unit.
         """
         self.z_bins.convert_to_units(new_unit)
         self.z = 0.5 * (self.z_bins[1:] + self.z_bins[:-1])

--- a/yt/data_objects/selection_objects/data_selection_objects.py
+++ b/yt/data_objects/selection_objects/data_selection_objects.py
@@ -699,8 +699,8 @@ class YTSelectionContainer3D(YTSelectionContainer):
 
         This is only meant to be used internally.
 
-        Example
-        -------
+        Examples
+        --------
         >>> ds._build_operator_cut(">", ("gas", "density"), 1e-24)
         ... # is equivalent to
         ... ds.cut_region(['obj["gas", "density"] > 1e-24'])
@@ -721,8 +721,8 @@ class YTSelectionContainer3D(YTSelectionContainer):
 
         This is only meant to be used internally.
 
-        Example
-        -------
+        Examples
+        --------
         >>> ds._build_function_cut("np.isnan", ("gas", "density"), locals={"np": np})
         ... # is equivalent to
         ... ds.cut_region(['np.isnan(obj["gas", "density"])'], locals={"np": np})
@@ -755,9 +755,8 @@ class YTSelectionContainer3D(YTSelectionContainer):
         cut_region : YTCutRegion
             The YTCutRegion with the field above the given value masked.
 
-        Example
-        -------
-
+        Examples
+        --------
         To find the total mass of hot gas with temperature colder than 10^6 K
         in your volume:
 
@@ -790,14 +789,11 @@ class YTSelectionContainer3D(YTSelectionContainer):
         cut_region : YTCutRegion
             The YTCutRegion with the field above the given value masked.
 
-        Example
-        -------
-
+        Examples
+        --------
         To find the total mass of hot gas with temperature warmer than 10^6 K
         in your volume:
 
-        Example
-        -------
         >>> ds = yt.load("RedshiftOutput0005")
         >>> ad = ds.all_data()
         >>> cr = ad.include_above(('gas', 'temperature'), 1e6)
@@ -827,9 +823,8 @@ class YTSelectionContainer3D(YTSelectionContainer):
         cut_region : YTCutRegion
             The YTCutRegion with the field equal to the given value masked.
 
-        Example
-        -------
-
+        Examples
+        --------
         >>> ds = yt.load("RedshiftOutput0005")
         >>> ad = ds.all_data()
         >>> cr = ad.exclude_equal(('gas', 'temperature'), 1e6)
@@ -858,8 +853,8 @@ class YTSelectionContainer3D(YTSelectionContainer):
         cut_region : YTCutRegion
             The YTCutRegion with the field equal to the given value included.
 
-        Example
-        -------
+        Examples
+        --------
         >>> ds = yt.load("RedshiftOutput0005")
         >>> ad = ds.all_data()
         >>> cr = ad.include_equal(('gas', 'temperature'), 1e6)
@@ -889,8 +884,8 @@ class YTSelectionContainer3D(YTSelectionContainer):
         cut_region : YTCutRegion
             The YTCutRegion with the field inside the given interval excluded.
 
-        Example
-        -------
+        Examples
+        --------
         >>> ds = yt.load("RedshiftOutput0005")
         >>> ad = ds.all_data()
         >>> cr = ad.exclude_inside(('gas', 'temperature'), 1e5, 1e6)
@@ -933,8 +928,8 @@ class YTSelectionContainer3D(YTSelectionContainer):
         cut_region : YTCutRegion
             The YTCutRegion with the field inside the given interval excluded.
 
-        Example
-        -------
+        Examples
+        --------
         >>> ds = yt.load("RedshiftOutput0005")
         >>> ad = ds.all_data()
         >>> cr = ad.include_inside(('gas', 'temperature'), 1e5, 1e6)
@@ -976,8 +971,8 @@ class YTSelectionContainer3D(YTSelectionContainer):
         cut_region : YTCutRegion
             The YTCutRegion with the field outside the given interval excluded.
 
-        Example
-        -------
+        Examples
+        --------
         >>> ds = yt.load("RedshiftOutput0005")
         >>> ad = ds.all_data()
         >>> cr = ad.exclude_outside(('gas', 'temperature'), 1e5, 1e6)
@@ -1010,8 +1005,8 @@ class YTSelectionContainer3D(YTSelectionContainer):
         cut_region : YTCutRegion
             The YTCutRegion with the field outside the given interval excluded.
 
-        Example
-        -------
+        Examples
+        --------
         >>> ds = yt.load("RedshiftOutput0005")
         >>> ad = ds.all_data()
         >>> cr = ad.exclude_outside(('gas', 'temperature'), 1e5, 1e6)
@@ -1041,8 +1036,8 @@ class YTSelectionContainer3D(YTSelectionContainer):
         cut_region : YTCutRegion
             The YTCutRegion with the field below the given value masked.
 
-        Example
-        -------
+        Examples
+        --------
         >>> ds = yt.load("RedshiftOutput0005")
         >>> ad = ds.all_data()
         >>> cr = ad.exclude_below(('gas', 'temperature'), 1e6)
@@ -1059,9 +1054,6 @@ class YTSelectionContainer3D(YTSelectionContainer):
         ----------
         field : string
             The field in which the conditional will be applied.
-        value : float
-            The minimum value that will not be masked in the output
-            YTCutRegion.
         units : string or None
             The units of the value threshold. None will use the default units
             given in the field.
@@ -1071,8 +1063,8 @@ class YTSelectionContainer3D(YTSelectionContainer):
         cut_region : YTCutRegion
             The YTCutRegion with the NaN entries of the field masked.
 
-        Example
-        -------
+        Examples
+        --------
         >>> ds = yt.load("RedshiftOutput0005")
         >>> ad = ds.all_data()
         >>> cr = ad.exclude_nan(('gas', 'temperature'))
@@ -1102,8 +1094,8 @@ class YTSelectionContainer3D(YTSelectionContainer):
             The YTCutRegion with only regions with the field below the given
             value included.
 
-        Example
-        -------
+        Examples
+        --------
         >>> ds = yt.load("RedshiftOutput0005")
         >>> ad = ds.all_data()
         >>> cr = ad.include_below(('gas', 'temperature'), 1e5, 1e6)

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -899,14 +899,11 @@ class Dataset(abc.ABC):
 
         Parameters
         ----------
-        field: str or tuple(str, str)
-
-        ext: str
+        field : str or tuple(str, str)
+        ext : str
             'min' or 'max', select an extremum
-
-        source: a Yt data object
-
-        to_array: bool
+        source : a Yt data object
+        to_array : bool
             select the return type.
 
         Returns

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -465,8 +465,8 @@ class DatasetSeries:
         >>> for t in trajs :
         >>>     print(t[("all", "particle_velocity_x")].max(), t[("all", "particle_velocity_x")].min())
 
-        Note
-        ----
+        Notes
+        -----
         This function will fail if there are duplicate particle ids or if some of the
         particle disappear.
         """
@@ -623,10 +623,10 @@ class SimulationTimeSeries(DatasetSeries):
 
         Parameters
         ----------
-        key: str
+        key : str
             The key by which to retrieve outputs, usually 'time' or
             'redshift'.
-        values: array_like
+        values : array_like
             A list of values, given as floats.
         tolerance : float
             If not None, do not return a dataset unless the value is

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -273,9 +273,9 @@ class FieldInfoContainer(dict):
 
         Parameters
         ----------
-        sampling_type: str
+        sampling_type : str
             One of "cell", "particle" or "local" (case insensitive)
-        particle_type: str
+        particle_type : str
             This is a deprecated argument of the add_field method,
             which was replaced by sampling_type.
 


### PR DESCRIPTION
This uses https://github.com/Carreau/velin to try to automatically fix a
couple of issues in docstrings to match the numpydoc syntax.

 - Space before colon in Parameter sections is necessary for numpydoc to
 properly recognize parameter name and type.
 - Naming of sections in numpydoc is plural usually

This also remove a couple of documented parameters that don't exists
(either removed, or copy-past is my guess).