### PR TITLE
Cache _determine_fields for a given dataset

### DIFF
--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1441,6 +1441,8 @@ class YTDataContainer:
         raise YTFieldNotParseable(field)
 
     def _determine_fields(self, fields):
+        if str(fields) in self.ds._determined_fields:
+            return self.ds._determined_fields[str(fields)]
         explicit_fields = []
         for field in iter_fields(fields):
             if field in self._container_fields:
@@ -1474,6 +1476,8 @@ class YTDataContainer:
             elif not particle_field and ftype not in self.ds.fluid_types:
                 raise YTFieldTypeNotFound(ftype, ds=self.ds)
             explicit_fields.append((ftype, fname))
+
+        self.ds._determined_fields[str(fields)] = explicit_fields
         return explicit_fields
 
     _tree = None

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -129,6 +129,7 @@ class Dataset(abc.ABC):
     _particle_type_counts = None
     _proj_type = "quad_proj"
     _ionization_label_format = "roman_numeral"
+    _determined_fields = None
     fields_detected = False
 
     # these are set in self._parse_parameter_file()
@@ -195,6 +196,7 @@ class Dataset(abc.ABC):
         self.known_filters = self.known_filters or {}
         self.particle_unions = self.particle_unions or {}
         self.field_units = self.field_units or {}
+        self._determined_fields = {}
         self.units_override = self.__class__._sanitize_units_override(units_override)
         self.default_species_fields = default_species_fields
 


### PR DESCRIPTION
## PR Summary

`_determine_fields(field)` is used (as name suggest) to create a list of fields needed to generate a `field`. It's not a particularly costly method, but it can be called *a lot* and it adds up. One example is iterating over all grids, like we do in `GridValuesTest`. This PR caches the result of `_determine_fields` and keeps it in the `Dataset` object.
