### PR TITLE
Future proofing: add a scheduled job with dev versions of core deps

### DIFF
--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -1,0 +1,54 @@
+name: CI (bleeding edge)
+# this workflow is heavily inspired from pandas, see
+# https://github.com/pandas-dev/pandas/blob/master/.github/workflows/python-dev.yml
+
+# goals: check stability against
+# - dev version of Python, numpy, and matplotlib
+# - building with future pip default options
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    # run this every day at 3 am UTC
+    - cron: '0 3 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Python3.10-dev
+    timeout-minutes: 60
+
+    concurrency:
+      group: ${{ github.ref }}-dev
+      cancel-in-progress: true
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python Dev Version
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10-dev'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade setuptools wheel
+        python -m pip install git+https://github.com/numpy/numpy.git
+        python -m pip install git+https://github.com/matplotlib/matplotlib.git
+        python -m pip install cython
+
+    - name: Build yt
+      # --no-build-isolation is used to guarantee that build time dependencies
+      # are not installed by pip as specified from pyproject.toml, hence we get
+      # to use the dev version of numpy at build time.
+      run: |
+        python setup.py build_ext -q -j2
+        python -m pip install -e .[test] --no-build-isolation
+
+    - name: Run Tests
+      run: pytest -vvv

--- a/.github/workflows/build-test-pytest.yaml
+++ b/.github/workflows/build-test-pytest.yaml
@@ -1,6 +1,13 @@
 name: Build and Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths-ignore:
+      - "doc/**"
+      - README.md
 
 defaults:
   run:

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1,6 +1,13 @@
 name: Build and Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths-ignore:
+      - "doc/**"
+      - README.md
 
 defaults:
   run:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 
 <!--- Tests and style --->
 ![Build and Test](https://github.com/yt-project/yt/workflows/Build%20and%20Test/badge.svg?branch=main)
+[![CI (bleeding edge)](https://github.com/yt-project/yt/actions/workflows/bleeding-edge.yaml/badge.svg)](https://github.com/yt-project/yt/actions/workflows/bleeding-edge.yaml)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/yt-project/yt/main.svg)](https://results.pre-commit.ci/latest/github/yt-project/yt/main)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)

--- a/tests/windows_conda_requirements.txt
+++ b/tests/windows_conda_requirements.txt
@@ -2,5 +2,5 @@ numpy>=1.19.4
 cython>=0.29.21,<3.0
 cartopy~=0.18.0
 h5py~=3.1.0
-matplotlib<3.6
+matplotlib>=2.0.2,<3.6
 scipy~=1.5.0


### PR DESCRIPTION
## PR Summary

This adds a workflow to run essential tests against Python 3.10, with dev versions of numpy and matplotlib. The goal is to buy ourselves more time to fix issues (or reporting upstream) before it's too late.

The job is setup to be triggered at least once a day, as well as on every push to the main branch.
GH actions currently do not support a way to signal this properly ([yet](https://github.com/actions/toolkit/issues/399)),
so I won't make it trigger on PRs

This is _heavily_ inspired from a similar workflow in the pandas repo.

While I'm at it I'm updating the triggers for regular CI workflows so we can save a few hours of CPU time by skipping tests on PRs that only touch documentation.