### PR TITLE
ENH: Allow user to set data set of the time for ambiguous data

### DIFF
--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -418,14 +418,14 @@ class DatasetSeries:
 
     _dataset_cls = None
 
-    def _load(self, output_fn, **kwargs):
+    def _load(self, output_fn, dataset=None, **kwargs):
         from yt.loaders import load
 
         if self._dataset_cls is not None:
             return self._dataset_cls(output_fn, **kwargs)
         elif self._mixed_dataset_types:
             return load(output_fn, **kwargs)
-        ds = load(output_fn, **kwargs)
+        ds = load(output_fn, dataset=dataset, **kwargs)
         self._dataset_cls = ds.__class__
         return ds
 

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -34,7 +34,7 @@ from yt.utilities.on_demand_imports import _pooch as pooch
 # --- Loaders for known data formats ---
 
 
-def load(fn, *args, **kwargs):
+def load(fn, *args, dataset=None, **kwargs):
     """
     Load a Dataset or DatasetSeries object.
     The data format is automatically discovered, and the exact return type is the
@@ -84,7 +84,8 @@ def load(fn, *args, **kwargs):
     candidates = []
     for cls in output_type_registry.values():
         if cls._is_valid(fn, *args, **kwargs):
-            candidates.append(cls)
+            if dataset is None or dataset in cls.__name__:
+                candidates.append(cls)
 
     # Find only the lowest subclasses, i.e. most specialised front ends
     candidates = find_lowest_subclasses(candidates)


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

This pull request is meant to fix an issue when a time series object is created but there is ambiguity in the data type. This PR should enable the user to set the data type in the argument, for example
```python
ts = yt.DatasetSeries("plt?????", parallel=True, dataset='AMReXDataset')
```
to ensure that data loads as an AMReX data set. This is meant to address #3510 .

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [x] New features are add
- [ ] New features are documented
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

Would love some feed back to see if this modification makes sense or what needs to be changed before adding the documentation. Thanks!

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
