### PR TITLE
ci: pin proj to 7.x version on OsX while cartopy isn't updated

### DIFF
--- a/tests/ci_install.sh
+++ b/tests/ci_install.sh
@@ -16,7 +16,9 @@ osx|macOS)
     sudo mkdir -p /usr/local/man
     sudo chown -R "${USER}:admin" /usr/local/man
     brew update
-    HOMEBREW_NO_AUTO_UPDATE=1 brew install hdf5 proj geos open-mpi netcdf ccache
+    # proj can be unpinned when upstream incompatibility issue is resolved. See
+    # https://github.com/SciTools/cartopy/issues/1140
+    HOMEBREW_NO_AUTO_UPDATE=1 brew install hdf5 proj@7 geos open-mpi netcdf ccache
     ;;
 esac
 


### PR DESCRIPTION
## PR Summary

this should fix the build failures we're currently getting in OsX CI.
Thanks @Xarthisius for unraveling the issue
