### PR TITLE
Changed _project_coords to create new array instead of modifying in-place

### DIFF
--- a/nose_unit.cfg
+++ b/nose_unit.cfg
@@ -6,5 +6,5 @@ nologcapture=1
 verbosity=2
 where=yt
 with-timer=1
-ignore-files=(test_load_errors.py|test_load_sample.py|test_commons.py|test_ambiguous_fields.py|test_field_access_pytest.py|test_save.py)
+ignore-files=(test_load_errors.py|test_load_sample.py|test_commons.py|test_ambiguous_fields.py|test_field_access_pytest.py|test_save.py|test_line_annotation_unit.py)
 exclude-test=yt.frontends.gdf.tests.test_outputs.TestGDF

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -182,6 +182,7 @@ other_tests:
      - '--ignore=test_outputs_pytest'
      - '--ignore-files=test_load_errors.py'
      - '--ignore-files=test_commons.py'
+     - '--ignore-files=test_line_annotation_unit.py'
      - '--ignore-files=test_load_sample.py'
      - '--ignore-files=test_field_access_pytest.py'
      - '--ignore-files=test_ambiguous_fields.py'

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -78,9 +78,9 @@ class PlotCallback:
         if len(coord) == 3:
             if not isinstance(coord, YTArray):
                 coord_copy = plot.data.ds.arr(coord, "code_length")
-            # coord is being copied so that if the user has a unyt_array already
-            # we don't change the user's version
             else:
+                # coord is being copied so that if the user has a unyt_array already
+                # we don't change the user's version
                 coord_copy = coord.to("code_length")
             ax = plot.data.axis
             # if this is an on-axis projection or slice, then

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -78,7 +78,7 @@ class PlotCallback:
         if len(coord) == 3:
             if not isinstance(coord, YTArray):
                 coord = plot.data.ds.arr(coord, "code_length")
-            coord.convert_to_units("code_length")
+            coord.to("code_length")
             ax = plot.data.axis
             # if this is an on-axis projection or slice, then
             # just grab the appropriate 2 coords for the on-axis view

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -80,7 +80,8 @@ class PlotCallback:
                 coord_copy = plot.data.ds.arr(coord, "code_length")
             #coord is being copied so that if the user has a unyt_array already
             #we don't change the user's version
-            coord_copy = coord.to("code_length")
+            else:
+                coord_copy = coord.to("code_length")
             ax = plot.data.axis
             # if this is an on-axis projection or slice, then
             # just grab the appropriate 2 coords for the on-axis view

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -78,7 +78,7 @@ class PlotCallback:
         if len(coord) == 3:
             if not isinstance(coord, YTArray):
                 coord = plot.data.ds.arr(coord, "code_length")
-            coord.to("code_length")
+            coord = coord.to("code_length")
             ax = plot.data.axis
             # if this is an on-axis projection or slice, then
             # just grab the appropriate 2 coords for the on-axis view

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -78,8 +78,8 @@ class PlotCallback:
         if len(coord) == 3:
             if not isinstance(coord, YTArray):
                 coord_copy = plot.data.ds.arr(coord, "code_length")
