### PR TITLE
make CoordinateHandler an abstract class

### DIFF
--- a/yt/geometry/coordinates/coordinate_handler.py
+++ b/yt/geometry/coordinates/coordinate_handler.py
@@ -1,3 +1,4 @@
+import abc
 import weakref
 from numbers import Number
 
@@ -61,7 +62,7 @@ def validate_sequence_width(width, ds, unit=None):
             )
 
 
-class CoordinateHandler:
+class CoordinateHandler(abc.ABC):
     name = None
 
     def __init__(self, ds, ordering):
@@ -70,38 +71,46 @@ class CoordinateHandler:
 
     def setup_fields(self):
         # This should return field definitions for x, y, z, r, theta, phi
-        raise NotImplementedError
+        pass
 
+    @abc.abstractmethod
     def pixelize(self, dimension, data_source, field, bounds, size, antialias=True):
         # This should *actually* be a pixelize call, not just returning the
         # pixelizer
-        raise NotImplementedError
+        pass
 
+    @abc.abstractmethod
     def pixelize_line(self, field, start_point, end_point, npoints):
-        raise NotImplementedError
+        pass
 
     def distance(self, start, end):
         p1 = self.convert_to_cartesian(start)
         p2 = self.convert_to_cartesian(end)
         return np.sqrt(((p1 - p2) ** 2.0).sum())
 
+    @abc.abstractmethod
     def convert_from_cartesian(self, coord):
-        raise NotImplementedError
+        pass
 
+    @abc.abstractmethod
     def convert_to_cartesian(self, coord):
-        raise NotImplementedError
+        pass
 
+    @abc.abstractmethod
     def convert_to_cylindrical(self, coord):
-        raise NotImplementedError
+        pass
 
+    @abc.abstractmethod
     def convert_from_cylindrical(self, coord):
-        raise NotImplementedError
+        pass
 
+    @abc.abstractmethod
     def convert_to_spherical(self, coord):
-        raise NotImplementedError
+        pass
 
+    @abc.abstractmethod
     def convert_from_spherical(self, coord):
-        raise NotImplementedError
+        pass
 
     _data_projection = None
 
@@ -194,8 +203,9 @@ class CoordinateHandler:
         return ya
 
     @property
+    @abc.abstractproperty
     def period(self):
-        raise NotImplementedError
+        pass
 
     def sanitize_depth(self, depth):
         if is_sequence(depth):

--- a/yt/geometry/coordinates/coordinate_handler.py
+++ b/yt/geometry/coordinates/coordinate_handler.py
@@ -69,6 +69,7 @@ class CoordinateHandler(abc.ABC):
         self.ds = weakref.proxy(ds)
         self.axis_order = ordering
 
+    @abc.abstractmethod
     def setup_fields(self):
         # This should return field definitions for x, y, z, r, theta, phi
         pass

--- a/yt/geometry/coordinates/cylindrical_coordinates.py
+++ b/yt/geometry/coordinates/cylindrical_coordinates.py
@@ -165,6 +165,9 @@ class CylindricalCoordinateHandler(CoordinateHandler):
             # Pixelizing along a cylindrical surface is a bit tricky
             raise NotImplementedError
 
+    def pixelize_line(self, field, start_point, end_point, npoints):
+        raise NotImplementedError
+
     def _ortho_pixelize(
         self, data_source, field, bounds, size, antialias, dim, periodic
     ):

--- a/yt/geometry/coordinates/geographic_coordinates.py
+++ b/yt/geometry/coordinates/geographic_coordinates.py
@@ -245,6 +245,9 @@ class GeographicCoordinateHandler(CoordinateHandler):
         else:
             raise NotImplementedError
 
+    def pixelize_line(self, field, start_point, end_point, npoints):
+        raise NotImplementedError
+
     def _ortho_pixelize(
         self, data_source, field, bounds, size, antialias, dimension, periodic
     ):

--- a/yt/geometry/coordinates/spherical_coordinates.py
+++ b/yt/geometry/coordinates/spherical_coordinates.py
@@ -164,6 +164,9 @@ class SphericalCoordinateHandler(CoordinateHandler):
         else:
             raise NotImplementedError
 
+    def pixelize_line(self, field, start_point, end_point, npoints):
+        raise NotImplementedError
+
     def _ortho_pixelize(
         self, data_source, field, bounds, size, antialias, dim, periodic
     ):


### PR DESCRIPTION
## PR Summary

`CoordinateHandler` defines a base class that is clearly not meant to be instantiated as most of its methods go straight to `NotImplementedError`. While it is an easy way to implement base classes, it is not trivial for new comers to guess where the missing code should be injected in case they run into one of the raise statements, since it should really be added to the specialised child class rather than the base class that the traceback leads to.

To make things clearer, I'm making `CoordinateHandler` an actual abstract class.
I will use CI to discover which methods should be added to child classes, and write `NotImplementedError`s _there_.