### PR TITLE
MAINT: add check-manifest to pre-commit toolkit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,10 @@ repos:
     rev: v1.17.0
     hooks:
     -   id: setup-cfg-fmt
+-   repo: https://github.com/mgedmin/check-manifest
+    rev: '0.46'
+    hooks:
+    - id: check-manifest
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
     hooks:


### PR DESCRIPTION
## PR Summary
In reaction to PR #3403, add check-manifest to .pre-commit-config.yaml
This will *fail* on pre-commit.ci as long as #3403 isn't merged and the remaining issues aren't solved, but this PR shouldn't be necessary for the 4.0 release.
@Xarthisius, feel free to integrate this in #3403 if you wish _and_ if that PR is intended to solve *all* issues currently reported by check-manifest.