### PR TITLE
load_sample: update amrvac sample data files registry

### DIFF
--- a/yt/sample_data_registry.json
+++ b/yt/sample_data_registry.json
@@ -498,59 +498,65 @@
     "load_name": "ahf_halos/snap_N64L16_068.parameter",
     "url": "https://yt-project.org/data/ahf_halos.tar.gz"
   },
-  "amrvac_bw_cartesian_3d.tar.gz": {
-    "hash": "d8222eabbcca6e76da53ca88d2e7ef407e4831df5a908770874147326a3d2c89",
+  "bw_cartesian_3d.tar.gz": {
+    "hash": "de8b3b4c2a8c93f857c6729a118960eb1bcf244e1de07aee231d6fcc589c5628",
     "load_kwargs": {},
-    "load_name": "amrvac/bw_3d0000.dat",
+    "load_name": "output0001.dat",
     "url": "https://yt-project.org/data/amrvac_bw_cartesian_3d.tar.gz"
   },
-  "amrvac_bw_cylindrical_3d.tar.gz": {
-    "hash": "8b863863423ac56fab413cd345e03f971c717dd4e2fb04c2e2149523673df70e",
+  "bw_cylindrical_3d.tar.gz": {
+    "hash": "7392e60dabd7ef636ce98929c56d4d8ece89958716a67e32792dce5981d64709",
     "load_kwargs": {},
-    "load_name": "amrvac/bw_cylindrical_3D0000.dat",
+    "load_name": "output0001.dat",
     "url": "https://yt-project.org/data/amrvac_bw_cylindrical_3d.tar.gz"
   },
-  "amrvac_bw_polar_2d.tar.gz": {
-    "hash": "ace5437299c4a6192df98f3d3580b8c6c8478ca836774da2e0299f1269c62edd",
+  "bw_polar_2d.tar.gz": {
+    "hash": "85308582ab55049474a9a302d1e88459a89f4e8925c5b901fbf3c590b1f269ab",
     "load_kwargs": {},
-    "load_name": "amrvac/bw_polar_2D0000.dat",
+    "load_name": "output0001.dat",
     "url": "https://yt-project.org/data/amrvac_bw_polar_2d.tar.gz"
   },
-  "amrvac_bw_spherical_2d.tar.gz": {
-    "hash": "f489c95d753f611b50b5baf9f43b4dfe4f06bb1a3da40b1af13af91971c5dca1",
+  "bw_spherical_2d.tar.gz": {
+    "hash": "2407f8f3352d7f2687a608bdfb7143e892d54b983d5a0d1f869132f41c98dbcc",
     "load_kwargs": {},
-    "load_name": "amrvac/bw_2d0000.dat",
+    "load_name": "output0001.dat",
     "url": "https://yt-project.org/data/amrvac_bw_spherical_2d.tar.gz"
   },
-  "amrvac_kh2d.tar.gz": {
-    "hash": "0a4e00d1480143fd76ac95a3446357d373c84e9a8add8da662a5fed589a092bf",
+  "kh2d.tar.gz": {
+    "hash": "2ea94f4f24b3423dcb67dc1b1eb28c83a02b66b6c79b29d1703b7aa2aa76b71e",
     "load_kwargs": {},
-    "load_name": "amrvac/kh_2d0000.dat",
+    "load_name": "output0001.dat",
     "url": "https://yt-project.org/data/amrvac_kh2d.tar.gz"
   },
-  "amrvac_kh3d.tar.gz": {
-    "hash": "288a821300729f7c3d1eb282c3fae8e8f169d0903496d5105f61028fa591b165",
+  "kh3d.tar.gz": {
+    "hash": "ae354a29eb88e2cd6720efdb98de96a22b4988364cd65cf8f8dce071914430c3",
     "load_kwargs": {},
-    "load_name": "amrvac/kh_3D0000.dat",
+    "load_name": "output0001.dat",
     "url": "https://yt-project.org/data/amrvac_kh3d.tar.gz"
   },
-  "amrvac_mhd_jet.tar.gz": {
-    "hash": "dce37206ef844966a4cff36b367decbf29619ddc033f5c3ac0762acfbecc8d50",
+  "mhd_jet.tar.gz": {
+    "hash": "24b7d24ec10d876dcc508563d516e1a4fe323150a6d5aef2f4640b020da817d7",
     "load_kwargs": {},
     "load_name": "Jet0003.dat",
     "url": "https://yt-project.org/data/amrvac_mhd_jet.tar.gz"
   },
-  "amrvac_riemann1d.tar.gz": {
-    "hash": "fb2ddf82f854b42f9cca75871503421c12fe8a082a855f0e9adbcfadbace5d89",
+  "riemann1d.tar.gz": {
+    "hash": "377483c6b74c1826b5f7c5e2b52a5b8ffeb974515d62d6135208cc96f7f09ae4",
     "load_kwargs": {},
-    "load_name": "amrvac/R_1d0005.dat",
+    "load_name": "output0001.dat",
     "url": "https://yt-project.org/data/amrvac_riemann1d.tar.gz"
   },
-  "amrvac_rmi_dust_2d.tar.gz": {
-    "hash": "2827b8670933b1e75e00f5fbe01eb97cd22785dd569aedf4430fdff99eea3c95",
-    "load_kwargs": {},
-    "load_name": "Richtmyer_Meshkov_dust_2D/RM2D_dust_Kwok0000.dat",
+  "rmi_dust_2d.tar.gz": {
+    "hash": "96fafc63755b065ffa17d63a7ab5f01d4183ed1b10728ce1c5a23281cb43f5a6",
+    "load_kwargs": {"parfiles": ["rmi_dust_2d/amrvac.par"]},
+    "load_name": "output0001.dat",
     "url": "https://yt-project.org/data/amrvac_rmi_dust_2d.tar.gz"
+  },
+  "solar_prom2d.tar.gz": {
+    "hash": "a8ddb034c27badf8160af1c4622ec9e9835c4434a5556e55212df6803c5020dc",
+    "load_kwargs": {"parfiles": ["solar_prom2d/amrvac.par"]},
+    "load_name": "output0001.dat",
+    "url": "https://yt-project.org/data/solar_prom2d.tar.gz"
   },
   "arbor.tar.gz": {
     "hash": "d6c89c6496acdd92ef086736b8644996de58b1f4292b67b01d5db94ce60210fb",


### PR DESCRIPTION
## PR Summary

in combination with https://github.com/yt-project/website/pull/97, this should fix #3178

A point that is not clear to me is how to better approach the proposed migration on the testing side. I imaging go as follow:
- install (download) the renamed datafiles on Jenkins,
- update yt/frontends/amrvac/tests files
- drop (delete) the old files on Jenkins

@Xarthisius, any thoughts ?

Since the issue was caused by non standardised packaging, I had to regenerate the hashes for each file.
While I'm at it, I also register the solar_prom2d dataset, which is already on the website but lacking a registration in the pooch registry.

note: I realise that this update breaks alphabetical ordering of the json file entries, but the patch was hard enough to keep track on, so I figure it's preferable to stick to a minimal diff to ease reviews.