### PR TITLE
Make sure we add the Parameters group to hvals if it's present

### DIFF
--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -611,6 +611,10 @@ class GadgetHDF5Dataset(GadgetDataset):
             self.gen_hsmls = "SmoothingLength" not in handle[sph_ptypes[0]]
         else:
             self.gen_hsmls = False
+        # Later versions of Gadget and its derivatives have a "Parameters"
+        # group in the HDF5 file.
+        if "Parameters" in handle:
+            hvals.update((str(k), v) for k, v in handle["/Parameters"].attrs.items())
         handle.close()
         return hvals
 


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

Gadget 4 datasets have a `Parameters` group in the HDF5 file which store runtime parameters. Crucially, the parameters needed to determine the cosmology are now stored in this group and are not in the `Header` group. This PR ensures that these parameters can be found regardless of the Gadget version used. 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
