### PR TITLE
[gdf] dimensionality doesn't imply which dimension is reduced

### DIFF
--- a/yt/frontends/gdf/data_structures.py
+++ b/yt/frontends/gdf/data_structures.py
@@ -46,11 +46,6 @@ class GDFGrid(AMRGridPatch):
         else:
             LE, RE = self.index.grid_left_edge[id, :], self.index.grid_right_edge[id, :]
             self.dds = np.array((RE - LE) / self.ActiveDimensions)
-        if self.ds.data_software != "piernik":
-            if self.ds.dimensionality < 2:
-                self.dds[1] = 1.0
-            if self.ds.dimensionality < 3:
-                self.dds[2] = 1.0
         self.field_data["dx"], self.field_data["dy"], self.field_data["dz"] = self.dds
         self.dds = self.ds.arr(self.dds, "code_length")
 


### PR DESCRIPTION
Root cause that I was hitting this is that `b"piernik" != "piernik"`... However, I came to a conclusion that this clause is wrong for any GDF output, not just that one particular flavor. GDF already implies that RE/LE is a 3-element array, so there's no point in making assumptions about 1) which dimension is reduced or 2) what the value of dds in that dimension should be.

Using script from #3629:

```python
import yt

ds = yt.load("crwind_tst_0001.h5")
slc = yt.SlicePlot(ds, "x", "density")
slc.save("zy.png")

ds.coordinates.x_axis["x"] = 2
ds.coordinates.x_axis[0] = 2
ds.coordinates.y_axis["x"] = 1
ds.coordinates.y_axis[0] = 1
slc = yt.SlicePlot(ds, "x", "density")
slc.save("yz.png")
```

now I get:

![yz](https://user-images.githubusercontent.com/352673/139562971-d2ae3e0d-35cd-4678-af74-ef6f365fb118.png)
![zy](https://user-images.githubusercontent.com/352673/139562972-1887a25d-a44e-4ccf-9806-da53826aed7c.png)