### PR TITLE
Future proofing: drop distutils.version (targeted for removal in Python 3.12)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
     matplotlib!=3.4.2,>=2.0.2,<3.6
     more-itertools>=8.4
     numpy>=1.13.3
+    packaging>=20.9
     pyyaml>=4.2b1
     setuptools>=19.6
     sympy>=1.2

--- a/setupext.py
+++ b/setupext.py
@@ -12,7 +12,6 @@ from distutils import log
 from distutils.ccompiler import CCompiler, new_compiler
 from distutils.errors import CompileError, LinkError
 from distutils.sysconfig import customize_compiler
-from distutils.version import LooseVersion
 from subprocess import PIPE, Popen
 from sys import platform as _platform
 
@@ -372,31 +371,6 @@ def create_build_ext(lib_exts, cythonize_aliases):
         # subclass setuptools extension builder to avoid importing cython and numpy
         # at top level in setup.py. See http://stackoverflow.com/a/21621689/1382869
         def finalize_options(self):
-            try:
-                import cython
-                import numpy
-            except ImportError as e:
-                raise ImportError(
-                    """Could not import cython or numpy. Building yt from source requires
-    cython and numpy to be installed. Please install these packages using
-    the appropriate package manager for your python environment."""
-                ) from e
-            if LooseVersion(cython.__version__) < LooseVersion("0.26.1"):
-                # keep in sync with pyproject.toml [build-system]
-                raise RuntimeError(
-                    """Building yt from source requires Cython 0.26.1 or newer but
-    Cython %s is installed. Please update Cython using the appropriate
-    package manager for your python environment."""
-                    % cython.__version__
-                )
-            if LooseVersion(numpy.__version__) < LooseVersion("1.13.3"):
-                # keep in sync with pyproject.toml [build-system]
-                raise RuntimeError(
-                    """Building yt from source requires NumPy 1.13.3 or newer but
-    NumPy %s is installed. Please update NumPy using the appropriate
-    package manager for your python environment."""
-                    % numpy.__version__
-                )
             from Cython.Build import cythonize
 
             # Override the list of extension modules

--- a/setupext.py
+++ b/setupext.py
@@ -370,6 +370,9 @@ def create_build_ext(lib_exts, cythonize_aliases):
     class build_ext(_build_ext):
         # subclass setuptools extension builder to avoid importing cython and numpy
         # at top level in setup.py. See http://stackoverflow.com/a/21621689/1382869
+        # NOTE: this is likely not necessary anymore since
+        # pyproject.toml was introduced in the project
+
         def finalize_options(self):
             from Cython.Build import cythonize
 

--- a/yt/frontends/open_pmd/data_structures.py
+++ b/yt/frontends/open_pmd/data_structures.py
@@ -1,10 +1,10 @@
-from distutils.version import StrictVersion
 from functools import reduce
 from operator import mul
 from os import listdir, path
 from re import match
 
 import numpy as np
+from packaging.version import Version
 
 from yt.data_objects.index_subobjects.grid_patch import AMRGridPatch
 from yt.data_objects.static_output import Dataset
@@ -17,11 +17,7 @@ from yt.utilities.file_handler import HDF5FileHandler, warn_h5py
 from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.on_demand_imports import _h5py as h5py
 
-ompd_known_versions = [
-    StrictVersion("1.0.0"),
-    StrictVersion("1.0.1"),
-    StrictVersion("1.1.0"),
-]
+ompd_known_versions = [Version(_) for _ in ("1.0.0", "1.0.1", "1.1.0")]
 opmd_required_attributes = ["openPMD", "basePath"]
 
 
@@ -447,7 +443,7 @@ class OpenPMDDataset(Dataset):
     ):
         self._handle = HDF5FileHandler(filename)
         self.gridsize = kwargs.pop("open_pmd_virtual_gridsize", 10 ** 9)
