### PR TITLE
Future proofing: treat most warnings as errors in pytest, and fix existing ones

### DIFF
--- a/.github/workflows/rules-checks.yaml
+++ b/.github/workflows/rules-checks.yaml
@@ -1,3 +1,6 @@
+# FUTURE: this file can be deleted at condition that warnings are treated
+# as errors in all CI jobs covering h5py.
+# In practice, this will only be possible when we're done transitioning to pytest.
 name: Auto review bad practice
 on: [pull_request]
 

--- a/conftest.py
+++ b/conftest.py
@@ -76,6 +76,7 @@ def pytest_configure(config):
         # treat most warnings as errors
         "error",
         # >>> internal deprecation warnings with no obvious solution
+        # see https://github.com/yt-project/yt/issues/3381
         (
             r"ignore:The requested field name 'pd?[xyz]' is ambiguous and corresponds "
             "to any one of the following field types.*:yt._maintenance.deprecation.VisibleDeprecationWarning"

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import tempfile
+from importlib.util import find_spec
 from pathlib import Path
 
 import pytest
@@ -71,6 +72,90 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "big_data: Run answer tests that require large data files."
     )
+    for value in (
+        # treat most warnings as errors
+        "error",
+        # >>> internal deprecation warnings with no obvious solution
+        (
+            r"ignore:The requested field name 'pd?[xyz]' is ambiguous and corresponds "
+            "to any one of the following field types.*:yt._maintenance.deprecation.VisibleDeprecationWarning"
+        ),
+        # >>> warnings emitted by testing frameworks, or in testing contexts
+        # we still have some yield-based tests, awaiting for transition into pytest
+        "ignore::pytest.PytestCollectionWarning",
+        # imp is used in nosetest
+        "ignore:the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses:DeprecationWarning",
+        # the deprecation warning message for imp changed in Python 3.10, so we ignore both versions
+        "ignore:the imp module is deprecated in favour of importlib and slated for removal in Python 3.12; see the module's documentation for alternative uses:DeprecationWarning",
+        # matplotlib warnings related to the Agg backend which is used in CI, not much we can do about it
+        "ignore:Matplotlib is currently using agg, which is a non-GUI backend, so cannot show the figure.:UserWarning",
+        "ignore:tight_layout . falling back to Agg renderer:UserWarning",
+        #
+        # >>> warnings from wrong values passed to numpy
+        # these should normally be curated out of the test suite but they are too numerous
+        # to deal with in a reasonable time at the moment.
+        "ignore:invalid value encountered in log10:RuntimeWarning",
+        "ignore:divide by zero encountered in log10:RuntimeWarning",
+        "ignore:invalid value encountered in true_divide:RuntimeWarning",
+        #
+        # >>> there are many places in yt (most notably at the frontend level)
+        # where we open files but never explicitly close them
+        # Although this is in general bad practice, it can be intentional and
+        # justified in contexts where reading speeds should be optimized.
+        # It is not clear at the time of writing how to approach this,
+        # so I'm going to ignore this class of warnings altogether for now.
+        "ignore:unclosed file.*:ResourceWarning",
+    ):
+        config.addinivalue_line("filterwarnings", value)
+
+    # at the time of writing, astropy's wheels are behind numpy's latest
+    # version but this doesn't cause actual problems in our test suite, so
+    # we allow this warning to pass.
+    # last checked with astropy 4.2.1
+    config.addinivalue_line(
+        "filterwarnings",
+        (
+            "ignore:numpy.ndarray size changed, may indicate binary incompatibility. "
+            "Expected 80 from C header, got 88 from PyObject:RuntimeWarning"
+        ),
+    )
+    if find_spec("astropy") is not None:
+        # astropy triggers this warning from itself, there's not much we can do on our side
+        # last checked with astropy 4.2.1
+        config.addinivalue_line(
+            "filterwarnings", "ignore::astropy.wcs.wcs.FITSFixedWarning"
+        )
+
+    if find_spec("cartopy") is not None:
+        # cartopy still triggers this numpy warning
+        # last checked wtih cartopy 0.19.0
+        config.addinivalue_line(
+            "filterwarnings",
+            (
+                "ignore:`np.float` is a deprecated alias for the builtin `float`. "
+                "To silence this warning, use `float` by itself. "
+                "Doing this will not modify any behavior and is safe. "
+                "If you specifically wanted the numpy scalar type, use `np.float64` here."
+                ":DeprecationWarning: "
+            ),
+        )
+        # this warning *still* shows up on cartopy 0.19 so we'll ignore it
+        config.addinivalue_line(
+            "filterwarnings",
+            (
+                r"ignore:The default value for the \*approx\* keyword argument to "
+                r"\w+ will change from True to False after 0\.18\.:UserWarning"
+            ),
+        )
+        # this one could be resolved by upgrading PROJ on Jenkins,
+        # but there's isn't much else that can be done about it.
+        config.addinivalue_line(
+            "filterwarnings",
+            (
+                "ignore:The Stereographic projection in Proj older than 5.0.0 incorrectly "
+                "transforms points when central_latitude=0. Use this projection with caution.:UserWarning"
+            ),
+        )
 
 
 def pytest_collection_modifyitems(config, items):

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     toml>=0.10.2
     tqdm>=3.4.0
     unyt>=2.8.0
