### PR TITLE
Updating cookbook recipes and notebooks to reflect yt4 changes

### DIFF
--- a/doc/source/analyzing/domain_analysis/XrayEmissionFields.ipynb
+++ b/doc/source/analyzing/domain_analysis/XrayEmissionFields.ipynb
@@ -18,7 +18,7 @@
     "`yt download cloudy_emissivity_v2.h5 /path/to/data`\n",
     "\n",
     "`# Put the data in the location set by \"supp_data_dir\"`  \n",
-    "`yt download apec_emissivity_v2.h5 supp_data_dir`\n",
+    "`yt download apec_emissivity_v3.h5 supp_data_dir`\n",
     "\n",
     "The data path can be a directory on disk, or it can be \"supp_data_dir\", which will download the data to the directory specified by the `\"supp_data_dir\"` yt configuration entry. It is easiest to put these files in the directory from which you will be running yt or `\"supp_data_dir\"`, but see the note below about putting them in alternate locations."
    ]

--- a/doc/source/cookbook/annotate_timestamp_and_scale.py
+++ b/doc/source/cookbook/annotate_timestamp_and_scale.py
@@ -2,7 +2,7 @@ import yt
 
 ts = yt.load("enzo_tiny_cosmology/DD000?/DD000?")
 for ds in ts:
-    p = yt.ProjectionPlot(ds, "z", "density")
+    p = yt.ProjectionPlot(ds, "z", ("gas", "density"))
     p.annotate_timestamp(corner="upper_left", redshift=True, draw_inset_box=True)
     p.annotate_scale(corner="upper_right")
     p.save()

--- a/doc/source/cookbook/annotations.py
+++ b/doc/source/cookbook/annotations.py
@@ -1,7 +1,7 @@
 import yt
 
 ds = yt.load("enzo_tiny_cosmology/DD0046/DD0046")
-p = yt.ProjectionPlot(ds, "z", "density")
+p = yt.ProjectionPlot(ds, "z", ("gas", "density"))
 p.annotate_sphere([0.54, 0.72], radius=(1, "Mpc"), coord_system="axis", text="Halo #7")
 p.annotate_sphere(
     [0.65, 0.38, 0.3],

--- a/doc/source/cookbook/average_value.py
+++ b/doc/source/cookbook/average_value.py
@@ -2,8 +2,8 @@ import yt
 
 ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")  # load data
 
-field = "temperature"  # The field to average
-weight = "mass"  # The weight for the average
+field = ("gas", "temperature")  # The field to average
+weight = ("gas", "mass")  # The weight for the average
 
 ad = ds.all_data()  # This is a region describing the entire box,
 # but note it doesn't read anything in yet!
@@ -13,5 +13,5 @@ average_value = ad.quantities.weighted_average_quantity(field, weight)
 
 print(
     "Average %s (weighted by %s) is %0.3e %s"
-    % (field, weight, average_value, average_value.units)
+    % (field[1], weight[1], average_value, average_value.units)
 )

--- a/doc/source/cookbook/changing_label_formats.py
+++ b/doc/source/cookbook/changing_label_formats.py
@@ -6,5 +6,5 @@ ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
 # instead of the default `roman_numeral`
 ds.set_field_label_format("ionization_label", "plus_minus")
 
-slc = yt.SlicePlot(ds, "x", "H_p1_number_density")
+slc = yt.SlicePlot(ds, "x", ("gas", "H_p1_number_density"))
 slc.save("plus_minus_ionization_format_sliceplot.png")

--- a/doc/source/cookbook/colormaps.py
+++ b/doc/source/cookbook/colormaps.py
@@ -4,7 +4,7 @@ import yt
 ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
 
 # Create a projection and save it with the default colormap ('algae')
-p = yt.ProjectionPlot(ds, "z", "density", width=(100, "kpc"))
+p = yt.ProjectionPlot(ds, "z", ("gas", "density"), width=(100, "kpc"))
 p.save()
 
 # Change the colormap to 'dusk' and save again.  We must specify

--- a/doc/source/cookbook/contours_on_slice.py
+++ b/doc/source/cookbook/contours_on_slice.py
@@ -4,11 +4,11 @@ import yt
 ds = yt.load("GasSloshing/sloshing_nomag2_hdf5_plt_cnt_0150")
 
 # add density contours on the density slice.
-p = yt.SlicePlot(ds, "x", "density")
-p.annotate_contour("density")
+p = yt.SlicePlot(ds, "x", ("gas", "density"))
+p.annotate_contour(("gas", "density"))
 p.save()
 
 # then add temperature contours on the same density slice
-p = yt.SlicePlot(ds, "x", "density")
-p.annotate_contour("temperature")
+p = yt.SlicePlot(ds, "x", ("gas", "density"))
+p.annotate_contour(("gas", "temperature"))
 p.save(str(ds) + "_T_contour")

--- a/doc/source/cookbook/custom_colorbar_tickmarks.ipynb
+++ b/doc/source/cookbook/custom_colorbar_tickmarks.ipynb
@@ -20,7 +20,7 @@
    "outputs": [],
    "source": [
     "ds = yt.load('IsolatedGalaxy/galaxy0030/galaxy0030')\n",
-    "slc = yt.SlicePlot(ds, 'x', 'density')\n",
+    "slc = yt.SlicePlot(ds, 'x', ('gas', 'density'))\n",
     "slc"
    ]
   },
