### PR TITLE
Support for enzop vlct

### DIFF
--- a/yt/frontends/enzo_e/fields.py
+++ b/yt/frontends/enzo_e/fields.py
@@ -1,3 +1,4 @@
+import numpy as np
 from yt.fields.field_info_container import FieldInfoContainer
 from yt.fields.particle_fields import add_union_field
 from yt.frontends.enzo_e.misc import nested_dict_get
@@ -6,9 +7,15 @@ rho_units = "code_mass / code_length**3"
 vel_units = "code_velocity"
 acc_units = "code_velocity / code_time"
 energy_units = "code_velocity**2"
+b_units = "code_magnetic"
 
 known_species_names = {}
 
+NODAL_FLAGS = {
+    'bfieldi_x': [1, 0, 0],
+    'bfieldi_y': [0, 1, 0],
+    'bfieldi_z': [0, 0, 1],
+}
 
 class EnzoEFieldInfo(FieldInfoContainer):
     known_other_fields = (
@@ -22,6 +29,12 @@ class EnzoEFieldInfo(FieldInfoContainer):
         ("density_total", (rho_units, ["total_density"], None)),
         ("total_energy", (energy_units, ["specific_total_energy"], None)),
         ("internal_energy", (energy_units, ["specific_internal_energy"], None)),
+        ("bfield_x", (b_units, [], None)),
+        ("bfield_y", (b_units, [], None)),
+        ("bfield_z", (b_units, [], None)),
+        ("bfieldi_x", (b_units, [], None)),
+        ("bfieldi_y", (b_units, [], None)),
+        ("bfieldi_z", (b_units, [], None)),
     )
 
     known_particle_fields = (
@@ -40,14 +53,51 @@ class EnzoEFieldInfo(FieldInfoContainer):
     def __init__(self, ds, field_list, slice_info=None):
         super().__init__(ds, field_list, slice_info=slice_info)
 
+        # setup nodal flag information
+        for field in NODAL_FLAGS:
+            if ('enzoe', field) in self:
+                finfo = self['enzoe', field]
+                finfo.nodal_flag = np.array(NODAL_FLAGS[field])
+
     def setup_fluid_fields(self):
-        super().setup_fluid_fields()
+        from yt.fields.magnetic_field import setup_magnetic_field_aliases
+
+        self.setup_energy_field()
+        setup_magnetic_field_aliases(self, "enzoe",
+                                     ["bfield_%s" % ax for ax in "xyz"])
         self.alias(
             ("gas", "total_energy"),
             ("gas", "specific_total_energy"),
             deprecate=("4.0.0", "4.1.0"),
         )
 
+    def setup_energy_field(self):
+        unit_system = self.ds.unit_system
+        # check if we need to include magnetic energy
+        has_magnetic = ('bfield_x' in self.ds.parameters['Field']['list'])
+
+        def _tot_minus_kin(field, data):
+            return data["enzoe", "total_energy"] - 0.5 * data["gas", "velocity_magnitude"] ** 2.0
+
+        if not has_magnetic:
+            # thermal energy = total energy - kinetic energy
+            self.add_field(("gas", "specific_thermal_energy"),
+                           sampling_type="cell",
+                           function = _tot_minus_kin,
+                           units = unit_system["specific_energy"])
+        else:
+            # thermal energy = total energy - kinetic energy - magnetic energy
+            def _sub_b(field, data):
+                ret = _tot_minus_kin(field, data)
+                ret -= (
+                    data["gas", "magnetic_energy_density"] / data["gas", "density"]
+                )
+                return ret
+            self.add_field(("gas", "specific_thermal_energy"),
+                           sampling_type="cell",
+                           function=_sub_b,
+                           units = unit_system["specific_energy"])
+        
     def setup_particle_fields(self, ptype, ftype="gas", num_neighbors=64):
         super().setup_particle_fields(ptype, ftype=ftype, num_neighbors=num_neighbors)
         self.setup_particle_mass_field(ptype)

--- a/yt/frontends/enzo_e/fields.py
+++ b/yt/frontends/enzo_e/fields.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from yt.fields.field_info_container import FieldInfoContainer
 from yt.fields.particle_fields import add_union_field
 from yt.frontends.enzo_e.misc import nested_dict_get
@@ -12,10 +13,11 @@ b_units = "code_magnetic"
 known_species_names = {}
 
 NODAL_FLAGS = {
-    'bfieldi_x': [1, 0, 0],
-    'bfieldi_y': [0, 1, 0],
-    'bfieldi_z': [0, 0, 1],
+    "bfieldi_x": [1, 0, 0],
+    "bfieldi_y": [0, 1, 0],
+    "bfieldi_z": [0, 0, 1],
 }
+
 
 class EnzoEFieldInfo(FieldInfoContainer):
     known_other_fields = (
@@ -55,16 +57,15 @@ class EnzoEFieldInfo(FieldInfoContainer):
 
         # setup nodal flag information
         for field in NODAL_FLAGS:
-            if ('enzoe', field) in self:
-                finfo = self['enzoe', field]
+            if ("enzoe", field) in self:
+                finfo = self["enzoe", field]
                 finfo.nodal_flag = np.array(NODAL_FLAGS[field])
 
     def setup_fluid_fields(self):
         from yt.fields.magnetic_field import setup_magnetic_field_aliases
 
         self.setup_energy_field()
-        setup_magnetic_field_aliases(self, "enzoe",
-                                     ["bfield_%s" % ax for ax in "xyz"])
+        setup_magnetic_field_aliases(self, "enzoe", ["bfield_%s" % ax for ax in "xyz"])
         self.alias(
             ("gas", "total_energy"),
             ("gas", "specific_total_energy"),
@@ -73,46 +74,57 @@ class EnzoEFieldInfo(FieldInfoContainer):
 
     def uses_dual_energy_formalism(self):
         for name in ["ppm", "mhd_vlct"]:
-            param = nested_dict_get(self.ds.parameters, ('Method', name), None)
-            if ((param is not None) and param.get("dual_energy",False)):
+            param = nested_dict_get(self.ds.parameters, ("Method", name), None)
+            if (param is not None) and param.get("dual_energy", False):
                 return True
         return False
 
     def setup_energy_field(self):
         unit_system = self.ds.unit_system
         # check if we need to include magnetic energy
-        has_magnetic = ('bfield_x' in self.ds.parameters['Field']['list'])
+        has_magnetic = "bfield_x" in self.ds.parameters["Field"]["list"]
 
         # identify if the dual energy formalism is in use:
         if self.uses_dual_energy_formalism():
-            self.alias(("gas", "specific_thermal_energy"),
-                       ("enzop", "specific_internal_energy"))
+            self.alias(
+                ("gas", "specific_thermal_energy"),
+                ("enzop", "specific_internal_energy"),
+            )
         else:
 
             def _tot_minus_kin(field, data):
-                return data["enzoe", "total_energy"] - 0.5 * data["gas", "velocity_magnitude"] ** 2.0
+                return (
+                    data["enzoe", "total_energy"]
+                    - 0.5 * data["gas", "velocity_magnitude"] ** 2.0
+                )
 
             # check if we need to include magnetic energy
-            has_magnetic = ('bfield_x' in self.ds.parameters['Field']['list'])
+            has_magnetic = "bfield_x" in self.ds.parameters["Field"]["list"]
 
             if not has_magnetic:
                 # thermal energy = total energy - kinetic energy
-                self.add_field(("gas", "specific_thermal_energy"),
-                               sampling_type="cell",
-                               function = _tot_minus_kin,
-                               units = unit_system["specific_energy"])
+                self.add_field(
+                    ("gas", "specific_thermal_energy"),
+                    sampling_type="cell",
+                    function=_tot_minus_kin,
+                    units=unit_system["specific_energy"],
+                )
             else:
                 # thermal energy = total energy - kinetic energy - magnetic energy
                 def _sub_b(field, data):
                     ret = _tot_minus_kin(field, data)
-                    ret -= (data["gas", "magnetic_energy_density"]
-                            / data["gas", "density"])
+                    ret -= (
+                        data["gas", "magnetic_energy_density"] / data["gas", "density"]
+                    )
                     return ret
-                self.add_field(("gas", "specific_thermal_energy"),
-                               sampling_type="cell",
-                               function=_sub_b,
-                               units = unit_system["specific_energy"])
-        
+
+                self.add_field(
+                    ("gas", "specific_thermal_energy"),
+                    sampling_type="cell",
+                    function=_sub_b,
+                    units=unit_system["specific_energy"],
+                )
+
     def setup_particle_fields(self, ptype, ftype="gas", num_neighbors=64):
         super().setup_particle_fields(ptype, ftype=ftype, num_neighbors=num_neighbors)
         self.setup_particle_mass_field(ptype)

--- a/yt/frontends/enzo_e/io.py
+++ b/yt/frontends/enzo_e/io.py
@@ -140,8 +140,10 @@ class EnzoEIOHandler(BaseIOHandler):
                 for field in fields:
                     grid_dim = self.ds.grid_dimensions
                     nodal_flag = self.ds.field_info[field].nodal_flag
-                    dims = (grid_dim[:self.ds.dimensionality][::-1]
-                            + nodal_flag[:self.ds.dimensionality][::-1])
+                    dims = (
+                        grid_dim[: self.ds.dimensionality][::-1]
+                        + nodal_flag[: self.ds.dimensionality][::-1]
+                    )
                     data = np.empty(dims, dtype=self._field_dtype)
                     yield field, obj, self._read_obj_field(obj, field, (fid, data))
         if fid is not None:

--- a/yt/frontends/enzo_e/io.py
+++ b/yt/frontends/enzo_e/io.py
@@ -138,7 +138,11 @@ class EnzoEIOHandler(BaseIOHandler):
                     )
                     filename = obj.filename
                 for field in fields:
-                    data = None
+                    grid_dim = self.ds.grid_dimensions
+                    nodal_flag = self.ds.field_info[field].nodal_flag
+                    dims = (grid_dim[:self.ds.dimensionality][::-1]
+                            + nodal_flag[:self.ds.dimensionality][::-1])
+                    data = np.empty(dims, dtype=self._field_dtype)
                     yield field, obj, self._read_obj_field(obj, field, (fid, data))
         if fid is not None:
             fid.close()
@@ -146,7 +150,7 @@ class EnzoEIOHandler(BaseIOHandler):
     def _read_obj_field(self, obj, field, fid_data):
         if fid_data is None:
             fid_data = (None, None)
-        fid, data = fid_data
+        fid, rdata = fid_data
         if fid is None:
             close = True
             fid = h5py.h5f.open(obj.filename.encode("latin-1"), h5py.h5f.ACC_RDONLY)
@@ -155,10 +159,11 @@ class EnzoEIOHandler(BaseIOHandler):
         ftype, fname = field
         node = f"/{obj.block_name}/field{self._sep}{fname}"
         dg = h5py.h5d.open(fid, node.encode("latin-1"))
-        rdata = np.empty(
-            self.ds.grid_dimensions[: self.ds.dimensionality][::-1],
-            dtype=self._field_dtype,
-        )
+        if rdata is None:
+            rdata = np.empty(
+                self.ds.grid_dimensions[: self.ds.dimensionality][::-1],
+                dtype=self._field_dtype,
+            )
         dg.read(h5py.h5s.ALL, h5py.h5s.ALL, rdata)
         if close:
             fid.close()

--- a/yt/frontends/enzo_e/tests/test_outputs.py
+++ b/yt/frontends/enzo_e/tests/test_outputs.py
@@ -126,6 +126,12 @@ def test_face_centered_bfields():
             assert_equal(grid[field].shape, block_dims + (2 * sum(flag),))
 
     # Average of face-centered fields should be the same as cell-centered field
-    assert (ad["enzoe", "bfieldi_x"].sum(axis=-1) / 2 == ad["enzoe", "bfield_x"]).all()
-    assert (ad["enzoe", "bfieldi_y"].sum(axis=-1) / 2 == ad["enzoe", "bfield_y"]).all()
-    assert (ad["enzoe", "bfieldi_z"].sum(axis=-1) / 2 == ad["enzoe", "bfield_z"]).all()
+    assert_array_equal(
+        ad["enzoe", "bfieldi_x"].sum(axis=-1) / 2, ad["enzoe", "bfield_x"]
+    )
+    assert_array_equal(
+        ad["enzoe", "bfieldi_y"].sum(axis=-1) / 2, ad["enzoe", "bfield_y"]
+    )
+    assert_array_equal(
+        ad["enzoe", "bfieldi_z"].sum(axis=-1) / 2, ad["enzoe", "bfield_z"]
+    )

--- a/yt/frontends/enzo_e/tests/test_outputs.py
+++ b/yt/frontends/enzo_e/tests/test_outputs.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from yt.frontends.enzo_e.api import EnzoEDataset
+from yt.frontends.enzo_e.fields import NODAL_FLAGS
 from yt.testing import assert_array_equal, assert_equal, requires_file
 from yt.utilities.answer_testing.framework import (
     FieldValuesTest,
@@ -29,6 +30,7 @@ _pfields = (
 
 hello_world = "hello-0210/hello-0210.block_list"
 ep_cosmo = "ENZOP_DD0140/ENZOP_DD0140.block_list"
+orszag_tang = "ENZOE_orszag-tang_0.5/ENZOE_orszag-tang_0.5.block_list"
 
 
 @requires_file(hello_world)
@@ -103,3 +105,26 @@ def test_critical_density():
     )
 
     assert np.abs(c1 - c2) / max(c1, c2) < 1e-3
+
+@requires_file(orszag_tang)
+def test_face_centered_bfields():
+    # this is based on the enzo frontend test, test_face_centered_mhdct_fields
+    ds = data_dir_load(orszag_tang)
+
+    ad = ds.all_data()
+    assert len(ds.index.grids) == 4
+
+    for field, flag in NODAL_FLAGS.items():
+        dims = ds.domain_dimensions
+        assert_equal(ad[field].shape, (dims.prod(), 2 * sum(flag)))
+
+        # the x and y domains are each split across 2 blocks. The z domain
+        # is all located on a single block
+        block_dims = (dims[0]//2, dims[1]//2, dims[2])
+        for grid in ds.index.grids:
+            assert_equal(grid[field].shape, block_dims + (2 * sum(flag),))
+
+    # Average of face-centered fields should be the same as cell-centered field
+    assert (ad["enzoe", "bfieldi_x"].sum(axis=-1) / 2 == ad["enzoe", "bfield_x"]).all()
+    assert (ad["enzoe", "bfieldi_y"].sum(axis=-1) / 2 == ad["enzoe", "bfield_y"]).all()
+    assert (ad["enzoe", "bfieldi_z"].sum(axis=-1) / 2 == ad["enzoe", "bfield_z"]).all()

--- a/yt/frontends/enzo_e/tests/test_outputs.py
+++ b/yt/frontends/enzo_e/tests/test_outputs.py
@@ -106,6 +106,7 @@ def test_critical_density():
 
     assert np.abs(c1 - c2) / max(c1, c2) < 1e-3
 
+
 @requires_file(orszag_tang)
 def test_face_centered_bfields():
     # this is based on the enzo frontend test, test_face_centered_mhdct_fields
@@ -120,7 +121,7 @@ def test_face_centered_bfields():
 
         # the x and y domains are each split across 2 blocks. The z domain
         # is all located on a single block
-        block_dims = (dims[0]//2, dims[1]//2, dims[2])
+        block_dims = (dims[0] // 2, dims[1] // 2, dims[2])
         for grid in ds.index.grids:
             assert_equal(grid[field].shape, block_dims + (2 * sum(flag),))
 

--- a/yt/sample_data_registry.json
+++ b/yt/sample_data_registry.json
@@ -95,6 +95,12 @@
     "load_name": "eagle_0005.hdf5",
     "url": "https://yt-project.org/data/EAGLE_6.tar.gz"
   },
+  "ENZOE_orszag-tang_0.5.tar.gz": {
+    "hash": "dbd93068131d3d100c186adb801302a303ac2c5c54118ab5f9e19b409eee5efc",
+    "load_kwargs": {},
+    "load_name": "ENZOE_orszag-tang_0.5.block_list",
+    "url": "https://yt-project.org/data/ENZOE_orszag-tang_0.5.tar.gz"
+  },
   "ENZOP_DD0140.tar.gz": {
     "hash": "8df14326a82845479398447b8b55bd93d8eea1c5f31657536b390e6703458e0d",
     "load_kwargs": {},


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

This PR introduces support for outputs generated by Enzo-E's VL+CT integrator. This basically just adds handling for magnetic fields. It also adds proper handling for determining `"specific_thermal_energy"` when the dual-energy-formalism is being used.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

I just wanted a little clarification on the tests I should be adding. Would it be adequate to introduce an answer test involving a new dataset generated with this integrator and an answer test similar to the `test_hello_world` in `enzo_p/tests/test_outputs.py`? Should I also be introducing an additional dataset for checking the dual-energy-formalism handling? 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
