### PR TITLE
CI: deactivate conda update as a workaround to external failure

### DIFF
--- a/.github/workflows/build-test-pytest.yaml
+++ b/.github/workflows/build-test-pytest.yaml
@@ -37,7 +37,7 @@ jobs:
     - uses: s-weigand/setup-conda@v1
       if: matrix.os == 'windows-latest'
       with:
-        update-conda: true
+        update-conda: false # TEMP
         conda-channels: conda-forge
         activate-conda: true
         python-version: ${{matrix.python-version}}

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -41,7 +41,7 @@ jobs:
     - uses: s-weigand/setup-conda@v1
       if: matrix.os == 'windows-latest'
       with:
-        update-conda: false
+        update-conda: false # TEMP
         conda-channels: conda-forge
         activate-conda: true
         python-version: ${{matrix.python-version}}

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -41,7 +41,7 @@ jobs:
     - uses: s-weigand/setup-conda@v1
       if: matrix.os == 'windows-latest'
       with:
-        update-conda: true
+        update-conda: false
         conda-channels: conda-forge
         activate-conda: true
         python-version: ${{matrix.python-version}}


### PR DESCRIPTION
This is a temporary measure to work around an external failure do to some update upstream (not sure where from exactly) that cascades down and breaks the GH action we use to setup conda on windows.
The failure affects #3380 and #3384 at the moment, and soon, everyone else.
See for instance:
https://github.com/yt-project/yt/runs/2954378672?check_suite_focus=true

Since only windows is affected, I think this can be merged as soon as both windows jobs pass