### PR TITLE
Make symlog choose a better default linthresh

### DIFF
--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -791,11 +791,29 @@ linear.
    slc.save()
 
 Specifically, a field containing both positive and negative values can be plotted
-with symlog scale, by setting the boolean to be ``True`` and providing an extra
-parameter ``linthresh``. In the region around zero (when the log scale approaches
-to infinity), the linear scale will be applied to the region ``(-linthresh, linthresh)``
-and stretched relative to the logarithmic range. You can also plot a positive field
-under symlog scale with the linear range of ``(0, linthresh)``.
+with symlog scale, by setting the boolean to be ``True`` and either providing an extra
+parameter ``linthresh`` or setting ``symlog_auto = True``. In the region around zero
+(when the log scale approaches to infinity), the linear scale will be applied to the
+region ``(-linthresh, linthresh)`` and stretched relative to the logarithmic range.
+In some cases, if yt detects zeros present in the dataset and the user has selected
+``log`` scaling, yt automatically switches to ``symlog`` scaling and automatically
+chooses a ``linthresh`` value to avoid errors.  This is the same behavior you can
+achieve by setting the keyword ``symlog_auto`` to ``True``. In these cases, yt will
+choose the smallest non-zero value in a dataset to be the ``linthresh`` value.
+As an example,
+
+.. python-script::
+
+   import yt
+
+   ds = yt.load_sample("FIRE_M12i_ref11")
+   p = yt.ProjectionPlot(ds, "x", ("gas", "density"))
+   p.set_log(("gas", "density"), True, symlog_auto=True)
+   p.save()
+
+Symlog is very versatile, and will work with positive or negative dataset ranges.
+Here is an example using symlog scaling to plot a postive field with a linear range of
+``(0, linthresh)``.
 
 .. python-script::
 

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -167,7 +167,7 @@ answer_tests:
   local_axialpix_007:
     - yt/geometry/coordinates/tests/test_axial_pixelization.py:test_axial_pixelization
 
-  local_cylindrical_background_006:  # PR 3153
+  local_cylindrical_background_007:  # PR 3295
     - yt/geometry/coordinates/tests/test_cylindrical_coordinates.py:test_noise_plots
 
   #local_particle_trajectory_001:

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -213,21 +213,16 @@ class ImagePlotMPL(PlotMPL):
         elif cbnorm == "symlog":
             # if cblinthresh is not specified, try to come up with a reasonable default
             vmin = float(np.nanmin(data))
-            vmax = float(np.nanmin(data))
+            vmax = float(np.nanmax(data))
             if cblinthresh is None:
                 # negative and positive range: choose val closest to zero
                 if vmin < 0 and vmax > 0:
                     vmin_pos = np.nanmin(data[data > 0])
                     vmax_neg = np.nanmax(data[data < 0])
                     cblinthresh = np.min([vmin_pos, -vmax_neg])
-                # only positive range: choose smallest non-zero number
-                elif vmin >= 0 and vmax > 0:
-                    cblinthresh = np.nanmin(data[data > 0])
-                # only negative range: same as positive but cblinthresh needs to be
-                # positive!
+                # only positive or negative range: choose smallest non-zero number
                 else:
-                    cblinthresh = -np.nanmax(data[data < 0])
-                cblinthresh = float(cblinthresh)
+                    cblinthresh = np.nanmin(np.absolute(data)[np.absolute(data) > 0])
 
             cbnorm_kwargs.update(dict(linthresh=cblinthresh, vmin=vmin, vmax=vmax))
             MPL_VERSION = LooseVersion(matplotlib.__version__)

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -215,14 +215,7 @@ class ImagePlotMPL(PlotMPL):
             vmin = float(np.nanmin(data))
             vmax = float(np.nanmax(data))
             if cblinthresh is None:
-                # negative and positive range: choose val closest to zero
-                if vmin < 0 and vmax > 0:
-                    vmin_pos = np.nanmin(data[data > 0])
-                    vmax_neg = np.nanmax(data[data < 0])
-                    cblinthresh = np.min([vmin_pos, -vmax_neg])
-                # only positive or negative range: choose smallest non-zero number
-                else:
-                    cblinthresh = np.nanmin(np.absolute(data)[np.absolute(data) > 0])
+                cblinthresh = np.nanmin(np.absolute(data)[data != 0])
 
             cbnorm_kwargs.update(dict(linthresh=cblinthresh, vmin=vmin, vmax=vmax))
             MPL_VERSION = LooseVersion(matplotlib.__version__)

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -311,9 +311,12 @@ class PlotContainer:
             the field to set a transform
             if field == 'all', applies to all plots.
         log : boolean
