### PR TITLE
MNT: hotfix CI

### DIFF
--- a/.github/workflows/build-test-pytest.yaml
+++ b/.github/workflows/build-test-pytest.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [
-          # macos-latest, # TEMP see https://github.com/yt-project/yt/pull/3504#issuecomment-914365378
+          macos-latest,
           windows-latest,
           ubuntu-18.04,
         ]

--- a/.github/workflows/build-test-pytest.yaml
+++ b/.github/workflows/build-test-pytest.yaml
@@ -21,7 +21,11 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-18.04]
+        os: [
+          # macos-latest, # TEMP see https://github.com/yt-project/yt/pull/3504#issuecomment-914365378
+          windows-latest,
+          ubuntu-18.04,
+        ]
         python-version: [3.9]
         dependencies: [full]
         tests-type: [unit]

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [
-          # macos-latest, # TEMP see https://github.com/yt-project/yt/pull/3504#issuecomment-914365378
+          macos-latest,
           windows-latest,
           ubuntu-18.04,
         ]

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -21,7 +21,11 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-18.04]
+        os: [
+          # macos-latest, # TEMP see https://github.com/yt-project/yt/pull/3504#issuecomment-914365378
+          windows-latest,
+          ubuntu-18.04,
+        ]
         python-version: [3.9]
         dependencies: [full]
         tests-type: [unit]

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    iPython>=1.0
+    ipython>=2.0.0
     matplotlib!=3.4.2,>=2.0.2,<3.6
     more-itertools>=8.4
     numpy>=1.13.3
@@ -93,7 +93,7 @@ full =
 mapserver =
     bottle
 minimal =
-    ipython==1.0.0
+    ipython==2.0.0
     matplotlib==2.0.2
     more-itertools==8.4
     numpy==1.13.3

--- a/tests/ci_install.sh
+++ b/tests/ci_install.sh
@@ -42,7 +42,7 @@ if [[ "${RUNNER_OS}" == "Windows" ]] && [[ ${dependencies} != "minimal" ]]; then
 else
     python -m pip install --upgrade pip
     python -m pip install --upgrade wheel
-    python -m pip install --upgrade setuptools\<58.0 # see https://github.com/pypa/setuptools/issues/2775
+    python -m pip install --upgrade setuptools
 fi
 
 # Step 2: install deps and yt

--- a/tests/ci_install.sh
+++ b/tests/ci_install.sh
@@ -42,7 +42,7 @@ if [[ "${RUNNER_OS}" == "Windows" ]] && [[ ${dependencies} != "minimal" ]]; then
 else
     python -m pip install --upgrade pip
     python -m pip install --upgrade wheel
-    python -m pip install --upgrade setuptools
+    python -m pip install --upgrade setuptools\<58.0 # see https://github.com/pypa/setuptools/issues/2775
 fi
 
 # Step 2: install deps and yt


### PR DESCRIPTION
## PR Summary

Right now our Github Actions-based CI is completely broken as it fails the install stage.
I'm suspecting the most recent updates in setuptools to be responsible. Specifically https://github.com/pypa/setuptools/issues/2775

This is meant as a temporary patch to allow our CI to run.
