### PR TITLE
doc: fix some bugs/warnings in documentation build

### DIFF
--- a/doc/source/analyzing/astropy_integrations.rst
+++ b/doc/source/analyzing/astropy_integrations.rst
@@ -15,8 +15,7 @@ similar to that in yt. For this reason, we have implemented "round-trip"
 conversions between :class:`~yt.units.yt_array.YTArray` objects
 and AstroPy's :class:`~astropy.units.Quantity` objects. These are implemented
 in the :meth:`~yt.units.yt_array.YTArray.from_astropy` and
-:meth:`~yt.units.yt_array.YTArray.to_astropy` methods. See
-:ref:`fields_and_unit_conversion` for more information.
+:meth:`~yt.units.yt_array.YTArray.to_astropy` methods.
 
 FITS Image File Reading and Writing
 -----------------------------------
@@ -48,7 +47,7 @@ specifically a
 `QTable <http://docs.astropy.org/en/stable/table/mixin_columns.html#quantity-and-qtable>`_.
 ``QTable`` is unit-aware, and can be manipulated in a number of ways
 and written to disk in several formats, including ASCII text or FITS
-files. For more details, see :ref:`fields-astropy-export`.
+files.
 
 Similarly, 1D profile objects can also be exported to AstroPy
 ``QTable``, optionally writing all of the profile bins or only the ones

--- a/doc/source/analyzing/domain_analysis/index.rst
+++ b/doc/source/analyzing/domain_analysis/index.rst
@@ -25,6 +25,7 @@ These modules exist within yt itself.
    cosmology_calculator
    clump_finding
    xray_emission_fields
+   xray_data_README
 
 External Analysis Modules
 -------------------------
@@ -62,9 +63,7 @@ not kept up to date as yt evolved. Tools in here are looking for
 a new owner and a new home. If you find something in here that
 you'd like to bring back to life, either by adding it to
 :ref:`yt-astro` or as part of your own package, you are welcome
-to it! If you'd like any help, let us know! See
-:ref:`yt_attic:attic_modules` for a list of inventory of the
-attic.
+to it! If you'd like any help, let us know!
 
 Extensions
 ----------

--- a/doc/source/analyzing/domain_analysis/index.rst
+++ b/doc/source/analyzing/domain_analysis/index.rst
@@ -63,7 +63,9 @@ not kept up to date as yt evolved. Tools in here are looking for
 a new owner and a new home. If you find something in here that
 you'd like to bring back to life, either by adding it to
 :ref:`yt-astro` or as part of your own package, you are welcome
-to it! If you'd like any help, let us know!
+to it! If you'd like any help, let us know! See
+:ref:`yt_attic:attic-modules` for a list of inventory of the
+attic.
 
 Extensions
 ----------

--- a/doc/source/analyzing/fields.rst
+++ b/doc/source/analyzing/fields.rst
@@ -249,8 +249,7 @@ aliasing process allows universally-defined derived fields to take advantage of
 internal names, and it also provides an easy way to address what units something
 should be returned in.  If an aliased field is requested (and aliased fields
 will always be lowercase, with underscores separating words) it will be returned
-in the units specified by the unit system of the database (see :ref:`unit_systems`
-for a guide to using the different unit systems in yt), whereas if the
+in the units specified by the unit system of the database, whereas if the
 frontend-specific field is requested, it will not undergo any unit conversions
 from its natural units.  (This rule is occasionally violated for fields which
 are mesh-dependent, specifically particle masses in some cosmology codes.)