-            Log on/off.
-        linthresh : float (must be positive)
-            manually setting linthresh will enable symlog scale
+            Log on/off: on means log scaling; off means linear scaling. Unless
+            a linthresh is set or symlog_auto is set in which case symlog is used.
+        linthresh : float, optional
+            when using symlog scaling, linthresh is the value at which scaling
+            transitions from linear to logarithmic.  linthresh must be positive.
+            Note: setting linthresh will automatically enable symlog scale
         symlog_auto : boolean
             if symlog_auto is True, then yt will use symlog scaling and attempt to
             determine a linthresh automatically.  Setting a linthresh manually

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -295,8 +295,15 @@ class PlotContainer:
 
     @accepts_all_fields
     @invalidate_plot
-    def set_log(self, field, log, linthresh=None):
-        """set a field to log or linear.
+    def set_log(self, field, log, linthresh=None, symlog_auto=False):
+        """set a field to log, linear, or symlog.
+
+        Symlog scaling is a combination of linear and log, where from 0 to a
+        threshold value, it operates as linear, and then beyond that it operates as
+        log.  Symlog can also work with negative values in log space as well as
+        negative and positive values simultaneously and symmetrically.  If symlog
+        scaling is desired, please set log=True and either set symlog_auto=True or
+        select a alue for linthresh.
 
         Parameters
         ----------
@@ -306,19 +313,24 @@ class PlotContainer:
         log : boolean
             Log on/off.
         linthresh : float (must be positive)
