### PR TITLE
Accounting for AREPO datasets to be correctly identified.

### DIFF
--- a/yt/frontends/arepo/data_structures.py
+++ b/yt/frontends/arepo/data_structures.py
@@ -55,7 +55,7 @@ class ArepoHDF5Dataset(GadgetHDF5Dataset):
                     or "AMR" in fh["/Config"].attrs.keys()
                 )
                 # Datasets with GFM_ fields present are AREPO
-                or any(True for field in fh["/PartType0"] if field.startswith("GFM_"))))
+                or any(field.startswith("GFM_") for field in fh["/PartType0"])))
             fh.close()
         except Exception:
             valid = False

--- a/yt/frontends/arepo/data_structures.py
+++ b/yt/frontends/arepo/data_structures.py
@@ -47,13 +47,14 @@ class ArepoHDF5Dataset(GadgetHDF5Dataset):
         valid = True
         try:
             fh = h5py.File(filename, mode="r")
-            valid = (
+            valid = ((
                 all(ng in fh["/"] for ng in need_groups)
                 and not any(vg in fh["/"] for vg in veto_groups)
                 and (
                     "VORONOI" in fh["/Config"].attrs.keys()
                     or "AMR" in fh["/Config"].attrs.keys()
                 )
+                or ("GFM_Metals" in fh["/PartType0"]))
             )
             fh.close()
         except Exception:

--- a/yt/frontends/arepo/data_structures.py
+++ b/yt/frontends/arepo/data_structures.py
@@ -54,8 +54,8 @@ class ArepoHDF5Dataset(GadgetHDF5Dataset):
                     "VORONOI" in fh["/Config"].attrs.keys()
                     or "AMR" in fh["/Config"].attrs.keys()
                 )
-                or ("GFM_Metals" in fh["/PartType0"]))
-            )
+                # Datasets with GFM_ fields present are AREPO
+                or any(True for field in fh["/PartType0"] if field.startswith("GFM_"))))
             fh.close()
         except Exception:
             valid = False

--- a/yt/frontends/arepo/data_structures.py
+++ b/yt/frontends/arepo/data_structures.py
@@ -47,7 +47,7 @@ class ArepoHDF5Dataset(GadgetHDF5Dataset):
         valid = True
         try:
             fh = h5py.File(filename, mode="r")
-            valid = ((
+            valid = (
                 all(ng in fh["/"] for ng in need_groups)
                 and not any(vg in fh["/"] for vg in veto_groups)
                 and (
@@ -55,7 +55,8 @@ class ArepoHDF5Dataset(GadgetHDF5Dataset):
                     or "AMR" in fh["/Config"].attrs.keys()
                 )
                 # Datasets with GFM_ fields present are AREPO
-                or any(field.startswith("GFM_") for field in fh["/PartType0"])))
+                or any(field.startswith("GFM_") for field in fh["/PartType0"])
+            )
             fh.close()
         except Exception:
             valid = False


### PR DESCRIPTION
I currently have an AREPO dataset from the AURIGA simulation suite, and it is failing to get loaded in.  It appears that one of the requirements for the AREPO frontend is that all datasets must have a CONFIG group in their HDF5 file.  This one does not.  However, any datasets that have fields beginning with `GFM_` (for Galaxy Formation Model) *are* AREPO datasets, so I'm using that as an alternate hook for ID'ing AREPO datasets.

I have written to Dylan Nelson from TNG and Freeke van de Voort from Auriga to confirm that GFM fields mean AREPO, so this should not be merged until I report back here.

UPDATE1: I received word back from Dylan that GFM fields are only present in Auriga, SURGE, and TNG datasets (all part of AREPO), so this should be accurate and ready for review.