### PR TITLE
docs: normalize python code blocks + formatting

### DIFF
--- a/doc/source/visualizing/callbacks.rst
+++ b/doc/source/visualizing/callbacks.rst
@@ -57,39 +57,42 @@ set to ``data``.  The valid coordinate systems are:
 Here we will demonstrate these different coordinate systems for an projection
 of the x-plane (i.e. with axes in the y and z directions):
 
-.. python-script::
+.. code-block:: python
 
     import yt
 
     ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-    s = yt.SlicePlot(ds, 'x', 'density')
-    s.set_axes_unit('kpc')
+    s = yt.SlicePlot(ds, "x", "density")
+    s.set_axes_unit("kpc")
 
     # Plot marker and text in data coords
-    s.annotate_marker((0.2, 0.5, 0.9), coord_system='data')
-    s.annotate_text((0.2, 0.5, 0.9), 'data: (0.2, 0.5, 0.9)', coord_system='data')
+    s.annotate_marker((0.2, 0.5, 0.9), coord_system="data")
+    s.annotate_text((0.2, 0.5, 0.9), "data: (0.2, 0.5, 0.9)", coord_system="data")
 
     # Plot marker and text in plot coords
-    s.annotate_marker((200, -300), coord_system='plot')
-    s.annotate_text((200, -300), 'plot: (200, -300)', coord_system='plot')
+    s.annotate_marker((200, -300), coord_system="plot")
+    s.annotate_text((200, -300), "plot: (200, -300)", coord_system="plot")
 
     # Plot marker and text in axis coords
-    s.annotate_marker((0.1, 0.2), coord_system='axis')
-    s.annotate_text((0.1, 0.2), 'axis: (0.1, 0.2)', coord_system='axis')
+    s.annotate_marker((0.1, 0.2), coord_system="axis")
+    s.annotate_text((0.1, 0.2), "axis: (0.1, 0.2)", coord_system="axis")
 
     # Plot marker and text in figure coords
     # N.B. marker will not render outside of axis bounds
-    s.annotate_marker((0.1, 0.2), coord_system='figure',
-                    plot_args={'color':'black'})
-    s.annotate_text((0.1, 0.2), 'figure: (0.1, 0.2)', coord_system='figure',
-                    text_args={'color':'black'})
+    s.annotate_marker((0.1, 0.2), coord_system="figure", plot_args={"color": "black"})
+    s.annotate_text(
+        (0.1, 0.2),
+        "figure: (0.1, 0.2)",
+        coord_system="figure",
+        text_args={"color": "black"},
+    )
     s.save()
 
 Note that for non-cartesian geometries and ``coord_system="data"``, the coordinates
 are still interpreted in the corresponding cartesian system. For instance using a polar
 dataset from AMRVAC :
 
-.. python-script::
+.. code-block:: python
 
     import yt
 
@@ -98,21 +101,21 @@ dataset from AMRVAC :
     s.set_background_color("density", "black")
 
     # Plot marker and text in data coords
-    s.annotate_marker((0.2, 0.5, 0.9), coord_system='data')
-    s.annotate_text((0.2, 0.5, 0.9), 'data: (0.2, 0.5, 0.9)', coord_system='data')
+    s.annotate_marker((0.2, 0.5, 0.9), coord_system="data")
+    s.annotate_text((0.2, 0.5, 0.9), "data: (0.2, 0.5, 0.9)", coord_system="data")
 
     # Plot marker and text in plot coords
-    s.annotate_marker((0.4, -0.5), coord_system='plot')
-    s.annotate_text((0.4, -0.5), 'plot: (0.4, -0.5)', coord_system='plot')
+    s.annotate_marker((0.4, -0.5), coord_system="plot")
+    s.annotate_text((0.4, -0.5), "plot: (0.4, -0.5)", coord_system="plot")
 
     # Plot marker and text in axis coords
-    s.annotate_marker((0.1, 0.2), coord_system='axis')
-    s.annotate_text((0.1, 0.2), 'axis: (0.1, 0.2)', coord_system='axis')
+    s.annotate_marker((0.1, 0.2), coord_system="axis")
+    s.annotate_text((0.1, 0.2), "axis: (0.1, 0.2)", coord_system="axis")
 
     # Plot marker and text in figure coords
     # N.B. marker will not render outside of axis bounds
-    s.annotate_marker((0.6, 0.2), coord_system='figure')
-    s.annotate_text((0.6, 0.2), 'figure: (0.6, 0.2)', coord_system='figure')
+    s.annotate_marker((0.6, 0.2), coord_system="figure")
+    s.annotate_text((0.6, 0.2), "figure: (0.6, 0.2)", coord_system="figure")
     s.save()
 
 Available Callbacks
@@ -133,11 +136,12 @@ Clear Callbacks (Some or All)
     to the plot.  Note that the index goes from 0..N, and you can
     specify the index of the last added annotation as -1.
 
-.. python-script::
+.. code-block:: python
 
     import yt
+
     ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-    p = yt.SlicePlot(ds, 'z', 'density', center='c', width=(20, 'kpc'))
+    p = yt.SlicePlot(ds, "z", "density", center="c", width=(20, "kpc"))
     p.annotate_scale()
     p.annotate_timestamp()
 
@@ -157,11 +161,12 @@ List Currently Applied Callbacks
    :ref:`annotate_clear() function <annotate-clear>` to remove a
    specific callback.
 
-.. python-script::
+.. code-block:: python
 
     import yt
+
     ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-    p = yt.SlicePlot(ds, 'z', 'density', center='c', width=(20, 'kpc'))
+    p = yt.SlicePlot(ds, "z", "density", center="c", width=(20, "kpc"))
     p.annotate_scale()
     p.annotate_timestamp()
     p.list_annotations()
@@ -181,12 +186,13 @@ Overplot Arrow
     feature.  Arrow points from lower left to the designated position with
     arrow length "length".
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   slc = yt.SlicePlot(ds, 'z', 'density', width=(10,'kpc'), center='c')
-   slc.annotate_arrow((0.5, 0.5, 0.5), length=0.06, plot_args={'color':'blue'})
+   slc = yt.SlicePlot(ds, "z", "density", width=(10, "kpc"), center="c")
+   slc.annotate_arrow((0.5, 0.5, 0.5), length=0.06, plot_args={"color": "blue"})
    slc.save()
 
 .. _annotate-clumps:
@@ -202,29 +208,27 @@ Clump Finder Callback
    Take a list of ``clumps`` and plot them as a set of
    contours.
 
-.. python-script::
+.. code-block:: python
 
    import yt
    import numpy as np
-   from yt.data_objects.level_sets.api import \
-       Clump, find_clumps
+   from yt.data_objects.level_sets.api import Clump, find_clumps
 
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   data_source = ds.disk([0.5, 0.5, 0.5], [0., 0., 1.],
-                         (8., 'kpc'), (1., 'kpc'))
+   data_source = ds.disk([0.5, 0.5, 0.5], [0.0, 0.0, 1.0], (8.0, "kpc"), (1.0, "kpc"))
 
-   c_min = 10**np.floor(np.log10(data_source['density']).min()  )
-   c_max = 10**np.floor(np.log10(data_source['density']).max()+1)
+   c_min = 10 ** np.floor(np.log10(data_source["density"]).min())
+   c_max = 10 ** np.floor(np.log10(data_source["density"]).max() + 1)
 
-   master_clump = Clump(data_source, 'density')
+   master_clump = Clump(data_source, "density")
    master_clump.add_validator("min_cells", 20)
 
    find_clumps(master_clump, c_min, c_max, 2.0)
    leaf_clumps = master_clump.leaves
 
-   prj = yt.ProjectionPlot(ds, 2, 'density', center='c', width=(20,'kpc'))
+   prj = yt.ProjectionPlot(ds, 2, "density", center="c", width=(20, "kpc"))
    prj.annotate_clumps(leaf_clumps)
-   prj.save('clumps')
+   prj.save("clumps")
 
 .. _annotate-contours:
 
@@ -243,9 +247,10 @@ Overplot Contours
    interpolation, ``take_log`` governs how it is contoured and ``clim`` gives
    the (upper, lower) limits for contouring.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("Enzo_64/DD0043/data0043")
    s = yt.SlicePlot(ds, "x", "density", center="max")
    s.annotate_contour("temperature")
@@ -274,14 +279,20 @@ Axis-Aligned Data Sources
    Additional arguments can be passed to the ``plot_args`` dictionary, see
    matplotlib.axes.Axes.quiver for more info.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   p = yt.ProjectionPlot(ds, 'z', 'density', center=[0.5, 0.5, 0.5],
-                         weight_field='density', width=(20, 'kpc'))
-   p.annotate_quiver('velocity_x', 'velocity_y', factor=16,
-                     plot_args={"color": "purple"})
+   p = yt.ProjectionPlot(
+       ds,
+       "z",
+       "density",
+       center=[0.5, 0.5, 0.5],
+       weight_field="density",
+       width=(20, "kpc"),
+   )
+   p.annotate_quiver("velocity_x", "velocity_y", factor=16, plot_args={"color": "purple"})
    p.save()
 
 Off-Axis Data Sources
@@ -302,13 +313,18 @@ Off-Axis Data Sources
    Additional arguments can be passed to the ``plot_args`` dictionary, see
    matplotlib.axes.Axes.quiver for more info.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("Enzo_64/DD0043/data0043")
-   s = yt.OffAxisSlicePlot(ds, [1,1,0], ["density"], center="c")
-   s.annotate_cquiver('cutting_plane_velocity_x', 'cutting_plane_velocity_y',
-                      factor=10, plot_args={'color':'orange'})
+   s = yt.OffAxisSlicePlot(ds, [1, 1, 0], ["density"], center="c")
+   s.annotate_cquiver(
+       "cutting_plane_velocity_x",
+       "cutting_plane_velocity_y",
+       factor=10,
+       plot_args={"color": "orange"},
+   )
    s.zoom(1.5)
    s.save()
 
@@ -331,11 +347,12 @@ Overplot Grids
    puts the grid id in the ``id_loc`` corner of the grid. (``id_loc`` can be
    upper/lower left/right. ``draw_ids`` is not so great in projections...)
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   slc = yt.SlicePlot(ds, 'z', 'density', width=(10,'kpc'), center='max')
+   slc = yt.SlicePlot(ds, "z", "density", width=(10, "kpc"), center="max")
    slc.annotate_grids()
    slc.save()
 
@@ -356,11 +373,12 @@ Overplot Cell Edges
     effect of doubling the line width.  Color here is a matplotlib color name or
     a 3-tuple of RGB float values.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   slc = yt.SlicePlot(ds, 'z', 'density', width=(10,'kpc'), center='max')
+   slc = yt.SlicePlot(ds, "z", "density", width=(10, "kpc"), center="max")
    slc.annotate_cell_edges()
    slc.save()
 
@@ -408,15 +426,15 @@ Overplot Halo Annotations
    radius is multiplied by for plotting the circles. Ex: ``factor=2.0`` will
    plot circles with twice the radius of each halo virial radius.
 
-.. python-script::
+.. code-block:: python
 
    import yt
 
-   data_ds = yt.load('Enzo_64/RD0006/RedshiftOutput0006')
-   halos_ds = yt.load('rockstar_halos/halos_0.0.bin')
+   data_ds = yt.load("Enzo_64/RD0006/RedshiftOutput0006")
+   halos_ds = yt.load("rockstar_halos/halos_0.0.bin")
 
-   prj = yt.ProjectionPlot(data_ds, 'z', 'density')
-   prj.annotate_halos(halos_ds, annotate_field='particle_identifier')
+   prj = yt.ProjectionPlot(data_ds, "z", "density")
+   prj.annotate_halos(halos_ds, annotate_field="particle_identifier")
    prj.save()
 
 .. _annotate-image-line:
