### PR TITLE
[bugfix] Fix FITSParticleProjection for all axes

### DIFF
--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -888,11 +888,12 @@ def construct_image(ds, axis, data_source, center, image_res, width, length_unit
         else:
             frb = data_source.to_frb(width[0], (nx, ny), center=center, height=width[1])
     elif isinstance(data_source, ParticleAxisAlignedDummyDataSource):
+        axes = axis_wcs[axis]
         bounds = (
-            center[0] - width[0] / 2,
-            center[0] + width[0] / 2,
-            center[1] - width[1] / 2,
-            center[1] + width[1] / 2,
+            center[axes[0]] - width[0] / 2,
+            center[axes[0]] + width[0] / 2,
+            center[axes[1]] - width[1] / 2,
+            center[axes[1]] + width[1] / 2,
         )
         frb = ParticleImageBuffer(
             data_source, bounds, (nx, ny), periodic=all(ds.periodicity)

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -845,6 +845,9 @@ def sanitize_fits_unit(unit):
     return unit
 
 
+# This list allows one to determine which axes are the
+# correct axes of the image in a right-handed coordinate
+# system depending on which axis is sliced or projected
 axis_wcs = [[1, 2], [0, 2], [0, 1]]
 
 


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

This PR fixes the recently added `FITSParticleProjection` class. The bounds for the FITS image were incorrectly being calculated--they assumed that the appropriate values for the center of the image were those in the x and y axes, which is only true for a projection along the z-axis. This fix ensures that the correct values of the center coordinate are chosen depending on the axis of the projection. 