@@ -39,7 +39,7 @@
    },
    "outputs": [],
    "source": [
-    "plot = slc.plots['density']"
+    "plot = slc.plots[('gas', 'density')]"
    ]
   },
   {

--- a/doc/source/cookbook/derived_field.py
+++ b/doc/source/cookbook/derived_field.py
@@ -27,5 +27,9 @@ for i in sorted(ds.derived_field_list):
 # Let's use it to make a projection
 ad = ds.all_data()
 yt.ProjectionPlot(
-    ds, "x", "thermal_energy_density", weight_field="density", width=(200, "kpc")
+    ds,
+    "x",
+    ("gas", "thermal_energy_density"),
+    weight_field=("gas", "density"),
+    width=(200, "kpc"),
 ).save()

--- a/doc/source/cookbook/downsampling_amr.py
+++ b/doc/source/cookbook/downsampling_amr.py
@@ -8,7 +8,7 @@ print(ds.max_level)
 # If we ask for *all* of the AMR data, we get back field
 # values sampled at about 3.6 million AMR zones
 ad = ds.all_data()
-print(ad[("gas", "density")].shape)
+print(ad["gas", "density"].shape)
 
 # Let's only sample data up to AMR level 2
 ad.max_level = 2

--- a/doc/source/cookbook/downsampling_amr.py
+++ b/doc/source/cookbook/downsampling_amr.py
@@ -14,7 +14,7 @@ print(ad["gas", "density"].shape)
 ad.max_level = 2
 
 # Now we only sample from about 200,000 zones
-print(ad[("gas", "density")].shape)
+print(ad["gas", "density"].shape)
 
 # Note that this includes data at level 2 that would
 # normally be masked out. There aren't any "holes" in

--- a/doc/source/cookbook/downsampling_amr.py
+++ b/doc/source/cookbook/downsampling_amr.py
@@ -8,19 +8,19 @@ print(ds.max_level)
 # If we ask for *all* of the AMR data, we get back field
 # values sampled at about 3.6 million AMR zones
 ad = ds.all_data()
-print(ad["gas", "density"].shape)
+print(ad[("gas", "density")].shape)
 
 # Let's only sample data up to AMR level 2
 ad.max_level = 2
 
 # Now we only sample from about 200,000 zones
-print(ad["gas", "density"].shape)
+print(ad[("gas", "density")].shape)
 
 # Note that this includes data at level 2 that would
 # normally be masked out. There aren't any "holes" in
 # the downsampled AMR mesh, the volume still sums to
 # the volume of the domain:
-print(ad["index", "cell_volume"].sum())
+print(ad[("gas", "volume")].sum())
 print(ds.domain_width.prod())
 
 # Now let's make a downsampled plot

--- a/doc/source/cookbook/downsampling_amr.py
+++ b/doc/source/cookbook/downsampling_amr.py
@@ -20,7 +20,7 @@ print(ad["gas", "density"].shape)
 # normally be masked out. There aren't any "holes" in
 # the downsampled AMR mesh, the volume still sums to
 # the volume of the domain:
-print(ad[("gas", "volume")].sum())
+print(ad["gas", "volume"].sum())
 print(ds.domain_width.prod())
 
 # Now let's make a downsampled plot

--- a/doc/source/cookbook/find_clumps.py
+++ b/doc/source/cookbook/find_clumps.py
@@ -65,10 +65,10 @@ prj.annotate_clumps(leaf_clumps_reloaded)
 prj.save("clumps_reloaded")
 
 # Query fields for clumps in the tree.
-print(cds.tree["clump", "center_of_mass"])
-print(cds.tree.children[0]["grid", "density"])
-print(cds.tree.children[1]["all", "particle_mass"])
+print(cds.tree[("clump", "center_of_mass")])
+print(cds.tree.children[0][("grid", "density")])
+print(cds.tree.children[1][("all", "particle_mass")])
 
 # Get all of the leaf clumps.
 print(cds.leaves)
-print(cds.leaves[0]["clump", "cell_mass"])
+print(cds.leaves[0][("clump", "cell_mass")])

--- a/doc/source/cookbook/find_clumps.py
+++ b/doc/source/cookbook/find_clumps.py
@@ -71,4 +71,4 @@ print(cds.tree.children[1]["all", "particle_mass"])
 
 # Get all of the leaf clumps.
 print(cds.leaves)
-print(cds.leaves[0][("clump", "cell_mass")])
+print(cds.leaves[0]["clump", "cell_mass"])

--- a/doc/source/cookbook/find_clumps.py
+++ b/doc/source/cookbook/find_clumps.py
@@ -65,9 +65,9 @@ prj.annotate_clumps(leaf_clumps_reloaded)
 prj.save("clumps_reloaded")
 
 # Query fields for clumps in the tree.
-print(cds.tree[("clump", "center_of_mass")])
-print(cds.tree.children[0][("grid", "density")])
-print(cds.tree.children[1][("all", "particle_mass")])
+print(cds.tree["clump", "center_of_mass"])
+print(cds.tree.children[0]["grid", "density"])
+print(cds.tree.children[1]["all", "particle_mass"])
 
 # Get all of the leaf clumps.
 print(cds.leaves)

--- a/doc/source/cookbook/fits_radio_cubes.ipynb
+++ b/doc/source/cookbook/fits_radio_cubes.ipynb
@@ -61,7 +61,7 @@
    },
    "outputs": [],
    "source": [
-    "slc = yt.SlicePlot(ds, \"z\", [(\"gas\", \"intensity\")], origin=\"native\")\n",
+    "slc = yt.SlicePlot(ds, \"z\", [\"gas\", \"intensity\"], origin=\"native\")\n",
     "slc.show()"
    ]
   },

--- a/doc/source/cookbook/fits_radio_cubes.ipynb
+++ b/doc/source/cookbook/fits_radio_cubes.ipynb
@@ -61,7 +61,7 @@
    },
    "outputs": [],
    "source": [
-    "slc = yt.SlicePlot(ds, \"z\", [\"intensity\"], origin=\"native\")\n",
+    "slc = yt.SlicePlot(ds, \"z\", [(\"gas\", \"intensity\")], origin=\"native\")\n",
     "slc.show()"
    ]
   },
@@ -137,7 +137,7 @@
    },
    "outputs": [],
    "source": [
-    "slc = yt.SlicePlot(ds, \"z\", [\"intensity\"], center=new_center, origin=\"native\")\n",
+    "slc = yt.SlicePlot(ds, \"z\", [(\"gas\", \"intensity\")], center=new_center, origin=\"native\")\n",
     "slc.show()"
    ]
   },
@@ -157,7 +157,7 @@
    "outputs": [],
    "source": [
     "new_center[2] = ds.spec2pixel(-100000.*u.m/u.s)\n",
-    "slc = yt.SlicePlot(ds, \"z\", [\"intensity\"], center=new_center, origin=\"native\")\n",
+    "slc = yt.SlicePlot(ds, \"z\", [(\"gas\", \"intensity\")], center=new_center, origin=\"native\")\n",
     "slc.show()"
    ]
   },
@@ -170,7 +170,7 @@
    "outputs": [],
    "source": [
     "new_center[2] = ds.spec2pixel(-150000.*u.m/u.s)\n",
-    "slc = yt.SlicePlot(ds, \"z\", [\"intensity\"], center=new_center, origin=\"native\")\n",
+    "slc = yt.SlicePlot(ds, \"z\", [(\"gas\", \"intensity\")], center=new_center, origin=\"native\")\n",
     "slc.show()"
    ]
   },
@@ -196,7 +196,7 @@
    },
    "outputs": [],
    "source": [
-    "prj = yt.ProjectionPlot(ds, \"z\", [\"intensity\"], origin=\"native\")\n",
+    "prj = yt.ProjectionPlot(ds, \"z\", [(\"gas\", \"intensity\")], origin=\"native\")\n",
     "prj.show()"
    ]
   },
@@ -215,7 +215,7 @@
    },
    "outputs": [],
    "source": [
-    "slc = yt.SlicePlot(ds, \"x\", [\"intensity\"], origin=\"native\", window_size=(8,8))\n",
+    "slc = yt.SlicePlot(ds, \"x\", [(\"gas\", \"intensity\")], origin=\"native\", window_size=(8,8))\n",
     "slc.show()"
    ]
   },
@@ -279,7 +279,7 @@
    "outputs": [],
    "source": [
     "dd = ds.all_data() # A region containing the entire dataset\n",
-    "extrema = dd.quantities.extrema(\"temperature\")\n",
+    "extrema = dd.quantities.extrema((\"gas\", \"temperature\"))\n",
     "print (extrema)"
    ]
   },
@@ -298,9 +298,9 @@
    },
    "outputs": [],
    "source": [
-    "prj = yt.ProjectionPlot(ds, \"z\", [\"temperature\"], origin=\"native\", \n",
-    "                        weight_field=\"ones\") # \"ones\" weights each cell by 1\n",
-    "prj.set_log(\"temperature\", True)\n",
+    "prj = yt.ProjectionPlot(ds, \"z\", (\"gas\", \"temperature\"), origin=\"native\", \n",
+    "                        weight_field=(\"index\", \"ones\")) # \"ones\" weights each cell by 1\n",
+    "prj.set_log((\"gas\", \"temperature\"), True)\n",
     "prj.show()"
    ]
   },
@@ -319,7 +319,7 @@
    },
    "outputs": [],
    "source": [
-    "pplot = yt.ProfilePlot(dd, \"temperature\", [\"ones\"], weight_field=None, n_bins=128)\n",
+    "pplot = yt.ProfilePlot(dd, (\"gas\", \"temperature\"), [(\"index\", \"ones\")], weight_field=None, n_bins=128)\n",
     "pplot.show()"
    ]
   },
