### PR TITLE
MNT: run bleeding edge CI against the next future Python version (3.11)

### DIFF
--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -18,7 +18,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Python3.10-dev
+    name: Python3.11-dev
     timeout-minutes: 60
 
     concurrency:
@@ -33,7 +33,7 @@ jobs:
     - name: Set up Python Dev Version
       uses: actions/setup-python@v2
       with:
-        python-version: '3.10-dev'
+        python-version: '3.11-dev'
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
## PR Summary
This is what the bleeding edge CI is for !
Python 3.11 alpha 1 is now available on actions/python-versions , see https://github.com/actions/python-versions/releases/tag/3.11.0-alpha.1-117726

job is running on my fork https://github.com/neutrinoceros/yt/actions/runs/1336925980
