### PR TITLE
fix a bug where set_background_color wouldn't work with colormaps from third party libs

### DIFF
--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -6,6 +6,7 @@ from functools import wraps
 
 import matplotlib
 import numpy as np
+from matplotlib.cm import get_cmap
 from more_itertools.more import always_iterable
 
 from yt._maintenance.deprecation import issue_deprecation_warning
@@ -16,7 +17,6 @@ from yt.units import YTQuantity
 from yt.units.unit_object import Unit
 from yt.utilities.definitions import formatted_length_unit_names
 from yt.utilities.exceptions import YTNotInsideNotebook
-from yt.visualization.color_maps import yt_colormaps
 
 from ._commons import validate_image_name
 
@@ -892,10 +892,7 @@ class ImagePlotContainer(PlotContainer):
         if color is None:
             cmap = self._colormap_config[field]
             if isinstance(cmap, str):
-                try:
-                    cmap = yt_colormaps[cmap]
-                except KeyError:
-                    cmap = getattr(matplotlib.cm, cmap)
+                cmap = get_cmap(cmap)
             color = cmap(0)
         self._background_color[field] = color
         return self


### PR DESCRIPTION
## PR Summary

fix #3208

edit: looks like my solution doesn't work across all versions of matplotlib.
For reference, I wrote it for ppl 3.3, now trying to generalise it.
edit 2: it also work with matplotlib 3.4
edit 3: should work for all currently supported versions of matplotlib now 🎉  (thanks to @cphyc  for his help in testing locally with "old" versions)