-            #coord is being copied so that if the user has a unyt_array already
-            #we don't change the user's version
+            # coord is being copied so that if the user has a unyt_array already
+            # we don't change the user's version
             else:
                 coord_copy = coord.to("code_length")
             ax = plot.data.axis

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -77,8 +77,10 @@ class PlotCallback:
         """
         if len(coord) == 3:
             if not isinstance(coord, YTArray):
-                coord = plot.data.ds.arr(coord, "code_length")
-            coord = coord.to("code_length")
+                coord_copy = plot.data.ds.arr(coord, "code_length")
+            #coord is being copied so that if the user has a unyt_array already
+            #we don't change the user's version
+            coord_copy = coord.to("code_length")
             ax = plot.data.axis
             # if this is an on-axis projection or slice, then
             # just grab the appropriate 2 coords for the on-axis view
@@ -87,7 +89,7 @@ class PlotCallback:
                     plot.data.ds.coordinates.x_axis[ax],
                     plot.data.ds.coordinates.y_axis[ax],
                 )
-                coord = (coord[xi], coord[yi])
+                ret_coord = (coord_copy[xi], coord_copy[yi])
 
             # if this is an off-axis project or slice (ie cutting plane)
             # we have to calculate where the data coords fall in the projected
@@ -95,20 +97,20 @@ class PlotCallback:
             elif ax == 4:
                 # transpose is just to get [[x1,x2,...],[y1,y2,...],[z1,z2,...]]
                 # in the same order as plot.data.center for array arithmetic
-                coord_vectors = coord.transpose() - plot.data.center
+                coord_vectors = coord_copy.transpose() - plot.data.center
                 x = np.dot(coord_vectors, plot.data.orienter.unit_vectors[1])
                 y = np.dot(coord_vectors, plot.data.orienter.unit_vectors[0])
                 # Transpose into image coords. Due to VR being not a
                 # right-handed coord system
-                coord = (y, x)
+                ret_coord = (y, x)
             else:
-                raise ValueError("Object being plot must have a `data.axis` defined")
+                raise ValueError("Object being plotted must have a `data.axis` defined")
 
         # if the position is already two-coords, it is expected to be
         # in the proper projected orientation
         else:
             raise ValueError("'data' coordinates must be 3 dimensions")
-        return coord
+        return ret_coord
 
     def _convert_to_plot(self, plot, coord, offset=True):
         """

--- a/yt/visualization/tests/test_line_annotation_unit.py
+++ b/yt/visualization/tests/test_line_annotation_unit.py
@@ -18,10 +18,9 @@ def test_ds_arr_invariance_under_projection_plot():
 
     p = yt.ProjectionPlot(ds, 0, "number_density")
     p.annotate_line(start, end)
-    p.show()
 
     # for lack of a unyt.testing.assert_unit_array_equal function
     np.testing.assert_array_equal(start_i, start)
-    assert start_i.units == start
+    assert start_i.units == start.units
     np.testing.assert_array_equal(end_i, end)
-    assert end_i.units == end
+    assert end_i.units == end.units

--- a/yt/visualization/tests/test_line_annotation_unit.py
+++ b/yt/visualization/tests/test_line_annotation_unit.py
@@ -18,7 +18,8 @@ def test_ds_arr_invariance_under_projection_plot():
 
     p = yt.ProjectionPlot(ds, 0, "number_density")
     p.annotate_line(start, end)
-
+    p.show()
+    
     # for lack of a unyt.testing.assert_unit_array_equal function
     np.testing.assert_array_equal(start_i, start)
     assert start_i.units == start.units

--- a/yt/visualization/tests/test_line_annotation_unit.py
+++ b/yt/visualization/tests/test_line_annotation_unit.py
@@ -1,6 +1,8 @@
+import numpy as np
+
 from yt.loaders import load_uniform_grid
 from yt.visualization.plot_window import ProjectionPlot
-import numpy as np
+
 
 def test_ds_arr_invariance_under_projection_plot(tmp_path):
     data_array = np.random.random((10, 10, 10))

--- a/yt/visualization/tests/test_line_annotation_unit.py
+++ b/yt/visualization/tests/test_line_annotation_unit.py
@@ -1,13 +1,12 @@
+from yt.loaders import load_uniform_grid
+from yt.visualization.plot_window import ProjectionPlot
 import numpy as np
-
-import yt
-
 
 def test_ds_arr_invariance_under_projection_plot(tmp_path):
     data_array = np.random.random((10, 10, 10))
     bbox = np.array([[-100, 100], [-100, 100], [-100, 100]])
     data = {("gas", "density"): (data_array, "g*cm**(-3)")}