-            linthresh will be enabled for symlog scale only when log is true
+            manually setting linthresh will enable symlog scale
+        symlog_auto : boolean
+            if symlog_auto is True, then yt will use symlog scaling and attempt to
+            determine a linthresh automatically.  Setting a linthresh manually
+            overrides this value.
 
         """
+        if symlog_auto:
+            self._field_transform[field] = symlog_transform
         if log:
-            if linthresh is not None:
-                if not linthresh > 0.0:
-                    raise ValueError('"linthresh" must be positive')
-                self._field_transform[field] = symlog_transform
-                self._field_transform[field].func = linthresh
-            else:
-                self._field_transform[field] = log_transform
+            self._field_transform[field] = log_transform
         else:
             self._field_transform[field] = linear_transform
+        if linthresh is not None:
+            if not linthresh > 0.0:
+                raise ValueError('"linthresh" must be positive')
+            self._field_transform[field] = symlog_transform
+            self._field_transform[field].func = linthresh
         return self
 
     def get_log(self, field):

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -992,15 +992,15 @@ class PWViewerMPL(PlotWindow):
                 if zlim != (None, None):
                     pass
                 elif np.nanmax(image) == np.nanmin(image):
-                    msg = "Plotting %s: All values = %f."(f, np.nanmax(image))
+                    msg = "Plotting %s: All values = %f" % (np.nanmax(image), f)
                 elif np.nanmax(image) <= 0:
-                    msg = "Plotting {}: All negative values. Max = {:f}.".format(
+                    msg = "Plotting %s: All negative values. Max = %f." % (
                         f,
                         np.nanmax(image),
                     )
                     use_symlog = True
                 elif not np.any(np.isfinite(image)):
-                    msg = "Plotting %s: All values = NaN." % f
+                    msg = "Plotting %s: All values = NaN." % (f,)
                 elif np.nanmax(image) > 0.0 and np.nanmin(image) < 0:
                     msg = (
                         "Plotting %s: Wide range of values. "
@@ -1021,9 +1021,7 @@ class PWViewerMPL(PlotWindow):
                         - np.log10(np.nanmin(image[image > 0]))
                         > cutoff_sigdigs
                     ):
-                        msg = "Plotting %s: Wide range and zeros."(
-                            f,
-                        )
+                        msg = "Plotting %s: Wide range and zeros." % (f,)
                         use_symlog = True
                 if msg is not None:
                     mylog.warning(msg)

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -992,22 +992,19 @@ class PWViewerMPL(PlotWindow):
                 if zlim != (None, None):
                     pass
                 elif np.nanmax(image) == np.nanmin(image):
-                    msg = (
-                        "Plot image for field %s has zero dynamic "
-                        "range. Min = Max = %f." % (f, np.nanmax(image))
-                    )
+                    msg = "Plotting %s: All values = %f."(f, np.nanmax(image))
                 elif np.nanmax(image) <= 0:
-                    msg = (
-                        "Plot image for field %s has no positive "
-                        "values.  Max = %f." % (f, np.nanmax(image))
+                    msg = "Plotting {}: All negative values. Max = {:f}.".format(
+                        f,
+                        np.nanmax(image),
                     )
+                    use_symlog = True
                 elif not np.any(np.isfinite(image)):
-                    msg = f"Plot image for field {f} is filled with NaNs."
+                    msg = "Plotting %s: All values = NaN." % f
                 elif np.nanmax(image) > 0.0 and np.nanmin(image) < 0:
                     msg = (
-                        "Plot image for field %s has both positive "
-                        "and negative/zero values. Min = %f, Max = %f."
-                        % (f, np.nanmin(image), np.nanmax(image))
+                        "Plotting %s: Wide range of values. "
+                        "Min = %f, Max = %f." % (f, np.nanmin(image), np.nanmax(image))
                     )
                     use_symlog = True
                 elif np.nanmax(image) > 0.0 and np.nanmin(image) == 0:
@@ -1024,19 +1021,14 @@ class PWViewerMPL(PlotWindow):
                         - np.log10(np.nanmin(image[image > 0]))
                         > cutoff_sigdigs
                     ):
-                        msg = (
-                            "Plot image for field %s has both positive "
-                            "and zero values with large dynamic range." % (f,)
+                        msg = "Plotting %s: Wide range and zeros."(
+                            f,
                         )
                         use_symlog = True
                 if msg is not None:
                     mylog.warning(msg)
                     if use_symlog:
-                        mylog.warning(
-                            "Log-scaling specified: switching to symlog "
-                            "colorbar scaling unless linear scaling is "
-                            "specified later"
-                        )
+                        mylog.warning("Switching to symlog colorbar scaling.")
                         self._field_transform[f] = symlog_transform
                         self._field_transform[f].func = None
                     else:

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -992,16 +992,16 @@ class PWViewerMPL(PlotWindow):
                 if zlim != (None, None):
                     pass
                 elif np.nanmax(image) == np.nanmin(image):
-                    msg = f"Plotting {f}: All values = {np.nanmax(image):.2g}"
+                    msg = f"Plotting {f}: All values = {np.nanmax(image):.2e}"
                 elif np.nanmax(image) <= 0:
-                    msg = f"Plotting {f}: All negative values. Max = {np.nanmax(image):.2g}."
+                    msg = f"Plotting {f}: All negative values. Max = {np.nanmax(image):.2e}."
                     use_symlog = True
                 elif not np.any(np.isfinite(image)):
                     msg = f"Plotting {f}: All values = NaN."
                 elif np.nanmax(image) > 0.0 and np.nanmin(image) < 0:
                     msg = (
                         f"Plotting {f}: Both positive and negative values. "
-                        f"Min = {np.nanmin(image):.2g}, Max = {np.nanmax(image):.2g}."
+                        f"Min = {np.nanmin(image):.2e}, Max = {np.nanmax(image):.2e}."
                     )
                     use_symlog = True
                 elif np.nanmax(image) > 0.0 and np.nanmin(image) == 0:

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -992,16 +992,18 @@ class PWViewerMPL(PlotWindow):
                 if zlim != (None, None):
                     pass
                 elif np.nanmax(image) == np.nanmin(image):
-                    msg = f"Plotting {f}: All values = {np.nanmax(image):.2e}"
+                    msg = f"Plotting {f}: All values = {np.nanmax(image)}"
                 elif np.nanmax(image) <= 0:
-                    msg = f"Plotting {f}: All negative values. Max = {np.nanmax(image):.2e}."
+                    msg = (
+                        f"Plotting {f}: All negative values. Max = {np.nanmax(image)}."
+                    )
                     use_symlog = True
                 elif not np.any(np.isfinite(image)):
                     msg = f"Plotting {f}: All values = NaN."
                 elif np.nanmax(image) > 0.0 and np.nanmin(image) < 0:
                     msg = (
                         f"Plotting {f}: Both positive and negative values. "
-                        f"Min = {np.nanmin(image):.2e}, Max = {np.nanmax(image):.2e}."
+                        f"Min = {np.nanmin(image)}, Max = {np.nanmax(image)}."
                     )
                     use_symlog = True
                 elif np.nanmax(image) > 0.0 and np.nanmin(image) == 0:

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -992,16 +992,16 @@ class PWViewerMPL(PlotWindow):
                 if zlim != (None, None):
                     pass
                 elif np.nanmax(image) == np.nanmin(image):
-                    msg = f"Plotting {f}: All values = {np.nanmax(image):f}"
+                    msg = f"Plotting {f}: All values = {np.nanmax(image):.2g}"
                 elif np.nanmax(image) <= 0:
-                    msg = f"Plotting {f}: All negative values. Max = {np.nanmax(image):f}."
+                    msg = f"Plotting {f}: All negative values. Max = {np.nanmax(image):.2g}."
                     use_symlog = True
                 elif not np.any(np.isfinite(image)):
                     msg = f"Plotting {f}: All values = NaN."
                 elif np.nanmax(image) > 0.0 and np.nanmin(image) < 0:
                     msg = (
-                        f"Plotting {f}: Wide range of values. "
-                        f"Min = {np.nanmin(image):f}, Max = {np.nanmax(image):f}."
+                        f"Plotting {f}: Both positive and negative values. "
+                        f"Min = {np.nanmin(image):.2g}, Max = {np.nanmax(image):.2g}."
                     )
                     use_symlog = True
                 elif np.nanmax(image) > 0.0 and np.nanmin(image) == 0:

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -994,17 +994,14 @@ class PWViewerMPL(PlotWindow):
                 elif np.nanmax(image) == np.nanmin(image):
                     msg = f"Plotting {f}: All values = {np.nanmax(image):f}"
                 elif np.nanmax(image) <= 0:
-                    msg = "Plotting {}: All negative values. Max = {:f}.".format(
-                        f,
-                        np.nanmax(image),
-                    )
+                    msg = f"Plotting {f}: All negative values. Max = {np.nanmax(image):f}."
                     use_symlog = True
                 elif not np.any(np.isfinite(image)):
                     msg = f"Plotting {f}: All values = NaN."
                 elif np.nanmax(image) > 0.0 and np.nanmin(image) < 0:
                     msg = (
-                        "Plotting %s: Wide range of values. "
-                        "Min = %f, Max = %f." % (f, np.nanmin(image), np.nanmax(image))
+                        f"Plotting {f}: Wide range of values. "
+                        f"Min = {np.nanmin(image):f}, Max = {np.nanmax(image):f}."
                     )
                     use_symlog = True
                 elif np.nanmax(image) > 0.0 and np.nanmin(image) == 0:

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -992,15 +992,15 @@ class PWViewerMPL(PlotWindow):
                 if zlim != (None, None):
                     pass
                 elif np.nanmax(image) == np.nanmin(image):
-                    msg = "Plotting %s: All values = %f" % (np.nanmax(image), f)
+                    msg = f"Plotting {f}: All values = {np.nanmax(image):f}"
                 elif np.nanmax(image) <= 0:
-                    msg = "Plotting %s: All negative values. Max = %f." % (
+                    msg = "Plotting {}: All negative values. Max = {:f}.".format(
                         f,
                         np.nanmax(image),
                     )
                     use_symlog = True
                 elif not np.any(np.isfinite(image)):
-                    msg = "Plotting %s: All values = NaN." % (f,)
+                    msg = f"Plotting {f}: All values = NaN."
                 elif np.nanmax(image) > 0.0 and np.nanmin(image) < 0:
                     msg = (
                         "Plotting %s: Wide range of values. "
@@ -1021,7 +1021,7 @@ class PWViewerMPL(PlotWindow):
                         - np.log10(np.nanmin(image[image > 0]))
                         > cutoff_sigdigs
                     ):
-                        msg = "Plotting %s: Wide range and zeros." % (f,)
+                        msg = f"Plotting {f}: Wide range and zeros."
                         use_symlog = True
                 if msg is not None:
                     mylog.warning(msg)


### PR DESCRIPTION
## PR Summary

Following a patch (PR #3161) for an upstream bug in MPL (see Issue #2890), yt now uses symlog scaling to plot some particle-based datasets.  But the default behavior of symlog sometimes guesses poorly at the `linthresh`, the transition value between scaling the data linearly vs log.  This PR attempts to do a slightly better job of this so users get a decent plot out of the box.

I am definitely open to suggestions on how to improve this behavior.  I feel like there is a lot to unpack here, and I'm not sure this is the right way to do it, but it's a start.  In particular, I realize that by choosing a `linthresh` that is the smallest non-zero value in a dataset, it's wasting the colorbar range between 0 and `linthresh`.  I think one could do a better job by modifying the values of `linthresh` and `linscale` that are passed to MPL (see [this page](https://matplotlib.org/3.1.1/api/_as_gen/matplotlib.colors.SymLogNorm.html)) depending on the data range being plotted.

Here is an example with the FIRE sample dataset.  

```
import yt
ds = yt.load_sample('FIRE_M12i_ref11')
p = yt.ProjectionPlot(ds, 'x', ('gas', 'density')).save()
```

Before this PR:

![snapshot_600_Projection_x_density](https://user-images.githubusercontent.com/8250999/119243562-bed46100-bb1c-11eb-83a9-1ad9fd458eef.png)

And now with this PR:

![snapshot_600_Projection_x_density](https://user-images.githubusercontent.com/8250999/119243557-abc19100-bb1c-11eb-9d89-ddef2449f44e.png)


## PR Checklist

- [x] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

UPDATE1: This changes the default behavior.  Currently, if a user specifies that they want `log` scaling, and there is a negative number present, it switches to `linear`.  This PR changes that behavior to roughly remain in `log` scaling but switch to `symlog` to plot things up in negative log.  The failing answer test demonstrates this change in behavior.  I would argue that this is closer to what the user would want than switching to linear.

As noted above, this optionally allows the user to specify `symlog` scaling without specifying a `linthresh` value, which was previously not an option.  Again, I'm open to hearing people's opinions on this before I write docs and tests for this behavior, but I think it's operating as desired.
