### PR TITLE
TST: add answer testing to bleeding edge CI

### DIFF
--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -17,8 +17,16 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        include:
+          - tests-type: unit
+            python-version: '3.10-dev'
+          - tests-type: answer
+            python-version: 3.7
+
     runs-on: ubuntu-latest
-    name: Python3.10-dev
+    name: Future Env
     timeout-minutes: 60
 
     concurrency:
@@ -28,18 +36,30 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
+        submodules: recursive
         fetch-depth: 0
 
     - name: Set up Python Dev Version
       uses: actions/setup-python@v2
       with:
-        python-version: '3.10-dev'
+        python-version: ${{ matrix.python-version }}
 
-    - name: Install dependencies
+    - name: Install dependencies (unit)
+      if: ${{ matrix.tests-type == 'unit' }}
       run: |
         python -m pip install --upgrade pip
         python -m pip install --upgrade setuptools wheel
         python -m pip install git+https://github.com/numpy/numpy.git
+        python -m pip install git+https://github.com/matplotlib/matplotlib.git
+        python -m pip install cython
+
+    - name: Install dependencies (answer)
+      if: ${{ matrix.tests-type == 'answer' }}
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade setuptools wheel
+        python -m pip install numpy
+        cp tests/matplotlibrc .  # this line should become useless with https://github.com/yt-project/yt/pull/3520
         python -m pip install git+https://github.com/matplotlib/matplotlib.git
         python -m pip install cython
 
@@ -51,5 +71,13 @@ jobs:
         python setup.py build_ext -q -j2
         python -m pip install -e .[test] --no-build-isolation
 
-    - name: Run Tests
+    - name: Unit Tests
+      if: ${{ matrix.tests-type == 'unit' }}
       run: pytest -vvv
+    - name: Answer Tests
+      if: ${{ matrix.tests-type == 'answer' }}
+      run: python -m nose -c nose_answer.cfg --traverse-namespace
+    - name: Report Failed Answers
+      if: ${{ matrix.tests-type == 'answer' && failure() }}
+      shell: bash
+      run: python tests/report_failed_answers.py -f -m --xunit-file answer_nosetests.xml


### PR DESCRIPTION
## PR Summary
matplotlib 3.5 is about to be released, and answer tests are clearly much better at catching integration bugs, so it seems like agood opportunity to add our answer test suite to the "bleeding edge" CI workflow. Hopefully we don't catch anything weird. Otherwise, matplotlib's maintainers are on the lookout so we still have a chance to report stuff before the actual release is out.
