### PR TITLE
CI: Enable GHA answer tests for tests that require no data.

### DIFF
--- a/.github/workflows/build-test-pytest.yaml
+++ b/.github/workflows/build-test-pytest.yaml
@@ -68,3 +68,10 @@ jobs:
       if: ${{ matrix.tests-type == 'answer' && failure() }}
       shell: bash
       run: python tests/report_failed_answers.py --xunit-file answers.xml
+    - name: Archive Regenerated Tests
+      if: ${{ matrix.tests-type == 'answer' && failure() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: new-answers
+        path: artifacts/
+        if-no-files-found: ignore

--- a/.github/workflows/build-test-pytest.yaml
+++ b/.github/workflows/build-test-pytest.yaml
@@ -24,7 +24,7 @@ jobs:
         os: [macos-latest, windows-latest, ubuntu-18.04]
         python-version: [3.9]
         dependencies: [full]
-        tests-type: [unit]
+        tests-type: [unit, answer]
         include:
           - os: ubuntu-18.04
             python-version: 3.6
@@ -54,6 +54,17 @@ jobs:
         dependencies: ${{ matrix.dependencies }}
       run: source ./tests/ci_install.sh
     - name: Run Tests
+      if: ${{ matrix.tests-type == 'unit' }}
       env:
         testsuite: ${{ matrix.tests-type }}
-      run: pytest
+      run: pytest -m "not answer_test"
+    - name: Run Answer Tests
+      if: ${{ matrix.tests-type == 'answer' }}
+      env:
+        testsuite: ${{ matrix.tests-type }}
+        PYTEST_MARKERS: no_data
+      run: python tests/pytest_runner.py
+    - name: Report Failed Answers
+      if: ${{ matrix.tests-type == 'answer' && failure() }}
+      shell: bash
+      run: python tests/report_failed_answers.py --xunit-file answers.xml

--- a/conftest.py
+++ b/conftest.py
@@ -315,24 +315,19 @@ def hashing(request):
 
     # Compare hashes
     if not no_hash and not store_hash:
-        try:
-            for class_name, answers in hashes.items():
-                assert class_name in request.cls.saved_hashes
-                old_images, new_images = [], []
-                for answer in list(answers.keys()):
-                    if not answer.startswith("image_"):
-                        continue
-                    new_images.append(answers.pop(answer))
-                    old_images.append(request.cls.saved_hashes[class_name].pop(answer))
-                assert answers == request.cls.saved_hashes[class_name]
-                if len(old_images) != len(new_images):
-                    pytest.fail(
-                        f"Missing image answer: {request.node.name}", pytrace=False
-                    )
-                if old_images:
-                    compare_image_lists(new_images, old_images, 10)
-        except AssertionError:
-            pytest.fail(f"Comparison failure: {request.node.name}", pytrace=False)
+        for class_name, answers in hashes.items():
+            assert class_name in request.cls.saved_hashes
+            old_images, new_images = [], []
+            for answer in list(answers.keys()):
+                if not answer.startswith("image_"):
+                    continue
+                new_images.append(answers.pop(answer))
+                old_images.append(request.cls.saved_hashes[class_name].pop(answer))
+            assert answers == request.cls.saved_hashes[class_name]
+            if len(old_images) != len(new_images):
+                pytest.fail(f"Missing image answer: {request.node.name}", pytrace=False)
+            if old_images:
+                compare_image_lists(new_images, old_images, 10)
 
     # Compare raw data. This is done one test at a time because the
     # arrays can get quite large and storing everything in memory would

--- a/conftest.py
+++ b/conftest.py
@@ -327,8 +327,13 @@ def hashing(request):
             if len(old_images) != len(new_images):
                 pytest.fail(f"Missing image answer: {request.node.name}", pytrace=False)
             if old_images:
-                compare_image_lists(new_images, old_images, 10)
-
+                try:
+                    compare_image_lists(new_images, old_images, 10)
+                except AssertionError as exc:
+                    pytest.fail(
+                        f"Comparison failed: {request.node.name} {exc}",
+                        pytrace=False,
+                    )
     # Compare raw data. This is done one test at a time because the
     # arrays can get quite large and storing everything in memory would
     # be bad

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,10 @@ sections = ["FUTURE", "STDLIB", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]
 # -rsfE: The -r tells pytest to provide extra test summary info on the events
 # specified by the characters following the r. s: skipped, f: failed, E: error
 [tool.pytest.ini_options]
+markers = [
+    "no_data: marks answer tests that require no external data",
+    "answer_test",
+]
 addopts = '''
     -s
     -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ sections = ["FUTURE", "STDLIB", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]
 # -rsfE: The -r tells pytest to provide extra test summary info on the events
 # specified by the characters following the r. s: skipped, f: failed, E: error
 [tool.pytest.ini_options]
+junit_family = "xunit2"
 markers = [
     "no_data: marks answer tests that require no external data",
     "answer_test",

--- a/tests/pytest_runner.py
+++ b/tests/pytest_runner.py
@@ -9,6 +9,7 @@ for executing answer tests and optionally generating new answers.
 
 import glob
 import os
+import sys
 
 import pytest
 
@@ -23,7 +24,9 @@ if __name__ == "__main__":
         f"-n {int(os.environ.get('NUM_WORKERS', 1))}",
         "--dist=loadscope",
     ]
-    pytest.main(pytest_args + ["--local-dir=answer-store", "--junitxml=answers.xml"])
+    retval = pytest.main(
+        pytest_args + ["--local-dir=answer-store", "--junitxml=answers.xml"]
+    )
 
     if files := glob.glob("generate_test*.txt"):
         tests = set()
@@ -36,3 +39,4 @@ if __name__ == "__main__":
         pytest.main(
             pytest_args + [f"--local-dir={output_dir}", "--answer-store"] + list(tests)
         )
+    sys.exit(retval)

--- a/tests/pytest_runner.py
+++ b/tests/pytest_runner.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
         "-v",
         "-rsfE",  # it means -r "sfE" (show skipped, failed, errors), no -r -s -f -E
         "--with-answer-testing",
-        "-m answer_test",
+        f"-m {os.environ.get('PYTEST_MARKERS', 'answer_test')}",
         f"-n {int(os.environ.get('NUM_WORKERS', 1))}",
         "--dist=loadscope",
     ]

--- a/tests/report_failed_answers.py
+++ b/tests/report_failed_answers.py
@@ -16,12 +16,10 @@ import shutil
 import tempfile
 import xml.etree.ElementTree as ET
 
-import nose
 import numpy
 import requests
 
 from yt.config import ytcfg
-from yt.utilities.answer_testing.framework import AnswerTesting
 from yt.utilities.command_line import FileStreamer
 
 logging.basicConfig(level=logging.INFO)
@@ -204,10 +202,8 @@ def generate_answers(answer_dir, answers):
     ]
 
     for job in answers:
-        log.info("\n Generating answers for %s", job)
-        status &= nose.run(
-            argv=test_argv + [job], addplugins=[AnswerTesting()], exit=False
-        )
+        log.error("\n [TODO] Generating answers for %s", job)
+        log.debug(test_argv)
     return status
 
 

--- a/yt/utilities/answer_testing/answer_tests.py
+++ b/yt/utilities/answer_testing/answer_tests.py
@@ -262,8 +262,7 @@ def phase_plot_attribute(
 
 
 def generic_image(img_fname):
-    img_data = mpimg.imread(img_fname)
-    return img_data
+    return mpimg.imread(img_fname)
 
 
 def axial_pixelization(ds):

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -815,8 +815,8 @@ def compare_image_lists(new_result, old_result, decimals):
     num_images = len(old_result)
     assert num_images > 0
     for i in range(num_images):
-        mpimg.imsave(fns[0], np.loads(zlib.decompress(old_result[i])))
-        mpimg.imsave(fns[1], np.loads(zlib.decompress(new_result[i])))
+        mpimg.imsave(fns[0], pickle.loads(zlib.decompress(old_result[i])))
+        mpimg.imsave(fns[1], pickle.loads(zlib.decompress(new_result[i])))
         results = compare_images(fns[0], fns[1], 10 ** (-decimals))
         if results is not None:
             if os.environ.get("JENKINS_HOME") is not None:

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -826,8 +826,8 @@ def compare_image_lists(new_result, old_result, decimals):
                     if line.endswith(".png")
                 ]
                 for fn in tempfiles:
-                    sys.stderr.write(f"\n[[ATTACHMENT|{fn}]]")
-                sys.stderr.write("\n")
+                    results += f"\n[[ATTACHMENT|{fn}]]"
+                results += "\n"
         assert_equal(results, None, results)
         for fn in fns:
             os.remove(fn)

--- a/yt/utilities/answer_testing/testing_utilities.py
+++ b/yt/utilities/answer_testing/testing_utilities.py
@@ -126,7 +126,10 @@ def _hash_results(results):
     # results in case those are to be saved
     hashed_results = {}
     for test_name, test_value in results.items():
-        hashed_results[test_name] = generate_hash(test_value)
+        if test_name.startswith("image_"):
+            hashed_results[test_name] = zlib.compress(test_value.dumps())
+        else:
+            hashed_results[test_name] = generate_hash(test_value)
     return hashed_results
 
 

--- a/yt/visualization/tests/test_line_plots.py
+++ b/yt/visualization/tests/test_line_plots.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 
 import yt

--- a/yt/visualization/tests/test_line_plots.py
+++ b/yt/visualization/tests/test_line_plots.py
@@ -1,65 +1,51 @@
-from nose.plugins.attrib import attr
-from nose.tools import assert_raises
+import os
+import pytest
 
 import yt
-from yt.testing import ANSWER_TEST_TAG, assert_equal, fake_random_ds
-from yt.utilities.answer_testing.framework import GenericImageTest
+from yt.testing import assert_equal, fake_random_ds
+from yt.utilities.answer_testing.answer_tests import generic_image
 from yt.visualization.line_plot import _validate_point
 
 
-def setup():
-    """Test specific setup."""
-    from yt.config import ytcfg
+@pytest.mark.no_data
+@pytest.mark.answer_test
+@pytest.mark.usefixtures("hashing", "temp_dir")
+class TestLinePlots:
+    answer_file = None
+    saved_hashes = None
+    answer_version = "000"
 
-    ytcfg["yt", "internals", "within_testing"] = True
+    def test_line_plot(self):
+        ds = fake_random_ds(4)
+        fields = [field for field in ds.field_list if field[0] == "stream"]
+        field_labels = {f: f[1] for f in fields}
+        plot = yt.LinePlot(
+            ds, fields, (0, 0, 0), (1, 1, 0), 1000, field_labels=field_labels
+        )
+        plot.annotate_legend(fields[0])
+        plot.annotate_legend(fields[1])
+        plot.set_x_unit("cm")
+        plot.set_unit(fields[0], "kg/cm**3")
+        plot.annotate_title(fields[0], "Density Plot")
+        for fname in plot.save():
+            gi = generic_image(os.path.join(os.getcwd(), fname))
+            self.hashes.update({f"image_{fname}": gi})
 
-
-def compare(ds, plot, test_prefix, test_name, decimals=12):
-    def image_from_plot(filename_prefix):
-        return plot.save(filename_prefix)
-
-    image_from_plot.__name__ = f"line_{test_prefix}"
-    test = GenericImageTest(ds, image_from_plot, decimals)
-    test.prefix = test_prefix
-    test.answer_name = test_name
-    return test
-
-
-@attr(ANSWER_TEST_TAG)
-def test_line_plot():
-    ds = fake_random_ds(4)
-    fields = [field for field in ds.field_list if field[0] == "stream"]
-    field_labels = {f: f[1] for f in fields}
-    plot = yt.LinePlot(
-        ds, fields, (0, 0, 0), (1, 1, 0), 1000, field_labels=field_labels
-    )
-    plot.annotate_legend(fields[0])
-    plot.annotate_legend(fields[1])
-    plot.set_x_unit("cm")
-    plot.set_unit(fields[0], "kg/cm**3")
-    plot.annotate_title(fields[0], "Density Plot")
-    yield compare(
-        ds, plot, test_prefix="answers_line_plot", test_name="answers_line_plot"
-    )
-
-
-@attr(ANSWER_TEST_TAG)
-def test_multi_line_plot():
-    ds = fake_random_ds(4)
-    fields = [field for field in ds.field_list if field[0] == "stream"]
-    field_labels = {f: f[1] for f in fields}
-    lines = []
-    lines.append(yt.LineBuffer(ds, [0.25, 0, 0], [0.25, 1, 0], 100, label="x = 0.5"))
-    lines.append(yt.LineBuffer(ds, [0.5, 0, 0], [0.5, 1, 0], 100, label="x = 0.5"))
-    plot = yt.LinePlot.from_lines(ds, fields, lines, field_labels=field_labels)
-    plot.annotate_legend(fields[0])
-    plot.annotate_legend(fields[1])
-    yield compare(
-        ds,
-        plot,
-        test_prefix="answers_multi_line_plot",
-        test_name="answers_multi_line_plot",
-    )
+    def test_multi_line_plot(self):
+        ds = fake_random_ds(4)
+        fields = [field for field in ds.field_list if field[0] == "stream"]
+        field_labels = {f: f[1] for f in fields}
+        lines = []
+        lines.append(
+            yt.LineBuffer(ds, [0.25, 0, 0], [0.25, 1, 0], 100, label="x = 0.5")
+        )
+        lines.append(yt.LineBuffer(ds, [0.5, 0, 0], [0.5, 1, 0], 100, label="x = 0.5"))
+        plot = yt.LinePlot.from_lines(ds, fields, lines, field_labels=field_labels)
+        plot.annotate_legend(fields[0])
+        plot.annotate_legend(fields[1])
+        for fname in plot.save():
+            gi = generic_image(os.path.join(os.getcwd(), fname))
+            self.hashes.update({f"image_{fname}": gi})
 
 
 def test_line_buffer():
@@ -77,19 +63,17 @@ def test_line_buffer():
 
 def test_validate_point():
     ds = fake_random_ds(3)
-    with assert_raises(RuntimeError) as ex:
+    with pytest.raises(RuntimeError) as ex:
         _validate_point(0, ds, start=True)
-    assert_equal(str(ex.exception), "Input point must be array-like")
+    assert "Input point must be array-like" in str(ex.value)
 
-    with assert_raises(RuntimeError) as ex:
+    with pytest.raises(RuntimeError) as ex:
         _validate_point(ds.arr([[0], [1]], "code_length"), ds, start=True)
-    assert_equal(str(ex.exception), "Input point must be a 1D array")
+    assert "Input point must be a 1D array" in str(ex.value)
 
-    with assert_raises(RuntimeError) as ex:
+    with pytest.raises(RuntimeError) as ex:
         _validate_point(ds.arr([0, 1], "code_length"), ds, start=True)
-    assert_equal(
-        str(ex.exception), "Input point must have an element for each dimension"
-    )
+    assert "Input point must have an element for each dimension" in str(ex.value)
 
     ds = fake_random_ds([32, 32, 1])
     _validate_point(ds.arr([0, 1], "code_length"), ds, start=True)


### PR DESCRIPTION
### Summary of changes

* answers called `image_...` are used to store a zipped, raw image instead of a hash (required for comparisons when test are failing)
* introduced new marker `no_data` for answer tests suitable to be run on GHA, as they require no external data
* answer tests for marker `no_data` are now enabled on GHA
   * new answers or answers regenerated due to failures are stored as an artifact on a GHA run  
   * differences in image answer tests are uploaded to use.yt (link can be found in the stdout of `Report Failed Answer` task)


## PR Checklist

- [ ] New features are documented, with docstrings and narrative docs