### PR TITLE
DEPR: deprecate iyt

### DIFF
--- a/doc/cheatsheet.tex
+++ b/doc/cheatsheet.tex
@@ -116,7 +116,6 @@ Commands can be followed by
 {\bf {-}{-}help} (e.g. {\bf yt render {-}{-}help}) for detailed help for that command
 including a list of the available flags.
 
-\texttt{iyt}\textemdash\ Load yt and IPython. \\
 \texttt{yt load} \textit{dataset}   \textemdash\ Load a single dataset.  \\
 \texttt{yt help} \textemdash\ Print yt help information. \\
 \texttt{yt stats} \textit{dataset} \textemdash\ Print stats of a dataset. \\
@@ -182,7 +181,7 @@ that are \textit{True}. In the above example \texttt{b} would be all elements of
 \subsection{IPython Tips}
 \settowidth{\MyLen}{\texttt{multicol} }
 These tips work if IPython has been loaded, typically either by invoking
-\texttt{iyt} or \texttt{yt load} on the command line, or using the IPython notebook (\texttt{yt notebook}).
+\texttt{yt load} on the command line, or using the IPython notebook (\texttt{yt notebook}).
 \texttt{Tab complete} \textemdash\ IPython will attempt to auto-complete a
 variable or function name when the \texttt{Tab} key is pressed, e.g. \textit{HaloFi}\textendash\texttt{Tab} would auto-complete
 to \textit{HaloFinder}. This also works with imports, e.g. \textit{from numpy.random.}\textendash\texttt{Tab}

--- a/doc/source/reference/command-line.rst
+++ b/doc/source/reference/command-line.rst
@@ -8,6 +8,10 @@ Command-Line Usage
 Interactive Prompt
 ~~~~~~~~~~~~~~~~~~
 
+.. warning::
+
+   This section describes a script targeted for removal in yt 4.2.0
+
 The interactive prompt offers a number of excellent opportunities for
 exploration of data.  While there are challenges for repeatability, and some
 operations will be more challenging to operate in parallel, interactive prompts
@@ -137,11 +141,6 @@ instinfo and version
 This gives information about where your yt installation is, what version
 and changeset you're using and more.
 
-load
-++++
-
-This will start the iyt interactive environment with your specified
-dataset already loaded. See :ref:`interactive-prompt` for more details.
 
 mapserver
 +++++++++

--- a/doc/source/reference/configuration.rst
+++ b/doc/source/reference/configuration.rst
@@ -207,8 +207,8 @@ by defining ``plugin_filename`` in your ``yt.toml`` file, as mentioned above.
 .. note::
 
    You can tell that your system plugin file is being parsed by watching for a logging
-   message when you import yt. Note that both the ``yt load`` and ``iyt``
-   command line entry points parse the plugin file.
+   message when you import yt. Note that the ``yt load`` command line entry point parses
+   the plugin file.
 
 
 Local project plugin file

--- a/scripts/iyt
+++ b/scripts/iyt
@@ -8,7 +8,12 @@ from IPython.terminal.interactiveshell import TerminalInteractiveShell
 
 from yt.data_objects.data_containers import YTDataContainer
 from yt.mods import *
+from yt._maintenance.deprecation import issue_deprecation_warning
 
+issue_deprecation_warning(
+    "The iyt script is no longer maintained and targeted for removal.",
+    since="4.1.0", removal="4.2.0",
+)
 namespace = locals().copy()
 namespace.pop("__builtins__", None)
 


### PR DESCRIPTION
## PR Summary

This script can essentially be emulated with
```shell
$ ipython -i "import yt"
```
It hasn't received any significant update/maintenance for 13yrs, and doesn't have a clear added value now with a decade of improvements in IPython's autocompletion (and it's getting env better in IPython 8.0, thanks to our own @cphyc : https://github.com/ipython/ipython/pull/12395).
I think it should be removed.
