### PR TITLE
Future proofing: set a minimal required wheel version in build system specs to improve compatibility with Python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,8 @@
 # See https://github.com/scipy/scipy/pull/10431 for the AIX issue.
 requires = [
   "setuptools>=19.6",
-  "wheel",
+  # see https://github.com/numpy/numpy/pull/18389
+  "wheel>=0.36.2",
 
   # keep in sync with travis.yml "minimal" specs (Cython and numpy for py36)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,6 @@ requires = [
   # see https://github.com/numpy/numpy/pull/18389
   "wheel>=0.36.2",
 
-  # keep in sync with travis.yml "minimal" specs (Cython and numpy for py36)
-
   # cython version is imposed by that of numpy, see release notes
   # https://github.com/numpy/numpy/releases/tag/v1.19.2
   "Cython>=0.26.1; python_version=='3.6'",


### PR DESCRIPTION
## PR Summary
Old versions of wheel are not compatible with the latest updates in numpy + Python 3.10, see
https://github.com/numpy/numpy/pull/18389

This should make installation against Python 3.10 more reliable
