### PR TITLE
Updating FAQ for 4

### DIFF
--- a/doc/source/faq/index.rst
+++ b/doc/source/faq/index.rst
@@ -18,7 +18,7 @@ How can I tell what version of yt I'm using?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you run into problems with yt and you're writing to the mailing list
-or contacting developers on IRC, they will likely want to know what version of
+or contacting developers on Slack, they will likely want to know what version of
 yt you're using.  Oftentimes, you'll want to know both the yt version,
 as well as the last changeset that was committed to the branch you're using.
 To reveal this, go to a command line and type:
@@ -27,32 +27,34 @@ To reveal this, go to a command line and type:
 
     $ yt version
 
+The result will look something like this:
+
+.. code-block:: bash
+
     yt module located at:
-        /Users/username/src/yt-conda/src/yt-git
+        /Users/mitchell/src/yt-conda/src/yt-git
 
     The current version of yt is:
 
     ---
-    Version = 3.4-dev
-    Changeset = 94033fca00e5
+    Version = 4.0.dev0
+    Changeset = 9f947a930ab4
     ---
-
     This installation CAN be automatically updated.
+
 
 For more information on this topic, see :ref:`updating-yt`.
 
 .. _yt-3.0-problems:
 
-I upgraded to yt 3.0 but my code no longer works.  What do I do?
+I upgraded to yt 4.0 but my code no longer works.  What do I do?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Because there are a lot of backwards-incompatible changes in yt 3.0 (see
-:ref:`yt3differences`, it can
-be a daunting effort in transitioning old scripts from yt 2.x to 3.0.
-We have tried to describe the basic process of making that transition
-in :ref:`transitioning-to-3.0`.  If you just want to change back to yt 2.x
-for a while until you're ready to make the transition, you can follow
-the instructions in :ref:`switching-between-yt-versions`.
+We've tried to keep the number of backward-incompatible changes to a minimum
+with the release of yt-4.0, but because of the wide-reaching changes to how
+yt manages data, there may be updates you have to make.
+You can see many of the changes in :ref:`yt4differences`, and
+in :ref:`transitioning-to-4.0` there are helpful tips on how to modify your scripts to update them.
 
 Code Errors and Failures
 ------------------------
@@ -73,7 +75,7 @@ where ``$YT_GIT`` is the path to the yt git repository.
 
 This error tends to occur when there are changes in the underlying cython
 files that need to be rebuilt, like after a major code update or in switching
-from 2.x to 3.x.  For more information on this, see
+from 3.x to 4.x.  For more information on this, see
 :ref:`switching-between-yt-versions`.
 
 .. _faq-mpi4py:
@@ -133,19 +135,13 @@ Units
 
 .. _conversion-factors:
 
-How do I get the convert between code units and physical units for my dataset?
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+How do I convert between code units and physical units for my dataset?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Converting between physical units and code units is a common task.  In yt-2.x,
-the syntax for getting conversion factors was in the units dictionary
-(``pf.units['kpc']``). So in order to convert a variable ``x`` in code units to
-kpc, you might run:
-
-.. code-block:: python
-
-    x = x * pf.units["kpc"]
-
-In yt-3.0, this no longer works.  Conversion factors are tied up in the
+Starting with yt-3.0, and continuing to yt-4.0, yt uses an internal symbolic
+unit system.  In yt-3.0 this was bundled with the main yt codebase, and with
+yt-4.0 it is now available as a separate package called `unyt
+<https://unyt.readthedocs.org/>`_.  Conversion factors are tied up in the
 ``length_unit``, ``times_unit``, ``mass_unit``, and ``velocity_unit``
 attributes, which can be converted to any arbitrary desired physical unit:
 
@@ -162,7 +158,7 @@ attributes, which can be converted to any arbitrary desired physical unit:
     print("Velocity unit: ", ds.velocity_unit.in_units("Mpc/year"))
 
 So to accomplish the example task of converting a scalar variable ``x`` in
-code units to kpc in yt-3.0, you can do one of two things.  If ``x`` is
+code units to kpc in yt-4.0, you can do one of two things.  If ``x`` is
 already a YTQuantity with units in ``code_length``, you can run:
 
 .. code-block:: python
@@ -260,7 +256,7 @@ logged, you could type:
 
     ds = load("my_data")
     ds.index
-    ds.field_info["density"].take_log = False
+    ds.field_info["gas", "density"].take_log = False
 
 From that point forward, data products such as slices, projections, etc., would
 be presented in linear space. Note that you have to instantiate ds.index before
@@ -386,6 +382,9 @@ This means you can download these datasets to ``/big_drive/data_for_yt`` , add
 the appropriate item to ``~/.config/yt/yt.toml``, and no matter which directory you are
 in when running yt, it will also check in *that* directory.
 
+In many cases, these are also available using the ``load_sample`` command,
+described in :ref:`loading-sample-data`.
+
 
 .. _faq-scroll-up:
 
@@ -401,25 +400,6 @@ environment can use readline, run the following command:
    $ ~/yt/bin/pip install gnureadline
 
 .. _faq-old-data:
-
-yt seems to be plotting from old data
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-yt does check the time stamp of the simulation so that if you
-overwrite your data outputs, the new set will be read in fresh by
-yt. However, if you have problems or the yt output seems to be
-in someway corrupted, try deleting the ``.yt`` and
-``.harray`` files from inside your data directory. If this proves to
-be a persistent problem add the line:
-
-.. code-block:: python
-
-   from yt.config import ytcfg
-
-   ytcfg["yt", "serialize"] = "False"
-
-to the very top of your yt script.  Turning off serialization is the default
-behavior in yt-3.0.
 
 .. _faq-log-level:
 


### PR DESCRIPTION
This updates the FAQ (where it needs to be updated, which is not everywhere!) to reflect the current state of yt 4.0.

This addresses issue #3353.
