### PR TITLE
Fix various doc and source comment typos

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -129,7 +129,7 @@ def pytest_configure(config):
 
     if find_spec("cartopy") is not None:
         # cartopy still triggers this numpy warning
-        # last checked wtih cartopy 0.19.0
+        # last checked with cartopy 0.19.0
         config.addinivalue_line(
             "filterwarnings",
             (

--- a/doc/source/analyzing/generating_processed_data.rst
+++ b/doc/source/analyzing/generating_processed_data.rst
@@ -218,7 +218,7 @@ whether to use a log or linear scale, and whether or not to do accumulation to
 create a cumulative distribution function.  For more information, see the API
 documentation on the :func:`~yt.data_objects.profiles.create_profile` function.
 
-For custom bins the other keyword arguments can be overriden using the
+For custom bins the other keyword arguments can be overridden using the
 ``override_bins`` keyword argument. This accepts a dictionary with an array
 for each bin field or ``None`` to use the default settings.
 

--- a/doc/source/analyzing/objects.rst
+++ b/doc/source/analyzing/objects.rst
@@ -597,7 +597,7 @@ This is equivalent to:
 The ``min`` operator does not do this, however, as a minimum intensity
 projection is not currently implemented.
 
-You can also compute the ``mean`` value, which accepts a field, axis and wight
+You can also compute the ``mean`` value, which accepts a field, axis and weight
 function.  If the axis is not specified, it will return the average value of
 the specified field, weighted by the weight argument.  The weight argument
 defaults to ``ones``, which performs an arithmetic average.  For instance:

--- a/doc/source/cookbook/amrkdtree_downsampling.py
+++ b/doc/source/cookbook/amrkdtree_downsampling.py
@@ -60,7 +60,7 @@ sc.save("v2.png", sigma_clip=6.0)
 tf.grey_opacity = True
 sc.save("v3.png", sigma_clip=6.0)
 #
-## That seemed to pick out som interesting structures.  Now let's bump up the
+## That seemed to pick out some interesting structures.  Now let's bump up the
 ## opacity.
 #
 tf.clear()

--- a/doc/source/cookbook/complex_plots.rst
+++ b/doc/source/cookbook/complex_plots.rst
@@ -65,7 +65,7 @@ matter.  On the other hand, increasing these without increasing
 ``buff_size`` accordingly will simply blow up your resolution
 elements to fill several real pixels.
 
-4. (only for meshed particle data) ``n_ref``, the maximum nubmer of
+4. (only for meshed particle data) ``n_ref``, the maximum number of
 particles in a cell in the oct-tree allowed before it is refined
 (removed in yt-4.0 as particle data is no longer deposited onto
 an oct-tree).  For particle data, ``n_ref`` effectively sets the

--- a/doc/source/cookbook/geographic_xforms_and_projections.ipynb
+++ b/doc/source/cookbook/geographic_xforms_and_projections.ipynb
@@ -153,7 +153,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that the data is loaded, we can plot it with a yt SlicePlot along the altitude. This will crate a figure with latitude and longitude as the plot axes and the colormap will correspond to the air density. Because no projection type has been set, the geographic geometry type assumes that the data is of the `PlateCarree` form. The resulting figure will be a `Mollweide` plot. "
+    "Now that the data is loaded, we can plot it with a yt SlicePlot along the altitude. This will create a figure with latitude and longitude as the plot axes and the colormap will correspond to the air density. Because no projection type has been set, the geographic geometry type assumes that the data is of the `PlateCarree` form. The resulting figure will be a `Mollweide` plot. "
    ]
   },
   {

--- a/doc/source/cookbook/various_lens.py
+++ b/doc/source/cookbook/various_lens.py
@@ -5,7 +5,7 @@ from yt.visualization.volume_rendering.api import Scene, create_volume_source
 
 field = ("gas", "density")
 
-# normal_vector points from camera to the center of tbe final projection.
+# normal_vector points from camera to the center of the final projection.
 # Now we look at the positive x direction.
 normal_vector = [1.0, 0.0, 0.0]
 # north_vector defines the "top" direction of the projection, which is
@@ -21,7 +21,7 @@ tf.grey_opacity = True
 
 # Plane-parallel lens
 cam = sc.add_camera(ds, lens_type="plane-parallel")
-# Set the resolution of tbe final projection.
+# Set the resolution of the final projection.
 cam.resolution = [250, 250]
 # Set the location of the camera to be (x=0.2, y=0.5, z=0.5)
 # For plane-parallel lens, the location info along the normal_vector (here

--- a/doc/source/developing/creating_frontend.rst
+++ b/doc/source/developing/creating_frontend.rst
@@ -40,7 +40,7 @@ To get started
  * make a new directory in ``yt/frontends`` with the name of your code and add the name
    into ``yt/frontends/api.py:_frontends`` (in alphabetical order).
  * copy the contents of the ``yt/frontends/_skeleton`` directory, and replace every
-   occurence of ``Skeleton`` with your frontend's name (preserving case). This
+   occurrence of ``Skeleton`` with your frontend's name (preserving case). This
    adds a lot of boilerplate for the required classes and methods that are needed.
 
 

--- a/doc/source/developing/releasing.rst
+++ b/doc/source/developing/releasing.rst
@@ -140,7 +140,7 @@ Access to yt-project.org mediated via SSH login. Please contact one of the
 current yt developers for access to the webserver running yt-project.org if you
 do not already have it. You will need a copy of your SSH public key so that your
 key can be added to the list of authorized keys. Once you login, use
-e.g. ``scp`` to upload a copy of the souce distribution tarball to
+e.g. ``scp`` to upload a copy of the source distribution tarball to
 https://yt-project.org/sdist, like so::
 
   $ scp dist/yt-3.5.1.tar.gz yt_analysis@dickenson.dreamhost.com:yt-project.org/sdist

--- a/doc/source/developing/testing.rst
+++ b/doc/source/developing/testing.rst
@@ -80,8 +80,8 @@ Our dependencies are specified in ``setup.cfg``. Hard dependencies are found in
 test suite, which are intended to be as modern as possible (we don't set upper
 limits to versions unless we need to). The ``minimal`` target is used to check
 that we don't break backward compatibility with old versions of upstream
-projects by accident. It is intended to pin stricly our minimal supported
-versions. The ``test`` target specifies the tools neeed to run the tests, but
+projects by accident. It is intended to pin strictly our minimal supported
+versions. The ``test`` target specifies the tools need to run the tests, but
 not needed by yt itself.
 
 **Python version support.**

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -143,7 +143,7 @@ Appropriate errors are thrown for other combinations.
 * particle data: currently not supported (but might come later)
 * staggered grids (AMRVAC 2.2 and later): yt logs a warning if you load
   staggered datasets, but the flag is currently ignored.
-* "stretched grids" as defined in AMRVAC have no correspondance in yt,
+* "stretched grids" as defined in AMRVAC have no correspondence in yt,
   hence will never be supported.
 
 .. note::

--- a/doc/source/reference/changelog.rst
+++ b/doc/source/reference/changelog.rst
@@ -739,8 +739,8 @@ Additional Improvements
   will be registered for a dataset if the dependent particle filter is
   registered with a dataset. See `PR 1624
   <https://github.com/yt-project/yt/pull/1624>`__.
-- The ``save()`` method of the various yt plot objets now optionally can accept
-  a tuple of strings instead of a string. If a tuple is supplied, the elments
+- The ``save()`` method of the various yt plot objects now optionally can accept
+  a tuple of strings instead of a string. If a tuple is supplied, the elements
   are joined with ``os.sep`` to form a path. See `PR 1630
   <https://github.com/yt-project/yt/pull/1630>`__.
 - The quiver callback now accepts a ``plot_args`` keyword argument that allows
@@ -790,7 +790,7 @@ Additional Improvements
   1914 <https://github.com/yt-project/yt/pull/1914>`__.
 - ``ParticleProjectionPlot`` now supports the ``annotate_particles`` plot
   callback. See `PR 1765 <https://github.com/yt-project/yt/pull/1765>`__.
-- Optmized the performance of off-axis projections for octree AMR data. See `PR
+- Optimized the performance of off-axis projections for octree AMR data. See `PR
   1766 <https://github.com/yt-project/yt/pull/1766>`__.
 - Added support for several radiative transfer fields in the ARTIO frontend. See
   `PR 1804 <https://github.com/yt-project/yt/pull/1804>`__.

--- a/doc/source/reference/demeshening.rst
+++ b/doc/source/reference/demeshening.rst
@@ -144,7 +144,7 @@ be read from disk before expensive selection operations are conducted.
 
 For those situations that involve particles with regions of influence -- such
 as smoothed particle hydrodynamics, where particles have associated smoothing
-lenghts -- these are taken into account when conducting the indexing system.
+lengths -- these are taken into account when conducting the indexing system.
 
 Efficiency of Index Orders
 --------------------------

--- a/doc/source/visualizing/Volume_Rendering_Tutorial.ipynb
+++ b/doc/source/visualizing/Volume_Rendering_Tutorial.ipynb
@@ -178,7 +178,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For the change to the camera to take affect, we have to explictly render again: "
+    "For the change to the camera to take affect, we have to explicitly render again: "
    ]
   },
   {

--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -2133,7 +2133,7 @@ an example that includes slices and phase plots:
     p1 = SlicePlot(ds, "x", ("gas", "density"))
     p1.set_width(10, "kpc")
 
-    p2 = SlicePlot(ds, "x", ("gas", "tempature"))
+    p2 = SlicePlot(ds, "x", ("gas", "temperature"))
     p2.set_width(10, "kpc")
     p2.set_cmap(("gas", "temperature"), "hot")
 

--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -824,7 +824,7 @@ As an example,
    p.save()
 
 Symlog is very versatile, and will work with positive or negative dataset ranges.
-Here is an example using symlog scaling to plot a postive field with a linear range of
+Here is an example using symlog scaling to plot a positive field with a linear range of
 ``(0, linthresh)``.
 
 .. python-script::
@@ -1310,7 +1310,7 @@ field. Thus, allowing us the option to have different plot titles for different 
 Annotating plot with text
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Plots can be annotated at a desired (x,y) co-ordinate using :meth:`~yt.visualization.profile_plotter.ProfilePlot.annotate_text` function.
+Plots can be annotated at a desired (x,y) coordinate using :meth:`~yt.visualization.profile_plotter.ProfilePlot.annotate_text` function.
 This function accepts the x-position, y-position, a text string to
 be annotated in the plot area, and an optional list of fields for annotating plots with the specified field.
 Furthermore, any keyword argument accepted by the matplotlib ``axes.text`` function could also be passed which will can be useful to change fontsize, text-alignment, text-color or other such properties of annotated text.
@@ -1973,7 +1973,7 @@ be separated from the easy part (generating images).  The intermediate
 slice, projection, and profile objects can be saved as reloadable
 datasets, then handed back to the plotting machinery discussed here.
 
-For slices and projections, the savable object is associated with the
+For slices and projections, the saveable object is associated with the
 plot object as ``data_source``.  This can be saved with the
 :func:`~yt.data_objects.data_containers.YTDataContainer.save_as_dataset` function.  For
 more information, see :ref:`saving_data`.

--- a/doc/source/yt4differences.rst
+++ b/doc/source/yt4differences.rst
@@ -150,7 +150,7 @@ As mentioned, previously operations such as slice, projection and arbitrary
 grids would smooth the particle data onto the global octree. As this is no
 longer used, a different approach was required to visualize the SPH data. Using
 SPLASH as inspiration, SPH smoothing pixelization operations were created using
-smooting operations via "scatter" and "gather" approaches. We estimate the
+smoothing operations via "scatter" and "gather" approaches. We estimate the
 contributions of a particle to a single pixel by considering the point at the
 centre of the pixel and using the standard SPH smoothing formula. The heavy
 lifting in these functions is undertaken by cython functions.
@@ -180,7 +180,7 @@ method:
 
 In the above example the ``covering_grid`` and the ``arbitrary_grid`` will return
 the same data. In fact, these containers are very similar but provide a
-slighlty different API.
+slightly different API.
 
 The above code can be modified to use the gather approach by changing a global
 setting for the dataset. This can be achieved with
@@ -194,7 +194,7 @@ disable the normalization for all future interpolations.
 
 The gather approach requires finding nearest neighbors using the KDTree. The
 first call will generate a KDTree for the entire dataset which will be stored in
-a sidecar file. This will be loaded whenever neccesary.
+a sidecar file. This will be loaded whenever necessary.
 
 Off-Axis Projection for SPH Data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -225,7 +225,7 @@ Smoothing Data onto an Octree
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Whilst the move away from the global octree is a promising one in terms of
-perfomance and dealing with SPH data in a more intuitive manner, it does remove
+performance and dealing with SPH data in a more intuitive manner, it does remove
 a useful feature. We are aware that many users will have older scripts which take
 advantage of the global octree.
 

--- a/tests/pytest_runner.py
+++ b/tests/pytest_runner.py
@@ -17,7 +17,7 @@ if __name__ == "__main__":
     pytest_args = [
         "-s",
         "-v",
-        "-rsfE",  # it means -r "sfE" (show skiped, failed, errors), no -r -s -f -E
+        "-rsfE",  # it means -r "sfE" (show skipped, failed, errors), no -r -s -f -E
         "--with-answer-testing",
         "-m answer_test",
         f"-n {int(os.environ.get('NUM_WORKERS', 1))}",

--- a/tests/report_failed_answers.py
+++ b/tests/report_failed_answers.py
@@ -63,7 +63,7 @@ def generate_failed_answers_html(failed_answers):
       the answer tests.
     </p>
     <p>
-      <strong>Acutal Image:</strong> plot generated while running the test<br/>
+      <strong>Actual Image:</strong> plot generated while running the test<br/>
       <strong>Expected Image:</strong> golden answer image<br/>
       <strong>Difference Image:</strong> difference in the "actual"
       and "expected" image

--- a/yt/_maintenance/deprecation.py
+++ b/yt/_maintenance/deprecation.py
@@ -28,7 +28,7 @@ def issue_deprecation_warning(msg, *, removal, since=None, stacklevel=3):
     beware that `removal` is required (it doesn't have a default value). This is
     vital since deprecated code is typically untested and not specifying a required
     keyword argument will turn the warning into a TypeError.
-    What it gets us however is that the release manager will know for a fact wether it
+    What it gets us however is that the release manager will know for a fact whether it
     is safe to remove a feature at any given point, and users have a better idea when
     their code will become incompatible.
 

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -1797,7 +1797,7 @@ class YTSurface(YTSelectionContainer3D):
 
         filename : string
             The file this will be exported to.  This cannot be a file-like
-            object. If there are no file extentions included - both obj & mtl
+            object. If there are no file extensions included - both obj & mtl
             files are created.
         transparency : float
             This gives the transparency of the output surface plot.  Values
@@ -1946,7 +1946,7 @@ class YTSurface(YTSelectionContainer3D):
             cs = (cs - mi) / (ma - mi)
         else:
             cs[:] = 1.0
-        # to get color indicies for OBJ formatting
+        # to get color indices for OBJ formatting
         from yt.visualization._colormap_data import color_map_luts
 
         lut = color_map_luts[color_map]
@@ -2602,7 +2602,7 @@ class YTSurface(YTSelectionContainer3D):
         try:
             r = requests.post(SKETCHFAB_API_URL, data=data, files=files, verify=False)
         except requests.exceptions.RequestException:
-            mylog.exception("An error has occured")
+            mylog.exception("An error has occurred")
             return
 
         result = r.json()

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -858,7 +858,7 @@ class ParticleProfile(Profile2D):
     weight_field : string field name
         The field to use for weighting. Default is None.
     deposition : string, optional
-        The interpolation kernal to be used for
+        The interpolation kernel to be used for
         deposition. Valid choices:
         "ngp" : nearest grid point interpolation
         "cic" : cloud-in-cell interpolation

--- a/yt/data_objects/selection_objects/spheroids.py
+++ b/yt/data_objects/selection_objects/spheroids.py
@@ -139,7 +139,7 @@ class YTEllipsoid(YTSelectionContainer3D):
     e0 : array_like (automatically normalized)
         the direction of the largest semi-major axis of the ellipsoid
     tilt : float
-        After the rotation about the z-axis to allign e0 to x in the x-y
+        After the rotation about the z-axis to align e0 to x in the x-y
         plane, and then rotating about the y-axis to align e0 completely
         to the x-axis, tilt is the angle in radians remaining to
         rotate about the x-axis to align both e1 to the y-axis and e2 to

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -264,7 +264,7 @@ class Dataset(abc.ABC):
     def periodicity(self, val):
         # remove this setter to break backward compatibility
         issue_deprecation_warning(
-            "Dataset.periodicity should not be overriden manually. "
+            "Dataset.periodicity should not be overridden manually. "
             "In the future, this will become an error. "
             "Use `Dataset.force_periodicity` instead.",
             since="4.0.0",
@@ -731,7 +731,7 @@ class Dataset(abc.ABC):
     def add_particle_filter(self, filter):
         """Add particle filter to the dataset.
 
-        Add ``filter`` to the dataset and set up relavent derived_field.
+        Add ``filter`` to the dataset and set up relevant derived_field.
         It will also add any ``filtered_type`` that the ``filter`` depends on.
 
         """
@@ -1338,7 +1338,7 @@ class Dataset(abc.ABC):
             except KeyError:
                 continue
 
-            # Now attempt to instanciate a unyt.unyt_quantity from val ...
+            # Now attempt to instantiate a unyt.unyt_quantity from val ...
             try:
                 # ... directly (valid if val is a number, or a unyt_quantity)
                 uo[key] = YTQuantity(val)

--- a/yt/fields/species_fields.py
+++ b/yt/fields/species_fields.py
@@ -263,7 +263,7 @@ def _default_nuclei_density(field, data):
     element = field.name[1][: field.name[1].find("_")]
     amu_cgs = data.ds.units.physical_constants.amu_cgs
     if element == "El":
-        # This is for determing the electron number density.
+        # This is for determining the electron number density.
         # If we got here, this assumes full ionization!
         muinv = 1.0 * _primordial_mass_fraction["H"] / ChemicalFormula("H").weight
         muinv += 2.0 * _primordial_mass_fraction["He"] / ChemicalFormula("He").weight

--- a/yt/frontends/_skeleton/data_structures.py
+++ b/yt/frontends/_skeleton/data_structures.py
@@ -145,7 +145,7 @@ class SkeletonDataset(Dataset):
         #   self.omega_matter               <= float
         #   self.hubble_constant            <= float
 
-        # optional (the followin have default implementations)
+        # optional (the following have default implementations)
         #   self.unique_identifier      <= unique identifier for the dataset
         #                                  being read (e.g., UUID or ST_CTIME) (int)
         #

--- a/yt/frontends/adaptahop/tests/test_outputs.py
+++ b/yt/frontends/adaptahop/tests/test_outputs.py
@@ -56,7 +56,7 @@ def test_get_halo():
 
     halo = ds.halo(1, ptype="io")
 
-    # Check halo objet has position, velocity, mass and members attributes
+    # Check halo object has position, velocity, mass and members attributes
     for attr_name in ("mass", "position", "velocity", "member_ids"):
         getattr(halo, attr_name)
 

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -146,7 +146,7 @@ class AMRVACDataset(Dataset):
         parfiles=None,
         default_species_fields=None,
     ):
-        """Instanciate AMRVACDataset.
+        """Instantiate AMRVACDataset.
 
         Parameters
         ----------
@@ -157,7 +157,7 @@ class AMRVACDataset(Dataset):
             This should always be 'amrvac'.
 
         units_override : dict, optional
-            A dictionnary of physical normalisation factors to interpret on disk data.
+            A dictionary of physical normalisation factors to interpret on disk data.
 
         unit_system : str, optional
             Either "cgs" (default), "mks" or "code"

--- a/yt/frontends/art/io.py
+++ b/yt/frontends/art/io.py
@@ -533,7 +533,7 @@ def _read_child_level(
         # idc = np.argsort(arr['idc']) #correct fortran indices
         # translate idc into icell, and then to iOct
         icell = (arr["idc"] >> 3) << 3
-        iocts = (icell - ncell0) / nchild  # without a F correction, theres a +1
+        iocts = (icell - ncell0) / nchild  # without a F correction, there's a +1
         # assert that the children are read in the same order as the octs
         assert np.all(octs == iocts[::nchild])
     else:

--- a/yt/frontends/art/tests/test_outputs.py
+++ b/yt/frontends/art/tests/test_outputs.py
@@ -57,7 +57,7 @@ def test_d9p_global_values():
     assert_equal(ad[("stars", "particle_type")].size, AnaNStars)
     assert_equal(ad[("specie4", "particle_type")].size, AnaNStars)
 
-    # The *real* asnwer is 2833405, but yt misses one particle since it lives
+    # The *real* answer is 2833405, but yt misses one particle since it lives
     # on a domain boundary. See issue 814. When that is fixed, this test
     # will need to be updated
     AnaNDM = 2833404

--- a/yt/frontends/chombo/data_structures.py
+++ b/yt/frontends/chombo/data_structures.py
@@ -149,7 +149,7 @@ class ChomboHierarchy(GridIndex):
             elif "boxes" in d:
                 self.num_grids += d["boxes"].len()
             else:
-                raise RuntimeError("Uknown file specification")
+                raise RuntimeError("Unknown file specification")
 
     def _parse_index(self):
         f = self._handle  # shortcut

--- a/yt/frontends/enzo_e/misc.py
+++ b/yt/frontends/enzo_e/misc.py
@@ -7,7 +7,7 @@ def bdecode(block):
     Decode a block descriptor to get its left and right sides and level.
 
     A block string consisting of (0, 1), with optionally one colon. The
-    number of digits after the colon is the refinemenet level. The combined
+    number of digits after the colon is the refinement level. The combined
     digits denote the binary representation of the left edge.
     """
 

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -87,7 +87,7 @@ class GadgetBinaryHeader:
         # Read the first 4 bytes assuming little endian int32
         with self.open() as f:
             (rhead,) = struct.unpack("<I", f.read(4))
-        # Foramt 1?
+        # Format 1?
         if rhead == first_header_size:
             return 1, "<"
         elif rhead == _byte_swap_32(first_header_size):
@@ -267,7 +267,7 @@ class GadgetDataset(SPHDataset):
                 "Make sure a non-standard header is actually expected. "
                 "Otherwise something is wrong, "
                 "and you might want to check how the dataset is loaded. "
-                "Futher information about header specification can be found in "
+                "Further information about header specification can be found in "
                 "https://yt-project.org/docs/dev/examining/loading_data.html#header-specification.",
                 header_size,
             )

--- a/yt/frontends/gadget_fof/data_structures.py
+++ b/yt/frontends/gadget_fof/data_structures.py
@@ -484,7 +484,7 @@ class GadgetFOFHaloDataset(ParticleDataset):
 
     @classmethod
     def _is_valid(cls, *args, **kwargs):
-        # This class is not meant to be instanciated by yt.load()
+        # This class is not meant to be instantiated by yt.load()
         return False
 
 

--- a/yt/frontends/nc4_cm1/data_structures.py
+++ b/yt/frontends/nc4_cm1/data_structures.py
@@ -126,9 +126,9 @@ class CM1Dataset(Dataset):
             # _handle here is a netcdf Dataset object, we need to parse some metadata
             # for constructing our yt ds.
 
-            # TO DO: generalize this to be coordiante variable name agnostic in order to
+            # TO DO: generalize this to be coordinate variable name agnostic in order to
             # make useful for WRF or climate data. For now, we're hard coding for CM1
-            # specifically and have named the classes appropriately. Additionaly, we
+            # specifically and have named the classes appropriately. Additionally, we
             # are only handling the cell-centered grid ("xh","yh","zh") at present.
             # The cell-centered grid contains scalar fields and interpolated velocities.
             dims = [_handle.dimensions[i].size for i in ["xh", "yh", "zh"]]

--- a/yt/frontends/nc4_cm1/tests/test_outputs.py
+++ b/yt/frontends/nc4_cm1/tests/test_outputs.py
@@ -52,7 +52,7 @@ def test_dims_and_meta():
     dims = ds.parameters["dimensions"]
 
     ## check the file for 2 grids and a time dimension -
-    ## (time, xf, xh, yf, yh, zf, zh). The dimesions ending in
+    ## (time, xf, xh, yf, yh, zf, zh). The dimensions ending in
     ## f are the staggered velocity grid components and the
     ## dimensions ending in h are the scalar grid components
     assert_equal(len(dims), len(known_dims))

--- a/yt/frontends/owls/fields.py
+++ b/yt/frontends/owls/fields.py
@@ -328,7 +328,7 @@ class OWLSFieldInfo(SPHFieldInfo):
         # ----------------------------------------------
         tdir = ytcfg.get("yt", "test_data_dir")
 
-        # set download destination to tdir or ./ if tdir isnt defined
+        # set download destination to tdir or ./ if tdir isn't defined
         # ----------------------------------------------
         if tdir == "/does/not/exist":
             data_dir = "./"

--- a/yt/frontends/ramses/field_handlers.py
+++ b/yt/frontends/ramses/field_handlers.py
@@ -31,9 +31,9 @@ class HandlerMixin:
 
     def setup_handler(self, domain):
         """
-        Initalize an instance of the class. This automatically sets
+        Initialize an instance of the class. This automatically sets
         the full path to the file. This is not intended to be
-        overriden in most cases.
+        overridden in most cases.
 
         If you need more flexibility, rewrite this function to your
         need in the inherited class.

--- a/yt/frontends/ramses/io.py
+++ b/yt/frontends/ramses/io.py
@@ -176,7 +176,7 @@ class IOHandlerRAMSES(BaseIOHandler):
         # Sequential read depending on particle type
         for ptype in {f[0] for f in fields}:
 
-            # Select relevant fiels
+            # Select relevant files
             subs_fields = filter(lambda f: f[0] == ptype, fields)
 
             ok = False

--- a/yt/frontends/ramses/io_utils.pyx
+++ b/yt/frontends/ramses/io_utils.pyx
@@ -174,7 +174,7 @@ def fill_hydro(FortranFile f,
                 continue
             f.seek(offset)
             tmp = {}
-            # Initalize temporary data container for io
+            # Initialize temporary data container for io
             # note: we use Fortran ordering to reflect the in-file ordering
             for field in all_fields:
                 tmp[field] = np.empty((nc, twotondim), dtype="float64", order='F')

--- a/yt/frontends/swift/data_structures.py
+++ b/yt/frontends/swift/data_structures.py
@@ -48,7 +48,7 @@ class SwiftDataset(SPHDataset):
 
         Currently sets length, mass, time, and temperature.
 
-        SWIFT uses comoving co-ordinates without the usual h-factors.
+        SWIFT uses comoving coordinates without the usual h-factors.
         """
         units = self._get_info_attributes("Units")
 

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -878,7 +878,7 @@ def enable_plugins(plugin_filename=None):
     in yt scripts without modifying the yt source directly.
 
     If ``plugin_filename`` is omitted, this function will look for a plugin file at
-    ``$HOME/.config/yt/my_plugins.py``, which is the prefered behaviour for a
+    ``$HOME/.config/yt/my_plugins.py``, which is the preferred behaviour for a
     system-level configuration.
 
     Warning: a script using this function will only be reproducible if your plugin

--- a/yt/geometry/_selection_routines/selector_object.pxi
+++ b/yt/geometry/_selection_routines/selector_object.pxi
@@ -594,7 +594,7 @@ cdef class SelectorObject:
         return state_tuple
 
     def __getnewargs__(self):
-        # __setstate__ will always call __cinit__, this pickle hoook returns arguments
+        # __setstate__ will always call __cinit__, this pickle hook returns arguments
         # to __cinit__. We will give it None so we dont error then set attributes in
         # __setstate__ Note that we could avoid this by making dobj an optional argument
         # to __cinit__

--- a/yt/geometry/_selection_routines/sphere_selector.pxi
+++ b/yt/geometry/_selection_routines/sphere_selector.pxi
@@ -35,7 +35,7 @@ cdef class SphereSelector(SelectorObject):
             pos[2] - 0.5*dds[2] <= self.center[2] <= pos[2]+0.5*dds[2]):
             return 1
         return self.select_point(pos)
-        # # langmm: added to allow sphere to interesect edge/corner of cell
+        # # langmm: added to allow sphere to intersect edge/corner of cell
         # cdef np.float64_t LE[3]
         # cdef np.float64_t RE[3]
         # cdef int i

--- a/yt/geometry/oct_visitors.pyx
+++ b/yt/geometry/oct_visitors.pyx
@@ -136,7 +136,7 @@ cdef class IndexOcts(OctVisitor):
             self.oct_index[o.domain_ind] = self.index
             self.index += 1
 
-# Compute a mapping from domain_ind to flattend index with some octs masked.
+# Compute a mapping from domain_ind to flattened index with some octs masked.
 cdef class MaskedIndexOcts(OctVisitor):
     @cython.boundscheck(False)
     @cython.initializedcheck(False)

--- a/yt/geometry/particle_geometry_handler.py
+++ b/yt/geometry/particle_geometry_handler.py
@@ -145,7 +145,7 @@ class ParticleIndex(Index):
             dont_cache = False
 
         # If we have applied a bounding box then we can't cache the
-        # ParticleBitmap because it is doman dependent
+        # ParticleBitmap because it is domain dependent
         if getattr(ds, "_domain_override", False):
             dont_cache = True
 

--- a/yt/geometry/particle_oct_container.pyx
+++ b/yt/geometry/particle_oct_container.pyx
@@ -70,7 +70,7 @@ from ..utilities.lib.ewah_bool_wrap cimport BoolArrayCollection
 import os
 import struct
 
-# If set to 1, ghost cells are added at the refined level reguardless of if the
+# If set to 1, ghost cells are added at the refined level regardless of if the
 # coarse cell containing it is refined in the selector.
 # If set to 0, ghost cells are only added at the refined level of the coarse
 # index for the ghost cell is refined in the selector.
@@ -92,7 +92,7 @@ cdef class ParticleOctreeContainer(OctreeContainer):
     #The starting oct index of each domain
     cdef np.int64_t *dom_offsets
     cdef public int max_level
-    #How many particles do we keep befor refining
+    #How many particles do we keep before refining
     cdef public int n_ref
 
     def allocate_root(self):
@@ -2171,7 +2171,7 @@ cdef class ParticleBitmapOctreeContainer(SparseOctreeContainer):
         cdef np.int64_t index_root = 0
         cdef int root_count
         beg = end = 0
-        self._octs_per_root[:] = 1 # Roots count reguardless
+        self._octs_per_root[:] = 1 # Roots count regardless
         while end < no:
             # Determine number of octs with this prefix
             beg = end

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -936,7 +936,7 @@ def load_octree(
         of size n_octs * 8 (but see note about the root oct below), where
         each item is 1 for an oct-cell being refined and 0 for it not being
         refined.  For over_refine_factors != 1, the children count will
-        still be 8, so there will stil be n_octs * 8 entries. Note that if
+        still be 8, so there will still be n_octs * 8 entries. Note that if
         the root oct is not refined, there will be only one entry
         for the root, so the size of the mask will be (n_octs - 1)*8 + 1.
     data : dict
@@ -1442,7 +1442,7 @@ def load_sample(
 
     # pooch has functionalities to unpack downloaded archive files,
     # but it needs to be told in advance that we are downloading a tarball.
-    # Since that information is not necessarily trival to guess from the filename,
+    # Since that information is not necessarily trivial to guess from the filename,
     # we rely on the standard library to perform a conditional unpacking instead.
     if tarfile.is_tarfile(tmp_file):
         mylog.info("Untaring downloaded file to '%s'", save_dir)

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -218,7 +218,7 @@ class AnswerTestCloudStorage(AnswerTestStorage):
                 except Exception:
                     time.sleep(0.01)
                 else:
-                    # We were succesful
+                    # We were successful
                     break
             else:
                 # Raise error if all tries were unsuccessful

--- a/yt/utilities/answer_testing/testing_utilities.py
+++ b/yt/utilities/answer_testing/testing_utilities.py
@@ -154,7 +154,7 @@ def _hash_dict(data):
             hashed_data = _hash_dict(value)
         else:
             hashed_data = bytearray(key.encode("utf8")) + bytearray(value)
-        # If we're returning from a recusive call (and therefore hashed_data
+        # If we're returning from a recursive call (and therefore hashed_data
         # is a hex digest), we need to encode the string before it can be
         # hashed
         if isinstance(hashed_data, str):

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -1066,7 +1066,7 @@ class YTNotebookCmd(YTCommand):
             action="store",
             default=None,
             dest="profile",
-            help="The IPython profile to use when lauching the kernel.",
+            help="The IPython profile to use when launching the kernel.",
         ),
         dict(
             short="-n",

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -296,7 +296,7 @@ class YTFieldUnitError(YTException):
 
 class YTFieldUnitParseError(YTException):
     def __init__(self, field_info):
-        self.msg = "The field '%s' has unparseable units '%s'."
+        self.msg = "The field '%s' has unparsable units '%s'."
         self.msg = self.msg % (field_info.name, field_info.units)
 
     def __str__(self):

--- a/yt/utilities/fortran_utils.py
+++ b/yt/utilities/fortran_utils.py
@@ -60,7 +60,7 @@ def read_attrs(f, attrs, endian="="):
         if s1 != s2:
             size = struct.calcsize(endian + "I" + "".join(n * [t]) + "I")
             raise OSError(
-                "An error occured while reading a Fortran record. "
+                "An error occurred while reading a Fortran record. "
                 "Got a different size at the beginning and at the "
                 "end of the record: %s %s",
                 s1,
@@ -71,7 +71,7 @@ def read_attrs(f, attrs, endian="="):
         if isinstance(a, tuple):
             if len(a) != len(v):
                 raise OSError(
-                    "An error occured while reading a Fortran "
+                    "An error occurred while reading a Fortran "
                     "record. Record length is not equal to expected "
                     "length: %s %s",
                     len(a),
@@ -138,7 +138,7 @@ def read_cattrs(f, attrs, endian="="):
         if isinstance(a, tuple):
             if len(a) != len(v):
                 raise OSError(
-                    "An error occured while reading a Fortran "
+                    "An error occurred while reading a Fortran "
                     "record. Record length is not equal to expected "
                     "length: %s %s",
                     len(a),
@@ -183,7 +183,7 @@ def read_vector(f, d, endian="="):
     vec_size = struct.calcsize(vec_fmt)
     if vec_len % vec_size != 0:
         raise OSError(
-            "An error occured while reading a Fortran record. "
+            "An error occurred while reading a Fortran record. "
             "Vector length is not compatible with data type: %s %s",
             vec_len,
             vec_size,
@@ -196,7 +196,7 @@ def read_vector(f, d, endian="="):
     vec_len2 = struct.unpack(pad_fmt, f.read(pad_size))[0]
     if vec_len != vec_len2:
         raise OSError(
-            "An error occured while reading a Fortran record. "
+            "An error occurred while reading a Fortran record. "
             "Got a different size at the beginning and at the "
             "end of the record: %s %s",
             vec_len,
@@ -239,7 +239,7 @@ def skip(f, n=1, endian="="):
         s2 = struct.unpack(fmt, size)[0]
         if s1 != s2:
             raise OSError(
-                "An error occured while reading a Fortran record. "
+                "An error occurred while reading a Fortran record. "
                 "Got a different size at the beginning and at the "
                 "end of the record: %s %s",
                 s1,
@@ -314,7 +314,7 @@ def read_record(f, rspec, endian="="):
     s1, s2 = vals.pop(0), vals.pop(-1)
     if s1 != s2:
         raise OSError(
-            "An error occured while reading a Fortran record. Got "
+            "An error occurred while reading a Fortran record. Got "
             "a different size at the beginning and at the end of "
             "the record: %s %s",
             s1,

--- a/yt/utilities/grid_data_format/docs/gdf_specification.txt
+++ b/yt/utilities/grid_data_format/docs/gdf_specification.txt
@@ -271,7 +271,7 @@ yt will also provide a writer for this data, which will operate on any existing
 data format.  Provided that a simulation code can read this data, this will
 enable cross-platform comparison.  Furthermore, any external piece of software
 (i.e., Stranger) that implements reading this format will be able to read any
-format of data tha yt understands.
+format of data that yt understands.
 
 Example File
 ------------

--- a/yt/utilities/lib/cykdtree/c_kdtree.hpp
+++ b/yt/utilities/lib/cykdtree/c_kdtree.hpp
@@ -67,7 +67,7 @@ public:
     less = NULL;
     greater = NULL;
   }
-  // emtpy node with some info
+  // empty node with some info
   Node(uint32_t ndim0, double *le, double *re, bool *ple, bool *pre) {
     is_empty = true;
     is_leaf = false;
@@ -153,7 +153,7 @@ public:
     }
   }
   Node(std::istream &is) {
-    // Note that Node instances intialized via this method do not have
+    // Note that Node instances initialized via this method do not have
     // any neighbor information. We will build neighbor information later
     // by walking the tree
     bool check_bit = deserialize_scalar<bool>(is);

--- a/yt/utilities/lib/cykdtree/kdtree.pyx
+++ b/yt/utilities/lib/cykdtree/kdtree.pyx
@@ -60,7 +60,7 @@ cdef class PyNode:
                                        range(node.right_neighbors[i].size())]
 
     def __cinit__(self):
-        # Initialize everthing to NULL/0/None to prevent seg fault
+        # Initialize everything to NULL/0/None to prevent seg fault
         self._node = NULL
         self.id = 0
         self.npts = 0
@@ -169,7 +169,7 @@ cdef class PyKDTree:
             Defaults to False.
 
     Raises:
-        ValueError: If `leafsize < 2`. This currectly segfaults.
+        ValueError: If `leafsize < 2`. This currently segfaults.
 
     Attributes:
         npts (uint64): Number of points in the tree.
@@ -201,7 +201,7 @@ cdef class PyKDTree:
             self._idx[i] = tree.all_idx[i]
 
     def __cinit__(self):
-        # Initialize everthing to NULL/0/None to prevent seg fault
+        # Initialize everything to NULL/0/None to prevent seg fault
         self._tree = NULL
         self.npts = 0
         self.ndim = 0
@@ -286,7 +286,7 @@ cdef class PyKDTree:
                 can be in any order. Defaults to True.
 
         Raises:
-            AssertionError: If there are missmatches between any of the two
+            AssertionError: If there are mismatches between any of the two
                 trees' parameters.
 
         """
@@ -388,7 +388,7 @@ cdef class PyKDTree:
             np.ndarray of uint32: Leaves containing/neighboring `pos`.
 
         Raises:
-            ValueError: If pos is not contained withing the KDTree.
+            ValueError: If pos is not contained within the KDTree.
 
         """
         return self._get_neighbor_ids(pos)
@@ -419,7 +419,7 @@ cdef class PyKDTree:
             :class:`cykdtree.PyNode`: Leaf containing `pos`.
 
         Raises:
-            ValueError: If pos is not contained withing the KDTree.
+            ValueError: If pos is not contained within the KDTree.
 
         """
         return self._get(pos)

--- a/yt/utilities/lib/cykdtree/tests/__init__.py
+++ b/yt/utilities/lib/cykdtree/tests/__init__.py
@@ -198,7 +198,7 @@ def run_test(
     suppress_final_output=False,
     **kwargs,
 ):
-    r"""Run a rountine with a designated number of points & dimensions on a
+    r"""Run a routine with a designated number of points & dimensions on a
     selected number of processors.
 
     Args:

--- a/yt/utilities/lib/cykdtree/tests/scaling.py
+++ b/yt/utilities/lib/cykdtree/tests/scaling.py
@@ -60,7 +60,7 @@ def stats_run(
 def time_run(
     npart, nproc, ndim, nrep=1, periodic=False, leafsize=10, suppress_final_output=False
 ):
-    r"""Get runing times using :package:`time`.
+    r"""Get running times using :package:`time`.
 
     Args:
         npart (int): Number of particles.

--- a/yt/utilities/lib/cykdtree/utils.pyx
+++ b/yt/utilities/lib/cykdtree/utils.pyx
@@ -269,7 +269,7 @@ def py_partition_given_pivot(np.ndarray[np.float64_t, ndim=2] pos,
 
 def py_select(np.ndarray[np.float64_t, ndim=2] pos, np.uint32_t d,
               np.int64_t t):
-    r"""Get the indices required to partition coordiantes such that the first
+    r"""Get the indices required to partition coordinates such that the first
     t elements in pos[:,d] are the smallest t elements in pos[:,d].
 
     Args:

--- a/yt/utilities/lib/ewah_bool_wrap.pyx
+++ b/yt/utilities/lib/ewah_bool_wrap.pyx
@@ -548,7 +548,7 @@ cdef class FileBitmasks:
         cdef ewahmap_it it_map
         cdef np.uint64_t nrefn, mi1
         cdef ewah_bool_array mi1_ewah
-        # Write mi1 ewah & refinment ewah
+        # Write mi1 ewah & refinement ewah
         ewah_keys[0].write(ss,1)
         ewah_refn[0].write(ss,1)
         # Number of refined bool arrays
@@ -575,7 +575,7 @@ cdef class FileBitmasks:
         nrefn = mi1 = 0
         # Write string to string stream
         ss.write(s, len(s))
-        # Read keys and refinment arrays
+        # Read keys and refinement arrays
         ewah_keys[0].read(ss,1)
         ewah_refn[0].read(ss,1)
         # Read and check number of refined cells
@@ -1197,7 +1197,7 @@ cdef class BoolArrayCollection:
         cdef ewahmap_it it_map
         cdef np.uint64_t nrefn, mi1
         cdef ewah_bool_array mi1_ewah
-        # Write mi1 ewah & refinment ewah
+        # Write mi1 ewah & refinement ewah
         ewah_keys[0].write(ss,1)
         ewah_refn[0].write(ss,1)
         # Number of refined bool arrays
@@ -1227,7 +1227,7 @@ cdef class BoolArrayCollection:
         nrefn = mi1 = 0
         # Write string to string stream
         ss.write(s, len(s))
-        # Read keys and refinment arrays
+        # Read keys and refinement arrays
         ewah_keys[0].read(ss,1)
         ewah_refn[0].read(ss,1)
         # Read and check number of refined cells

--- a/yt/utilities/lib/ewahboolarray/ewah.h
+++ b/yt/utilities/lib/ewahboolarray/ewah.h
@@ -444,7 +444,7 @@ public:
 
   /**
    * Save this bitmap to a stream. The file format is
-   * | sizeinbits | buffer lenth | buffer content|
+   * | sizeinbits | buffer length | buffer content|
    * the sizeinbits part can be omitted if "savesizeinbits=false".
    * Both sizeinbits and buffer length are saved using the size_t data
    * type which is typically a 32-bit unsigned integer for 32-bit CPUs
@@ -480,7 +480,7 @@ public:
   /**
    * this is the counterpart to the write method.
    * if you set savesizeinbits=false, then you are responsible
-   * for setting the value fo the attribute sizeinbits (see method
+   * for setting the value of the attribute sizeinbits (see method
    * setSizeInBits).
    *
    * Returns how many bytes were queried from the stream.
@@ -694,7 +694,7 @@ public:
    */
   inline void fastaddStreamOfEmptyWords(const bool v, size_t number);
   /**
-   * LikeaddStreamOfDirtyWords but does not return the cost increse,
+   * LikeaddStreamOfDirtyWords but does not return the cost increase,
    * does not update sizeinbits.
    */
   inline void fastaddStreamOfDirtyWords(const uword *v, const size_t number);

--- a/yt/utilities/lib/geometry_utils.pxd
+++ b/yt/utilities/lib/geometry_utils.pxd
@@ -284,7 +284,7 @@ cdef inline np.uint64_t bounded_morton_relative(np.float64_t x, np.float64_t y, 
     return mi2
 
 
-# This dosn't seem to be much, if at all, faster...
+# This doesn't seem to be much, if at all, faster...
 @cython.cdivision(True)
 cdef inline np.uint64_t bounded_morton_dds(np.float64_t x, np.float64_t y, np.float64_t z,
                                np.float64_t *DLE, np.float64_t *dds):

--- a/yt/utilities/lib/geometry_utils.pyx
+++ b/yt/utilities/lib/geometry_utils.pyx
@@ -820,7 +820,7 @@ def morton_qsort_iterative(np.ndarray[floating, ndim=2] pos,
                            np.ndarray[np.uint64_t, ndim=1] ind,
                            use_loop = False):
     # http://www.geeksforgeeks.org/iterative-quick-sort/
-    # Auxillary stack
+    # Auxiliary stack
     cdef np.ndarray[np.int64_t, ndim=1] stack = np.zeros(h-l+1, dtype=np.int64)
     cdef np.int64_t top = -1
     cdef np.int64_t p
@@ -1019,7 +1019,7 @@ def knn_direct(np.ndarray[np.float64_t, ndim=2] P, np.uint64_t k, np.uint64_t i,
         P (np.ndarray): (N,d) array of points to search sorted by Morton order.
         k (int): number of nearest neighbors to find.
         i (int): index of point that nearest neighbors should be found for.
-        idx (np.ndarray): indicies of points from P to be considered.
+        idx (np.ndarray): indices of points from P to be considered.
         return_dist (Optional[bool]): If True, distances to the k nearest
             neighbors are also returned (in order of proximity).
             (default = False)
@@ -1028,7 +1028,7 @@ def knn_direct(np.ndarray[np.float64_t, ndim=2] P, np.uint64_t k, np.uint64_t i,
             True. (default = False)
 
     Returns:
-        np.ndarray: Indicies of k nearest neighbors to point i.
+        np.ndarray: Indices of k nearest neighbors to point i.
 
     """
     cdef int j,m
@@ -1139,7 +1139,7 @@ def csearch_morton(np.ndarray[np.float64_t, ndim=2] P, int k, np.uint64_t i,
     if dist_to_box(cbox_sol,cbox_hl,rbox_hl) >= 1.5*rbox_sol:
         print('{} outside: rad = {}, rbox = {}, dist = {}'.format(m,rad_Ai,rbox_sol,dist_to_box(P[i,:],cbox_hl,rbox_hl)))
         return Ai
-    # Expand search to lower/higher indicies as needed
+    # Expand search to lower/higher indices as needed
     if i < m: # They are already sorted...
         Ai = csearch_morton(P,k,i,Ai,l,m-1,order,DLE,DRE,nu=nu)
         if compare_morton(P[m,:],P[i,:]+dist(P[i,:],P[Ai[k-1],:])):
@@ -1158,13 +1158,13 @@ def knn_morton(np.ndarray[np.float64_t, ndim=2] P0, int k, np.uint64_t i0,
                float c = 1.0, int nu = 4, issorted = False, int order = ORDER_MAX,
                np.ndarray[np.float64_t, ndim=1] DLE = np.zeros(3,dtype=np.float64),
                np.ndarray[np.float64_t, ndim=1] DRE = np.zeros(3,dtype=np.float64)):
-    """Get the indicies of the k nearest neighbors to point i.
+    """Get the indices of the k nearest neighbors to point i.
 
     Args:
         P (np.ndarray): (N,d) array of points to search.
         k (int): number of nearest neighbors to find for each point in P.
         i (np.uint64): index of point to find neighbors for.
-        c (float): factor determining how many indicies before/after i are used
+        c (float): factor determining how many indices before/after i are used
             in the initial search (i-c*k to i+c*k, default = 1.0)
         nu (int): minimum number of points before a direct knn search is
             performed. (default = 4)
@@ -1178,7 +1178,7 @@ def knn_morton(np.ndarray[np.float64_t, ndim=2] P0, int k, np.uint64_t i0,
             If not provided, this is determined from the points.
 
     Returns:
-        np.ndarray: (N,k) indicies of k nearest neighbors for each point in P.
+        np.ndarray: (N,k) indices of k nearest neighbors for each point in P.
 """
     cdef int j
     cdef np.uint64_t i

--- a/yt/utilities/lib/particle_kdtree_tools.pyx
+++ b/yt/utilities/lib/particle_kdtree_tools.pyx
@@ -62,7 +62,7 @@ def generate_smoothing_length(np.float64_t[:, ::1] tree_positions,
 
     tree_positions: arrays of floats with shape (n_particles, 3)
         The positions of particles in kdtree sorted order. Currently assumed
-        to be 3D postions.
+        to be 3D positions.
     kdtree: A PyKDTree instance
         A kdtree to do nearest neighbors searches with
     n_neighbors: The neighbor number to calculate the distance to
@@ -120,7 +120,7 @@ def estimate_density(np.float64_t[:, ::1] tree_positions, np.float64_t[:] mass,
 
     tree_positions: array of floats with shape (n_particles, 3)
         The positions of particles in kdtree sorted order. Currently assumed
-        to be 3D postions.
+        to be 3D positions.
     mass: array of floats with shape (n_particles)
         The masses of particles in kdtree sorted order.
     smoothing_length: array of floats with shape (n_particles)

--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -1224,7 +1224,7 @@ def interpolate_sph_grid_gather(np.float64_t[:, :, :] buff,
         int num_neigh=32):
     """
     This function takes in the bounds and number of cells in a grid (well,
-    actually we implicity calculate this from the size of buff). Then we can
+    actually we implicitly calculate this from the size of buff). Then we can
     perform nearest neighbor search and SPH interpolation at the centre of each
     cell in the grid.
     """

--- a/yt/utilities/math_utils.py
+++ b/yt/utilities/math_utils.py
@@ -883,7 +883,7 @@ def get_perspective_matrix(fovy, aspect, z_near, z_far):
     """
     Given a field of view in radians, an aspect ratio, and a near
     and far plane distance, this routine computes the transformation matrix
-    corresponding to perspective projection using homogenous coordinates.
+    corresponding to perspective projection using homogeneous coordinates.
 
     Parameters
     ----------
@@ -955,7 +955,7 @@ def get_orthographic_matrix(maxr, aspect, z_near, z_far):
     """
     Given a field of view in radians, an aspect ratio, and a near
     and far plane distance, this routine computes the transformation matrix
-    corresponding to perspective projection using homogenous coordinates.
+    corresponding to perspective projection using homogeneous coordinates.
 
     Parameters
     ----------

--- a/yt/utilities/parallel_tools/parallel_analysis_interface.py
+++ b/yt/utilities/parallel_tools/parallel_analysis_interface.py
@@ -64,7 +64,7 @@ def default_mpi_excepthook(exception_type, exception_value, tb):
     mylog.error("%s: %s", exception_type.__name__, exception_value)
     comm = yt.communication_system.communicators[-1]
     if comm.size > 1:
-        mylog.error("Error occured on rank %d.", comm.rank)
+        mylog.error("Error occurred on rank %d.", comm.rank)
     MPI.COMM_WORLD.Abort(1)
 
 

--- a/yt/utilities/sdf.py
+++ b/yt/utilities/sdf.py
@@ -777,7 +777,7 @@ class SDFIndex:
 
     def get_ibbox_slow(self, ileft, iright):
         """
-        Given left and right indicies, return a mask and
+        Given left and right indices, return a mask and
         set of offsets+lengths into the sdf data.
         """
         mask = np.zeros(self.indexdata["index"].shape, dtype="bool")
@@ -796,7 +796,7 @@ class SDFIndex:
 
     def get_ibbox(self, ileft, iright):
         """
-        Given left and right indicies, return a mask and
+        Given left and right indices, return a mask and
         set of offsets+lengths into the sdf data.
         """
         # print('Getting data from ileft to iright:',  ileft, iright)
@@ -863,7 +863,7 @@ class SDFIndex:
 
     def get_bbox(self, left, right):
         """
-        Given left and right indicies, return a mask and
+        Given left and right indices, return a mask and
         set of offsets+lengths into the sdf data.
         """
         ileft = np.floor((left - self.rmin) / self.domain_width * self.domain_dims)

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -238,7 +238,7 @@ class ImagePlotMPL(PlotMPL):
 
         if self._transform is None:
             # sets the transform to be an ax.TransData object, where the
-            # coordiante system of the data is controlled by the xlim and ylim
+            # coordinate system of the data is controlled by the xlim and ylim
             # of the data.
             transform = self.axes.transData
         else:

--- a/yt/visualization/geo_plot_utils.py
+++ b/yt/visualization/geo_plot_utils.py
@@ -59,7 +59,7 @@ def get_mpl_transform(mpl_proj):
     ... )
 
     """
-    # first check to see if the tranform dict is empty, if it is fill it with
+    # first check to see if the transform dict is empty, if it is fill it with
     # the cartopy functions
     if not valid_transforms:
         for mpl_transform in transform_list:

--- a/yt/visualization/mapserver/html/Leaflet.Coordinates-0.1.5.src.js
+++ b/yt/visualization/mapserver/html/Leaflet.Coordinates-0.1.5.src.js
@@ -74,7 +74,7 @@ L.Control.Coordinates = L.Control.extend({
 		map.whenReady(this._update, this);
 
 		this._showsCoordinates = true;
-		//wether or not to show inputs on click
+		//whether or not to show inputs on click
 		if (options.enableUserInput) {
 			L.DomEvent.addListener(this._container, "click", this._switchUI, this);
 		}

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -303,7 +303,7 @@ class PlotContainer:
         log.  Symlog can also work with negative values in log space as well as
         negative and positive values simultaneously and symmetrically.  If symlog
         scaling is desired, please set log=True and either set symlog_auto=True or
-        select a alue for linthresh.
+        select a value for linthresh.
 
         Parameters
         ----------

--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -284,7 +284,7 @@ class Scene:
             If specified, save the rendering as to the file "fname".
             If unspecified, it creates a default based on the dataset filename.
             The file format is inferred from the filename's suffix. Supported
-            fomats are png, pdf, eps, and ps.
+            formats are png, pdf, eps, and ps.
             Default: None
         sigma_clip: float, optional
             Image values greater than this number times the standard deviation

--- a/yt/visualization/volume_rendering/transfer_functions.py
+++ b/yt/visualization/volume_rendering/transfer_functions.py
@@ -409,7 +409,7 @@ class ColorTransferFunction(MultiVariateTransferFunction):
     def add_gaussian(self, location, width, height):
         r"""Add a Gaussian distribution to the transfer function.
 
-        Typically, when rendering isocontours, a Guassian distribution is the
+        Typically, when rendering isocontours, a Gaussian distribution is the
         easiest way to draw out features.  The spread provides a softness.
         The values are calculated as :math:`f(x) = h \exp{-(x-x_0)^2 / w}`.
 


### PR DESCRIPTION
Found via `codespell -q 3 -S ./answer-store,./CREDITS -L alow,ans,ba,childs,dout,emiss,fof,hist,nax,nd,pres,solf,upto`