### PR TITLE
RFC: decouple yt.config from initialization

### DIFF
--- a/yt/__init__.py
+++ b/yt/__init__.py
@@ -100,6 +100,7 @@ def run_nose(*args, **kwargs):
     return run_nose(*args, **kwargs)
 
 
+from yt.config import _setup_postinit_configuration
 from yt.units.unit_systems import UnitSystem, unit_system_registry  # type: ignore
 
 # Import some helpful math utilities
@@ -153,3 +154,8 @@ from yt.visualization.volume_rendering.api import (
 
 #    TransferFunctionHelper, MultiVariateTransferFunction
 #    off_axis_projection
+
+
+# run configuration callbacks
+_setup_postinit_configuration()
+del _setup_postinit_configuration

--- a/yt/config.py
+++ b/yt/config.py
@@ -1,12 +1,6 @@
 import os
-import warnings
 
-# TODO: import tomllib from the standard library instead in Python >= 3.11
-import tomli as tomllib
-import tomli_w
-from more_itertools import always_iterable
-
-from yt.utilities.configuration_tree import ConfigLeaf, ConfigNode
+from yt.utilities.configure import YTConfig, config_dir, configuration_callbacks
 
 ytcfg_defaults = {}
 
@@ -64,143 +58,12 @@ ytcfg_defaults["yt"] = dict(
 )
 
 
-def config_dir():
-    config_root = os.environ.get(
-        "XDG_CONFIG_HOME", os.path.join(os.path.expanduser("~"), ".config")
-    )
-    conf_dir = os.path.join(config_root, "yt")
-
-    if not os.path.exists(conf_dir):
-        try:
-            os.makedirs(conf_dir)
-        except OSError:
-            warnings.warn("unable to create yt config directory")
-    return conf_dir
-
-
 # For backward compatibility, do not use these vars internally in yt
 CONFIG_DIR = config_dir()
 
 
-class YTConfig:
-    def __init__(self, defaults=None):
-        if defaults is None:
-            defaults = {}
-        self.config_root = ConfigNode(None)
-
-    def get(self, section, *keys, callback=None):
-        node_or_leaf = self.config_root.get(section, *keys)
-        if isinstance(node_or_leaf, ConfigLeaf):
-            if callback is not None:
-                return callback(node_or_leaf)
-            return node_or_leaf.value
-        return node_or_leaf
-
-    def get_most_specific(self, section, *keys, **kwargs):
-        use_fallback = "fallback" in kwargs
-        fallback = kwargs.pop("fallback", None)
-        try:
-            return self.config_root.get_deepest_leaf(section, *keys)
-        except KeyError as err:
-            if use_fallback:
-                return fallback
-            else:
-                raise err
-
-    def update(self, new_values, metadata=None):
-        if metadata is None:
-            metadata = {}
-        self.config_root.update(new_values, metadata)
-
-    def has_section(self, section):
-        try:
-            self.config_root.get_child(section)
-            return True
-        except KeyError:
-            return False
-
-    def add_section(self, section):
-        self.config_root.add_child(section)
-
-    def remove_section(self, section):
-        if self.has_section(section):
-            self.config_root.remove_child(section)
-            return True
-        else:
-            return False
-
-    def set(self, *args, metadata=None):
-        section, *keys, value = args
-        if metadata is None:
-            metadata = {"source": "runtime"}
-        self.config_root.upsert_from_list(
-            [section] + list(keys), value, extra_data=metadata
-        )
-
-    def remove(self, *args):
-        self.config_root.pop_leaf(args)
-
-    def read(self, file_names):
-        file_names_read = []
-        for fname in always_iterable(file_names):
-            if not os.path.exists(fname):
-                continue
-            metadata = {"source": f"file: {fname}"}
-            with open(fname, "rb") as fh:
-                data = tomllib.load(fh)
-            self.update(data, metadata=metadata)
-            file_names_read.append(fname)
-
-        return file_names_read
-
-    def write(self, file_handler):
-        value = self.config_root.as_dict()
-        config_as_str = tomli_w.dumps(value)
-
-        try:
-            # Assuming file_handler has a write attribute
-            file_handler.write(config_as_str)
-        except AttributeError:
-            # Otherwise we expect a path to a file
-            with open(file_handler, mode="w") as fh:
-                fh.write(config_as_str)
-
-    @staticmethod
-    def get_global_config_file():
-        return os.path.join(config_dir(), "yt.toml")
-
-    @staticmethod
-    def get_local_config_file():
-        return os.path.join(os.path.abspath(os.curdir), "yt.toml")
-
-    def __setitem__(self, args, value):
-        section, *keys = always_iterable(args)
-        self.set(section, *keys, value, metadata=None)
-
-    def __getitem__(self, key):
-        section, *keys = always_iterable(key)
-        return self.get(section, *keys)
-
-    def __contains__(self, item):
-        return item in self.config_root
-
-    # Add support for IPython rich display
-    # see https://ipython.readthedocs.io/en/stable/config/integrating.html
-    def _repr_json_(self):
-        return self.config_root._repr_json_()
-
-
 _global_config_file = YTConfig.get_global_config_file()
 _local_config_file = YTConfig.get_local_config_file()
-
-if not os.path.exists(_global_config_file):
-    cfg = {"yt": {}}  # type: ignore
-    try:
-        with open(_global_config_file, mode="wb") as fd:
-            tomli_w.dump(cfg, fd)
-    except OSError:
-        warnings.warn("unable to write new config file")
-
 
 # Load the config
 ytcfg = YTConfig()
@@ -211,3 +74,9 @@ if os.path.exists(_local_config_file):
     ytcfg.read(_local_config_file)
 elif os.path.exists(_global_config_file):
     ytcfg.read(_global_config_file)
+
+
+def _setup_postinit_configuration():
+    """This is meant to be run last in yt.__init__"""
+    for callback in configuration_callbacks:
+        callback(ytcfg)

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -6,6 +6,7 @@ from typing import List, Tuple, Union
 
 import numpy as np
 
+from yt.config import ytcfg
 from yt.data_objects.field_data import YTFieldData
 from yt.data_objects.profiles import create_profile
 from yt.fields.field_exceptions import NeedsGridType
@@ -676,8 +677,6 @@ class YTDataContainer(abc.ABC):
         otherwise Glue will be started.
         """
         from glue.core import Data, DataCollection
-
-        from yt.config import ytcfg
 
         if ytcfg.get("yt", "internals", "within_testing"):
             from glue.core.application_base import Application as GlueApplication

--- a/yt/data_objects/index_subobjects/grid_patch.py
+++ b/yt/data_objects/index_subobjects/grid_patch.py
@@ -20,8 +20,6 @@ from yt.utilities.lib.interpolators import ghost_zone_interpolate
 from yt.utilities.lib.mesh_utilities import clamp_edges
 from yt.utilities.nodal_data_utils import get_nodal_slices
 
-RECONSTRUCT_INDEX = bool(ytcfg.get("yt", "reconstruct_index"))
-
 
 class AMRGridPatch(YTSelectionContainer):
     _spatial = True
@@ -170,7 +168,7 @@ class AMRGridPatch(YTSelectionContainer):
         self.RightEdge = h.grid_right_edge[my_ind]
         # This can be expensive so we allow people to disable this behavior
         # via a config option
-        if RECONSTRUCT_INDEX:
+        if ytcfg.get("yt", "reconstruct_index"):
             if is_sequence(self.Parent) and len(self.Parent) > 0:
                 p = self.Parent[0]
             else:

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -44,6 +44,7 @@ from yt.units.unit_systems import (  # type: ignore
     unit_system_registry,
 )
 from yt.units.yt_array import YTArray, YTQuantity
+from yt.utilities.configure import YTConfig, configuration_callbacks
 from yt.utilities.cosmology import Cosmology
 from yt.utilities.exceptions import (
     YTFieldNotFound,
@@ -69,7 +70,20 @@ else:
 _cached_datasets: MutableMapping[
     Union[int, str], "Dataset"
 ] = weakref.WeakValueDictionary()
-_ds_store = ParameterFileStore()
+
+# we set this global to None as a place holder
+# its actual instanciation is delayed until after yt.__init__
+# is completed because we need yt.config.ytcfg to be instanciated first
+
+_ds_store: Optional[ParameterFileStore] = None
+
+
+def _setup_ds_store(ytcfg: YTConfig) -> None:
+    global _ds_store
+    _ds_store = ParameterFileStore()
+
+
+configuration_callbacks.append(_setup_ds_store)
 
 
 def _unsupported_object(ds, obj_name):

--- a/yt/fields/tests/test_fields_plugins.py
+++ b/yt/fields/tests/test_fields_plugins.py
@@ -4,8 +4,9 @@ import tempfile
 import unittest
 
 import yt
-from yt.config import YTConfig, config_dir, ytcfg
+from yt.config import ytcfg
 from yt.testing import assert_raises, fake_random_ds
+from yt.utilities.configure import YTConfig, config_dir
 
 _TEST_PLUGIN = "_test_plugin.py"
 
@@ -35,6 +36,7 @@ class TestPluginFile(unittest.TestCase):
     def setUpClass(cls):
         cls.xdg_config_home = os.environ.get("XDG_CONFIG_HOME")
         cls.tmpdir = tempfile.mkdtemp()
+        os.mkdir(os.path.join(cls.tmpdir, "yt"))
         os.environ["XDG_CONFIG_HOME"] = cls.tmpdir
         with open(YTConfig.get_global_config_file(), mode="w") as fh:
             fh.write(_DUMMY_CFG_TOML)

--- a/yt/frontends/ramses/definitions.py
+++ b/yt/frontends/ramses/definitions.py
@@ -1,8 +1,8 @@
 # These functions are RAMSES-specific
 import re
 
-from yt.config import ytcfg
 from yt.funcs import mylog
+from yt.utilities.configure import YTConfig, configuration_callbacks
 
 
 def ramses_header(hvals):
@@ -70,7 +70,10 @@ particle_families = {
     "gas_tracer": 0,
 }
 
-if ytcfg.has_section("ramses-families"):
+
+def _setup_ramses_particle_families(ytcfg: YTConfig) -> None:
+    if not ytcfg.has_section("ramses-families"):
+        return
     for key in particle_families.keys():
         val = ytcfg.get("ramses-families", key, callback=None)
         if val is not None:
@@ -78,3 +81,6 @@ if ytcfg.has_section("ramses-families"):
                 "Changing family %s from %s to %s", key, particle_families[key], val
             )
             particle_families[key] = val
+
+
+configuration_callbacks.append(_setup_ramses_particle_families)

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -28,6 +28,7 @@ from packaging.version import Version
 from tqdm import tqdm
 
 from yt._maintenance.deprecation import issue_deprecation_warning
+from yt.config import ytcfg
 from yt.units import YTArray, YTQuantity
 from yt.utilities.exceptions import YTInvalidWidthError
 from yt.utilities.logger import ytLogger as mylog
@@ -188,8 +189,6 @@ def time_execution(func):
         mylog.debug("%s took %0.3f s", func.__name__, (t2 - t1))
         return res
 
-    from yt.config import ytcfg
-
     if ytcfg.get("yt", "time_functions"):
         return wrapper
     else:
@@ -230,7 +229,6 @@ def rootonly(func):
        def some_root_only_function(*args, **kwargs):
            ...
     """
-    from yt.config import ytcfg
 
     @wraps(func)
     def check_parallel_rank(*args, **kwargs):
@@ -343,7 +341,6 @@ def get_pbar(title, maxval):
     and a *maxval*.
     """
     maxval = max(maxval, 1)
-    from yt.config import ytcfg
 
     if (
         ytcfg.get("yt", "suppress_stream_logging")
@@ -361,8 +358,6 @@ def only_on_root(func, *args, **kwargs):
     on the root processor calls the function.  All other processors get "None"
     handed back.
     """
-    from yt.config import ytcfg
-
     if kwargs.pop("global_rootonly", False):
         cfg_option = "global_parallel_rank"
     else:
@@ -379,8 +374,6 @@ def is_root():
     This function returns True if it is on the root processor of the
     topcomm and False otherwise.
     """
-    from yt.config import ytcfg
-
     if not ytcfg.get("yt", "internals", "parallel"):
         return True
     return ytcfg.get("yt", "internals", "topcomm_parallel_rank") == 0
@@ -696,8 +689,6 @@ def parallel_profile(prefix):
     ...     plot = PhasePlot(ds.all_data(), *fields)
     """
     import cProfile
-
-    from yt.config import ytcfg
 
     fn = "%s_%04i_%04i.cprof" % (
         prefix,

--- a/yt/mods.py
+++ b/yt/mods.py
@@ -15,7 +15,7 @@ import yt.startup_tasks as __startup_tasks
 from yt import *
 from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.config import ytcfg, ytcfg_defaults
-from yt.utilities.logger import _level
+from yt.utilities.logger import ytLogger
 
 issue_deprecation_warning(
     "The yt.mods module is deprecated.", since="4.1.0", removal="4.2.0"
@@ -24,7 +24,7 @@ issue_deprecation_warning(
 unparsed_args = __startup_tasks.unparsed_args
 
 
-if _level >= int(ytcfg_defaults["yt"]["log_level"]):  # type: ignore
+if ytLogger.getEffectiveLevel() >= int(ytcfg_defaults["yt"]["log_level"]):  # type: ignore
     # This won't get displayed.
     mylog.debug("Turning off NumPy error reporting")
     np.seterr(all="ignore")

--- a/yt/sample_data/api.py
+++ b/yt/sample_data/api.py
@@ -11,6 +11,7 @@ from warnings import warn
 
 import pkg_resources
 
+from yt.config import ytcfg
 from yt.funcs import mylog
 from yt.utilities.on_demand_imports import (
     _pandas as pd,
@@ -137,8 +138,6 @@ def get_data_registry_table():
 
 
 def _get_test_data_dir_path():
-    from yt.config import ytcfg
-
     p = Path(ytcfg.get("yt", "test_data_dir"))
     if p.is_dir():
         return p

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -1330,6 +1330,7 @@ class YTConfigLocalConfigHandler:
         elif getattr(args, "global", False):
             config_file = global_config_file
         else:
+            config_file: Optional[str] = None
             if local_exists and global_exists:
                 s = (
                     "Yt detected a local and a global configuration file, refusing "
@@ -1347,14 +1348,15 @@ class YTConfigLocalConfigHandler:
                 sys.exit(s)
             elif local_exists:
                 config_file = local_config_file
-            else:
+            elif global_exists:
                 config_file = global_config_file
-            sys.stderr.write(f"INFO: using configuration file: {config_file}.\n")
 
-        if not os.path.exists(config_file):
-            with open(config_file, "w") as f:
-                f.write("[yt]\n")
-
+            if config_file is None:
+                print("WARNING: no configuration file installed.", file=sys.stderr)
+            else:
+                print(
+                    f"INFO: reading configuration file: {config_file}", file=sys.stderr
+                )
         CONFIG.read(config_file)
 
         self.config_file = config_file
@@ -1407,7 +1409,12 @@ class YTConfigSetCmd(YTCommand, YTConfigLocalConfigHandler):
         from yt.utilities.configure import set_config
 
         self.load_config(args)
-
+        if self.config_file is None:
+            self.config_file = os.path.join(os.getcwd(), "yt.toml")
+            print(
+                f"INFO: configuration will be written to {self.config_file}",
+                file=sys.stderr,
+            )
         set_config(args.section, args.option, args.value, self.config_file)
 
 

--- a/yt/utilities/configure.py
+++ b/yt/utilities/configure.py
@@ -1,6 +1,131 @@
 import os
+from typing import Callable, List
 
-from yt.config import YTConfig
+# TODO: import tomllib from the standard library instead in Python >= 3.11
+import tomli as tomllib
+import tomli_w
+from more_itertools import always_iterable
+
+from yt.utilities.configuration_tree import ConfigLeaf, ConfigNode
+
+configuration_callbacks: List[Callable[["YTConfig"], None]] = []
+
+
+def config_dir():
+    config_root = os.environ.get(
+        "XDG_CONFIG_HOME", os.path.join(os.path.expanduser("~"), ".config")
+    )
+    conf_dir = os.path.join(config_root, "yt")
+    return conf_dir
+
+
+class YTConfig:
+    def __init__(self, defaults=None):
+        if defaults is None:
+            defaults = {}
+        self.config_root = ConfigNode(None)
+
+    def get(self, section, *keys, callback=None):
+        node_or_leaf = self.config_root.get(section, *keys)
+        if isinstance(node_or_leaf, ConfigLeaf):
+            if callback is not None:
+                return callback(node_or_leaf)
+            return node_or_leaf.value
+        return node_or_leaf
+
+    def get_most_specific(self, section, *keys, **kwargs):
+        use_fallback = "fallback" in kwargs
+        fallback = kwargs.pop("fallback", None)
+        try:
+            return self.config_root.get_deepest_leaf(section, *keys)
+        except KeyError as err:
+            if use_fallback:
+                return fallback
+            else:
+                raise err
+
+    def update(self, new_values, metadata=None):
+        if metadata is None:
+            metadata = {}
+        self.config_root.update(new_values, metadata)
+
+    def has_section(self, section):
+        try:
+            self.config_root.get_child(section)
+            return True
+        except KeyError:
+            return False
+
+    def add_section(self, section):
+        self.config_root.add_child(section)
+
+    def remove_section(self, section):
+        if self.has_section(section):
+            self.config_root.remove_child(section)
+            return True
+        else:
+            return False
+
+    def set(self, *args, metadata=None):
+        section, *keys, value = args
+        if metadata is None:
+            metadata = {"source": "runtime"}
+        self.config_root.upsert_from_list(
+            [section] + list(keys), value, extra_data=metadata
+        )
+
+    def remove(self, *args):
+        self.config_root.pop_leaf(args)
+
+    def read(self, file_names):
+        file_names_read = []
+        for fname in always_iterable(file_names):
+            if not os.path.exists(fname):
+                continue
+            metadata = {"source": f"file: {fname}"}
+            with open(fname, "rb") as fh:
+                data = tomllib.load(fh)
+            self.update(data, metadata=metadata)
+            file_names_read.append(fname)
+
+        return file_names_read
+
+    def write(self, file_handler):
+        value = self.config_root.as_dict()
+        config_as_str = tomli_w.dumps(value)
+
+        try:
+            # Assuming file_handler has a write attribute
+            file_handler.write(config_as_str)
+        except AttributeError:
+            # Otherwise we expect a path to a file
+            with open(file_handler, mode="w") as fh:
+                fh.write(config_as_str)
+
+    @staticmethod
+    def get_global_config_file():
+        return os.path.join(config_dir(), "yt.toml")
+
+    @staticmethod
+    def get_local_config_file():
+        return os.path.join(os.path.abspath(os.curdir), "yt.toml")
+
+    def __setitem__(self, args, value):
+        section, *keys = always_iterable(args)
+        self.set(section, *keys, value, metadata=None)
+
+    def __getitem__(self, key):
+        section, *keys = always_iterable(key)
+        return self.get(section, *keys)
+
+    def __contains__(self, item):
+        return item in self.config_root
+
+    # Add support for IPython rich display
+    # see https://ipython.readthedocs.io/en/stable/config/integrating.html
+    def _repr_json_(self):
+        return self.config_root._repr_json_()
+
 
 CONFIG = YTConfig()
 

--- a/yt/utilities/parallel_tools/parallel_analysis_interface.py
+++ b/yt/utilities/parallel_tools/parallel_analysis_interface.py
@@ -681,8 +681,6 @@ class CommunicationSystem:
         return new_comm
 
     def _update_parallel_state(self, new_comm):
-        from yt.config import ytcfg
-
         ytcfg["yt", "internals", "topcomm_parallel_size"] = new_comm.size
         ytcfg["yt", "internals", "topcomm_parallel_rank"] = new_comm.rank
         if new_comm.rank > 0 and ytcfg.get("yt", "serialize"):

--- a/yt/utilities/tests/test_config.py
+++ b/yt/utilities/tests/test_config.py
@@ -9,7 +9,7 @@ from io import StringIO
 
 import yt.config
 import yt.utilities.command_line
-from yt.config import YTConfig
+from yt.utilities.configure import YTConfig
 
 _TEST_PLUGIN = "_test_plugin.py"
 # NOTE: the normalization of the crazy camel-case will be checked
@@ -50,6 +50,12 @@ class TestYTConfig(unittest.TestCase):
         self.xdg_config_home = os.environ.get("XDG_CONFIG_HOME")
         self.tmpdir = tempfile.mkdtemp()
         os.environ["XDG_CONFIG_HOME"] = self.tmpdir
+        os.mkdir(os.path.join(self.tmpdir, "yt"))
+
+        # run inside another temporary directory to avoid poluting the
+        # local space when we dump configuration to a local yt.toml file
+        self.origin = os.getcwd()
+        os.chdir(tempfile.mkdtemp())
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
@@ -57,6 +63,7 @@ class TestYTConfig(unittest.TestCase):
             os.environ["XDG_CONFIG_HOME"] = self.xdg_config_home
         else:
             os.environ.pop("XDG_CONFIG_HOME")
+        os.chdir(self.origin)
 
     def _runYTConfig(self, args):
         args = ["yt", "config"] + args
@@ -138,6 +145,7 @@ class TestYTConfigCommands(TestYTConfig):
     def tearDown(self):
         if os.path.exists(YTConfig.get_global_config_file()):
             os.remove(YTConfig.get_global_config_file())
+        super().tearDown()
 
 
 class TestYTConfigGlobalLocal(TestYTConfig):


### PR DESCRIPTION
## PR Summary

This patch postpones the "live" part of the configuration to the very end of `yt.__init__` and disentangle the configuration code a bit. This is achieved by
- never importing yt.config at the top of any module. Import statements are relocated to inside functions that need to access the global `yt.config.ytcfg` object. This is in line with the existing practice in the `yt.funcs` module
- making yt.config depend on yt.utilities.configure (instead of the other way around). This means a sizeable part of the diff here is simply due to relocating the `YTConfig` class
- adding a small callback system in `yt.utilities.configure`, allowing any module to perform configuration at runtime, but delaying it until `yt.config` is imported from for the first time (in `yt.__init__`)

The first commit fixes #3625 while the second fixes #3045

It also has obvious conflicts with #3106, but I think it'd be easier to merge the present PR first.