### PR TITLE
Update MANIFEST.in to include *.pxi and conftest.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,12 @@
 include README* CREDITS COPYING.txt CITATION  setupext.py CONTRIBUTING.rst
 include yt/visualization/mapserver/html/map.js
 include yt/visualization/mapserver/html/map_index.html
+include yt/visualization/mapserver/html/Leaflet.Coordinates-0.1.5.css
+include yt/visualization/mapserver/html/Leaflet.Coordinates-0.1.5.src.js
 include yt/utilities/tests/cosmology_answers.yml
 include yt/utilities/mesh_types.yaml
 exclude scripts/pr_backport.py
+exclude yt/utilities/lib/cykdtree/c_kdtree.cpp
 prune tests
 prune docker
 prune answer-store

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,10 @@ include yt/visualization/mapserver/html/map_index.html
 include yt/utilities/tests/cosmology_answers.yml
 include yt/utilities/mesh_types.yaml
 exclude scripts/pr_backport.py
-recursive-include yt *.py *.pyx *.pxd *.h *.hpp README* *.txt LICENSE* *.cu
+prune tests
+prune docker
+prune answer-store
+recursive-include yt *.py *.pyx *.pxi *.pxd *.h *.hpp README* *.txt LICENSE* *.cu
 recursive-include doc *.rst *.txt *.py *.ipynb *.png *.jpg *.css *.html
 recursive-include doc *.h *.c *.sh *.svgz *.pdf *.svg *.pyx
 include doc/README doc/activate doc/activate.csh doc/cheatsheet.tex
@@ -13,5 +16,8 @@ prune doc/source/reference/api/generated
 prune doc/build
 recursive-include yt/visualization/volume_rendering/shaders *.fragmentshader *.vertexshader
 include yt/sample_data_registry.json
+include conftest.py
 prune yt/frontends/_skeleton
 recursive-include yt/frontends/amrvac *.par
+exclude .codecov.yml .coveragerc .git-blame-ignore-revs .gitmodules .hgchurn .mailmap
+exclude .pre-commit-config.yaml clean.sh nose_answer.cfg nose_unit.cfg


### PR DESCRIPTION
## PR Summary

`check-manifest` shows a lot of missing files. Especially `yt/geometry/_selection_routines/*.pxi` look critical, i.e. building yt from source will fail without them. I threw in `conftest.py` as a cherry on top. Prunes / excludes that I added are mostly cosmetic. With this PR I still get:

```
missing from sdist:
  yt/utilities/lib/cykdtree/c_kdtree.cpp
  yt/visualization/mapserver/html/Leaflet.Coordinates-0.1.5.css
  yt/visualization/mapserver/html/Leaflet.Coordinates-0.1.5.src.js
```

`yt/utilities/lib/cykdtree/c_kdtree.cpp` is empty and I don't know if it's needed. Maybe we should remove it. What about vendored Leaflet?