### PR TITLE
BUG: fixup amrvac sample data file names in tests

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -3,7 +3,7 @@ answer_tests:
   local_art_003: # PR 3081, 3101
     - yt/frontends/art/tests/test_outputs.py:test_d9p
 
-  local_amrvac_008: # PR 2945
+  local_amrvac_2_001: # PR 3317
     - yt/frontends/amrvac/tests/test_outputs.py:test_domain_size
     - yt/frontends/amrvac/tests/test_outputs.py:test_bw_polar_2d
     - yt/frontends/amrvac/tests/test_outputs.py:test_blastwave_cartesian_3D

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -3,16 +3,34 @@ answer_tests:
   local_art_003: # PR 3081, 3101
     - yt/frontends/art/tests/test_outputs.py:test_d9p
 
-  local_amrvac_2_001: # PR 3317
+  local_amrvac_domain_size_001: # PR 3317
     - yt/frontends/amrvac/tests/test_outputs.py:test_domain_size
+
+  local_amrvac_bw_polar_2D_001: # PR 3317
     - yt/frontends/amrvac/tests/test_outputs.py:test_bw_polar_2d
+
+  local_amrvac_bw_cart_3D_001: # PR 3317
     - yt/frontends/amrvac/tests/test_outputs.py:test_blastwave_cartesian_3D
+
+  local_amrvac_bw_sph_2D_001: # PR 3317
     - yt/frontends/amrvac/tests/test_outputs.py:test_blastwave_spherical_2D
+
+  local_amrvac_bw_cyl_3D_001: # PR 3317
     - yt/frontends/amrvac/tests/test_outputs.py:test_blastwave_cylindrical_3D
+
+  local_amrvac_khi2D_001: # PR 3317
     - yt/frontends/amrvac/tests/test_outputs.py:test_khi_cartesian_2D
+
+  local_amrvac_khi3D_001: # PR 3317
     - yt/frontends/amrvac/tests/test_outputs.py:test_khi_cartesian_3D
+
+  local_amrvac_jet_001: # PR 3317
     - yt/frontends/amrvac/tests/test_outputs.py:test_jet_cylindrical_25D
+
+  local_amrvac_riemann_001: # PR 3317
     - yt/frontends/amrvac/tests/test_outputs.py:test_riemann_cartesian_175D
+
+  local_amrvac_rmi_001: # PR 3317
     - yt/frontends/amrvac/tests/test_outputs.py:test_rmi_cartesian_dust_2D
 
   local_arepo_008:  # PR 2909

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -30,7 +30,7 @@ answer_tests:
   local_amrvac_riemann_001: # PR 3317
     - yt/frontends/amrvac/tests/test_outputs.py:test_riemann_cartesian_175D
 
-  local_amrvac_rmi_001: # PR 3317
+  local_amrvac_rmi_002: # PR 3317
     - yt/frontends/amrvac/tests/test_outputs.py:test_rmi_cartesian_dust_2D
 
   local_arepo_008:  # PR 2909

