### PR TITLE
Refactoring "default" species fields

### DIFF
--- a/doc/source/analyzing/fields.rst
+++ b/doc/source/analyzing/fields.rst
@@ -481,15 +481,15 @@ any default species fields. If the ``default_species_fields`` argument is not se
 More specifically, if ``default_species_fields="ionized"``, then these
 additional fields are defined:
 
-* ``H_p1_number_density`` (equal to the value of ``H_nuclei_density``)
-* ``He_p2_number_density`` (equal to the value of ``He_nuclei_density``)
-* ``El_number_density``
+* ``H_p1_number_density`` (Ionized hydrogen: equal to the value of ``H_nuclei_density``)
+* ``He_p2_number_density`` (Doubly ionized helium: equal to the value of ``He_nuclei_density``)
+* ``El_number_density`` (Free electrons: assuming full ionization)
 
 Whereas if ``default_species_fields="neutral"``, then these additional
 fields are defined:
 
-* ``H_p0_number_density`` (equal to the value of ``H_nuclei_density``)
-* ``He_p0_number_density`` (equal to the value of ``He_nuclei_density``)
+* ``H_p0_number_density`` (Neutral hydrogen: equal to the value of ``H_nuclei_density``)
+* ``He_p0_number_density`` (Neutral helium: equal to the value of ``He_nuclei_density``)
 
 In this latter case, because the gas is neutral, ``El_number_density`` is not defined.
 

--- a/doc/source/analyzing/fields.rst
+++ b/doc/source/analyzing/fields.rst
@@ -481,15 +481,17 @@ any default species fields. If the ``default_species_fields`` argument is not se
 More specifically, if ``default_species_fields="ionized"``, then these
 additional fields are defined:
 
-* ``H_p1_number_density``
-* ``He_p2_number_density``
+* ``H_p1_number_density`` (equal to the value of ``H_nuclei_density``)
+* ``He_p2_number_density`` (equal to the value of ``He_nuclei_density``)
 * ``El_number_density``
 
 Whereas if ``default_species_fields="neutral"``, then these additional
 fields are defined:
 
-* ``H_p0_number_density``
-* ``He_p0_number_density``
+* ``H_p0_number_density`` (equal to the value of ``H_nuclei_density``)
+* ``He_p0_number_density`` (equal to the value of ``He_nuclei_density``)
+
+In this latter case, because the gas is neutral, ``El_number_density`` is not defined.
 
 The ``mean_molecular_weight`` field will be constructed from the abundances of the elements
 in the dataset. If no element or molecule fields are defined, the value of this field

--- a/doc/source/analyzing/fields.rst
+++ b/doc/source/analyzing/fields.rst
@@ -456,22 +456,50 @@ defined:
 To refer to the number density of the entirety of a single atom or molecule (regardless
 of its ionization state), please use the ``MM_nuclei_density`` fields.
 
-Finally, if the abundances of hydrogen and helium are not defined, it is
-assumed that these elements are fully ionized with primordial abundances In this case,
-the following fields are defined:
+Many datasets do not have species defined, but there may be an underlying assumption
+of primordial abundances of H and He which are either fully ionized or fully neutral.
+This will also determine the value of the mean molecular weight of the gas, which
+will determine the value of the temperature if derived from another quantity like the
+pressure or thermal energy. To allow for these possibilities, there is a keyword
+argument ``default_species_fields`` which can be passed to :func:`~yt.loaders.load`:
+
+.. code-block:: python
+
+    import yt
+
+    ds = yt.load(
+        "GasSloshing/sloshing_nomag2_hdf5_plt_cnt_0150", default_species_fields="ionized"
+    )
+
+By default, the value of this optional argument is ``None``, which will not initialize
+any default species fields. If the ``default_species_fields`` argument is not set to
+``None``, then the following fields are defined:
+
+* ``H_nuclei_density``
+* ``He_nuclei_density``
+
+More specifically, if ``default_species_fields="ionized"``, then these
+additional fields are defined:
 
 * ``H_p1_number_density``
-* ``H_nuclei_density``
 * ``He_p2_number_density``
-* ``He_nuclei_density``
 * ``El_number_density``
 
+Whereas if ``default_species_fields="neutral"``, then these additional
+fields are defined:
+
+* ``H_p0_number_density``
+* ``He_p0_number_density``
+
 The ``mean_molecular_weight`` field will be constructed from the abundances of the elements
-in the dataset. If no element or molecule fields are defined, the above fields for the ionized
-primordial H/He plasma are defined, and the ``mean_molecular_weight`` field is correspondingly set
-to :math:`\mu \approx 0.6`. Some frontends do not directly store the gas temperature in their
-datasets, in which case it must be computed from the pressure and/or thermal energy as well
-as the mean molecular weight, so check this carefully!
+in the dataset. If no element or molecule fields are defined, the value of this field
+is determined by the value of ``default_species_fields``. If it is set to ``None`` or
+``"ionized"``, the ``mean_molecular_weight`` field is set to :math:`\mu \approx 0.6`,
+whereas if ``default_species_fields`` is set to ``"neutral"``, then the
+``mean_molecular_weight`` field is set to :math:`\mu \approx 1.14`. Some frontends do
+not directly store the gas temperature in their datasets, in which case it must be
+computed from the pressure and/or thermal energy as well as the mean molecular weight,
+so check this carefully!
 
 Particle Fields
 ---------------

--- a/doc/source/cookbook/time_series.py
+++ b/doc/source/cookbook/time_series.py
@@ -9,7 +9,13 @@ yt.enable_parallelism()
 
 # By using wildcards such as ? and * with the load command, we can load up a
 # Time Series containing all of these datasets simultaneously.
-ts = yt.load("GasSloshingLowRes/sloshing_low_res_hdf5_plt_cnt_0*")
+# The "entropy" field that we will use below depends on the electron number
+# density, which is not in these datasets by default, so we assume full
+# ionization using the "default_species_fields" kwarg.
+ts = yt.load(
+    "GasSloshingLowRes/sloshing_low_res_hdf5_plt_cnt_0*",
+    default_species_fields="ionized",
+)
 
 storage = {}
 

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1918,6 +1918,7 @@ class ParticleDataset(Dataset):
         unit_system="cgs",
         index_order=None,
         index_filename=None,
+        default_species_fields=None,
     ):
         self.index_order = validate_index_order(index_order)
         self.index_filename = index_filename
@@ -1927,6 +1928,7 @@ class ParticleDataset(Dataset):
             file_style=file_style,
             units_override=units_override,
             unit_system=unit_system,
+            default_species_fields=default_species_fields,
         )
 
 

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -176,6 +176,7 @@ class Dataset(abc.ABC):
         file_style=None,
         units_override=None,
         unit_system="cgs",