-python_requires = >=3.6
+python_requires = >=3.6,<3.12
 include_package_data = True
 scripts = scripts/iyt
 zip_safe = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,11 +70,11 @@ doc =
     sphinx-bootstrap-theme
     sphinx-rtd-theme
 full =
-    astropy~=4.0.1
+    astropy>=4.0.1,<5.0.0
     f90nml>=1.1.2
     fastcache~=1.0.2
     glueviz~=0.13.3
-    h5py~=3.1.0
+    h5py>=3.1.0,<4.0.0
     libconf~=1.0.1
     miniballcpp>=0.2.1
     mpi4py~=3.0.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ project_urls =
 packages = find:
 install_requires =
     iPython>=1.0
-    matplotlib!=3.4.2,>=2.0.2,<3.5
+    matplotlib!=3.4.2,>=2.0.2,<3.6
     more-itertools>=8.4
     numpy>=1.13.3
     pyyaml>=4.2b1

--- a/tests/windows_conda_requirements.txt
+++ b/tests/windows_conda_requirements.txt
@@ -2,5 +2,5 @@ numpy>=1.19.4
 cython>=0.29.21,<3.0
 cartopy~=0.18.0
 h5py~=3.1.0
-matplotlib<3.5
+matplotlib<3.6
 scipy~=1.5.0

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -8,6 +8,7 @@ from re import finditer
 from tempfile import NamedTemporaryFile, TemporaryFile
 
 import numpy as np
+from more_itertools import always_iterable
 from tqdm import tqdm
 
 from yt.config import ytcfg
@@ -638,7 +639,10 @@ class YTCoveringGrid(YTSelectionContainer3D):
         self.ActiveDimensions = self._sanitize_dims(dims)
 
         rdx = self.ds.domain_dimensions * self.ds.relative_refinement(0, level)
-        rdx[np.where(np.array(dims) - 2 * num_ghost_zones <= 1)] = 1  # issue 602
+
+        # normalize dims as a non-zero dim array
+        dims = np.array(list(always_iterable(dims)))
+        rdx[np.where(dims - 2 * num_ghost_zones <= 1)] = 1  # issue 602
         self.base_dds = self.ds.domain_width / self.ds.domain_dimensions
         self.dds = self.ds.domain_width / rdx.astype("float64")
         self.right_edge = self.left_edge + self.ActiveDimensions * self.dds

