### PR TITLE
MAINT: readd firefly_api to full install target

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -158,6 +158,12 @@ def pytest_configure(config):
             ),
         )
 
+    if find_spec("firefly_api"):
+        # see https://github.com/yt-project/yt/pull/3419
+        config.addinivalue_line(
+            "filterwarnings", r"ignore::firefly_api.errors.FireflyWarning"
+        )
+
 
 def pytest_collection_modifyitems(config, items):
     r"""

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,7 @@ full =
     astropy>=4.0.1,<5.0.0
     f90nml>=1.1.2
     fastcache~=1.0.2
+    firefly_api==0.0.3
     glueviz~=0.13.3
     h5py>=3.1.0,<4.0.0
     libconf~=1.0.1


### PR DESCRIPTION
## PR Summary
fix #3415
This is a temporary yet stable solution to #3415 while firefly_api's replacement isn't as easy to install.
Thanks to @agurvich for reuploading firefly_api to PyPI, making this patch possible.

An issue I've run into while testing this locally is that the one test this enable
(namely yt/data_objects/tests/test_firefly.py) is now failing because firefly raises a warning
(treated as an error since #3380).

If the warning can be easily avoided by refactoring the test, this would be the prefered solution.
Otherwise, if we _know_ that the future replacement for firefly_api isn't going to pose a similar "complication", we could just go back to ignoring this warning as was implicitly done last time we ran this test.

Here's the exact warning I'm getting:

```
firefly_api.errors.FireflyWarning: JSONdir: /var/folders/xh/yfmp7l9n3x50ln2yvrndt7c801pbkm/T/tmpwm92eyqz/data/test -- is not a sub-directory of Firefly/static/data.
This may produce confusing or inoperable results. As such, we will create a symlink for you. You're welcome.
```
@agurvich, can you weight in on this please ?