+        default_species_fields=None,
     ):
         """
         Base class for generating new output types.  Principally consists of
@@ -194,6 +195,7 @@ class Dataset(abc.ABC):
         self.particle_unions = self.particle_unions or {}
         self.field_units = self.field_units or {}
         self.units_override = self.__class__._sanitize_units_override(units_override)
+        self.default_species_fields = default_species_fields
 
         # path stuff
         self.parameter_filename = str(filename)

--- a/yt/fields/fluid_fields.py
+++ b/yt/fields/fluid_fields.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from yt.units.unit_object import Unit
-from yt.utilities.chemical_formulas import default_mu
+from yt.utilities.chemical_formulas import compute_mu
 from yt.utilities.lib.misc_utilities import obtain_relative_velocity_vector
 
 from .derived_field import ValidateParameter, ValidateSpatial
@@ -214,7 +214,7 @@ def setup_fluid_fields(registry, ftype="gas", slice_info=None):
     else:
 
         def _number_density(field, data):
-            mu = getattr(data.ds, "mu", default_mu)
+            mu = getattr(data.ds, "mu", compute_mu(data.ds.default_species_fields))
             return data[ftype, "density"] / (pc.mh * mu)
 
     registry.add_field(

--- a/yt/fields/species_fields.py
+++ b/yt/fields/species_fields.py
@@ -209,47 +209,53 @@ def add_nuclei_density_fields(registry, ftype):
     # Here, we add default nuclei and number density fields for H and
     # He if they are not defined above, and if it was requested by
     # setting "default_species_fields"
-    if registry.ds.default_species_fields is not None:
-        dsf = registry.ds.default_species_fields
-        # Right now, this only handles default fields for H and He
-        for element in ["H", "He"]:
-            # If these elements are already present in the dataset,
-            # DO NOT set them
-            if element in elements:
-                continue
-            # First add the default nuclei density fields
-            registry.add_field(
-                (ftype, f"{element}_nuclei_density"),
-                sampling_type="local",
-                function=_default_nuclei_density,
-                units=unit_system["number_density"],
-            )
-            # Set up number density fields for hydrogen, either fully ionized or neutral.
-            if element == "H":
-                if dsf == "ionized":
-                    state = "p1"
-                elif dsf == "neutral":
-                    state = "p0"
-                registry.alias(
-                    (ftype, f"H_{state}_number_density"), (ftype, "H_nuclei_density")
+    if registry.ds.default_species_fields is None:
+        return
+
+    dsf = registry.ds.default_species_fields
+    # Right now, this only handles default fields for H and He
+    for element in ["H", "He"]:
+        # If these elements are already present in the dataset,
+        # DO NOT set them
+        if element in elements:
+            continue
+        # First add the default nuclei density fields
+        registry.add_field(
+            (ftype, f"{element}_nuclei_density"),
+            sampling_type="local",
+            function=_default_nuclei_density,
+            units=unit_system["number_density"],
+        )
+        # Set up number density fields for hydrogen, either fully ionized or neutral.
+        if element == "H":
+            if dsf == "ionized":
+                state = "p1"
+            elif dsf == "neutral":
+                state = "p0"
+            else:
+                raise NotImplementedError(
+                    f"'default_species_fields' option '{dsf}' is not implemented!"
                 )
-            # Set up number density fields for helium, either fully ionized or neutral.
-            if element == "He":
-                if dsf == "ionized":
-                    state = "p2"
-                elif dsf == "neutral":
-                    state = "p0"
-                registry.alias(
-                    (ftype, f"He_{state}_number_density"), (ftype, "He_nuclei_density")
-                )
-        # If we're fully ionized, we need to setup the electron number density field
-        if (ftype, "El_number_density") not in registry and dsf == "ionized":
-            registry.add_field(
-                (ftype, "El_number_density"),
-                sampling_type="local",
-                function=_default_nuclei_density,
-                units=unit_system["number_density"],
+            registry.alias(
+                (ftype, f"H_{state}_number_density"), (ftype, "H_nuclei_density")
             )
+        # Set up number density fields for helium, either fully ionized or neutral.
+        if element == "He":
+            if dsf == "ionized":
+                state = "p2"
+            elif dsf == "neutral":
+                state = "p0"
+            registry.alias(
+                (ftype, f"He_{state}_number_density"), (ftype, "He_nuclei_density")
+            )
+    # If we're fully ionized, we need to setup the electron number density field
+    if (ftype, "El_number_density") not in registry and dsf == "ionized":
+        registry.add_field(
+            (ftype, "El_number_density"),
+            sampling_type="local",
+            function=_default_nuclei_density,
+            units=unit_system["number_density"],
+        )
 
 
 def _default_nuclei_density(field, data):

--- a/yt/fields/species_fields.py
+++ b/yt/fields/species_fields.py
@@ -207,18 +207,24 @@ def add_nuclei_density_fields(registry, ftype):
         )
 
     # Here, we add default nuclei and number density fields for H and
-    # He if they are not defined above. This assumes full ionization!
+    # He if they are not defined above, and if it was requested by
+    # setting "default_species_fields"
     if registry.ds.default_species_fields is not None:
         dsf = registry.ds.default_species_fields
+        # Right now, this only handles default fields for H and He
         for element in ["H", "He"]:
+            # If these elements are already present in the dataset,
+            # DO NOT set them
             if element in elements:
                 continue
+            # First add the default nuclei density fields
             registry.add_field(
                 (ftype, f"{element}_nuclei_density"),
                 sampling_type="local",
                 function=_default_nuclei_density,
                 units=unit_system["number_density"],
             )
+            # Set up number density fields for hydrogen, either fully ionized or neutral.
             if element == "H":
                 if dsf == "ionized":
                     state = "p1"
@@ -227,7 +233,7 @@ def add_nuclei_density_fields(registry, ftype):
                 registry.alias(
                     (ftype, f"H_{state}_number_density"), (ftype, "H_nuclei_density")
                 )
-
+            # Set up number density fields for helium, either fully ionized or neutral.
             if element == "He":
                 if dsf == "ionized":
                     state = "p2"
@@ -236,7 +242,7 @@ def add_nuclei_density_fields(registry, ftype):
                 registry.alias(
                     (ftype, f"He_{state}_number_density"), (ftype, "He_nuclei_density")
                 )
-
+        # If we're fully ionized, we need to setup the electron number density field
         if (ftype, "El_number_density") not in registry and dsf == "ionized":
             registry.add_field(
                 (ftype, "El_number_density"),
@@ -251,10 +257,12 @@ def _default_nuclei_density(field, data):
     element = field.name[1][: field.name[1].find("_")]
     amu_cgs = data.ds.units.physical_constants.amu_cgs
     if element == "El":
+        # This is for determing the electron number density.
         # If we got here, this assumes full ionization!
         muinv = 1.0 * _primordial_mass_fraction["H"] / ChemicalFormula("H").weight
         muinv += 2.0 * _primordial_mass_fraction["He"] / ChemicalFormula("He").weight
     else:
+        # This is for anything else besides electrons
         muinv = _primordial_mass_fraction[element] / ChemicalFormula(element).weight
     return data[ftype, "density"] * muinv / amu_cgs
 

--- a/yt/fields/tests/test_species_fields.py
+++ b/yt/fields/tests/test_species_fields.py
@@ -73,7 +73,7 @@ def test_default_species_fields():
     assert_equal(spn["gas", "H_p0_number_density"], spn["gas", "H_nuclei_density"])
     assert_equal(spn["gas", "He_p0_number_density"], spn["gas", "He_nuclei_density"])
 
-    mu = 1.1442496928403585
+    mu = 1.2285402715185552
 
     assert_allclose_units(
         mu * spn["index", "ones"], spn["gas", "mean_molecular_weight"]

--- a/yt/fields/tests/test_species_fields.py
+++ b/yt/fields/tests/test_species_fields.py
@@ -1,31 +1,80 @@
-from yt.testing import assert_allclose_units, assert_equal, requires_file
-from yt.utilities.answer_testing.framework import data_dir_load
+from yt.testing import assert_allclose_units, assert_equal, fake_random_ds
 from yt.utilities.chemical_formulas import ChemicalFormula
 from yt.utilities.physical_ratios import _primordial_mass_fraction
 
-sloshing = "GasSloshing/sloshing_nomag2_hdf5_plt_cnt_0100"
 
-
-@requires_file(sloshing)
 def test_default_species_fields():
-    ds = data_dir_load(sloshing, kwargs={"default_species_fields": "ionized"})
+
+    # Test default case (no species fields)
+
+    ds = fake_random_ds(32)
     sp = ds.sphere("c", (0.2, "unitary"))
-    amu_cgs = ds.units.physical_constants.amu_cgs
+
+    mu = 0.5924489101195808
+
+    assert_allclose_units(mu * sp["index", "ones"], sp["gas", "mean_molecular_weight"])
+
+    assert ("gas", "H_nuclei_density") not in ds.derived_field_list
+    assert ("gas", "He_nuclei_density") not in ds.derived_field_list
+    assert ("gas", "El_number_density") not in ds.derived_field_list
+    assert ("gas", "H_p1_number_density") not in ds.derived_field_list
+    assert ("gas", "He_p2_number_density") not in ds.derived_field_list
+    assert ("gas", "H_p0_number_density") not in ds.derived_field_list
+    assert ("gas", "He_p0_number_density") not in ds.derived_field_list
+
+    # Test fully ionized case
+    dsi = fake_random_ds(32, default_species_fields="ionized")
+    spi = dsi.sphere("c", (0.2, "unitary"))
+    amu_cgs = dsi.units.physical_constants.amu_cgs
 
     mueinv = 1.0 * _primordial_mass_fraction["H"] / ChemicalFormula("H").weight
-    mueinv *= sp["index", "ones"]
+    mueinv *= spi["index", "ones"]
     mueinv += 2.0 * _primordial_mass_fraction["He"] / ChemicalFormula("He").weight
     mupinv = _primordial_mass_fraction["H"] / ChemicalFormula("H").weight
-    mupinv *= sp["index", "ones"]
+    mupinv *= spi["index", "ones"]
     muainv = _primordial_mass_fraction["He"] / ChemicalFormula("He").weight
-    muainv *= sp["index", "ones"]
-    mueinv2 = sp["gas", "El_number_density"] * amu_cgs / sp["gas", "density"]
-    mupinv2 = sp["gas", "H_p1_number_density"] * amu_cgs / sp["gas", "density"]
-    muainv2 = sp["gas", "He_p2_number_density"] * amu_cgs / sp["gas", "density"]
+    muainv *= spi["index", "ones"]
+    mueinv2 = spi["gas", "El_number_density"] * amu_cgs / spi["gas", "density"]
+    mupinv2 = spi["gas", "H_p1_number_density"] * amu_cgs / spi["gas", "density"]
+    muainv2 = spi["gas", "He_p2_number_density"] * amu_cgs / spi["gas", "density"]
 
     assert_allclose_units(mueinv, mueinv2)
     assert_allclose_units(mupinv, mupinv2)
     assert_allclose_units(muainv, muainv2)
 
-    assert_equal(sp["gas", "H_p1_number_density"], sp["gas", "H_nuclei_density"])
-    assert_equal(sp["gas", "He_p2_number_density"], sp["gas", "He_nuclei_density"])
+    assert_equal(spi["gas", "H_p1_number_density"], spi["gas", "H_nuclei_density"])
+    assert_equal(spi["gas", "He_p2_number_density"], spi["gas", "He_nuclei_density"])
+
+    mu = 0.5924489101195808
+
+    assert_allclose_units(
+        mu * spi["index", "ones"], spi["gas", "mean_molecular_weight"]
+    )
+
+    # Test fully neutral case
+
+    dsn = fake_random_ds(32, default_species_fields="neutral")
+    spn = dsn.sphere("c", (0.2, "unitary"))
+    amu_cgs = dsn.units.physical_constants.amu_cgs
+
+    assert ("gas", "El_number_density") not in ds.derived_field_list
+
+    mupinv = _primordial_mass_fraction["H"] / ChemicalFormula("H").weight
+    mupinv *= spn["index", "ones"]
+    muainv = _primordial_mass_fraction["He"] / ChemicalFormula("He").weight
+    muainv *= spn["index", "ones"]
+    mupinv2 = spn["gas", "H_p0_number_density"] * amu_cgs / spn["gas", "density"]
+    muainv2 = spn["gas", "He_p0_number_density"] * amu_cgs / spn["gas", "density"]
+
+    assert_allclose_units(mueinv, mueinv2)
+    assert_allclose_units(mupinv, mupinv2)
+    assert_allclose_units(muainv, muainv2)
+
+    assert_equal(spn["gas", "H_p0_number_density"], spn["gas", "H_nuclei_density"])
+    assert_equal(spn["gas", "He_p0_number_density"], spn["gas", "He_nuclei_density"])
+
+    mu = 1.1442496928403585
+
+    assert_allclose_units(
+        mu * spn["index", "ones"], spn["gas", "mean_molecular_weight"]
+    )

--- a/yt/fields/tests/test_species_fields.py
+++ b/yt/fields/tests/test_species_fields.py
@@ -8,7 +8,7 @@ sloshing = "GasSloshing/sloshing_nomag2_hdf5_plt_cnt_0100"
 
 @requires_file(sloshing)
 def test_default_species_fields():
-    ds = data_dir_load(sloshing)
+    ds = data_dir_load(sloshing, kwargs={"default_species_fields": "ionized"})
     sp = ds.sphere("c", (0.2, "unitary"))
     amu_cgs = ds.units.physical_constants.amu_cgs
 

--- a/yt/fields/tests/test_xray_fields.py
+++ b/yt/fields/tests/test_xray_fields.py
@@ -31,7 +31,7 @@ d9p = "D9p_500/10MpcBox_HartGal_csf_a0.500.d"
 
 @requires_ds(sloshing, big_data=True)
 def test_sloshing_apec():
-    ds = data_dir_load(sloshing)
+    ds = data_dir_load(sloshing, kwargs={"default_species_fields": "ionized"})
     fields = add_xray_emissivity_field(ds, 0.5, 7.0, table_type="apec", metallicity=0.3)
     for test in check_xray_fields(ds, fields):
         test_sloshing_apec.__name__ = test.description
@@ -40,7 +40,7 @@ def test_sloshing_apec():
 
 @requires_ds(d9p, big_data=True)
 def test_d9p_cloudy():
-    ds = data_dir_load(d9p)
+    ds = data_dir_load(d9p, kwargs={"default_species_fields": "ionized"})
     fields = add_xray_emissivity_field(
         ds,
         0.5,

--- a/yt/fields/tests/test_xray_fields.py
+++ b/yt/fields/tests/test_xray_fields.py
@@ -58,7 +58,7 @@ def test_d9p_cloudy():
 
 @requires_ds(d9p, big_data=True)
 def test_d9p_cloudy_local():
-    ds = data_dir_load(d9p)
+    ds = data_dir_load(d9p, kwargs={"default_species_fields": "ionized"})
     fields = add_xray_emissivity_field(
         ds,
         0.5,

--- a/yt/frontends/_skeleton/data_structures.py
+++ b/yt/frontends/_skeleton/data_structures.py
@@ -85,9 +85,17 @@ class SkeletonDataset(Dataset):
         dataset_type="skeleton",
         storage_filename=None,
         units_override=None,
+        unit_system="cgs",
+        default_species_fields=None,
     ):
         self.fluid_types += ("skeleton",)
-        super().__init__(filename, dataset_type, units_override=units_override)
+        super().__init__(
+            filename,
+            dataset_type,
+            units_override=units_override,
+            unit_system=unit_system,
+            default_species_fields=default_species_fields,
+        )
         self.storage_filename = storage_filename
         # refinement factor between a grid and its subgrid
         # self.refine_by = 2

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -144,6 +144,7 @@ class AMRVACDataset(Dataset):
         unit_system="cgs",
         geometry_override=None,
         parfiles=None,
+        default_species_fields=None,
     ):
         """Instanciate AMRVACDataset.
 
