### PR TITLE
BUG: use tight layout by default when saving figures (PlotMPL) to avoid cropping labels out

### DIFF
--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -137,6 +137,7 @@ class PlotMPL:
         ):
             mpl_kwargs["papertype"] = "auto"
 
+        mpl_kwargs.setdefault("bbox_inches", "tight")
         name = validate_image_name(name)
 
         try:


### PR DESCRIPTION
fix #3601
