### PR TITLE
Restore auto creation of save dirs in PlotContainer.save

### DIFF
--- a/nose_unit.cfg
+++ b/nose_unit.cfg
@@ -6,5 +6,5 @@ nologcapture=1
 verbosity=2
 where=yt
 with-timer=1
-ignore-files=(test_load_errors.py|test_load_sample.py|test_commons.py|test_ambiguous_fields.py|test_field_access_pytest.py)
+ignore-files=(test_load_errors.py|test_load_sample.py|test_commons.py|test_ambiguous_fields.py|test_field_access_pytest.py|test_save.py)
 exclude-test=yt.frontends.gdf.tests.test_outputs.TestGDF

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -183,6 +183,7 @@ other_tests:
      - '--ignore-files=test_load_sample.py'
      - '--ignore-files=test_field_access_pytest.py'
      - '--ignore-files=test_ambiguous_fields.py'
+     - "--ignore-files=test_save.py"
      - '--exclude-test=yt.frontends.gdf.tests.test_outputs.TestGDF'
   cookbook:
      - 'doc/source/cookbook/tests/test_cookbook.py'

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -555,15 +555,24 @@ class PlotContainer:
         names = []
         if mpl_kwargs is None:
             mpl_kwargs = {}
-        if isinstance(name, (tuple, list)):
-            name = os.path.join(*name)
+
         if name is None:
             name = str(self.ds)
+
+        # ///// Magic area. Muggles, keep out !
+        if isinstance(name, (tuple, list)):
+            name = os.path.join(*name)
+
         name = os.path.expanduser(name)
-        if name[-1] == os.sep and not os.path.isdir(name):
-            ensure_dir(name)
-        if os.path.isdir(name) and name != str(self.ds):
-            name = name + (os.sep if name[-1] != os.sep else "") + str(self.ds)
+
+        parent_dir, _, prefix1 = name.replace(os.sep, "/").rpartition("/")
+        parent_dir = parent_dir.replace("/", os.sep)
+
+        if parent_dir and not os.path.isdir(parent_dir):
+            ensure_dir(parent_dir)
+
+        if name.endswith(("/", os.path.sep)):
+            name = os.path.join(name, str(self.ds))
 
         new_name = validate_image_name(name, suffix)
         if new_name == name:

--- a/yt/visualization/tests/test_save.py
+++ b/yt/visualization/tests/test_save.py
@@ -1,0 +1,34 @@
+import os
+
+import yt
+
+
+def test_save_to_path(tmp_path):
+    ds = yt.testing.fake_amr_ds()
+    p = yt.SlicePlot(ds, "z", "Density")
+    p.save(f"{tmp_path}/")
+    assert len(list((tmp_path).glob("*.png"))) == 1
+
+
+def test_save_to_missing_path(tmp_path):
+    # the missing layer should be created
+    ds = yt.testing.fake_amr_ds()
+    p = yt.SlicePlot(ds, "z", "Density")
+
+    # using forward slashes should work even on windows !
+    save_path = os.path.join(tmp_path / "out") + "/"
+    p.save(save_path)
+    assert os.path.exists(save_path)
+    assert len(list((tmp_path / "out").glob("*.png"))) == 1
+
+
+def test_save_to_missing_path_with_file_prefix(tmp_path):
+    # see issue
+    # https://github.com/yt-project/yt/issues/3210
+    ds = yt.testing.fake_amr_ds()
+    p = yt.SlicePlot(ds, "z", "Density")
+    p.save(tmp_path.joinpath("out", "saymyname"))
+    assert (tmp_path / "out").exists()
+    output_files = list((tmp_path / "out").glob("*.png"))
+    assert len(output_files) == 1
+    assert output_files[0].stem.startswith("saymyname")  # you're goddamn right


### PR DESCRIPTION
## PR Summary

Intent: fix #3210
The patch is not elegant at all, but it works ™️ (at least the tests I wrote for it pass)
Note that in order to make this work I "sacrificed" a feature that was deemed unintuitive in the original disscussion. Namely,
`PlotContainer.save("img")` used to interpret `"img"` as a file prefix OR an output directory depending on wether such a directory existed already or not. This PR intentionally breaks this undocumented (AFAIK) feature to make room for the one @chummels wanted back in his original report.

Following the discussions in the issue, I think the best course of action in the foreseeable future would be rethink the amount of magic we want to support in saving functions, but for now, we've agreed that it's best to just try and restore the old behaviours in time for the 4.0 release.