@@ -180,6 +181,7 @@ class AMRVACDataset(Dataset):
             dataset_type,
             units_override=units_override,
             unit_system=unit_system,
+            default_species_fields=default_species_fields,
         )
 
         self._parfiles = parfiles

--- a/yt/frontends/arepo/data_structures.py
+++ b/yt/frontends/arepo/data_structures.py
@@ -22,6 +22,7 @@ class ArepoHDF5Dataset(GadgetHDF5Dataset):
         bounding_box=None,
         units_override=None,
         unit_system="cgs",
+        default_species_fields=None,
     ):
         super().__init__(
             filename,
@@ -33,6 +34,7 @@ class ArepoHDF5Dataset(GadgetHDF5Dataset):
             bounding_box=bounding_box,
             units_override=units_override,
             unit_system=unit_system,
+            default_species_fields=default_species_fields,
         )
         # The "smoothing_factor" is a user-configurable parameter which
         # is multiplied by the radius of the sphere with a volume equal

--- a/yt/frontends/art/data_structures.py
+++ b/yt/frontends/art/data_structures.py
@@ -151,6 +151,7 @@ class ARTDataset(Dataset):
         file_particle_stars=None,
         units_override=None,
         unit_system="cgs",
+        default_species_fields=None,
     ):
         self.fluid_types += ("art",)
         if fields is None:
