### PR TITLE
BUG: fixes for Hammer-Aitoff projection (r-normal) 2D viz in spherical geometries

### DIFF
--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -444,7 +444,7 @@ keyword arguments, as described in
 Slice Plots and Projection Plots in Spherical Geometry
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-What to expect when plotting data in spherical geometry ? Here we explain
+What to expect when plotting data in spherical geometry? Here we explain
 the notations and projections system yt uses for to render 2D images of
 spherical data.
 

--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -438,6 +438,65 @@ to project along, and a field to project.  For example:
 keyword arguments, as described in
 :class:`~yt.visualization.plot_window.OffAxisProjectionPlot`
 
+
+.. _slices-and-projections-in-spherical-geometry:
+
+Slice Plots and Projection Plots in Spherical Geometry
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+What to expect when plotting data in spherical geometry ? Here we explain
+the notations and projections system yt uses for to render 2D images of
+spherical data.
+
+The native spherical coordinates are
+- the spherical radius :math:`r`
+- the colatitude :math:`\theta`, defined between :math:`0` and :math:`\pi`
+- the azimuth :math:`\varphi`, defined between :math:`0` and :math:`2\pi`
+
+:math:`\varphi`-normal slices are represented in the poloidal plane, with axes :math:`R, z`, where
+- :math:`R = r \sin \theta` is the cylindrical radius
+- :math:`z = r \cos \theta` is the elevation
+
+.. python-script::
+
+   import yt
+
+   ds = yt.load_sample("KeplerianDisk", unit_system="cgs")
+   slc = yt.SlicePlot(ds, "phi", ("gas", "density"))
+   slc.save()
+
+:math:`\theta`-normal slices are represented in a
+:math:`x/\sin(\theta)` VS :math:` y/(\theta)` plane, where
+- :math:`x = R \cos \varphi`
+- :math:`y = R \sin \varphi`
+
+are the cartesian plane coordinates
+
+.. python-script::
+
+   import yt
+
+   ds = yt.load_sample("KeplerianDisk", unit_system="cgs")
+   slc = yt.SlicePlot(ds, "theta", ("gas", "density"))
+   slc.save()
+
+
+Finally, :math:`r`-normal slices are represented following a
+`Aitoff-Hammer projection <http://paulbourke.net/geometry/transformationprojection/>`_
+
+We denote
+- the latitude :math:`\bar\theta = \frac{\pi}{2} - \theta`
+- the longitude :math:`\lambda = \varphi - \pi`
+
+.. python-script::
+
+   import yt
+
+   ds = yt.load_sample("KeplerianDisk", unit_system="cgs")
+   slc = yt.SlicePlot(ds, "r", ("gas", "density"))
+   slc.save()
+
+
 .. _unstructured-mesh-slices:
 
 Unstructured Mesh Slices

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -164,7 +164,7 @@ answer_tests:
     - yt/frontends/ytdata/tests/test_old_outputs.py:test_old_profile_data
     - yt/frontends/ytdata/tests/test_old_outputs.py:test_old_nonspatial_data
 
-  local_axialpix_007:
+  local_axialpix_008: # PR 3628
     - yt/geometry/coordinates/tests/test_axial_pixelization.py:test_axial_pixelization
 
   local_cylindrical_background_011:  # PR 3670

--- a/yt/geometry/coordinates/spherical_coordinates.py
+++ b/yt/geometry/coordinates/spherical_coordinates.py
@@ -24,7 +24,7 @@ class SphericalCoordinateHandler(CoordinateHandler):
         super().__init__(ds, ordering)
         # Generate
         self.image_units = {}
-        self.image_units[self.axis_id["r"]] = ("rad", "rad")
+        self.image_units[self.axis_id["r"]] = (1, 1)
         self.image_units[self.axis_id["theta"]] = (None, None)
         self.image_units[self.axis_id["phi"]] = (None, None)
 
@@ -114,17 +114,20 @@ class SphericalCoordinateHandler(CoordinateHandler):
     def _ortho_pixelize(
         self, data_source, field, bounds, size, antialias, dim, periodic
     ):
