### PR TITLE
MNT: stop requiring coverage and codecov as they break bleeding-edge CI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -100,8 +100,6 @@ minimal =
     sympy==1.2
     unyt==2.8.0
 test =
-    codecov~=2.0.15
-    coverage~=4.5.1
     nose~=1.3.7
     nose-exclude
     nose-timer~=1.0.0


### PR DESCRIPTION
## PR Summary
In reaction to [tonight's failure on the bleeding edge CI job](https://github.com/yt-project/yt/actions/runs/1207918327)

<details>
<summary>Error message</summary>

```
Collecting coverage~=4.5.1
1466
  Downloading coverage-4.5.4.tar.gz (385 kB)
1467
    ERROR: Command errored out with exit status 1:
1468
     command: /opt/hostedtoolcache/Python/3.10.0-rc.1/x64/bin/python -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-0onj1mp6/coverage_59f238c4ba514f778709911b2697c3ca/setup.py'"'"'; __file__='"'"'/tmp/pip-install-0onj1mp6/coverage_59f238c4ba514f778709911b2697c3ca/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-2jeu1lkx
1469
         cwd: /tmp/pip-install-0onj1mp6/coverage_59f238c4ba514f778709911b2697c3ca/
1470
    Complete output (1 lines):
1471
    error in coverage setup command: use_2to3 is invalid.
1472
    ----------------------------------------
1473
WARNING: Discarding https://files.pythonhosted.org/packages/85/d5/818d0e603685c4a613d56f065a721013e942088047ff1027a632948bdae6/coverage-4.5.4.tar.gz#sha256=e07d9f1a23e9e93ab5c62902833bf3e4b1f65502927379148b6622686223125c (from https://pypi.org/simple/coverage/) (requires-python:>=2.6, !=3.0.*, !=3.1.*, !=3.2.*, <4). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
1474
  Downloading coverage-4.5.3.tar.gz (384 kB)
1475
    ERROR: Command errored out with exit status 1:
1476
     command: /opt/hostedtoolcache/Python/3.10.0-rc.1/x64/bin/python -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-0onj1mp6/coverage_4bdba8314eb34bd28c26421f4008ca14/setup.py'"'"'; __file__='"'"'/tmp/pip-install-0onj1mp6/coverage_4bdba8314eb34bd28c26421f4008ca14/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-sh3_8d8p
1477
         cwd: /tmp/pip-install-0onj1mp6/coverage_4bdba8314eb34bd28c26421f4008ca14/
1478
    Complete output (1 lines):
1479
    error in coverage setup command: use_2to3 is invalid.
1480
    ----------------------------------------
WARNING: Discarding https://files.pythonhosted.org/packages/82/70/2280b5b29a0352519bb95ab0ef1ea942d40466ca71c53a2085bdeff7b0eb/coverage-4.5.3.tar.gz#sha256=9de60893fb447d1e797f6bf08fdf0dbcda0c1e34c1b06c92bd3a363c0ea8c609 (from https://pypi.org/simple/coverage/) (requires-python:>=2.6, !=3.0.*, !=3.1.*, !=3.2.*, <4). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
1482
  Downloading coverage-4.5.2.tar.gz (384 kB)
1483
    ERROR: Command errored out with exit status 1:
1484
     command: /opt/hostedtoolcache/Python/3.10.0-rc.1/x64/bin/python -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-0onj1mp6/coverage_0d8308bdf26946928c47d8da4fd92c36/setup.py'"'"'; __file__='"'"'/tmp/pip-install-0onj1mp6/coverage_0d8308bdf26946928c47d8da4fd92c36/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-y3wrl5js
1485
         cwd: /tmp/pip-install-0onj1mp6/coverage_0d8308bdf26946928c47d8da4fd92c36/
1486
    Complete output (1 lines):
1487
    error in coverage setup command: use_2to3 is invalid.
1488
    ----------------------------------------
1489
WARNING: Discarding https://files.pythonhosted.org/packages/fb/af/ce7b0fe063ee0142786ee53ad6197979491ce0785567b6d8be751d2069e8/coverage-4.5.2.tar.gz#sha256=ab235d9fe64833f12d1334d29b558aacedfbca2356dfb9691f2d0d38a8a7bfb4 (from https://pypi.org/simple/coverage/) (requires-python:>=2.6, !=3.0.*, !=3.1.*, !=3.2.*, <4). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
1490
  Downloading coverage-4.5.1.tar.gz (379 kB)
1491
    ERROR: Command errored out with exit status 1:
1492
     command: /opt/hostedtoolcache/Python/3.10.0-rc.1/x64/bin/python -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-0onj1mp6/coverage_8246b2b5c5b04cb6b9f6742ae6c25c9b/setup.py'"'"'; __file__='"'"'/tmp/pip-install-0onj1mp6/coverage_8246b2b5c5b04cb6b9f6742ae6c25c9b/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-lb_mxgb6
1493
         cwd: /tmp/pip-install-0onj1mp6/coverage_8246b2b5c5b04cb6b9f6742ae6c25c9b/
1494
    Complete output (1 lines):
1495
    error in coverage setup command: use_2to3 is invalid.
1496
    ----------------------------------------
1497
WARNING: Discarding https://files.pythonhosted.org/packages/35/fe/e7df7289d717426093c68d156e0fd9117c8f4872b6588e8a8928a0f68424/coverage-4.5.1.tar.gz#sha256=56e448f051a201c5ebbaa86a5efd0ca90d327204d8b059ab25ad0f35fbfd79f1 (from https://pypi.org/simple/coverage/) (requires-python:>=2.6, !=3.0.*, !=3.1.*, !=3.2.*, <4). Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
1498
ERROR: Could not find a version that satisfies the requirement coverage~=4.5.1; extra == "test" (from yt[test]) (from versions: 3.0b3, 3.0, 3.0.1, 3.1b1, 3.1, 3.2b1, 3.2b2, 3.2b3, 3.2b4, 3.2, 3.3, 3.3.1, 3.4b1, 3.4b2, 3.4, 3.5b1, 3.5, 3.5.1b1, 3.5.1, 3.5.2b1, 3.5.2, 3.5.3, 3.6b1, 3.6b2, 3.6b3, 3.6, 3.7, 3.7.1, 4.0a1, 4.0a2, 4.0a3, 4.0a4, 4.0a5, 4.0a6, 4.0b1, 4.0b2, 4.0b3, 4.0, 4.0.1, 4.0.2, 4.0.3, 4.1b1, 4.1b2, 4.1b3, 4.1, 4.2b1, 4.2, 4.3, 4.3.1, 4.3.2, 4.3.3, 4.3.4, 4.4b1, 4.4, 4.4.1, 4.4.2, 4.5, 4.5.1, 4.5.2, 4.5.3, 4.5.4, 5.0a1, 5.0a2, 5.0a3, 5.0a4, 5.0a5, 5.0a6, 5.0a7, 5.0a8, 5.0b1, 5.0b2, 5.0, 5.0.1, 5.0.2, 5.0.3, 5.0.4, 5.1, 5.2, 5.2.1, 5.3, 5.3.1, 5.4, 5.5, 5.6b1, 6.0b1)
1499
ERROR: No matching distribution found for coverage~=4.5.1; extra == "test"
1500
Error: Process completed with exit code 1.
```

</details>

It should be ok to simply drop this requirement since we haven't been using coverage for over a year now.
I'll run the bleeding edge job manually with this branch to check if it is sufficent

## PR Checklist

- [N/A] New features are documented, with docstrings and narrative docs
- [N/A] Adds a test for any bugs fixed. Adds tests for new features.