-    ds = yt.load_uniform_grid(data, data_array.shape, length_unit="kpc", bbox=bbox)
+    ds = load_uniform_grid(data, data_array.shape, length_unit="kpc", bbox=bbox)
 
     start_source = np.array((0, 0, -0.5))
     end_source = np.array((0, 0, 0.5))
@@ -17,7 +16,7 @@ def test_ds_arr_invariance_under_projection_plot(tmp_path):
     start_i = start.copy()
     end_i = end.copy()
 
-    p = yt.ProjectionPlot(ds, 0, "number_density")
+    p = ProjectionPlot(ds, 0, "number_density")
     p.annotate_line(start, end)
     p.save(tmp_path)
 

--- a/yt/visualization/tests/test_line_annotation_unit.py
+++ b/yt/visualization/tests/test_line_annotation_unit.py
@@ -1,0 +1,27 @@
+import yt
+import numpy as np
+
+
+def test_ds_arr_invariance_under_projection_plot():
+    data_array = np.random.random((10, 10, 10))
+    bbox = np.array([[-100, 100], [-100, 100], [-100, 100]])
+    data = {("gas", "density"): (data_array, "g*cm**(-3)")}
+    ds = yt.load_uniform_grid(data, data_array.shape, length_unit="kpc", bbox=bbox)
+
+    start_source = np.array((0, 0, -0.5))
+    end_source = np.array((0, 0, 0.5))
+    start = ds.arr(start_source, "unitary")
+    end = ds.arr(end_source, "unitary")
+
+    start_i = start.copy()
+    end_i = end.copy()
+
+    p = yt.ProjectionPlot(ds, 0, "number_density")
+    p.annotate_line(start, end)
+    p.show()
+
+    # for lack of a unyt.testing.assert_unit_array_equal function
+    np.testing.assert_array_equal(start_i, start)
+    assert start_i.units == start
+    np.testing.assert_array_equal(end_i, end)
+    assert end_i.units == end

--- a/yt/visualization/tests/test_line_annotation_unit.py
+++ b/yt/visualization/tests/test_line_annotation_unit.py
@@ -1,5 +1,6 @@
-import yt
 import numpy as np
+
+import yt
 
 
 def test_ds_arr_invariance_under_projection_plot(tmp_path):
@@ -19,7 +20,7 @@ def test_ds_arr_invariance_under_projection_plot(tmp_path):
     p = yt.ProjectionPlot(ds, 0, "number_density")
     p.annotate_line(start, end)
     p.save(tmp_path)
-    
+
     # for lack of a unyt.testing.assert_unit_array_equal function
     np.testing.assert_array_equal(start_i, start)
     assert start_i.units == start.units

--- a/yt/visualization/tests/test_line_annotation_unit.py
+++ b/yt/visualization/tests/test_line_annotation_unit.py
@@ -2,7 +2,7 @@ import yt
 import numpy as np
 
 
-def test_ds_arr_invariance_under_projection_plot():
+def test_ds_arr_invariance_under_projection_plot(tmp_path):
     data_array = np.random.random((10, 10, 10))
     bbox = np.array([[-100, 100], [-100, 100], [-100, 100]])
     data = {("gas", "density"): (data_array, "g*cm**(-3)")}
@@ -18,7 +18,7 @@ def test_ds_arr_invariance_under_projection_plot():
 
     p = yt.ProjectionPlot(ds, 0, "number_density")
     p.annotate_line(start, end)
-    p.show()
+    p.save(tmp_path)
     
     # for lack of a unyt.testing.assert_unit_array_equal function
     np.testing.assert_array_equal(start_i, start)


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

When running plot.annotate_line() in a SlicePlot or ProjectionPlot, it modifies the existing array in-place, without correctly using the units in certain cases. When the same line is used again for another plot (say, at a different angle or something) it and its original source array are unexpectedly modified. Fixed by creating a new array converting with `.to` instead of `.convert_to_units`. Since this is used for 2 arrays which are only 3 elements long, the memory added is negligible.
<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->
This is the fix to issue #3449 suggested by @chrishavlin 
## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
