### PR TITLE
BUG: fix colorbar minor ticks drawing for symlog norms

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -167,7 +167,7 @@ answer_tests:
   local_axialpix_007:
     - yt/geometry/coordinates/tests/test_axial_pixelization.py:test_axial_pixelization
 
-  local_cylindrical_background_007:  # PR 3295
+  local_cylindrical_background_008:  # PR 3536
     - yt/geometry/coordinates/tests/test_cylindrical_coordinates.py:test_noise_plots
 
   #local_particle_trajectory_001:

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -280,7 +280,7 @@ class ImagePlotMPL(PlotMPL):
                     10
                     ** np.arange(
                         np.rint(np.log10(cblinthresh)),
-                        np.ceil(np.log10(np.nanmax(data))) + 1,
+                        np.ceil(np.log10(np.nanmax(data))),
                     )
                 )
             elif np.nanmax(data) <= 0.0:
@@ -314,7 +314,7 @@ class ImagePlotMPL(PlotMPL):
                         10
                         ** np.arange(
                             np.rint(np.log10(cblinthresh)),
-                            np.ceil(np.log10(np.nanmax(data))) + 1,
+                            np.ceil(np.log10(np.nanmax(data))),
                         )
                     )
                 )

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from more_itertools import always_iterable
 from mpl_toolkits.axes_grid1 import ImageGrid
-from packaging.version import parse as parse_version
+from packaging.version import Version, parse as parse_version
 from unyt.exceptions import UnitConversionError
 
 from yt._maintenance.deprecation import issue_deprecation_warning
@@ -1193,13 +1193,19 @@ class PWViewerMPL(PlotWindow):
                     self.plots[f].cax.minorticks_on()
 
                 elif self._field_transform[f] == symlog_transform:
-                    flinthresh = 10 ** np.floor(
-                        np.log10(self.plots[f].cb.norm.linthresh)
-                    )
-                    mticks = self.plots[f].image.norm(
-                        get_symlog_minorticks(flinthresh, vmin, vmax)
-                    )
-                    self.plots[f].cax.yaxis.set_ticks(mticks, minor=True)
+                    if Version("3.2.0") <= MPL_VERSION < Version("3.5.0"):
+                        # no known working method to draw symlog minor ticks
+                        # see https://github.com/yt-project/yt/issues/3535
+                        pass
+                    else:
+                        flinthresh = 10 ** np.floor(
+                            np.log10(self.plots[f].cb.norm.linthresh)
+                        )
+                        mticks = get_symlog_minorticks(flinthresh, vmin, vmax)
+                        if MPL_VERSION < Version("3.5.0"):
+                            # https://github.com/matplotlib/matplotlib/issues/21258
+                            mticks = self.plots[f].image.norm(mticks)
+                        self.plots[f].cax.yaxis.set_ticks(mticks, minor=True)
 
                 elif self._field_transform[f] == log_transform:
                     if MPL_VERSION >= parse_version("3.0.0"):


### PR DESCRIPTION
## PR Summary

This is the patch I suggested in #3535
As far as I can tell the bug is very likely to be in Matplotlib itself, though I wasn't able to replicate it in isolation for now.
I'm opening this a a draft while I attempt to show that this buggy behaviour can be reproduced without yt, in which case I'll report upstream and link the report in a comment.

