### PR TITLE
hotfix: don't require firefly_api even in full build as it's not available on Pypi any more

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -71,7 +71,6 @@ full =
     astropy~=4.0.1
     f90nml>=1.1.2
     fastcache~=1.0.2
-    firefly_api>=0.0.2
     glueviz~=0.13.3
     h5py~=3.1.0
     libconf~=1.0.1


### PR DESCRIPTION
## PR Summary

firefly-api seems to have suddenly been removed from Pypi today (not _yanked_, *removed*, which means we can not even require the last version specifically).
ATM I can't find information on this event, so I'm just proposing this hotfix in order to allow CI to pass on other PRs on the short term.

Further action will be required when we find out what happened.

edit: these were the urls for this package :
https://pypi.org/project/firefly-api/
https://github.com/agurvich/firefly_api