@@ -175,6 +176,7 @@ class ARTDataset(Dataset):
             dataset_type,
             units_override=units_override,
             unit_system=unit_system,
+            default_species_fields=default_species_fields,
         )
         self.storage_filename = storage_filename
 

--- a/yt/frontends/artio/data_structures.py
+++ b/yt/frontends/artio/data_structures.py
@@ -347,6 +347,7 @@ class ARTIODataset(Dataset):
         max_range=1024,
         units_override=None,
         unit_system="cgs",
+        default_species_fields=None,
     ):
         from sys import version
 
@@ -368,6 +369,7 @@ class ARTIODataset(Dataset):
             dataset_type,
             units_override=units_override,
             unit_system=unit_system,
+            default_species_fields=default_species_fields,
         )
         self.storage_filename = storage_filename
 

--- a/yt/frontends/athena/data_structures.py
+++ b/yt/frontends/athena/data_structures.py
@@ -476,6 +476,7 @@ class AthenaDataset(Dataset):
         units_override=None,
         nprocs=1,
         unit_system="cgs",
+        default_species_fields=None,
     ):
         self.fluid_types += ("athena",)
         self.nprocs = nprocs
@@ -490,6 +491,7 @@ class AthenaDataset(Dataset):
             dataset_type,
             units_override=units_override,
             unit_system=unit_system,
+            default_species_fields=default_species_fields,
         )
         self.filename = filename
         if storage_filename is None:

--- a/yt/frontends/athena/data_structures.py
+++ b/yt/frontends/athena/data_structures.py
@@ -8,7 +8,7 @@ from yt.data_objects.static_output import Dataset
 from yt.funcs import mylog, sglob
 from yt.geometry.geometry_handler import YTDataChunk
 from yt.geometry.grid_geometry_handler import GridIndex
-from yt.utilities.chemical_formulas import default_mu
+from yt.utilities.chemical_formulas import compute_mu
 from yt.utilities.decompose import decompose_array, get_psize
 from yt.utilities.lib.misc_utilities import get_box_grids_level
 
@@ -624,7 +624,9 @@ class AthenaDataset(Dataset):
             self.parameters["Gamma"] = 5.0 / 3.0
         self.geometry = self.specified_parameters.get("geometry", "cartesian")
         self._handle.close()
-        self.mu = self.specified_parameters.get("mu", default_mu)
+        self.mu = self.specified_parameters.get(
+            "mu", compute_mu(self.default_species_fields)
+        )
 
     @classmethod
     def _is_valid(cls, filename, *args, **kwargs):

--- a/yt/frontends/athena_pp/data_structures.py
+++ b/yt/frontends/athena_pp/data_structures.py
@@ -10,7 +10,7 @@ from yt.data_objects.static_output import Dataset
 from yt.funcs import get_pbar, mylog
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.geometry.unstructured_mesh_handler import UnstructuredIndex
-from yt.utilities.chemical_formulas import default_mu
+from yt.utilities.chemical_formulas import compute_mu
 from yt.utilities.file_handler import HDF5FileHandler
 
 from .fields import AthenaPPFieldInfo
@@ -352,7 +352,9 @@ class AthenaPPDataset(Dataset):
             self.parameters["Gamma"] = self.specified_parameters["gamma"]
         else:
             self.parameters["Gamma"] = 5.0 / 3.0
-        self.mu = self.specified_parameters.get("mu", default_mu)
+        self.mu = self.specified_parameters.get(
+            "mu", compute_mu(self.default_species_fields)
+        )
 
     @classmethod
     def _is_valid(cls, filename, *args, **kwargs):