+        # use Aitoff projection
+        # http://paulbourke.net/geometry/transformationprojection/
+        bounds = tuple(_.ndview for _ in self._aitoff_bounds)
         buff = pixelize_aitoff(
-            data_source["py"],
-            data_source["pdy"],
-            data_source["px"],
-            data_source["pdx"],
-            size,
-            data_source[field],
-            None,
-            None,
-            theta_offset=0,
-            phi_offset=0,
+            azimuth=data_source["py"],
+            dazimuth=data_source["pdy"],
+            colatitude=data_source["px"],
+            dcolatitude=data_source["pdx"],
+            buff_size=size,
+            field=data_source[field],
+            bounds=bounds,
+            input_img=None,
+            azimuth_offset=0,
+            colatitude_offset=0,
         ).transpose()
         return buff
 
@@ -204,7 +207,17 @@ class SphericalCoordinateHandler(CoordinateHandler):
         # non-Cartesian coordinates, we usually want to override these for
         # Cartesian coordinates, since we transform them.
         rv = {
-            self.axis_id["r"]: ("\\theta", "\\phi"),
+            self.axis_id["r"]: (
+                # these are the Hammer-Aitoff normalized coordinates
+                # conventions:
+                #   - theta is the colatitude, from 0 to PI
+                #   - bartheta is the latitude, from -PI/2 to +PI/2 (bartheta = PI/2 - theta)
+                #   - phi is the azimuth, from 0 to 2PI
+                #   - lambda is the longitude, from -PI to PI (lambda = phi - PI)
+                r"\frac{2\cos(\mathrm{\bar{\theta}})\sin(\lambda/2)}{\sqrt{1 + \cos(\bar{\theta}) \cos(\lambda/2)}}",
+                r"\frac{sin(\bar{\theta})}{\sqrt{1 + \cos(\bar{\theta}) \cos(\lambda/2)}}",
+                "\\theta",
+            ),
             self.axis_id["theta"]: ("x / \\sin(\\theta)", "y / \\sin(\\theta)"),
             self.axis_id["phi"]: ("R", "z"),
         }
@@ -307,11 +320,82 @@ class SphericalCoordinateHandler(CoordinateHandler):
 
         return xxmin, xxmax, yymin, yymax
 
+    @cached_property
+    def _aitoff_bounds(self):
+        # at the time of writing this function, yt's support for curvilinear
+        # coordinates is a bit hacky, as many components of the system still
+        # expect to receive coordinates with a length dimension. Ultimately
+        # this is not needed but calls for a large refactor.
+        ONE = self.ds.quan(1, "code_length")
+
+        # colatitude
+        ti = self.axis_id["theta"]
+        thetamin = self.ds.domain_left_edge[ti]
+        thetamax = self.ds.domain_right_edge[ti]
+        # latitude
+        latmin = ONE * np.pi / 2 - thetamax
+        latmax = ONE * np.pi / 2 - thetamin
+
+        # azimuth
+        pi = self.axis_id["phi"]
+        phimin = self.ds.domain_left_edge[pi]
+        phimax = self.ds.domain_right_edge[pi]
+        # longitude
+        lonmin = phimin - ONE * np.pi
+        lonmax = phimax - ONE * np.pi
+
+        corners = [
+            (latmin, lonmin),
+            (latmin, lonmax),
+            (latmax, lonmin),
+            (latmax, lonmax),
+        ]
+
+        def aitoff_z(latitude, longitude):
+            return np.sqrt(1 + np.cos(latitude) * np.cos(longitude / 2))
+
+        def aitoff_x(latitude, longitude):
+            return (
+                2
+                * np.cos(latitude)
+                * np.sin(longitude / 2)
+                / aitoff_z(latitude, longitude)
+            )
+
+        def aitoff_y(latitude, longitude):
+            return np.sin(latitude) / aitoff_z(latitude, longitude)
+
+        def to_aitoff_plane(latitude, longitude):
+            return aitoff_x(latitude, longitude), aitoff_y(latitude, longitude)
+
+        aitoff_corner_coords = [to_aitoff_plane(*corner) for corner in corners]
+
+        xmin = ONE * min(x for x, y in aitoff_corner_coords)
+        xmax = ONE * max(x for x, y in aitoff_corner_coords)
+
+        # theta is the colatitude
+        # What this branch is meant to do is check whether the equator (latitude = 0)
+        # is included in the domain.
+
+        if latmin < 0 < latmax:
+            xmin = min(xmin, ONE * aitoff_x(0, lonmin))
+            xmax = max(xmax, ONE * aitoff_x(0, lonmax))
+
+        # the y direction is more straighforward because aitoff-projected parallels (y)
+        # draw a convex shape, while aitoff-projected meridians (x) draw a concave shape
+        ymin = ONE * min(y for x, y in aitoff_corner_coords)
+        ymax = ONE * max(y for x, y in aitoff_corner_coords)
+
+        return xmin, xmax, ymin, ymax
+
     def sanitize_center(self, center, axis):
         center, display_center = super().sanitize_center(center, axis)
         name = self.axis_name[axis]
         if name == "r":
