### PR TITLE
replace cmap with ndarray for refined_count

### DIFF
--- a/yt/geometry/particle_oct_container.pyx
+++ b/yt/geometry/particle_oct_container.pyx
@@ -723,14 +723,12 @@ cdef class ParticleBitmap:
         cdef int axiter[3][2]
         cdef np.float64_t axiterv[3][2]
         cdef CoarseRefinedSets coarse_refined_map
-        cdef cmap[np.uint64_t, np.uint64_t] refined_count
         cdef np.uint64_t nfully_enclosed = 0, n_calls = 0
         mi1_max = (1 << self.index_order1) - 1
         mi2_max = (1 << self.index_order2) - 1
         cdef np.uint64_t max_mi1_elements = 1 << (3*self.index_order1)
         cdef np.uint64_t max_mi2_elements = 1 << (3*self.index_order2)
-        for i in range(max_mi1_elements):
-            refined_count[i] = 0
+        cdef np.ndarray[np.uint64_t, ndim=1] refined_count = np.zeros(max_mi1_elements, dtype="uint64")
         # Copy things from structure (type cast)
         for i in range(3):
             LE[i] = self.left_edge[i]


### PR DESCRIPTION
`refined_count` was declared as a `cmap` and it was initialized to zeros using a loop. This was really expensive and takes a lot of time to load. This PR replaces `cmap` with `ndarray` with an initialization and omits the loop.

## Before the change
![Screenshot from 2021-08-10 17-19-14](https://user-images.githubusercontent.com/33940798/128878199-7c458f32-e67d-45cc-ab73-c7f51dde73d1.png)

## After the change
![Screenshot from 2021-08-10 17-50-25](https://user-images.githubusercontent.com/33940798/128878213-6072d0ee-e369-4f47-9a9c-3434e7b290fd.png)
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
