### PR TITLE
remove a log warning that cannot be acted upon

### DIFF
--- a/yt/fields/fluid_fields.py
+++ b/yt/fields/fluid_fields.py
@@ -1,7 +1,5 @@
 import numpy as np
 
-from yt.funcs import mylog
-from yt.geometry.geometry_handler import is_curvilinear
 from yt.units.unit_object import Unit
 from yt.utilities.chemical_formulas import default_mu
 from yt.utilities.lib.misc_utilities import obtain_relative_velocity_vector
@@ -255,14 +253,6 @@ def setup_fluid_fields(registry, ftype="gas", slice_info=None):
 
 
 def setup_gradient_fields(registry, grad_field, field_units, slice_info=None):
-
-    geom = registry.ds.geometry
-    if is_curvilinear(geom):
-        mylog.warning(
-            "In %s geometry, gradient fields may contain "
-            "artifacts near cartesian axes.",
-            geom,
-        )
 
     assert isinstance(grad_field, tuple)
     ftype, fname = grad_field


### PR DESCRIPTION
## PR Summary

I wrote this warning a year ago when I added support for gradient computations in curvilinear geometries.
I now find that this warning provides little benefit, and breaks the rule that warnings should be emitted when and if the user is able to act upon them, which isn't the case here.
It also tends to discourage users to report errors this may be hiding.
What's more, it's also showing up quite a lot in our CI logs and makes any actual warning that we _should_ care about less discoverable.
Overall I think it creates way more problems than it solves.