### PR TITLE
[WIP] SnapshotSeries Object

### DIFF
--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -76,6 +76,16 @@ def load(fn, *args, **kwargs):
 
         return DatasetSeries(fn, *args, **kwargs)
 
+    # QMC data files have multiple snapshots per file, so we check for
+    # a slice here to see if we need to return a DatasetSeries. This
+    # differs from the above wildcard check because it's only looking
+    # at one file
+    if "snapshot" in kwargs:
+        if isinstance(kwargs["snapshot"], str) and ":" in kwargs["snapshot"]:
+            from yt.data_objects.time_series import SnapshotSeries
+
+            return SnapshotSeries(fn, *args, **kwargs)
+
     # This will raise FileNotFoundError if the path isn't matched
     # either in the current dir or yt.config.ytcfg['data_dir_directory']
     if not fn.startswith("http"):


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->
Currently, yt has the `DatasetSeries` object for dealing with time series data. However, this object was designed for the case when the data for each time step is contained in its own file (e.g., the data at t=0 is in file0, t=1 is in file1, etc). For certain frontends (the qmc frontend, in this case) the data for multiple time steps can be contained in the same file.

Rather than muck up the existing `DatasetSeries` object to be able to handle this functionality, this PR introduces a new object, the `SnapshotSeries` object. This object is purposely similar to the `DatasetSeries` object, but is geared towards handling multiple time steps existing in the same data file.

A check to use and return such an object is done in `load()` right after the check to determine if a `DatasetSeries` is needed.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