--- a/yt/data_objects/index_subobjects/grid_patch.py
+++ b/yt/data_objects/index_subobjects/grid_patch.py
@@ -270,7 +270,10 @@ class AMRGridPatch(YTSelectionContainer):
         return cube
 
     def get_vertex_centered_data(
-        self, fields: List[Tuple[str, str]], smoothed: bool=True, no_ghost: bool=False
+        self,
+        fields: List[Tuple[str, str]],
+        smoothed: bool = True,
+        no_ghost: bool = False,
     ):
         _old_api = isinstance(fields, (str, tuple))
         if _old_api:

--- a/yt/data_objects/index_subobjects/grid_patch.py
+++ b/yt/data_objects/index_subobjects/grid_patch.py
@@ -270,7 +270,7 @@ class AMRGridPatch(YTSelectionContainer):
         return cube
 
     def get_vertex_centered_data(
-        self, fields: List[Tuple[str, str]], smoothed=True, no_ghost=False
+        self, fields: List[Tuple[str, str]], smoothed: bool=True, no_ghost: bool=False
     ):
         _old_api = isinstance(fields, (str, tuple))
         if _old_api:

--- a/yt/data_objects/index_subobjects/grid_patch.py
+++ b/yt/data_objects/index_subobjects/grid_patch.py
@@ -1,5 +1,6 @@
 import warnings
 import weakref
+from typing import List, Tuple
 
 import numpy as np
 
@@ -268,7 +269,9 @@ class AMRGridPatch(YTSelectionContainer):
         cube._base_grid = self
         return cube
 
