### PR TITLE
Port wheels build to GHA

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -46,7 +46,7 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir dist
         env:
-          CIBW_BUILD: "cp37-* cp38-* cp39-*"
+          CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-*"
           CIBW_ARCHS_LINUX: "x86_64"
           CIBW_ARCHS_MACOS: "x86_64"
           CIBW_ARCHS_WINDOWS: "auto"

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -1,0 +1,60 @@
+name: Build CI Wheels
+
+on:
+  push:
+    branches:
+      - main
+      - stable
+    tags:
+      - 'yt-*'
+
+jobs:
+  build_wheels:
+    name: Wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, windows-latest, macos-latest]
+      fail-fast: false
+
+    steps:
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: 3.9
+
+      - uses: s-weigand/setup-conda@v1
+        if: matrix.os == 'windows-latest'
+        with:
+          update-conda: true
+          conda-channels: conda-forge
+          activate-conda: true
+          python-version: 3.9
+
+      - uses: actions/checkout@v2
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==1.9.0
+
+      - name: Install dependencies and yt
+        shell: bash
+        env:
+          dependencies: "full"
+          LDFLAGS: "-static-libstdc++"
+        run: source ./tests/ci_install.sh
+
+      - name: Build wheels for CPython
+        run: |
+          python -m cibuildwheel --output-dir dist
+        env:
+          CIBW_BUILD: "cp37-* cp38-* cp39-*"
+          CIBW_ARCHS_LINUX: "x86_64"
+          CIBW_ARCHS_MACOS: "x86_64"
+          CIBW_ARCHS_WINDOWS: "auto"
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_MANYLINUX_I686_IMAGE: manylinux2014
+          CIBW_ENVIRONMENT: "LDFLAGS='-static-libstdc++'"
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: ./dist/*.whl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,4 @@
 [build-system]
-# See https://github.com/scipy/scipy/pull/10431 for the AIX issue.
 requires = [
   "setuptools>=19.6",
   # see https://github.com/numpy/numpy/pull/18389
@@ -11,8 +10,7 @@ requires = [
   # we forbid it until we can properly test against it
   "Cython>=0.26.1,<3.0; python_version=='3.6'",
   "Cython>=0.29.21,<3.0; python_version>='3.7'",
-  "numpy==1.13.3; python_version=='3.6' and platform_system!='AIX'",
-  "numpy>=1.19.2; python_version>='3.7' and platform_system!='AIX'",
+  "oldest-supported-numpy",
 ]
 
 [tool.black]


### PR DESCRIPTION
## PR Summary

This adds GHA for building wheels. It covers both the release process and dev (building after every push to master).

Things noteworthy:
* We need to statically link `libstdc++` due to fact we're shipping/building a lot of C++14 code. Otherwise linux wheels are unusable  due to the ABI conflicts. Some info on this can be found [here](https://github.com/pypa/cibuildwheel/blob/184a9feb24ee38d0b0a39fa93b6bb8247cbd636b/docs/cpp_standards.md)
* I switched to `oldest-supported-numpy` for numpy build dependency.
* 32bit linux build fails and I disable it. I don't think anyone uses i686 these days anyway...