@@ -275,8 +274,7 @@ Recall that fields are formally accessed in two parts: ('*field type*',
 * ``gas`` -- This is the usual default for simulation frontends for fluid
   types.  These fields are typically aliased to the frontend-specific mesh
   fields for grid-based codes or to the deposit fields for particle-based
-  codes.  Default units are in the unit system of the dataset (see
-  :ref:`unit_systems` for more information).
+  codes.  Default units are in the unit system of the dataset.
 * particle type -- These are particle fields that exist on-disk as written
   by individual frontends.  If the frontend designates names for these particles
   (i.e. particle type) those names are the field types.
@@ -417,7 +415,7 @@ systems in terms of the definition of the magnetic pressure:
 
 where :math:`\mu_0 = 4\pi \times 10^{-7}~\rm{N/A^2}` is the vacuum permeability. yt automatically
 detects on a per-frontend basis what units the magnetic should be in, and allows conversion between
-different magnetic field units in the different :ref:`unit systems <unit_systems>` as well. To
+different magnetic field units in the different unit systems as well. To
 determine how to set up special magnetic field handling when designing a new frontend, check out
 :ref:`bfields-frontend`.
 

--- a/doc/source/analyzing/saving_data.rst
+++ b/doc/source/analyzing/saving_data.rst
@@ -27,7 +27,7 @@ Geometric Data Containers
 -------------------------
 
 Data from geometric data containers can be saved with the
-:func:`~yt.data_objects.data_containers.save_as_dataset` function.
+:func:`~yt.data_objects.data_containers.YTDataContainer.save_as_dataset` function.
 
 .. notebook-cell::
 

--- a/doc/source/analyzing/saving_data.rst
+++ b/doc/source/analyzing/saving_data.rst
@@ -27,7 +27,7 @@ Geometric Data Containers
 -------------------------
 
 Data from geometric data containers can be saved with the
-:func:`~yt.data_objects.data_containers.save_as_dataset`` function.
+:func:`~yt.data_objects.data_containers.save_as_dataset` function.
 
 .. notebook-cell::
 

--- a/doc/source/analyzing/units.rst
+++ b/doc/source/analyzing/units.rst
@@ -160,6 +160,9 @@ about the dataset's code unit system and can convert data into it. Unit objects
 from ``unyt`` or ``yt.units`` will not know about any particular dataset's unit
 system.
 
+
+.. _cosmological-units:
+
 Comoving units for Cosmological Simulations
 -------------------------------------------
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -267,4 +267,4 @@ if not on_rtd:
 
 # as of Sphinx 3.1.2 this is the supported way to link custom style sheets
 def setup(app):
-    app.add_stylesheet("custom.css")
+    app.add_css_file("custom.css")

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -265,7 +265,6 @@ intersphinx_mapping = {
 if not on_rtd:
     autosummary_generate = glob.glob("reference/api/api.rst")
 
-# as of Sphinx/1.6.1 this is the supported way to link custom style sheets
-#   see: https://github.com/ryan-roemer/sphinx-bootstrap-theme#adding-custom-css
+# as of Sphinx 3.1.2 this is the supported way to link custom style sheets
 def setup(app):
     app.add_stylesheet("custom.css")

--- a/doc/source/cookbook/streamlines.py
+++ b/doc/source/cookbook/streamlines.py
@@ -33,7 +33,9 @@ streamlines.integrate_through_volume()
 
 # Create a 3D plot, trace the streamlines through the 3D volume of the plot
 fig = plt.figure()
-ax = Axes3D(fig)
+ax = Axes3D(fig, auto_add_to_figure=False)
+fig.add_axes(ax)
+
 for stream in streamlines.streamlines:
     stream = stream[np.all(stream != 0.0, axis=1)]
     ax.plot3D(stream[:, 0], stream[:, 1], stream[:, 2], alpha=0.1)

--- a/doc/source/cookbook/streamlines_isocontour.py
+++ b/doc/source/cookbook/streamlines_isocontour.py
@@ -32,7 +32,8 @@ streamlines.integrate_through_volume()
 
 # Create a 3D matplotlib figure for visualizing the streamlines
 fig = plt.figure()
-ax = Axes3D(fig)
+ax = Axes3D(fig, auto_add_to_figure=False)
+fig.add_axes(ax)
 
 # Trace the streamlines through the volume of the 3D figure
 for stream in streamlines.streamlines:

--- a/doc/source/cookbook/surface_plot.py
+++ b/doc/source/cookbook/surface_plot.py
@@ -20,7 +20,7 @@ colors = yt.apply_colormap(np.log10(surface[("gas", "temperature")]), cmap_name=
 
 # Create a 3D matplotlib figure for visualizing the surface
 fig = plt.figure()
-ax = fig.gca(projection="3d")
+ax = fig.add_subplot(projection="3d")
 p3dc = Poly3DCollection(surface.triangles, linewidth=0.0)
 
 # Set the surface colors in the right scaling [0,1]

--- a/doc/source/developing/creating_derived_fields.rst
+++ b/doc/source/developing/creating_derived_fields.rst
@@ -35,7 +35,7 @@ In this example, the ``density`` field will return data with units of
 ``erg/g``, so the result will automatically have units of pressure,
 ``erg/cm**3``. This assumes the unit system is set to the default, which is
 CGS: if a different unit system is selected, the result will be in the same
-dimensions of pressure but different units. See :ref:`unit_systems` for more
+dimensions of pressure but different units. See :ref:`units` for more
 information.
 
 Once we've defined our function, we need to notify yt that the field is
@@ -72,7 +72,7 @@ The units parameter is a "raw" string, in the format that yt
 uses in its :ref:`symbolic units implementation <units>` (e.g., employing only
 unit names, numbers, and mathematical operators in the string, and using
 ``"**"`` for exponentiation). For cosmological datasets and fields, see
-:ref:`cosmological-units`.  We suggest that you name the function that creates
+:ref:`cosmological-units <cosmological units>`.  We suggest that you name the function that creates
 a derived field with the intended field name prefixed by a single underscore,
 as in the ``_pressure`` example above.
 
@@ -100,9 +100,9 @@ instances by making use of the
 Lastly, if you do not know the units of your field ahead of time, you can
 specify ``units='auto'`` in the call to ``add_field`` for your field.  This will
 automatically determine the appropriate units based on the units of the data
-returned by the field function. This is also a good way to let your derived fields
-be automatically converted to the units of the :ref:`unit system <unit_systems>` in
-your dataset.
+returned by the field function. This is also a good way to let your derived
+fields be automatically converted to the units of the unit system in your
+dataset.
 
 If ``units='auto'`` is set, it is also required to set the ``dimensions`` keyword
 argument so that error-checking can be done on the derived field to make sure that
@@ -164,9 +164,9 @@ dataset objects. The calling syntax is the same:
        units="dyne/cm**2",
    )
 
-If you specify fields in this way, you can take advantage of the dataset's
-:ref:`unit system <unit_systems>` to define the units for you, so that
-the units will be returned in the units of that system:
+If you specify fields in this way, you can take advantage of the dataset's unit
+system to define the units for you, so that the units will be returned in the
+units of that system:
 
 .. code-block:: python
 
@@ -321,7 +321,7 @@ There are a number of options available, but the only mandatory ones are ``name`
 ``function``
      This is a function handle that defines the field
 ``units``
-     This is a string that describes the units, or a query to a :ref:`UnitSystem <unit_systems>`
+     This is a string that describes the units, or a query to a UnitSystem
      object, e.g. ``ds.unit_system["energy"]``. Powers must be in Python syntax (``**``
      instead of ``^``). Alternatively, it may be set to ``"auto"`` to have the units
      determined automatically. In this case, the ``dimensions`` keyword must be set to the

--- a/doc/source/developing/creating_frontend.rst
+++ b/doc/source/developing/creating_frontend.rst
@@ -37,12 +37,11 @@ Boostraping a new frontend
 
 To get started
 
-* make a new directory in ``yt/frontends`` with the name of your code and add the name
-into ``yt/frontends/api.py:_frontends`` (in alphabetical order).
-
-* copy the contents of the ``yt/frontends/_skeleton`` directory, and replace every
-occurence of ``Skeleton`` with your frontend's name (preserving case). This adds a lot of
-boilerplate for the required classes and methods that are needed.
+ * make a new directory in ``yt/frontends`` with the name of your code and add the name
+   into ``yt/frontends/api.py:_frontends`` (in alphabetical order).
+ * copy the contents of the ``yt/frontends/_skeleton`` directory, and replace every
+   occurence of ``Skeleton`` with your frontend's name (preserving case). This
+   adds a lot of boilerplate for the required classes and methods that are needed.
 
 
 Data Meaning Structures
@@ -158,7 +157,7 @@ example of how this is implemented in the FLASH frontend:
 This function should always be imported and called from within the
 ``setup_fluid_fields`` method of the ``FieldInfoContainer``. If this
 function is used, converting between magnetic fields in different
-:ref:`unit systems <unit_systems>` will be handled automatically.
+unit systems will be handled automatically.
 
 Data Localization Structures
 ----------------------------

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -2443,6 +2443,7 @@ information.  At this time, halo member particles cannot be loaded.
 YTHaloCatalog
 ^^^^^^^^^^^^^
 
+These are catalogs produced by the analysis discussed in :ref:`halo-analysis`.
 In the case where multiple files were produced, one need only provide the path
 to a single one of them.  The field type for all fields is "halos".  The fields
 available here are similar to other catalogs.  Any addition

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -1251,7 +1251,7 @@ where :math:`n_e` and :math:`n_i` are the electron and ion number densities,
 .. rubric:: Caveats
 
 * Please be careful that the units are correctly utilized; yt assumes cgs by default, but conversion to
-  other :ref:`unit systems <unit_systems>` is also possible.
+  other unit systems is also possible.
 
 .. _loading-gadget-data:
 
@@ -2171,7 +2171,7 @@ containers.  See :ref:`halo_containers` for more information.
 
 If you have access to both the halo catalog and the simulation snapshot from
 the same redshift, additional analysis can be performed for each halo using
-:ref:`halo_catalog`.  The resulting product can be reloaded in a similar manner
+:ref:`halo-catalog`.  The resulting product can be reloaded in a similar manner
 to the other halo catalogs shown here.
 
 .. _adaptahop:
@@ -2438,12 +2438,11 @@ information.  At this time, halo member particles cannot be loaded.
    # The halo mass
    print(ad["FOF", "particle_mass"])
 
-.. _halocatalog:
+.. _halo-catalog:
 
 YTHaloCatalog
 ^^^^^^^^^^^^^
 
-These are catalogs produced by the analysis discussed in :ref:`halo_catalog`.
 In the case where multiple files were produced, one need only provide the path
 to a single one of them.  The field type for all fields is "halos".  The fields
 available here are similar to other catalogs.  Any addition
@@ -2964,9 +2963,7 @@ Tipsy Data
 See :ref:`tipsy-notebook` and :ref:`loading-sph-data` for more details.
 
 yt also supports loading Tipsy data.  Many of its characteristics are similar
-to how Gadget data is loaded; specifically, it shares its definition of
-indexing and mesh-identification with that described in
-:ref:`particle-indexing-criteria`.
+to how Gadget data is loaded.
 
 .. code-block:: python
 

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -2171,7 +2171,7 @@ containers.  See :ref:`halo_containers` for more information.
 
 If you have access to both the halo catalog and the simulation snapshot from
 the same redshift, additional analysis can be performed for each halo using
-:ref:`halo-catalog`.  The resulting product can be reloaded in a similar manner
+:ref:`halo-analysis`.  The resulting product can be reloaded in a similar manner
 to the other halo catalogs shown here.
 
 .. _adaptahop:
@@ -2438,7 +2438,7 @@ information.  At this time, halo member particles cannot be loaded.
    # The halo mass
    print(ad["FOF", "particle_mass"])
 
-.. _halo-catalog:
+.. _halocatalog:
 
 YTHaloCatalog
 ^^^^^^^^^^^^^

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -188,6 +188,7 @@ Table of Contents
    intro/index
    installing
    yt Quickstart <quickstart/index>
+   yt4differences
    yt3differences
    cookbook/index
    visualizing/index
@@ -195,7 +196,6 @@ Table of Contents
    analyzing/domain_analysis/index
    examining/index
    developing/index
-   sharing_data
    reference/index
    faq/index
    Getting Help <help/index>

--- a/doc/source/intro/index.rst
+++ b/doc/source/intro/index.rst
@@ -56,8 +56,7 @@ processors simultaneously <parallel-computation>`.
 Datasets can be analyzed by simply :ref:`examining raw source data
 <low-level-data-inspection>`, or they can be processed in a number of ways
 to extract relevant information and to explore the data including
-:ref:`visualizing data <visualizing>` and employing :ref:`topic-specific
-analysis modules <analysis-modules>`.
+:ref:`visualizing data <visualizing>`.
 
 Visualization
 ^^^^^^^^^^^^^
@@ -95,30 +94,6 @@ creating photorealistic isocontour images of your data called :ref:`volume
 renderings <volume_rendering>`, and :ref:`visualizing isosurfaces in an external
 interactive tool <surfaces>`.  yt even has a special web-based tool for
 exploring your data with a :ref:`google-maps-like interface <mapserver>`.
-
-Topic-Specific Analysis Modules
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Beyond visualization and general analysis tools, yt contains a number
-of :ref:`topic-specific analysis modules <analysis-modules>` for processing
-datasets.  These analysis modules operate somewhat autonomous and oftentimes
-use external libraries or codes.  While they are installed with yt, they are
-not loaded by default in every session so you have to call them specifically.
-Examples include :ref:`halo analysis <halo-analysis>` (including
-:ref:`halo finding <halo-analysis>`, :ref:`merger trees <merger_tree>`,
-:ref:`halo mass functions <halo_mass_function>`), :ref:`synthetic observations
-<synthetic-observations>` (including :ref:`cosmological light cones
-<light-cone-generator>`, :ref:`cosmological light rays <light-ray-generator>`,
-:ref:`synthetic absorption spectra <absorption_spectrum>`, :ref:`spectral
-emission distributions (SEDS) <synthetic_spectrum>`, :ref:`star formation
-rates <star_analysis>`, :ref:`synthetic x-ray observations
-<xray_emission_fields>`, and :ref:`synthetic sunyaev-zeldovich effect
-observations <sunyaev-zeldovich>`), :ref:`two-point correlations functions
-<two_point_functions>`, :ref:`identification of overdensities in arbitrary
-fields (clump finding) <clump_finding>`, :ref:`tracking particle trajectories
-<particle-trajectories>`, and exporting data to external radiative transfer
-codes (e.g. :ref:`Sunrise <sunrise_export>` and :ref:`RadMC-3D
-<radmc3d_export>`).
 
 Executing and Scripting yt
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/reference/api/api.rst
+++ b/doc/source/reference/api/api.rst
@@ -103,7 +103,7 @@ geometric.
    ~yt.data_objects.selection_objects.object_collection.YTDataCollection
    ~yt.data_objects.selection_objects.spheroids.YTSphere
    ~yt.data_objects.selection_objects.spheroids.YTEllipsoid
-   ~yt.data_objects.selection_objects.cur_region.YTCutRegion
+   ~yt.data_objects.selection_objects.cut_region.YTCutRegion
    ~yt.data_objects.index_subobjects.grid_patch.AMRGridPatch
    ~yt.data_objects.index_subobjects.octree_subset.OctreeSubset
    ~yt.data_objects.index_subobjects.particle_container.ParticleContainer
@@ -157,27 +157,16 @@ These objects generate an "index" into multiresolution data.
 Units
 -----
 
-These classes and functions enable yt's symbolic unit handling system.
+yt's symbolic unit handling system is now based on the external library unyt. In
+complement, Dataset objects support the following methods to build arrays and
+scalars with physical dimensions.
 
 .. autosummary::
 
    yt.data_objects.static_output.Dataset.arr
    yt.data_objects.static_output.Dataset.quan
-   ~yt.units.unit_object.define_unit
-   ~yt.units.unit_object.Unit
-   ~yt.units.unit_registry.UnitRegistry
-   ~yt.units.unit_systems.UnitSystem
-   ~yt.units.yt_array.YTArray
-   ~yt.units.yt_array.YTQuantity
-   ~yt.units.yt_array.uconcatenate
-   ~yt.units.yt_array.uintersect1d
-   ~yt.units.yt_array.uunion1d
-   ~yt.units.yt_array.unorm
-   ~yt.units.yt_array.udot
-   ~yt.units.yt_array.uvstack
-   ~yt.units.yt_array.uhstack
-   ~yt.units.yt_array.ustack
-   ~yt.units.yt_array.display_ytarray
+
+
 
 Frontends
 ---------
@@ -535,7 +524,7 @@ Field Functions
    ~yt.data_objects.static_output.Dataset.add_mesh_sampling_particle_field
    ~yt.data_objects.static_output.Dataset.add_smoothed_particle_field
    ~yt.data_objects.static_output.Dataset.add_gradient_fields
-   ~yt.frontends.stream.data_structures.StreamParticlesDataset.add_SPH_fields
+   ~yt.frontends.stream.data_structures.StreamParticlesDataset.add_sph_fields
 
 Particle Filters
 ----------------
@@ -797,7 +786,7 @@ Miscellaneous Types
 
 .. autosummary::
 
-   ~yt.config.YTConfigParser
+   ~yt.config.YTConfig
    ~yt.utilities.parameter_file_storage.ParameterFileStore
    ~yt.utilities.parallel_tools.parallel_analysis_interface.ObjectIterator
    ~yt.utilities.parallel_tools.parallel_analysis_interface.ParallelAnalysisInterface
@@ -819,7 +808,6 @@ Cosmology Calculator
    ~yt.utilities.cosmology.Cosmology.angular_scale
    ~yt.utilities.cosmology.Cosmology.luminosity_distance
    ~yt.utilities.cosmology.Cosmology.lookback_time
-   ~yt.utilities.cosmology.Cosmology.hubble_time
    ~yt.utilities.cosmology.Cosmology.critical_density
    ~yt.utilities.cosmology.Cosmology.hubble_parameter
    ~yt.utilities.cosmology.Cosmology.expansion_factor
@@ -858,8 +846,6 @@ These are for the pytest infrastructure:
 
 .. autosummary::
 
-    ~conftest.tempdir
-    ~conftest.answer_file
     ~conftest.hashing
     ~yt.utilities.answer_testing.answer_tests.grid_hierarchy
     ~yt.utilities.answer_testing.answer_tests.parentage_relationships
@@ -867,8 +853,6 @@ These are for the pytest infrastructure:
     ~yt.utilities.answer_testing.answer_tests.projection_values
     ~yt.utilities.answer_testing.answer_tests.field_values
     ~yt.utilities.answer_testing.answer_tests.pixelized_projection_values
-    ~yt.utilities.answer_testing.answer_tests.simulated_halo_mass_function
-    ~yt.utilities.answer_testing.answer_tests.analytic_halo_mass_function
     ~yt.utilities.answer_testing.answer_tests.small_patch_amr
     ~yt.utilities.answer_testing.answer_tests.big_patch_amr
     ~yt.utilities.answer_testing.answer_tests.generic_array
@@ -878,6 +862,5 @@ These are for the pytest infrastructure:
     ~yt.utilities.answer_testing.answer_tests.phase_plot_attribute
     ~yt.utilities.answer_testing.answer_tests.generic_image
     ~yt.utilities.answer_testing.answer_tests.axial_pixelization
-    ~yt.utilities.answer_testing.answer_tests.light_cone_projection
     ~yt.utilities.answer_testing.answer_tests.extract_connected_sets
     ~yt.utilities.answer_testing.answer_tests.VR_image_comparison

--- a/doc/source/reference/changelog.rst
+++ b/doc/source/reference/changelog.rst
@@ -39,33 +39,35 @@ Major Changes and New Features
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
-- New frontend support for the code AMRVAC. Many thanks to Clement Robert
-  and Niels Claes who were major contributors to this initiative. Relevant PRs include:
-    - Initial PR to support AMRVAC native data files
-      `PR 2321 <https://github.com/yt-project/yt/pull/2321>`__.
-    - added support for dust fields and derived fields
-      `PR 2387 <https://github.com/yt-project/yt/pull/2387>`__.
-    - added support for derived fields for hydro runs
-      `PR 2381 <https://github.com/yt-project/yt/pull/2381>`__.
-    - API documentation and docstrings for AMRVAC frontend
-      `PR 2384 <https://github.com/yt-project/yt/pull/2384>`__,
-      `PR 2380 <https://github.com/yt-project/yt/pull/2380>`__,
-      `PR 2382 <https://github.com/yt-project/yt/pull/2382>`__.
-    - testing-related PRs for AMRVAC:
-      `PR 2379 <https://github.com/yt-project/yt/pull/2379>`__,
-      `PR 2360 <https://github.com/yt-project/yt/pull/2360>`__.
-    - add verbosity to logging of geometry or `geometry_override`
-      `PR 2421 <https://github.com/yt-project/yt/pull/2421>`__.
-    - add attribute to `_code_unit_attributes` specific to AMRVAC to ensure
-      consistent renormalisation of AMRVAC datasets. See
-      `PR 2357 <https://github.com/yt-project/yt/pull/2357>`__.
-    - parse AMRVAC's parfiles if user-provided
-      `PR 2369 <https://github.com/yt-project/yt/pull/2369>`__.
-    - ensure that min_level reflects dataset that has refinement
-      `PR 2475 <https://github.com/yt-project/yt/pull/2475>`__.
-    - fix derived unit parsing  `PR 2362 <https://github.com/yt-project/yt/pull/2362>`__.
-    - update energy field to be `energy_density` and have units of code
-      pressure  `PR 2376 <https://github.com/yt-project/yt/pull/2376>`__.
+- New frontend support for the code AMRVAC. Many thanks to Clément Robert
+  and Niels Claes who were major contributors to this initiative. Relevant PRs include
+
+  - Initial PR to support AMRVAC native data files
+    `PR 2321 <https://github.com/yt-project/yt/pull/2321>`__.
+  - added support for dust fields and derived fields
+    `PR 2387 <https://github.com/yt-project/yt/pull/2387>`__.
+  - added support for derived fields for hydro runs
+    `PR 2381 <https://github.com/yt-project/yt/pull/2381>`__.
+  - API documentation and docstrings for AMRVAC frontend
+    `PR 2384 <https://github.com/yt-project/yt/pull/2384>`__,
+    `PR 2380 <https://github.com/yt-project/yt/pull/2380>`__,
+    `PR 2382 <https://github.com/yt-project/yt/pull/2382>`__.
+  - testing-related PRs for AMRVAC:
+    `PR 2379 <https://github.com/yt-project/yt/pull/2379>`__,
+    `PR 2360 <https://github.com/yt-project/yt/pull/2360>`__.
+  - add verbosity to logging of geometry or ``geometry_override``
+    `PR 2421 <https://github.com/yt-project/yt/pull/2421>`__.
+  - add attribute to ``_code_unit_attributes`` specific to AMRVAC to ensure
+    consistent renormalisation of AMRVAC datasets. See
+    `PR 2357 <https://github.com/yt-project/yt/pull/2357>`__.
+  - parse AMRVAC's parfiles if user-provided
+    `PR 2369 <https://github.com/yt-project/yt/pull/2369>`__.
+  - ensure that min_level reflects dataset that has refinement
+    `PR 2475 <https://github.com/yt-project/yt/pull/2475>`__.
+  - fix derived unit parsing  `PR 2362 <https://github.com/yt-project/yt/pull/2362>`__.
+  - update energy field to be ``energy_density`` and have units of code
+    pressure  `PR 2376 <https://github.com/yt-project/yt/pull/2376>`__.
+
 - Support for the AdaptaHOP halo finder code
   `PR 2385 <https://github.com/yt-project/yt/pull/2385>`__.
 - yt now supports geographic transforms and projections of data with
@@ -1147,7 +1149,7 @@ Major enhancements
   :ref:`GAMER <loading-gamer-data>`, and :ref:`Gizmo <loading-gizmo-data>` data
   formats.
 * The unit system associated with a dataset is now customizable, defaulting to
-  CGS. See :ref:`unit_systems`.
+  CGS.
 * Enhancements and usability improvements for analysis modules, especially the
   ``absorption_spectrum``, ``photon_simulator``, and ``light_ray`` modules. See
   :ref:`synthetic-observations`.

--- a/doc/source/reference/configuration.rst
+++ b/doc/source/reference/configuration.rst
@@ -14,7 +14,9 @@ The Configuration
 
 The configuration is stored in simple text files (in the `toml <https://github.com/toml-lang/toml>`_ format).
 The files allow to set internal yt variables to custom default values to be used in future sessions.
-The configuration can either be stored :ref:`globally<Global Configuration>` or :ref:`locally<Local Configuration>`.
+The configuration can either be stored :ref:`globally <global-conf>` or :ref:`locally <local-conf>`.
+
+.. _global-conf:
 
 Global Configuration
 ^^^^^^^^^^^^^^^^^^^^
@@ -44,6 +46,8 @@ options from the configuration file, e.g.:
    $ yt config set yt log_level 1
    $ yt config rm yt maximum_stored_datasets
 
+
+.. _local-conf:
 
 Local Configuration
 ^^^^^^^^^^^^^^^^^^^
@@ -98,10 +102,10 @@ file. Note that a log level of 1 means that all log messages are printed to
 stdout.  To disable logging, set the log level to 50.
 
 
-.. _global-config:
+.. _config-options:
 
-Available Global Configuration Options
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Available Configuration Options
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The following external parameters are available.  A number of parameters are
 used internally.
@@ -152,7 +156,7 @@ It is possible to customize the default behaviour of plots using per-field confi
 The default options for plotting a given field can be specified in the configuration file
 in ``[plot.field_type.field_name]`` blocks. The available keys are
 
-* ``cmap`` (default: ``yt.default_colormap``, see :ref:`global-config`): the colormap to
+* ``cmap`` (default: ``yt.default_colormap``, see :ref:`config-options`): the colormap to
   use for the field.
 * ``log`` (default: ``True``): use a log scale (or symlog if ``linthresh`` is also set).
 * ``linthresh`` (default: ``None``): if set to a float different than ``None`` and ``log`` is

--- a/doc/source/reference/demeshening.rst
+++ b/doc/source/reference/demeshening.rst
@@ -7,9 +7,9 @@ With yt-4.0, the method by which particles are indexed changed considerably.
 Whereas in previous versions, particles were indexed based on their position in
 an octree (the structure of which was determined by particle number density),
 in yt-4.0 this system was overhauled to utilize a `bitmap
-index<https://en.wikipedia.org/wiki/Bitmap_index>`_ based on a space-filling
+index <https://en.wikipedia.org/wiki/Bitmap_index>`_ based on a space-filling
 curve, using a `enhanced word-aligned
-hybrid<https://github.com/lemire/ewahboolarray>` boolean array as their
+hybrid <https://github.com/lemire/ewahboolarray>`_ boolean array as their
 backend.
 
 .. note::
@@ -21,7 +21,7 @@ backend.
 
 By avoiding the use of octrees as a base mesh, yt is able to create *much* more
 accurate SPH visualizations.  We have a `gallery demonstrating
-this<https://matthewturk.github.io/yt4-gallery/>`_ but even in this
+this <https://matthewturk.github.io/yt4-gallery/>`_ but even in this
 side-by-side comparison the differences can be seen quite easily, with the left
 image being from the old, octree-based approach and the right image the new,
 meshless approach.
@@ -39,10 +39,8 @@ load only those particles it needs.
 .. note::
 
    The theory and implementation of yt's bitmap indexing system is described in
-   some detail in the `yt 4.0
-   paper<https://yt-project.github.io/yt-4.0-paper/>`_ in the section entitled
-   `Indexing Discrete-Point
-   Datasets<https://yt-project.github.io/yt-4.0-paper/#sec:point_indexing>`_.
+   some detail in the `yt 4.0 paper <https://yt-project.github.io/yt-4.0-paper/>`_
+   in the section entitled `Indexing Discrete-Point Datasets <https://yt-project.github.io/yt-4.0-paper/#sec:point_indexing>`_.
 
 In brief, however, what this relies on is two numbers, ``index_order1`` and
 ``index_order2``.  These control the "coarse" and "refined" sets of indices,

--- a/doc/source/reference/index.rst
+++ b/doc/source/reference/index.rst
@@ -13,7 +13,9 @@ code.
    code_support
    command-line
    api/api
+   api/modules
    configuration
    python_introduction
    field_list
+   demeshening
    changelog

--- a/doc/source/visualizing/callbacks.rst
+++ b/doc/source/visualizing/callbacks.rst
@@ -30,7 +30,7 @@ the plot object.  All of the callbacks listed below are available via
 similar ``annotate_`` functions.
 
 To clear one or more annotations from an existing plot, see the
-:ref:`clear_annotations() function <clear-annotations>`.
+:ref:`clear_annotations function <clear-annotations>`.
 
 For a brief demonstration of a few of these callbacks in action together,
 see the cookbook recipe: :ref:`annotations-recipe`.
@@ -158,7 +158,7 @@ List Currently Applied Callbacks
 
    This function will print a list of each of the currently applied
    callbacks together with their index.  The index can be used with
-   :ref:`clear_annotations() function <annotate-clear>` to remove a
+   :ref:`clear_annotations() function <clear-annotations>` to remove a
    specific callback.
 
 .. python-script::

--- a/doc/source/visualizing/interactive_data_visualization.rst
+++ b/doc/source/visualizing/interactive_data_visualization.rst
@@ -7,6 +7,6 @@ The interactive, OpenGL-based volume rendering system for yt has been exported
 into its own package, called ``yt_idv``.
 
 Documentation, including installation instructions, can be found at `its
-website<https://yt-idv.readthedocs.io/en/latest/>`_, and the source code is
+website <https://yt-idv.readthedocs.io/en/latest/>`_, and the source code is
 hosted under the yt-project organization on github at `yt_idv
 <https://github.com/yt-project/yt_idv>`_.

--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -546,7 +546,7 @@ Below are some important caveats to note when visualizing particle data.
    However, axis-aligned slice plots (as described in :ref:`slice-plots`)
    will work.
 
-2. Off axis projections (as in :ref:`off-axis-projection`) will only work
+2. Off axis projections (as in :ref:`off-axis-projections`) will only work
    for SPH particles, i.e., particles that have a defined smoothing length.
 
 Two workaround methods are available for plotting non-SPH particles with off-axis
@@ -554,7 +554,7 @@ projections.
 
 1. :ref:`smooth-non-sph` - this method involves extracting particle data to be
    reloaded with :class:`~yt.loaders.load_particles` and using the
-   :class:`~yt.frontends.stream.data_structures.StreamParticlesDataset.add_SPH_fields`
+   :class:`~yt.frontends.stream.data_structures.StreamParticlesDataset.add_sph_fields`
    function to create smoothing lengths. This works well for relatively small datasets,
    but is not parallelized and may take too long for larger data.
 
@@ -1497,7 +1497,7 @@ something like:
 
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
    my_sphere = ds.sphere("c", (50, "kpc"))
-   plot = yt.PhasePlot(my_sphere, ("gas", "density"), ("gas", "temperature"), [("gas", "H_fraction")])
+   plot = yt.PhasePlot(my_sphere, ("gas", "density"), ("gas", "temperature"), [("gas", "H_p0_fraction")])
    plot.save()
 
 Customizing Phase Plots

--- a/doc/source/visualizing/streamlines.rst
+++ b/doc/source/visualizing/streamlines.rst
@@ -88,7 +88,8 @@ Example Script
 
     # Create a 3D plot, trace the streamlines through the 3D volume of the plot
     fig = plt.figure()
-    ax = Axes3D(fig)
+    ax = Axes3D(fig, auto_add_to_figure=False)
+    fig.add_axes(ax)
     for stream in streamlines.streamlines:
         stream = stream[np.all(stream != 0.0, axis=1)]
         ax.plot3D(stream[:, 0], stream[:, 1], stream[:, 2], alpha=0.1)

--- a/doc/source/yt4differences.rst
+++ b/doc/source/yt4differences.rst
@@ -72,7 +72,7 @@ The list below is arranged in order of most to least important changes.
   field was actually a field for kinetic energy density, and so it has been
   renamed to ``"gas", "kinetic_energy_density"``. The old name still exists
   as an alias as of yt v4.0.0, but it will be removed in yt v4.1.0. See
-  :ref:`deprecated_field_names` below for more information.
+  next item below for more information.
   Other examples include ``"gas", "specific_thermal_energy"`` for thermal
   energy per unit mass, and ``("gas", "momentum_density_x")`` for the x-axis
   component of momentum density. See :ref:`efields` for more information.

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,7 @@ nose.plugins.0.10 =
 [options.extras_require]
 doc =
     alabaster
+    bottle
     nbconvert==5.6.1
     pyregion
     pyx>=0.15

--- a/yt/convenience.py
+++ b/yt/convenience.py
@@ -1,3 +1,0 @@
-from yt.utilities.exceptions import YTModuleRemoved
-
-raise YTModuleRemoved("yt.convenience", "yt.loaders")

--- a/yt/data_objects/derived_quantities.py
+++ b/yt/data_objects/derived_quantities.py
@@ -497,12 +497,12 @@ class AngularMomentumVector(DerivedQuantity):
     Examples
     --------
 
-    # Find angular momentum vector of galaxy in grid-based isolated galaxy dataset
+    Find angular momentum vector of galaxy in grid-based isolated galaxy dataset
     >>> ds = load("IsolatedGalaxy/galaxy0030/galaxy0030")
     >>> ad = ds.all_data()
     >>> print(ad.quantities.angular_momentum_vector())
 
-    # Find angular momentum vector of gas disk in particle-based dataset
+    Find angular momentum vector of gas disk in particle-based dataset
     >>> ds = load("FIRE_M12i_ref11/snapshot_600.hdf5")
     >>> _, c = ds.find_max(("gas", "density"))
     >>> sp = ds.sphere(c, (10, "kpc"))

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -268,7 +268,7 @@ class GadgetDataset(SPHDataset):
                 "Otherwise something is wrong, "
                 "and you might want to check how the dataset is loaded. "
                 "Futher information about header specification can be found in "
-                "https://yt-project.org/docs/dev/examining/loading_data.html#header-specification.",  # NOQA E501
+                "https://yt-project.org/docs/dev/examining/loading_data.html#header-specification.",
                 header_size,
             )
         self._field_spec = self._setup_binary_spec(field_spec, gadget_field_specs)