-            display_center = center
+            xxmin, xxmax, yymin, yymax = self._aitoff_bounds
+            xc = (xxmin + xxmax) / 2
+            yc = (yymin + yymax) / 2
+            display_center = (0 * xc, xc, yc)
         elif name == "theta":
             xxmin, xxmax, yymin, yymax = self._conic_bounds
             xc = (xxmin + xxmax) / 2
@@ -329,10 +413,10 @@ class SphericalCoordinateHandler(CoordinateHandler):
         if width is not None:
             width = super().sanitize_width(axis, width, depth)
         elif name == "r":
-            width = [
-                self.ds.domain_width[self.x_axis["r"]],
-                self.ds.domain_width[self.y_axis["r"]],
-            ]
+            xxmin, xxmax, yymin, yymax = self._aitoff_bounds
+            xw = xxmax - xxmin
+            yw = yymax - yymin
+            width = [xw, yw]
         elif name == "theta":
             # Remember, in spherical coordinates when we cut in theta,
             # we create a conic section

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -720,6 +720,9 @@ class PlotContainer:
                         self.data_source.axis
                     ]
                     unn = self.ds.coordinates.default_unit_label.get(axax, None)
+            if unn in (1, "1", "dimensionless"):
+                axes_unit_labels[i] = ""
+                continue
             if unn is not None:
                 axes_unit_labels[i] = r"\ \ \left(" + unn + r"\right)"
                 continue

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1001,12 +1001,17 @@ class PWViewerMPL(PlotWindow):
                 unit_x = unit_y = unit
                 coords = self.ds.coordinates
                 if hasattr(coords, "image_units"):
-                    # this should detect angular coordinates
+                    # check for special cases defined in
+                    # non cartesian CoordinateHandler subclasses
                     image_units = coords.image_units[coords.axis_id[axis_index]]
                     if image_units[0] in ("deg", "rad"):
                         unit_x = "code_length"
+                    elif image_units[0] == 1:
+                        unit_x = "dimensionless"
                     if image_units[1] in ("deg", "rad"):
                         unit_y = "code_length"
+                    elif image_units[1] == 1:
+                        unit_y = "dimensionless"
             else:
                 (unit_x, unit_y) = self._axes_unit_names
 
@@ -1017,10 +1022,22 @@ class PWViewerMPL(PlotWindow):
                 self.aspect = float(
                     (self.ds.quan(1.0, unit_y) / self.ds.quan(1.0, unit_x)).in_cgs()
                 )
-            extentx = [(self.xlim[i] - xc).in_units(unit_x) for i in (0, 1)]
-            extenty = [(self.ylim[i] - yc).in_units(unit_y) for i in (0, 1)]
+            extentx = (self.xlim - xc)[:2]
+            extenty = (self.ylim - yc)[:2]
 
-            extent = extentx + extenty
+            # extentx/y arrays inherit units from xlim and ylim attributes
+            # and these attributes are always length even for angular and
+            # dimensionless axes so we need to stip out units for consistency
+            if unit_x == "dimensionless":
+                extentx = extentx / extentx.units
+            else:
+                extentx.convert_to_units(unit_x)
+            if unit_y == "dimensionless":
+                extenty = extenty / extenty.units
+            else:
+                extenty.convert_to_units(unit_y)
+
+            extent = [*extentx, *extenty]
 
             if f in self.plots.keys():
                 zlim = (self.plots[f].zmin, self.plots[f].zmax)


### PR DESCRIPTION
## PR Summary
This is a jab at the first item in #1796
Spherical geometries need more work but this is a first step to improve maintainability.
Right now, the defintions of "theta" and "phi" are misaligned between the aitoff pixelizer and the rest of the code base.
Fortunately, the latter is correct (aligned with most common notations AFAIC), while the former isn't user facing so it's an easy fix.

edit: this now completes the 3rd item of #1796