### PR TITLE
Use a fancier repr for labels in Profile/PhasePlots. Fixes #3269

### DIFF
--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -725,7 +725,7 @@ class ProfilePlot:
 
     def _get_field_label(self, field, field_info, field_unit, fractional=False):
         field_unit = field_unit.latex_representation()
-        field_name = field_info.display_name
+        field_name = field_info.get_latex_display_name()
         if isinstance(field, tuple):
             field = field[1]
         if field_name is None:
@@ -1013,7 +1013,7 @@ class PhasePlot(ImagePlotContainer):
 
     def _get_field_label(self, field, field_info, field_unit, fractional=False):
         field_unit = field_unit.latex_representation()
-        field_name = field_info.display_name
+        field_name = field_info.get_latex_display_name()
         if isinstance(field, tuple):
             field = field[1]
         if field_name is None:


### PR DESCRIPTION
## PR Summary

Handling of ion field labels only happens in `DerivedField.get_latex_display_name`. It has to be used whenever we need to display nicer labels. Fixes #3269 