### PR TITLE
Document particle visualization workarounds

### DIFF
--- a/doc/source/analyzing/fields.rst
+++ b/doc/source/analyzing/fields.rst
@@ -727,6 +727,9 @@ Possible deposition methods are:
 In addition, the :meth:`~yt.data_objects.static_outputs.add_deposited_particle_field` function
 returns the name of the newly created field.
 
+Deposited particle fields can be useful for visualizing particle data, including
+particles without defined smoothing lengths. See :ref:`particle-plotting-workarounds`
+for more information.
 
 .. _mesh-sampling-particle-fields:
 

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -2035,6 +2035,11 @@ The ``load_particles`` function also accepts the following keyword parameters:
 ``bbox``
        The bounding box for the particle positions.
 
+.. _smooth-non-sph:
+
+Adding Smoothing Lengths for Non-SPH Particles
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 A novel use of the ``load_particles`` function is to facilitate SPH
 visualization of non-SPH particles. See the example below:
 

--- a/doc/source/reference/api/api.rst
+++ b/doc/source/reference/api/api.rst
@@ -531,7 +531,11 @@ Field Functions
 
    ~yt.fields.field_info_container.FieldInfoContainer.add_field
    ~yt.data_objects.static_output.Dataset.add_field
-
+   ~yt.data_objects.static_outputs.add_deposited_particle_field
+   ~yt.data_objects.static_outputs.add_mesh_sampling_particle_field
+   ~yt.data_objects.static_outputs.add_smoothed_particle_field
+   ~yt.data_objects.static_outputs.add_gradient_fields
+   ~yt.frontends.stream.data_structures.add_SPH_fields
 
 Particle Filters
 ----------------
@@ -727,6 +731,7 @@ Function List
 .. autosummary::
 
    ~yt.frontends.ytdata.utilities.save_as_dataset
+   ~yt.data_objects.data_containers.YTDataContainer.save_as_dataset
    ~yt.data_objects.static_output.Dataset.all_data
    ~yt.data_objects.static_output.Dataset.box
    ~yt.funcs.enable_plugins

--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -523,6 +523,57 @@ simply pass ``all`` as the first argument of the field tuple:
    sl = yt.SlicePlot(ds, "z", ("all", "diffused"))
    sl.save()
 
+.. _particle-plotting-workarounds:
+
+Additional Notes for Plotting Particle Data
+-------------------------------------------
+
+Below are some important caveats to note when visualizing particle data.
+
+1. Off axis slice plotting is not available for any particle data.
+   However, axis-aligned slice plots (as described in :ref:`slice-plots`)
+   will work.
+
+2. Off axis projections (as in :ref:`off-axis-projection`) will only work
+   for SPH particles, i.e., particles that have a defined smoothing length.
+
+Two workaround methods are available for plotting non-SPH particles with off-axis
+projections.
+
+1. :ref:`smooth-non-sph` - this method involves extracting particle data to be
+   reloaded with :ref:`~yt.loaders.load_particles` and using the
+   :ref:`~yt.frontends.stream.data_structures.add_SPH_fields` function to
+   create smoothing lengths. This works well for relatively small datasets,
+   but is not parallelized and may take too long for larger data.
+
+2. Plot from a saved
+   :class:`~yt.data_objects.construction_data_containers.YTCoveringGrid`,
+   :class:`~yt.data_objects.construction_data_containers.YTSmoothedCoveringGrid`,
+   or :class:`~yt.data_objects.construction_data_containers.YTArbitraryGrid`
+   dataset.
+
+This second method is illustrated below. First, construct one of the grid data
+objects listed above. Then, use the
+:func:`~yt.data_objects.data_containers.YTDataContainer.save_as_dataset`
+function (see :ref:`saving_data`) to save a deposited particle field
+(see :ref:`deposited-particle-fields`) as a reloadable dataset. This dataset
+can then be loaded and visualized using both off-axis projections and slices.
+Note, the change in the field name from `("deposit", "nbody_mass")` to
+`("grid", "nbody_mass")` after reloading.
+
+.. python-script::
+
+   import yt
+
+   ds = yt.load("gadget_cosmology_plus/snap_N128L16_132.hdf5")
+   # create a 128^3 covering grid over the entire domain
+   L = 7
+   cg = ds.covering_grid(level=L, left_edge=ds.domain_left_edge, dims=[2**L]*3)
+
+   fn = cg.save_as_dataset(fields=[("deposit", "nbody_mass")])
+   ds_grid = yt.load(fn)
+   p = yt.OffAxisProjectionPlot(ds_grid, [1, 1, 1], ("grid", "nbody_mass"))
+   p.save()
 
 Plot Customization: Recentering, Resizing, Colormaps, and More
 --------------------------------------------------------------

--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -558,8 +558,8 @@ objects listed above. Then, use the
 function (see :ref:`saving_data`) to save a deposited particle field
 (see :ref:`deposited-particle-fields`) as a reloadable dataset. This dataset
 can then be loaded and visualized using both off-axis projections and slices.
-Note, the change in the field name from `("deposit", "nbody_mass")` to
-`("grid", "nbody_mass")` after reloading.
+Note, the change in the field name from ``("deposit", "nbody_mass")`` to
+``("grid", "nbody_mass")`` after reloading.
 
 .. python-script::
 


### PR DESCRIPTION
Resolves Issue #3230.

This adds a discussion of a method to plot particle data by depositing onto a grid data object ([smooth] covering grid, arbitrary grid), saving a new dataset, reloading, and plotting from that. I also add a little more visibility to the `add_SPH_fields` method. Finally, I caught some more cases of functions missing from the api reference.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

<!-- Note that some of these check boxes may not apply to all pull requests -->

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
