### PR TITLE
Adding note in docs about cmocean cmap changes.

### DIFF
--- a/doc/source/yt4differences.rst
+++ b/doc/source/yt4differences.rst
@@ -55,19 +55,25 @@ names raise errors. The fix is to explicitly import the ``cmocean`` module and p
 (like ``balance``) with ``cmo.``.  Note that this solution works with any yt-supported version of Matplotlib, but is not backward compatible with earlier versions of yt. Example:
 
 Old Script (no longer works):
+
 .. code-block:: python
-import yt
-ds = yt.testing.fake_amr_ds()
-p = yt.SlicePlot(ds, "z", "Density")
-p.set_cmap("Density", "balance")
+
+    import yt
+
+    ds = yt.testing.fake_amr_ds()
+    p = yt.SlicePlot(ds, "z", ("gas", "Density"))
+    p.set_cmap(("gas", "Density"), "balance")
 
 New Script:
+
 .. code-block:: python
-import yt
-import cmocean
-ds = yt.testing.fake_amr_ds()
-p = yt.SlicePlot(ds, "z", "Density")
-p.set_cmap("Density", "cmo.balance")
+
+    import yt
+    import cmocean
+
+    ds = yt.testing.fake_amr_ds()
+    p = yt.SlicePlot(ds, "z", ("gas", "Density"))
+    p.set_cmap(("gas", "Density"), "cmo.balance")
 
 Cool New Things
 ---------------

--- a/doc/source/yt4differences.rst
+++ b/doc/source/yt4differences.rst
@@ -53,7 +53,7 @@ yt used to automatically register colormaps from ``cmocean``, unprefixed.
 This unfortunately became unsustainable with the 3.4 release of Matplotlib,
 in which colormaps with colliding names raise errors. The fix is to explicitly
 import the ``cmocean`` module and prefix ``cmocean`` colormaps (like
-``balance``) with ``cmo.``.  Note that this solution works with any 
+``balance``) with ``cmo.``.  Note that this solution works with any
 yt-supported version of Matplotlib, but is not backward compatible with earlier
 versions of yt. Example:
 

--- a/doc/source/yt4differences.rst
+++ b/doc/source/yt4differences.rst
@@ -47,6 +47,27 @@ are being removed entirely. When the deprecated field names are used for the
 first time in a session, a warning will be logged, so it is advisable to set
 your logging level to ``WARNING`` at a minimum to catch these.
 
+Colormaps
+^^^^^^^^^
+yt previously included ``cmocean`` colormaps.  Due to collisions between some
+of our dependencies, you now have to explicitly import the ``cmocean`` module
+and prefix ``cmocean`` colormaps (like ``balance``) with ``cmo.``.  Example:
+
+Old Script (no longer works):
+.. code-block:: python
+import yt
+ds = yt.testing.fake_amr_ds()
+p = yt.SlicePlot(ds, "z", "Density")
+p.set_cmap("Density", "balance")
+
+New Script:
+.. code-block:: python
+import yt
+import cmocean
+ds = yt.testing.fake_amr_ds()
+p = yt.SlicePlot(ds, "z", "Density")
+p.set_cmap("Density", "cmo.balance")
+
 Cool New Things
 ---------------
 

--- a/doc/source/yt4differences.rst
+++ b/doc/source/yt4differences.rst
@@ -49,9 +49,10 @@ your logging level to ``WARNING`` at a minimum to catch these.
 
 Colormaps
 ^^^^^^^^^
-yt previously included ``cmocean`` colormaps.  Due to collisions between some
-of our dependencies, you now have to explicitly import the ``cmocean`` module
-and prefix ``cmocean`` colormaps (like ``balance``) with ``cmo.``.  Example:
+yt used to automatically register colormaps from ``cmocean``, unprefixed.
+This unfortunately became unsustainable with the 3.4 release of Matplotlib, in which colormaps with colliding
+names raise errors. The fix is to explicitly import the ``cmocean`` module and prefix ``cmocean`` colormaps
+(like ``balance``) with ``cmo.``.  Note that this solution works with any yt-supported version of Matplotlib, but is not backward compatible with earlier versions of yt. Example:
 
 Old Script (no longer works):
 .. code-block:: python

--- a/doc/source/yt4differences.rst
+++ b/doc/source/yt4differences.rst
@@ -50,9 +50,12 @@ your logging level to ``WARNING`` at a minimum to catch these.
 Colormaps
 ^^^^^^^^^
 yt used to automatically register colormaps from ``cmocean``, unprefixed.
-This unfortunately became unsustainable with the 3.4 release of Matplotlib, in which colormaps with colliding
-names raise errors. The fix is to explicitly import the ``cmocean`` module and prefix ``cmocean`` colormaps
-(like ``balance``) with ``cmo.``.  Note that this solution works with any yt-supported version of Matplotlib, but is not backward compatible with earlier versions of yt. Example:
+This unfortunately became unsustainable with the 3.4 release of Matplotlib,
+in which colormaps with colliding names raise errors. The fix is to explicitly
+import the ``cmocean`` module and prefix ``cmocean`` colormaps (like
+``balance``) with ``cmo.``.  Note that this solution works with any 
+yt-supported version of Matplotlib, but is not backward compatible with earlier
+versions of yt. Example:
 
 Old Script (no longer works):
 

--- a/doc/source/yt4differences.rst
+++ b/doc/source/yt4differences.rst
@@ -57,7 +57,7 @@ import the ``cmocean`` module and prefix ``cmocean`` colormaps (like
 yt-supported version of Matplotlib, but is not backward compatible with earlier
 versions of yt. Example:
 
-Old Script (no longer works):
+Old Script (will not work in the near future):
 
 .. code-block:: python
 

--- a/doc/source/yt4differences.rst
+++ b/doc/source/yt4differences.rst
@@ -60,9 +60,9 @@ Old Script (no longer works):
 
     import yt
 
-    ds = yt.testing.fake_amr_ds()
-    p = yt.SlicePlot(ds, "z", ("gas", "Density"))
-    p.set_cmap(("gas", "Density"), "balance")
+    ds = yt.testing.fake_random_ds(1)
+    p = yt.SlicePlot(ds, "z", ("gas", "density"))
+    p.set_cmap(("gas", "density"), "balance")
 
 New Script:
 
@@ -71,9 +71,9 @@ New Script:
     import yt
     import cmocean
 
-    ds = yt.testing.fake_amr_ds()
-    p = yt.SlicePlot(ds, "z", ("gas", "Density"))
-    p.set_cmap(("gas", "Density"), "cmo.balance")
+    ds = yt.testing.fake_random_ds(1)
+    p = yt.SlicePlot(ds, "z", ("gas", "density"))
+    p.set_cmap(("gas", "density"), "cmo.balance")
 
 Cool New Things
 ---------------


### PR DESCRIPTION
PR #3175 made a backwards incompatible change to yt dev that breaks existing scripts (it broke mine right under my nose).  This sort of thing needs to be documented in our yt4 differences page to minimize problems for users making a transition to yt4.  I've tried to update the docs appropriately.

Update1: Including @neutrinoceros 's changes.  
Update2: Ensuring the codeblocks work.