### PR TITLE
Checking if extrema are all None in PhasePlot; fixes #3431

### DIFF
--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -1,4 +1,5 @@
 import numpy as np
+from more_itertools import collapse
 
 from yt.data_objects.field_data import YTFieldData
 from yt.fields.derived_field import DerivedField

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -1347,7 +1347,14 @@ def create_profile(
         else:
             logs_list.append(data_source.ds.field_info[bin_field].take_log)
     logs = logs_list
-    if extrema is None:
+
+    # Are the extrema all Nones? Then treat them as though extrema was set as None
+    if extrema is not None:
+        extrema_vals = list(extrema.values())
+        flat_list = [item for sublist in extrema_vals for item in sublist]
+        extrema_all_nones = not any(flat_list)
+
+    if extrema is None or extrema_all_nones:
         ex = [
             data_source.quantities["Extrema"](f, non_zero=l)
             for f, l in zip(bin_fields, logs)

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -1349,12 +1349,7 @@ def create_profile(
     logs = logs_list
 
     # Are the extrema all Nones? Then treat them as though extrema was set as None
-    if extrema is not None:
-        extrema_vals = list(extrema.values())
-        flat_list = [item for sublist in extrema_vals for item in sublist]
-        extrema_all_nones = not any(flat_list)
-
-    if extrema is None or extrema_all_nones:
+    if extrema is None or not any(collapse(extrema.values())):
         ex = [
             data_source.quantities["Extrema"](f, non_zero=l)
             for f, l in zip(bin_fields, logs)

--- a/yt/data_objects/tests/test_profiles.py
+++ b/yt/data_objects/tests/test_profiles.py
@@ -642,6 +642,21 @@ class TestBadProfiles(unittest.TestCase):
                 ("gas", "mass"),
             )
 
+    def test_set_linear_scaling_for_none_extrema(self):
+        # See Issue #3431
+        # Ensures that extrema are calculated in the same way on subsequent passes
+        # through the PhasePlot machinery.
+        ds = fake_sph_orientation_ds()
+        p = yt.PhasePlot(
+            ds,
+            ("all", "particle_position_spherical_theta"),
+            ("all", "particle_position_spherical_radius"),
+            ("all", "particle_mass"),
+            weight_field=None,
+        )
+        p.set_log(("all", "particle_position_spherical_theta"), False)
+        p.save()
+
 
 def test_index_field_units():
     # see #1849


### PR DESCRIPTION
## PR Summary

Attempts to fix Issue #3431 by checking if `extrema` values are all `None` when using a `PhasePlot`, and if so, treats as though `extrema` itself is `None`.  See description in #3431 notes for more details.