### PR TITLE
MNT: add button to manually run bleeding edge CI job

### DIFF
--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -13,6 +13,7 @@ on:
   schedule:
     # run this every day at 3 am UTC
     - cron: '0 3 * * *'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## PR Summary
This will help closing #3473 faster by triggering a run of the bleeding edge CI job as this PR is merged.
It adds a button so the job can be triggered manually next time a similar situation occurs instead of having to wait the next natural trigger (scheduled or merge) to validate a patch upstream.

