### PR TITLE
do not automatically create a global configuration file/dirs when it is not found

### DIFF
--- a/yt/config.py
+++ b/yt/config.py
@@ -1,5 +1,6 @@
 import os
 import warnings
+from pathlib import Path
 
 import toml
 from more_itertools import always_iterable
@@ -157,17 +158,13 @@ class YTConfig:
 
         return file_names_read
 
-    def write(self, file_handler):
+    def write(self, filename):
         value = self.config_root.as_dict()
         config_as_str = toml.dumps(value)
 
-        try:
-            # Assuming file_handler has a write attribute
-            file_handler.write(config_as_str)
-        except AttributeError:
-            # Otherwise we expect a path to a file
-            with open(file_handler, mode="w") as fh:
-                fh.write(config_as_str)
+        os.makedirs(Path(filename).parent, exist_ok=True)
+        with open(filename, mode="w") as fh:
+            fh.write(config_as_str)
 
     @staticmethod
     def get_global_config_file():

--- a/yt/config.py
+++ b/yt/config.py
@@ -1,5 +1,4 @@
 import os
-import warnings
 from pathlib import Path
 
 import toml
@@ -212,16 +211,6 @@ if os.path.exists(old_config_file()):
             since="4.0.0",
             removal="4.1.0",
         )
-
-
-if not os.path.exists(_global_config_file):
-    cfg = {"yt": {}}
-    try:
-        with open(_global_config_file, mode="w") as fd:
-            toml.dump(cfg, fd)
-    except OSError:
-        warnings.warn("unable to write new config file")
-
 
 # Load the config
 ytcfg = YTConfig()

--- a/yt/config.py
+++ b/yt/config.py
@@ -158,13 +158,13 @@ class YTConfig:
 
         return file_names_read
 
-    def write(self, filename):
-        value = self.config_root.as_dict()
-        config_as_str = toml.dumps(value)
+    def dumps(self) -> str:
+        return toml.dumps(self.config_root.as_dict())
 
+    def write(self, filename):
         os.makedirs(Path(filename).parent, exist_ok=True)
         with open(filename, mode="w") as fh:
-            fh.write(config_as_str)
+            fh.write(self.dumps())
 
     @staticmethod
     def get_global_config_file():

--- a/yt/config.py
+++ b/yt/config.py
@@ -72,11 +72,6 @@ def config_dir():
     )
     conf_dir = os.path.join(config_root, "yt")
 
-    if not os.path.exists(conf_dir):
-        try:
-            os.makedirs(conf_dir)
-        except OSError:
-            warnings.warn("unable to create yt config directory")
     return conf_dir
 
 

--- a/yt/fields/tests/test_fields_plugins.py
+++ b/yt/fields/tests/test_fields_plugins.py
@@ -36,6 +36,7 @@ class TestPluginFile(unittest.TestCase):
         cls.xdg_config_home = os.environ.get("XDG_CONFIG_HOME")
         cls.tmpdir = tempfile.mkdtemp()
         os.environ["XDG_CONFIG_HOME"] = cls.tmpdir
+        os.makedirs(config_dir())
         with open(YTConfig.get_global_config_file(), mode="w") as fh:
             fh.write(_DUMMY_CFG_TOML)
         cls.plugin_path = os.path.join(config_dir(), ytcfg.get("yt", "plugin_filename"))

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -1670,7 +1670,7 @@ class YTConfigLocalConfigHandler:
 
         self.config_file = config_file
         if config_file is None:
-            print("INFO: no configuration file available")
+            print("INFO: no configuration file available", file=sys.stderr)
         else:
             CONFIG.read(config_file)
 

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -1666,7 +1666,7 @@ class YTConfigLocalConfigHandler:
             elif global_exists:
                 config_file = global_config_file
             if config_file is not None:
-                sys.stderr.write(f"INFO: using configuration file: {config_file}.\n")
+                sys.stderr.write(f"INFO: loading configuration from {config_file}\n")
 
         self.config_file = config_file
         if config_file is not None:

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -1645,6 +1645,7 @@ class YTConfigLocalConfigHandler:
         elif getattr(args, "global", False):
             config_file = global_config_file
         else:
+            config_file = None
             if local_exists and global_exists:
                 s = (
                     "Yt detected a local and a global configuration file, refusing "
@@ -1662,9 +1663,10 @@ class YTConfigLocalConfigHandler:
                 sys.exit(s)
             elif local_exists:
                 config_file = local_config_file
-            else:
+            elif global_exists:
                 config_file = global_config_file
-            sys.stderr.write(f"INFO: using configuration file: {config_file}.\n")
+            if config_file is not None:
+                sys.stderr.write(f"INFO: using configuration file: {config_file}.\n")
 
         try:
             CONFIG.read(config_file)

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -1668,11 +1668,9 @@ class YTConfigLocalConfigHandler:
             if config_file is not None:
                 sys.stderr.write(f"INFO: using configuration file: {config_file}.\n")
 
-        try:
+        self.config_file = config_file
+        if config_file is not None:
             CONFIG.read(config_file)
-            self.config_file = config_file
-        except FileNotFoundError:
-            self.config_file = None
 
 
 _global_local_args = [

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -1666,13 +1666,11 @@ class YTConfigLocalConfigHandler:
                 config_file = global_config_file
             sys.stderr.write(f"INFO: using configuration file: {config_file}.\n")
 
-        if not os.path.exists(config_file):
-            with open(config_file, "w") as f:
-                f.write("[yt]\n")
-
-        CONFIG.read(config_file)
-
-        self.config_file = config_file
+        try:
+            CONFIG.read(config_file)
+            self.config_file = config_file
+        except FileNotFoundError:
+            self.config_file = None
 
 
 _global_local_args = [

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -1669,7 +1669,9 @@ class YTConfigLocalConfigHandler:
                 sys.stderr.write(f"INFO: loading configuration from {config_file}\n")
 
         self.config_file = config_file
-        if config_file is not None:
+        if config_file is None:
+            print("INFO: no configuration file available")
+        else:
             CONFIG.read(config_file)
 
 
@@ -1755,7 +1757,7 @@ class YTConfigListCmd(YTCommand, YTConfigLocalConfigHandler):
         from yt.utilities.configure import print_config
 
         self.load_config(args)
-        print_config(file=sys.stdout)
+        print_config(filter_sources=["defaults", "runtime"], file=sys.stdout)
 
 
 class YTConfigMigrateCmd(YTCommand, YTConfigLocalConfigHandler):

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -1752,11 +1752,10 @@ class YTConfigListCmd(YTCommand, YTConfigLocalConfigHandler):
     args = _global_local_args
 
     def __call__(self, args):
-        from yt.utilities.configure import write_config
+        from yt.utilities.configure import print_config
 
         self.load_config(args)
-
-        write_config(sys.stdout)
+        print_config(file=sys.stdout)
 
 
 class YTConfigMigrateCmd(YTCommand, YTConfigLocalConfigHandler):

--- a/yt/utilities/configure.py
+++ b/yt/utilities/configure.py
@@ -2,9 +2,9 @@ import configparser
 import os
 import sys
 
-from yt.config import YTConfig, old_config_file, ytcfg_defaults
+from yt.config import YTConfig, old_config_file, ytcfg, ytcfg_defaults
 
-CONFIG = YTConfig()
+CONFIG = ytcfg
 
 
 def _cast_bool_helper(value):

--- a/yt/utilities/configure.py
+++ b/yt/utilities/configure.py
@@ -47,6 +47,10 @@ def write_config(config_file):
     CONFIG.write(config_file)
 
 
+def print_config(file=None):
+    print(CONFIG.dumps(), file=file)
+
+
 def migrate_config():
     if not os.path.exists(old_config_file()):
         print("Old config not found.")

--- a/yt/utilities/configure.py
+++ b/yt/utilities/configure.py
@@ -48,7 +48,10 @@ def write_config(config_file):
 
 
 def print_config(file=None):
-    print(CONFIG.dumps(), file=file)
+    conf_as_str = CONFIG.dumps()
+    if conf_as_str:
+        # print nothing if the config happens to be empty
+        print(conf_as_str, file=file)
 
 
 def migrate_config():

--- a/yt/utilities/configure.py
+++ b/yt/utilities/configure.py
@@ -2,7 +2,7 @@ import configparser
 import os
 import sys
 
-from yt.config import YTConfig, old_config_file, ytcfg, ytcfg_defaults
+from yt.config import YTConfig, config_dir, old_config_file, ytcfg, ytcfg_defaults
 
 CONFIG = ytcfg
 
@@ -44,6 +44,9 @@ def set_config(section, option, value, config_file):
 
 
 def write_config(config_file):
+    if config_file is None:
+        config_file = os.path.join(config_dir(), "yt.toml")
+        print(f"INFO: writing configuration to {config_file}", file=sys.stderr)
     CONFIG.write(config_file)
 
 

--- a/yt/utilities/configure.py
+++ b/yt/utilities/configure.py
@@ -47,8 +47,8 @@ def write_config(config_file):
     CONFIG.write(config_file)
 
 
-def print_config(file=None):
-    conf_as_str = CONFIG.dumps()
+def print_config(filter_sources=None, file=None):
+    conf_as_str = CONFIG.dumps(filter_sources)
     if conf_as_str:
         # print nothing if the config happens to be empty
         print(conf_as_str, file=file)

--- a/yt/utilities/tests/test_config.py
+++ b/yt/utilities/tests/test_config.py
@@ -7,6 +7,8 @@ import unittest
 import unittest.mock as mock
 from io import StringIO
 
+import toml
+
 import yt.config
 import yt.utilities.command_line
 from yt.config import YTConfig, config_dir, old_config_file
@@ -141,6 +143,20 @@ class TestYTConfigCommands(TestYTConfig):
         assert info["rc"] == 0
         assert info["stdout"] == "arbre\n"
         assert info["stderr"] == "INFO: no configuration file available\n"
+
+    def test_set_from_missing_config_file(self):
+        assert not os.path.exists(config_dir())
+        info = self._runYTConfig(["set", "yt", "default_colormap", "RdBu"])
+        assert info["rc"] == 0
+        assert info["stdout"] == ""
+        assert info["stderr"] == (
+            "INFO: no configuration file available\n"
+            f"INFO: writing configuration to {YTConfig.get_global_config_file()}\n"
+        )
+        self.assertEqual(
+            toml.load(YTConfig.get_global_config_file()),
+            {"yt": {"default_colormap": "RdBu"}},
+        )
 
     def tearDown(self):
         if os.path.exists(YTConfig.get_global_config_file()):

--- a/yt/utilities/tests/test_config.py
+++ b/yt/utilities/tests/test_config.py
@@ -135,6 +135,13 @@ class TestYTConfigCommands(TestYTConfig):
         self._testKeyTypeError("foo.bar", 10, 20, expect_error=False)
         self._testKeyTypeError("foo.bar", "foo", "bar", expect_error=False)
 
+    def test_get_from_missing_config_file(self):
+        assert not os.path.exists(config_dir())
+        info = self._runYTConfig(["get", "yt", "default_colormap"])
+        assert info["retcode"] == 0
+        assert info["stdout"] == "arbre\n"
+        assert info["stderr"] == ""
+
     def tearDown(self):
         if os.path.exists(YTConfig.get_global_config_file()):
             os.remove(YTConfig.get_global_config_file())

--- a/yt/utilities/tests/test_config.py
+++ b/yt/utilities/tests/test_config.py
@@ -138,7 +138,7 @@ class TestYTConfigCommands(TestYTConfig):
     def test_get_from_missing_config_file(self):
         assert not os.path.exists(config_dir())
         info = self._runYTConfig(["get", "yt", "default_colormap"])
-        assert info["retcode"] == 0
+        assert info["rc"] == 0
         assert info["stdout"] == "arbre\n"
         assert info["stderr"] == ""
 

--- a/yt/utilities/tests/test_config.py
+++ b/yt/utilities/tests/test_config.py
@@ -140,7 +140,7 @@ class TestYTConfigCommands(TestYTConfig):
         info = self._runYTConfig(["get", "yt", "default_colormap"])
         assert info["rc"] == 0
         assert info["stdout"] == "arbre\n"
-        assert info["stderr"] == ""
+        assert info["stderr"] == "INFO: no configuration file available\n"
 
     def tearDown(self):
         if os.path.exists(YTConfig.get_global_config_file()):

--- a/yt/utilities/tests/test_config.py
+++ b/yt/utilities/tests/test_config.py
@@ -9,7 +9,7 @@ from io import StringIO
 
 import yt.config
 import yt.utilities.command_line
-from yt.config import YTConfig, old_config_file
+from yt.config import YTConfig, config_dir, old_config_file
 
 _TEST_PLUGIN = "_test_plugin.py"
 # NOTE: the normalization of the crazy camel-case will be checked
@@ -145,6 +145,7 @@ class TestYTConfigGlobalLocal(TestYTConfig):
         super().setUp()
         with open(YTConfig.get_local_config_file(), mode="w") as f:
             f.writelines("[yt]\n")
+        os.makedirs(config_dir())
         with open(YTConfig.get_global_config_file(), mode="w") as f:
             f.writelines("[yt]\n")
 

--- a/yt/utilities/tests/test_config.py
+++ b/yt/utilities/tests/test_config.py
@@ -138,20 +138,23 @@ class TestYTConfigCommands(TestYTConfig):
         self._testKeyTypeError("foo.bar", "foo", "bar", expect_error=False)
 
     def test_get_from_missing_config_file(self):
-        assert not os.path.exists(config_dir())
+        self.assertFalse(os.path.exists(config_dir()))
         info = self._runYTConfig(["get", "yt", "default_colormap"])
-        assert info["rc"] == 0
-        assert info["stdout"] == "arbre\n"
-        assert info["stderr"] == "INFO: no configuration file available\n"
+        self.assertEqual(info["rc"], 0)
+        self.assertEqual(info["stdout"], "arbre\n")
+        self.assertEqual(info["stderr"], "INFO: no configuration file available\n")
 
     def test_set_from_missing_config_file(self):
-        assert not os.path.exists(config_dir())
+        self.assertFalse(os.path.exists(config_dir()))
         info = self._runYTConfig(["set", "yt", "default_colormap", "RdBu"])
-        assert info["rc"] == 0
-        assert info["stdout"] == ""
-        assert info["stderr"] == (
-            "INFO: no configuration file available\n"
-            f"INFO: writing configuration to {YTConfig.get_global_config_file()}\n"
+        self.assertEqual(info["rc"], 0)
+        self.assertEqual(info["stdout"], "")
+        self.assertEqual(
+            info["stderr"],
+            (
+                "INFO: no configuration file available\n"
+                f"INFO: writing configuration to {YTConfig.get_global_config_file()}\n"
+            ),
         )
         self.assertEqual(
             toml.load(YTConfig.get_global_config_file()),


### PR DESCRIPTION
## PR Summary

this is an implementation of the change I proposed in #3045
I wouldn't be surprised that the naive approach breaks a test or two, but maybe it won't. If it does, I hope it will still be easy to fix the places where we currently can't recover from a state where the config file simply doesn't exist, if any.