@@ -433,12 +451,13 @@ Overplot a Straight Line
     should be 2D or 3D coordinates consistent with the coordinate
     system denoted in the "coord_system" keyword.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   p = yt.ProjectionPlot(ds, 'z', 'density', center='m', width=(10, 'kpc'))
-   p.annotate_line((0.3, 0.4), (0.8, 0.9), coord_system='axis')
+   p = yt.ProjectionPlot(ds, "z", "density", center="m", width=(10, "kpc"))
+   p.annotate_line((0.3, 0.4), (0.8, 0.9), coord_system="axis")
    p.save()
 
 .. _annotate-magnetic-field:
@@ -461,13 +480,19 @@ Overplot Magnetic Field Quivers
    variation in field strength. Additional arguments can be passed to the
    ``plot_args`` dictionary, see matplotlib.axes.Axes.quiver for more info.
 
-.. python-script::
+.. code-block:: python
 
    import yt
-   ds = yt.load("MHDSloshing/virgo_low_res.0054.vtk",
-                parameters={"time_unit":(1, 'Myr'), "length_unit":(1, 'Mpc'),
-                            "mass_unit":(1e17, 'Msun')})
-   p = yt.ProjectionPlot(ds, 'z', 'density', center='c', width=(300, 'kpc'))
+
+   ds = yt.load(
+       "MHDSloshing/virgo_low_res.0054.vtk",
+       parameters={
+           "time_unit": (1, "Myr"),
+           "length_unit": (1, "Mpc"),
+           "mass_unit": (1e17, "Msun"),
+       },
+   )
+   p = yt.ProjectionPlot(ds, "z", "density", center="c", width=(300, "kpc"))
    p.annotate_magnetic_field(plot_args={"headlength": 3})
    p.save()
 
@@ -484,13 +509,13 @@ Annotate a Point With a Marker
 
     Overplot a marker on a position for highlighting specific features.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   s = yt.SlicePlot(ds, 'z', 'density', center='c', width=(10, 'kpc'))
-   s.annotate_marker((-2,-2), coord_system='plot',
-                     plot_args={'color':'blue','s':500})
+   s = yt.SlicePlot(ds, "z", "density", center="c", width=(10, "kpc"))
+   s.annotate_marker((-2, -2), coord_system="plot", plot_args={"color": "blue", "s": 500})
    s.save()
 
 .. _annotate-particles:
@@ -513,23 +538,25 @@ Overplotting Particle Positions
    WARNING: if ``data_source`` is a :class:`yt.data_objects.selection_data_containers.YTCutRegion`
    then the ``width`` parameter is ignored.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("Enzo_64/DD0043/data0043")
-   p = yt.ProjectionPlot(ds, "x", "density", center='m', width=(10, 'Mpc'))
-   p.annotate_particles((10, 'Mpc'))
+   p = yt.ProjectionPlot(ds, "x", "density", center="m", width=(10, "Mpc"))
+   p.annotate_particles((10, "Mpc"))
    p.save()
 
 To plot only the central particles
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("Enzo_64/DD0043/data0043")
-   p = yt.ProjectionPlot(ds, "x", "density", center='m', width=(10, 'Mpc'))
-   sp = ds.sphere([0.5,0.5,0.5],ds.quan(1,'Mpc'))
-   p.annotate_particles((10, 'Mpc'),data_source=sp)
+   p = yt.ProjectionPlot(ds, "x", "density", center="m", width=(10, "Mpc"))
+   sp = ds.sphere([0.5, 0.5, 0.5], ds.quan(1, "Mpc"))
+   p.annotate_particles((10, "Mpc"), data_source=sp)
    p.save()
 
 .. _annotate-sphere:
@@ -545,13 +572,13 @@ Overplot a Circle on a Plot
 
     Overplot a circle with designated center and radius with optional text.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   p = yt.ProjectionPlot(ds, 'z', 'density', center='c', width=(20, 'kpc'))
-   p.annotate_sphere([0.5, 0.5, 0.5], radius=(2, 'kpc'),
-                     circle_args={'color':'black'})
+   p = yt.ProjectionPlot(ds, "z", "density", center="c", width=(20, "kpc"))
+   p.annotate_sphere([0.5, 0.5, 0.5], radius=(2, "kpc"), circle_args={"color": "black"})
    p.save()
 
 .. _annotate-streamlines:
@@ -573,12 +600,13 @@ Overplot Streamlines
    ``start_at_yedge``.  A line with the qmean vector magnitude will cover
    1.0/``factor`` of the image.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   s = yt.SlicePlot(ds, 'z', 'density', center='c', width=(20, 'kpc'))
-   s.annotate_streamlines('velocity_x', 'velocity_y')
+   s = yt.SlicePlot(ds, "z", "density", center="c", width=(20, "kpc"))
+   s.annotate_streamlines("velocity_x", "velocity_y")
    s.save()
 
 .. _annotate-line-integral-convolution:
@@ -602,12 +630,13 @@ Overplot Line Integral Convolution
    spatially by the values of line integral convolution; otherwise a constant value
    of the given alpha is used.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   s = yt.SlicePlot(ds, 'z', 'density', center='c', width=(20, 'kpc'))
-   s.annotate_line_integral_convolution('velocity_x', 'velocity_y', lim=(0.5,0.65))
+   s = yt.SlicePlot(ds, "z", "density", center="c", width=(20, "kpc"))
+   s.annotate_line_integral_convolution("velocity_x", "velocity_y", lim=(0.5, 0.65))
    s.save()
 
 .. _annotate-text:
@@ -625,12 +654,13 @@ Overplot Text
     box around your text, set one with the inset_box_args dictionary
     keyword.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   s = yt.SlicePlot(ds, 'z', 'density', center='max', width=(10, 'kpc'))
-   s.annotate_text((2, 2), 'Galaxy!', coord_system='plot')
+   s = yt.SlicePlot(ds, "z", "density", center="max", width=(10, "kpc"))
+   s.annotate_text((2, 2), "Galaxy!", coord_system="plot")
    s.save()
 
 .. _annotate-title:
@@ -645,12 +675,13 @@ Add a Title
 
    Accepts a ``title`` and adds it to the plot.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   p = yt.ProjectionPlot(ds, 'z', 'density', center='c', width=(20, 'kpc'))
-   p.annotate_title('Density Plot')
+   p = yt.ProjectionPlot(ds, "z", "density", center="c", width=(20, "kpc"))
+   p.annotate_title("Density Plot")
    p.save()
 
 .. _annotate-velocity:
@@ -672,11 +703,12 @@ Overplot Quivers for the Velocity Field
    variation in field strength. Additional arguments can be passed to the
    ``plot_args`` dictionary, see matplotlib.axes.Axes.quiver for more info.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   p = yt.SlicePlot(ds, 'z', 'density', center='m', width=(10, 'kpc'))
+   p = yt.SlicePlot(ds, "z", "density", center="m", width=(10, "kpc"))
    p.annotate_velocity(plot_args={"headwidth": 4})
    p.save()
 
@@ -704,11 +736,12 @@ Add the Current Time and/or Redshift
     of an inset box around the text, and changing the value of the timestamp
     via a constant offset.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   p = yt.SlicePlot(ds, 'z', 'density', center='c', width=(20, 'kpc'))
+   p = yt.SlicePlot(ds, "z", "density", center="c", width=(20, "kpc"))
    p.annotate_timestamp()
    p.save()
 
@@ -742,11 +775,12 @@ Add a Physical Scale Bar
     matplotlib's axes_grid toolkit. Finally, the format of the scale bar text
     can be adjusted using the scale_text_format keyword argument.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   p = yt.SlicePlot(ds, 'z', 'density', center='c', width=(20, 'kpc'))
+   p = yt.SlicePlot(ds, "z", "density", center="c", width=(20, "kpc"))
    p.annotate_scale()
    p.save()
 
@@ -764,7 +798,7 @@ Annotate Triangle Facets Callback
    with the triangles to the plot. This callback is ideal for a
    dataset representing a geometric model of triangular facets.
 
-.. python-script::
+.. code-block:: python
 
    import h5py
    import os
@@ -774,20 +808,21 @@ Annotate Triangle Facets Callback
    pf = yt.load("MoabTest/fng_usrbin22.h5m")
 
    # Create the desired slice plot
-   s = yt.SlicePlot(pf, 'z', ('moab','TALLY_TAG'))
+   s = yt.SlicePlot(pf, "z", ("moab", "TALLY_TAG"))
 
-   #get triangle vertices from file (in this case hdf5)
+   # get triangle vertices from file (in this case hdf5)
 
-   #setup file path for yt test directory
-   filename = os.path.join(yt.config.ytcfg.get("yt", "test_data_dir"),
-                           "MoabTest/mcnp_n_impr_fluka.h5m")
+   # setup file path for yt test directory
+   filename = os.path.join(
+       yt.config.ytcfg.get("yt", "test_data_dir"), "MoabTest/mcnp_n_impr_fluka.h5m"
+   )
    f = h5py.File(filename, mode="r")
    coords = f["/tstt/nodes/coordinates"][:]
    conn = f["/tstt/elements/Tri3/connectivity"][:]
-   points = coords[conn-1]
+   points = coords[conn - 1]
 
    # Annotate slice-triangle intersection contours to the plot
-   s.annotate_triangle_facets(points, plot_args={"colors": 'black'})
+   s.annotate_triangle_facets(points, plot_args={"colors": "black"})
    s.save()
 
 .. _annotate-mesh-lines:
@@ -804,12 +839,13 @@ Annotate Mesh Lines Callback
    line collection. This callback is only useful for unstructured or
    semi-structured mesh datasets.
 
-.. python-script::
+.. code-block:: python
 
    import yt
-   ds = yt.load('MOOSE_sample_data/out.e')
-   sl = yt.SlicePlot(ds, 2, ('connect1', 'nodal_aux'))
-   sl.annotate_mesh_lines(plot_args={'color':'black'})
+
+   ds = yt.load("MOOSE_sample_data/out.e")
+   sl = yt.SlicePlot(ds, 2, ("connect1", "nodal_aux"))
+   sl.annotate_mesh_lines(plot_args={"color": "black"})
    sl.save()
 
 .. _annotate-ray:
@@ -830,13 +866,14 @@ Overplot the Path of a Ray
     object.  annotate_ray() will properly account for periodic rays across the
     volume.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
    oray = ds.ortho_ray(0, (0.3, 0.4))
    ray = ds.ray((0.1, 0.2, 0.3), (0.6, 0.7, 0.8))
-   p = yt.ProjectionPlot(ds, 'z', 'density')
+   p = yt.ProjectionPlot(ds, "z", "density")
    p.annotate_ray(oray)
    p.annotate_ray(ray)
    p.save()

--- a/doc/source/visualizing/manual_plotting.rst
+++ b/doc/source/visualizing/manual_plotting.rst
@@ -32,24 +32,26 @@ the FRB returns a fully pixelized image. The simplest way to
 generate an FRB is to use the ``.to_frb(width, resolution, center=None)`` method
 of any data two-dimensional data object:
 
-.. python-script::
+.. code-block:: python
 
    import matplotlib
-   matplotlib.use('Agg')
+
+   matplotlib.use("Agg")
    from matplotlib import pyplot as plt
    import numpy as np
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
 
-   c = ds.find_max('density')[1]
-   proj = ds.proj('density', 0)
+   c = ds.find_max("density")[1]
+   proj = ds.proj("density", 0)
 
-   width = (10, 'kpc') # we want a 1.5 mpc view
-   res = [1000, 1000] # create an image with 1000x1000 pixels
+   width = (10, "kpc")  # we want a 1.5 mpc view
+   res = [1000, 1000]  # create an image with 1000x1000 pixels
    frb = proj.to_frb(width, res, center=c)
 
-   plt.imshow(np.array(frb['density']))
-   plt.savefig('my_perfect_figure.png')
+   plt.imshow(np.array(frb["density"]))
+   plt.savefig("my_perfect_figure.png")
 
 Note that in the above example the axes tick marks indicate pixel indices.  If you
 want to represent physical distances on your plot axes, you will need to use the
