### PR TITLE
cleanup pylab-based code (switch to matplotlib.pyplot)

### DIFF
--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -86,7 +86,9 @@ class YTStreamline(YTSelectionContainer1D):
     >>> streamlines = Streamlines(ds, [0.5]*3)
     >>> streamlines.integrate_through_volume()
     >>> stream = streamlines.path(0)
-    >>> matplotlib.pylab.semilogy(stream['t'], stream[('gas', 'density')], '-x')
+    >>> fig, ax = plt.subplots()
+    >>> ax.set_yscale("log")
+    >>> ax.plot(stream['t'], stream[('gas', 'density')], '-x')
 
     """
 

--- a/yt/geometry/geometry_handler.py
+++ b/yt/geometry/geometry_handler.py
@@ -244,6 +244,8 @@ class Index(ParallelAnalysisInterface, abc.ABC):
 
 
 def cached_property(func):
+    # TODO: remove this once minimal supported version of Python reaches 3.8
+    # and replace with functools.cached
     n = f"_{func.__name__}"
 
     def cached_func(self):

--- a/yt/visualization/streamlines.py
+++ b/yt/visualization/streamlines.py
@@ -229,7 +229,9 @@ class Streamlines(ParallelAnalysisInterface):
         >>> streamlines = Streamlines(ds, [0.5]*3)
         >>> streamlines.integrate_through_volume()
         >>> stream = streamlines.path(0)
-        >>> matplotlib.pylab.semilogy(stream['t'], stream[('gas', 'density')], '-x')
+        >>> fig, ax = plt.subplots()
+        >>> ax.set_yscale("log")
+        >>> ax.plot(stream['t'], stream[('gas', 'density')], '-x')
 
         """
         return YTStreamline(

--- a/yt/visualization/volume_rendering/image_handling.py
+++ b/yt/visualization/volume_rendering/image_handling.py
@@ -75,31 +75,34 @@ def plot_channel(
     elements.  Optionally, *label*, *label_color* and *label_size* may be
     specified.
     """
-    import matplotlib
-    import pylab
+    from matplotlib import pyplot as plt
+    from matplotlib.cm import get_cmap
+    from matplotlib.colors import LogNorm
 
     Nvec = image.shape[0]
     image[np.isnan(image)] = 0.0
     ma = image[image > 0.0].max()
     image[image == 0.0] = ma * zero_factor
     if log:
-        mynorm = matplotlib.colors.LogNorm(ma / (10.0 ** dex), ma)
+        mynorm = LogNorm(ma / (10.0 ** dex), ma)
 
-    pylab.clf()
-    pylab.gcf().set_dpi(100)
-    pylab.gcf().set_size_inches((Nvec / 100.0, Nvec / 100.0))
-    pylab.gcf().subplots_adjust(
+    fig = plt.gcf()
+    ax = plt.gca()
+    fig.clf()
+    fig.set_dpi(100)
+    fig.set_size_inches((Nvec / 100.0, Nvec / 100.0))
+    fig.subplots_adjust(
         left=0.0, right=1.0, bottom=0.0, top=1.0, wspace=0.0, hspace=0.0
     )
-    mycm = pylab.cm.get_cmap(cmap)
+    mycm = get_cmap(cmap)
     if log:
-        pylab.imshow(image, cmap=mycm, norm=mynorm, interpolation="nearest")
+        ax.imshow(image, cmap=mycm, norm=mynorm, interpolation="nearest")
     else:
-        pylab.imshow(image, cmap=mycm, interpolation="nearest")
+        ax.imshow(image, cmap=mycm, interpolation="nearest")
     if label is not None:
-        pylab.text(20, 20, label, color=label_color, size=label_size)
-    pylab.savefig(f"{name}_{cmap}.png")
-    pylab.clf()
+        ax.text(20, 20, label, color=label_color, size=label_size)
+    fig.savefig(f"{name}_{cmap}.png")
+    fig.clf()
 
 
 def plot_rgb(image, name, label=None, label_color="w", label_size="large"):
@@ -109,20 +112,23 @@ def plot_rgb(image, name, label=None, label_color="w", label_size="large"):
     with "_rgb.png."  *label*, *label_color* and *label_size* may also be
     specified.
     """
-    import pylab
+    import matplotlib.pyplot as plt
 
     Nvec = image.shape[0]
     image[np.isnan(image)] = 0.0
     if image.shape[2] >= 4:
         image = image[:, :, :3]
-    pylab.clf()
-    pylab.gcf().set_dpi(100)
-    pylab.gcf().set_size_inches((Nvec / 100.0, Nvec / 100.0))
-    pylab.gcf().subplots_adjust(
+
+    fig = plt.gcf()
+    ax = plt.gca()
+    fig.clf()
+    fig.set_dpi(100)
+    fig.set_size_inches((Nvec / 100.0, Nvec / 100.0))
+    fig.subplots_adjust(
         left=0.0, right=1.0, bottom=0.0, top=1.0, wspace=0.0, hspace=0.0
     )
-    pylab.imshow(image, interpolation="nearest")
+    ax.imshow(image, interpolation="nearest")
     if label is not None:
-        pylab.text(20, 20, label, color=label_color, size=label_size)
-    pylab.savefig(f"{name}_rgb.png")
-    pylab.clf()
+        ax.text(20, 20, label, color=label_color, size=label_size)
+    fig.savefig(f"{name}_rgb.png")
+    fig.clf()

--- a/yt/visualization/volume_rendering/old_camera.py
+++ b/yt/visualization/volume_rendering/old_camera.py
@@ -1191,15 +1191,13 @@ class InteractiveCamera(Camera):
     frames = []
 
     def snapshot(self, fn=None, clip_ratio=None):
-        import matplolib.pyplot as plt
-
-        plt.figure(2)
+        self._pyplot.figure(2)
         self.transfer_function.show()
-        plt.draw()
+        self._pyplot.draw()
         im = Camera.snapshot(self, fn, clip_ratio)
-        plt.figure(1)
-        plt.imshow(im / im.max())
-        plt.draw()
+        self._pyplot.figure(1)
+        self._pyplot.imshow(im / im.max())
+        self._pyplot.draw()
         self.frames.append(im)
 
     def rotation(self, theta, n_steps, rot_vector=None):

--- a/yt/visualization/volume_rendering/old_camera.py
+++ b/yt/visualization/volume_rendering/old_camera.py
@@ -1,12 +1,12 @@
 import builtins
 from copy import deepcopy
-from functools import cached_property
 
 import numpy as np
 
 from yt.config import ytcfg
 from yt.data_objects.api import ImageArray
 from yt.funcs import ensure_numpy_array, get_num_threads, get_pbar, is_sequence, mylog
+from yt.geometry.geometry_handler import cached_property
 from yt.units.yt_array import YTArray
 from yt.utilities.amr_kdtree.api import AMRKDTree
 from yt.utilities.exceptions import YTNotInsideNotebook

--- a/yt/visualization/volume_rendering/old_camera.py
+++ b/yt/visualization/volume_rendering/old_camera.py
@@ -1,5 +1,6 @@
 import builtins
 from copy import deepcopy
+from functools import cached_property
 
 import numpy as np
 
@@ -145,7 +146,6 @@ class Camera(ParallelAnalysisInterface):
 
     """
     _sampler_object = VolumeRenderSampler
-    _pylab = None
     _tf_figure = None
     _render_figure = None
 
@@ -728,22 +728,24 @@ class Camera(ParallelAnalysisInterface):
         image = self.finalize_image(image)
         return image
 
-    def show_tf(self):
-        if self._pylab is None:
-            import pylab
+    @cached_property
+    def _pyplot(self):
+        from matplotlib import pyplot
 
-            self._pylab = pylab
+        return pyplot
+
+    def show_tf(self):
         if self._tf_figure is None:
-            self._tf_figure = self._pylab.figure(2)
+            self._tf_figure = self._pyplot.figure(2)
             self.transfer_function.show(ax=self._tf_figure.axes)
-        self._pylab.draw()
+        self._pyplot.draw()
 
     def annotate(self, ax, enhance=True, label_fmt=None):
         ax.get_xaxis().set_visible(False)
         ax.get_xaxis().set_ticks([])
         ax.get_yaxis().set_visible(False)
         ax.get_yaxis().set_ticks([])
-        cb = self._pylab.colorbar(
+        cb = self._pyplot.colorbar(
             ax.images[0], pad=0.0, fraction=0.05, drawedges=True, shrink=0.9
         )
         label = self.ds._get_field_info(self.fields[0]).get_label()
@@ -752,12 +754,8 @@ class Camera(ParallelAnalysisInterface):
         self.transfer_function.vert_cbar(ax=cb.ax, label=label, label_fmt=label_fmt)
 
     def show_mpl(self, im, enhance=True, clear_fig=True):
-        if self._pylab is None:
-            import pylab
-
-            self._pylab = pylab
         if self._render_figure is None:
-            self._render_figure = self._pylab.figure(1)
+            self._render_figure = self._pyplot.figure(1)
         if clear_fig:
             self._render_figure.clf()
 
@@ -769,11 +767,11 @@ class Camera(ParallelAnalysisInterface):
             del nz
         else:
             nim = im
-        ax = self._pylab.imshow(nim[:, :, :3] / nim[:, :, :3].max(), origin="upper")
+        ax = self._pyplot.imshow(nim[:, :, :3] / nim[:, :, :3].max(), origin="upper")
         return ax
 
     def draw(self):
-        self._pylab.draw()
+        self._pyplot.draw()
 
     def save_annotated(
         self, fn, image, enhance=True, dpi=100, clear_fig=True, label_fmt=None
@@ -792,7 +790,7 @@ class Camera(ParallelAnalysisInterface):
         dpi : int, optional
            Dots per inch in the output image (default: 100)
         clear_fig : bool, optional
-           Reset the figure (through pylab.clf()) before drawing.  Setting
+           Reset the figure (through matplotlib.pyplot.clf()) before drawing.  Setting
            this to false can allow us to overlay the image onto an
            existing figure
         label_fmt : str, optional
@@ -803,7 +801,7 @@ class Camera(ParallelAnalysisInterface):
         image = image.swapaxes(0, 1)
         ax = self.show_mpl(image, enhance=enhance, clear_fig=clear_fig)
         self.annotate(ax.axes, enhance, label_fmt=label_fmt)
-        self._pylab.savefig(fn, bbox_inches="tight", facecolor="black", dpi=dpi)
+        self._pyplot.savefig(fn, bbox_inches="tight", facecolor="black", dpi=dpi)
 
     def save_image(self, image, fn=None, clip_ratio=None, transparent=False):
         if self.comm.rank == 0 and fn is not None:
@@ -1193,15 +1191,15 @@ class InteractiveCamera(Camera):
     frames = []
 
     def snapshot(self, fn=None, clip_ratio=None):
-        from matplotlib import pylab as pylab
+        import matplolib.pyplot as plt
 
-        pylab.figure(2)
+        plt.figure(2)
         self.transfer_function.show()
-        pylab.draw()
+        plt.draw()
         im = Camera.snapshot(self, fn, clip_ratio)
-        pylab.figure(1)
-        pylab.imshow(im / im.max())
-        pylab.draw()
+        plt.figure(1)
+        plt.imshow(im / im.max())
+        plt.draw()
         self.frames.append(im)
 
     def rotation(self, theta, n_steps, rot_vector=None):
@@ -1219,7 +1217,7 @@ class InteractiveCamera(Camera):
         self.frames = []
 
     def save(self, fn):
-        self._pylab.savefig(fn, bbox_inches="tight", facecolor="black")
+        self._pyplot.savefig(fn, bbox_inches="tight", facecolor="black")
 
     def save_frames(self, basename, clip_ratio=None):
         for i, frame in enumerate(self.frames):

--- a/yt/visualization/volume_rendering/transfer_functions.py
+++ b/yt/visualization/volume_rendering/transfer_functions.py
@@ -199,15 +199,15 @@ class TransferFunction:
         >>> tf.plot("sample.png")
         """
         import matplotlib
+        import matplotlib.pyplot as plt
 
         matplotlib.use("Agg")
-        import pylab
 
-        pylab.clf()
-        pylab.plot(self.x, self.y, "xk-")
-        pylab.xlim(*self.x_bounds)
-        pylab.ylim(0.0, 1.0)
-        pylab.savefig(filename)
+        plt.clf()
+        plt.plot(self.x, self.y, "xk-")
+        plt.xlim(*self.x_bounds)
+        plt.ylim(0.0, 1.0)
+        plt.savefig(filename)
 
     def show(self):
         r"""Display an image of the transfer function
@@ -224,13 +224,13 @@ class TransferFunction:
         >>> tf.add_gaussian(-9.0, 0.01, 1.0)
         >>> tf.show()
         """
-        import pylab
+        import matplotlib.pyplot as plt
 
-        pylab.clf()
-        pylab.plot(self.x, self.y, "xk-")
-        pylab.xlim(*self.x_bounds)
-        pylab.ylim(0.0, 1.0)
-        pylab.draw()
+        plt.clf()
+        plt.plot(self.x, self.y, "xk-")
+        plt.xlim(*self.x_bounds)
+        plt.ylim(0.0, 1.0)
+        plt.draw()
 
     def clear(self):
         self.y[:] = 0.0


### PR DESCRIPTION
## PR Summary

In the spirit of #3144
get rid of every remaining occurence of pylab
