### PR TITLE
Future proofing: forbid cython 3.0 until we can properly test against it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,10 @@ requires = [
 
   # cython version is imposed by that of numpy, see release notes
   # https://github.com/numpy/numpy/releases/tag/v1.19.2
-  "Cython>=0.26.1; python_version=='3.6'",
-  "Cython>=0.29.21; python_version>='3.7'",
+  # Cython 3.0 is the next version after 0.29, and a major change,
+  # we forbid it until we can properly test against it
+  "Cython>=0.26.1,<3.0; python_version=='3.6'",
+  "Cython>=0.29.21,<3.0; python_version>='3.7'",
   "numpy==1.13.3; python_version=='3.6' and platform_system!='AIX'",
   "numpy>=1.19.2; python_version>='3.7' and platform_system!='AIX'",
 ]

--- a/tests/ci_install.sh
+++ b/tests/ci_install.sh
@@ -57,7 +57,7 @@ else
     # which means we have to install the build-time requirements first.
     # It is possible that these problems will be fixed in the future if upstream projects
     # include a pyproject.toml file or use any pip-comptatible solution to remedy this.
-    python -m pip install numpy>=1.19.4 cython>=0.29.21
+    python -m pip install numpy>=1.19.4 cython~=0.29.21
 
     # this is required for cartopy. It should normally be specified in our setup.cfg as
     # cartopy[plotting]

--- a/tests/windows_conda_requirements.txt
+++ b/tests/windows_conda_requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.19.4
-cython>=0.29.21
+cython>=0.29.21,<3.0
 cartopy~=0.18.0
 h5py~=3.1.0
 matplotlib<3.5


### PR DESCRIPTION
## PR Summary

Cython 3.0 is coming soon and already has some release-candidates available.
It seems very likely that yt will _not_ be compatible with it out of the box, but I don't think anyone has time to future proof this right now, so I think it's much preferable to forbid it completely for now. For reference, this is inline with the current specs in numpy itself, see
[numpy's pyproject.toml](https://github.com/numpy/numpy/blob/57863f598ddaade14b3d81e6e91ebecca881f996/pyproject.toml#L7)