-        self.standard_version = StrictVersion(self._handle.attrs["openPMD"].decode())
+        self.standard_version = Version(self._handle.attrs["openPMD"].decode())
         self.iteration = kwargs.pop("iteration", None)
         self._set_paths(self._handle, path.dirname(filename), self.iteration)
         Dataset.__init__(
@@ -512,7 +508,7 @@ class OpenPMDDataset(Dataset):
             self.meshes_path = self._handle["/"].attrs["meshesPath"].decode()
             handle[self.base_path + self.meshes_path]
         except (KeyError):
-            if self.standard_version <= StrictVersion("1.1.0"):
+            if self.standard_version <= Version("1.1.0"):
                 mylog.info(
                     "meshesPath not present in file. "
                     "Assuming file contains no meshes and has a domain extent of 1m^3!"
@@ -524,7 +520,7 @@ class OpenPMDDataset(Dataset):
             self.particles_path = self._handle["/"].attrs["particlesPath"].decode()
             handle[self.base_path + self.particles_path]
         except (KeyError):
-            if self.standard_version <= StrictVersion("1.1.0"):
+            if self.standard_version <= Version("1.1.0"):
                 mylog.info(
                     "particlesPath not present in file."
                     " Assuming file contains no particles!"
@@ -593,7 +589,7 @@ class OpenPMDDataset(Dataset):
             self.domain_left_edge = np.append(dle, np.zeros(3 - len(dle)))
             self.domain_right_edge = np.append(dre, np.ones(3 - len(dre)))
         except (KeyError, TypeError, AttributeError):
-            if self.standard_version <= StrictVersion("1.1.0"):
+            if self.standard_version <= Version("1.1.0"):
                 self.dimensionality = 3
                 self.domain_dimensions = np.ones(3, dtype=np.float64)
                 self.domain_left_edge = np.zeros(3, dtype=np.float64)
@@ -614,10 +610,7 @@ class OpenPMDDataset(Dataset):
                     if i not in attrs:
                         return False
 
-                if (
-                    StrictVersion(f.attrs["openPMD"].decode())
-                    not in ompd_known_versions
-                ):
+                if Version(f.attrs["openPMD"].decode()) not in ompd_known_versions:
                     return False
 
                 if f.attrs["iterationEncoding"].decode() == "fileBased":
@@ -680,10 +673,7 @@ class OpenPMDGroupBasedDataset(Dataset):
                     if i not in attrs:
                         return False
 
-                if (
-                    StrictVersion(f.attrs["openPMD"].decode())
-                    not in ompd_known_versions
-                ):
+                if Version(f.attrs["openPMD"].decode()) not in ompd_known_versions:
                     return False
 
                 if f.attrs["iterationEncoding"].decode() == "groupBased":

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -18,7 +18,6 @@ import traceback
 import urllib.parse
 import urllib.request
 import warnings
-from distutils.version import LooseVersion
 from functools import lru_cache, wraps
 from numbers import Number as numeric_type
 from typing import Any, Callable, Type
@@ -26,6 +25,7 @@ from typing import Any, Callable, Type
 import matplotlib
 import numpy as np
 from more_itertools import always_iterable, collapse, first
+from packaging.version import parse as parse_version
 from tqdm import tqdm
 
 from yt.units import YTArray, YTQuantity
@@ -1039,7 +1039,7 @@ def matplotlib_style_context(style_name=None, after_reset=False):
         import matplotlib
 
         style_name = {"mathtext.fontset": "cm"}
-        if LooseVersion(matplotlib.__version__) >= LooseVersion("3.3.0"):
+        if parse_version(matplotlib.__version__) >= parse_version("3.3.0"):
             style_name["mathtext.fallback"] = "cm"
         else:
             style_name["mathtext.fallback_to_cm"] = True

--- a/yt/utilities/on_demand_imports.py
+++ b/yt/utilities/on_demand_imports.py
@@ -1,5 +1,6 @@
 import sys
-from distutils.version import LooseVersion
+
+from packaging.version import parse as parse_version
 
 
 class NotAModule:
@@ -360,7 +361,7 @@ class h5py_imports:
         try:
             import h5py
 
-            if LooseVersion(h5py.__version__) < LooseVersion("2.4.0"):
+            if parse_version(h5py.__version__) < parse_version("2.4.0"):
                 self._err = RuntimeError(
                     "yt requires h5py version 2.4.0 or newer, "
                     "please update h5py with e.g. `python -m pip install -U h5py` "

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -1,8 +1,8 @@
-from distutils.version import LooseVersion
 from io import BytesIO
 
 import matplotlib
 import numpy as np
+from packaging.version import parse as parse_version
 
 from yt.funcs import (
     get_brewer_cmap,
@@ -132,9 +132,9 @@ class PlotMPL:
 
         if mpl_kwargs is None:
             mpl_kwargs = {}
-        if "papertype" not in mpl_kwargs and LooseVersion(
+        if "papertype" not in mpl_kwargs and parse_version(
             matplotlib.__version__
-        ) < LooseVersion("3.3.0"):
+        ) < parse_version("3.3.0"):
             mpl_kwargs["papertype"] = "auto"
 
         name = validate_image_name(name)
@@ -218,8 +218,8 @@ class ImagePlotMPL(PlotMPL):
                 cblinthresh = np.nanmin(np.absolute(data)[data != 0])
 
             cbnorm_kwargs.update(dict(linthresh=cblinthresh, vmin=vmin, vmax=vmax))
-            MPL_VERSION = LooseVersion(matplotlib.__version__)
-            if MPL_VERSION >= "3.2.0":
+            MPL_VERSION = parse_version(matplotlib.__version__)
+            if MPL_VERSION >= parse_version("3.2.0"):
                 # note that this creates an inconsistency between mpl versions
                 # since the default value previous to mpl 3.4.0 is np.e
                 # but it is only exposed since 3.2.0

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from distutils.version import LooseVersion
 from functools import wraps
 from numbers import Number
 
@@ -8,6 +7,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from more_itertools import always_iterable
 from mpl_toolkits.axes_grid1 import ImageGrid
+from packaging.version import parse as parse_version
 from unyt.exceptions import UnitConversionError
 
 from yt._maintenance.deprecation import issue_deprecation_warning
@@ -62,8 +62,7 @@ else:
         # function directly where due
         return zip(*args, strict=True)
 
-
-MPL_VERSION = LooseVersion(matplotlib.__version__)
+MPL_VERSION = parse_version(matplotlib.__version__)
 
 # Some magic for dealing with pyparsing being included or not
 # included in matplotlib (not in gentoo, yes in everything else)
@@ -1202,7 +1201,7 @@ class PWViewerMPL(PlotWindow):
                     self.plots[f].cax.yaxis.set_ticks(mticks, minor=True)
 
                 elif self._field_transform[f] == log_transform:
-                    if MPL_VERSION >= LooseVersion("3.0.0"):
+                    if MPL_VERSION >= parse_version("3.0.0"):
                         self.plots[f].cax.minorticks_on()
                         self.plots[f].cax.xaxis.set_visible(False)
                     else:

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -62,6 +62,7 @@ else:
         # function directly where due
         return zip(*args, strict=True)
 
+
 MPL_VERSION = parse_version(matplotlib.__version__)
 
 # Some magic for dealing with pyparsing being included or not

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -2,12 +2,12 @@ import base64
 import builtins
 import os
 from collections import OrderedDict
-from distutils.version import LooseVersion
 from functools import wraps
 
 import matplotlib
 import numpy as np
 from more_itertools.more import always_iterable, unzip
+from packaging.version import parse as parse_version
 
 from yt.data_objects.profiles import create_profile, sanitize_field_tuple_keys
 from yt.data_objects.static_output import Dataset
@@ -28,7 +28,7 @@ from .plot_container import (
     validate_plot,
 )
 
-MPL_VERSION = LooseVersion(matplotlib.__version__)
+MPL_VERSION = parse_version(matplotlib.__version__)
 
 
 def invalidate_profile(f):
@@ -1174,7 +1174,7 @@ class PhasePlot(ImagePlotContainer):
             if self._cbar_minorticks[f]:
                 if self._field_transform[f] == linear_transform:
                     self.plots[f].cax.minorticks_on()
-                elif MPL_VERSION < LooseVersion("3.0.0"):
+                elif MPL_VERSION < parse_version("3.0.0"):
                     # before matplotlib 3 log-scaled colorbars internally used
                     # a linear scale going from zero to one and did not draw
                     # minor ticks. Since we want minor ticks, calculate


### PR DESCRIPTION
## PR Summary

This is a first step in resolving #3384, though other parts of distutils are still used elsewhere in the code base.
Here I'm following official migration recommendations from [PEP 632](https://www.python.org/dev/peps/pep-0632/#migration-advice), in which `disutils`' removal was discussed.

