### PR TITLE
ENH: only parse matplotlib's version once at runtime

### DIFF
--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -22,7 +22,6 @@ from functools import lru_cache, wraps
 from numbers import Number as numeric_type
 from typing import Any, Callable, Type
 
-import matplotlib
 import numpy as np
 from more_itertools import always_iterable, collapse, first
 from packaging.version import Version
@@ -32,6 +31,7 @@ from yt.units import YTArray, YTQuantity
 from yt.utilities.exceptions import YTInvalidWidthError
 from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.on_demand_imports import _requests as requests
+from yt.visualization._commons import MPL_VERSION
 
 # Some functions for handling sequences and other types
 
@@ -576,7 +576,7 @@ def get_version_stack():
     version_info = {}
     version_info["yt"] = get_yt_version()
     version_info["numpy"] = np.version.version
-    version_info["matplotlib"] = matplotlib.__version__
+    version_info["matplotlib"] = str(MPL_VERSION)
     return version_info
 
 
@@ -1039,7 +1039,7 @@ def matplotlib_style_context(style_name=None, after_reset=False):
         import matplotlib
 
         style_name = {"mathtext.fontset": "cm"}
-        if Version(matplotlib.__version__) >= Version("3.3.0"):
+        if MPL_VERSION >= Version("3.3.0"):
             style_name["mathtext.fallback"] = "cm"
         else:
             style_name["mathtext.fallback_to_cm"] = True

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -12,7 +12,7 @@ from yt.funcs import (
     mylog,
 )
 
-from ._commons import get_canvas, validate_image_name
+from ._commons import MPL_VERSION, get_canvas, validate_image_name
 
 BACKEND_SPECS = {
     "GTK": ["backend_gtk", "FigureCanvasGTK", "FigureManagerGTK"],
@@ -132,10 +132,8 @@ class PlotMPL:
 
         if mpl_kwargs is None:
             mpl_kwargs = {}
-        if "papertype" not in mpl_kwargs and Version(matplotlib.__version__) < Version(
-            "3.3.0"
-        ):
-            mpl_kwargs["papertype"] = "auto"
+        if MPL_VERSION < Version("3.3.0"):
+            mpl_kwargs.setdefault("papertype", "auto")
 
         name = validate_image_name(name)
 
@@ -216,7 +214,6 @@ class ImagePlotMPL(PlotMPL):
                 cblinthresh = np.nanmin(np.absolute(data)[data != 0])
 
             cbnorm_kwargs.update(dict(linthresh=cblinthresh))
-            MPL_VERSION = Version(matplotlib.__version__)
             if MPL_VERSION >= Version("3.2.0"):
                 # note that this creates an inconsistency between mpl versions
                 # since the default value previous to mpl 3.4.0 is np.e

--- a/yt/visualization/color_maps.py
+++ b/yt/visualization/color_maps.py
@@ -1,11 +1,9 @@
 import numpy as np
-from matplotlib import __version__ as mpl_ver, cm as mcm, colors as cc
+from matplotlib import cm as mcm, colors as cc
 from packaging.version import Version
 
 from . import _colormap_data as _cm
-
-MPL_VERSION = Version(mpl_ver)
-del mpl_ver
+from ._commons import MPL_VERSION
 
 
 def is_colormap(cmap):

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -29,6 +29,7 @@ from yt.utilities.exceptions import (
 from yt.utilities.math_utils import ortho_find
 from yt.utilities.orientation import Orientation
 
+from ._commons import MPL_VERSION
 from .base_plot_types import CallbackWrapper, ImagePlotMPL
 from .fixed_resolution import (
     FixedResolutionBuffer,
@@ -63,8 +64,6 @@ else:
         # function directly where due
         return zip(*args, strict=True)
 
-
-MPL_VERSION = Version(matplotlib.__version__)
 
 # Some magic for dealing with pyparsing being included or not
 # included in matplotlib (not in gentoo, yes in everything else)

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -18,7 +18,7 @@ from yt.utilities.exceptions import YTNotInsideNotebook
 from yt.utilities.logger import ytLogger as mylog
 
 from ..data_objects.selection_objects.data_selection_objects import YTSelectionContainer
-from ._commons import DEFAULT_FONT_PROPERTIES, validate_image_name
+from ._commons import DEFAULT_FONT_PROPERTIES, MPL_VERSION, validate_image_name
 from .base_plot_types import ImagePlotMPL, PlotMPL
 from .plot_container import (
     ImagePlotContainer,
@@ -29,8 +29,6 @@ from .plot_container import (
     log_transform,
     validate_plot,
 )
-
-MPL_VERSION = Version(matplotlib.__version__)
 
 
 def invalidate_profile(f):


### PR DESCRIPTION
## PR Summary
A recent PR added a `MPL_VERSION` constant to the `visualization._commons` module.
This means we can now import from there instead of repeating the parsing recipe everywhere it's needed.