--- a/yt/frontends/open_pmd/fields.py
+++ b/yt/frontends/open_pmd/fields.py
@@ -134,7 +134,7 @@ class OpenPMDFieldInfo(FieldInfoContainer):
     References
     ----------
     * http://yt-project.org/docs/dev/analyzing/fields.html
-    * http://yt-project.org/docs/dev/developing/creating_frontend.html#data-meaning-structures  # NOQA E501
+    * http://yt-project.org/docs/dev/developing/creating_frontend.html#data-meaning-structures
     * https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md
     * [1] http://yt-project.org/docs/dev/reference/field_list.html#universal-fields
     """

--- a/yt/frontends/open_pmd/misc.py
+++ b/yt/frontends/open_pmd/misc.py
@@ -4,7 +4,7 @@ from yt.utilities.logger import ytLogger as mylog
 
 
 def parse_unit_dimension(unit_dimension):
-    """Transforms an openPMD unitDimension into a string.
+    r"""Transforms an openPMD unitDimension into a string.
 
     Parameters
     ----------
@@ -22,8 +22,8 @@ def parse_unit_dimension(unit_dimension):
 
     References
     ----------
-    ..
-    https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#unit-systems-and-dimensionality  # NOQA E501
+
+    https://github.com/openPMD/openPMD-standard/blob/latest/STANDARD.md#unit-systems-and-dimensionality
 
 
     Returns

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -448,7 +448,7 @@ def paste_traceback_detailed(exc_type, exc, tb):
     print()
 
 
-_ss = "fURbBUUBE0cLXgETJnZgJRMXVhVGUQpQAUBuehQMUhJWRFFRAV1ERAtBXw1dAxMLXT4zXBFfABNN\nC0ZEXw1YUURHCxMXVlFERwxWCQw=\n"  # NOQA 501
+_ss = "fURbBUUBE0cLXgETJnZgJRMXVhVGUQpQAUBuehQMUhJWRFFRAV1ERAtBXw1dAxMLXT4zXBFfABNN\nC0ZEXw1YUURHCxMXVlFERwxWCQw=\n"
 
 
 def _rdbeta(key):

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -1308,22 +1308,23 @@ def load_unstructured_mesh(
 def load_sample(
     fn: Optional[str] = None, *, progressbar: bool = True, timeout=None, **kwargs
 ):
-    """
+    r"""
     Load sample data with yt.
 
-    This is a simple wrapper around `yt.load` to include fetching
+    This is a simple wrapper around :func:`~yt.loaders.load` to include fetching
     data with pooch from remote source.
 
     The data registry table can be retrieved and visualized using
-    `yt.sample_data.api.get_data_registry_table()`.
+    :func:`~yt.sample_data.api.get_data_registry_table`.
     The `filename` column contains usable keys that can be passed
-    as the first positional argument to `load_sample`.
+    as the first positional argument to load_sample.
     Some data samples contain series of datasets. It may be required to
     supply the relative path to a specific dataset.
 
     Parameters
     ----------
-    fn : str
+
+    fn: str
         The `filename` of the dataset to load, as defined in the data registry
         table.
 
@@ -1337,16 +1338,18 @@ def load_sample(
 
     Notes
     -----
+
     - This function is experimental as of yt 4.0.0, do not rely on its exact behaviour.
-    - Any additional keyword argument is passed down to `yt.load`.
+    - Any additional keyword argument is passed down to :func:`~yt.loaders.load`.
     - In case of collision with predefined keyword arguments as set in
-    the data registry, the ones passed to this function take priority.
+      the data registry, the ones passed to this function take priority.
     - Datasets with slashes '/' in their names can safely be used even on Windows.
       On the contrary, paths using backslashes '\' won't work outside of Windows, so
       it is recommended to favour the UNIX convention ('/') in scripts that are meant
       to be cross-platform.
     - This function requires pandas and pooch.
     - Corresponding sample data live at https://yt-project.org/data
+
     """
 
     if fn is None:

