### PR TITLE
MAINT: remove a unreachable conditional

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -523,8 +523,6 @@ class Dataset(abc.ABC):
     @property
     def index(self):
         if self._instantiated_index is None:
-            if self._index_class is None:
-                raise RuntimeError("You should not instantiate Dataset.")
             self._instantiated_index = self._index_class(
                 self, dataset_type=self.dataset_type
             )


### PR DESCRIPTION
## PR Summary

Found this while working on something else.
This guard condition is unreachable since PR #2556 made the base Dataset class abstract, which means it _cannot_ be instantiated.