--- a/yt/frontends/athena_pp/data_structures.py
+++ b/yt/frontends/athena_pp/data_structures.py
@@ -240,6 +240,7 @@ class AthenaPPDataset(Dataset):
         parameters=None,
         units_override=None,
         unit_system="code",
+        default_species_fields=None,
     ):
         self.fluid_types += ("athena_pp",)
         if parameters is None:
@@ -263,6 +264,7 @@ class AthenaPPDataset(Dataset):
             dataset_type,
             units_override=units_override,
             unit_system=unit_system,
+            default_species_fields=default_species_fields,
         )
         self.filename = filename
         if storage_filename is None:

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -643,6 +643,7 @@ class BoxlibDataset(Dataset):
         storage_filename=None,
         units_override=None,
         unit_system="cgs",
+        default_species_fields=None,
     ):
         """
         The paramfile is usually called "inputs"
@@ -667,6 +668,7 @@ class BoxlibDataset(Dataset):
             dataset_type,
             units_override=units_override,
             unit_system=unit_system,
+            default_species_fields=default_species_fields,
         )
 
         # These are still used in a few places.
@@ -1033,6 +1035,7 @@ class OrionDataset(BoxlibDataset):
         storage_filename=None,
         units_override=None,
         unit_system="cgs",
+        default_species_fields=None,
     ):
 
         BoxlibDataset.__init__(
@@ -1043,6 +1046,7 @@ class OrionDataset(BoxlibDataset):
             dataset_type,
             units_override=units_override,
             unit_system=unit_system,
+            default_species_fields=default_species_fields,
         )
 
 
@@ -1085,6 +1089,7 @@ class CastroDataset(BoxlibDataset):
         storage_filename=None,
         units_override=None,
         unit_system="cgs",
+        default_species_fields=None,
     ):
 
         super().__init__(
@@ -1095,6 +1100,7 @@ class CastroDataset(BoxlibDataset):
             storage_filename,
             units_override,
             unit_system,
+            default_species_fields=default_species_fields,
         )
 
     def _parse_parameter_file(self):
@@ -1163,6 +1169,7 @@ class MaestroDataset(BoxlibDataset):
         storage_filename=None,
         units_override=None,
         unit_system="cgs",
+        default_species_fields=None,
     ):
 
         super().__init__(
@@ -1173,6 +1180,7 @@ class MaestroDataset(BoxlibDataset):
             storage_filename,
             units_override,
             unit_system,
+            default_species_fields=default_species_fields,
         )
 
     def _parse_parameter_file(self):
@@ -1253,6 +1261,7 @@ class NyxDataset(BoxlibDataset):
         storage_filename=None,
         units_override=None,
         unit_system="cgs",
+        default_species_fields=None,
     ):
 
         super().__init__(
@@ -1263,6 +1272,7 @@ class NyxDataset(BoxlibDataset):
             storage_filename,
             units_override,
             unit_system,
+            default_species_fields=default_species_fields,
         )
 
     def _parse_parameter_file(self):
@@ -1535,6 +1545,7 @@ class WarpXDataset(BoxlibDataset):
         storage_filename=None,
         units_override=None,
         unit_system="mks",
+        default_species_fields=None,
     ):
 
         self.default_fluid_type = "mesh"
@@ -1549,6 +1560,7 @@ class WarpXDataset(BoxlibDataset):
             storage_filename,
             units_override,
             unit_system,
+            default_species_fields=default_species_fields,
         )
 
     def _parse_parameter_file(self):
@@ -1618,6 +1630,7 @@ class AMReXDataset(BoxlibDataset):
         storage_filename=None,
         units_override=None,
         unit_system="cgs",
+        default_species_fields=None,
     ):
 
         super().__init__(
@@ -1628,6 +1641,7 @@ class AMReXDataset(BoxlibDataset):
             storage_filename,
             units_override,
             unit_system,
+            default_species_fields=default_species_fields,
         )
 
     def _parse_parameter_file(self):

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -1545,7 +1545,6 @@ class WarpXDataset(BoxlibDataset):
         storage_filename=None,
         units_override=None,
         unit_system="mks",
-        default_species_fields=None,
     ):
 
         self.default_fluid_type = "mesh"
@@ -1560,7 +1559,6 @@ class WarpXDataset(BoxlibDataset):
             storage_filename,
             units_override,
             unit_system,
-            default_species_fields=default_species_fields,
         )
 
     def _parse_parameter_file(self):

--- a/yt/frontends/chombo/data_structures.py
+++ b/yt/frontends/chombo/data_structures.py
@@ -246,6 +246,7 @@ class ChomboDataset(Dataset):
         ini_filename=None,
         units_override=None,
         unit_system="cgs",
+        default_species_fields=None,
     ):
         self.fluid_types += ("chombo",)
         self._handle = HDF5FileHandler(filename)
@@ -260,6 +261,7 @@ class ChomboDataset(Dataset):
             self.dataset_type,
             units_override=units_override,
             unit_system=unit_system,
+            default_species_fields=default_species_fields,
         )
         self.storage_filename = storage_filename
         self.cosmological_simulation = False
@@ -474,6 +476,7 @@ class PlutoDataset(ChomboDataset):
         ini_filename=None,
         units_override=None,
         unit_system="cgs",
+        default_species_fields=None,
     ):
 
         ChomboDataset.__init__(
@@ -484,6 +487,7 @@ class PlutoDataset(ChomboDataset):
             ini_filename,
             units_override=units_override,
             unit_system=unit_system,
+            default_species_fields=default_species_fields,
         )
 
     def _parse_parameter_file(self):
@@ -646,6 +650,7 @@ class Orion2Dataset(ChomboDataset):
         storage_filename=None,
         ini_filename=None,
         units_override=None,
+        default_species_fields=None,
     ):
 
         ChomboDataset.__init__(
@@ -655,6 +660,7 @@ class Orion2Dataset(ChomboDataset):
             storage_filename,
             ini_filename,
             units_override=units_override,
+            default_species_fields=default_species_fields,
         )
 
     def _parse_parameter_file(self):

--- a/yt/frontends/enzo/data_structures.py
+++ b/yt/frontends/enzo/data_structures.py
@@ -690,6 +690,7 @@ class EnzoDataset(Dataset):
         storage_filename=None,
         units_override=None,
         unit_system="cgs",
+        default_species_fields=None,
     ):
         """
         This class is a stripped down class that simply reads and parses
@@ -717,6 +718,7 @@ class EnzoDataset(Dataset):
             file_style=file_style,
             units_override=units_override,
             unit_system=unit_system,
+            default_species_fields=default_species_fields,
         )
 
     def _setup_1d(self):

--- a/yt/frontends/enzo_e/data_structures.py
+++ b/yt/frontends/enzo_e/data_structures.py
@@ -307,6 +307,7 @@ class EnzoEDataset(Dataset):
         storage_filename=None,
         units_override=None,
         unit_system="cgs",
