### PR TITLE
BLD: Fix build on i386

### DIFF
--- a/yt/utilities/lib/ewahboolarray/boolarray.h
+++ b/yt/utilities/lib/ewahboolarray/boolarray.h
@@ -344,7 +344,7 @@ public:
   size_t numberOfOnes() const {
     size_t count = 0;
     for (size_t i = 0; i < buffer.size(); ++i) {
-      count += countOnes(buffer[i]);
+      count += countOnes((UWORD)buffer[i]);
     }
     return count;
   }

--- a/yt/utilities/lib/ewahboolarray/ewah-inl.h
+++ b/yt/utilities/lib/ewahboolarray/ewah-inl.h
@@ -213,7 +213,7 @@ public:
         return;
     } else {
       uword t = static_cast<uword>(word & (~word + 1));
-      answer = literalPosition + countOnes((uword)(t - 1));
+      answer = literalPosition + countOnes((UWORD)(t - 1));
       word ^= t;
     }
     hasNext = moveToNext();
@@ -371,7 +371,7 @@ template <class uword> size_t EWAHBoolArray<uword>::numberOfOnes() const {
     }
     ++pointer;
     for (size_t k = 0; k < rlw.getNumberOfLiteralWords(); ++k) {
-      tot += countOnes((uword)buffer[pointer]);
+      tot += countOnes((UWORD)buffer[pointer]);
       ++pointer;
     }
   }

--- a/yt/utilities/lib/ewahboolarray/ewahutil.h
+++ b/yt/utilities/lib/ewahboolarray/ewahutil.h
@@ -28,6 +28,14 @@
 #ifdef _MSC_VER
 #include <intrin.h>
 #endif
+
+
+#if ((ULONG_MAX) == (UINT_MAX))
+#define UWORD uint32_t
+#else
+#define UWORD uint64_t
+#endif
+
 namespace ewah {
 
 static inline uint32_t ctz64(uint64_t n) {


### PR DESCRIPTION
This removes ambiguity in the ewah C utils on i386 platforms. In particular, this PR explicitely defines UWORD as a 32bit unsigned integer on i386 and as a 64bit unsigned integer on x86-64.

## PR Summary

This fixes #3477.