### PR TITLE
Make Arepo units play nice with unit_base

### DIFF
--- a/yt/frontends/arepo/data_structures.py
+++ b/yt/frontends/arepo/data_structures.py
@@ -89,23 +89,26 @@ class ArepoHDF5Dataset(GadgetHDF5Dataset):
         # units which are present in the Arepo dataset will be used
         # no matter what but that the user gets warned
         if arepo_unit_base is not None:
-            for unit in arepo_unit_base:
-                if unit == "cmcm":
-                    continue
-                short_unit = unit.split("_")[0][4:].lower()
-                if short_unit in self._unit_base:
-                    which_unit = short_unit
-                    self._unit_base.pop(short_unit, None)
-                elif unit in self._unit_base:
-                    which_unit = unit
-                else:
-                    which_unit = None
-                if which_unit is not None:
-                    msg = f"Overwriting '{which_unit}' in unit_base with what we found in the dataset."
-                    mylog.warning(msg)
-                self._unit_base[unit] = arepo_unit_base[unit]
-            if "cmcm" in arepo_unit_base:
-                self._unit_base["cmcm"] = arepo_unit_base["cmcm"]
+            if self._unit_base is None:
+                self._unit_base = arepo_unit_base
+            else:
+                for unit in arepo_unit_base:
+                    if unit == "cmcm":
+                        continue
+                    short_unit = unit.split("_")[0][4:].lower()
+                    if short_unit in self._unit_base:
+                        which_unit = short_unit
+                        self._unit_base.pop(short_unit, None)
+                    elif unit in self._unit_base:
+                        which_unit = unit
+                    else:
+                        which_unit = None
+                    if which_unit is not None:
+                        msg = f"Overwriting '{which_unit}' in unit_base with what we found in the dataset."
+                        mylog.warning(msg)
+                    self._unit_base[unit] = arepo_unit_base[unit]
+                if "cmcm" in arepo_unit_base:
+                    self._unit_base["cmcm"] = arepo_unit_base["cmcm"]
         super()._set_code_unit_attributes()
         munit = np.sqrt(self.mass_unit / (self.time_unit ** 2 * self.length_unit)).to(
             "gauss"

--- a/yt/frontends/arepo/data_structures.py
+++ b/yt/frontends/arepo/data_structures.py
@@ -90,6 +90,8 @@ class ArepoHDF5Dataset(GadgetHDF5Dataset):
         # no matter what but that the user gets warned
         if arepo_unit_base is not None:
             for unit in arepo_unit_base:
+                if unit == "cmcm":
+                    continue
                 short_unit = unit.split("_")[0][4:].lower()
                 if short_unit in self._unit_base:
                     which_unit = short_unit

--- a/yt/frontends/arepo/data_structures.py
+++ b/yt/frontends/arepo/data_structures.py
@@ -76,7 +76,6 @@ class ArepoHDF5Dataset(GadgetHDF5Dataset):
                     # integration the redshift will be zero.
                     uvals["cmcm"] = 1.0 / uvals[unit]
             else:
-                mylog.warning("Arepo header is missing %s!", unit)
                 missing[i] = True
         handle.close()
         if all(missing):


### PR DESCRIPTION

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

`GadgetDataset` and its various subclasses allow for a `unit_base` argument to be passed in to set units if they aren't in the dataset. This was not working for `ArepoHDF5Dataset`, which usually (but not always) has the units in the file--if they weren't in the file, then whatever was in `unit_base` was simply being ignored, mainly because the attribute `_unit_base` was simply being clobbered by `ArepoHDF5Dataset` and erasing whatever had been inputted by the user. 

This fixes it by allowing Arepo to figure out what kind of units it has, save them, and then update the `_unit_base` dict with its values (if it has any) before letting the superclass `GadgetDataset` check them. 

However, whatever units are in the dataset must take precedence--and we will warn the user about this.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