+        default_species_fields=None,
     ):
         """
         This class is a stripped down class that simply reads and parses
@@ -332,6 +333,7 @@ class EnzoEDataset(Dataset):
             file_style=file_style,
             units_override=units_override,
             unit_system=unit_system,
+            default_species_fields=default_species_fields,
         )
         warnings.warn(
             "The Enzo-E file format is still under development and may "

--- a/yt/frontends/flash/data_structures.py
+++ b/yt/frontends/flash/data_structures.py
@@ -174,6 +174,7 @@ class FLASHDataset(Dataset):
         particle_filename=None,
         units_override=None,
         unit_system="cgs",
+        default_species_fields=None,
     ):
 
         self.fluid_types += ("flash",)
@@ -223,6 +224,7 @@ class FLASHDataset(Dataset):
             dataset_type,
             units_override=units_override,
             unit_system=unit_system,
+            default_species_fields=default_species_fields,
         )
         self.storage_filename = storage_filename
 

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -7,7 +7,7 @@ import numpy as np
 from yt.data_objects.static_output import ParticleFile
 from yt.frontends.sph.data_structures import SPHDataset, SPHParticleIndex
 from yt.funcs import only_on_root
-from yt.utilities.chemical_formulas import default_mu
+from yt.utilities.chemical_formulas import compute_mu
 from yt.utilities.cosmology import Cosmology
 from yt.utilities.fortran_utils import read_record
 from yt.utilities.logger import ytLogger as mylog
@@ -323,7 +323,7 @@ class GadgetDataset(SPHDataset):
             self.length_unit.convert_to_units("kpc")
             self.mass_unit.convert_to_units("Msun")
         if mean_molecular_weight is None:
-            self.mu = default_mu
+            self.mu = compute_mu(self.default_species_fields)
         else:
             self.mu = mean_molecular_weight
 

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -239,6 +239,7 @@ class GadgetDataset(SPHDataset):
         use_dark_factor=False,
         w_0=-1.0,
         w_a=0.0,
+        default_species_fields=None,
     ):
         if self._instantiated:
             return
@@ -313,6 +314,7 @@ class GadgetDataset(SPHDataset):
             index_filename=index_filename,
             kdtree_filename=kdtree_filename,
             kernel_name=kernel_name,
+            default_species_fields=default_species_fields,
         )
         if self.cosmological_simulation:
             self.time_unit.convert_to_units("s/h")
@@ -576,6 +578,7 @@ class GadgetHDF5Dataset(GadgetDataset):
         bounding_box=None,
         units_override=None,
         unit_system="cgs",
+        default_species_fields=None,
     ):
         self.storage_filename = None
         filename = os.path.abspath(filename)
@@ -593,6 +596,7 @@ class GadgetHDF5Dataset(GadgetDataset):
             kernel_name=kernel_name,
             bounding_box=bounding_box,
             unit_system=unit_system,
+            default_species_fields=default_species_fields,
         )
 
     def _get_hvals(self):

--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -218,6 +218,7 @@ class GAMERDataset(Dataset):
         particle_filename=None,
         units_override=None,
         unit_system="cgs",
+        default_species_fields=None,
     ):
 
         if self._handle is not None:
@@ -250,6 +251,7 @@ class GAMERDataset(Dataset):
             dataset_type,
             units_override=units_override,
             unit_system=unit_system,
+            default_species_fields=default_species_fields,
         )
         self.storage_filename = storage_filename
 

--- a/yt/frontends/gdf/data_structures.py
+++ b/yt/frontends/gdf/data_structures.py
@@ -163,6 +163,7 @@ class GDFDataset(Dataset):
         geometry=None,
         units_override=None,
         unit_system="cgs",
+        default_species_fields=None,
     ):
         self.geometry = geometry
         self.fluid_types += ("gdf",)
@@ -172,6 +173,7 @@ class GDFDataset(Dataset):
             dataset_type,
             units_override=units_override,
             unit_system=unit_system,
+            default_species_fields=default_species_fields,
         )
         self.storage_filename = storage_filename
         self.filename = filename

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -655,6 +655,7 @@ class RAMSESDataset(Dataset):
         bbox=None,
         max_level=None,
         max_level_convention=None,
+        default_species_fields=None,
     ):
         # Here we want to initiate a traceback, if the reader is not built.
         if isinstance(fields, str):
@@ -710,6 +711,7 @@ class RAMSESDataset(Dataset):
             dataset_type,
             units_override=units_override,
             unit_system=unit_system,
+            default_species_fields=default_species_fields,
         )
 
         # Add the particle types

--- a/yt/frontends/ramses/fields.py
+++ b/yt/frontends/ramses/fields.py
@@ -48,6 +48,21 @@ known_species_masses = {
     ]
 }
 
+known_species_names = {
+    "HI": "H_p0",
+    "HII": "H_p1",
+    "Electron": "El",
+    "HeI": "He_p0",
+    "HeII": "He_p1",
+    "HeIII": "He_p2",
+    "H2I": "H2_p0",
+    "H2II": "H2_p1",
+    "HM": "H_m1",
+    "DI": "D_p0",
+    "DII": "D_p1",
+    "HDI": "HD_p0",
+}
+
 _cool_axes = ("lognH", "logT")  # , "logTeq")
 _cool_arrs = (
     ("cooling_primordial", cooling_function_units),
@@ -172,6 +187,12 @@ class RAMSESFieldInfo(FieldInfoContainer):
             units=self.ds.unit_system["temperature"],
         )
         self.create_cooling_fields()
+
+        self.species_names = [
+            known_species_names[fn]
+            for ft, fn in self.field_list
+            if fn in known_species_names
+        ]
 
         # See if we need to load the rt fields
         rt_flag = RTFieldFileHandler.any_exist(self.ds)

--- a/yt/frontends/sph/data_structures.py
+++ b/yt/frontends/sph/data_structures.py
@@ -25,6 +25,7 @@ class SPHDataset(ParticleDataset):
         index_filename=None,
         kdtree_filename=None,
         kernel_name=None,
+        default_species_fields=None,
     ):
         if kernel_name is None:
             self.kernel_name = self.default_kernel_name
@@ -39,6 +40,7 @@ class SPHDataset(ParticleDataset):
             unit_system=unit_system,
             index_order=index_order,
             index_filename=index_filename,
+            default_species_fields=default_species_fields,
         )
 
     @property

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -272,6 +272,7 @@ class StreamDataset(Dataset):
         storage_filename=None,
         geometry="cartesian",
         unit_system="cgs",
+        default_species_fields=None,
     ):
         self.fluid_types += ("stream",)
         self.geometry = geometry
@@ -281,7 +282,13 @@ class StreamDataset(Dataset):
         from yt.data_objects.static_output import _cached_datasets
 
         _cached_datasets[name] = self
-        Dataset.__init__(self, name, self._dataset_type, unit_system=unit_system)
+        Dataset.__init__(
+            self,
+            name,
+            self._dataset_type,
+            unit_system=unit_system,
+            default_species_fields=default_species_fields,
+        )
 
     def _parse_parameter_file(self):
         self.basename = self.stream_handler.name
@@ -441,12 +448,14 @@ class StreamParticlesDataset(StreamDataset):
         storage_filename=None,
         geometry="cartesian",
         unit_system="cgs",
+        default_species_fields=None,
     ):
         super().__init__(
             stream_handler,
             storage_filename=storage_filename,
             geometry=geometry,
             unit_system=unit_system,
+            default_species_fields=default_species_fields,
         )
         fields = list(stream_handler.fields["stream_file"].keys())
         # This is the current method of detecting SPH data.
@@ -822,8 +831,15 @@ class StreamOctreeDataset(StreamDataset):
         storage_filename=None,
         geometry="cartesian",
         unit_system="cgs",
+        default_species_fields=None,
     ):
-        super().__init__(stream_handler, storage_filename, geometry, unit_system)
+        super().__init__(
+            stream_handler,
+            storage_filename,
+            geometry,
+            unit_system,
+            default_species_fields=default_species_fields,
+        )
         # Set up levelmax
         self.max_level = stream_handler.levels.max()
         self.min_level = stream_handler.levels.min()

--- a/yt/frontends/swift/data_structures.py
+++ b/yt/frontends/swift/data_structures.py
@@ -22,12 +22,24 @@ class SwiftDataset(SPHDataset):
     _suffix = ".hdf5"
 
     def __init__(
-        self, filename, dataset_type="swift", storage_filename=None, units_override=None
+        self,
+        filename,
+        dataset_type="swift",
+        storage_filename=None,
+        units_override=None,
+        unit_system="cgs",
+        default_species_fields=None,
     ):
 
         self.filename = filename
 
-        super().__init__(filename, dataset_type, units_override=units_override)
+        super().__init__(
+            filename,
+            dataset_type,
+            units_override=units_override,
+            unit_system=unit_system,
+            default_species_fields=default_species_fields,
+        )
         self.storage_filename = storage_filename
 
     def _set_code_unit_attributes(self):

--- a/yt/frontends/tipsy/data_structures.py
+++ b/yt/frontends/tipsy/data_structures.py
@@ -58,6 +58,7 @@ class TipsyDataset(SPHDataset):
         bounding_box=None,
         units_override=None,
         unit_system="cgs",
+        default_species_fields=None,
     ):
         # Because Tipsy outputs don't have a fixed domain boundary, one can
         # specify a bounding box which effectively gives a domain_left_edge
@@ -107,6 +108,7 @@ class TipsyDataset(SPHDataset):
             index_filename=index_filename,
             kdtree_filename=kdtree_filename,
             kernel_name=kernel_name,
+            default_species_fields=default_species_fields,
         )
 
     def __str__(self):

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -159,6 +159,7 @@ def load_uniform_grid(
     periodicity=(True, True, True),
     geometry="cartesian",
     unit_system="cgs",
+    default_species_fields=None,
 ):
     r"""Load a uniform grid of data into yt as a
     :class:`~yt.frontends.stream.data_structures.StreamHandler`.
