### PR TITLE
MNT: bump minimal required IPython version from 1.0.0 to 2.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    iPython>=1.0
+    ipython>=2.0.0
     matplotlib!=3.4.2,>=2.0.2,<3.6
     more-itertools>=8.4
     numpy>=1.13.3
@@ -93,7 +93,7 @@ full =
 mapserver =
     bottle
 minimal =
-    ipython==1.0.0
+    ipython==2.0.0
     matplotlib==2.0.2
     more-itertools==8.4
     numpy==1.13.3


### PR DESCRIPTION
## PR Summary
This replaces #3504 (see therein for details), and fixes our remaining CI failures that weren't resolved upstream.
Explanation: setuptools 58.0 dropped support for the `use_lib2to3=True` flag, used to convert Python 2 code to Python 3 at build time, see
- https://github.com/pypa/setuptools/pull/2769
- https://github.com/pypa/setuptools/pull/2770
- https://github.com/pypa/setuptools/pull/2777

Exactly one of our dependencies is broken by this change, namely: IPython 1.0.0 (released on August 2013)
The earliest version of IPython that is still supported by the latest version of setuptools is 2.0.0 (released on April 2014), so I assume it is reasonable to just bump our minimal supported version and call it a day.