@@ -76,21 +78,22 @@ create realistically looking, mock observation images out of simulation data.
 Applying filter is an irreversible operation, hence the order in which you are
 using them matters.
 
-.. python-script::
+.. code-block:: python
 
    import matplotlib
-   matplotlib.use('Agg')
+
+   matplotlib.use("Agg")
    from matplotlib import pyplot as plt
 
    import yt
 
-   ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
-   slc = ds.slice('z', 0.5)
-   frb = slc.to_frb((20, 'kpc'), 512)
+   ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
+   slc = ds.slice("z", 0.5)
+   frb = slc.to_frb((20, "kpc"), 512)
    frb.apply_gauss_beam(nbeam=30, sigma=2.0)
    frb.apply_white_noise(5e-23)
-   plt.imshow(frb['density'].d)
-   plt.savefig('frb_filters.png')
+   plt.imshow(frb["density"].d)
+   plt.savefig("frb_filters.png")
 
 Currently available filters:
 
@@ -128,10 +131,11 @@ direct dictionary access. As a simple example, take a
 :class:`~yt.data_objects.selection_data_containers.YTOrthoRay` object, which can be
 created from a index by calling ``pf.ortho_ray(axis, center)``.
 
-.. python-script::
+.. code-block:: python
 
    import matplotlib
-   matplotlib.use('Agg')
+
+   matplotlib.use("Agg")
    from matplotlib import pyplot as plt
 
    import yt
@@ -139,22 +143,22 @@ created from a index by calling ``pf.ortho_ray(axis, center)``.
 
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
    c = ds.find_max("density")[1]
-   ax = 0 # take a line cut along the x axis
+   ax = 0  # take a line cut along the x axis
 
    # cutting through the y0,z0 such that we hit the max density
    ray = ds.ortho_ray(ax, (c[1], c[2]))
 
    # Sort the ray values by 'x' so there are no discontinuities
    # in the line plot
-   srt = np.argsort(ray['x'])
+   srt = np.argsort(ray["x"])
 
    plt.subplot(211)
-   plt.semilogy(np.array(ray['x'][srt]), np.array(ray['density'][srt]))
-   plt.ylabel('density')
+   plt.semilogy(np.array(ray["x"][srt]), np.array(ray["density"][srt]))
+   plt.ylabel("density")
    plt.subplot(212)
-   plt.semilogy(np.array(ray['x'][srt]), np.array(ray['temperature'][srt]))
-   plt.xlabel('x')
-   plt.ylabel('temperature')
+   plt.semilogy(np.array(ray["x"][srt]), np.array(ray["temperature"][srt]))
+   plt.xlabel("x")
+   plt.ylabel("temperature")
 
    plt.savefig("den_temp_xsweep.png")
 

--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -170,13 +170,20 @@ in the image itself) can be controlled with the ``buff_size`` argument:
 
 Here is an example that combines all of the options we just discussed.
 
-.. python-script::
+.. code-block:: python
 
    import yt
    from yt.units import kpc
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   slc = yt.SlicePlot(ds, 'z', 'density', center=[0.5, 0.5, 0.5],
-                      width=(20,'kpc'), buff_size=(1000, 1000))
+   slc = yt.SlicePlot(
+       ds,
+       "z",
+       "density",
+       center=[0.5, 0.5, 0.5],
+       width=(20, "kpc"),
+       buff_size=(1000, 1000),
+   )
    slc.save()
 
 The above example will display an annotated plot of a slice of the
@@ -188,14 +195,15 @@ a png file.
 Conceptually, you can think of the plot object as an adjustable window
 into the data. For example:
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   slc = yt.SlicePlot(ds, 'z', 'pressure', center='c')
+   slc = yt.SlicePlot(ds, "z", "pressure", center="c")
    slc.save()
    slc.zoom(30)
-   slc.save('zoom')
+   slc.save("zoom")
 
 will save a plot of the pressure field in a slice along the z
 axis across the entire simulation domain followed by another plot that
@@ -225,9 +233,10 @@ arguments as ``SlicePlot``. The one other difference is that the
 ``center`` keyword argument can be a two-dimensional coordinate instead
 of a three-dimensional one:
 
-.. python-script::
+.. code-block:: python
 
     import yt
+
     ds = yt.load("WindTunnel/windtunnel_4lev_hdf5_plt_cnt_0030")
     p = yt.plot_2d(ds, "density", center=[1.0, 0.4])
     p.set_log("density", False)
@@ -252,14 +261,14 @@ plane, and the name of the fields to plot.  Just like an
 :class:`~yt.visualization.plot_window.OffAxisSlicePlot` can be created via the
 :class:`~yt.visualization.plot_window.SlicePlot` class. For example:
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   L = [1,1,0] # vector normal to cutting plane
-   north_vector = [-1,1,0]
-   cut = yt.SlicePlot(ds, L, 'density', width=(25, 'kpc'),
-                      north_vector=north_vector)
+   L = [1, 1, 0]  # vector normal to cutting plane
+   north_vector = [-1, 1, 0]
+   cut = yt.SlicePlot(ds, L, "density", width=(25, "kpc"), north_vector=north_vector)
    cut.save()
 
 In this case, a normal vector for the cutting plane is supplied in the second
@@ -278,13 +287,15 @@ Projection plots are created by instantiating a
 :class:`~yt.visualization.plot_window.ProjectionPlot` object.  For
 example:
 
-.. python-script::
+.. code-block:: python
 
    import yt
    from yt.units import kpc
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   prj = yt.ProjectionPlot(ds, 2, 'temperature', width=25*kpc,
-                           weight_field='density', buff_size=(1000, 1000))
+   prj = yt.ProjectionPlot(
+       ds, 2, "temperature", width=25 * kpc, weight_field="density", buff_size=(1000, 1000)
+   )
    prj.save()
 
 will create a density-weighted projection of the temperature field along
@@ -370,13 +381,14 @@ projection image buffer.  These images can be saved to disk or
 used in custom plots.  This snippet creates an off axis
 projection through a simulation.
 
-.. python-script::
+.. code-block:: python
 
    import yt
    import numpy as np
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   L = [1,1,0] # vector normal to cutting plane
-   north_vector = [-1,1,0]
+   L = [1, 1, 0]  # vector normal to cutting plane
+   north_vector = [-1, 1, 0]
    W = [0.02, 0.02, 0.02]
    c = [0.5, 0.5, 0.5]
    N = 512
@@ -392,14 +404,16 @@ plots can be created in much the same way as an
 ``OffAxisSlicePlot``, requiring only an open dataset, a direction
 to project along, and a field to project.  For example:
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   L = [1,1,0] # vector normal to cutting plane
-   north_vector = [-1,1,0]
-   prj = yt.OffAxisProjectionPlot(ds,L,'density',width=(25, 'kpc'),
-                                  north_vector=north_vector)
+   L = [1, 1, 0]  # vector normal to cutting plane
+   north_vector = [-1, 1, 0]
+   prj = yt.OffAxisProjectionPlot(
+       ds, L, "density", width=(25, "kpc"), north_vector=north_vector
+   )
    prj.save()
 
 OffAxisProjectionPlots can also be created with a number of
@@ -414,11 +428,12 @@ Unstructured Mesh Slices
 Unstructured Mesh datasets can be sliced using the same syntax as above.
 Here is an example script using a publicly available MOOSE dataset:
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("MOOSE_sample_data/out.e-s010")
-   sl = yt.SlicePlot(ds, 'x', ('connect1', 'diffused'))
+   sl = yt.SlicePlot(ds, "x", ("connect1", "diffused"))
    sl.zoom(0.75)
    sl.save()
 
@@ -428,11 +443,12 @@ center of the domain. We have also zoomed out a bit to get a better view of the
 resulting structure. To instead plot the ``'convected'`` variable, using a slice normal
 to the ``'z'`` direction through the mesh labelled by ``'connect2'``, we do:
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("MOOSE_sample_data/out.e-s010")
-   sl = yt.SlicePlot(ds, 'z', ('connect2', 'convected'))
+   sl = yt.SlicePlot(ds, "z", ("connect2", "convected"))
    sl.zoom(0.75)
    sl.save()
 
@@ -442,22 +458,24 @@ so this interpolation is performed by converting the sample point the reference 
 system of the element and evaluating the appropriate shape functions. You can also
 plot element-centered fields:
 
-.. python-script::
+.. code-block:: python
 
    import yt
-   ds = yt.load('MOOSE_sample_data/out.e-s010')
-   sl = yt.SlicePlot(ds, 'y', ('connect1', 'conv_indicator'))
+
+   ds = yt.load("MOOSE_sample_data/out.e-s010")
+   sl = yt.SlicePlot(ds, "y", ("connect1", "conv_indicator"))
    sl.zoom(0.75)
    sl.save()
 
 We can also annotate the mesh lines, as follows:
 
-.. python-script::
+.. code-block:: python
 
    import yt
-   ds = yt.load('MOOSE_sample_data/out.e-s010')
-   sl = yt.SlicePlot(ds, 'z', ('connect1', 'diffused'))
-   sl.annotate_mesh_lines(plot_args={'color':'black'})
+
+   ds = yt.load("MOOSE_sample_data/out.e-s010")
+   sl = yt.SlicePlot(ds, "z", ("connect1", "diffused"))
+   sl.annotate_mesh_lines(plot_args={"color": "black"})
    sl.zoom(0.75)
    sl.save()
 
@@ -467,33 +485,36 @@ to matplotlib. It can be used to control the mesh line color, thickness, etc...
 The above examples all involve 8-node hexahedral mesh elements. Here is another example from
 a dataset that uses 6-node wedge elements:
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("MOOSE_sample_data/wedge_out.e")
-   sl = yt.SlicePlot(ds, 2, ('connect2', 'diffused'))
+   sl = yt.SlicePlot(ds, 2, ("connect2", "diffused"))
    sl.save()
 
 Slices can also be used to examine 2D unstructured mesh datasets, but the
 slices must be taken to be normal to the ``'z'`` axis, or you'll get an error. Here is
 an example using another MOOSE dataset that uses triangular mesh elements:
 
-.. python-script::
+.. code-block:: python
 
    import yt
-   ds = yt.load('MOOSE_sample_data/out.e')
-   sl = yt.SlicePlot(ds, 2, ('connect1', 'nodal_aux'))
+
+   ds = yt.load("MOOSE_sample_data/out.e")
+   sl = yt.SlicePlot(ds, 2, ("connect1", "nodal_aux"))
    sl.save()
 
 You may run into situations where you have a variable you want to visualize that
 exists on multiple mesh blocks. To view the variable on ``all`` mesh blocks,
 simply pass ``all`` as the first argument of the field tuple:
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("MultiRegion/two_region_example_out.e", step=-1)
-   sl = yt.SlicePlot(ds, 'z', ('all', 'diffused'))
+   sl = yt.SlicePlot(ds, "z", ("all", "diffused"))
    sl.save()
 
 
@@ -504,11 +525,12 @@ You can customize each of the four plot types above in identical ways.  We'll go
 over each of the customizations methods below.  For each of the examples below we
 will modify the following plot.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   slc = yt.SlicePlot(ds, 'z', 'density', width=(10,'kpc'))
+   slc = yt.SlicePlot(ds, "z", "density", width=(10, "kpc"))
    slc.save()
 
 Panning and zooming
@@ -519,33 +541,36 @@ There are three methods to dynamically pan around the data.
 :meth:`~yt.visualization.plot_window.AxisAlignedSlicePlot.pan` accepts x and y
 deltas.
 