@@ -208,6 +209,9 @@ def load_uniform_grid(
         be z, x, y, this would be: ("cartesian", ("z", "x", "y")).  The same
         can be done for other coordinates, for instance:
         ("spherical", ("theta", "phi", "r")).
+    default_species_fields : string, optional
+        If set, default species fields are created for H and He which also
+        determine the mean molecular weight. Options are "ionized" and "neutral".
 
     Examples
     --------
@@ -337,7 +341,12 @@ def load_uniform_grid(
     handler.simulation_time = sim_time
     handler.cosmology_simulation = 0
 
-    sds = StreamDataset(handler, geometry=geometry, unit_system=unit_system)
+    sds = StreamDataset(
+        handler,
+        geometry=geometry,
+        unit_system=unit_system,
+        default_species_fields=default_species_fields,
+    )
 
     # Now figure out where the particles go
     if number_of_particles > 0:
@@ -361,6 +370,7 @@ def load_amr_grids(
     geometry="cartesian",
     refine_by=2,
     unit_system="cgs",
+    default_species_fields=None,
 ):
     r"""Load a set of grids of data into yt as a
     :class:`~yt.frontends.stream.data_structures.StreamHandler`.
@@ -419,6 +429,9 @@ def load_amr_grids(
         instance, this can be used to say that some datasets have refinement of
         1 in one dimension, indicating that they span the full range in that
         dimension.
+    default_species_fields : string, optional
+        If set, default species fields are created for H and He which also
+        determine the mean molecular weight. Options are "ionized" and "neutral".
 
     Examples
     --------
@@ -565,7 +578,12 @@ def load_amr_grids(
     handler.simulation_time = sim_time
     handler.cosmology_simulation = 0
 
-    sds = StreamDataset(handler, geometry=geometry, unit_system=unit_system)
+    sds = StreamDataset(
+        handler,
+        geometry=geometry,
+        unit_system=unit_system,
+        default_species_fields=default_species_fields,
+    )
     return sds
 
 
@@ -582,6 +600,7 @@ def load_particles(
     geometry="cartesian",
     unit_system="cgs",
     data_source=None,
+    default_species_fields=None,
 ):
     r"""Load a set of particles into yt as a
     :class:`~yt.frontends.stream.data_structures.StreamParticleHandler`.
@@ -625,6 +644,9 @@ def load_particles(
     data_source : YTSelectionContainer, optional
         If set, parameters like `bbox`, `sim_time`, and code units are derived
         from it.
+    default_species_fields : string, optional
+        If set, default species fields are created for H and He which also
+        determine the mean molecular weight. Options are "ionized" and "neutral".
 
     Examples
     --------
@@ -730,7 +752,12 @@ def load_particles(
     handler.simulation_time = sim_time
     handler.cosmology_simulation = 0
 
-    sds = StreamParticlesDataset(handler, geometry=geometry, unit_system=unit_system)
+    sds = StreamParticlesDataset(
+        handler,
+        geometry=geometry,
+        unit_system=unit_system,
+        default_species_fields=default_species_fields,
+    )
 
     return sds
 
@@ -890,6 +917,7 @@ def load_octree(
     over_refine_factor=1,
     partial_coverage=1,
     unit_system="cgs",
+    default_species_fields=None,
 ):
     r"""Load an octree mask into yt.
 
@@ -932,6 +960,9 @@ def load_octree(
     partial_coverage : boolean
         Whether or not an oct can be refined cell-by-cell, or whether all
         8 get refined.
+    default_species_fields : string, optional
+        If set, default species fields are created for H and He which also
+        determine the mean molecular weight. Options are "ionized" and "neutral".
 
     Example
     -------
@@ -1018,7 +1049,9 @@ def load_octree(
     handler.simulation_time = sim_time
     handler.cosmology_simulation = 0
 
-    sds = StreamOctreeDataset(handler, unit_system=unit_system)
+    sds = StreamOctreeDataset(
+        handler, unit_system=unit_system, default_species_fields=default_species_fields
+    )
     sds.octree_mask = octree_mask
     sds.partial_coverage = partial_coverage
     sds.over_refine_factor = over_refine_factor

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -225,6 +225,7 @@ def fake_random_ds(
     length_unit=1.0,
     unit_system="cgs",
     bbox=None,
+    default_species_fields=None,
 ):
     from yt.loaders import load_uniform_grid
 
@@ -284,6 +285,7 @@ def fake_random_ds(
         nprocs=nprocs,
         unit_system=unit_system,
         bbox=bbox,
+        default_species_fields=default_species_fields,
     )
     return ug
 

--- a/yt/utilities/chemical_formulas.py
+++ b/yt/utilities/chemical_formulas.py
@@ -35,8 +35,6 @@ class ChemicalFormula:
 
 
 def compute_mu(ion_state):
-    # Assume full ionization and cosmic abundances
-    # This assumes full ionization!
     if ion_state == "ionized" or ion_state is None:
         Z_H = 2.0
         Z_He = 3.0

--- a/yt/utilities/chemical_formulas.py
+++ b/yt/utilities/chemical_formulas.py
@@ -36,11 +36,12 @@ class ChemicalFormula:
 
 def compute_mu(ion_state):
     if ion_state == "ionized" or ion_state is None:
-        Z_H = 2.0
-        Z_He = 3.0
+        # full ionization
+        n_H = 2.0  # fully ionized hydrogen gives two particles
+        n_He = 3.0  # fully ionized helium gives three particles
     elif ion_state == "neutral":
-        Z_H = 1.0
-        Z_He = 2.0
-    muinv = Z_H * _primordial_mass_fraction["H"] / ChemicalFormula("H").weight
-    muinv += Z_He * _primordial_mass_fraction["He"] / ChemicalFormula("He").weight
+        n_H = 1.0  # neutral hydrogen gives one particle
+        n_He = 1.0  # neutral helium gives one particle
+    muinv = n_H * _primordial_mass_fraction["H"] / ChemicalFormula("H").weight
+    muinv += n_He * _primordial_mass_fraction["He"] / ChemicalFormula("He").weight
     return 1.0 / muinv

--- a/yt/utilities/chemical_formulas.py
+++ b/yt/utilities/chemical_formulas.py
@@ -34,12 +34,15 @@ class ChemicalFormula:
         return self.formula_string
 
 
-def compute_mu():
+def compute_mu(ion_state):
     # Assume full ionization and cosmic abundances
     # This assumes full ionization!
-    muinv = 2.0 * _primordial_mass_fraction["H"] / ChemicalFormula("H").weight
-    muinv += 3.0 * _primordial_mass_fraction["He"] / ChemicalFormula("He").weight
+    if ion_state == "ionized" or ion_state is None:
+        Z_H = 2.0
+        Z_He = 3.0
+    elif ion_state == "neutral":
+        Z_H = 1.0
+        Z_He = 2.0
+    muinv = Z_H * _primordial_mass_fraction["H"] / ChemicalFormula("H").weight
+    muinv += Z_He * _primordial_mass_fraction["He"] / ChemicalFormula("He").weight
     return 1.0 / muinv
-
-
-default_mu = compute_mu()

--- a/yt/utilities/tests/test_chemical_formulas.py
+++ b/yt/utilities/tests/test_chemical_formulas.py
@@ -1,5 +1,5 @@
 from yt.testing import assert_allclose, assert_equal
-from yt.utilities.chemical_formulas import ChemicalFormula, default_mu
+from yt.utilities.chemical_formulas import ChemicalFormula, compute_mu
 from yt.utilities.periodic_table import periodic_table
 
 _molecules = (
@@ -24,4 +24,6 @@ def test_formulas():
 
 
 def test_default_mu():
-    assert_allclose(default_mu, 0.5924489101195808)
+    assert_allclose(compute_mu(None), 0.5924489101195808)
+    assert_allclose(compute_mu("ionized"), 0.5924489101195808)
+    assert_allclose(compute_mu("neutral"), 1.1442496928403585)

--- a/yt/utilities/tests/test_chemical_formulas.py
+++ b/yt/utilities/tests/test_chemical_formulas.py
@@ -26,4 +26,4 @@ def test_formulas():
 def test_default_mu():
     assert_allclose(compute_mu(None), 0.5924489101195808)
     assert_allclose(compute_mu("ionized"), 0.5924489101195808)
-    assert_allclose(compute_mu("neutral"), 1.1442496928403585)
+    assert_allclose(compute_mu("neutral"), 1.2285402715185552)


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

Two years ago, PR #2245 refactored (among other things) a number of fields which depended on assumptions about the mean molecular weight and the electron number density, such as `("gas","entropy")`, `("gas","szy")`, etc. The decision was made to have the `("gas","mean_molecular_weight")`, `("gas","El_number_density")`, and H/He nuclei and number density fields always exist for datasets which had a `("gas","density")` field, regardless of whether or not species are defined in the dataset. In the case they were not, the assumption was made of a primordial H/He composition with full ionization. 

This was probably never the ideal situation--though it was documented, it is an assumption that would not necessarily apply to many datasets. More importantly, certain downstream projects (like Trident, see https://github.com/trident-project/trident/issues/165) relied on the assumption that if H and He were not defined that they could supply a new field based on physical assumptions about the medium, but trust that if the field was present in the dataset that it was correct.

Based on these considerations, and after a long and productive conversation with @chummels, this PR partially reverts the effect of PR #2245 by making this feature optional. It adds a new kwarg to the `Dataset` class, `default_species_fields`, which by default is `None`, and can also take the options of `"ionized"` or `"neutral"`. These options are:

* `"ionized"`: sets up nuclei and number density fields for primordial H/He and free electrons assuming full ionization.
* `"neutral"`: sets up nuclei and number density fields for primordial H/He assuming full neutrality.

In theory this scheme could be extended to support other scenarios which are common. 

A number of temperature fields in various frontends rely on the assumption of a mean molecular weight--if one is not defined by the dataset, at load time, or by `default_species_fields`, the default will continue to be that of a fully ionized H/He-dominated plasma. This is usually overridden by the frontend if the dataset has a value for it, and many frontends allow you to change it when `load`ing a dataset. 

Unfortunately this also required adding the `default_species_fields` kwarg to nearly every subclass of `Dataset`--I tried to only do it for those which it would definitely make sense based on domain context. 

This should fix https://github.com/trident-project/trident/issues/165. 

EDIT: This also fixes a bug I found in the RAMSES frontend (ping @cphyc) which wasn't actually registering the species from the dataset and mapping them to the standard yt names, so you weren't getting number and nuclei density fields. This bug was actually being hidden(!) because the default fields for H were being set up by the previous behavior (further showing why this was the wrong thing to do on my part originally). 

### Is there an alternative? 

Unfortunately not one that is less hacky. It was considered that one could create a method such as `ds.setup_species_fields`, but this would need to be run _before_ field detection (basically before you did anything else after loading a dataset), and there are a small number of frontends that have to do field detection at `load` time in any case. 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
