### PR TITLE
BUG: fix incorrect default axis labels in 'r' oriented slice plots for spherical data

### DIFF
--- a/yt/geometry/coordinates/spherical_coordinates.py
+++ b/yt/geometry/coordinates/spherical_coordinates.py
@@ -260,7 +260,7 @@ class SphericalCoordinateHandler(CoordinateHandler):
         # non-Cartesian coordinates, we usually want to override these for
         # Cartesian coordinates, since we transform them.
         rv = {
-            self.axis_id["r"]: ("theta", "phi"),
+            self.axis_id["r"]: ("\\theta", "\\phi"),
             self.axis_id["theta"]: ("x / \\sin(\\theta)", "y / \\sin(\\theta)"),
             self.axis_id["phi"]: ("R", "z"),
         }


### PR DESCRIPTION
## PR Summary
Fix #3531