@@ -338,7 +338,7 @@
    },
    "outputs": [],
    "source": [
-    "fc = dd.cut_region([\"obj['temperature'] > 0\"])"
+    "fc = dd.cut_region([\"obj[('gas', 'temperature')] > 0\"])"
    ]
   },
   {
@@ -356,7 +356,7 @@
    },
    "outputs": [],
    "source": [
-    "print (fc.quantities.extrema(\"temperature\"))"
+    "print (fc.quantities.extrema((\"gas\", \"temperature\")))"
    ]
   },
   {
@@ -374,7 +374,7 @@
    },
    "outputs": [],
    "source": [
-    "fc.quantities.weighted_average_quantity(\"temperature\", \"ones\")"
+    "fc.quantities.weighted_average_quantity((\"gas\", \"temperature\"), (\"index\", \"ones\"))"
    ]
   },
   {
@@ -392,9 +392,9 @@
    },
    "outputs": [],
    "source": [
-    "prj = yt.ProjectionPlot(ds, \"z\", [\"temperature\"], data_source=fc, origin=\"native\", \n",
-    "                        weight_field=\"ones\") # \"ones\" weights each cell by 1\n",
-    "prj.set_log(\"temperature\", True)\n",
+    "prj = yt.ProjectionPlot(ds, \"z\", [(\"gas\", \"temperature\")], data_source=fc, origin=\"native\", \n",
+    "                        weight_field=(\"index\", \"ones\")) # \"ones\" weights each cell by 1\n",
+    "prj.set_log((\"gas\", \"temperature\"), True)\n",
     "prj.show()"
    ]
   },
@@ -450,7 +450,7 @@
    },
    "outputs": [],
    "source": [
-    "print (box_reg.quantities.extrema(\"temperature\"))"
+    "print (box_reg.quantities.extrema(\"gas\", (\"temperature\")))"
    ]
   },
   {
@@ -468,10 +468,10 @@
    },
    "outputs": [],
    "source": [
-    "prj = yt.ProjectionPlot(ds, \"z\", [\"temperature\"], origin=\"native\", \n",
-    "                        data_source=box_reg, weight_field=\"ones\") # \"ones\" weights each cell by 1\n",
-    "prj.set_zlim(\"temperature\", 1.0e-2, 1.5)\n",
-    "prj.set_log(\"temperature\", True)\n",
+    "prj = yt.ProjectionPlot(ds, \"z\", (\"gas\", \"temperature\"), origin=\"native\", \n",
+    "                        data_source=box_reg, weight_field=(\"index\", \"ones\")) # \"ones\" weights each cell by 1\n",
+    "prj.set_zlim((\"gas\", \"temperature\"), 1.0e-2, 1.5)\n",
+    "prj.set_log((\"gas\", \"temperature\"), True)\n",
     "prj.show()"
    ]
   }

--- a/doc/source/cookbook/fits_radio_cubes.ipynb
+++ b/doc/source/cookbook/fits_radio_cubes.ipynb
@@ -338,7 +338,7 @@
    },
    "outputs": [],
    "source": [
-    "fc = dd.cut_region([\"obj[('gas', 'temperature')] > 0\"])"
+    "fc = dd.cut_region([\"obj['gas', 'temperature'] > 0\"])"
    ]
   },
   {

--- a/doc/source/cookbook/fits_radio_cubes.ipynb
+++ b/doc/source/cookbook/fits_radio_cubes.ipynb
@@ -450,7 +450,7 @@
    },
    "outputs": [],
    "source": [
-    "print (box_reg.quantities.extrema(\"gas\", (\"temperature\")))"
+    "print (box_reg.quantities.extrema((\"gas\", \"temperature\")))"
    ]
   },
   {

--- a/doc/source/cookbook/fits_xray_images.ipynb
+++ b/doc/source/cookbook/fits_xray_images.ipynb
@@ -357,8 +357,8 @@
    "outputs": [],
    "source": [
     "dd = ds2.all_data()\n",
-    "print (dd[(\"io\", \"event_x\")])\n",
-    "print (dd[(\"io\", \"event_y\")])"
+    "print (dd[\"io\", \"event_x\"])\n",
+    "print (dd[\"io\", \"event_y\"])"
    ]
   },
   {

--- a/doc/source/cookbook/fits_xray_images.ipynb
+++ b/doc/source/cookbook/fits_xray_images.ipynb
@@ -70,7 +70,7 @@
    "source": [
     "def _counts(field, data):\n",
     "    exposure_time = data.get_field_parameter(\"exposure_time\")\n",
-    "    return data[(\"fits\", \"flux\")]*data[(\"fits\", \"pixel\")]*exposure_time\n",
+    "    return data[\"fits\", \"flux\"]*data[\"fits\", \"pixel\"]*exposure_time\n",
     "ds.add_field((\"gas\",\"counts\"), function=_counts, sampling_type=\"cell\", units=\"counts\", take_log=False)\n",
     "\n",
     "def _pp(field, data):\n",

--- a/doc/source/cookbook/fits_xray_images.ipynb
+++ b/doc/source/cookbook/fits_xray_images.ipynb
@@ -74,7 +74,7 @@
     "ds.add_field((\"gas\",\"counts\"), function=_counts, sampling_type=\"cell\", units=\"counts\", take_log=False)\n",
     "\n",
     "def _pp(field, data):\n",
-    "    return np.sqrt(data[(\"gas\", \"counts\")])*data[(\"fits\", \"projected_temperature\")]\n",
+    "    return np.sqrt(data[\"gas\", \"counts\"])*data[\"fits\", \"projected_temperature\"]\n",
     "ds.add_field((\"gas\",\"pseudo_pressure\"), function=_pp, sampling_type=\"cell\", units=\"sqrt(counts)*keV\", take_log=False)\n",
     "\n",
     "def _pe(field, data):\n",

--- a/doc/source/cookbook/fits_xray_images.ipynb
+++ b/doc/source/cookbook/fits_xray_images.ipynb
@@ -70,15 +70,15 @@
    "source": [
     "def _counts(field, data):\n",
     "    exposure_time = data.get_field_parameter(\"exposure_time\")\n",
-    "    return data[\"flux\"]*data[\"pixel\"]*exposure_time\n",
+    "    return data[(\"fits\", \"flux\")]*data[(\"fits\", \"pixel\")]*exposure_time\n",
     "ds.add_field((\"gas\",\"counts\"), function=_counts, sampling_type=\"cell\", units=\"counts\", take_log=False)\n",
     "\n",
     "def _pp(field, data):\n",
-    "    return np.sqrt(data[\"counts\"])*data[\"projected_temperature\"]\n",
+    "    return np.sqrt(data[(\"gas\", \"counts\")])*data[(\"fits\", \"projected_temperature\")]\n",
     "ds.add_field((\"gas\",\"pseudo_pressure\"), function=_pp, sampling_type=\"cell\", units=\"sqrt(counts)*keV\", take_log=False)\n",
     "\n",
     "def _pe(field, data):\n",
-    "    return data[\"projected_temperature\"]*data[\"counts\"]**(-1./3.)\n",
+    "    return data[(\fits\", \"projected_temperature\")]*data[(\"gas\", \"counts\")]**(-1./3.)\n",
     "ds.add_field((\"gas\",\"pseudo_entropy\"), function=_pe, sampling_type=\"cell\", units=\"keV*(counts)**(-1/3)\", take_log=False)"
    ]
   },
@@ -116,11 +116,11 @@
    "outputs": [],
    "source": [
     "slc = yt.SlicePlot(ds, \"z\", \n",
-    "                   [\"flux\",\"projected_temperature\",\"pseudo_pressure\",\"pseudo_entropy\"], \n",
+    "                   [(\"fits\", \"flux\"), (\"fits\", \"projected_temperature\"), (\"gas\", \"pseudo_pressure\"), (\"gas\", \"pseudo_entropy\")], \n",
     "                   origin=\"native\", field_parameters={\"exposure_time\":exposure_time})\n",
-    "slc.set_log(\"flux\",True)\n",
-    "slc.set_log(\"pseudo_pressure\",False)\n",
-    "slc.set_log(\"pseudo_entropy\",False)\n",
+    "slc.set_log((\"fits\", \"flux\"),True)\n",
+    "slc.set_log((\"gas\", \"pseudo_pressure\"),False)\n",
+    "slc.set_log((\"gas\", \"pseudo_entropy\"),False)\n",
     "slc.set_width(250.)\n",
     "slc.show()"
    ]
@@ -160,7 +160,7 @@
    },
    "outputs": [],
    "source": [
-    "v, c = ds.find_max(\"flux\") # Find the maximum flux and its center\n",
+    "v, c = ds.find_max((\"fits\", \"flux\")) # Find the maximum flux and its center\n",
     "my_sphere = ds.sphere(c, (100.,\"code_length\")) # Radius of 150 pixels\n",
     "my_sphere.set_field_parameter(\"exposure_time\", exposure_time)"
    ]
