### PR TITLE
CI: Only run check-manifest on stable and release branches

### DIFF
--- a/.github/workflows/check-manifest.yaml
+++ b/.github/workflows/check-manifest.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches:
       - stable
-      - 'yt-4.*'
+      - 'yt-*'
 
 jobs:
   check-manifest:


### PR DESCRIPTION
The check-manifest workflow is reasonably expensive, on the order of 6 minutes or so.  Additionally, it's not one that will typically get hit, and it doesn't really require a huge amount of work to fix once it has been triggered.

This PR restricts us to only running it when pull requesting against `stable` or any `yt-4*` branch.
