### PR TITLE
load_sample: fix datasets without a loadname + bugfix

### DIFF
--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -1387,11 +1387,7 @@ def load_sample(
     except IndexError as err:
         raise KeyError(f"Could not find '{fn}' in the registry.") from err
 
-    load_name = specific_file or specs["load_name"]
-    if not load_name:
-        raise ValueError(
-            "Missing a 'load_name' entry for this dataset. This may be fixed by requesting the full path of the loadable file."
-        )
+    load_name = specific_file or specs["load_name"] or ""
 
     if not isinstance(specs["load_kwargs"], dict):
         raise ValueError(
@@ -1409,9 +1405,8 @@ def load_sample(
     if data_path.exists():
         # if the data is already available locally, `load_sample`
         # only acts as a thin wrapper around `load`
-        appendum = specific_file or specs["load_name"]
-        if appendum not in str(data_path):
-            data_path = data_path.joinpath(appendum)
+        if load_name not in str(data_path):
+            data_path = data_path.joinpath(load_name)
         mylog.info("Sample dataset found in '%s'", data_path)
         if timeout is not None:
             mylog.info("Ignoring the `timeout` keyword argument received.")
@@ -1443,8 +1438,8 @@ def load_sample(
         os.replace(tmp_file, save_dir)
 
     loadable_path = Path.joinpath(save_dir, fn)
-    if not specs["load_name"] in str(loadable_path):
-        loadable_path = loadable_path.joinpath(specs["load_name"], specific_file)
+    if load_name not in str(loadable_path):
+        loadable_path = loadable_path.joinpath(load_name, specific_file)
 
     if specific_file and not loadable_path.exists():
         raise ValueError(f"Could not find file '{loadable_path}'.")

--- a/yt/sample_data_registry.json
+++ b/yt/sample_data_registry.json
@@ -116,7 +116,7 @@
   "Enzo_64.tar.gz": {
     "hash": "2b17fffb6a2e8e471ef85dbdbfa5568f09f7bdb77715c69b40dfe48be8f71bc9",
     "load_kwargs": {},
-    "load_name": null,
+    "load_name": "DD0043/data0043",
     "url": "https://yt-project.org/data/Enzo_64.tar.gz"
   },
   "ExodusII_tests.tar.gz": {
@@ -432,7 +432,7 @@
   "SimbaExample.tar.gz": {
     "hash": "6770e4d5ead92cfc966bca5b8735903389809885f0f1b50523448f68bc53a5ec",
     "load_kwargs": {},
-    "load_name": null,
+    "load_name": "simba_example.hdf5",
     "url": "https://yt-project.org/data/SimbaExample.tar.gz"
   },
   "StarParticles.tar.gz": {
@@ -648,7 +648,7 @@
   "fiducial_1to1_b0.tar.gz": {
     "hash": "1af47a8230addb96055a5c73d1fab9b413f566df191d03c60f0f202df845e7ff",
     "load_kwargs": {},
-    "load_name": null,
+    "load_name": "fiducial_1to1_b0_hdf5_part_0004",
     "url": "https://yt-project.org/data/fiducial_1to1_b0.tar.gz"
   },
   "fiducial_1to3_b1.tar.gz": {
@@ -684,7 +684,7 @@
   "gizmo_cosmology_plus.tar.gz": {
     "hash": "73062872b13c6a8c86ac134b18e177c3526250000cef5559ceb0b2383cbaba6b",
     "load_kwargs": {},
-    "load_name": null,
+    "load_name": "snap_N128L16_131.hdf5",
     "url": "https://yt-project.org/data/gizmo_cosmology_plus.tar.gz"
   },
   "gizmo_mhd_mwdisk.tar.gz": {
@@ -726,7 +726,7 @@
   "maestro_xrb_lores_23437.tar.gz": {
     "hash": "a17b63609a2c50a829e26420f093ee898237b1ef8256ef38ee8be56a6f824460",
     "load_kwargs": {},
-    "load_name": "",
+    "load_name": null,
     "url": "https://yt-project.org/data/maestro_xrb_lores_23437.tar.gz"
   },
   "medium_tipsy.tar.gz": {
@@ -739,7 +739,7 @@
     "hash": "308f6b2a81363c5aada35941c199f149d8688f8ce65803f33d6dedce43a57a1c",
     "load_kwargs": {},
     "load_name": null,
-    "url": "https://yt-project.org/data/nyx_sedov_plt00086.tgz.tar.gz"
+    "url": "https://yt-project.org/data/nyx_sedov_plt00086.tgz"
   },
   "nyx_small.tar.gz": {
     "hash": "1eefb443c2de6d9c6f4546bb87e1bde89ae98adb97c860a6065ac3177ecf1127",


### PR DESCRIPTION
## PR Summary

This fixes a few leftovers from  #2699+#2951: datasets that cannot  currently load with `yt.load_sample` because they lack a default "load_name".
I needed to tweak `yt.load_sample` itself, and I want to stress that I've performed a systematic check that the change *doesn't* break any of the previously working cases (the check takes a few *hours* to download the whole database).
Note to reviewers: I encourage you to manually test this patch (I already did), but note that some of the datasets that this patch fixes are pretty big (between 5 and 15GB), so it might take a little while for them do download.