### PR TITLE
[bugfix] Allow the magnetic field unit to be set from unit_base in all Gadget-based frontends

### DIFF
--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -1312,11 +1312,11 @@ this in the constructor.  yt can accept units such as ``Mpc``, ``kpc``, ``cm``,
 ``Mpccm/h`` and so on.  In particular, note that ``Mpc/h`` and ``Mpccm/h``
 (``cm`` for comoving here) are usable unit definitions.
 
-yt will attempt to use units for ``mass``, ``length`` and ``time`` as supplied
-in the argument ``unit_base``.  The ``bounding_box`` argument is a list of
-two-item tuples or lists that describe the left and right extents of the
-particles. In this example we load a dataset with a custom bounding box
-and units.
+yt will attempt to use units for ``mass``, ``length``, ``time``, and
+``magnetic`` as supplied in the argument ``unit_base``.  The ``bounding_box``
+argument is a list of two-item tuples or lists that describe the left and right
+extents of the particles. In this example we load a dataset with a custom bounding
+box and units.
 
 .. code-block:: python
 
@@ -1326,9 +1326,10 @@ and units.
    ds = yt.load("snap_004", unit_base=unit_base, bounding_box=bbox)
 
 In addition, you can use ``UnitLength_in_cm``, ``UnitVelocity_in_cm_per_s``,
-and ``UnitMass_in_g`` as keys for the ``unit_base`` dictionary. These names
-come from the names used in the Gadget runtime parameter file. This example
-will initialize a dataset with the same units as the example above:
+``UnitMass_in_g``, and ``UnitMagneticField_in_gauss`` as keys for the
+``unit_base`` dictionary. These name come from the names used in the Gadget
+runtime parameter file. This example will initialize a dataset with the same
+units as the example above:
 
 .. code-block:: python
 

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -520,6 +520,16 @@ class GadgetDataset(SPHDataset):
         specific_energy_unit = _fix_unit_ordering(specific_energy_unit)
         self.specific_energy_unit = self.quan(*specific_energy_unit)
 
+        if "magnetic" in unit_base:
+            magnetic_unit = unit_base["magnetic"]
+        elif "UnitMagneticField_in_gauss" in unit_base:
+            magnetic_unit = (unit_base["UnitMagneticField_in_gauss"], "gauss")
+        else:
+            # Sane default
+            magnetic_unit = (1.0, "gauss")
+        magnetic_unit = _fix_unit_ordering(magnetic_unit)
+        self.magnetic_unit = self.quan(*magnetic_unit)
+
     @classmethod
     def _is_valid(cls, filename, *args, **kwargs):
         if "header_spec" in kwargs:

--- a/yt/frontends/gizmo/data_structures.py
+++ b/yt/frontends/gizmo/data_structures.py
@@ -49,4 +49,3 @@ class GizmoDataset(GadgetHDF5Dataset):
 
     def _set_code_unit_attributes(self):
         super()._set_code_unit_attributes()
-        self.magnetic_unit = self.quan(1.0, "gauss")


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

The GIZMO frontend by default sets the magnetic field code unit to be 1.0 Gauss, but it says [here](http://www.tapir.caltech.edu/~phopkins/Site/GIZMO_files/gizmo_documentation.html#params-generic-units) you can set the value of the magnetic unit to something else. This PR allows for that by adding the code to set the magnetic field from `unit_base` in the Gadget frontend, but the "sane default" is still 1.0 Gauss. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [x] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
