### PR TITLE
fix a bug with DatasetSeries instances created via __new__

### DIFF
--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -155,6 +155,7 @@ class DatasetSeries:
             pass
         ret = super().__new__(cls)
         ret._pre_outputs = outputs[:]
+        ret.kwargs = {}
         return ret
 
     def __init__(


### PR DESCRIPTION
## PR Summary

I believe this is the appropriate to fix #3200, though I'll admit I haven't been able to test it.
