### PR TITLE
fix: add pyx to documentation build deps

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,7 @@ doc =
     alabaster
     nbconvert==5.6.1
     pyregion
+    pyx>=0.15
     runnotebook
     sphinx==3.1.2
     sphinx-bootstrap-theme


### PR DESCRIPTION
## PR Summary

Noticed this warning
```
WARNING: autodoc: failed to import module 'eps_writer' from module 'yt.visualization'; the following exception was raised:
No module named 'pyx'
```
while scanning through the logs in docs build, e.g.
https://tests.yt-project.org/job/yt_docs_new/1526/consoleFull

This is the quick-and-dirty fix, but maybe `pyx` should actually be either a hard dependency or an optional one referenced in the on_demand_import.py module