### PR TITLE
BUG: fix a broken call to warnings.warn

### DIFF
--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -1412,8 +1412,7 @@ class YTSmoothedCoveringGrid(YTCoveringGrid):
             warnings.warn(
                 "Something went wrong during field computation. "
                 "This is likely due to missing ghost-zones support "
-                "in class %s",
-                self.ds.__class__,
+                f"in class {type(self.ds)}",
                 category=RuntimeWarning,
             )
             mylog.debug("Caught %d runtime errors.", runtime_errors_count)


### PR DESCRIPTION
## PR Summary

This was indirectly reported by @pgrete on Slack when he stumbled upon this broken warning I authored a year ago.

Here it is as a minimal example:
```python
import warnings

warnings.warn(
    "Something went wrong during field computation: %s",
    "just kidding",
    category=RuntimeWarning,
)
```
results in 
```
TypeError: argument for warn() given by name ('category') and position (2)
```
This is the correct version
```python
import warnings

insert = "just_kidding"
warnings.warn(
    f"Something went wrong during field computation: {insert}",
    category=RuntimeWarning,
)
```
and produces
```
RuntimeWarning: Something went wrong during field computation: just_kidding
```