### PR TITLE
Change the loop order to avoid executing the same test 3 times

### DIFF
--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -1193,13 +1193,13 @@ def small_patch_amr(ds_fn, fields, input_center="max", input_weight=("gas", "den
     yield ParentageRelationshipsTest(ds_fn)
     for field in fields:
         yield GridValuesTest(ds_fn, field)
-        for axis in [0, 1, 2]:
-            for dobj_name in dso:
+        for dobj_name in dso:
+            for axis in [0, 1, 2]:
                 for weight_field in [None, input_weight]:
                     yield ProjectionValuesTest(
                         ds_fn, axis, field, weight_field, dobj_name
                     )
-                yield FieldValuesTest(ds_fn, field, dobj_name)
+            yield FieldValuesTest(ds_fn, field, dobj_name)
 
 
 def big_patch_amr(ds_fn, fields, input_center="max", input_weight=("gas", "density")):


### PR DESCRIPTION
Just to be extra sure that we're doing the right thing, we've been running the same `FieldValuesTest` **3 times** every time `small_patch_amr` was used. No big deal! It's better to be safe than sorry! However, as I grow older I discover a daredevil in me. So I say: let's live our lives dangerously and run this test only once! How about that?

## PR Summary

This PR switches the order of loops in `small_patch_amr` to allow `FieldValuesTest` to be run once, since it's independent of `axis` parameter.
