### PR TITLE
Fix for 2D AMReX datasets in which 3 values are in the amr.n_cell entry in the job_info file.

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -138,7 +138,7 @@ answer_tests:
     - yt/frontends/boxlib/tests/test_outputs.py:test_units_override
     - yt/frontends/boxlib/tests/test_outputs.py:test_raw_fields
 
-  local_boxlib_particles_008:
+  local_boxlib_particles_009:
     - yt/frontends/boxlib/tests/test_outputs.py:test_LyA
     - yt/frontends/boxlib/tests/test_outputs.py:test_nyx_particle_io
     - yt/frontends/boxlib/tests/test_outputs.py:test_castro_particle_io

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -751,9 +751,9 @@ class BoxlibDataset(Dataset):
                 # domain_dimensions to have three elements, with 1 in the additional
                 # slots if we're not in 3D, so append them as necessary.
 
-                if len(vals) == 1:
+                if self.dimensionality == 1:
                     vals = self.domain_dimensions = np.array([vals[0], 1, 1])
-                elif len(vals) == 2:
+                elif self.dimensionality == 2:
                     vals = self.domain_dimensions = np.array([vals[0], vals[1], 1])
             elif param == "amr.ref_ratio":
                 vals = self.refine_by = int(vals[0])


### PR DESCRIPTION
The WarpX team has noticed that since the yt-4.0 release, some of our 2D CI jobs have been failing. To reproduce this, see the attached script and dataset. `ds.domain_dimensions` should be [64, 64, 1], but it is now shown as [64, 64, 64].  

I think this was introduced in [this](https://github.com/yt-project/yt/commit/8bcf84dbd938fc32f87f8ae476e583509866f74f#diff-d4ca70f009bc419366a8305237dfe5143869b6c6a781c363f4c4a0082f239a99) commit, which made changes to how 1d and 2d amrex datasets are set up. The issue is that we sometimes use inputs files that work for both 2D and 3D simulations. Hence, the `amr.n_cell` entry to `warpx_job_info` may have three values in it, even if the dataset is 2D. 

This PR seems to solve the issue for us. The fix was just to use `ds.dimensionality` to cap the number of entries used from the `job_info` file. 

```
import yt
ds = yt.load("diag100001")
print(ds.domain_dimensions)  # should be [64, 64, 1]
```

[diag100001.tar.gz](https://github.com/yt-project/yt/files/6850781/diag100001.tar.gz)