-.. python-script::
+.. code-block:: python
 
    import yt
    from yt.units import kpc
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   slc = yt.SlicePlot(ds, 'z', 'density', width=(10,'kpc'))
-   slc.pan((2*kpc, 2*kpc))
+   slc = yt.SlicePlot(ds, "z", "density", width=(10, "kpc"))
+   slc.pan((2 * kpc, 2 * kpc))
    slc.save()
 
 :meth:`~yt.visualization.plot_window.AxisAlignedSlicePlot.pan_rel` accepts deltas
 in units relative to the field of view of the plot.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   slc = yt.SlicePlot(ds, 'z', 'density', width=(10,'kpc'))
+   slc = yt.SlicePlot(ds, "z", "density", width=(10, "kpc"))
    slc.pan_rel((0.1, -0.1))
    slc.save()
 
 :meth:`~yt.visualization.plot_window.AxisAlignedSlicePlot.zoom` accepts a factor to zoom in by.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   slc = yt.SlicePlot(ds, 'z', 'density', width=(10,'kpc'))
+   slc = yt.SlicePlot(ds, "z", "density", width=(10, "kpc"))
    slc.zoom(2)
    slc.save()
 
@@ -555,12 +580,13 @@ Set axes units
 :meth:`~yt.visualization.plot_window.AxisAlignedSlicePlot.set_axes_unit` allows the customization of
 the axes unit labels.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   slc = yt.SlicePlot(ds, 'z', 'density', width=(10,'kpc'))
-   slc.set_axes_unit('Mpc')
+   slc = yt.SlicePlot(ds, "z", "density", width=(10, "kpc"))
+   slc.set_axes_unit("Mpc")
    slc.save()
 
 The same result could have been accomplished by explicitly setting the ``width``
@@ -572,12 +598,13 @@ Set image units
 :meth:`~yt.visualization.plot_window.AxisAlignedSlicePlot.set_axes_unit` allows
 the customization of the units used for the image and colorbar.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   slc = yt.SlicePlot(ds, 'z', 'density', width=(10,'kpc'))
-   slc.set_unit('density', 'Msun/pc**3')
+   slc = yt.SlicePlot(ds, "z", "density", width=(10, "kpc"))
+   slc.set_unit("density", "Msun/pc**3")
    slc.save()
 
 If the unit you would like to convert to needs an equivalency, this can be
@@ -585,12 +612,13 @@ specified via the ``equivalency`` keyword argument of ``set_unit``. For
 example, let's make a plot of the temperature field, but present it using
 an energy unit instead of a temperature unit:
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   slc = yt.SlicePlot(ds, 'z', 'temperature', width=(10,'kpc'))
-   slc.set_unit('temperature', 'keV', equivalency='thermal')
+   slc = yt.SlicePlot(ds, "z", "temperature", width=(10, "kpc"))
+   slc.set_unit("temperature", "keV", equivalency="thermal")
    slc.save()
 
 Set the plot center
@@ -600,11 +628,12 @@ The :meth:`~yt.visualization.plot_window.AxisAlignedSlicePlot.set_center`
 function accepts a new center for the plot, in code units.  New centers must be
 two element tuples.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   slc = yt.SlicePlot(ds, 'z', 'density', width=(10,'kpc'))
+   slc = yt.SlicePlot(ds, "z", "density", width=(10, "kpc"))
    slc.set_center((0.5, 0.503))
    slc.save()
 
@@ -617,18 +646,19 @@ coordinate system with the ``normal`` and ``north_vector`` for the system, wheth
 explicitly or implicitly defined. This setting can be toggled or explicitly defined
 by the user at initialization:
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   #slicing with non right-handed coordinates
-   slc = yt.SlicePlot(ds, 'x', 'velocity_x', right_handed=False)
-   slc.annotate_title('Not Right Handed')
+   # slicing with non right-handed coordinates
+   slc = yt.SlicePlot(ds, "x", "velocity_x", right_handed=False)
+   slc.annotate_title("Not Right Handed")
    slc.save("NotRightHanded.png")
 
-   #switching to right-handed coordinates
+   # switching to right-handed coordinates
    slc.toggle_right_handed()
-   slc.annotate_title('Right Handed')
+   slc.annotate_title("Right Handed")
    slc.save("Standard.png")
 
 .. _hiding-colorbar-and-axes:
@@ -640,11 +670,12 @@ The :class:`~yt.visualization.plot_window.PlotWindow` class has functions
 attached for hiding/showing the colorbar and axes.  This allows for making
 minimal plots that focus on the data:
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   slc = yt.SlicePlot(ds, 'z', 'density', width=(10,'kpc'))
+   slc = yt.SlicePlot(ds, "z", "density", width=(10, "kpc"))
    slc.hide_colorbar()
    slc.hide_axes()
    slc.save()
@@ -659,13 +690,13 @@ Fonts
 :meth:`~yt.visualization.plot_window.AxisAlignedSlicePlot.set_font` allows font
 customization.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   slc = yt.SlicePlot(ds, 'z', 'density', width=(10,'kpc'))
-   slc.set_font({'family': 'sans-serif', 'style': 'italic',
-                 'weight': 'bold', 'size': 24})
+   slc = yt.SlicePlot(ds, "z", "density", width=(10, "kpc"))
+   slc.set_font({"family": "sans-serif", "style": "italic", "weight": "bold", "size": 24})
    slc.save()
 
 Colormaps
@@ -679,12 +710,13 @@ To change the colormap for the plot, call the
 :meth:`~yt.visualization.plot_window.AxisAlignedSlicePlot.set_cmap` function.
 Use any of the colormaps listed in the :ref:`colormaps` section.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   slc = yt.SlicePlot(ds, 'z', 'density', width=(10,'kpc'))
-   slc.set_cmap('density', 'RdBu_r')
+   slc = yt.SlicePlot(ds, "z", "density", width=(10, "kpc"))
+   slc.set_cmap("density", "RdBu_r")
    slc.save()
 
 The :meth:`~yt.visualization.plot_window.AxisAlignedSlicePlot.set_log` function
@@ -692,12 +724,13 @@ accepts a field name and a boolean.  If the boolean is ``True``, the colormap
 for the field will be log scaled.  If it is ``False`` the colormap will be
 linear.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   slc = yt.SlicePlot(ds, 'z', 'density', width=(10,'kpc'))
-   slc.set_log('density', False)
+   slc = yt.SlicePlot(ds, "z", "density", width=(10, "kpc"))
+   slc.set_log("density", False)
    slc.save()
 
 Specifically, a field containing both positive and negative values can be plotted
