### PR TITLE
test: revert PR 3068. Reactivate a randomly failing answer test

### DIFF
--- a/yt/visualization/volume_rendering/tests/test_vr_orientation.py
+++ b/yt/visualization/volume_rendering/tests/test_vr_orientation.py
@@ -34,10 +34,13 @@ def test_orientation():
     orientations = [[-0.3, -0.1, 0.8]]
 
     theta = np.pi / n_frames
-    decimals = 12
     test_name = "vr_orientation"
 
-    for lens_type in ["perspective", "plane-parallel"]:
+    for lens_type, decimals in [("perspective", 12), ("plane-parallel", 2)]:
+        # set a much lower precision for plane-parallel tests, see
+        # https://github.com/yt-project/yt/issue/3069
+        # https://github.com/yt-project/yt/pull/3068
+        # https://github.com/yt-project/yt/pull/3294
         frame = 0
 
         cam = sc.add_camera(ds, lens_type=lens_type)

--- a/yt/visualization/volume_rendering/tests/test_vr_orientation.py
+++ b/yt/visualization/volume_rendering/tests/test_vr_orientation.py
@@ -37,12 +37,7 @@ def test_orientation():
     decimals = 12
     test_name = "vr_orientation"
 
-    for lens_type in [
-        "perspective",
-        # final name VRImageComparison_UniformGridData_vr_pitch_plane-parallel_0002
-        # deactivated because of a random failure since numpy 0.20.0 and 0.20.1
-        # "plane-parallel"
-    ]:
+    for lens_type in ["perspective", "plane-parallel"]:
         frame = 0
 
         cam = sc.add_camera(ds, lens_type=lens_type)


### PR DESCRIPTION
## PR Summary

Revert #3068
Aim: fix #3069 

I'll try to reproduce the failure in 5 CI runs or less.
If it doesn't pop up, the PR could probably go in as is. If it does, we'll see if it can be fixed by increasing the precision tolerance for this specific test.

update
- run 1: passed ✅
- run 2: failed ❌ 
RMS Value: 0.005627314338711377
Tolerance:  1e-12

For posterity, here's the diff
<img width="1788" alt="Screenshot 2021-05-22 at 18 14 05" src="https://user-images.githubusercontent.com/14075922/119233492-b46c9400-bb29-11eb-8fcc-9f678272e40a.png">

It seems like a big jump to bump the tolerance from 1e-3 to 1e-2...
