### PR TITLE
Restrict ubuntu to 18.04 for wheels build

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -17,7 +17,7 @@ jobs:
         os: [
           macos-latest,
           windows-latest,
-          ubuntu-latest,
+          ubuntu-18.04,  # has to be the oldest possible for manylinux
         ]
       fail-fast: false
 


### PR DESCRIPTION
Answering https://github.com/yt-project/yt/pull/3562#issuecomment-942297508 there was a reason after all. I just didn't remember it.