### PR TITLE
Remove unused RAMSES dataset

### DIFF
--- a/yt/sample_data_registry.json
+++ b/yt/sample_data_registry.json
@@ -777,12 +777,6 @@
     "load_name": "output_00003/info_00003.txt",
     "url": "https://yt-project.org/data/ramses_empty_record.tar.gz"
   },
-  "ramses_extra_fields.tar.gz": {
-    "hash": "f3cc7b95bd527c33c095e3fff04c083fcb9681629bdfba359deff2871e765e3f",
-    "load_kwargs": {},
-    "load_name": "info_00001.txt",
-    "url": "https://yt-project.org/data/ramses_extra_fields.tar.gz"
-  },
   "ramses_extra_fields_small.tar.gz": {
     "hash": "8d2dde6e6150f0767ebe3ace84e2e790503154c5d90474008afdfecbac68ffed",
     "load_kwargs": {},


### PR DESCRIPTION
This simply remove a dataset which isn't used anywhere in the code and that cannot be loaded from `load_sample`.

This is due to the `.tar.gz` having the structure:
```
ramses_extra_fields
├── amr_00001.out00001
├── amr_00001.out00002
├── amr_00001.out00003
├── amr_00001.out00004
├── amr_00001.out00005
├── amr_00001.out00006
├── amr_00001.out00007
├── amr_00001.out00008
├── compilation.txt
├── cooling_00001.out
├── grav_00001.out00001
├── grav_00001.out00002
├── grav_00001.out00003
├── grav_00001.out00004
├── grav_00001.out00005
├── grav_00001.out00006
├── grav_00001.out00007
├── grav_00001.out00008
├── header_00001.txt
├── hydro_00001.out00001
├── hydro_00001.out00002
├── hydro_00001.out00003
├── hydro_00001.out00004
├── hydro_00001.out00005
├── hydro_00001.out00006
├── hydro_00001.out00007
├── hydro_00001.out00008
├── hydro_file_descriptor.txt
├── info_00001.txt
├── makefile.txt
├── namelist.txt
├── part_00001.out00001
├── part_00001.out00002
├── part_00001.out00003
├── part_00001.out00004
├── part_00001.out00005
├── part_00001.out00006
├── part_00001.out00007
└── part_00001.out00008
```
Valid RAMSES datasets should always be contained in a folder named `output_XXXXX` where `XXXXX` should match the value in the `info_XXXXX.txt` filename. In this case, the structure should be `ramses_extra_fields/output_00001/` for it to be loaded properly.