@@ -707,12 +740,13 @@ to infinity), the linear scale will be applied to the region ``(-linthresh, lint
 and stretched relative to the logarithmic range. You can also plot a positive field
 under symlog scale with the linear range of ``(0, linthresh)``.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   slc = yt.SlicePlot(ds, 'z', 'x-velocity', width=(30,'kpc'))
-   slc.set_log('x-velocity', True, linthresh=1.e1)
+   slc = yt.SlicePlot(ds, "z", "x-velocity", width=(30, "kpc"))
+   slc.set_log("x-velocity", True, linthresh=1.0e1)
    slc.save()
 
 The :meth:`~yt.visualization.plot_container.ImagePlotContainer.set_background_color`
@@ -720,40 +754,43 @@ function accepts a field name and a color (optional). If color is given, the fun
 will set the plot's background color to that. If not, it will set it to the bottom
 value of the color map.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   slc = yt.SlicePlot(ds, 'z', 'density', width=(1.5, 'Mpc'))
-   slc.set_background_color('density')
-   slc.save('bottom_colormap_background')
-   slc.set_background_color('density', color='black')
-   slc.save('black_background')
+   slc = yt.SlicePlot(ds, "z", "density", width=(1.5, "Mpc"))
+   slc.set_background_color("density")
+   slc.save("bottom_colormap_background")
+   slc.set_background_color("density", color="black")
+   slc.save("black_background")
 
 If you would like to change the background for a plot and also hide the axes,
 you will need to make use of the ``draw_frame`` keyword argument for the ``hide_axes`` function. If you do not use this keyword argument, the call to
 ``set_background_color`` will have no effect. Here is an example illustrating how to use the ``draw_frame`` keyword argument for ``hide_axes``:
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   field = ('deposit', 'all_density')
-   slc = yt.ProjectionPlot(ds, 'z', field, width=(1.5, 'Mpc'))
+   field = ("deposit", "all_density")
+   slc = yt.ProjectionPlot(ds, "z", field, width=(1.5, "Mpc"))
    slc.set_background_color(field)
    slc.hide_axes(draw_frame=True)
    slc.hide_colorbar()
-   slc.save('just_image')
+   slc.save("just_image")
 
 Lastly, the :meth:`~yt.visualization.plot_window.AxisAlignedSlicePlot.set_zlim`
 function makes it possible to set a custom colormap range.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   slc = yt.SlicePlot(ds, 'z', 'density', width=(10,'kpc'))
-   slc.set_zlim('density', 1e-30, 1e-25)
+   slc = yt.SlicePlot(ds, "z", "density", width=(10, "kpc"))
+   slc.set_zlim("density", 1e-30, 1e-25)
    slc.save()
 
 Annotations
@@ -764,11 +801,12 @@ quiver plot, the location of grid boundaries, halo-finder annotations,
 and many other annotations, including user-customizable annotations.
 For example:
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   slc = yt.SlicePlot(ds, 'z', 'density', width=(10,'kpc'))
+   slc = yt.SlicePlot(ds, "z", "density", width=(10, "kpc"))
    slc.annotate_grids()
    slc.save()
 
@@ -788,22 +826,24 @@ To set the size of the plot, use the
 is the size of the longest edge of the plot in inches.  View the full resolution
 image to see the difference more clearly.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   slc = yt.SlicePlot(ds, 'z', 'density', width=(10,'kpc'))
+   slc = yt.SlicePlot(ds, "z", "density", width=(10, "kpc"))
    slc.set_figure_size(10)
    slc.save()
 
 To change the resolution of the image, call the
 :meth:`~yt.visualization.plot_window.AxisAlignedSlicePlot.set_buff_size` function.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   slc = yt.SlicePlot(ds, 'z', 'density', width=(10,'kpc'))
+   slc = yt.SlicePlot(ds, "z", "density", width=(10, "kpc"))
    slc.set_buff_size(1600)
    slc.save()
 
@@ -821,13 +861,14 @@ and the desired state for the plot as 'on' or 'off'. There is also an analogous
 :meth:`~yt.visualization.plot_window.AxisAlignedSlicePlot.set_colorbar_minorticks`
 function for the colorbar axis.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   slc = yt.SlicePlot(ds, 'z', 'density', width=(10,'kpc'))
-   slc.set_minorticks('all', False)
-   slc.set_colorbar_minorticks('all', False)
+   slc = yt.SlicePlot(ds, "z", "density", width=(10, "kpc"))
+   slc.set_minorticks("all", False)
+   slc.set_colorbar_minorticks("all", False)
    slc.save()
 
 
@@ -887,12 +928,13 @@ profile plot, create a (:class:`~yt.visualization.profile_plotter.ProfilePlot`)
 object, supplying the data object, the field for binning, and a list of fields
 to be profiled.
 
-.. python-script::
+.. code-block:: python
 
    import yt
    from yt.units import kpc
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-   my_galaxy = ds.disk(ds.domain_center, [0.0, 0.0, 1.0], 10*kpc, 3*kpc)
+   my_galaxy = ds.disk(ds.domain_center, [0.0, 0.0, 1.0], 10 * kpc, 3 * kpc)
    plot = yt.ProfilePlot(my_galaxy, "density", ["temperature"])
    plot.save()
 
@@ -905,13 +947,13 @@ contained in the cylinder.
 We could also have made a profile considering only the gas in a sphere.
 For instance:
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
    my_sphere = ds.sphere([0.5, 0.5, 0.5], (100, "kpc"))
-   plot = yt.ProfilePlot(my_sphere, "temperature", ["cell_mass"],
-                         weight_field=None)
+   plot = yt.ProfilePlot(my_sphere, "temperature", ["cell_mass"], weight_field=None)
    plot.save()
 
 Note that because we have specified the weighting field to be ``None``, the
@@ -926,13 +968,15 @@ is the x-axis in a ``ProfilePlot``, in the last example the bin field is
 The following example uses ``weight_field = None`` and ``accumulation = True`` to
 generate a plot of the enclosed mass in a sphere:
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
    my_sphere = ds.sphere([0.5, 0.5, 0.5], (100, "kpc"))
-   plot = yt.ProfilePlot(my_sphere, "radius", ["cell_mass"],
-                         weight_field=None, accumulation=True)
+   plot = yt.ProfilePlot(
+       my_sphere, "radius", ["cell_mass"], weight_field=None, accumulation=True
+   )
    plot.save()
 
 You can also access the data generated by profiles directly, which can be
@@ -963,7 +1007,7 @@ with time.  This is supported with the ``from_profiles`` class method.
 1D profiles are created with the :func:`~yt.data_objects.profiles.create_profile`
 method and then given to the ProfilePlot object.
 
-.. python-script::
+.. code-block:: python
 
    import yt
 
@@ -981,10 +1025,15 @@ method and then given to the ProfilePlot object.
        # Create a data container to hold the whole dataset.
        ad = ds.all_data()
        # Create a 1d profile of density vs. temperature.
-       profiles.append(yt.create_profile(ad, ["temperature"],
-                                         fields=["cell_mass"],
-                                         weight_field=None,
-                                         accumulation=True))
+       profiles.append(
+           yt.create_profile(
+               ad,
+               ["temperature"],
+               fields=["cell_mass"],
+               weight_field=None,
+               accumulation=True,
+           )
+       )
        # Add labels
        labels.append("z = %.2f" % ds.current_redshift)
 
@@ -1006,16 +1055,20 @@ First, you can create a custom profile object using
 :func:`~yt.data_objects.profiles.create_profile`.
 This function accepts a dictionary of ``(max, min)`` tuples keyed to field names.
 
-.. python-script::
+.. code-block:: python
 
     import yt
     import yt.units as u
-    ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
-    sp = ds.sphere('m', 10*u.kpc)
-    profiles = yt.create_profile(sp, "temperature", "density",
-                                 weight_field=None,
-                                 extrema={'temperature': (1e3, 1e7),
-                                          'density': (1e-26, 1e-22)})
+
+    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
+    sp = ds.sphere("m", 10 * u.kpc)
+    profiles = yt.create_profile(
+        sp,
+        "temperature",
+        "density",
+        weight_field=None,
+        extrema={"temperature": (1e3, 1e7), "density": (1e-26, 1e-22)},
+    )
     plot = yt.ProfilePlot.from_profiles(profiles)
     plot.save()
 
@@ -1030,12 +1083,13 @@ might be significantly faster.
 Note that since there is only one bin field, ``set_xlim``
 does not accept a field name as the first argument.
 
-.. python-script::
+.. code-block:: python
 
    import yt
    import yt.units as u
-   ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
-   sp = ds.sphere('m', 10*u.kpc)
+
+   ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
+   sp = ds.sphere("m", 10 * u.kpc)
    plot = yt.ProfilePlot(sp, "temperature", "density", weight_field=None)
    plot.set_xlim(1e3, 1e7)
    plot.set_ylim("density", 1e-26, 1e-22)
@@ -1053,12 +1107,13 @@ units will always be inexpensive, requiring only an in-place unit conversion.
 In the following example we create a plot of the average density in solar
 masses per cubic parsec as a function of radius in kiloparsecs.
 
-.. python-script::
+.. code-block:: python
 
     import yt
     import yt.units as u
-    ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
-    sp = ds.sphere('m', 10*u.kpc)
+
+    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
+    sp = ds.sphere("m", 10 * u.kpc)
     plot = yt.ProfilePlot(sp, "radius", "density", weight_field=None)
     plot.set_unit("density", "msun/pc**3")
     plot.set_unit("radius", "kpc")
@@ -1077,12 +1132,13 @@ In the following example we create a plot of the average x velocity as a
 function of radius.  Since the x component of the velocity vector can be
 negative, we set the scaling to be linear for this field.
 
-.. python-script::
+.. code-block:: python
 
    import yt
    import yt.units as u
-   ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
-   sp = ds.sphere('m', 10*u.kpc)
+
+   ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
+   sp = ds.sphere("m", 10 * u.kpc)
    plot = yt.ProfilePlot(sp, "radius", "x-velocity", weight_field=None)
    plot.set_log("x-velocity", False)
    plot.save()
@@ -1101,13 +1157,13 @@ In the following example we create a plot of the average x-velocity and density 
 function of radius. The xlabel is set to "Radius", for all plots, and the ylabel is set to
 "velocity in x direction" for the x-velocity plot.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("enzo_tiny_cosmology/DD0046/DD0046")
    ad = ds.all_data()
-   plot = yt.ProfilePlot(ad, "density", ["temperature", "velocity_x"],
-                    weight_field=None)
+   plot = yt.ProfilePlot(ad, "density", ["temperature", "velocity_x"], weight_field=None)
    plot.set_xlabel("Radius")
    plot.set_ylabel("velocity_x", "velocity in x direction")
    plot.save()
@@ -1123,9 +1179,10 @@ If ``field`` is not passed, plot title will be added for the fields.
 
 In the following example we create a plot and set the plot title.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("enzo_tiny_cosmology/DD0046/DD0046")
    ad = ds.all_data()
    plot = yt.ProfilePlot(ad, "density", ["temperature"], weight_field=None)
@@ -1135,14 +1192,17 @@ In the following example we create a plot and set the plot title.
 Another example where we create plots from profile. By specifying the fields we can add plot title to a
 specific plot.
 
-.. python-script::
+.. code-block:: python
 
    import yt
-   ds = yt.load('enzo_tiny_cosmology/DD0046/DD0046')
+
+   ds = yt.load("enzo_tiny_cosmology/DD0046/DD0046")
    sphere = ds.sphere("max", (1.0, "Mpc"))
    profiles = []
-   profiles.append(yt.create_profile(sphere, ["radius"], fields=["density"],n_bins=64))
-   profiles.append(yt.create_profile(sphere, ["radius"], fields=["dark_matter_density"],n_bins=64))
+   profiles.append(yt.create_profile(sphere, ["radius"], fields=["density"], n_bins=64))
+   profiles.append(
+       yt.create_profile(sphere, ["radius"], fields=["dark_matter_density"], n_bins=64)
+   )
    plot = yt.ProfilePlot.from_profiles(profiles)
    plot.annotate_title("Plot Title: Density", "density")
    plot.annotate_title("Plot Title: Dark Matter Density", "dark_matter_density")
@@ -1162,13 +1222,14 @@ Furthermore, any keyword argument accepted by the matplotlib ``axes.text`` funct
 
 In the following example we create a plot and add a simple annotation.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("enzo_tiny_cosmology/DD0046/DD0046")
    ad = ds.all_data()
    plot = yt.ProfilePlot(ad, "density", ["temperature"], weight_field=None)
-   plot.annotate_text(1e-30, 1e7,"Annotated Text")
+   plot.annotate_text(1e-30, 1e7, "Annotated Text")
    plot.save()
 
 To add annotations to a particular set of fields we need to pass in the list of fields as follows:
@@ -1255,16 +1316,16 @@ You can add a legend to a 1D sampling plot. The legend process takes two steps:
 X- and Y- axis units can be set with ``set_x_unit`` and ``set_unit`` methods
 respectively. The below code snippet combines all the features we've discussed:
 
-.. python-script::
+.. code-block:: python
 
    import yt
 
-   ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
+   ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
 
-   plot = yt.LinePlot(ds, 'density', [0, 0, 0], [1, 1, 1], 512)
-   plot.annotate_legend('density')
-   plot.set_x_unit('cm')
-   plot.set_unit('density', 'kg/cm**3')
+   plot = yt.LinePlot(ds, "density", [0, 0, 0], [1, 1, 1], 512)
+   plot.annotate_legend("density")
+   plot.set_x_unit("cm")
+   plot.set_unit("density", "kg/cm**3")
    plot.save()
 
 If a list of fields is passed to ``LinePlot``, yt will create a number of
@@ -1276,15 +1337,20 @@ one with plots of the "length/time" fields and another with the plot of the
 for one field of a multi-field plot to produce a legend containing all the
 labels passed in the initial construction of the ``LinePlot`` instance. Example:
 
-.. python-script::
+.. code-block:: python
 
    import yt
 
    ds = yt.load("SecondOrderTris/RZ_p_no_parts_do_nothing_bcs_cone_out.e", step=-1)
-   plot = yt.LinePlot(ds, [('all', 'v'), ('all', 'u')], [0, 0, 0], [0, 1, 0],
-                      100, field_labels={('all', 'u') : r"v$_x$",
-                                         ('all', 'v') : r"v$_y$"})
-   plot.annotate_legend(('all', 'u'))
+   plot = yt.LinePlot(
+       ds,
+       [("all", "v"), ("all", "u")],
+       [0, 0, 0],
+       [0, 1, 0],
+       100,
+       field_labels={("all", "u"): r"v$_x$", ("all", "v"): r"v$_y$"},
+   )
+   plot.annotate_legend(("all", "u"))
    plot.save()
 
 ``LinePlot`` is a bit different from yt ray objects which are data
@@ -1311,13 +1377,15 @@ but this behavior can be controlled through the ``weight_field`` parameter.
 For example, to generate a 2D distribution of mass enclosed in density and
 temperature bins, you can do:
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
    my_sphere = ds.sphere("c", (50, "kpc"))
-   plot = yt.PhasePlot(my_sphere, "density", "temperature", ["cell_mass"],
-                       weight_field=None)
+   plot = yt.PhasePlot(
+       my_sphere, "density", "temperature", ["cell_mass"], weight_field=None
+   )
    plot.save()
 
 If you would rather see the average value of a field as a function of two other
@@ -1325,9 +1393,10 @@ fields, leave off the ``weight_field`` argument, and it will average by
 the cell mass.  This would look
 something like:
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
    my_sphere = ds.sphere("c", (50, "kpc"))
    plot = yt.PhasePlot(my_sphere, "density", "temperature", ["H_fraction"])
@@ -1344,20 +1413,20 @@ can also be customized in a similar manner as
 :class:`~yt.visualization.plot_window.SlicePlot`, such as with ``hide_colorbar``
 and ``show_colorbar``.
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("sizmbhloz-clref04SNth-rs9_a0.9011/sizmbhloz-clref04SNth-rs9_a0.9011.art")
-   center = ds.arr([64.0, 64.0, 64.0], 'code_length')
+   center = ds.arr([64.0, 64.0, 64.0], "code_length")
    rvir = ds.quan(1e-1, "Mpccm/h")
    sph = ds.sphere(center, rvir)
 
-   plot = yt.PhasePlot(sph, "density", "temperature", "cell_mass",
-                       weight_field=None)
-   plot.set_unit('density', 'Msun/pc**3')
-   plot.set_unit('cell_mass', 'Msun')
-   plot.set_xlim(1e-5,1e1)
-   plot.set_ylim(1,1e7)
+   plot = yt.PhasePlot(sph, "density", "temperature", "cell_mass", weight_field=None)
+   plot.set_unit("density", "Msun/pc**3")
+   plot.set_unit("cell_mass", "Msun")
+   plot.set_xlim(1e-5, 1e1)
+   plot.set_ylim(1, 1e7)
    plot.save()
 
 It is also possible to construct a custom 2D profile object and then use the
@@ -1366,19 +1435,26 @@ create a ``PhasePlot`` using the profile object.
 This will sometimes be faster, especially if you need custom x and y axes
 limits.  The following example illustrates this workflow:
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("sizmbhloz-clref04SNth-rs9_a0.9011/sizmbhloz-clref04SNth-rs9_a0.9011.art")
-   center = ds.arr([64.0, 64.0, 64.0], 'code_length')
+   center = ds.arr([64.0, 64.0, 64.0], "code_length")
    rvir = ds.quan(1e-1, "Mpccm/h")
    sph = ds.sphere(center, rvir)
-   units = dict(density='Msun/pc**3', cell_mass='Msun')
+   units = dict(density="Msun/pc**3", cell_mass="Msun")
    extrema = dict(density=(1e-5, 1e1), temperature=(1, 1e7))
 
-   profile = yt.create_profile(sph, ['density', 'temperature'],
-                               n_bins=[128, 128], fields=['cell_mass'],
-                               weight_field=None, units=units, extrema=extrema)
+   profile = yt.create_profile(
+       sph,
+       ["density", "temperature"],
+       n_bins=[128, 128],
+       fields=["cell_mass"],
+       weight_field=None,
+       units=units,
+       extrema=extrema,
+   )
 
    plot = yt.PhasePlot.from_profile(profile)
 
@@ -1458,11 +1534,12 @@ or change the axis units:
 Here is a full example that shows the simplest way to use
 :class:`~yt.visualization.particle_plots.ParticlePlot`:
 
-.. python-script::
+.. code-block:: python
 
    import yt
-   ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
-   p = yt.ParticlePlot(ds, 'particle_position_x', 'particle_position_y')
+
+   ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
+   p = yt.ParticlePlot(ds, "particle_position_x", "particle_position_y")
    p.save()
 
 In the above examples, we are simply splatting particle x and y positions onto
@@ -1470,26 +1547,32 @@ a plot using some color. Colors can be applied to the plotted particles by
 providing a ``z_field``, which will be summed along the line of sight in a manner
 similar to a projection.
 
-.. python-script::
+.. code-block:: python
 
    import yt
-   ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
-   p = yt.ParticlePlot(ds, 'particle_position_x', 'particle_position_y',
-                       'particle_mass')
-   p.set_unit('particle_mass', 'Msun')
+
+   ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
+   p = yt.ParticlePlot(ds, "particle_position_x", "particle_position_y", "particle_mass")
+   p.set_unit("particle_mass", "Msun")
    p.zoom(32)
    p.save()
 
 Additionally, a ``weight_field`` can be given such that the value in each
 pixel is the weighted average along the line of sight.
 
-.. python-script::
+.. code-block:: python
 
    import yt
-   ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
-   p = yt.ParticlePlot(ds, 'particle_position_x', 'particle_position_y',
-                       'particle_mass', weight_field='particle_ones')
-   p.set_unit('particle_mass', 'Msun')
+
+   ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
+   p = yt.ParticlePlot(
+       ds,
+       "particle_position_x",
+       "particle_position_y",
+       "particle_mass",
+       weight_field="particle_ones",
+   )
+   p.set_unit("particle_mass", "Msun")
    p.zoom(32)
    p.save()
 
@@ -1505,15 +1588,17 @@ Here is a complete example that uses the ``particle_mass`` field
 to set the colorbar and shows off some of the modification functions for
 :class:`~yt.visualization.particle_plots.ParticleProjectionPlot`:
 
-.. python-script::
+.. code-block:: python
 
    import yt
-   ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
-   p = yt.ParticlePlot(ds, 'particle_position_x', 'particle_position_y',
-                       'particle_mass', width=(0.5, 0.5))
-   p.set_unit('particle_mass', 'Msun')
+
+   ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
+   p = yt.ParticlePlot(
+       ds, "particle_position_x", "particle_position_y", "particle_mass", width=(0.5, 0.5)
+   )
+   p.set_unit("particle_mass", "Msun")
    p.zoom(32)
-   p.annotate_title('Zoomed-in Particle Plot')
+   p.annotate_title("Zoomed-in Particle Plot")
    p.save()
 
 If the fields passed in to :class:`~yt.visualization.particle_plots.ParticlePlot`
@@ -1530,26 +1615,28 @@ should all work, however.
 Here is an example of making a :class:`~yt.visualization.particle_plots.ParticlePhasePlot`
 of ``particle_position_x`` versus ``particle_velocity_z``, with the ``particle_mass`` on the colorbar:
 
-.. python-script::
+.. code-block:: python
 
    import yt
-   ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
-   p = yt.ParticlePlot(ds, 'particle_position_x', 'particle_velocity_z', ['particle_mass'])
-   p.set_unit('particle_position_x', 'Mpc')
-   p.set_unit('particle_velocity_z', 'km/s')
-   p.set_unit('particle_mass', 'Msun')
+
+   ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
+   p = yt.ParticlePlot(ds, "particle_position_x", "particle_velocity_z", ["particle_mass"])
+   p.set_unit("particle_position_x", "Mpc")
+   p.set_unit("particle_velocity_z", "km/s")
+   p.set_unit("particle_mass", "Msun")
    p.save()
 
 and here is one with the particle x and y velocities on the plot axes:
 
-.. python-script::
+.. code-block:: python
 
    import yt
-   ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
-   p = yt.ParticlePlot(ds, 'particle_velocity_x', 'particle_velocity_y', 'particle_mass')
-   p.set_unit('particle_velocity_x', 'km/s')
-   p.set_unit('particle_velocity_y', 'km/s')
-   p.set_unit('particle_mass', 'Msun')
+
+   ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
+   p = yt.ParticlePlot(ds, "particle_velocity_x", "particle_velocity_y", "particle_mass")
+   p.set_unit("particle_velocity_x", "km/s")
+   p.set_unit("particle_velocity_y", "km/s")
+   p.set_unit("particle_mass", "Msun")
    p.set_ylim(-400, 400)
    p.set_xlim(-400, 400)
    p.save()
@@ -1560,30 +1647,33 @@ here is an example of using the ``depth`` argument to :class:`~yt.visualization.
 to only plot the particles that live in a thin slice around the center of the
 domain:
 
-.. python-script::
+.. code-block:: python
 
    import yt
-   ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
 
-   p = yt.ParticleProjectionPlot(ds, 2, ['particle_mass'], width=(0.5, 0.5), depth=0.01)
-   p.set_unit('particle_mass', 'Msun')
+   ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
+
+   p = yt.ParticleProjectionPlot(ds, 2, ["particle_mass"], width=(0.5, 0.5), depth=0.01)
+   p.set_unit("particle_mass", "Msun")
    p.save()
 
 and here is an example of using the ``data_source`` argument to :class:`~yt.visualization.particle_plots.ParticlePhasePlot`
 to only consider the particles that lie within a 50 kpc sphere around the domain center:
 
-.. python-script::
+.. code-block:: python
 
    import yt
+
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
 
    my_sphere = ds.sphere("c", (50.0, "kpc"))
 
-   p = yt.ParticlePhasePlot(my_sphere, "particle_velocity_x", "particle_velocity_y",
-                            "particle_mass")
-   p.set_unit('particle_velocity_x', 'km/s')
-   p.set_unit('particle_velocity_y', 'km/s')
-   p.set_unit('particle_mass', 'Msun')
+   p = yt.ParticlePhasePlot(
+       my_sphere, "particle_velocity_x", "particle_velocity_y", "particle_mass"
+   )
+   p.set_unit("particle_velocity_x", "km/s")
+   p.set_unit("particle_velocity_y", "km/s")
+   p.set_unit("particle_mass", "Msun")
    p.set_ylim(-400, 400)
    p.set_xlim(-400, 400)
 
@@ -1596,21 +1686,26 @@ create a :class:`~yt.visualization.particle_plots.ParticlePhasePlot` object usin
 we have also used the ``weight_field`` argument to compute the average ``particle_mass`` in each
 pixel, instead of the total:
 
-.. python-script::
+.. code-block:: python
 
    import yt
 
-   ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
+   ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
 
    ad = ds.all_data()
 
-   profile = yt.create_profile(ad, ['particle_velocity_x', 'particle_velocity_y'], ['particle_mass'],
-                               n_bins=800, weight_field='particle_ones')
+   profile = yt.create_profile(
+       ad,
+       ["particle_velocity_x", "particle_velocity_y"],
+       ["particle_mass"],
+       n_bins=800,
+       weight_field="particle_ones",
+   )
 
    p = yt.ParticlePhasePlot.from_profile(profile)
-   p.set_unit('particle_velocity_x', 'km/s')
-   p.set_unit('particle_velocity_y', 'km/s')
-   p.set_unit('particle_mass', 'Msun')
+   p.set_unit("particle_velocity_x", "km/s")
+   p.set_unit("particle_velocity_y", "km/s")
+   p.set_unit("particle_mass", "Msun")
    p.set_ylim(-400, 400)
    p.set_xlim(-400, 400)
    p.save()

--- a/doc/source/visualizing/streamlines.rst
+++ b/doc/source/visualizing/streamlines.rst
@@ -51,7 +51,7 @@ The implementation of streamlining  in yt is described below.
 Example Script
 ++++++++++++++
 
-.. python-script::
+.. code-block:: python
 
     import yt
     import numpy as np
@@ -62,7 +62,7 @@ Example Script
     from mpl_toolkits.mplot3d import Axes3D
 
     # Load the dataset
-    ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')
+    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
 
     # Define c: the center of the box, N: the number of streamlines,
     # scale: the spatial scale of the streamlines relative to the boxsize,
@@ -70,24 +70,31 @@ Example Script
     c = ds.domain_center
     N = 100
     scale = ds.domain_width[0]
-    pos_dx = np.random.random((N,3))*scale-scale/2.
-    pos = c+pos_dx
+    pos_dx = np.random.random((N, 3)) * scale - scale / 2.0
+    pos = c + pos_dx
 
     # Create streamlines of the 3D vector velocity and integrate them through
     # the box defined above
-    streamlines = Streamlines(ds, pos, 'velocity_x', 'velocity_y', 'velocity_z',
-                              length=1.0*Mpc, get_magnitude=True)
+    streamlines = Streamlines(
+        ds,
+        pos,
+        "velocity_x",
+        "velocity_y",
+        "velocity_z",
+        length=1.0 * Mpc,
+        get_magnitude=True,
+    )
     streamlines.integrate_through_volume()
 
     # Create a 3D plot, trace the streamlines through the 3D volume of the plot
-    fig=plt.figure()
+    fig = plt.figure()
     ax = Axes3D(fig)
     for stream in streamlines.streamlines:
         stream = stream[np.all(stream != 0.0, axis=1)]
-        ax.plot3D(stream[:,0], stream[:,1], stream[:,2], alpha=0.1)
+        ax.plot3D(stream[:, 0], stream[:, 1], stream[:, 2], alpha=0.1)
 
     # Save the plot to disk.
-    plt.savefig('streamlines.png')
+    plt.savefig("streamlines.png")
 
 
 Data Access Along the Streamline

--- a/doc/source/visualizing/unstructured_mesh_rendering.rst
+++ b/doc/source/visualizing/unstructured_mesh_rendering.rst
@@ -88,7 +88,7 @@ Examples
 
 First, here is an example of rendering an 8-node, hexahedral MOOSE dataset.
 
-.. python-script::
+.. code-block:: python
 
     import yt
 
@@ -99,13 +99,13 @@ First, here is an example of rendering an 8-node, hexahedral MOOSE dataset.
 
     # override the default colormap
     ms = sc.get_source()
-    ms.cmap = 'Eos A'
+    ms.cmap = "Eos A"
 
     # adjust the camera position and orientation
     cam = sc.camera
-    cam.focus = ds.arr([0.0, 0.0, 0.0], 'code_length')
-    cam_pos = ds.arr([-3.0, 3.0, -3.0], 'code_length')
-    north_vector = ds.arr([0.0, -1.0, -1.0], 'dimensionless')
+    cam.focus = ds.arr([0.0, 0.0, 0.0], "code_length")
+    cam_pos = ds.arr([-3.0, 3.0, -3.0], "code_length")
+    north_vector = ds.arr([0.0, -1.0, -1.0], "dimensionless")
     cam.set_position(cam_pos, north_vector)
 
     # increase the default resolution
@@ -116,7 +116,7 @@ First, here is an example of rendering an 8-node, hexahedral MOOSE dataset.
 
 You can also overplot the mesh boundaries:
 
-.. python-script::
+.. code-block:: python
 
     import yt
 
@@ -127,13 +127,13 @@ You can also overplot the mesh boundaries:
 
     # override the default colormap
     ms = sc.get_source()
-    ms.cmap = 'Eos A'
+    ms.cmap = "Eos A"
 
     # adjust the camera position and orientation
     cam = sc.camera
-    cam.focus = ds.arr([0.0, 0.0, 0.0], 'code_length')
-    cam_pos = ds.arr([-3.0, 3.0, -3.0], 'code_length')
-    north_vector = ds.arr([0.0, -1.0, -1.0], 'dimensionless')
+    cam.focus = ds.arr([0.0, 0.0, 0.0], "code_length")
+    cam_pos = ds.arr([-3.0, 3.0, -3.0], "code_length")
+    north_vector = ds.arr([0.0, -1.0, -1.0], "dimensionless")
     cam.set_position(cam_pos, north_vector)
 
     # increase the default resolution
@@ -148,24 +148,24 @@ As with slices, you can visualize different meshes and different fields. For exa
 Here is a script similar to the above that plots the "diffused" variable
 using the mesh labelled by "connect2":
 
-.. python-script::
+.. code-block:: python
 
     import yt
 
     ds = yt.load("MOOSE_sample_data/out.e-s010")
 
     # create a default scene
-    sc = yt.create_scene(ds, ('connect2', 'diffused'))
+    sc = yt.create_scene(ds, ("connect2", "diffused"))
 
     # override the default colormap
     ms = sc.get_source()
-    ms.cmap = 'Eos A'
+    ms.cmap = "Eos A"
 
     # adjust the camera position and orientation
     cam = sc.camera
-    cam.focus = ds.arr([0.0, 0.0, 0.0], 'code_length')
-    cam_pos = ds.arr([-3.0, 3.0, -3.0], 'code_length')
-    north_vector = ds.arr([0.0, -1.0, -1.0], 'dimensionless')
+    cam.focus = ds.arr([0.0, 0.0, 0.0], "code_length")
+    cam_pos = ds.arr([-3.0, 3.0, -3.0], "code_length")
+    north_vector = ds.arr([0.0, -1.0, -1.0], "dimensionless")
     cam.set_position(cam_pos, north_vector)
 
     # increase the default resolution
@@ -178,7 +178,7 @@ Next, here is an example of rendering a dataset with tetrahedral mesh elements.
 Note that in this dataset, there are multiple "steps" per file, so we specify
 that we want to look at the last one.
 
-.. python-script::
+.. code-block:: python
 
     import yt
 
@@ -190,13 +190,13 @@ that we want to look at the last one.
 
     # override the default colormap
     ms = sc.get_source()
-    ms.cmap = 'Eos A'
+    ms.cmap = "Eos A"
 
     # adjust the camera position and orientation
     cam = sc.camera
-    camera_position = ds.arr([3.0, 3.0, 3.0], 'code_length')
-    cam.set_width(ds.arr([2.0, 2.0, 2.0], 'code_length'))
-    north_vector = ds.arr([0.0, -1.0, 0.0], 'dimensionless')
+    camera_position = ds.arr([3.0, 3.0, 3.0], "code_length")
+    cam.set_width(ds.arr([2.0, 2.0, 2.0], "code_length"))
+    north_vector = ds.arr([0.0, -1.0, 0.0], "dimensionless")
     cam.set_position(camera_position, north_vector)
 
     # increase the default resolution
@@ -207,23 +207,23 @@ that we want to look at the last one.
 
 Here is an example using 6-node wedge elements:
 
-.. python-script::
+.. code-block:: python
 
    import yt
 
    ds = yt.load("MOOSE_sample_data/wedge_out.e")
 
    # create a default scene
-   sc = yt.create_scene(ds, ('connect2', 'diffused'))
+   sc = yt.create_scene(ds, ("connect2", "diffused"))
 
    # override the default colormap
    ms = sc.get_source()
-   ms.cmap = 'Eos A'
+   ms.cmap = "Eos A"
 
    # adjust the camera position and orientation
    cam = sc.camera
-   cam.set_position(ds.arr([1.0, -1.0, 1.0], 'code_length'))
-   cam.width = ds.arr([1.5, 1.5, 1.5], 'code_length')
+   cam.set_position(ds.arr([1.0, -1.0, 1.0], "code_length"))
+   cam.width = ds.arr([1.5, 1.5, 1.5], "code_length")
 
    # render and save
    sc.save()
@@ -231,7 +231,7 @@ Here is an example using 6-node wedge elements:
 Another example, this time plotting the temperature field from a 20-node hex
 MOOSE dataset:
 
-.. python-script::
+.. code-block:: python
 
     import yt
 
@@ -244,14 +244,14 @@ MOOSE dataset:
     # override the default colormap. This time we also override
     # the default color bounds
     ms = sc.get_source()
-    ms.cmap = 'hot'
+    ms.cmap = "hot"
     ms.color_bounds = (500.0, 1700.0)
 
     # adjust the camera position and orientation
     cam = sc.camera
-    camera_position = ds.arr([-1.0, 1.0, -0.5], 'code_length')
-    north_vector = ds.arr([0.0, -1.0, -1.0], 'dimensionless')
-    cam.width = ds.arr([0.04, 0.04, 0.04], 'code_length')
+    camera_position = ds.arr([-1.0, 1.0, -0.5], "code_length")
+    north_vector = ds.arr([0.0, -1.0, -1.0], "dimensionless")
+    cam.width = ds.arr([0.04, 0.04, 0.04], "code_length")
     cam.set_position(camera_position, north_vector)
 
     # increase the default resolution
@@ -267,13 +267,16 @@ opportunity to demonstrate their use. The following example is exactly like the
 above, except we scale the displacements by a factor of a 10.0, and additionally
 add an offset to the mesh by 1.0 unit in the x-direction:
 
-.. python-script::
+.. code-block:: python
 
     import yt
 
     # We load the last time frame
-    ds = yt.load("MOOSE_sample_data/mps_out.e", step=-1,
-                 displacements={'connect2': (10.0, [0.01, 0.0, 0.0])})
+    ds = yt.load(
+        "MOOSE_sample_data/mps_out.e",
+        step=-1,
+        displacements={"connect2": (10.0, [0.01, 0.0, 0.0])},
+    )
 
     # create a default scene
     sc = yt.create_scene(ds, ("connect2", "temp"))
@@ -281,14 +284,14 @@ add an offset to the mesh by 1.0 unit in the x-direction:
     # override the default colormap. This time we also override
     # the default color bounds
     ms = sc.get_source()
-    ms.cmap = 'hot'
+    ms.cmap = "hot"
     ms.color_bounds = (500.0, 1700.0)
 
     # adjust the camera position and orientation
     cam = sc.camera
-    camera_position = ds.arr([-1.0, 1.0, -0.5], 'code_length')
-    north_vector = ds.arr([0.0, -1.0, -1.0], 'dimensionless')
-    cam.width = ds.arr([0.05, 0.05, 0.05], 'code_length')
+    camera_position = ds.arr([-1.0, 1.0, -0.5], "code_length")
+    north_vector = ds.arr([0.0, -1.0, -1.0], "dimensionless")
+    cam.width = ds.arr([0.05, 0.05, 0.05], "code_length")
     cam.set_position(camera_position, north_vector)
 
     # increase the default resolution
@@ -303,7 +306,7 @@ As with other volume renderings in yt, you can swap out different lenses. Here i
 an example that uses a "perspective" lens, for which the rays diverge from the
 camera position according to some opening angle:
 
-.. python-script::
+.. code-block:: python
 
     import yt
 
@@ -314,13 +317,13 @@ camera position according to some opening angle:
 
     # override the default colormap
     ms = sc.get_source()
-    ms.cmap = 'Eos A'
+    ms.cmap = "Eos A"
 
     # Create a perspective Camera
-    cam = sc.add_camera(ds, lens_type='perspective')
-    cam.focus = ds.arr([0.0, 0.0, 0.0], 'code_length')
-    cam_pos = ds.arr([-4.5, 4.5, -4.5], 'code_length')
-    north_vector = ds.arr([0.0, -1.0, -1.0], 'dimensionless')
+    cam = sc.add_camera(ds, lens_type="perspective")
+    cam.focus = ds.arr([0.0, 0.0, 0.0], "code_length")
+    cam_pos = ds.arr([-4.5, 4.5, -4.5], "code_length")
+    north_vector = ds.arr([0.0, -1.0, -1.0], "dimensionless")
     cam.set_position(cam_pos, north_vector)
 
     # increase the default resolution
@@ -336,7 +339,7 @@ will keep track of the depth information for each source separately, and composi
 the final image accordingly. In the next example, we show how to render a scene
 with two meshes on it:
 
-.. python-script::
+.. code-block:: python
 
     import yt
     from yt.visualization.volume_rendering.api import MeshSource, Scene
@@ -348,15 +351,16 @@ with two meshes on it:
 
     # set up our Camera
     cam = sc.add_camera(ds)
-    cam.focus = ds.arr([0.0, 0.0, 0.0], 'code_length')
-    cam.set_position(ds.arr([-3.0, 3.0, -3.0], 'code_length'),
-                     ds.arr([0.0, -1.0, 0.0], 'dimensionless'))
-    cam.set_width = ds.arr([8.0, 8.0, 8.0], 'code_length')
+    cam.focus = ds.arr([0.0, 0.0, 0.0], "code_length")
+    cam.set_position(
+        ds.arr([-3.0, 3.0, -3.0], "code_length"), ds.arr([0.0, -1.0, 0.0], "dimensionless")
+    )
+    cam.set_width = ds.arr([8.0, 8.0, 8.0], "code_length")
     cam.resolution = (800, 800)
 
     # create two distinct MeshSources from 'connect1' and 'connect2'
-    ms1 = MeshSource(ds, ('connect1', 'diffused'))
-    ms2 = MeshSource(ds, ('connect2', 'diffused'))
+    ms1 = MeshSource(ds, ("connect1", "diffused"))
+    ms2 = MeshSource(ds, ("connect2", "diffused"))
 
     sc.add_source(ms1)
     sc.add_source(ms2)
@@ -372,7 +376,7 @@ This discontinuous color is due to an independent colormap setting for the two
 mesh sources. To fix it, we can explicitly specify the colormap bound for each
 mesh source as follows:
 
-.. python-script::
+.. code-block:: python
 
     import yt
     from yt.visualization.volume_rendering.api import MeshSource, Scene
@@ -384,15 +388,16 @@ mesh source as follows:
 
     # set up our Camera
     cam = sc.add_camera(ds)
-    cam.focus = ds.arr([0.0, 0.0, 0.0], 'code_length')
-    cam.set_position(ds.arr([-3.0, 3.0, -3.0], 'code_length'),
-                     ds.arr([0.0, -1.0, 0.0], 'dimensionless'))
-    cam.set_width = ds.arr([8.0, 8.0, 8.0], 'code_length')
+    cam.focus = ds.arr([0.0, 0.0, 0.0], "code_length")
+    cam.set_position(
+        ds.arr([-3.0, 3.0, -3.0], "code_length"), ds.arr([0.0, -1.0, 0.0], "dimensionless")
+    )
+    cam.set_width = ds.arr([8.0, 8.0, 8.0], "code_length")
     cam.resolution = (800, 800)
 
     # create two distinct MeshSources from 'connect1' and 'connect2'
-    ms1 = MeshSource(ds, ('connect1', 'diffused'))
-    ms2 = MeshSource(ds, ('connect2', 'diffused'))
+    ms1 = MeshSource(ds, ("connect1", "diffused"))
+    ms2 = MeshSource(ds, ("connect2", "diffused"))
 
     # add the following lines to set the range of the two mesh sources
     ms1.color_bounds = (0.0, 3.0)

--- a/doc/source/visualizing/volume_rendering.rst
+++ b/doc/source/visualizing/volume_rendering.rst
@@ -185,13 +185,13 @@ associated with a scene's ``VolumeSource`` to create an appealing transfer
 function between a physically motivated range of densities in a cosmological
 simulation:
 
-.. python-script::
+.. code-block:: python
 
    import yt
 
-   ds = yt.load('Enzo_64/DD0043/data0043')
+   ds = yt.load("Enzo_64/DD0043/data0043")
 
-   sc = yt.create_scene(ds, lens_type='perspective')
+   sc = yt.create_scene(ds, lens_type="perspective")
 
    # Get a reference to the VolumeSource associated with this scene
    # It is the first source associated with the scene, so we can refer to it
@@ -209,21 +209,21 @@ simulation:
 
    # Plot the transfer function, along with the CDF of the density field to
    # see how the transfer function corresponds to structure in the CDF
-   source.tfh.plot('transfer_function.png', profile_field='density')
+   source.tfh.plot("transfer_function.png", profile_field="density")
 
    # save the image, flooring especially bright pixels for better contrast
-   sc.save('rendering.png', sigma_clip=6.0)
+   sc.save("rendering.png", sigma_clip=6.0)
 
 For fun, let's make the same volume_rendering, but this time setting
 ``grey_opacity=False``, which will make overdense regions stand out more:
 
-.. python-script::
+.. code-block:: python
 
    import yt
 
-   ds = yt.load('Enzo_64/DD0043/data0043')
+   ds = yt.load("Enzo_64/DD0043/data0043")
 
-   sc = yt.create_scene(ds, lens_type='perspective')
+   sc = yt.create_scene(ds, lens_type="perspective")
 
    source = sc[0]
 
@@ -232,9 +232,9 @@ For fun, let's make the same volume_rendering, but this time setting
    source.tfh.set_log(True)
    source.tfh.grey_opacity = False
 
-   source.tfh.plot('transfer_function.png', profile_field='density')
+   source.tfh.plot("transfer_function.png", profile_field="density")
 
-   sc.save('rendering.png', sigma_clip=4.0)
+   sc.save("rendering.png", sigma_clip=4.0)
 
 To see a full example on how to use the ``TransferFunctionHelper`` interface,
 follow the annotated :ref:`transfer-function-helper-tutorial`.
@@ -266,18 +266,18 @@ The easiest way to create a ColorTransferFunction is to use the
 which will add evenly spaced isocontours along the transfer function, sampling a
 colormap to determine the colors of the layers.
 
-.. python-script::
+.. code-block:: python
 
    import numpy as np
    import yt
 
-   ds = yt.load('Enzo_64/DD0043/data0043')
+   ds = yt.load("Enzo_64/DD0043/data0043")
 
-   sc = yt.create_scene(ds, lens_type='perspective')
+   sc = yt.create_scene(ds, lens_type="perspective")
 
    source = sc[0]
 
-   source.set_field('density')
+   source.set_field("density")
    source.set_log(True)
 
    bounds = (3e-31, 5e-27)
@@ -286,14 +286,14 @@ colormap to determine the colors of the layers.
    # to be specified in log space.
    tf = yt.ColorTransferFunction(np.log10(bounds))
 
-   tf.add_layers(5, colormap='arbre')
+   tf.add_layers(5, colormap="arbre")
 
    source.tfh.tf = tf
    source.tfh.bounds = bounds
 
-   source.tfh.plot('transfer_function.png', profile_field='density')
+   source.tfh.plot("transfer_function.png", profile_field="density")
 
-   sc.save('rendering.png', sigma_clip=6)
+   sc.save("rendering.png", sigma_clip=6)
 
 sample_colormap
 """""""""""""""
@@ -301,18 +301,18 @@ sample_colormap
 To add a single gaussian layer with a color determined by a colormap value, use
 :meth:`~yt.visualization.volume_rendering.transfer_functions.ColorTransferFunction.sample_colormap`.
 
-.. python-script::
+.. code-block:: python
 
    import numpy as np
    import yt
 
-   ds = yt.load('Enzo_64/DD0043/data0043')
+   ds = yt.load("Enzo_64/DD0043/data0043")
 
-   sc = yt.create_scene(ds, lens_type='perspective')
+   sc = yt.create_scene(ds, lens_type="perspective")
 
    source = sc[0]
 
-   source.set_field('density')
+   source.set_field("density")
    source.set_log(True)
 
    bounds = (3e-31, 5e-27)
@@ -321,14 +321,14 @@ To add a single gaussian layer with a color determined by a colormap value, use
    # to be specified in log space.
    tf = yt.ColorTransferFunction(np.log10(bounds))
 
-   tf.sample_colormap(np.log10(1e-30), w=.01, colormap='arbre')
+   tf.sample_colormap(np.log10(1e-30), w=0.01, colormap="arbre")
 
    source.tfh.tf = tf
    source.tfh.bounds = bounds
 
-   source.tfh.plot('transfer_function.png', profile_field='density')
+   source.tfh.plot("transfer_function.png", profile_field="density")
 
-   sc.save('rendering.png', sigma_clip=6)
+   sc.save("rendering.png", sigma_clip=6)
 
 
 add_gaussian
@@ -337,18 +337,18 @@ add_gaussian
 If you would like to add a gaussian with a customized color or no color, use
 :meth:`~yt.visualization.volume_rendering.transfer_functions.ColorTransferFunction.add_gaussian`.
 
-.. python-script::
+.. code-block:: python
 
    import numpy as np
    import yt
 
-   ds = yt.load('Enzo_64/DD0043/data0043')
+   ds = yt.load("Enzo_64/DD0043/data0043")
 
-   sc = yt.create_scene(ds, lens_type='perspective')
+   sc = yt.create_scene(ds, lens_type="perspective")
 
    source = sc[0]
 
-   source.set_field('density')
+   source.set_field("density")
    source.set_log(True)
 
    bounds = (3e-31, 5e-27)
@@ -357,14 +357,14 @@ If you would like to add a gaussian with a customized color or no color, use
    # to be specified in log space.
    tf = yt.ColorTransferFunction(np.log10(bounds))
 
-   tf.add_gaussian(np.log10(1e-29), width=.005, height=[0.753, 1.0, 0.933, 1.0])
+   tf.add_gaussian(np.log10(1e-29), width=0.005, height=[0.753, 1.0, 0.933, 1.0])
 
    source.tfh.tf = tf
    source.tfh.bounds = bounds
 
-   source.tfh.plot('transfer_function.png', profile_field='density')
+   source.tfh.plot("transfer_function.png", profile_field="density")
 
-   sc.save('rendering.png', sigma_clip=6)
+   sc.save("rendering.png", sigma_clip=6)
 
 
 map_to_colormap
@@ -377,18 +377,18 @@ at a single alpha value. Where the above options produced layered volume
 renderings, this allows all of the density values in a dataset to contribute to
 the volume rendering.
 
-.. python-script::
+.. code-block:: python
 
    import numpy as np
    import yt
 
-   ds = yt.load('Enzo_64/DD0043/data0043')
+   ds = yt.load("Enzo_64/DD0043/data0043")
 
-   sc = yt.create_scene(ds, lens_type='perspective')
+   sc = yt.create_scene(ds, lens_type="perspective")
 
    source = sc[0]
 
-   source.set_field('density')
+   source.set_field("density")
    source.set_log(True)
 
    bounds = (3e-31, 5e-27)
@@ -397,18 +397,21 @@ the volume rendering.
    # to be specified in log space.
    tf = yt.ColorTransferFunction(np.log10(bounds))
 
-   def linramp(vals, minval, maxval):
-       return (vals - vals.min())/(vals.max() - vals.min())
 
-   tf.map_to_colormap(np.log10(3e-31), np.log10(5e-27), colormap='arbre',
-                      scale_func=linramp)
+   def linramp(vals, minval, maxval):
+       return (vals - vals.min()) / (vals.max() - vals.min())
+
+
+   tf.map_to_colormap(
+       np.log10(3e-31), np.log10(5e-27), colormap="arbre", scale_func=linramp
+   )
 
    source.tfh.tf = tf
    source.tfh.bounds = bounds
 
-   source.tfh.plot('transfer_function.png', profile_field='density')
+   source.tfh.plot("transfer_function.png", profile_field="density")
 
-   sc.save('rendering.png', sigma_clip=6)
+   sc.save("rendering.png", sigma_clip=6)
 
 Projection Transfer Function
 ++++++++++++++++++++++++++++
@@ -621,25 +624,26 @@ volume. Finally, the image and scene object is returned to the user. An example
 script the uses the high-level :func:`~yt.visualization.volume_rendering.volume_rendering.volume_render`
 function to quickly set up defaults is:
 
-.. python-script::
+.. code-block:: python
 
   import yt
+
   # load the data
   ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
 
   # volume render the 'density' field, and save the resulting image
-  im, sc = yt.volume_render(ds, 'density', fname='rendering.png')
+  im, sc = yt.volume_render(ds, "density", fname="rendering.png")
 
   # im is the image array generated. it is also saved to 'rendering.png'.
   # sc is an instance of a Scene object, which allows you to further refine
   # your renderings and later save them.
 
   # Let's zoom in and take a closer look
-  sc.camera.width = (300, 'kpc')
+  sc.camera.width = (300, "kpc")
   sc.camera.switch_orientation()
 
   # Save the zoomed in rendering
-  sc.save('zoomed_rendering.png')
+  sc.save("zoomed_rendering.png")
 
 Alternatively, if you don't want to immediately generate an image of your
 volume rendering, and you just want access to the default scene object,
@@ -649,25 +653,29 @@ function in lieu of the
 :func:`~yt.visualization.volume_rendering.volume_rendering.volume_render`
 function. Example:
 
-.. python-script::
+.. code-block:: python
 
     import numpy as np
     import yt
 
 
     ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
-    sc = yt.create_scene(ds, 'density')
+    sc = yt.create_scene(ds, "density")
 
     source = sc[0]
 
     source.transfer_function = yt.ColorTransferFunction(
-        np.log10((1e-30, 1e-23)), grey_opacity=True)
+        np.log10((1e-30, 1e-23)), grey_opacity=True
+    )
+
 
     def linramp(vals, minval, maxval):
-        return (vals - vals.min())/(vals.max() - vals.min())
+        return (vals - vals.min()) / (vals.max() - vals.min())
+
 
     source.transfer_function.map_to_colormap(
-        np.log10(1e-25), np.log10(8e-24), colormap='arbre', scale_func=linramp)
+        np.log10(1e-25), np.log10(8e-24), colormap="arbre", scale_func=linramp
+    )
 
     # For this low resolution dataset it's very important to use interpolated
     # vertex centered data to avoid artifacts. For high resolution data this
@@ -676,12 +684,12 @@ function. Example:
 
     cam = sc.camera
 
-    cam.width = 15*yt.units.kpc
+    cam.width = 15 * yt.units.kpc
     cam.focus = ds.domain_center
     cam.normal_vector = [-0.3, -0.3, 1]
     cam.switch_orientation()
 
-    sc.save('rendering.png')
+    sc.save("rendering.png")
 
 For an in-depth tutorial on how to create a Scene and modify its contents,
 see this annotated :ref:`volume-rendering-tutorial`.


### PR DESCRIPTION
## PR Summary

This is in reaction to #3206, which made me realise that our code formatter for documentation isn't working properly because some code blocks are specified as

```rst
.. python-script::
```
instead of
```rst
.. code-block:: python
```
This fixes those, and pre-commit + blacken-docs does the rest automatically.

edit: switching to draft after @cphyc brought to my attention that the `.. python-script::` directive isn't just an alias, and has special rules attached to it that allow these block to be run in parallel in the docs build.