### PR TITLE
MAINT: grooming README.md for upcoming PyPI publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # The yt Project
 
-![Supported Python Version](https://img.shields.io/badge/python%20version-≥%203.6-important)
+[![PyPI](https://img.shields.io/pypi/v/yt)](https://pypi.org/project/yt)
+[![Supported Python Versions](https://img.shields.io/pypi/pyversions/yt)](https://pypi.org/project/yt/)
 [![Latest Documentation](https://img.shields.io/badge/docs-latest-brightgreen.svg)](http://yt-project.org/docs/dev/)
 [![Users' Mailing List](https://img.shields.io/badge/Users-List-lightgrey.svg)](https://mail.python.org/archives/list/yt-users@python.org//)
 [![Devel Mailing List](https://img.shields.io/badge/Devel-List-lightgrey.svg)](https://mail.python.org/archives/list/yt-dev@python.org//)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
 <!--- [![codecov](https://codecov.io/gh/yt-project/yt/branch/main/graph/badge.svg)](https://codecov.io/gh/yt-project/yt) --->
 
-<a href="http://yt-project.org"><img src="doc/source/_static/yt_logo.png" width="300"></a>
+<a href="http://yt-project.org"><img src="https://raw.githubusercontent.com/yt-project/yt/main/doc/source/_static/yt_logo.png" width="300"></a>
 
 yt is an open-source, permissively-licensed python package for analyzing and
 visualizing volumetric data.


### PR DESCRIPTION
## PR Summary

This improves two things in the README in preparation for the upcoming release

- hardlink logo to the github repo so it is properly included on the PyPI page, even without including the image in MANIFEST.in
- badge up for PyPI (display latest published version and corresponding supported Python versions)

Opening as a draft to signal that this should only be merged when the release is about to happen, since the badges will be visibly out of sync in the interval.