-    def get_vertex_centered_data(self, fields, smoothed=True, no_ghost=False):
+    def get_vertex_centered_data(
+        self, fields: List[Tuple[str, str]], smoothed=True, no_ghost=False
+    ):
         _old_api = isinstance(fields, (str, tuple))
         if _old_api:
             message = (

--- a/yt/frontends/art/data_structures.py
+++ b/yt/frontends/art/data_structures.py
@@ -570,43 +570,41 @@ class DarkMatterARTDataset(ARTDataset):
             boxsize = np.fromfile(fh, count=1, dtype=">f4")
         n = nspecs[0]
         particle_header_vals = {}
-        tmp = np.array(
-            [
-                headerstr,
-                aexpn,
-                aexp0,
-                amplt,
-                astep,
-                istep,
-                partw,
-                tintg,
-                ekin,
-                ekin1,
-                ekin2,
-                au0,
-                aeu0,
-                nrowc,
-                ngridc,
-                nspecs,
-                nseed,
-                Om0,
-                Oml0,
-                hubble,
-                Wp5,
-                Ocurv,
-                wspecies,
-                lspecies,
-                extras,
-                boxsize,
-            ]
-        )
-        for i in range(len(tmp)):
+        tmp = [
+            headerstr,
+            aexpn,
+            aexp0,
+            amplt,
+            astep,
+            istep,
+            partw,
+            tintg,
+            ekin,
+            ekin1,
+            ekin2,
+            au0,
+            aeu0,
+            nrowc,
+            ngridc,
+            nspecs,
+            nseed,
+            Om0,
+            Oml0,
+            hubble,
+            Wp5,
+            Ocurv,
+            wspecies,
+            lspecies,
+            extras,
+            boxsize,
+        ]
+        for i, arr in enumerate(tmp):
             a1 = dmparticle_header_struct[0][i]
             a2 = dmparticle_header_struct[1][i]
             if a2 == 1:
-                particle_header_vals[a1] = tmp[i][0]
+                particle_header_vals[a1] = arr[0]
             else:
-                particle_header_vals[a1] = tmp[i][:a2]
+                particle_header_vals[a1] = arr[:a2]
         for specie in range(n):
             self.particle_types.append("specie%i" % specie)
         self.particle_types_raw = tuple(self.particle_types)

--- a/yt/frontends/art/data_structures.py
+++ b/yt/frontends/art/data_structures.py
@@ -292,7 +292,7 @@ class ARTDataset(Dataset):
             # lextra needs to be loaded as a string, but it's actually
             # array values.  So pop it off here, and then re-insert.
             lextra = amr_header_vals.pop("lextra")
-            amr_header_vals["lextra"] = np.fromstring(lextra, ">f4")
+            amr_header_vals["lextra"] = np.frombuffer(lextra, ">f4")
             self.parameters.update(amr_header_vals)
             amr_header_vals = None
             # estimate the root level
@@ -315,7 +315,7 @@ class ARTDataset(Dataset):
                 # extras needs to be loaded as a string, but it's actually
                 # array values.  So pop it off here, and then re-insert.
                 extras = particle_header_vals.pop("extras")
-                particle_header_vals["extras"] = np.fromstring(extras, ">f4")
+                particle_header_vals["extras"] = np.frombuffer(extras, ">f4")
             self.parameters["wspecies"] = wspecies[:n]
             self.parameters["lspecies"] = lspecies[:n]
             for specie in range(n):

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -1,7 +1,6 @@
 import glob
 import os
 import re
-import warnings
 from collections import namedtuple
 from stat import ST_CTIME
 
@@ -141,10 +140,9 @@ class BoxLibParticleHeader:
             try:
                 self.real_type = known_real_types[particle_real_type]
             except KeyError:
-                warnings.warn(
-                    f"yt did not recognize particle real type {particle_real_type} "
-                    "assuming double",
-                    category=RuntimeWarning,
+                mylog.warning(
+                    "yt did not recognize particle real type '%s'. Assuming 'double'.",
+                    particle_real_type,
                 )
                 self.real_type = known_real_types["double"]
 

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -261,7 +261,7 @@ class GadgetDataset(SPHDataset):
         header_size = self._header.size
         if header_size != [256]:
             only_on_root(
-                mylog.warn,
+                mylog.warning,
                 "Non-standard header size is detected! "
                 "Gadget-2 standard header is 256 bytes, but yours is %s. "
                 "Make sure a non-standard header is actually expected. "

--- a/yt/geometry/oct_geometry_handler.py
+++ b/yt/geometry/oct_geometry_handler.py
@@ -69,7 +69,7 @@ class OctreeIndex(Index):
                 remaining[remaining] = np.isnan(tmp[:Nremaining])
                 Nremaining = remaining.sum()
 
-            return data.ds.arr(ret.astype(np.float64), input_units="1")
+            return data.ds.arr(ret.astype(np.float64), units="1")
 
         def _mesh_sampling_particle_field(field, data):
             """
@@ -99,7 +99,7 @@ class OctreeIndex(Index):
 
                 ret[mask] = cell_data[icell[mask]]
 
-            return data.ds.arr(ret, input_units=cell_data.units)
+            return data.ds.arr(ret, units=cell_data.units)
 
         if (ptype, "cell_index") not in self.ds.derived_field_list:
             self.ds.add_field(

--- a/yt/tests/test_load_errors.py
+++ b/yt/tests/test_load_errors.py
@@ -10,12 +10,26 @@ from yt.utilities.exceptions import (
 from yt.utilities.object_registries import output_type_registry
 
 
+@pytest.fixture
+def tmp_data_dir(tmp_path):
+    from yt.config import ytcfg
+
+    pre_test_data_dir = ytcfg["yt", "test_data_dir"]
+    ytcfg.set("yt", "test_data_dir", str(tmp_path))
+
+    yield tmp_path
+
+    ytcfg.set("yt", "test_data_dir", pre_test_data_dir)
+
+
+@pytest.mark.usefixtures("tmp_data_dir")
 def test_load_not_a_file(tmp_path):
     with pytest.raises(FileNotFoundError):
         load(tmp_path / "not_a_file")
 
 
 @pytest.mark.parametrize("simtype", ["Enzo", "unregistered_simulation_type"])
+@pytest.mark.usefixtures("tmp_data_dir")
 def test_load_simulation_not_a_file(simtype, tmp_path):
     # it is preferable to report the most important problem in an error message
     # (missing data is worse than a typo insimulation_type)

--- a/yt/utilities/fortran_utils.py
+++ b/yt/utilities/fortran_utils.py
@@ -189,12 +189,10 @@ def read_vector(f, d, endian="="):
             vec_size,
         )
     vec_num = int(vec_len / vec_size)
-    if isinstance(f, io.TextIOBase):
-        tr = np.fromfile(f, vec_fmt, count=vec_num)
-    elif isinstance(f, io.BufferedIOBase):
+    if isinstance(f, io.IOBase):
         tr = np.frombuffer(f.read(vec_len), vec_fmt, count=vec_num)
     else:
-        raise TypeError(f"Expected a file object, got '{f}' with type '{type(f)}'.")
+        tr = np.frombuffer(f, vec_fmt, count=vec_num)
     vec_len2 = struct.unpack(pad_fmt, f.read(pad_size))[0]
     if vec_len != vec_len2:
         raise OSError(

--- a/yt/utilities/fortran_utils.py
+++ b/yt/utilities/fortran_utils.py
@@ -1,18 +1,8 @@
+import io
 import os
 import struct
 
 import numpy as np
-
-# This may not be the correct way to do this.  We should investigate what NumPy
-# does.
-try:
-    file
-except NameError:
-    # What we're doing here is making it always fail, so we read things in and
-    # THEN call numpy's fromstring.  I can't figure out an easy way of telling if
-    # an object is an actual file, reliably.
-    class file:
-        pass
 
 
 def read_attrs(f, attrs, endian="="):
@@ -199,10 +189,12 @@ def read_vector(f, d, endian="="):
             vec_size,
         )
     vec_num = int(vec_len / vec_size)
-    if isinstance(f, file):  # Needs to be explicitly a file
+    if isinstance(f, io.TextIOBase):
         tr = np.fromfile(f, vec_fmt, count=vec_num)
+    elif isinstance(f, io.BufferedIOBase):
+        tr = np.frombuffer(f.read(vec_len), vec_fmt, count=vec_num)
     else:
-        tr = np.fromstring(f.read(vec_len), vec_fmt, count=vec_num)
+        raise TypeError(f"Expected a file object, got '{f}' with type '{type(f)}'.")
     vec_len2 = struct.unpack(pad_fmt, f.read(pad_size))[0]
     if vec_len != vec_len2:
         raise OSError(

--- a/yt/utilities/tests/test_cosmology.py
+++ b/yt/utilities/tests/test_cosmology.py
@@ -216,7 +216,8 @@ def test_cosmology_calculator_answers():
     """
 
     fn = os.path.join(local_dir, "cosmology_answers.yml")
-    data = yaml.load(open(fn), Loader=yaml.FullLoader)
+    with open(fn) as fh:
+        data = yaml.load(fh, Loader=yaml.FullLoader)
 
     cosmologies = data["cosmologies"]
     functions = data["functions"]

--- a/yt/utilities/tests/test_interpolators.py
+++ b/yt/utilities/tests/test_interpolators.py
@@ -131,6 +131,14 @@ def test_get_vertex_centered_data():
         assert len(w) == 1
         assert issubclass(w[-1].category, DeprecationWarning)
         assert "requires list of fields" in str(w[-1].message)
-    vec_tuple = g.get_vertex_centered_data(("gas", "density"), no_ghost=True)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        vec_tuple = g.get_vertex_centered_data(("gas", "density"), no_ghost=True)
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert (
+            "get_vertex_centered_data() requires list of fields, rather than "
+            "a single field as an argument."
+        ) in str(w[-1].message)
     assert_array_equal(vec_list[("gas", "density")], vec_str)
     assert_array_equal(vec_list[("gas", "density")], vec_tuple)

--- a/yt/visualization/color_maps.py
+++ b/yt/visualization/color_maps.py
@@ -1,7 +1,11 @@
 import numpy as np
-from matplotlib import cm as mcm, colors as cc
+from matplotlib import __version__ as mpl_ver, cm as mcm, colors as cc
+from packaging.version import parse as parse_version
 
 from . import _colormap_data as _cm
+
+MPL_VERSION = parse_version(mpl_ver)
+del mpl_ver
 
 
 def is_colormap(cmap):
@@ -256,6 +260,30 @@ def show_colormaps(subset="all", filename=None):
                 "to be 'all', 'yt_native', or a list of "
                 "valid colormap names."
             ) from e
+    if parse_version("2.0.0") <= MPL_VERSION < parse_version("2.2.0"):
+        # the reason we do this filtering is to avoid spurious warnings in CI when
+        # testing against old versions of matplotlib (currently not older than 2.0.x)
+        # and we can't easily filter warnings at the level of the relevant test itself
+        # because it's not yet run exclusively with pytest.
+        # FUTURE: remove this completely when only matplotlib 2.2+ is supported
+        deprecated_cmaps = {
+            "spectral",
+            "spectral_r",
+            "Vega10",
+            "Vega10_r",
+            "Vega20",
+            "Vega20_r",
+            "Vega20b",
+            "Vega20b_r",
+            "Vega20c",
+            "Vega20c_r",
+        }
+        for cmap in deprecated_cmaps:
+            try:
+                maps.remove(cmap)
+            except ValueError:
+                pass
+
     maps = sorted(set(maps))
     # scale the image size by the number of cmaps
     plt.figure(figsize=(2.0 * len(maps) / 10.0, 6))

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -6,7 +6,7 @@ from numbers import Number
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
-from more_itertools import always_iterable, zip_equal
+from more_itertools import always_iterable
 from mpl_toolkits.axes_grid1 import ImageGrid
 from unyt.exceptions import UnitConversionError
 
@@ -47,6 +47,21 @@ from .plot_container import (
     symlog_transform,
 )
 from .plot_modifications import callback_registry
+
+import sys  # isort: skip
+
+if sys.version_info < (3, 10):
+    # this function is deprecated in more_itertools
+    # because it is superseded by the standard library
+    from more_itertools import zip_equal
+else:
+
+    def zip_equal(*args):
+        # FUTURE: when only Python 3.10+ is supported,
+        # drop this conditional and call the builtin zip
+        # function directly where due
+        return zip(*args, strict=True)
+
 
 MPL_VERSION = LooseVersion(matplotlib.__version__)
 

--- a/yt/visualization/volume_rendering/lens.py
+++ b/yt/visualization/volume_rendering/lens.py
@@ -180,8 +180,8 @@ class PerspectiveLens(Lens):
         north_vec = camera.unit_vectors[1]
         normal_vec = camera.unit_vectors[2]
 
-        px = np.mat(np.linspace(-0.5, 0.5, camera.resolution[0]))
-        py = np.mat(np.linspace(-0.5, 0.5, camera.resolution[1]))
+        px = np.linspace(-0.5, 0.5, camera.resolution[0])
+        py = np.linspace(-0.5, 0.5, camera.resolution[1])
 
         sample_x = camera.width[0] * np.array(east_vec.reshape(3, 1) * px)
         sample_x = sample_x.transpose()
@@ -384,8 +384,8 @@ class StereoPerspectiveLens(Lens):
         east_vec_rot = np.dot(R, east_vec)
         normal_vec_rot = np.dot(R, normal_vec)
 
-        px = np.mat(np.linspace(-0.5, 0.5, single_resolution_x))
-        py = np.mat(np.linspace(-0.5, 0.5, camera.resolution[1]))
+        px = np.linspace(-0.5, 0.5, single_resolution_x)
+        py = np.linspace(-0.5, 0.5, camera.resolution[1])
 
         sample_x = camera.width[0] * np.array(east_vec_rot.reshape(3, 1) * px)
         sample_x = sample_x.transpose()

--- a/yt/visualization/volume_rendering/lens.py
+++ b/yt/visualization/volume_rendering/lens.py
@@ -180,8 +180,8 @@ class PerspectiveLens(Lens):
         north_vec = camera.unit_vectors[1]
         normal_vec = camera.unit_vectors[2]
 
-        px = np.linspace(-0.5, 0.5, camera.resolution[0])
-        py = np.linspace(-0.5, 0.5, camera.resolution[1])
+        px = np.linspace(-0.5, 0.5, camera.resolution[0])[np.newaxis, :]
+        py = np.linspace(-0.5, 0.5, camera.resolution[1])[np.newaxis, :]
 
         sample_x = camera.width[0] * np.array(east_vec.reshape(3, 1) * px)
         sample_x = sample_x.transpose()
@@ -384,8 +384,8 @@ class StereoPerspectiveLens(Lens):
         east_vec_rot = np.dot(R, east_vec)
         normal_vec_rot = np.dot(R, normal_vec)
 
-        px = np.linspace(-0.5, 0.5, single_resolution_x)
-        py = np.linspace(-0.5, 0.5, camera.resolution[1])
+        px = np.linspace(-0.5, 0.5, single_resolution_x)[np.newaxis, :]
+        py = np.linspace(-0.5, 0.5, camera.resolution[1])[np.newaxis, :]
 
         sample_x = camera.width[0] * np.array(east_vec_rot.reshape(3, 1) * px)
         sample_x = sample_x.transpose()

--- a/yt/visualization/volume_rendering/old_camera.py
+++ b/yt/visualization/volume_rendering/old_camera.py
@@ -1309,8 +1309,8 @@ class PerspectiveCamera(Camera):
         east_vec = self.orienter.unit_vectors[0].reshape(3, 1)
         north_vec = self.orienter.unit_vectors[1].reshape(3, 1)
 
-        px = np.mat(np.linspace(-0.5, 0.5, self.resolution[0]))
-        py = np.mat(np.linspace(-0.5, 0.5, self.resolution[1]))
+        px = np.linspace(-0.5, 0.5, self.resolution[0])
+        py = np.linspace(-0.5, 0.5, self.resolution[1])
 
         sample_x = self.width[0] * np.array(east_vec * px).transpose()
         sample_y = self.width[1] * np.array(north_vec * py).transpose()

--- a/yt/visualization/volume_rendering/old_camera.py
+++ b/yt/visualization/volume_rendering/old_camera.py
@@ -1309,8 +1309,8 @@ class PerspectiveCamera(Camera):
         east_vec = self.orienter.unit_vectors[0].reshape(3, 1)
         north_vec = self.orienter.unit_vectors[1].reshape(3, 1)
 
-        px = np.linspace(-0.5, 0.5, self.resolution[0])
-        py = np.linspace(-0.5, 0.5, self.resolution[1])
+        px = np.linspace(-0.5, 0.5, self.resolution[0])[np.newaxis, :]
+        py = np.linspace(-0.5, 0.5, self.resolution[1])[np.newaxis, :]
 
         sample_x = self.width[0] * np.array(east_vec * px).transpose()
         sample_y = self.width[1] * np.array(north_vec * py).transpose()


### PR DESCRIPTION
## PR Summary

## PR Summary

fix #3379
Though independent, this is complementary with #3376.

An important note is that there are some internal deprecation warnings with no obvious solution yet, so I'm adding them to the ignore-list in conftest.py but they will need to be addressed in future releases. Specifically, I'm talking about fields `("all", "px")` and `("gas", "px")` (respectively `"py"`, `"dpx"` and `"dpy"`), that are used internally in slice selectors, but never with explicit field/particle types. Getting to a stable solution here requires much more thought and design that what I'm solving here so I'll defer it to future works, and in any case it's not as urgent as other deprecation warnings because it's internal so it won't break haphazardly.

## TODO
- [x] pass CI
- [x] document _why_ each ignored warning gets a pass (comments)