### PR TITLE
STY: remove meaningless NOQA statement with yesqa

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -47,8 +47,8 @@ if not on_rtd:
     extensions.append("pythonscript_sphinxext")
 
 try:
-    import nbconvert  # NOQA: F401
-    import RunNotebook  # NOQA: F401
+    import nbconvert  # noqa: F401
+    import RunNotebook  # noqa: F401
 
     if not on_rtd:
         extensions.append("RunNotebook.notebook_sphinxext")

--- a/yt/frontends/amrvac/tests/test_outputs.py
+++ b/yt/frontends/amrvac/tests/test_outputs.py
@@ -1,4 +1,4 @@
-import numpy as np  # NOQA
+import numpy as np
 
 import yt  # NOQA
 from yt.frontends.amrvac.api import AMRVACDataset, AMRVACGrid

--- a/yt/sample_data/api.py
+++ b/yt/sample_data/api.py
@@ -85,7 +85,7 @@ def get_data_registry_table():
 
     # it would be nicer to have an actual api on the yt website server,
     # but this will do for now
-    api_url = "https://raw.githubusercontent.com/yt-project/website/master/data/datafiles.json"  # noqa
+    api_url = "https://raw.githubusercontent.com/yt-project/website/master/data/datafiles.json"
 
     response = requests.get(api_url)
 

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -25,7 +25,7 @@ from yt.units.yt_array import YTArray, YTQuantity
 from numpy.testing import assert_array_equal, assert_almost_equal  # NOQA isort:skip
 from numpy.testing import assert_equal, assert_array_less  # NOQA isort:skip
 from numpy.testing import assert_string_equal  # NOQA isort:skip
-from numpy.testing import assert_array_almost_equal_nulp  # NOQA isort:skip
+from numpy.testing import assert_array_almost_equal_nulp  # isort:skip
 from numpy.testing import assert_allclose, assert_raises  # NOQA isort:skip
 from numpy.testing import assert_approx_equal  # NOQA isort:skip
 from numpy.testing import assert_array_almost_equal  # NOQA isort:skip

--- a/yt/utilities/grid_data_format/conversion/conversion_athena.py
+++ b/yt/utilities/grid_data_format/conversion/conversion_athena.py
@@ -284,7 +284,7 @@ class AthenaDistributedConverter(Converter):
                     self.write_gdf_field(gdf_name, i, field + "_z", data_z)
                     del data, data_x, data_y, data_z
                 del line
-                line = f.readline()  # NOQA
+                line = f.readline()
             f.close()
             del f
 

--- a/yt/utilities/logger.py
+++ b/yt/utilities/logger.py
@@ -72,7 +72,7 @@ class DuplicateFilter(logging.Filter):
     """A filter that removes duplicated successive log entries."""
 
     # source
-    # https://stackoverflow.com/questions/44691558/suppress-multiple-messages-with-same-content-in-python-logging-module-aka-log-co  # noqa
+    # https://stackoverflow.com/questions/44691558/suppress-multiple-messages-with-same-content-in-python-logging-module-aka-log-co
     def filter(self, record):
         current_log = (record.module, record.levelno, record.msg, record.args)
         if current_log != getattr(self, "last_log", None):

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -22,7 +22,7 @@ from yt.utilities.exceptions import YTNotInsideNotebook
 from ._commons import validate_image_name
 
 try:
-    import cmocean  # noqa
+    import cmocean
 except ImportError:
     cmocean = None
 


### PR DESCRIPTION
## PR Summary

Prune out noqa statements that fell out of use, using [yesqa](https://pypi.org/project/yesqa/).
Not going to add yesqa to the pre-commit toolbelt however because it would force duplication
of the list of flake8 plugins there for an extremely marginal benefit.

