### PR TITLE
Add support for global_startindex != 0 to covering_grid

### DIFF
--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -648,15 +648,17 @@ class YTCoveringGrid(YTSelectionContainer3D):
         self.right_edge = self.left_edge + self.ActiveDimensions * self.dds
         self._num_ghost_zones = num_ghost_zones
         self._use_pbar = use_pbar
-        self.global_startindex = np.rint(
-            (self.left_edge - self.ds.domain_left_edge) / self.dds
-        ).astype("int64")+self.ds.domain_offset
+        self.global_startindex = (
+            np.rint((self.left_edge - self.ds.domain_left_edge) / self.dds).astype(
+                "int64"
+            )
+            + self.ds.domain_offset
+        )
         self._setup_data_source()
         self.get_data(fields)
 
     def get_global_startindex(self):
-        r"""Get the global start index of the covering grid.
-        """
+        r"""Get the global start index of the covering grid."""
         return self.global_startindex
 
     def to_xarray(self, fields=None):

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -650,9 +650,14 @@ class YTCoveringGrid(YTSelectionContainer3D):
         self._use_pbar = use_pbar
         self.global_startindex = np.rint(
             (self.left_edge - self.ds.domain_left_edge) / self.dds
-        ).astype("int64")
+        ).astype("int64")+self.ds.domain_offset
         self._setup_data_source()
         self.get_data(fields)
+
+    def get_global_startindex(self):
+        r"""Get the global start index of the covering grid.
+        """
+        return self.global_startindex
 
     def to_xarray(self, fields=None):
         r"""Export this fixed-resolution object to an xarray Dataset

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -136,8 +136,8 @@ class Dataset(abc.ABC):
     domain_left_edge = MutableAttribute(True)
     domain_right_edge = MutableAttribute(True)
     domain_dimensions = MutableAttribute(True)
-    # the point in index space "domain_left_edge" maps to
-    # not necessarily (0, 0, 0)
+    # the point in index space "domain_left_edge" doesn't necessarily 
+    # map to (0, 0, 0)
     domain_offset = np.zeros(3, dtype="int64")
     _periodicity = MutableAttribute()
     _force_periodicity = False

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -136,6 +136,8 @@ class Dataset(abc.ABC):
     domain_left_edge = MutableAttribute(True)
     domain_right_edge = MutableAttribute(True)
     domain_dimensions = MutableAttribute(True)
+    # the point in index space "domain_left_edge" maps to
+    # not necessarily (0, 0, 0)
     domain_offset = np.zeros(3, dtype="int64")
     _periodicity = MutableAttribute()
     _force_periodicity = False

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -136,7 +136,7 @@ class Dataset(abc.ABC):
     domain_left_edge = MutableAttribute(True)
     domain_right_edge = MutableAttribute(True)
     domain_dimensions = MutableAttribute(True)
-    # the point in index space "domain_left_edge" doesn't necessarily 
+    # the point in index space "domain_left_edge" doesn't necessarily
     # map to (0, 0, 0)
     domain_offset = np.zeros(3, dtype="int64")
     _periodicity = MutableAttribute()

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -136,6 +136,7 @@ class Dataset(abc.ABC):
     domain_left_edge = MutableAttribute(True)
     domain_right_edge = MutableAttribute(True)
     domain_dimensions = MutableAttribute(True)
+    domain_offset = np.array([0, 0, 0])
     _periodicity = MutableAttribute()
     _force_periodicity = False
 

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -881,6 +881,9 @@ class BoxlibDataset(Dataset):
         stop = np.array(root_space[1].split(","), dtype="int64")
         dd = np.ones(3, dtype="int64")
         dd[: self.dimensionality] = stop - start + 1
+        do = np.zeros(3, dtype="int64")
+        do[: self.dimensionality] = start
+        self.domain_offset = do
         self.domain_dimensions = dd
 
         # Skip timesteps per level


### PR DESCRIPTION
Fixes Issue #3467 

Script to reproduce problem:

```python
# Import statements
import yt
import numpy as np
import matplotlib.pyplot as plt
%matplotlib inline

diag_name = 'diag3' # E.g., diagnostics.diags_names = diag
iteration = 1
plotfile = './diags/{}{:05d}'.format(diag_name, iteration)
field = 'rho'
ds = yt.load( plotfile ) # Load the plotfile
# ds.field_list # Print all available quantities

# Get field quantities
all_data_level_0 = ds.covering_grid(level=0,left_edge=ds.domain_left_edge, dims=ds.domain_dimensions)
Bx = all_data_level_0['boxlib', field].v.squeeze()

extent = [ds.domain_left_edge[ds.dimensionality-1], ds.domain_right_edge[ds.dimensionality-1],
              ds.domain_left_edge[0], ds.domain_right_edge[0] ]

# Plot image
fig, ax = plt.subplots()
clim = 1e-19
ax.imshow(Bx,aspect='auto', cmap = 'seismic', clim = [-clim, clim], extent= extent, origin='lower')
```

Dataset is attached.
[diag300001.tar.gz](https://github.com/yt-project/yt/files/6957948/diag300001.tar.gz)

