### PR TITLE
ENH: drop dependency to packaging, use tuples to parse and compare version numbers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,6 @@ install_requires =
     matplotlib!=3.4.2,>=2.0.2,<3.6
     more-itertools>=8.4
     numpy>=1.13.3
-    packaging>=20.9
     pyyaml>=4.2b1
     setuptools>=19.6
     sympy>=1.2,<1.9

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -25,10 +25,10 @@ from typing import Any, Callable, Type
 import matplotlib
 import numpy as np
 from more_itertools import always_iterable, collapse, first
-from packaging.version import Version
 from tqdm import tqdm
 
 from yt.units import YTArray, YTQuantity
+from yt.utilities._version import MPL_VERSION
 from yt.utilities.exceptions import YTInvalidWidthError
 from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.on_demand_imports import _requests as requests
@@ -1039,7 +1039,7 @@ def matplotlib_style_context(style_name=None, after_reset=False):
         import matplotlib
 
         style_name = {"mathtext.fontset": "cm"}
-        if Version(matplotlib.__version__) >= Version("3.3.0"):
+        if MPL_VERSION >= (3, 3, 0):
             style_name["mathtext.fallback"] = "cm"
         else:
             style_name["mathtext.fallback_to_cm"] = True

--- a/yt/utilities/_version.py
+++ b/yt/utilities/_version.py
@@ -1,0 +1,23 @@
+import re
+from typing import Tuple
+
+import matplotlib
+
+
+def version_tuple(version: str) -> Tuple[int, ...]:
+    elems = version.split(".")
+    if len(elems) > 3:
+        elems = elems[:3]
+
+    if not elems[-1].isnumeric():
+        # allow alpha/beta/release candidate versions
+        match = re.search(r"^\d+", elems[-1])
+        if match is None:
+            elems.pop()
+        else:
+            elems[-1] = match.group()
+
+    return tuple(int(_) for _ in elems)
+
+
+MPL_VERSION = version_tuple(matplotlib.__version__)

--- a/yt/utilities/on_demand_imports.py
+++ b/yt/utilities/on_demand_imports.py
@@ -1,7 +1,5 @@
 import sys
 
