### PR TITLE
ENH: allow direct dataset instanciation using the user path '~' glyph, consistently with yt.load

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -159,7 +159,7 @@ class Dataset(abc.ABC):
             if not is_stream:
                 obj.__init__(filename, *args, **kwargs)
             return obj
-        apath = os.path.abspath(filename)
+        apath = os.path.abspath(os.path.expanduser(filename))
         cache_key = (apath, pickle.dumps(args), pickle.dumps(kwargs))
         if ytcfg.get("yt", "skip_dataset_cache"):
             obj = object.__new__(cls)
@@ -212,9 +212,10 @@ class Dataset(abc.ABC):
         self.default_species_fields = default_species_fields
 
         # path stuff
-        self.parameter_filename = str(filename)
+        filename = os.path.expanduser(filename)
+        self.parameter_filename = filename
         self.basename = os.path.basename(filename)
-        self.directory = os.path.expanduser(os.path.dirname(filename))
+        self.directory = os.path.dirname(filename)
         self.fullpath = os.path.abspath(self.directory)
         self.backup_filename = self.parameter_filename + "_backup.gdf"
         self.read_from_backup = False

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -69,7 +69,7 @@ def load(fn, *args, **kwargs):
     yt.utilities.exceptions.YTAmbiguousDataType
         If the data format matches more than one class of similar specilization levels.
     """
-    fn = os.path.expanduser(fn)
+    fn = os.fspath(fn)
 
     if any(wildcard in fn for wildcard in "[]?!*"):
         from yt.data_objects.time_series import DatasetSeries


### PR DESCRIPTION
## PR Summary

In some occasion, it is useful (sometimes, mandatory) to load an exact dataset class explicitly. This happens with Boxlib-based datasets which are not easy to distinguish automatically with `yt.load`. It is also useful when developing a frontend.
Now, `yt.load` supports automatic expansion of `~/` via `os.path.expanduser`, however currently, this is not done in the `Dataset` classes themselves, resulting in an inconsistency where the first test pass, but not the second:

```python
import yt
from yt.frontends.enzo.api import EnzoDataset

fn = "~/dev/yt-project/test-data-dir/IsolatedGalaxy/galaxy0030/galaxy0030"

def test_load():
    ds = yt.load(fn)

def test_api():
    ds = EnzoDataset(fn)
```
this fixes that by moving the `os.path.expanduser` call to `Dataset.__init__`

## PR Checklist

- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

