### PR TITLE
load_sample: fix missing data sample registration

### DIFF
--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -1435,7 +1435,7 @@ def load_sample(
             fh.extractall(save_dir)
         os.remove(tmp_file)
     else:
-        os.replace(tmp_file, save_dir)
+        os.replace(tmp_file, os.path.join(save_dir, fn))
 
     loadable_path = Path.joinpath(save_dir, fn)
     if load_name not in str(loadable_path):

--- a/yt/sample_data_registry.json
+++ b/yt/sample_data_registry.json
@@ -500,7 +500,7 @@
     "hash": "6fc406dd056b525592f704b202dadf52c41024660dbbd96cfbeb830d710a70d8",
     "load_kwargs": {},
     "load_name": null,
-    "url": "https://yt-project.org/data/acisf05356N003_evt2.fits.gz.tar.gz"
+    "url": "https://yt-project.org/data/acisf05356N003_evt2.fits.gz"
   },
   "agora_1e11.00400.tar.gz": {
     "hash": "3a8820735bcf5067dfbe0fcd90d79121a801ea1a34c7d6de7e09185d3c635e6a",
@@ -698,7 +698,7 @@
     "hash": "1aff152f616d2626c8515c1493e65f07843d9b5f2ba73b7e4271a2dc6a9e6da7",
     "load_kwargs": {},
     "load_name": null,
-    "url": "https://yt-project.org/data/grs-50-cube.fits.gz.tar.gz"
+    "url": "https://yt-project.org/data/grs-50-cube.fits.gz"
   },
   "halo1e11_run1.00400.tar.gz": {
     "hash": "414d05f9d5aa2dc2811e55fab59ad2c1426ec51675aaf41db773b24cd2f0aa5f",
@@ -716,7 +716,7 @@
     "hash": "6a44b6c352a5c98c58f0b2b7498fd87e2430c530971eaff68b843146d82d6609",
     "load_kwargs": {},
     "load_name": null,
-    "url": "https://yt-project.org/data/m33_hi.fits.gz.tar.gz"
+    "url": "https://yt-project.org/data/m33_hi.fits.gz"
   },
   "maestro_subCh_plt00248.tar.gz": {
     "hash": "6de1b63b63ce9738e4596ccf4cc75087d5029c892c07f40c2c69887e76b8ec1a",

--- a/yt/sample_data_registry.json
+++ b/yt/sample_data_registry.json
@@ -610,6 +610,12 @@
     "load_name": null,
     "url": "https://yt-project.org/data/check_pooch.py.tar.gz"
   },
+  "cm1_tornado_lofs.tar.gz": {
+    "hash": "7a84f688b363b79d2ac7bf53d1a963f01d07926a0d268e4163ba87ea81699706",
+    "load_kwargs": {},
+    "load_name": "nc4_cm1_lofs_tornado_test.nc",
+    "url": "https://yt-project.org/data/cm1_tornado_lofs.tar.gz"
+  },
   "datafiles.json": {
     "hash": "56732241ddfe5770d0dacc52c1957a0c8b13ca095fd0d8f029dbd263be714838",
     "load_kwargs": {},
@@ -844,6 +850,12 @@
     "load_name": "sizmbhloz-clref04SNth-rs9_a0.9011.art",
     "url": "https://yt-project.org/data/sizmbhloz-clref04SNth-rs9_a0.9011.tar.gz"
   },
+  "SmartStars.tar.gz": {
+    "hash": "990ff61aa85408d33c4c6be7181e1f64fcd738526dcf0e34be5605d8bb158605",
+    "load_kwargs": {},
+    "load_name": "DD0100/output_0100",
+    "url": "https://yt-project.org/data/SmartStars.tar.gz"
+  },
   "snapshot_010.tar.gz": {
     "hash": "c98fa744de250d02833b643e3250dce2cf2c7a622c42c96b201024ee28582ba9",
     "load_kwargs": {},
@@ -873,6 +885,12 @@
     "load_kwargs": {},
     "load_name": "RadTube/plt00500",
     "url": "https://yt-project.org/data/test_outputs.tar.gz"
+  },
+  "tiny_fof_halos.tar.gz": {
+    "hash": "48555ba2c482be88d7944a79ecf27967b517366d4d1075a7a5639e6d2339d8f0",
+    "load_kwargs": {},
+    "load_name": "DD0045/DD0045.0.h5",
+    "url": "https://yt-project.org/data/tiny_fof_halos.tar.gz"
   },
   "ytdata_test.tar.gz": {
     "hash": "cafb2b06ab3190ba17909585b58a4724e25f27ac72f11d6dff1a482146eb8958",


### PR DESCRIPTION
## PR Summary

fix #3341

- fix a bug in load_sample where non-tarballs files couldn't be moved to the test-data-dir
- register sample datasets cm1_tornado, SmartStars, tiny_fof_halos
- update broken urls

note: two of the datasets reported in #3341 cannot be trivially fixed for now, namely:
- ParticleCavity. Reason: the tarball is "malformed" according to the rule followed by the rest of the datasamples and implemented in load_sample (update: this one is fixed in #3334 + https://github.com/yt-project/website/pull/103 )
- cm1_supercell_native.tar.gz: I wasn't able to find a way to load this one once untared. No matter what specific file is passed to `yt.load`, it fails with `YTUnidentifiedDataFormat`.
