### PR TITLE
CI: bump answers for numpy 1.21

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -94,7 +94,6 @@ answer_tests:
 
   local_pw_037:  # PR 3373
     - yt/visualization/tests/test_plotwindow.py:test_attributes
-    - yt/visualization/tests/test_plotwindow.py:test_attributes_wt
     - yt/visualization/tests/test_particle_plot.py:test_particle_projection_answers
     - yt/visualization/tests/test_particle_plot.py:test_particle_projection_filter
     - yt/visualization/tests/test_particle_plot.py:test_particle_phase_answers

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -92,7 +92,7 @@ answer_tests:
     - yt/frontends/owls/tests/test_outputs.py:test_snapshot_033
     - yt/frontends/owls/tests/test_outputs.py:test_OWLS_particlefilter
 
-  local_pw_036:  # PR 3272
+  local_pw_037:  # PR 3373
     - yt/visualization/tests/test_plotwindow.py:test_attributes
     - yt/visualization/tests/test_plotwindow.py:test_attributes_wt
     - yt/visualization/tests/test_particle_plot.py:test_particle_projection_answers

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -45,7 +45,6 @@ def setup():
 
 TEST_FLNMS = ["test.png"]
 M7 = "DD0010/moving7_0010"
-WT = "WindTunnel/windtunnel_4lev_hdf5_plt_cnt_0030"
 
 FPROPS = {"family": "sans-serif", "style": "italic", "weight": "bold", "size": 24}
 
@@ -188,29 +187,6 @@ def test_attributes():
                         callback_id=n,
                         callback_runners=r,
                     )
-
-
-@requires_ds(WT)
-def test_attributes_wt():
-    plot_field = ("gas", "density")
-    decimals = 12
-
-    ds = data_dir_load(WT)
-    ax = "z"
-    for attr_name in ATTR_ARGS.keys():
-        for args in ATTR_ARGS[attr_name]:
-            yield PlotWindowAttributeTest(ds, plot_field, ax, attr_name, args, decimals)
-            for n, r in CALLBACK_TESTS:
-                yield PlotWindowAttributeTest(
-                    ds,
-                    plot_field,
-                    ax,
-                    attr_name,
-                    args,
-                    decimals,
-                    callback_id=n,
-                    callback_runners=r,
-                )
 
 
 class TestHideAxesColorbar(unittest.TestCase):


### PR DESCRIPTION
## PR Summary

With the release of numpy 1.21, the following answer tests finale images changed slightly
yt/visualization/tests/test_plotwindow.py:test_attributes_wt

here's the existing reference
![tmpokwzf291](https://user-images.githubusercontent.com/14075922/123067633-7062fc80-d411-11eb-9769-27dc130dc76a.png)
and here's the new result
![tmp7j8gqehr](https://user-images.githubusercontent.com/14075922/123067654-75c04700-d411-11eb-8f5a-ff72bc2fe097.png)


Here's a minimal script to reproduce this (thanks @Xarthisius for posting this on Slack)
```python
import yt
from yt.utilities.answer_testing.framework import data_dir_load
WT = "WindTunnel/windtunnel_4lev_hdf5_plt_cnt_0030"
plot_field = ("gas", "density")
ds = data_dir_load(WT)
ax = "z" 
slc = yt.SlicePlot(ds, ax, plot_field)
slc.set_zlim(plot_field, 1e-25, 1e-23)
slc.save()
```

The actual range in the data is [0.05956075, 6.61460495] (g/cm^3), so the resulting image is kinda irrelevant in both cases and the new one is actually consistent with what can be obtained with a very simple, pure mpl + numpy example script:

```python
import matplotlib.pyplot as plt
from matplotlib.colors import LogNorm
import numpy as np
data = np.ones((10, 10))
fig, ax = plt.subplots()
im = ax.imshow(data, norm=LogNorm(vmin=1e-25, vmax=1e-23))
ax.set(title=f"numpy v{np.__version__}")
fig.colorbar(im)
fig.savefig(f"/tmp/v{np.__version__}.png")
```
![v1 21 0](https://user-images.githubusercontent.com/14075922/123068363-1e6ea680-d412-11eb-9d50-b4b11e787387.png)

My conclusion is that there is nothing to fix on our side so we can simply bump our answers and call it a day.

update: as discussed on Slack with @Xarthisius and @jzuhone , I've updated the PR to simply drop the problematic test.

