### PR TITLE
MNT: pin flake8 plugins

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,8 +50,8 @@ repos:
     hooks:
     - id: flake8
       additional_dependencies: [
-        flake8-bugbear>=20.3.2, # GH PR 2851
-        flake8-logging-format,
+        flake8-bugbear==21.9.1,
+        flake8-logging-format==0.6.0,
         flake8-2020==1.6.0,
       ]
 -   repo: https://github.com/asottile/blacken-docs


### PR DESCRIPTION
## PR Summary
With [the latest bugbear release](https://github.com/PyCQA/flake8-bugbear/releases/tag/21.9.1) came a new rule (B904).
Fortunately this additional validation already pass in yt (see https://github.com/yt-project/yt/pull/2760), but there could be new things coming upstream at random times in the future, potentially causing disruption in CI. The pre-commit framework is meant to unify tool versions used between devs, so it is counter productive to keep version specifications loose.
Also note that flake8 plugins are currently out of reach for pre-commit.ci and `pre-commit autoupdate` so they still need manual maintenance.
I think it's reasonable to pin to the current latest versions for now, then we can upgrade manually as required (for bugfixes or features relevant to yt).


## PR Checklist

- [N/A] New features are documented, with docstrings and narrative docs
- [N/A] Adds a test for any bugs fixed. Adds tests for new features.
