### PR TITLE
Remove unused imports from private CPython API that break PyPi builds

### DIFF
--- a/yt/geometry/particle_deposit.pyx
+++ b/yt/geometry/particle_deposit.pyx
@@ -14,8 +14,6 @@ cimport numpy as np
 import numpy as np
 
 cimport cython
-from cpython cimport PyObject
-from cpython.array cimport array, clone
 from cython.view cimport memoryview as cymemview
 from libc.math cimport sqrt
 from libc.stdlib cimport free, malloc


### PR DESCRIPTION
## PR Summary

Fixes #3399. Solution is to not use private CPython API. Fortunately, we weren't actually using it, just importing it for no reason.

Related Issues/PRs that helped me to identify the bug and find the solution:
* https://github.com/pyproj4/pyproj/issues/854
* https://github.com/h5py/h5py/pull/1515
