### PR TITLE
BUG: fix error message in lookup_on_disk_data

### DIFF
--- a/yt/sample_data/api.py
+++ b/yt/sample_data/api.py
@@ -162,14 +162,16 @@ def lookup_on_disk_data(fn) -> Path:
     if path.exists():
         return path
 
-    alt_path = _get_test_data_dir_path() / fn
-    if alt_path.exists():
-        return alt_path
-
     err_msg = f"No such file or directory: '{fn}'."
-    if alt_path.parent.is_dir() and alt_path != path:
-        err_msg += f"\n(Also tried '{alt_path}')."
+    test_data_dir = _get_test_data_dir_path()
+    if not test_data_dir.is_dir():
+        raise FileNotFoundError(err_msg)
 
+    alt_path = _get_test_data_dir_path() / fn
+    if alt_path != path:
+        if alt_path.exists():
+            return alt_path
+        err_msg += f"\n(Also tried '{alt_path}')."
     raise FileNotFoundError(err_msg)
 
 


### PR DESCRIPTION
## PR Summary

This is a second attempt at getting this function right after #3446

Here's the problematic edge case that this solves.
Assuming that `yt.test_data_dir` is correctly setup in in `yt.toml`

```python
import yt
yt.load("NotADir/NotADir")
```
on main
```
FileNotFoundError: No such file or directory: 'NotADir/NotADir'.
```

this branch
```
...
FileNotFoundError: No such file or directory: 'NotADir/NotADir'.
(Also tried '/Users/robcleme/dev/yt-project/test-data-dir/NotADir/NotADir').
```

