### PR TITLE
MNT: use ubuntu-latest in github action workflows

### DIFF
--- a/.github/workflows/build-test-pytest.yaml
+++ b/.github/workflows/build-test-pytest.yaml
@@ -21,12 +21,16 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-18.04]
+        os: [
+          macos-latest,
+          windows-latest,
+          ubuntu-latest,
+        ]
         python-version: [3.9]
         dependencies: [full]
         tests-type: [unit]
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-latest
             python-version: 3.6
             dependencies: minimal
             tests-type: unit

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -21,16 +21,20 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-18.04]
+        os: [
+          macos-latest,
+          windows-latest,
+          ubuntu-latest,
+        ]
         python-version: [3.9]
         dependencies: [full]
         tests-type: [unit]
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-latest
             python-version: 3.6
             dependencies: minimal
             tests-type: unit
-          - os: ubuntu-18.04
+          - os: ubuntu-latest
             python-version: 3.7
             dependencies: full
             tests-type: answer

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -14,7 +14,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-latest, macos-latest]
+        os: [
+          macos-latest,
+          windows-latest,
+          ubuntu-latest,
+        ]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
## PR Summary
I don't know why we're currently pinning ubuntu to 18.04 in CI, but the latest version is currently 21.x so on the off chances that there are any incompatibilities with it, I'm opening this to at least discover them. If everything stays green maybe it should be considered for merging too.
