### PR TITLE
avoid copying arrays with np.ndarray.astype where possible

### DIFF
--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -645,8 +645,8 @@ class YTCoveringGrid(YTSelectionContainer3D):
         self._num_ghost_zones = num_ghost_zones
         self._use_pbar = use_pbar
         self.global_startindex = np.rint(
-            (self.left_edge - self.ds.domain_left_edge) / self.dds
-        ).astype("int64")
+            (self.left_edge - self.ds.domain_left_edge) / self.dds, dtype="int64"
+        )
         self._setup_data_source()
         self.get_data(fields)
 
@@ -1457,7 +1457,7 @@ class YTSmoothedCoveringGrid(YTCoveringGrid):
             # How many root cells do we occupy?
             end_index = np.rint(cell_end).astype("int64")
             dims = end_index - start_index + 1
-        return start_index, end_index.astype("int64"), dims.astype("int32")
+        return start_index, end_index, dims.astype("int32")
 
     def _update_level_state(self, level_state):
         ls = level_state

--- a/yt/visualization/volume_rendering/old_camera.py
+++ b/yt/visualization/volume_rendering/old_camera.py
@@ -2003,7 +2003,7 @@ def plot_allsky_healpix(
     import matplotlib.figure
 
     if rotation is None:
-        rotation = np.eye(3).astype("float64")
+        rotation = np.eye(3, dtype="float64")
 
     img, count = pixelize_healpix(nside, image, resolution, resolution, rotation)
 


### PR DESCRIPTION
## PR Summary

Just a couple of very minor simplifications. There are probably many more that can be found but in many cases, the `dtype` argument was added in various numpy functions throughout the years, and it's not easy to automate detection. I may come up with a flake8 plugin to do that in the future.