@@ -268,13 +268,13 @@
    "outputs": [],
    "source": [
     "prj = yt.ProjectionPlot(ds, \"z\", \n",
-    "                   [\"flux\",\"projected_temperature\",\"pseudo_pressure\",\"pseudo_entropy\"], \n",
+    "                   [(\"fits\", \"flux\"), (\"fits\", \"projected_temperature\"), (\"gas\", \"pseudo_pressure\"), (\"gas\", \"pseudo_entropy\"]), \n",
     "                   origin=\"native\", field_parameters={\"exposure_time\":exposure_time},\n",
     "                   data_source=circle_reg,\n",
     "                   method=\"sum\")\n",
-    "prj.set_log(\"flux\",True)\n",
-    "prj.set_log(\"pseudo_pressure\",False)\n",
-    "prj.set_log(\"pseudo_entropy\",False)\n",
+    "prj.set_log((\"fits\", \"flux\"),True)\n",
+    "prj.set_log((\"gas\", \"pseudo_pressure\"),False)\n",
+    "prj.set_log((\"gas\", \"pseudo_entropy\"),False)\n",
     "prj.set_width(250.)\n",
     "prj.show()"
    ]
@@ -357,8 +357,8 @@
    "outputs": [],
    "source": [
     "dd = ds2.all_data()\n",
-    "print (dd[\"event_x\"])\n",
-    "print (dd[\"event_y\"])"
+    "print (dd[(\"io\", \"event_x\")])\n",
+    "print (dd[(\"io\", \"event_y\")])"
    ]
   },
   {
@@ -376,7 +376,7 @@
    },
    "outputs": [],
    "source": [
-    "slc = yt.SlicePlot(ds2, \"z\", [\"counts_0.1-2.0\",\"counts_2.0-5.0\"], origin=\"native\")\n",
+    "slc = yt.SlicePlot(ds2, \"z\", [(\"gas\", \"counts_0.1-2.0\"), (\"gas\", \"counts_2.0-5.0\")], origin=\"native\")\n",
     "slc.pan((100.,100.))\n",
     "slc.set_width(500.)\n",
     "slc.show()"
@@ -397,12 +397,12 @@
    },
    "outputs": [],
    "source": [
-    "slc = yt.SlicePlot(ds2, \"z\", [\"counts_0.1-2.0\",\"counts_2.0-5.0\"], origin=\"native\",\n",
+    "slc = yt.SlicePlot(ds2, \"z\", [(\"gas\", \"counts_0.1-2.0\"), (\"gas\", \"counts_2.0-5.0\")], origin=\"native\",\n",
     "                   field_parameters={\"sigma\":2.}) # This value is in pixel scale\n",
     "slc.pan((100.,100.))\n",
     "slc.set_width(500.)\n",
-    "slc.set_zlim(\"counts_0.1-2.0\", 0.01, 100.)\n",
-    "slc.set_zlim(\"counts_2.0-5.0\", 0.01, 50.)\n",
+    "slc.set_zlim((\"gas\", \"counts_0.1-2.0\"), 0.01, 100.)\n",
+    "slc.set_zlim((\"gas\", \"counts_2.0-5.0\"), 0.01, 50.)\n",
     "slc.show()"
    ]
   }

--- a/doc/source/cookbook/fits_xray_images.ipynb
+++ b/doc/source/cookbook/fits_xray_images.ipynb
@@ -78,7 +78,7 @@
     "ds.add_field((\"gas\",\"pseudo_pressure\"), function=_pp, sampling_type=\"cell\", units=\"sqrt(counts)*keV\", take_log=False)\n",
     "\n",
     "def _pe(field, data):\n",
-    "    return data[(\fits\", \"projected_temperature\")]*data[(\"gas\", \"counts\")]**(-1./3.)\n",
+    "    return data[\"fits\", \"projected_temperature\"]*data[\"gas\", \"counts\"]**(-1./3.)\n",
     "ds.add_field((\"gas\",\"pseudo_entropy\"), function=_pe, sampling_type=\"cell\", units=\"keV*(counts)**(-1/3)\", take_log=False)"
    ]
   },

--- a/doc/source/cookbook/matplotlib-animation.py
+++ b/doc/source/cookbook/matplotlib-animation.py
@@ -5,8 +5,8 @@ import yt
 
 ts = yt.load("GasSloshingLowRes/sloshing_low_res_hdf5_plt_cnt_*")
 
-plot = yt.SlicePlot(ts[0], "z", "density")
-plot.set_zlim("density", 8e-29, 3e-26)
+plot = yt.SlicePlot(ts[0], "z", ("gas", "density"))
+plot.set_zlim(("gas", "density"), 8e-29, 3e-26)
 
 fig = plot.plots[("gas", "density")].figure
 

--- a/doc/source/cookbook/multi_plot_3x2_FRB.py
+++ b/doc/source/cookbook/multi_plot_3x2_FRB.py
@@ -59,7 +59,7 @@ for ax in range(3):
 # .  Note that it cuts off after the shortest iterator is exhausted,
 # in this case, titles.
 titles = [
-    r"$\mathrm{Density}\ (\mathrm{g\ cm^{-3}})$",
+    r"$\mathrm{density}\ (\mathrm{g\ cm^{-3}})$",
     r"$\mathrm{temperature}\ (\mathrm{K})$",
 ]
 for p, cax, t in zip(plots, colorbars, titles):

--- a/doc/source/cookbook/multi_width_image.py
+++ b/doc/source/cookbook/multi_width_image.py
@@ -6,7 +6,7 @@ ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
 # Create a slice plot for the dataset.  With no additional arguments,
 # the width will be the size of the domain and the center will be the
 # center of the simulation box
-slc = yt.SlicePlot(ds, "z", "density")
+slc = yt.SlicePlot(ds, "z", ("gas", "density"))
 
 # Create a list of a couple of widths and units.
 # (N.B. Mpc (megaparsec) != mpc (milliparsec)
@@ -24,7 +24,7 @@ for width, unit in widths:
 zoomFactors = [2, 4, 5]
 
 # recreate the original slice
-slc = yt.SlicePlot(ds, "z", "density")
+slc = yt.SlicePlot(ds, "z", ("gas", "density"))
 
 for zoomFactor in zoomFactors:
 

--- a/doc/source/cookbook/multiplot_2x2.py
+++ b/doc/source/cookbook/multiplot_2x2.py
@@ -26,7 +26,12 @@ grid = AxesGrid(
     cbar_pad="0%",
 )
 
