### PR TITLE
FIX: add support for setting up derived fields from lambdas

### DIFF
--- a/yt/fields/derived_field.py
+++ b/yt/fields/derived_field.py
@@ -250,10 +250,7 @@ class DerivedField:
         This returns a list of names of fields that this field depends on.
         """
         e = FieldDetector(*args, **kwargs)
-        if self._function.__name__ == "<lambda>":
-            e.requested.append(self.name)
-        else:
-            e[self.name]
+        e[self.name]
         return e
 
     def _get_needed_parameters(self, fd):

--- a/yt/fields/tests/test_fields.py
+++ b/yt/fields/tests/test_fields.py
@@ -379,6 +379,32 @@ def test_add_field_unit_semantics():
     assert_raises(YTFieldUnitError, get_data, ds, ("gas", "dimensionful"))
 
 
+def test_add_field_from_lambda():
+    ds = fake_amr_ds(fields=["density"], units=["g/cm**3"])
+
+    def _function_density(field, data):
+        return data["gas", "density"]
+
+    ds.add_field(
+        ("gas", "function_density"),
+        function=_function_density,
+        sampling_type="cell",
+        units="g/cm**3",
+    )
+
+    ds.add_field(
+        ("gas", "lambda_density"),
+        function=lambda field, data: data["gas", "density"],
+        sampling_type="cell",
+        units="g/cm**3",
+    )
+
+    ad = ds.all_data()
+    # check that the fields are accessible
+    ad["gas", "function_density"]
+    ad["gas", "lambda_density"]
+
+
 def test_array_like_field():
     ds = fake_random_ds(4, particles=64)
     ad = ds.all_data()


### PR DESCRIPTION
## PR Summary
This is an alternative fix to #3434, and supersedes #3438.
The solution tried here was suggested by @forrestglines. It's not clear to me why the problematic check was ever necessary but it's
been here for 8yrs so my hypothesis is that it may have become inappropriate in Python 3 ?
I'm doubting this would break anything since there doesn't seem to be a single use case of lambdas in derived fields in the code base/docs/tests. On the other hand, the test I'm adding here fails on the main branch (as reported in #3434).
