### PR TITLE
CI: hotfix failing answer tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ project_urls =
 packages = find:
 install_requires =
     IPython>=1.0
-    matplotlib>=2.0.2,<3.5
+    matplotlib!=3.4.2,>=2.0.2,<3.5
     more-itertools>=8.4
     numpy>=1.10.4
     setuptools>=19.6

--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -5,7 +5,7 @@ fastcache~=1.0.2
 glueviz~=0.13.3
 h5py~=3.1.0
 ipython~=7.6.1
-matplotlib<3.5
+matplotlib<3.5,!=3.4.2
 nose-timer~=1.0.0
 nose~=1.3.7
 pandas~=1.1.2


### PR DESCRIPTION
## PR Summary

fix #3256 (?)
For now I'm just commenting out two tests functions that I strongly suspect are the ones generating the failing answers.
If CI validates my suspicions I'll be able to start digging into it for real.


update for posterity:
since I've rebased and force pushed a different fix, there is no trace left of the tests functions I was referring to, so here they are:
- `yt/visualization/tests/test_line_plots.test_line_plot`
- `yt/visualization/tests/test_line_plots.test_multi_line_plot`
eg the only tests that use the `LinePlot` class (that I'm aware of)