### PR TITLE
[bugfix] Get order of axes right for FITSParticleProjection

### DIFF
--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -848,7 +848,7 @@ def sanitize_fits_unit(unit):
 # This list allows one to determine which axes are the
 # correct axes of the image in a right-handed coordinate
 # system depending on which axis is sliced or projected
-axis_wcs = [[1, 2], [0, 2], [0, 1]]
+axis_wcs = [[1, 2], [2, 0], [0, 1]]
 
 
 def construct_image(ds, axis, data_source, center, image_res, width, length_unit):


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

This is a follow on to PR https://github.com/yt-project/yt/pull/3375. It turns out that the order of the `axis_wcs` list here, which is used to figure out what the axes should be for a given projection direction, had the 0/x and 2/z axes in the wrong order to pass to the `ParticleImageBuffer`.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
