### PR TITLE
load_sample: fix for load names matching directory names

### DIFF
--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -1441,7 +1441,4 @@ def load_sample(
     if load_name not in str(loadable_path):
         loadable_path = loadable_path.joinpath(load_name, specific_file)
 
-    if specific_file and not loadable_path.exists():
-        raise ValueError(f"Could not find file '{loadable_path}'.")
-
     return load(loadable_path, **kwargs)

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -1387,11 +1387,7 @@ def load_sample(
     except IndexError as err:
         raise KeyError(f"Could not find '{fn}' in the registry.") from err
 
-    load_name = specific_file or specs["load_name"]
-    if not load_name:
-        raise ValueError(
-            "Missing a 'load_name' entry for this dataset. This may be fixed by requesting the full path of the loadable file."
-        )
+    load_name = specific_file or specs["load_name"] or ""
 
     if not isinstance(specs["load_kwargs"], dict):
         raise ValueError(
@@ -1409,9 +1405,8 @@ def load_sample(
     if data_path.exists():
         # if the data is already available locally, `load_sample`
         # only acts as a thin wrapper around `load`
-        appendum = specific_file or specs["load_name"]
-        if appendum not in str(data_path):
-            data_path = data_path.joinpath(appendum)
+        if load_name not in str(data_path):
+            data_path = data_path.joinpath(load_name)
         mylog.info("Sample dataset found in '%s'", data_path)
         if timeout is not None:
             mylog.info("Ignoring the `timeout` keyword argument received.")
@@ -1443,8 +1438,8 @@ def load_sample(
         os.replace(tmp_file, save_dir)
 
     loadable_path = Path.joinpath(save_dir, fn)
-    if not specs["load_name"] in str(loadable_path):
-        loadable_path = loadable_path.joinpath(specs["load_name"], specific_file)
+    if load_name not in str(loadable_path):
+        loadable_path = loadable_path.joinpath(load_name, specific_file)
 
     if specific_file and not loadable_path.exists():
         raise ValueError(f"Could not find file '{loadable_path}'.")

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -1405,7 +1405,7 @@ def load_sample(
     if save_dir.joinpath(topdir).exists():
         # if the data is already available locally, `load_sample`
         # only acts as a thin wrapper around `load`
-        if load_name not in str(data_path):
+        if load_name and os.sep not in fn:
             data_path = data_path.joinpath(load_name)
         mylog.info("Sample dataset found in '%s'", data_path)
         if timeout is not None:

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -1402,7 +1402,7 @@ def load_sample(
     save_dir = _get_test_data_dir_path()
 
     data_path = save_dir.joinpath(fn)
-    if data_path.exists():
+    if save_dir.joinpath(topdir).exists():
         # if the data is already available locally, `load_sample`
         # only acts as a thin wrapper around `load`
         if load_name not in str(data_path):

--- a/yt/sample_data_registry.json
+++ b/yt/sample_data_registry.json
@@ -116,7 +116,7 @@
   "Enzo_64.tar.gz": {
     "hash": "2b17fffb6a2e8e471ef85dbdbfa5568f09f7bdb77715c69b40dfe48be8f71bc9",
     "load_kwargs": {},
-    "load_name": null,
+    "load_name": "DD0043/data0043",
     "url": "https://yt-project.org/data/Enzo_64.tar.gz"
   },
   "ExodusII_tests.tar.gz": {
@@ -432,7 +432,7 @@
   "SimbaExample.tar.gz": {
     "hash": "6770e4d5ead92cfc966bca5b8735903389809885f0f1b50523448f68bc53a5ec",
     "load_kwargs": {},
-    "load_name": null,
+    "load_name": "simba_example.hdf5",
     "url": "https://yt-project.org/data/SimbaExample.tar.gz"
   },
   "StarParticles.tar.gz": {
@@ -648,7 +648,7 @@
   "fiducial_1to1_b0.tar.gz": {
     "hash": "1af47a8230addb96055a5c73d1fab9b413f566df191d03c60f0f202df845e7ff",
     "load_kwargs": {},
-    "load_name": null,
+    "load_name": "fiducial_1to1_b0_hdf5_part_0004",
     "url": "https://yt-project.org/data/fiducial_1to1_b0.tar.gz"
   },
   "fiducial_1to3_b1.tar.gz": {
@@ -684,7 +684,7 @@
   "gizmo_cosmology_plus.tar.gz": {
     "hash": "73062872b13c6a8c86ac134b18e177c3526250000cef5559ceb0b2383cbaba6b",
     "load_kwargs": {},
-    "load_name": null,
+    "load_name": "snap_N128L16_131.hdf5",
     "url": "https://yt-project.org/data/gizmo_cosmology_plus.tar.gz"
   },
   "gizmo_mhd_mwdisk.tar.gz": {
@@ -726,7 +726,7 @@
   "maestro_xrb_lores_23437.tar.gz": {
     "hash": "a17b63609a2c50a829e26420f093ee898237b1ef8256ef38ee8be56a6f824460",
     "load_kwargs": {},
-    "load_name": "",
+    "load_name": null,
     "url": "https://yt-project.org/data/maestro_xrb_lores_23437.tar.gz"
   },
   "medium_tipsy.tar.gz": {
@@ -739,7 +739,7 @@
     "hash": "308f6b2a81363c5aada35941c199f149d8688f8ce65803f33d6dedce43a57a1c",
     "load_kwargs": {},
     "load_name": null,
-    "url": "https://yt-project.org/data/nyx_sedov_plt00086.tgz.tar.gz"
+    "url": "https://yt-project.org/data/nyx_sedov_plt00086.tgz"
   },
   "nyx_small.tar.gz": {
     "hash": "1eefb443c2de6d9c6f4546bb87e1bde89ae98adb97c860a6065ac3177ecf1127",

--- a/yt/sample_data_registry.json
+++ b/yt/sample_data_registry.json
@@ -600,13 +600,13 @@
   "castro_sedov_2d_cyl_in_cart_plt00150.tar.gz": {
     "hash": "8b73a37a0503dba593af65f8bf16dfcc11ac825d671f11e5a364a2dee63c9047",
     "load_kwargs": {},
-    "load_name": "castro_sedov_2d_cyl_in_cart_plt00150",
+    "load_name": null,
     "url": "https://yt-project.org/data/castro_sedov_2d_cyl_in_cart_plt00150.tar.gz"
   },
   "castro_sod_x_plt00036.tar.gz": {
     "hash": "3f0a586b41e7b54fa2b3cddd50f9384feb2efe1fe1a815e7348965ae7bf88f78",
     "load_kwargs": {},
-    "load_name": "castro_sod_x_plt00036",
+    "load_name": null,
     "url": "https://yt-project.org/data/castro_sod_x_plt00036.tar.gz"
   },
   "check_pooch.py": {
@@ -834,7 +834,7 @@
   "sedov_1d_sph_plt00120.tar.gz": {
     "hash": "25e8316a64a747043c2c95bfaaf6092a5aa2748a8e31295fa86a0bb793e7c1af",
     "load_kwargs": {},
-    "load_name": "sedov_1d_sph_plt00120",
+    "load_name": null,
     "url": "https://yt-project.org/data/sedov_1d_sph_plt00120.tar.gz"
   },
   "sedov_tst_0004.tar.gz": {


### PR DESCRIPTION
## PR Summary

This is also based on top of #3337 (only the last commit is exclusive to this branch), draft status shouldn't be removed before the previous PR goes in.
I will also perform a general test for this to make extra sure it's not breaking anything.

Here's a -likely, but not necessarily comprehensive- list of datasets that this patch makes loadable

- Gadget3-snap-format2
- snapshot_010
- agora_1e11.00400

On the main branch, and up to #3336, `load_sample(<any of the above>)` fails with a "YTUnidentifiedDataFormat".