### PR TITLE
fix combining FITS images

### DIFF
--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -735,12 +735,12 @@ class FITSImageData:
         w = first_image.wcs
         img_shape = first_image.shape
         data = []
-        for is_first, _is_last, fid in mark_ends(image_list):
+        for fid in image_list:
             assert_same_wcs(w, fid.wcs)
             if img_shape != fid.shape:
                 raise RuntimeError("Images do not have the same shape!")
             for hdu in fid.hdulist:
-                if is_first:
+                if len(data) == 0:
                     data.append(_astropy.pyfits.PrimaryHDU(hdu.data, header=hdu.header))
                 else:
                     data.append(_astropy.pyfits.ImageHDU(hdu.data, header=hdu.header))

--- a/yt/visualization/tests/test_fits_image.py
+++ b/yt/visualization/tests/test_fits_image.py
@@ -101,6 +101,9 @@ def test_fits_image():
     assert_equal(combined_fid.velocity_unit, dens_img.velocity_unit)
     assert_equal(combined_fid.magnetic_unit, dens_img.magnetic_unit)
     assert_equal(combined_fid.current_time, dens_img.current_time)
+    # Writing the FITS file ensures that we have assembled the images
+    # together correctly
+    combined_fid.writeto("combined.fits", overwrite=True)
 
     cut = ds.cutting([0.1, 0.2, -0.9], [0.5, 0.42, 0.6])
     cut_frb = cut.to_frb((0.5, "unitary"), 128)

--- a/yt/visualization/tests/test_fits_image.py
+++ b/yt/visualization/tests/test_fits_image.py
@@ -101,9 +101,13 @@ def test_fits_image():
     assert_equal(combined_fid.velocity_unit, dens_img.velocity_unit)
     assert_equal(combined_fid.magnetic_unit, dens_img.magnetic_unit)
     assert_equal(combined_fid.current_time, dens_img.current_time)
+
+    # Make sure that we can combine FITSImageData instances with more
+    # than one image each
+    combined_fid2 = FITSImageData.from_images([combined_fid, combined_fid])
     # Writing the FITS file ensures that we have assembled the images
     # together correctly
-    combined_fid.writeto("combined.fits", overwrite=True)
+    combined_fid2.writeto("combined.fits", overwrite=True)
 
     cut = ds.cutting([0.1, 0.2, -0.9], [0.5, 0.42, 0.6])
     cut_frb = cut.to_frb((0.5, "unitary"), 128)


### PR DESCRIPTION
…ed as the PrimaryHDU

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

The `combine_images` method of the `FITSImageData` class allows one to combine multiple images into one, but a FITS file is only valid if the first image is a `PrimaryHDU`. The previous implementation, when stitching multiple `FITSImageData` instances together, was attempting to create multiple `PrimaryHDU` instances (the first image from each instance). This PR fixes it and adds a single line to the `FITSImageData` tests which ensure that this functionality works correctly.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
