### PR TITLE
BUG: remove broken logging messages in lens module

### DIFF
--- a/yt/visualization/volume_rendering/lens.py
+++ b/yt/visualization/volume_rendering/lens.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 from yt.data_objects.image_array import ImageArray
-from yt.funcs import mylog
 from yt.units.yt_array import uhstack, unorm, uvstack
 from yt.utilities.lib.grid_traversal import arr_fisheye_vectors
 from yt.utilities.math_utils import get_rotation_matrix
@@ -233,9 +232,6 @@ class PerspectiveLens(Lens):
             lens_type="perspective",
         )
 
-        mylog.debug(positions)
-        mylog.debug(vectors)
-
         return sampler_params
 
     def set_viewpoint(self, camera):
@@ -426,9 +422,6 @@ class StereoPerspectiveLens(Lens):
 
         # Here the east_vecs is non-rotated one
         positions = positions + east_vecs * disparity
-
-        mylog.debug(positions)
-        mylog.debug(vectors)
 
         return vectors, positions
 


### PR DESCRIPTION
## PR Summary
Fix #3547
My original intent was to fix the formatting of these log entries, but our logger filters are performing object comparisons
at runtime, which are very costly to run on numpy/unyt arrays (*would be, since they'd require some changes to even work here), so I don't think it's actually worth keeping these logging entries that no ones has been relying on for at least a year, since we introduced logger filters in https://github.com/yt-project/yt/pull/2871

