### PR TITLE
ENH: warn user in case a Dataset subclass is redefined

### DIFF
--- a/nose_unit.cfg
+++ b/nose_unit.cfg
@@ -6,5 +6,5 @@ nologcapture=1
 verbosity=2
 where=yt
 with-timer=1
-ignore-files=(test_load_errors.py|test_load_sample.py|test_commons.py|test_ambiguous_fields.py|test_field_access_pytest.py|test_save.py|test_line_annotation_unit.py|test_eps_writer.py)
+ignore-files=(test_load_errors.py|test_load_sample.py|test_commons.py|test_ambiguous_fields.py|test_field_access_pytest.py|test_save.py|test_line_annotation_unit.py|test_eps_writer.py|test_registration.py)
 exclude-test=yt.frontends.gdf.tests.test_outputs.TestGDF

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -188,6 +188,7 @@ other_tests:
      - '--ignore-files=test_ambiguous_fields.py'
      - '--ignore-files=test_eps_writer.py'
      - "--ignore-files=test_save.py"
+     - '--ignore-files=test_registration.py'
      - '--exclude-test=yt.frontends.gdf.tests.test_outputs.TestGDF'
   cookbook:
      - 'doc/source/cookbook/tests/test_cookbook.py'

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -4,6 +4,7 @@ import itertools
 import os
 import pickle
 import time
+import warnings
 import weakref
 from collections import defaultdict
 from importlib.util import find_spec
@@ -172,6 +173,12 @@ class Dataset(abc.ABC):
 
     def __init_subclass__(cls, *args, **kwargs):
         super().__init_subclass__(*args, **kwargs)
+        if cls.__name__ in output_type_registry:
+            warnings.warn(
+                f"Overwritting {cls.__name__}, which was previously registered. "
+                "This is expected if you're importing a yt extension with a "
+                "frontend that was already migrated to the main code base."
+            )
         output_type_registry[cls.__name__] = cls
         mylog.debug("Registering: %s as %s", cls.__name__, cls)
 

--- a/yt/data_objects/tests/test_registration.py
+++ b/yt/data_objects/tests/test_registration.py
@@ -1,0 +1,23 @@
+import pytest
+
+from yt.data_objects.static_output import Dataset
+from yt.utilities.object_registries import output_type_registry
+
+
+def test_reregistration_warning():
+    true_EnzoDataset = output_type_registry["EnzoDataset"]
+    try:
+        with pytest.warns(
+            UserWarning,
+            match=(
+                "Overwritting EnzoDataset, which was previously registered. "
+                "This is expected if you're importing a yt extension with a "
+                "frontend that was already migrated to the main code base."
+            ),
+        ):
+
+            class EnzoDataset(Dataset):
+                pass
+
+    finally:
+        output_type_registry["EnzoDataset"] = true_EnzoDataset


### PR DESCRIPTION
## PR Summary

Following a recent discussion on the Slack space in which we discussed how yt extensions
provided support to create third party frontends, which allows users to extend over native one as

```python
import yt
import yt.extensions.my_frontend
```
The only issue I was able to see with this workflow is that, in case such a frontend gets integrated
into yt itself, then users may not realize that the extension import became useless, or worse. Shadowing a "first citizen" frontend may actually be useful as temporary measure, which is why I'm not making this an error, but it seems fair to emit a warning as a forgiving gesture to transiting users.

## PR Checklist

[N/A] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

note : I want to add documentation for the whole extension frontend workflow later, but I think this small patch counts as its own documentation.
