### PR TITLE
BUG: fix an outdated h5py idiom in a documentation notebook

### DIFF
--- a/doc/source/examining/Loading_Generic_Array_Data.ipynb
+++ b/doc/source/examining/Loading_Generic_Array_Data.ipynb
@@ -266,7 +266,7 @@
    },
    "outputs": [],
    "source": [
-    "data = {k:(v.value,u) for (k,v), u in zip(f.items(),units)}\n",
+    "data = {k:(v[()],u) for (k,v), u in zip(f.items(),units)}\n",
     "bbox = np.array([[-0.5, 0.5], [-0.5, 0.5], [-0.5, 0.5]])"
    ]
   },


### PR DESCRIPTION
## PR Summary
Closes #3500
The problem is that this notebook was still using a deprecated (and now removed) h5py idiom, see
https://docs.h5py.org/en/stable/whatsnew/2.1.html?highlight=value#dataset-value-property-is-now-deprecated


## PR Checklist

- [N/A] New features are documented, with docstrings and narrative docs
- [N/A] Adds a test for any bugs fixed. Adds tests for new features.

