### PR TITLE
BUG: fix two bugs in yt.visualization.eps_writer

### DIFF
--- a/nose_unit.cfg
+++ b/nose_unit.cfg
@@ -6,5 +6,5 @@ nologcapture=1
 verbosity=2
 where=yt
 with-timer=1
-ignore-files=(test_load_errors.py|test_load_sample.py|test_commons.py|test_ambiguous_fields.py|test_field_access_pytest.py|test_save.py|test_line_annotation_unit.py)
+ignore-files=(test_load_errors.py|test_load_sample.py|test_commons.py|test_ambiguous_fields.py|test_field_access_pytest.py|test_save.py|test_line_annotation_unit.py|test_eps_writer.py)
 exclude-test=yt.frontends.gdf.tests.test_outputs.TestGDF

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -186,6 +186,7 @@ other_tests:
      - '--ignore-files=test_load_sample.py'
      - '--ignore-files=test_field_access_pytest.py'
      - '--ignore-files=test_ambiguous_fields.py'
+     - '--ignore-files=test_eps_writer.py'
      - "--ignore-files=test_save.py"
      - '--exclude-test=yt.frontends.gdf.tests.test_outputs.TestGDF'
   cookbook:

--- a/yt/visualization/eps_writer.py
+++ b/yt/visualization/eps_writer.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 import pyx
 from matplotlib import cm, pyplot as plt
@@ -743,7 +745,7 @@ class DualEPS:
 
         # Convert the colormap into a string
         x = np.linspace(1, 0, 256)
-        cm_string = cm.get_cmap[name](x, bytes=True)[:, 0:3].tobytes()
+        cm_string = cm.get_cmap(name)(x, bytes=True)[:, 0:3].tobytes()
 
         cmap_im = pyx.bitmap.image(imsize[0], imsize[1], "RGB", cm_string)
         if orientation == "top" or orientation == "bottom":
@@ -1143,6 +1145,7 @@ class DualEPS:
         >>> d = DualEPS()
         >>> d.axis_box(xrange=(0, 100), yrange=(1e-3, 1), ylog=True)
         """
+        filename = os.path.expanduser(filename)
         if format == "eps":
             self.canvas.writeEPSfile(filename)
         elif format == "pdf":

--- a/yt/visualization/tests/test_eps_writer.py
+++ b/yt/visualization/tests/test_eps_writer.py
@@ -1,7 +1,8 @@
 import yt
-from yt.testing import fake_amr_ds, requires_module
+from yt.testing import fake_amr_ds, requires_external_executable, requires_module
 
 
+@requires_external_executable("tex")
 @requires_module("pyx")
 def test_eps_writer(tmp_path):
     import yt.visualization.eps_writer as eps

--- a/yt/visualization/tests/test_eps_writer.py
+++ b/yt/visualization/tests/test_eps_writer.py
@@ -1,0 +1,27 @@
+import yt
+from yt.testing import fake_amr_ds, requires_module
+
+
+@requires_module("pyx")
+def test_eps_writer(tmp_path):
+    import yt.visualization.eps_writer as eps
+
+    fields = [
+        ("gas", "density"),
+        ("gas", "temperature"),
+    ]
+    units = [
+        "g/cm**3",
+        "K",
+    ]
+    ds = fake_amr_ds(fields=fields, units=units)
+    slc = yt.SlicePlot(
+        ds,
+        "z",
+        fields=fields,
+    )
+    eps_fig = eps.multiplot_yt(2, 1, slc, bare_axes=True)
+    eps_fig.scale_line(0.2, "5 cm")
+    savefile = tmp_path / "multi"
+    eps_fig.save_fig(savefile, format="eps")
+    assert savefile.with_suffix(".eps").exists()


### PR DESCRIPTION
## PR Summary
Noticed that eps_writer didn't have tests so I ran an example from the documentation and was able to find a trivial but blocking bug.
While testing this I also fixed another bug where save_fig didn't accept Path objects.

## PR Checklist

[N/A] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