-fields = ["density", "velocity_x", "velocity_y", "velocity_magnitude"]
+fields = [
+    ("gas", "density"),
+    ("gas", "velocity_x"),
+    ("gas", "velocity_y"),
+    ("gas", "velocity_magnitude"),
+]
 
 # Create the plot.  Since SlicePlot accepts a list of fields, we need only
 # do this once.

--- a/doc/source/cookbook/multiplot_2x2_coordaxes_slice.py
+++ b/doc/source/cookbook/multiplot_2x2_coordaxes_slice.py
@@ -27,7 +27,12 @@ grid = AxesGrid(
 )
 
 cuts = ["x", "y", "z", "z"]
-fields = ["density", "density", "density", "temperature"]
+fields = [
+    ("gas", "density"),
+    ("gas", "density"),
+    ("gas", "density"),
+    ("gas", "temperature"),
+]
 
 for i, (direction, field) in enumerate(zip(cuts, fields)):
     # Load the data and create a single plot
@@ -44,9 +49,9 @@ for i, (direction, field) in enumerate(zip(cuts, fields)):
     # to index cbar_axes, yielding a plot without a temperature colorbar.
     # This unnecessarily redraws the Density colorbar three times, but that has
     # no effect on the final plot.
-    if field == "density":
+    if field == ("gas", "density"):
         plot.cax = grid.cbar_axes[0]
-    elif field == "temperature":
+    elif field == ("gas", "temperature"):
         plot.cax = grid.cbar_axes[1]
 
     # Finally, redraw the plot.

