### PR TITLE
ENH: loosen header matching for Athena vtk files to allow compatibility with single variable 'vtk outputs'

### DIFF
--- a/yt/frontends/athena/data_structures.py
+++ b/yt/frontends/athena/data_structures.py
@@ -639,10 +639,19 @@ class AthenaDataset(Dataset):
         with open(filename, "rb") as fh:
             if not re.match(b"# vtk DataFile Version \\d\\.\\d\n", fh.readline(256)):
                 return False
-            if not re.match(
-                b"(CONSERVED|PRIMITIVE) vars at time= .*, level= \\d, domain= \\d\n",
-                fh.readline(256),
+            if (
+                re.search(
+                    b"at time= .*, level= \\d, domain= \\d\n",
+                    fh.readline(256),
+                )
+                is None
             ):
+                # vtk Dumps headers start with either "CONSERVED vars" or "PRIMITIVE vars",
+                # while vtk output headers start with "Really cool Athena data", but
+                # we will consider this an implementation detail and not attempt to
+                # match it exactly here.
+                # See Athena's user guide for reference
+                # https://princetonuniversity.github.io/Athena-Cversion/AthenaDocsUGbtk
                 return False
         return True
 


### PR DESCRIPTION
## PR Summary
this is a hotfix to #3424 that was merged slighlty before I could integrate this change required by @jzuhone

