### PR TITLE
cleanup Python version checking 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,8 @@ repos:
     - id: flake8
       additional_dependencies: [
         flake8-bugbear>=20.3.2, # GH PR 2851
-        flake8-logging-format
+        flake8-logging-format,
+        flake8-2020==1.6.0,
       ]
 -   repo: https://github.com/asottile/blacken-docs
     rev: v1.10.0

--- a/yt/__init__.py
+++ b/yt/__init__.py
@@ -7,13 +7,6 @@ yt is a toolkit for analyzing and visualizing volumetric data.
 * Contribute: https://github.com/yt-project/yt
 
 """
-import sys
-
-if sys.version_info[0] < 3:
-    raise Exception(
-        "Python 2 is no longer supported.  Please install Python 3 for use with yt."
-    )
-
 __version__ = "4.0.dev0"
 
 import yt.units as units

--- a/yt/frontends/artio/_artio_caller.pyx
+++ b/yt/frontends/artio/_artio_caller.pyx
@@ -294,7 +294,6 @@ cdef class artio_fileset :
         if self.handle : artio_fileset_close(self.handle)
 
     def read_parameters(self) :
-        from sys import version
         cdef char key[64]
         cdef int type
         cdef int length
@@ -317,9 +316,8 @@ cdef class artio_fileset :
                 for i in range(length) :
                     free(char_values[i])
                 free(char_values)
-                if version[0] == '3':
-                    for i in range(0,len(parameter)):
-                        parameter[i] = parameter[i].decode('utf-8')
+                for i in range(len(parameter)):
+                    parameter[i] = parameter[i].decode('utf-8')
             elif type == ARTIO_TYPE_INT :
                 int_values = <int32_t *>malloc(length*sizeof(int32_t))
                 artio_parameter_get_int_array( self.handle, key, length, int_values )
@@ -343,10 +341,7 @@ cdef class artio_fileset :
             else :
                 raise RuntimeError("ARTIO file corruption detected: invalid type!")
 
-            if version[0] == '3':
-                self.parameters[key.decode('utf-8')] = parameter
-            else:
-                self.parameters[key] = parameter
+            self.parameters[key.decode('utf-8')] = parameter
 
     def abox_from_auni(self, np.float64_t a):
         if self.cosmology:

--- a/yt/frontends/artio/data_structures.py
+++ b/yt/frontends/artio/data_structures.py
@@ -349,7 +349,6 @@ class ARTIODataset(Dataset):
         unit_system="cgs",
         default_species_fields=None,
     ):
-        from sys import version
 
         if self._handle is not None:
             return
@@ -357,10 +356,7 @@ class ARTIODataset(Dataset):
         self.fluid_types += ("artio",)
         self._filename = filename
         self._fileset_prefix = filename[:-4]
-        if version < "3":
-            self._handle = artio_fileset(self._fileset_prefix)
-        else:
-            self._handle = artio_fileset(bytes(self._fileset_prefix, "utf-8"))
+        self._handle = artio_fileset(bytes(self._fileset_prefix, "utf-8"))
         self.artio_parameters = self._handle.parameters
         # Here we want to initiate a traceback, if the reader is not built.
         Dataset.__init__(

--- a/yt/frontends/gdf/io.py
+++ b/yt/frontends/gdf/io.py
@@ -21,7 +21,6 @@ class IOHandlerGDFHDF5(BaseIOHandler):
     _data_string = "data:datatype=0"
 
     def _read_fluid_selection(self, chunks, selector, fields, size):
-        from sys import version
 
         rv = {}
         chunks = list(chunks)
@@ -64,12 +63,9 @@ class IOHandlerGDFHDF5(BaseIOHandler):
                 if grid.filename is None:
                     continue
                 if fid is None:
-                    if version < "3":
-                        fid = h5py.h5f.open(grid.filename, h5py.h5f.ACC_RDONLY)
-                    else:
-                        fid = h5py.h5f.open(
-                            bytes(grid.filename, "utf-8"), h5py.h5f.ACC_RDONLY
-                        )
+                    fid = h5py.h5f.open(
+                        bytes(grid.filename, "utf-8"), h5py.h5f.ACC_RDONLY
+                    )
                 if self.ds.field_ordering == 1:
                     # check the dtype instead
                     data = np.empty(grid.ActiveDimensions[::-1], dtype="float64")
@@ -79,12 +75,9 @@ class IOHandlerGDFHDF5(BaseIOHandler):
                     data_view = data = np.empty(grid.ActiveDimensions, dtype="float64")
                 for field in fields:
                     ftype, fname = field
-                    if version < "3":
-                        dg = h5py.h5d.open(fid, _field_dname(grid.id, fname))
-                    else:
-                        dg = h5py.h5d.open(
-                            fid, bytes(_field_dname(grid.id, fname), "utf-8")
-                        )
+                    dg = h5py.h5d.open(
+                        fid, bytes(_field_dname(grid.id, fname), "utf-8")
+                    )
                     dg.read(h5py.h5s.ALL, h5py.h5s.ALL, data)
                     # caches
                     nd = grid.select(selector, data_view, rv[field], ind)

--- a/yt/startup_tasks.py
+++ b/yt/startup_tasks.py
@@ -166,7 +166,7 @@ else:
 if parallel_capable:
     pass
 elif (
-    exe_name in ["mpi4py", "embed_enzo", "python" + sys.version[:3] + "-mpi"]
+    exe_name in ["mpi4py", "embed_enzo", "python{}.{}-mpi".format(*sys.version_info)]
     or "_parallel" in dir(sys)
     or any(["ipengine" in arg for arg in sys.argv])
     or any(["cluster-id" in arg for arg in sys.argv])


### PR DESCRIPTION
## PR Summary

This cleans up reminiscent compatibility layers for Python 2, but more importantly, it fixes two bugs:
- in yt/startup_tasks.py where a conditional would break when Python 3.10 is released (later this year).
- in `yt/__init__.py`, where the version check would wrongfully pass under Python >=3.0;<3.5 
By adding a flake8 plugin to the pre-commit tool belt, I also prevent this kind of mishap to happen again in the future.
