### PR TITLE
Fix gizmo frontend

### DIFF
--- a/yt/frontends/gizmo/data_structures.py
+++ b/yt/frontends/gizmo/data_structures.py
@@ -39,7 +39,7 @@ class GizmoDataset(GadgetHDF5Dataset):
                 vg in fh["/"] for vg in veto_groups
             )
             dmetal = "/PartType0/Metallicity"
-            if dmetal not in fh or fh[dmetal].shape[1] not in (11, 17):
+            if dmetal not in fh or fh[dmetal].shape[1] < 11:
                 valid = False
             fh.close()
         except Exception:

--- a/yt/frontends/gizmo/fields.py
+++ b/yt/frontends/gizmo/fields.py
@@ -106,7 +106,7 @@ class GizmoFieldInfo(GadgetFieldInfo):
 
             def _el_number_density(field, data):
                 return (
-                    data[ptype, "ElectronAbundance"] * data[ptype, "H_number_density"]
+                    data[ptype, "ElectronAbundance"] * data[ptype, "H_nuclei_density"]
                 )
 
             self.add_field(


### PR DESCRIPTION
Two small changes to fix the gizmo frontend.

One, gizmo is still expecting the `H_number_density` field to exist to calculate the free electron content.  Recently `H_number_density` got swapped to `H_nuclei_density`.  This corrects that.

Another issue is that increasingly the FIRE datasets are using variable numbers of metallicity fields above 11 elements.  When the gizmo frontend was first created, it was set to accept 11 and 17 metallicity fields to indicate it was a FIRE (i.e., gizmo) dataset to differentiate it from Gadget datasets.  This has been somewhat relaxed and there are a number of FIRE datasets with 12, 13, etc. metallicity fields floating around.  This fixes this so any gadget-like dataset with more than 11 metallicity fields gets flagged as a gizmo dataset. 

In the long run, it seems like it might be more appropriate to change the gizmo frontend to be the FIRE frontend, since gizmo is meant to just use the same format as gadget and have the same modularity to have many different code_units set.  Currently the gizmo frontend is really acting to set the code units according to the FIRE defaults.  After all, we have an EAGLE and an OWL frontend, which are just extensions of the Gadget frontend for those datasets.  Furthermore, Phil has updated gizmo so the newest datasets have HDF attributes to describe the code_unit conversion to physical units, but those aren't widespread yet.  The correction in this PR is just a stop-gap.


