### PR TITLE
implement a more useful __repr__ for the base Dataset class

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -330,6 +330,9 @@ class Dataset(abc.ABC):
         return (_reconstruct_ds, args)
 
     def __repr__(self):
+        return f"{self.__class__.__name__}: {self.parameter_filename}"
+
+    def __str__(self):
         return self.basename
 
     def _hash(self):

--- a/yt/frontends/art/data_structures.py
+++ b/yt/frontends/art/data_structures.py
@@ -201,7 +201,7 @@ class ARTDataset(Dataset):
             else:
                 setattr(self, "_file_" + filetype, None)
 
-    def __repr__(self):
+    def __str__(self):
         return self._file_amr.split("/")[-1]
 
     def _set_code_unit_attributes(self):
@@ -482,7 +482,7 @@ class DarkMatterARTDataset(ARTDataset):
             else:
                 setattr(self, "_file_" + filetype, None)
 
-    def __repr__(self):
+    def __str__(self):
         return self._file_particle.split("/")[-1]
 
     def _set_code_unit_attributes(self):

--- a/yt/frontends/athena/data_structures.py
+++ b/yt/frontends/athena/data_structures.py
@@ -639,5 +639,5 @@ class AthenaDataset(Dataset):
     def _skip_cache(self):
         return True
 
-    def __repr__(self):
+    def __str__(self):
         return self.basename.rsplit(".", 1)[0]

--- a/yt/frontends/athena_pp/data_structures.py
+++ b/yt/frontends/athena_pp/data_structures.py
@@ -367,5 +367,5 @@ class AthenaPPDataset(Dataset):
     def _skip_cache(self):
         return True
 
-    def __repr__(self):
+    def __str__(self):
         return self.basename.rsplit(".", 1)[0]

--- a/yt/frontends/enzo_p/data_structures.py
+++ b/yt/frontends/enzo_p/data_structures.py
@@ -459,7 +459,7 @@ class EnzoPDataset(Dataset):
         magnetic_unit = np.float64(magnetic_unit.in_cgs())
         setdefaultattr(self, "magnetic_unit", self.quan(magnetic_unit, "gauss"))
 
-    def __repr__(self):
+    def __str__(self):
         return self.basename[: -len(self._suffix)]
 
     @classmethod

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -336,7 +336,7 @@ class GadgetDataset(SPHDataset):
             spec = _hs
         return spec
 
-    def __repr__(self):
+    def __str__(self):
         return os.path.basename(self.parameter_filename).split(".")[0]
 
     def _get_hvals(self):

--- a/yt/frontends/gadget_fof/data_structures.py
+++ b/yt/frontends/gadget_fof/data_structures.py
@@ -291,7 +291,7 @@ class GadgetFOFDataset(ParticleDataset):
             time_unit = (tu.d, tu.units)
         setdefaultattr(self, "time_unit", self.quan(time_unit[0], time_unit[1]))
 
-    def __repr__(self):
+    def __str__(self):
         return self.basename.split(".", 1)[0]
 
     @classmethod
@@ -476,7 +476,7 @@ class GadgetFOFHaloDataset(ParticleDataset):
             my_unit = f"{unit}_unit"
             setattr(self, my_unit, getattr(self.real_ds, my_unit, None))
 
-    def __repr__(self):
+    def __str__(self):
         return f"{self.real_ds}"
 
     def _setup_classes(self):

--- a/yt/frontends/gdf/data_structures.py
+++ b/yt/frontends/gdf/data_structures.py
@@ -294,5 +294,5 @@ class GDFDataset(Dataset):
             pass
         return False
 
-    def __repr__(self):
+    def __str__(self):
         return self.basename.rsplit(".", 1)[0]

--- a/yt/frontends/halo_catalog/data_structures.py
+++ b/yt/frontends/halo_catalog/data_structures.py
@@ -360,7 +360,7 @@ class HaloDataset(ParticleDataset):
             setattr(self, my_unit, getattr(self.real_ds, my_unit, None))
         self.unit_registry = self.real_ds.unit_registry
 
-    def __repr__(self):
+    def __str__(self):
         return f"{self.real_ds}"
 
     def _setup_classes(self):

--- a/yt/frontends/http_stream/data_structures.py
+++ b/yt/frontends/http_stream/data_structures.py
@@ -39,7 +39,7 @@ class HTTPStreamDataset(ParticleDataset):
             index_filename=index_filename,
         )
 
-    def __repr__(self):
+    def __str__(self):
         return self.base_url
 
     def _parse_parameter_file(self):

--- a/yt/frontends/moab/data_structures.py
+++ b/yt/frontends/moab/data_structures.py
@@ -100,7 +100,7 @@ class MoabHex8Dataset(Dataset):
     def _is_valid(cls, filename, *args, **kwargs):
         return filename.endswith(".h5m")
 
-    def __repr__(self):
+    def __str__(self):
         return self.basename.rsplit(".", 1)[0]
 
 
@@ -200,5 +200,5 @@ class PyneMoabHex8Dataset(Dataset):
     def _is_valid(cls, filename, *args, **kwargs):
         return False
 
-    def __repr__(self):
+    def __str__(self):
         return self.basename.rsplit(".", 1)[0]

--- a/yt/frontends/open_pmd/data_structures.py
+++ b/yt/frontends/open_pmd/data_structures.py
@@ -59,7 +59,7 @@ class OpenPMDGrid(AMRGridPatch):
         self.Children = []
         self.Level = level
 
-    def __repr__(self):
+    def __str__(self):
         return "OpenPMDGrid_%04i (%s)" % (self.id, self.ActiveDimensions)
 
 

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -785,7 +785,7 @@ class RAMSESDataset(Dataset):
                 mylog.info("Adding particle_type: %s", k)
                 self.add_particle_filter(f"{k}")
 
-    def __repr__(self):
+    def __str__(self):
         return self.basename.rsplit(".", 1)[0]
 
     def _set_code_unit_attributes(self):

--- a/yt/frontends/tipsy/data_structures.py
+++ b/yt/frontends/tipsy/data_structures.py
@@ -109,7 +109,7 @@ class TipsyDataset(SPHDataset):
             kernel_name=kernel_name,
         )
 
-    def __repr__(self):
+    def __str__(self):
         return os.path.basename(self.parameter_filename)
 
     def _parse_parameter_file(self):


### PR DESCRIPTION
## PR Summary

Try to implement an idea mentioned in https://github.com/yt-project/yt/issues/2737#issuecomment-765740805

Following the insight from the accepted answer in https://stackoverflow.com/questions/1436703/what-is-the-difference-between-str-and-repr

I'm proposing this small change that I think will help in inspecting datasets in REPLs, while hopefully avoiding breakage in any code that relies on the current implem e.g. to format strings.

To be clear on what this (doesn't) change(s), lets run this script
```python
import yt

ds = yt.load_sample("ToroShockTube")  # our tiniest data sample <3
print("raw printing")
print(ds)

print("\nconverting to str")
print(str(ds))

print("\nusing string formatting")
print(f"{ds}")

# simulate what happens if one runs the following line in any REPL (python, IPython, Jupiter Notebook, Jupyter Lab...)
# >>> ds
print("\ncalling __repr__")
print(ds.__repr__())
```

output (main branch) (cutting out logging outputs)
```
raw printing
data0001

converting to str
data0001

using string formatting
data0001

calling repr
data0001
```

this branch
```
raw printing
data0001

converting to str
data0001

using string formatting
data0001

calling repr
EnzoDataset: /Users/robcleme/dev/yt-project/testdata/ToroShockTube/DD0001/data0001
```