-from packaging.version import Version
-
 
 class NotAModule:
     """
@@ -356,20 +354,6 @@ _scipy = scipy_imports()
 class h5py_imports:
     _name = "h5py"
     _err = None
-
-    def __init__(self):
-        try:
-            import h5py
-
-            if Version(h5py.__version__) < Version("2.4.0"):
-                self._err = RuntimeError(
-                    "yt requires h5py version 2.4.0 or newer, "
-                    "please update h5py with e.g. `python -m pip install -U h5py` "
-                    "and try again"
-                )
-        except ImportError:
-            pass
-        super().__init__()
 
     _File = None
 

--- a/yt/visualization/_commons.py
+++ b/yt/visualization/_commons.py
@@ -2,9 +2,7 @@ import os
 import sys
 from typing import Optional, Type
 
-import matplotlib
-from packaging.version import Version
-
+from yt.utilities._version import MPL_VERSION
 from yt.utilities.logger import ytLogger as mylog
 
 from ._mpl_imports import (
@@ -15,14 +13,12 @@ from ._mpl_imports import (
     FigureCanvasSVG,
 )
 
-MPL_VERSION = Version(matplotlib.__version__)
-
 DEFAULT_FONT_PROPERTIES = {
     "family": "stixgeneral",
     "size": 18,
 }
 
-if MPL_VERSION >= Version("3.4"):
+if MPL_VERSION >= (3, 4, 0):
     DEFAULT_FONT_PROPERTIES["math_fontfamily"] = "cm"
 
 SUPPORTED_FORMATS = frozenset(FigureCanvasBase.get_supported_filetypes().keys())

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -2,7 +2,6 @@ from io import BytesIO
 
 import matplotlib
 import numpy as np
-from packaging.version import Version
 
 from yt.funcs import (
     get_brewer_cmap,
@@ -11,6 +10,7 @@ from yt.funcs import (
     matplotlib_style_context,
     mylog,
 )
+from yt.utilities._version import MPL_VERSION
 
 from ._commons import get_canvas, validate_image_name
 
@@ -132,10 +132,8 @@ class PlotMPL:
 
         if mpl_kwargs is None:
             mpl_kwargs = {}
-        if "papertype" not in mpl_kwargs and Version(matplotlib.__version__) < Version(
-            "3.3.0"
-        ):
-            mpl_kwargs["papertype"] = "auto"
+        if MPL_VERSION < (3, 3, 0):
+            mpl_kwargs.setdefault("papertype", "auto")
 
         name = validate_image_name(name)
 
@@ -216,8 +214,7 @@ class ImagePlotMPL(PlotMPL):
                 cblinthresh = np.nanmin(np.absolute(data)[data != 0])
 
             cbnorm_kwargs.update(dict(linthresh=cblinthresh))
-            MPL_VERSION = Version(matplotlib.__version__)
-            if MPL_VERSION >= Version("3.2.0"):
+            if MPL_VERSION >= (3, 2, 0):
                 # note that this creates an inconsistency between mpl versions
                 # since the default value previous to mpl 3.4.0 is np.e
                 # but it is only exposed since 3.2.0

--- a/yt/visualization/color_maps.py
+++ b/yt/visualization/color_maps.py
@@ -1,11 +1,9 @@
 import numpy as np
-from matplotlib import __version__ as mpl_ver, cm as mcm, colors as cc
-from packaging.version import Version
+from matplotlib import cm as mcm, colors as cc
+
+from yt.utilities._version import MPL_VERSION
 
 from . import _colormap_data as _cm
-
-MPL_VERSION = Version(mpl_ver)
-del mpl_ver
 
 
 def is_colormap(cmap):
@@ -260,7 +258,7 @@ def show_colormaps(subset="all", filename=None):
                 "to be 'all', 'yt_native', or a list of "
                 "valid colormap names."
             ) from e
-    if Version("2.0.0") <= MPL_VERSION < Version("2.2.0"):
+    if (2, 0, 0) <= MPL_VERSION < (2, 2, 0):
         # the reason we do this filtering is to avoid spurious warnings in CI when
         # testing against old versions of matplotlib (currently not older than 2.0.x)
         # and we can't easily filter warnings at the level of the relevant test itself

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -7,7 +7,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 from more_itertools import always_iterable
 from mpl_toolkits.axes_grid1 import ImageGrid
-from packaging.version import Version
 from unyt.exceptions import UnitConversionError
 
 from yt._maintenance.deprecation import issue_deprecation_warning
@@ -18,6 +17,7 @@ from yt.funcs import fix_axis, fix_unitary, is_sequence, iter_fields, mylog, obj
 from yt.units.unit_object import Unit
 from yt.units.unit_registry import UnitParseError
 from yt.units.yt_array import YTArray, YTQuantity
+from yt.utilities._version import MPL_VERSION
 from yt.utilities.exceptions import (
     YTCannotParseUnitDisplayName,
     YTDataTypeUnsupported,
@@ -63,8 +63,6 @@ else:
         # function directly where due
         return zip(*args, strict=True)
 
-
-MPL_VERSION = Version(matplotlib.__version__)
 
 # Some magic for dealing with pyparsing being included or not
 # included in matplotlib (not in gentoo, yes in everything else)
@@ -1223,7 +1221,7 @@ class PWViewerMPL(PlotWindow):
                     self.plots[f].cax.minorticks_on()
 
                 elif self._field_transform[f] == symlog_transform:
-                    if Version("3.2.0") <= MPL_VERSION < Version("3.5.0"):
+                    if (3, 2, 0) <= MPL_VERSION < (3, 5, 0):
                         # no known working method to draw symlog minor ticks
                         # see https://github.com/yt-project/yt/issues/3535
                         pass
@@ -1232,13 +1230,13 @@ class PWViewerMPL(PlotWindow):
                             np.log10(self.plots[f].cb.norm.linthresh)
                         )
                         mticks = get_symlog_minorticks(flinthresh, vmin, vmax)
-                        if MPL_VERSION < Version("3.5.0"):
+                        if MPL_VERSION < (3, 5, 0):
                             # https://github.com/matplotlib/matplotlib/issues/21258
                             mticks = self.plots[f].image.norm(mticks)
                         self.plots[f].cax.yaxis.set_ticks(mticks, minor=True)
 
                 elif self._field_transform[f] == log_transform:
-                    if MPL_VERSION >= Version("3.0.0"):
+                    if MPL_VERSION >= (3, 0, 0):
                         self.plots[f].cax.minorticks_on()
                         self.plots[f].cax.xaxis.set_visible(False)
                     else:

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -8,12 +8,12 @@ import matplotlib
 import numpy as np
 from matplotlib.font_manager import FontProperties
 from more_itertools.more import always_iterable, unzip
-from packaging.version import Version
 
 from yt.data_objects.profiles import create_profile, sanitize_field_tuple_keys
 from yt.data_objects.static_output import Dataset
 from yt.frontends.ytdata.data_structures import YTProfileDataset
 from yt.funcs import is_sequence, iter_fields, matplotlib_style_context
+from yt.utilities._version import MPL_VERSION
 from yt.utilities.exceptions import YTNotInsideNotebook
 from yt.utilities.logger import ytLogger as mylog
 
@@ -29,8 +29,6 @@ from .plot_container import (
     log_transform,
     validate_plot,
 )
-
-MPL_VERSION = Version(matplotlib.__version__)
 
 
 def invalidate_profile(f):
@@ -1178,7 +1176,7 @@ class PhasePlot(ImagePlotContainer):
             if self._cbar_minorticks[f]:
                 if self._field_transform[f] == linear_transform:
                     self.plots[f].cax.minorticks_on()
-                elif MPL_VERSION < Version("3.0.0"):
+                elif MPL_VERSION < (3, 0, 0):
                     # before matplotlib 3 log-scaled colorbars internally used
                     # a linear scale going from zero to one and did not draw
                     # minor ticks. Since we want minor ticks, calculate


### PR DESCRIPTION
## PR Summary
replaces #3600. Addionally to reducing duplicated code:

- code is less verbose
- one less dependency
- as a bonus, comparing tuples is 100x faster than parsing and comparing objects, though it should never really matter in practice


keeping this as a draft for now, conflicting PRs should be prioritised over this one:
- #3556
- #3565
- #3240