### PR TITLE
ENH: rewrite backports from Python std lib in a fashion that can be automatically cleaned up with pyupgrade

### DIFF
--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1,3 +1,4 @@
+import sys
 from collections import defaultdict
 from functools import wraps
 from numbers import Number
@@ -48,18 +49,11 @@ from .plot_container import (
 )
 from .plot_modifications import callback_registry
 
-import sys  # isort: skip
-
 if sys.version_info < (3, 10):
-    # this function is deprecated in more_itertools
-    # because it is superseded by the standard library
     from more_itertools import zip_equal
 else:
 
     def zip_equal(*args):
-        # FUTURE: when only Python 3.10+ is supported,
-        # drop this conditional and call the builtin zip
-        # function directly where due
         return zip(*args, strict=True)
 
 

--- a/yt/visualization/volume_rendering/old_camera.py
+++ b/yt/visualization/volume_rendering/old_camera.py
@@ -1,4 +1,5 @@
 import builtins
+import sys
 from copy import deepcopy
 
 import numpy as np
@@ -6,7 +7,6 @@ import numpy as np
 from yt.config import ytcfg
 from yt.data_objects.api import ImageArray
 from yt.funcs import ensure_numpy_array, get_num_threads, get_pbar, is_sequence, mylog
-from yt.geometry.geometry_handler import cached_property
 from yt.units.yt_array import YTArray
 from yt.utilities.amr_kdtree.api import AMRKDTree
 from yt.utilities.exceptions import YTNotInsideNotebook
@@ -34,6 +34,27 @@ from yt.visualization.image_writer import apply_colormap, write_bitmap, write_im
 from yt.visualization.volume_rendering.blenders import enhance_rgba
 
 from .transfer_functions import ProjectionTransferFunction
+
+if sys.version_info >= (3, 8):
+    from functools import cached_property
+else:
+
+    def cached_property(func):
+        n = f"_{func.__name__}"
+
+        def cached_func(self):
+            if self._cache and getattr(self, n, None) is not None:
+                return getattr(self, n)
+            if self.data_size is None:
+                tr = self._accumulate_values(n[1:])
+            else:
+                tr = func(self)
+            if self._cache:
+
+                setattr(self, n, tr)
+            return tr
+
+        return property(cached_func)
 
 
 def get_corners(le, re):


### PR DESCRIPTION
## PR Summary
Title.
With the latest version of pyupgrade (that we already use as part of our pre-commit hooks),
"versioned code branches" attached to specific versions of Python 3 will now be cleaned up automatically, making their technical debt effectively 0, but they have to include an `else` statement.

see https://github.com/asottile/pyupgrade/pull/530