--- a/yt/utilities/lib/cykdtree/plot.py
+++ b/yt/utilities/lib/cykdtree/plot.py
@@ -125,16 +125,22 @@ def _plot2D_root(
 def plot2D_serial(tree, pts=None, label_boxes=False, **kwargs):
     r"""Plot a 2D kd-tree constructed in serial.
 
-    Args:
-        tree (:class:`cykdtree.kdtree.PyKDTree`): kd-tree class.
-        pts (np.ndarray, optional): Points contained by the kdtree. Defaults to
-            None if not provided and points are not plotted.
-        label_boxes (bool, optional): If True, leaves in the tree are labeled
-            with their index. Defaults to False.
-        Additional keywords are passed to :func:`cykdtree.plot._plot2D_root`.
+    Parameters
+    ----------
 
-    Returns:
-        :obj:`matplotlib.pyplot.Axes`: Axes containing the plot.
+    tree: :class:`cykdtree.kdtree.PyKDTree`
+        kd-tree class.
+    pts: np.ndarray, optional
+        Points contained by the kdtree.
+    label_boxes: bool
+        If True, leaves in the tree are labeled with their index. Defaults to False.
+
+    Additional keywords are passed to :func:`cykdtree.plot._plot2D_root`.
+
+    Returns
+    -------
+
+    :obj:`matplotlib.pyplot.Axes`: Axes containing the plot.
 
     """
     # Box edges

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -577,7 +577,7 @@ class FITSImageData:
         if output is None:
             output = sys.stdout
         if num_cols == 8:
-            header = "No.    Name      Ver    Type      Cards   Dimensions   Format     Units"  # NOQA E501
+            header = "No.    Name      Ver    Type      Cards   Dimensions   Format     Units"
             format = "{:3d}  {:10}  {:3} {:11}  {:5d}   {}   {}   {}"
         else:
             header = (

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -2325,7 +2325,7 @@ class TriangleFacetsCallback(PlotCallback):
 
 
 class TimestampCallback(PlotCallback):
-    """
+    r"""
     Annotates the timestamp and/or redshift of the data output at a specified
     location in the image (either in a present corner, or by specifying (x,y)
     image coordinates with the x_pos, y_pos arguments.  If no time_units are
@@ -2563,7 +2563,7 @@ class TimestampCallback(PlotCallback):
 
 
 class ScaleCallback(PlotCallback):
-    """
+    r"""
     Annotates the scale of the plot at a specified location in the image
     (either in a preset corner, or by specifying (x,y) image coordinates with
     the pos argument.  Coeff and units (e.g. 1 Mpc or 100 kpc) refer to the
@@ -2620,7 +2620,7 @@ class ScaleCallback(PlotCallback):
     text_args : dictionary, optional
         A dictionary of parameters to used to update the font_properties
         for the text in this callback.  For any property not set, it will
-        use the defaults of the plot.  Thus one can modify the text size with:
+        use the defaults of the plot.  Thus one can modify the text size with
         ``text_args={'size':24}``
 
     size_bar_args : dictionary, optional


### PR DESCRIPTION
## PR Summary

This PR fixes about 40 various warnings (errors, really) in the docs build.
I also fixed a couple deprecations warnings from matplotlib while I was at it.
At the time of writing there are 37 warnings left to solve, which fall into 3 or 4 distinct categories, but I can't find a solution for any of these at the moment, so I'll open a separate issue for them and consider this PR complete (#3369)