### PR TITLE
RAMSES: Allow to read non-standard info files

### DIFF
--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -861,13 +861,13 @@ class RAMSESDataset(Dataset):
         with open(self.parameter_filename) as f:
             # Standard: first six are ncpu, ndim, levelmin, levelmax, ngridmax, nstep_coarse
             for _ in range(6):
-                key = read_rhs(f, int)
+                read_rhs(f, int)
             f.readline()
             # Standard: next 11 are boxlen, time, aexp, h0, omega_m, omega_l, omega_k, omega_b, unit_l, unit_d, unit_t
             for _ in range(11):
                 key = read_rhs(f, float)
 
-            # Read extra until hitting the ordering type
+            # Read non standard extra fields until hitting the ordering type
             while key != "ordering type":
                 key = read_rhs(f, cast_a_else_b(float, str))
 


### PR DESCRIPTION
At the moment, a RAMSES dataset with the following info file would not be detected as such due to the fact that `mu_gas`, `ngrp`, `nent`, `npscal` and `nextinct` aren't recognized by yt.

This prevents the ordering from being read and subsequently triggers an error in yt's internal.

```
# info_XXXXX.txt
ncpu        =         64
ndim        =          3
levelmin    =          6
levelmax    =         14
ngridmax    =     200000
nstep_coarse=      97250

boxlen      =  0.765621193260999E-01
time        =  0.112757624128973E-02
aexp        =  0.100000000000000E+01
H0          =  0.100000000000000E+01
omega_m     =  0.100000000000000E+01
omega_l     =  0.000000000000000E+00
omega_k     =  0.000000000000000E+00
omega_b     =  0.450000017881393E-01
unit_l      =  0.308000000000000E+19
unit_d      =  0.383460000000000E-23
unit_t      =  0.197732040946880E+16
mu_gas      =  0.231000000000000E+01
ngrp        =          1
nent        =          0
npscal      =          4
nextinct    =          0

ordering type=hilbert
   DOMAIN   ind_min                 ind_max
       1   0.000000000000000E+00   0.296693037056000E+13
       2   0.296693037056000E+13   0.296693492480000E+13
       3   0.296693492480000E+13   0.296693506372000E+13
... to be continued ...
```

## Expected:

This should be detected as a valid RAMSES output.