--- a/doc/source/cookbook/multiplot_2x2_time_series.py
+++ b/doc/source/cookbook/multiplot_2x2_time_series.py
@@ -33,7 +33,7 @@ grid = AxesGrid(
 for i, fn in enumerate(fns):
     # Load the data and create a single plot
     ds = yt.load(fn)  # load data
-    p = yt.ProjectionPlot(ds, "z", "density", width=(55, "Mpccm"))
+    p = yt.ProjectionPlot(ds, "z", ("gas", "density"), width=(55, "Mpccm"))
 
     # Ensure the colorbar limits match for all plots
     p.set_zlim(("gas", "density"), 1e-4, 1e-2)

--- a/doc/source/cookbook/multiplot_export_to_mpl.py
+++ b/doc/source/cookbook/multiplot_export_to_mpl.py
@@ -2,7 +2,13 @@ import yt
 
 ds = yt.load_sample("IsolatedGalaxy")
 
-fields = ["density", "velocity_x", "velocity_y", "velocity_magnitude"]
+fields = [
+    ("gas", "density"),
+    ("gas", "velocity_x"),
+    ("gas", "velocity_y"),
+    ("gas", "velocity_magnitude"),
+]
+
 p = yt.SlicePlot(ds, "z", fields)
 p.set_log(("gas", "velocity_x"), False)
 p.set_log(("gas", "velocity_y"), False)

--- a/doc/source/cookbook/multiplot_phaseplot.py
+++ b/doc/source/cookbook/multiplot_phaseplot.py
@@ -26,10 +26,10 @@ for i, SnapNum in enumerate([10, 40]):
     ad = ds.all_data()
     p = yt.PhasePlot(
         ad,
-        "density",
-        "temperature",
+        ("gas", "density"),
+        ("gas", "temperature"),
         [
-            "mass",
+            ("gas", "mass"),
         ],
         weight_field=None,
     )

--- a/doc/source/cookbook/opengl_ipython.py
+++ b/doc/source/cookbook/opengl_ipython.py
@@ -14,8 +14,8 @@ collection = BlockCollection()
 
 ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
 
-dd = ds.all_data()
-collection.add_data(dd, "density")
+ad = ds.all_data()
+collection.add_data(ad, ("gas", "density"))
 
 scene.add_collection(collection)
 

--- a/doc/source/cookbook/overplot_grids.py
+++ b/doc/source/cookbook/overplot_grids.py
@@ -4,7 +4,7 @@ import yt
 ds = yt.load("Enzo_64/DD0043/data0043")
 
 # Make a density projection.
-p = yt.ProjectionPlot(ds, "y", "density")
+p = yt.ProjectionPlot(ds, "y", ("gas", "density"))
 
 # Modify the projection
 # The argument specifies the region along the line of sight

--- a/doc/source/cookbook/overplot_particles.py
+++ b/doc/source/cookbook/overplot_particles.py
@@ -5,7 +5,7 @@ ds = yt.load("Enzo_64/DD0043/data0043")
 
 # Make a density projection centered on the 'm'aximum density location
 # with a width of 10 Mpc..
-p = yt.ProjectionPlot(ds, "y", "density", center="m", width=(10, "Mpc"))
+p = yt.ProjectionPlot(ds, "y", ("gas", "density"), center="m", width=(10, "Mpc"))
 
 # Modify the projection
 # The argument specifies the region along the line of sight

--- a/doc/source/cookbook/particle_filter.py
+++ b/doc/source/cookbook/particle_filter.py
@@ -9,19 +9,19 @@ from yt.data_objects.particle_filters import add_particle_filter
 # times arbitrarily far into the future, so stars with negative ages belong
 # in the old stars filter.
 def stars_10Myr(pfilter, data):
-    age = data.ds.current_time - data["Stars", "creation_time"]
+    age = data.ds.current_time - data[("Stars", "creation_time")]
     filter = np.logical_and(age >= 0, age.in_units("Myr") < 10)
     return filter
 
 
 def stars_100Myr(pfilter, data):
-    age = (data.ds.current_time - data["Stars", "creation_time"]).in_units("Myr")
+    age = (data.ds.current_time - data[("Stars", "creation_time")]).in_units("Myr")
     filter = np.logical_and(age >= 10, age < 100)
     return filter
 
 
 def stars_old(pfilter, data):
-    age = data.ds.current_time - data["Stars", "creation_time"]
+    age = data.ds.current_time - data[("Stars", "creation_time")]
     filter = np.logical_or(age < 0, age.in_units("Myr") >= 100)
     return filter
 
@@ -53,9 +53,9 @@ ds.add_particle_filter("stars_old")
 # What are the total masses of different ages of star in the whole simulation
 # volume?
 ad = ds.all_data()
-mass_young = ad["stars_young", "particle_mass"].in_units("Msun").sum()
-mass_medium = ad["stars_medium", "particle_mass"].in_units("Msun").sum()
-mass_old = ad["stars_old", "particle_mass"].in_units("Msun").sum()
+mass_young = ad[("stars_young", "particle_mass")].in_units("Msun").sum()
+mass_medium = ad[("stars_medium", "particle_mass")].in_units("Msun").sum()
+mass_old = ad[("stars_old", "particle_mass")].in_units("Msun").sum()
 print(f"Mass of young stars = {mass_young:g} Msun")
 print(f"Mass of medium stars = {mass_medium:g} Msun")
 print(f"Mass of old stars = {mass_old:g} Msun")

--- a/doc/source/cookbook/particle_filter.py
+++ b/doc/source/cookbook/particle_filter.py
@@ -53,9 +53,9 @@ ds.add_particle_filter("stars_old")
 # What are the total masses of different ages of star in the whole simulation
 # volume?
 ad = ds.all_data()
-mass_young = ad[("stars_young", "particle_mass")].in_units("Msun").sum()
-mass_medium = ad[("stars_medium", "particle_mass")].in_units("Msun").sum()
-mass_old = ad[("stars_old", "particle_mass")].in_units("Msun").sum()
+mass_young = ad["stars_young", "particle_mass"].in_units("Msun").sum()
+mass_medium = ad["stars_medium", "particle_mass"].in_units("Msun").sum()
+mass_old = ad["stars_old", "particle_mass"].in_units("Msun").sum()
 print(f"Mass of young stars = {mass_young:g} Msun")
 print(f"Mass of medium stars = {mass_medium:g} Msun")
 print(f"Mass of old stars = {mass_old:g} Msun")

--- a/doc/source/cookbook/particle_filter.py
+++ b/doc/source/cookbook/particle_filter.py
@@ -21,7 +21,7 @@ def stars_100Myr(pfilter, data):
 
 
 def stars_old(pfilter, data):
-    age = data.ds.current_time - data[("Stars", "creation_time")]
+    age = data.ds.current_time - data["Stars", "creation_time"]
     filter = np.logical_or(age < 0, age.in_units("Myr") >= 100)
     return filter
 

--- a/doc/source/cookbook/particle_filter.py
+++ b/doc/source/cookbook/particle_filter.py
@@ -9,13 +9,13 @@ from yt.data_objects.particle_filters import add_particle_filter
 # times arbitrarily far into the future, so stars with negative ages belong
 # in the old stars filter.
 def stars_10Myr(pfilter, data):
-    age = data.ds.current_time - data[("Stars", "creation_time")]
+    age = data.ds.current_time - data["Stars", "creation_time"]
     filter = np.logical_and(age >= 0, age.in_units("Myr") < 10)
     return filter
 
 
 def stars_100Myr(pfilter, data):
-    age = (data.ds.current_time - data[("Stars", "creation_time")]).in_units("Myr")
+    age = (data.ds.current_time - data["Stars", "creation_time"]).in_units("Myr")
     filter = np.logical_and(age >= 10, age < 100)
     return filter
 

--- a/doc/source/cookbook/particle_filter_sfr.py
+++ b/doc/source/cookbook/particle_filter_sfr.py
@@ -19,8 +19,8 @@ filename = "IsolatedGalaxy/galaxy0030/galaxy0030"
 ds = yt.load(filename)
 ds.add_particle_filter("formed_star")
 ad = ds.all_data()
-masses = ad[("formed_star", "particle_mass")].in_units("Msun")
-formation_time = ad[("formed_star", "creation_time")].in_units("yr")
+masses = ad["formed_star", "particle_mass"].in_units("Msun")
+formation_time = ad["formed_star", "creation_time"].in_units("yr")
 
 time_range = [0, 5e8]  # years
 n_bins = 1000

--- a/doc/source/cookbook/particle_filter_sfr.py
+++ b/doc/source/cookbook/particle_filter_sfr.py
@@ -6,7 +6,7 @@ from yt.data_objects.particle_filters import add_particle_filter
 
 
 def formed_star(pfilter, data):
-    filter = data[("all", "creation_time")] > 0
+    filter = data["all", "creation_time"] > 0
     return filter
 
 

--- a/doc/source/cookbook/particle_filter_sfr.py
+++ b/doc/source/cookbook/particle_filter_sfr.py
@@ -6,7 +6,7 @@ from yt.data_objects.particle_filters import add_particle_filter
 
 
 def formed_star(pfilter, data):
-    filter = data["all", "creation_time"] > 0
+    filter = data[("all", "creation_time")] > 0
     return filter
 
 
@@ -19,8 +19,8 @@ filename = "IsolatedGalaxy/galaxy0030/galaxy0030"
 ds = yt.load(filename)
 ds.add_particle_filter("formed_star")
 ad = ds.all_data()
-masses = ad["formed_star", "particle_mass"].in_units("Msun")
-formation_time = ad["formed_star", "creation_time"].in_units("yr")
+masses = ad[("formed_star", "particle_mass")].in_units("Msun")
+formation_time = ad[("formed_star", "creation_time")].in_units("yr")
 
 time_range = [0, 5e8]  # years
 n_bins = 1000

--- a/doc/source/cookbook/radial_profile_styles.py
+++ b/doc/source/cookbook/radial_profile_styles.py
@@ -13,7 +13,7 @@ sp = ds.sphere(ds.domain_center, (500.0, "kpc"))
 rp = yt.create_profile(
     sp,
     "radius",
-    ["density", "temperature"],
+    [("gas", "density"), ("gas", "temperature")],
     units={"radius": "kpc"},
     logs={"radius": False},
 )

--- a/doc/source/cookbook/simple_contour_in_slice.py
+++ b/doc/source/cookbook/simple_contour_in_slice.py
@@ -4,11 +4,11 @@ import yt
 ds = yt.load("Sedov_3d/sedov_hdf5_chk_0002")
 
 # Make a traditional slice plot.
-sp = yt.SlicePlot(ds, "x", "density")
+sp = yt.SlicePlot(ds, "x", ("gas", "density"))
 
 # Overlay the slice plot with thick red contours of density.
 sp.annotate_contour(
-    "density",
+    ("gas", "density"),
     ncont=3,
     clim=(1e-2, 1e-1),
     label=True,
@@ -17,7 +17,7 @@ sp.annotate_contour(
 
 # What about some nice temperature contours in blue?
 sp.annotate_contour(
-    "temperature",
+    ("gas", "temperature"),
     ncont=3,
     clim=(1e-8, 1e-6),
     label=True,

--- a/doc/source/cookbook/simple_pdf.py
+++ b/doc/source/cookbook/simple_pdf.py
@@ -9,7 +9,12 @@ ad = ds.all_data()
 # This is identical to the simple phase plot, except we supply
 # the fractional=True keyword to divide the profile data by the sum.
 plot = yt.PhasePlot(
-    ad, "density", "temperature", "mass", weight_field=None, fractional=True
+    ad,
+    ("gas", "density"),
+    ("gas", "temperature"),
+    ("gas", "mass"),
+    weight_field=None,
+    fractional=True,
 )
 
 # Save the image.

--- a/doc/source/cookbook/simple_projection.py
+++ b/doc/source/cookbook/simple_projection.py
@@ -3,8 +3,8 @@ import yt
 # Load the dataset.
 ds = yt.load("GalaxyClusterMerger/fiducial_1to3_b0.273d_hdf5_plt_cnt_0175")
 
-# Create projections of the density (non-weighted line integrals).
+# Create projections of the gas density (non-weighted line integrals).
 
-yt.ProjectionPlot(ds, "x", "density").save()
-yt.ProjectionPlot(ds, "y", "density").save()
-yt.ProjectionPlot(ds, "z", "density").save()
+yt.ProjectionPlot(ds, "x", ("gas", "density")).save()
+yt.ProjectionPlot(ds, "y", ("gas", "density")).save()
+yt.ProjectionPlot(ds, "z", ("gas", "density")).save()

--- a/doc/source/cookbook/simple_slice.py
+++ b/doc/source/cookbook/simple_slice.py
@@ -3,7 +3,7 @@ import yt
 # Load the dataset.
 ds = yt.load("GasSloshing/sloshing_nomag2_hdf5_plt_cnt_0150")
 
-# Create density slices in all three axes.
-yt.SlicePlot(ds, "x", "density", width=(800.0, "kpc")).save()
-yt.SlicePlot(ds, "y", "density", width=(800.0, "kpc")).save()
-yt.SlicePlot(ds, "z", "density", width=(800.0, "kpc")).save()
+# Create gas density slices in all three axes.
+yt.SlicePlot(ds, "x", ("gas", "density"), width=(800.0, "kpc")).save()
+yt.SlicePlot(ds, "y", ("gas", "density"), width=(800.0, "kpc")).save()
+yt.SlicePlot(ds, "z", ("gas", "density"), width=(800.0, "kpc")).save()

--- a/doc/source/cookbook/simple_slice_matplotlib_example.py
+++ b/doc/source/cookbook/simple_slice_matplotlib_example.py
@@ -6,7 +6,7 @@ import yt
 ds = yt.load("GasSloshing/sloshing_nomag2_hdf5_plt_cnt_0150")
 
 # Create a slice object
-slc = yt.SlicePlot(ds, "x", "density", width=(800.0, "kpc"))
+slc = yt.SlicePlot(ds, "x", ("gas", "density"), width=(800.0, "kpc"))
 
 # Get a reference to the matplotlib axes object for the plot
 ax = slc.plots[("gas", "density")].axes

--- a/doc/source/cookbook/simple_slice_with_multiple_fields.py
+++ b/doc/source/cookbook/simple_slice_with_multiple_fields.py
@@ -3,7 +3,10 @@ import yt
 # Load the dataset
 ds = yt.load("GasSloshing/sloshing_nomag2_hdf5_plt_cnt_0150")
 
-# Create density slices of several fields along the x axis
+# Create gas density slices of several fields along the x axis simultaneously
 yt.SlicePlot(
-    ds, "x", ["density", "temperature", "pressure"], width=(800.0, "kpc")
+    ds,
+    "x",
+    [("gas", "density"), ("gas", "temperature"), ("gas", "pressure")],
+    width=(800.0, "kpc"),
 ).save()

--- a/doc/source/cookbook/streamlines.py
+++ b/doc/source/cookbook/streamlines.py
@@ -23,9 +23,9 @@ pos = c + pos_dx
 streamlines = Streamlines(
     ds,
     pos,
-    "velocity_x",
-    "velocity_y",
-    "velocity_z",
+    ("gas", "velocity_x"),
+    ("gas", "velocity_y"),
+    ("gas", "velocity_z"),
     length=1.0 * Mpc,
     get_magnitude=True,
 )

--- a/doc/source/cookbook/tipsy_and_yt.ipynb
+++ b/doc/source/cookbook/tipsy_and_yt.ipynb
@@ -115,9 +115,9 @@
    "outputs": [],
    "source": [
     "ad = ds.all_data()\n",
-    "xcoord = ad[('Gas','Coordinates')][:,0].v\n",
-    "ycoord = ad[('Gas','Coordinates')][:,1].v\n",
-    "logT = np.log10(ad[('Gas','Temperature')])\n",
+    "xcoord = ad['Gas', 'Coordinates'][:,0].v\n",
+    "ycoord = ad['Gas', 'Coordinates'][:,1].v\n",
+    "logT = np.log10(ad['Gas', 'Temperature'])\n",
     "plt.scatter(xcoord, ycoord, c=logT, s=2*logT, marker='o', edgecolor='none', vmin=2, vmax=6)\n",
     "plt.xlim(-20,20)\n",
     "plt.ylim(-20,20)\n",

--- a/doc/source/cookbook/tipsy_and_yt.ipynb
+++ b/doc/source/cookbook/tipsy_and_yt.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Alright, let's start with some basics.  Before we do anything, we will need to load a snapshot.  You can do this using the ```load``` convenience function.  yt will autodetect that you have a tipsy snapshot, and automatically set itself up appropriately."
+    "Alright, let's start with some basics.  Before we do anything, we will need to load a snapshot.  You can do this using the ```load_sample``` convenience function.  yt will autodetect that you want a tipsy snapshot and download it from the yt hub."
    ]
   },
   {
@@ -29,7 +29,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will be looking at a fairly low resolution dataset.  In the next cell, the `ds` object has an attribute called `n_ref` that tells the oct-tree how many particles to refine on.  The default is 64, but we'll get prettier plots (at the expense of a deeper tree) with 8.  Just passing the argument `n_ref=8` to load does this for us."
+    "We will be looking at a fairly low resolution dataset."
    ]
   },
   {
@@ -47,7 +47,7 @@
    },
    "outputs": [],
    "source": [
-    "ds = yt.load('TipsyGalaxy/galaxy.00300', n_ref=8)"
+    "ds = yt.load_sample('TipsyGalaxy')"
    ]
   },
   {
@@ -114,10 +114,10 @@
    },
    "outputs": [],
    "source": [
-    "dd = ds.all_data()\n",
-    "xcoord = dd['Gas','Coordinates'][:,0].v\n",
-    "ycoord = dd['Gas','Coordinates'][:,1].v\n",
-    "logT = np.log10(dd['Gas','Temperature'])\n",
+    "ad = ds.all_data()\n",
+    "xcoord = ad[('Gas','Coordinates')][:,0].v\n",
+    "ycoord = ad[('Gas','Coordinates')][:,1].v\n",
+    "logT = np.log10(ad[('Gas','Temperature')])\n",
     "plt.scatter(xcoord, ycoord, c=logT, s=2*logT, marker='o', edgecolor='none', vmin=2, vmax=6)\n",
     "plt.xlim(-20,20)\n",
     "plt.ylim(-20,20)\n",

--- a/doc/source/cookbook/velocity_vectors_on_slice.py
+++ b/doc/source/cookbook/velocity_vectors_on_slice.py
@@ -3,7 +3,7 @@ import yt
 # Load the dataset.
 ds = yt.load("GasSloshing/sloshing_nomag2_hdf5_plt_cnt_0150")
 
-p = yt.SlicePlot(ds, "x", "density")
+p = yt.SlicePlot(ds, "x", ("gas", "density"))
 
 # Draw a velocity vector every 16 pixels.
 p.annotate_velocity(factor=16)

--- a/doc/source/cookbook/yt_gadget_owls_analysis.ipynb
+++ b/doc/source/cookbook/yt_gadget_owls_analysis.ipynb
@@ -20,15 +20,7 @@
    "source": [
     "The first thing you will need to run these examples is a working installation of yt.  The author or these examples followed the instructions under \"Get yt: from source\" at https://yt-project.org/ to install an up to date development version of yt.\n",
     "\n",
-    "Next you should set the default ``test_data_dir`` in the ``~/.config/yt/ytrc`` file in your home directory.  Note that you may have to create the directory and file if it doesn't exist already.\n",
-    "\n",
-    "> [yt]\n",
-    "\n",
-    "> test_data_dir=/home/galtay/yt-data\n",
-    "\n",
-    "Now you should create the directory referenced above (in this case ``/home/galtay/yt-data``).  The first time you request ion fields from yt it will download a supplementary data file to this directory. \n",
-    "\n",
-    "Next we will get an example OWLS snapshot.  There is a snapshot available on the yt data site, https://yt-project.org/data/snapshot_033.tar.gz (269 MB).  Save this tar.gz file in the same directory as this notebook, then unzip and untar it.  "
+    "We will be working with an OWLS snapshot: snapshot_033"
    ]
   },
   {
@@ -71,7 +63,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we will load the snapshot.  See the docs (http://yt-project.org/docs/dev/examining/loading_data.html#indexing-criteria) for a description of ``n_ref`` and ``over_refine_factor``."
+    "Now we will load the snapshot."
    ]
   },
   {
@@ -82,8 +74,7 @@
    },
    "outputs": [],
    "source": [
-    "fname = 'snapshot_033/snap_033.0.hdf5'\n",
-    "ds = yt.load(fname, n_ref=64, over_refine_factor=1)"
+    "ds = yt.load_sample('snapshot_033')"
    ]
   },
   {
@@ -169,7 +160,7 @@
    },
    "outputs": [],
    "source": [
-    "ad['PartType0', 'Coordinates']"
+    "ad[('PartType0', 'Coordinates')]"
    ]
   },
   {
@@ -180,7 +171,7 @@
    },
    "outputs": [],
    "source": [
-    "ad['PartType4', 'IronFromSNIa']"
+    "ad[('PartType4', 'IronFromSNIa')]"
    ]
   },
   {
@@ -191,7 +182,7 @@
    },
    "outputs": [],
    "source": [
-    "ad['PartType1', 'ParticleIDs']"
+    "ad[('PartType1', 'ParticleIDs')]"
    ]
   },
   {
@@ -202,7 +193,7 @@
    },
    "outputs": [],
    "source": [
-    "ad['PartType0', 'Hydrogen']"
+    "ad[('PartType0', 'Hydrogen')]"
    ]
   },
   {

--- a/doc/source/cookbook/zoomin_frames.py
+++ b/doc/source/cookbook/zoomin_frames.py
@@ -16,8 +16,8 @@ min_dx = 40
 
 frame_template = "frame_%05i"  # Template for frame filenames
 
-p = yt.SlicePlot(ds, "z", "density")  # Add our slice, along z
-p.annotate_contour("temperature")  # We'll contour in temperature
+p = yt.SlicePlot(ds, "z", ("gas", "density"))  # Add our slice, along z
+p.annotate_contour(("gas", "temperature"))  # We'll contour in temperature
 
 # What we do now is a bit fun.  "enumerate" returns a tuple for every item --
 # the index of the item, and the item itself.  This saves us having to write

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -1346,24 +1346,6 @@ units as the example above:
 
   ds = yt.load("snap_004", unit_base=unit_base, bounding_box=bbox)
 
-.. _particle-indexing-criteria:
-
-Indexing Criteria
-^^^^^^^^^^^^^^^^^
-
-yt generates a global mesh index via octree that governs the resolution of
-volume elements.  This is governed by two parameters, ``n_ref`` and
-``over_refine_factor``.  They are weak proxies for each other.  The first,
-``n_ref``, governs how many particles in an oct results in that oct being
-refined into eight child octs.  Lower values mean higher resolution; the
-default is 64.  The second parameter, ``over_refine_factor``, governs how many
-cells are in a given oct; the default value of 1 corresponds to 8 cells.
-The number of cells in an oct is defined by the expression
-``2**(3*over_refine_factor)``.
-
-It's recommended that if you want higher-resolution, try reducing the value of
-``n_ref`` to 32 or 16.
-
 .. _gadget-field-spec:
 
 Field Specifications

--- a/doc/source/visualizing/TransferFunctionHelper_Tutorial.ipynb
+++ b/doc/source/visualizing/TransferFunctionHelper_Tutorial.ipynb
@@ -85,7 +85,7 @@
    "source": [
     "# Build a transfer function that is a multivariate gaussian in temperature\n",
     "tfh = TransferFunctionHelper(ds)\n",
-    "tfh.set_field('temperature')\n",
+    "tfh.set_field(('gas', 'temperature'))\n",
     "tfh.set_log(True)\n",
     "tfh.set_bounds()\n",
     "tfh.build_transfer_function()\n",
@@ -108,7 +108,7 @@
    },
    "outputs": [],
    "source": [
-    "tfh.plot(profile_field='mass')"
+    "tfh.plot(profile_field=('gas', 'mass'))"
    ]
   },
   {
@@ -127,7 +127,7 @@
    "outputs": [],
    "source": [
     "tfh = TransferFunctionHelper(ds)\n",
-    "tfh.set_field('temperature')\n",
+    "tfh.set_field(('gas', 'temperature'))\n",
     "tfh.set_bounds()\n",
     "tfh.set_log(True)\n",
     "tfh.build_transfer_function()\n",
@@ -135,7 +135,7 @@
     "tfh.tf.map_to_colormap(6.0, 8.0, colormap='Reds')\n",
     "tfh.tf.map_to_colormap(-1.0, 6.0, colormap='Blues_r')\n",
     "\n",
-    "tfh.plot(profile_field='mass')"
+    "tfh.plot(profile_field=('gas', 'mass'))"
    ]
   },
   {
@@ -153,7 +153,7 @@
    },
    "outputs": [],
    "source": [
-    "im, sc = yt.volume_render(ds, ['temperature'])\n",
+    "im, sc = yt.volume_render(ds, [('gas', 'temperature')])\n",
     "\n",
     "source = sc.get_source()\n",
     "source.set_transfer_function(tfh.tf)\n",
@@ -178,7 +178,7 @@
    "outputs": [],
    "source": [
     "tfh2 = TransferFunctionHelper(ds)\n",
-    "tfh2.set_field('temperature')\n",
+    "tfh2.set_field(('gas', 'temperature'))\n",
     "tfh2.set_bounds()\n",
     "tfh2.set_log(True)\n",
     "tfh2.build_transfer_function()\n",
@@ -186,7 +186,7 @@
     "tfh2.tf.map_to_colormap(6.0, 8.0, colormap='Reds', scale=5.0)\n",
     "tfh2.tf.map_to_colormap(-1.0, 6.0, colormap='Blues_r', scale=1.0)\n",
     "\n",
-    "tfh2.plot(profile_field='mass')"
+    "tfh2.plot(profile_field=('gas', 'mass'))"
    ]
   },
   {

--- a/doc/source/visualizing/Volume_Rendering_Tutorial.ipynb
+++ b/doc/source/visualizing/Volume_Rendering_Tutorial.ipynb
@@ -35,7 +35,6 @@
     "import yt\n",
     "import numpy as np\n",
     "from yt.visualization.volume_rendering.transfer_function_helper import TransferFunctionHelper\n",
-    "from yt.visualization.volume_rendering.api import Scene, VolumeSource\n",
     "\n",
     "ds = yt.load(\"IsolatedGalaxy/galaxy0030/galaxy0030\")\n",
     "sc = yt.create_scene(ds)"

--- a/doc/source/yt4differences.rst
+++ b/doc/source/yt4differences.rst
@@ -49,6 +49,13 @@ The list below is arranged in order of most to least important changes.
   The yt-4.0 release will be the final release of yt to support Python 3.6.
   Starting with yt-4.1, python 3.6 will no longer be supported, so please
   start using 3.7+ as soon as possible.
+* **Particle-based datasets no longer accept n_ref and over_refine_factor**
+  One of the major upgrades in yt-4 is native treatment of particle-based
+  datasets.  This is in contrast to previous yt behavior which loaded particle-based
+  datasets as octrees, which could then be treated like grid-based datasets.
+  In order to define the octrees, users were required to specify ``n_ref``
+  and ``over_refine_factor`` values at load time.  Please remove
+  any reference to ``n_ref`` and ``over_refine_factor`` in your scripts.
 * **Neutral ion fields changing format**
   In previous versions, neutral ion fields were specified as
   ``ELEMENT_number_density`` (e.g., ``H_number_density`` to represent H I

--- a/yt/frontends/fits/misc.py
+++ b/yt/frontends/fits/misc.py
@@ -24,7 +24,7 @@ def _make_counts(emin, emax):
         else:
             sigma = None
         if sigma is not None and sigma > 0.0:
-            kern = _astropy.conv.Gaussian2DKernel(stddev=sigma)
+            kern = _astropy.conv.Gaussian2DKernel(x_stddev=sigma)
             img[:, :, 0] = _astropy.conv.convolve(img[:, :, 0], kern)
         return data.ds.arr(img, "counts/pixel")
 


### PR DESCRIPTION
This is a pass at updating the docs to reflect the current state of code in yt4.  Namely, this updates the cookbook, fixing some breakages in the notebooks, and ensuring full tuples are used to specify each field reference, among some other changes.

Note, I'm removing the description surrounding n_ref in the Gadget loading data page, since it is no longer relevant in yt4: http://yt-project.org/docs/dev/examining/loading_data.html#indexing-criteria