### PR TITLE
ENH: Cythonize Gamer's SRHD fields

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ lib_exts = [
     "yt/geometry/*.pyx",
     "yt/utilities/cython_fortran_utils.pyx",
     "yt/frontends/ramses/io_utils.pyx",
+    "yt/frontends/gamer/cfields.pyx",
     "yt/utilities/lib/cykdtree/kdtree.pyx",
     "yt/utilities/lib/cykdtree/utils.pyx",
     "yt/frontends/artio/_artio_caller.pyx",

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -68,7 +68,7 @@ answer_tests:
     - yt/frontends/gadget/tests/test_outputs.py:test_bigendian_field_access
     - yt/frontends/gadget/tests/test_outputs.py:test_magneticum
 
-  local_gamer_009:
+  local_gamer_010:  # PR 3401
     - yt/frontends/gamer/tests/test_outputs.py:test_jet
     - yt/frontends/gamer/tests/test_outputs.py:test_psiDM
     - yt/frontends/gamer/tests/test_outputs.py:test_plummer

--- a/yt/frontends/gamer/cfields.pyx
+++ b/yt/frontends/gamer/cfields.pyx
@@ -3,9 +3,9 @@
 cimport cython
 cimport libc.math as math
 cimport numpy as np
+
 import numpy as np
 
-np.import_array()
 
 cdef np.float64_t h_eos4(np.float64_t kT, np.float64_t g):
     cdef np.float64_t x
@@ -51,6 +51,7 @@ cdef class SRHDFields:
         self._gamma = gamma
         self._c = clight
         self._c2 = clight * clight
+        # Select aux functions based on eos no.
         if (eos == 4):
             self.h = h_eos4
             self.gamma = gamma_eos4
@@ -59,7 +60,7 @@ cdef class SRHDFields:
             self.h = h_eos
             self.gamma = gamma_eos
             self.cs = cs_eos
-    
+
     cdef np.float64_t _lorentz_factor(
             self,
             np.float64_t rho,
@@ -83,6 +84,9 @@ cdef class SRHDFields:
     ):
         return mi / (rho * (self.h(kT, self._gamma) + 1.0))
 
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
     def lorentz_factor(self, dens, momx, momy, momz, temp):
         cdef np.float64_t[:] rho = dens.ravel()
 
@@ -100,6 +104,9 @@ cdef class SRHDFields:
             outp[i] = self._lorentz_factor(rho[i], mx[i], my[i], mz[i], kT[i])
         return out
 
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
     def gamma_field(self, temp):
         cdef np.float64_t[:] kT = temp.ravel()
 
@@ -111,6 +118,9 @@ cdef class SRHDFields:
             outp[i] = self.gamma(kT[i], self._gamma)
         return out
 
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
     def sound_speed(self, temp):
         cdef np.float64_t[:] kT = temp.ravel()
         out = np.empty_like(kT)
@@ -122,11 +132,14 @@ cdef class SRHDFields:
             outp[i] = self.cs(kT[i], self._c, self._gamma)
         return out
 
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
     def four_velocity_xyz(self, mom, dens, temp):
         cdef np.float64_t[:] rho = dens.ravel()
         cdef np.float64_t[:] mi = mom.ravel()
         cdef np.float64_t[:] kT = temp.ravel()
-        
+
         out = np.empty_like(dens)
         cdef np.float64_t[:] outp = out.ravel()
         cdef np.float64_t[:] ui
@@ -136,6 +149,9 @@ cdef class SRHDFields:
             outp[i] = self._four_vel(rho[i], kT[i], mi[i])
         return out
 
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
     def velocity_xyz(self, dens, momx, momy, momz, temp, momi):
         cdef np.float64_t[:] rho = dens.ravel()
         cdef np.float64_t[:] mx = momx.ravel()
@@ -154,6 +170,9 @@ cdef class SRHDFields:
             outp[i] = self._four_vel(rho[i], kT[i], mi[i]) / lf
         return out
 
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
     def density(self, dens, momx, momy, momz, temp):
         cdef np.float64_t[:] rho = dens.ravel()
 
@@ -172,6 +191,9 @@ cdef class SRHDFields:
             outp[i] = rho[i] / lf
         return out
 
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
     def pressure(self, dens, momx, momy, momz, temp):
         cdef np.float64_t[:] rho = dens.ravel()
         cdef np.float64_t[:] mx = momx.ravel()
@@ -189,6 +211,9 @@ cdef class SRHDFields:
             outp[i] = rho[i] / lf * self._c2 * kT[i]
         return out
 
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
     def specific_thermal_energy(self, dens, momx, momy, momz, temp):
         cdef np.float64_t[:] rho = dens.ravel()
         cdef np.float64_t[:] mx = momx.ravel()
@@ -205,6 +230,9 @@ cdef class SRHDFields:
             outp[i] = self._c2 * (self.h(kT[i], self._gamma)- kT[i])
         return out
 
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
     def kinetic_energy_density(self, dens, momx, momy, momz, temp):
         cdef np.float64_t[:] rho = dens.ravel()
         cdef np.float64_t[:] mx = momx.ravel()
@@ -229,6 +257,9 @@ cdef class SRHDFields:
             outp[i] = gm1 * (rho[i] * hp * self._c2 + p)
         return out
 
+    @cython.boundscheck(False)
+    @cython.wraparound(False)
+    @cython.cdivision(True)
     def mach_number(self, dens, momx, momy, momz, temp):
         cdef np.float64_t[:] rho = dens.ravel()
         cdef np.float64_t[:] mx = momx.ravel()

--- a/yt/frontends/gamer/cfields.pyx
+++ b/yt/frontends/gamer/cfields.pyx
@@ -1,0 +1,215 @@
+# distutils: include_dirs = LIB_DIR
+# distutils: libraries = STD_LIBS
+cimport cython
+cimport libc.math as math
+cimport numpy as np
+import numpy as np
+
+np.import_array()
+
+cdef np.float64_t h_eos4(np.float64_t e):
+    cdef np.float64_t x
+    x = 2.25 * e * e
+    return 2.5 * e + x / (1.0 + math.sqrt(x + 1.0))
+
+cdef np.float64_t _lorentz_factor_eos4(
+        np.float64_t rho, 
+        np.float64_t mx,
+        np.float64_t my,
+        np.float64_t mz,
+        np.float64_t e,
+        np.float64_t c
+    ):
+    cdef np.float64_t u2, c2, vx, vy, vz
+    cdef np.float64_t htilde, fac;
+
+    c2 = c * c
+    fac = (1.0 / (rho * (h_eos4(e) + 1.0))) ** 2
+    u2 = (mx * mx + my * my + mz * mz) * fac
+    return math.sqrt(1.0 + u2 / c2)
+
+def gamma_eos4(temp):
+    cdef np.float64_t[:] kT = temp.ravel()
+    
+    out = np.empty_like(kT)
+    cdef np.float64_t[:] outp = out.ravel()
+    cdef np.float64_t x, c_p, c_v
+    cdef int i
+
+    for i in range(outp.shape[0]):
+        x = 2.25 * kT[i] / math.sqrt(2.25 * kT[i] * kT[i] + 1.0)
+        c_p = 2.5 + x
+        c_v = 1.5 + x
+        outp[i] = c_p / c_v
+    return out
+
+cdef np.float64_t cs_eos4(np.float64_t kT, np.float64_t c):
+    cdef np.float64_t hp, cs2;
+    hp = h_eos4(kT) + 1.0
+    cs2 = kT / (3.0 * hp)
+    cs2 *= (5.0 * hp - 8.0 * kT) / (hp - kT)
+    return c * math.sqrt(cs2)
+
+def sound_speed_eos4(temp, np.float64_t c):
+    cdef np.float64_t[:] kT = temp.ravel()
+    out = np.empty_like(kT)
+    cdef np.float64_t[:] outp = out.ravel()
+    cdef np.float64_t hp, cs2;
+
+    cdef int i
+    for i in range(outp.shape[0]):
+        outp[i] = cs_eos4(kT[i], c)
+    return out
+
+cdef np.float64_t _four_vel(
+    np.float64_t rho, 
+    np.float64_t kT,
+    np.float64_t mi
+):
+    return mi / (rho * (h_eos4(kT) + 1.0))
+
+def four_velocity_xyz_eos4(mom, dens, temp, np.float64_t c):
+    cdef np.float64_t[:] rho = dens.ravel()
+    cdef np.float64_t[:] mi = mom.ravel()
+    cdef np.float64_t[:] kT = temp.ravel()
+    
+    out = np.empty_like(dens)
+    cdef np.float64_t[:] outp = out.ravel()
+    cdef np.float64_t[:] ui
+    cdef int i
+
+    for i in range(outp.shape[0]):
+        outp[i] = _four_vel(rho[i], kT[i], mi[i])
+    return out
+
+def lorentz_factor_eos4(dens, momx, momy, momz, temp, np.float64_t c):
+    cdef np.float64_t[:] rho = dens.ravel()
+    
+    cdef np.float64_t[:] mx = momx.ravel()
+    cdef np.float64_t[:] my = momy.ravel()
+    cdef np.float64_t[:] mz = momz.ravel()
+    cdef np.float64_t[:] kT = temp.ravel()
+    
+    out = np.empty_like(dens)
+    cdef np.float64_t[:] outp = out.ravel()
+    cdef np.float64_t lf
+    cdef int i
+
+    for i in range(outp.shape[0]):
+        outp[i] = _lorentz_factor_eos4(rho[i], mx[i], my[i], mz[i], kT[i], c)
+    return out
+
+def velocity_xyz_eos4(dens, momx, momy, momz, temp, momi, np.float64_t c):
+    cdef np.float64_t[:] rho = dens.ravel()
+    cdef np.float64_t[:] mx = momx.ravel()
+    cdef np.float64_t[:] my = momy.ravel()
+    cdef np.float64_t[:] mz = momz.ravel()
+    cdef np.float64_t[:] kT = temp.ravel()
+    cdef np.float64_t[:] mi = momi.ravel()
+    
+    out = np.empty_like(dens)
+    cdef np.float64_t[:] outp = out.ravel()
+    cdef np.float64_t lf
+    cdef int i
+
+    for i in range(outp.shape[0]):
+        lf = _lorentz_factor_eos4(rho[i], mx[i], my[i], mz[i], kT[i], c)
+        outp[i] = _four_vel(rho[i], kT[i], mi[i]) / lf
+    return out
+
+def density_eos4(dens, momx, momy, momz, temp, np.float64_t c):
+    cdef np.float64_t[:] rho = dens.ravel()
+    
+    cdef np.float64_t[:] mx = momx.ravel()
+    cdef np.float64_t[:] my = momy.ravel()
+    cdef np.float64_t[:] mz = momz.ravel()
+    cdef np.float64_t[:] kT = temp.ravel()
+    
+    out = np.empty_like(dens)
+    cdef np.float64_t[:] outp = out.ravel()
+    cdef np.float64_t lf
+    cdef int i
+
+    for i in range(outp.shape[0]):
+        lf = _lorentz_factor_eos4(rho[i], mx[i], my[i], mz[i], kT[i], c)
+        outp[i] = rho[i] / lf
+    return out
+
+def pressure_eos4(dens, momx, momy, momz, temp, np.float64_t c):
+    cdef np.float64_t[:] rho = dens.ravel()
+    cdef np.float64_t[:] mx = momx.ravel()
+    cdef np.float64_t[:] my = momy.ravel()
+    cdef np.float64_t[:] mz = momz.ravel()
+    cdef np.float64_t[:] kT = temp.ravel()
+    
+    out = np.empty_like(dens)
+    cdef np.float64_t[:] outp = out.ravel()
+    cdef np.float64_t lf, c2
+    cdef int i
+
+    c2 = c * c
+    for i in range(outp.shape[0]):
+        lf = _lorentz_factor_eos4(rho[i], mx[i], my[i], mz[i], kT[i], c)
+        outp[i] = rho[i] / lf * c2 * kT[i]
+    return out
+
+def specific_thermal_energy_eos4(dens, momx, momy, momz, temp, np.float64_t c):
+    cdef np.float64_t[:] rho = dens.ravel()
+    cdef np.float64_t[:] mx = momx.ravel()
+    cdef np.float64_t[:] my = momy.ravel()
+    cdef np.float64_t[:] mz = momz.ravel()
+    cdef np.float64_t[:] kT = temp.ravel()
+    
+    out = np.empty_like(dens)
+    cdef np.float64_t[:] outp = out.ravel()
+    cdef np.float64_t lf, p, c2, ht
+    cdef int i
+        
+    c2 = c * c
+    for i in range(outp.shape[0]):
+        outp[i] = c2 * (h_eos4(kT[i])- kT[i])
+    return out
+
+def kinetic_energy_density_eos4(dens, momx, momy, momz, temp, np.float64_t c):
+    cdef np.float64_t[:] rho = dens.ravel()
+    cdef np.float64_t[:] mx = momx.ravel()
+    cdef np.float64_t[:] my = momy.ravel()
+    cdef np.float64_t[:] mz = momz.ravel()
+    cdef np.float64_t[:] kT = temp.ravel()
+    
+    out = np.empty_like(dens)
+    cdef np.float64_t[:] outp = out.ravel()
+    cdef np.float64_t lf, u2, hp, ux, uy, uz, c2
+    cdef int i
+
+    c2 = c * c
+    for i in range(outp.shape[0]):
+        hp = h_eos4(kT[i]) + 1.0
+        ux = _four_vel(rho[i], kT[i], mx[i])
+        uy = _four_vel(rho[i], kT[i], my[i])
+        uz = _four_vel(rho[i], kT[i], mz[i])
+        u2 = ux**2 + uy**2 + uz**2
+        lf = _lorentz_factor_eos4(rho[i], mx[i], my[i], mz[i], kT[i], c)
+        gm1 = u2 / c2 / (lf + 1.0)
+        p = rho[i] / lf * c2 * kT[i]
+        outp[i] = gm1 * (rho[i] * hp * c2 + p)
+    return out
+
+def mach_number_eos4(dens, momx, momy, momz, temp, np.float64_t c):
+    cdef np.float64_t[:] rho = dens.ravel()
+    cdef np.float64_t[:] mx = momx.ravel()
+    cdef np.float64_t[:] my = momy.ravel()
+    cdef np.float64_t[:] mz = momz.ravel()
+    cdef np.float64_t[:] kT = temp.ravel()
+    
+    out = np.empty_like(dens)
+    cdef np.float64_t[:] outp = out.ravel()
+    cdef np.float64_t lf, u2, hp, cs
+    cdef int i
+    
+    for i in range(outp.shape[0]):
+        cs = cs_eos4(kT[i], c)
+        us = cs / math.sqrt(1.0 - cs**2 / c**2)
+        u = math.sqrt(mx[i]**2 + my[i]**2 + mz[i]**2) / (rho[i] * (h_eos4(kT[i]) + 1.0))
+        outp[i] = u / us
+    return out

--- a/yt/frontends/gamer/fields.py
+++ b/yt/frontends/gamer/fields.py
@@ -433,6 +433,9 @@ class GAMERFieldInfo(FieldInfoContainer):
             def _specific_thermal_energy(field, data):
                 return et(data) / data["gamer", "Dens"]
 
+            def _specific_thermal_energy_new(field, data):  # TODO
+                return _specific_thermal_energy(field, data)
+
             # total energy per mass
             def _specific_total_energy(field, data):
                 return data["gamer", "Engy"] / data["gamer", "Dens"]
@@ -440,6 +443,9 @@ class GAMERFieldInfo(FieldInfoContainer):
             # pressure
             def _pressure(field, data):
                 return et(data) * (data.ds.gamma - 1.0)
+
+            def _pressure_new(field, data):  # TODO
+                return _pressure(field, data)
 
         self.add_field(
             ("gas", "specific_thermal_energy_old"),

--- a/yt/frontends/gamer/fields.py
+++ b/yt/frontends/gamer/fields.py
@@ -4,18 +4,7 @@ from yt._typing import KnownFieldsT
 from yt.fields.field_info_container import FieldInfoContainer
 from yt.fields.vector_operations import create_magnitude_field
 
-from .cfields import (
-    density_eos4,
-    four_velocity_xyz_eos4,
-    gamma_eos4,
-    kinetic_energy_density_eos4,
-    lorentz_factor_eos4,
-    mach_number_eos4,
-    pressure_eos4,
-    sound_speed_eos4,
-    specific_thermal_energy_eos4,
-    velocity_xyz_eos4,
-)
+from .cfields import SRHDFields
 
 b_units = "code_magnetic"
 pre_units = "code_mass / (code_length*code_time**2)"
@@ -74,6 +63,11 @@ class GAMERFieldInfo(FieldInfoContainer):
         if self.ds.srhd:
 
             c2 = pc.clight * pc.clight
+            c = pc.clight.in_units("code_length / code_time")
+            if self.ds.eos == 4:
+                fgen = SRHDFields(self.ds.eos, 0.0, c.d)
+            else:
+                fgen = SRHDFields(self.ds.eos, self.ds.gamma, c.d)
 
             if self.ds.eos == 4:
 
@@ -84,10 +78,6 @@ class GAMERFieldInfo(FieldInfoContainer):
                     c_p = 2.5 + x
                     c_v = 1.5 + x
                     return c_p / c_v
-
-                def _gamma_new(field, data):
-                    out = gamma_eos4(data["gamer", "Temp"].d)
-                    return data.ds.arr(out, "dimensionless")
 
                 def htilde(data):
                     kT = data["gamer", "Temp"]
@@ -101,11 +91,6 @@ class GAMERFieldInfo(FieldInfoContainer):
                     cs2 = kT / (3.0 * h)
                     cs2 *= (5.0 * h - 8.0 * kT) / (h - kT)
                     return pc.clight * np.sqrt(cs2)
-
-                def _sound_speed_new(field, data):
-                    c = pc.clight.in_units("code_length / code_time")
-                    out = sound_speed_eos4(data["gamer", "Temp"].d, c)
-                    return data.ds.arr(out, "code_velocity").to(unit_system["velocity"])
 
             else:
 
@@ -123,6 +108,14 @@ class GAMERFieldInfo(FieldInfoContainer):
                     h = htilde(data) / c2 + 1.0
                     cs2 = data["gas", "gamma"] / h * data["gamer", "Temp"]
                     return pc.clight * np.sqrt(cs2)
+
+            def _sound_speed_new(field, data):
+                out = fgen.sound_speed(data["gamer", "Temp"].d)
+                return data.ds.arr(out, "code_velocity").to(unit_system["velocity"])
+
+            def _gamma_new(field, data):
+                out = fgen.gamma_field(data["gamer", "Temp"].d)
+                return data.ds.arr(out, "dimensionless")
 
             # coordinate frame density
             self.alias(
@@ -150,12 +143,10 @@ class GAMERFieldInfo(FieldInfoContainer):
 
             def four_velocity_xyz_new(u):
                 def _four_velocity(field, data):
-                    c = pc.clight.in_units("code_length / code_time")
-                    out = four_velocity_xyz_eos4(
+                    out = fgen.four_velocity_xyz(
                         data["gamer", f"Mom{u.upper()}"].d,
                         data["gamer", "Dens"].d,
                         data["gamer", "Temp"].d,
-                        c.d,
                     )
                     return data.ds.arr(out, "code_velocity").to(unit_system["velocity"])
 
@@ -193,14 +184,12 @@ class GAMERFieldInfo(FieldInfoContainer):
             )
 
             def _lorentz_factor_new(field, data):
-                c = pc.clight.in_units("code_length / code_time")
-                out = lorentz_factor_eos4(
+                out = fgen.lorentz_factor(
                     data["gamer", "Dens"].d,
                     data["gamer", "MomX"].d,
                     data["gamer", "MomY"].d,
                     data["gamer", "MomZ"].d,
                     data["gamer", "Temp"].d,
-                    c.d,
                 )
                 return data.ds.arr(out, "dimensionless")
 
@@ -223,15 +212,13 @@ class GAMERFieldInfo(FieldInfoContainer):
 
             def velocity_xyz_new(v):
                 def _velocity(field, data):
-                    c = pc.clight.in_units("code_length / code_time")
-                    out = velocity_xyz_eos4(
+                    out = fgen.velocity_xyz(
                         data["gamer", "Dens"].d,
                         data["gamer", "MomX"].d,
                         data["gamer", "MomY"].d,
                         data["gamer", "MomZ"].d,
                         data["gamer", "Temp"].d,
                         data["gamer", f"Mom{v.upper()}"].d,
-                        c.d,
                     )
                     return data.ds.arr(out, "code_velocity").to(unit_system["velocity"])
 
@@ -268,14 +255,12 @@ class GAMERFieldInfo(FieldInfoContainer):
             )
 
             def _density_new(field, data):
-                c = pc.clight.in_units(vel_units)
-                dens = density_eos4(
+                dens = fgen.density(
                     data["gamer", "Dens"].d,
                     data["gamer", "MomX"].d,
                     data["gamer", "MomY"].d,
                     data["gamer", "MomZ"].d,
                     data["gamer", "Temp"].d,
-                    c.d,
                 )
                 return data.ds.arr(dens, rho_units).to(unit_system["density"])
 
@@ -291,14 +276,12 @@ class GAMERFieldInfo(FieldInfoContainer):
                 return data["gas", "density"] * c2 * data["gamer", "Temp"]
 
             def _pressure_new(field, data):
-                c = pc.clight.in_units(vel_units)
-                out = pressure_eos4(
+                out = fgen.pressure(
                     data["gamer", "Dens"].d,
                     data["gamer", "MomX"].d,
                     data["gamer", "MomY"].d,
                     data["gamer", "MomZ"].d,
                     data["gamer", "Temp"].d,
-                    c.d,
                 )
                 return data.ds.arr(out, pre_units).to(unit_system["pressure"])
 
@@ -308,14 +291,12 @@ class GAMERFieldInfo(FieldInfoContainer):
                 return eps / data["gas", "density"]
 
             def _specific_thermal_energy_new(field, data):
-                c = pc.clight.in_units(vel_units)
-                out = specific_thermal_energy_eos4(
+                out = fgen.specific_thermal_energy(
                     data["gamer", "Dens"].d,
                     data["gamer", "MomX"].d,
                     data["gamer", "MomY"].d,
                     data["gamer", "MomZ"].d,
                     data["gamer", "Temp"].d,
-                    c.d,
                 )
                 return data.ds.arr(out, "code_length**2 / code_time**2").to(
                     unit_system["specific_energy"]
@@ -333,14 +314,12 @@ class GAMERFieldInfo(FieldInfoContainer):
                 return gm1 * (data["gamer", "Dens"] * h + data["gas", "pressure"])
 
             def _kinetic_energy_density_new(field, data):
-                c = pc.clight.in_units(vel_units)
-                out = kinetic_energy_density_eos4(
+                out = fgen.kinetic_energy_density(
                     data["gamer", "Dens"].d,
                     data["gamer", "MomX"].d,
                     data["gamer", "MomY"].d,
                     data["gamer", "MomZ"].d,
                     data["gamer", "Temp"].d,
-                    c.d,
                 )
                 return data.ds.arr(out, erg_units).to(unit_system["pressure"])
 
@@ -378,14 +357,12 @@ class GAMERFieldInfo(FieldInfoContainer):
                 return data["gas", "oldfour_velocity_magnitude"] / u_s
 
             def _mach_number_new(field, data):
-                c = pc.clight.in_units("code_length / code_time")
-                out = mach_number_eos4(
+                out = fgen.mach_number(
                     data["gamer", "Dens"].d,
                     data["gamer", "MomX"].d,
                     data["gamer", "MomY"].d,
                     data["gamer", "MomZ"].d,
                     data["gamer", "Temp"].d,
-                    c.d,
                 )
                 return data.ds.arr(out, "dimensionless")
 

--- a/yt/frontends/gamer/fields.py
+++ b/yt/frontends/gamer/fields.py
@@ -3,7 +3,6 @@ from yt.fields.field_info_container import FieldInfoContainer
 
 from .cfields import SRHDFields
 
-
 b_units = "code_magnetic"
 pre_units = "code_mass / (code_length*code_time**2)"
 erg_units = "code_mass / (code_length*code_time**2)"


### PR DESCRIPTION
### Rationale

The main goal of this PR is to optimize memory usage during field generation, by decreasing the amount of fields used as dependencies in derived fields. There's a significant performance boost, but it's just a side effect. As an example prior to this PR:

```
>>> pprint.pprint(list(ds.field_dependencies[("gas", "temperature")].keys()))
[('gamer', 'Dens'),
 ('gas', 'frame_density'),
 ('gamer', 'MomX'),
 ('gas', 'momentum_density_x'),
 ('gamer', 'Temp'),
 ('gas', 'four_velocity_x'),
 ('gamer', 'MomY'),
 ('gas', 'momentum_density_y'),
 ('gas', 'four_velocity_y'),
 ('gamer', 'MomZ'),
 ('gas', 'momentum_density_z'),
 ('gas', 'four_velocity_z'),
 ('gas', 'four_velocity_magnitude'),
 ('gas', 'lorentz_factor'),
 ('gas', 'density'),
 ('gas', 'pressure'),
 ('gas', 'temperature')]
```

with this PR:

```
>>> pprint.pprint(list(ds.field_dependencies[("gas", "temperature")].keys()))
[('gamer', 'Dens'),
 ('gamer', 'MomX'),
 ('gamer', 'MomY'),
 ('gamer', 'MomZ'),
 ('gamer', 'Temp'),
 ('gas', 'pressure'),
 ('gas', 'density'),
 ('gas', 'temperature')]
```

I left old fields for now, so that they can be easily compared with the new ones. I've been using the following script to run a comparison:

```
import yt

ds = yt.load("JetICMWall/Data_000060")
g = ds.index.grids[0]

for field in ("velocity", "four_velocity"):
    for v in "xyz":
        field_old = ("gas", f"old{field}_{v}")
        field_new = ("gas", f"{field}_{v}")
        diff = abs((g[field_old] - g[field_new]) / g[field_old]).max()
        print(f"{field}_{v}", diff)

for field in (
    "gamma",
    "lorentz_factor",
    "density",
    "pressure",
    "kinetic_energy_density",
    "specific_thermal_energy",
    "sound_speed",
    "mach_number"
):
    field_old = ("gas", f"{field}_old")
    field_new = ("gas", field)
    diff = abs((g[field_old] - g[field_new]) / g[field_old]).max()
    print(field, diff)
```