--- a/yt/frontends/amrvac/tests/test_outputs.py
+++ b/yt/frontends/amrvac/tests/test_outputs.py
@@ -13,12 +13,12 @@ from yt.utilities.answer_testing.framework import (
 blastwave_spherical_2D = "bw_spherical_2d/output0001.dat"
 khi_cartesian_2D = "kh2d/output0001.dat"
 khi_cartesian_3D = "kh3d/output0001.dat"
-jet_cylindrical_25D = "amrvac/Jet0003.dat"
+jet_cylindrical_25D = "mhd_jet/Jet0003.dat"
 riemann_cartesian_175D = "riemann1d/output0001.dat"
 blastwave_cartesian_3D = "bw_cartesian_3d/output0001.dat"
 blastwave_polar_2D = "bw_polar_2d/output0001.dat"
 blastwave_cylindrical_3D = "bw_cylindrical_3d/output0001.dat"
-rmi_cartesian_dust_2D = "amrvac/Richtmyer_Meshkov_dust_2D/RM2D_dust_Kwok0000.dat"
+rmi_cartesian_dust_2D = "rmi_dust_2d/RM2D_dust_Kwok0000.dat"
 
 
 def _get_fields_to_check(ds):

--- a/yt/frontends/amrvac/tests/test_outputs.py
+++ b/yt/frontends/amrvac/tests/test_outputs.py
@@ -18,7 +18,7 @@ riemann_cartesian_175D = "riemann1d/output0001.dat"
 blastwave_cartesian_3D = "bw_cartesian_3d/output0001.dat"
 blastwave_polar_2D = "bw_polar_2d/output0001.dat"
 blastwave_cylindrical_3D = "bw_cylindrical_3d/output0001.dat"
-rmi_cartesian_dust_2D = "rmi_dust_2d/RM2D_dust_Kwok0000.dat"
+rmi_cartesian_dust_2D = "rmi_dust_2d/output0001.dat"
 
 
 def _get_fields_to_check(ds):

--- a/yt/frontends/amrvac/tests/test_outputs.py
+++ b/yt/frontends/amrvac/tests/test_outputs.py
@@ -10,14 +10,14 @@ from yt.utilities.answer_testing.framework import (
     small_patch_amr,
 )
 
-blastwave_spherical_2D = "amrvac/bw_2d0000.dat"
-khi_cartesian_2D = "amrvac/kh_2d0000.dat"
-khi_cartesian_3D = "amrvac/kh_3D0000.dat"
+blastwave_spherical_2D = "bw_spherical_2d/output0001.dat"
+khi_cartesian_2D = "kh2d/output0001.dat"
+khi_cartesian_3D = "kh3d/output0001.dat"
 jet_cylindrical_25D = "amrvac/Jet0003.dat"
-riemann_cartesian_175D = "amrvac/R_1d0005.dat"
-blastwave_cartesian_3D = "amrvac/bw_3d0000.dat"
-blastwave_polar_2D = "amrvac/bw_polar_2D0000.dat"
-blastwave_cylindrical_3D = "amrvac/bw_cylindrical_3D0000.dat"
+riemann_cartesian_175D = "riemann1d/output0001.dat"
+blastwave_cartesian_3D = "bw_cartesian_3d/output0001.dat"
+blastwave_polar_2D = "bw_polar_2d/output0001.dat"
+blastwave_cylindrical_3D = "bw_cylindrical_3d/output0001.dat"
 rmi_cartesian_dust_2D = "amrvac/Richtmyer_Meshkov_dust_2D/RM2D_dust_Kwok0000.dat"
 
 

--- a/yt/frontends/amrvac/tests/test_units_override.py
+++ b/yt/frontends/amrvac/tests/test_units_override.py
@@ -2,7 +2,7 @@ from yt.testing import assert_allclose_units, assert_raises, requires_file
 from yt.units import YTQuantity
 from yt.utilities.answer_testing.framework import data_dir_load
 
-khi_cartesian_2D = "amrvac/kh_2d0000.dat"
+khi_cartesian_2D = "kh2d/output0001.dat"
 
 # Tests for units: check that overriding certain units yields the correct derived units.
 # The following are the correct normalisations

--- a/yt/visualization/tests/test_plot_modifications.py
+++ b/yt/visualization/tests/test_plot_modifications.py
@@ -3,9 +3,11 @@ from yt.utilities.answer_testing.framework import data_dir_load
 from yt.visualization.plot_window import SlicePlot
 
 
-@requires_file("amrvac/bw_3d0000.dat")
+@requires_file("bw_cartesian_3d/output0001.dat")
 def test_code_units_xy_labels():
-    ds = data_dir_load("amrvac/bw_3d0000.dat", kwargs=dict(unit_system="code"))
+    ds = data_dir_load(
+        "bw_cartesian_3d/output0001.dat", kwargs=dict(unit_system="code")
+    )
     p = SlicePlot(ds, "x", ("gas", "density"))
 
     ax = p.plots[("gas", "density")].axes

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -664,7 +664,7 @@ def test_set_unit():
 
 
 WD = "WDMerger_hdf5_chk_1000/WDMerger_hdf5_chk_1000.hdf5"
-blast_wave = "amrvac/bw_2d0000.dat"
+blast_wave = "bw_spherical_2d/output0001.dat"
 
 
 @requires_file(WD)


### PR DESCRIPTION


## PR Summary

fix #3315
substitutions were done semi-automatically with the [apply-subs](https://pypi.org/project/apply-subs/) CLI, using this input file:
```json
{
    "bw_cartesian_3d/output0001.dat": "amrvac/bw_3d0000.dat",
    "bw_cylindrical_3d/output0001.dat": "amrvac/bw_cylindrical_3D0000.dat",
    "bw_polar_2d/output0001.dat": "amrvac/bw_polar_2D0000.dat",
    "bw_spherical_2d/output0001.dat": "amrvac/bw_2d0000.dat",
    "kh2d/output0001.dat": "amrvac/kh_2d0000.dat",
    "kh3d/output0001.dat": "amrvac/kh_3D0000.dat",
    "riemann1d/output0001.dat": "amrvac/R_1d0005.dat"
}
```
and using the following command
```shell
git ls-files | egrep '.py$' | xargs apply-subs -s subs.json --inplace
```
