### PR TITLE
DOC: have PyPI 'supported Python versions' badge point to the current release instead of the latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # The yt Project
 
 [![PyPI](https://img.shields.io/pypi/v/yt)](https://pypi.org/project/yt)
-[![Supported Python Versions](https://img.shields.io/pypi/pyversions/yt)](https://pypi.org/project/yt/)
+[![Supported Python Versions](https://img.shields.io/pypi/pyversions/yt/4.1.0)](https://pypi.org/project/yt/)
 [![Latest Documentation](https://img.shields.io/badge/docs-latest-brightgreen.svg)](http://yt-project.org/docs/dev/)
 [![Users' Mailing List](https://img.shields.io/badge/Users-List-lightgrey.svg)](https://mail.python.org/archives/list/yt-users@python.org//)
 [![Devel Mailing List](https://img.shields.io/badge/Devel-List-lightgrey.svg)](https://mail.python.org/archives/list/yt-dev@python.org//)


### PR DESCRIPTION
## PR Summary
Just found out that this badge _can_ be setup to point to an exact release number instead of "the latest available".
It's too late for yt 4.0.1 but this future-proofs upcoming releases against any variation in the range of supported Python versions that _follows_ them (e.g. #2917).
To be more accurate this makes one more place where we should update the version string manually for each release. Is there a place where we document that kind of stuff ?

This shouldn't be merged until the very last moment before yt 4.1 is released.

