### PR TITLE
[bugfix] generate_smoothing_length expects 64-bit positions

### DIFF
--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -119,7 +119,9 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
             offset += count
         kdtree = index.kdtree
         positions = uconcatenate(positions)[kdtree.idx]
-        hsml = generate_smoothing_length(positions, kdtree, self.ds._num_neighbors)
+        hsml = generate_smoothing_length(
+            positions.astype("float64"), kdtree, self.ds._num_neighbors
+        )
         dtype = positions.dtype
         hsml = hsml[np.argsort(kdtree.idx)].astype(dtype)
         mylog.warning("Writing smoothing lengths to hsml files.")


### PR DESCRIPTION
## PR Summary

In PR #2645 we added the capability to generate smoothing lengths for a Gadget HDF5 dataset that didn't have one. It turns out the example I used had 64-bit particle positions (which is not typical, Gadget datasets usually have 32-bit positions), and the `generate_smoothing_length` function expects 64-bit positions. 

There may be a better way of handling this (with a fused type or something) but this is a quick fix. Note that we have to cast the `positions` array upon entry into the `generate_smoothing_length` function so that the original array retains its original type. 
