### PR TITLE
MNT: add explicit support for Python 3.10 on UNIX

### DIFF
--- a/.github/workflows/build-test-pytest.yaml
+++ b/.github/workflows/build-test-pytest.yaml
@@ -26,7 +26,7 @@ jobs:
           windows-latest,
           ubuntu-latest,
         ]
-        python-version: [3.9]
+        python-version: ['3.10']
         dependencies: [full]
         tests-type: [unit]
         include:
@@ -34,6 +34,12 @@ jobs:
             python-version: 3.7
             dependencies: minimal
             tests-type: unit
+          # temporary: Python 3.10 is not available on conda, so we pin this job to Python 3.9
+          - os: windows-latest
+            python-version: '3.9'
+        exclude:
+          - os: windows-latest
+            python-version: '3.10'
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,6 @@ repos:
     rev: v1.19.0
     hooks:
     -   id: setup-cfg-fmt
-        args: [--max-py-version, '3.9']
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
     hooks:

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Scientific/Engineering :: Astronomy
     Topic :: Scientific/Engineering :: Physics
     Topic :: Scientific/Engineering :: Visualization
@@ -71,25 +72,25 @@ doc =
     sphinx-bootstrap-theme
     sphinx-rtd-theme
 full =
-    astropy>=4.0.1,<5.0.0
+    astropy>=4.0.1,<6.0.0
     f90nml>=1.1.2
-    fastcache~=1.0.2
+    fastcache>=1.0.2
     firefly-vis>=2.0.4,<3.0.0
-    glueviz~=0.13.3
     h5py>=3.1.0,<4.0.0
-    libconf~=1.0.1
+    libconf>=1.0.1
     miniballcpp>=0.2.1
-    mpi4py~=3.0.3
-    netCDF4~=1.5.3
-    pandas~=1.1.2
+    mpi4py>=3.0.3
+    netCDF4>=1.5.3
+    pandas>=1.1.2
     pooch>=0.7.0
-    pyaml~=17.10.0
-    pykdtree~=1.3.1
-    pyqt5~=5.15.2
-    pyx~=0.15
-    requests~=2.20.0
-    scipy~=1.5.0
-    xarray~=0.16.1
+    pyaml>=17.10.0
+    pykdtree>=1.3.1
+    pyqt5>=5.15.2
+    pyx>=0.15
+    requests>=2.20.0
+    scipy>=1.5.0
+    xarray>=0.16.1
+    glueviz>=0.13.3;python_version < '3.10'
 mapserver =
     bottle
 minimal =

--- a/setup.cfg
+++ b/setup.cfg
@@ -90,7 +90,7 @@ full =
     requests>=2.20.0
     scipy>=1.5.0
     xarray>=0.16.1
-    glueviz>=0.13.3;python_version < '3.10'
+    glueviz>=0.13.3;python_version < '3.10' # FUTURE: lift this limitation when glueviz has Python 3.10 compatibility
 mapserver =
     bottle
 minimal =


### PR DESCRIPTION
## PR Summary

Python 3.10 is now available for GitHub Actions !
We might want to hold onto this PR for as long a upstream wheels are not stabilised. I think MacOS wheels for numpy are not stable yet, so I'll leave this as a draft for the time being.
Note that we still have two concurrent workflows for CI, namely `.github/workflows/build-test-pytest.yaml` and `.github/workflows/build-test.yaml`. The latter cannot be upgraded because it is based on nose, which is not compatible with Python 3.10, and never will be since it is unmaintained.

## Todo
get non-image tests CI green on
- [x] ubuntu
- [x] macos

## Known limitations

glueviz has no wheels for Python 3.10 and fails to build so I'm excluding it from the "full" requirements on Python 3.10

Python 3.10 doesn't seem to be distributed by conda yet, which is blocking on windows. I do not currently know what's the typical timescale on which we should expect it, or where to look for progress on the matter, so I'm not 100% sure it's worth waiting on this to consider merging this PR. Last year we only did this in January, about 4 month after Python 3.9 was first released. This time we have a bugfix release in the shop and I personnally think it'd be worth including this. We can hold on windows wheels for yt 4.0.2 and still provide some for UNIX systems.


