### PR TITLE
BUG: fix figure layout in case the long axis is vertical

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -170,7 +170,7 @@ answer_tests:
   local_cylindrical_background_011:  # PR 3670
     - yt/geometry/coordinates/tests/test_cylindrical_coordinates.py:test_noise_plots
 
-  local_spherical_background_004:  # PR 3670
+  local_spherical_background_005:  # PR 3633
     - yt/geometry/coordinates/tests/test_spherical_coordinates.py:test_noise_plots
 
   #local_particle_trajectory_001:

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -340,15 +340,17 @@ class ImagePlotMPL(PlotMPL):
     def _get_best_layout(self):
 
         # Ensure the figure size along the long axis is always equal to _figure_size
+        unit_aspect = getattr(self, "_unit_aspect", 1)
         if is_sequence(self._figure_size):
-            x_fig_size = self._figure_size[0]
-            y_fig_size = self._figure_size[1]
+            x_fig_size, y_fig_size = self._figure_size
+            y_fig_size *= unit_aspect
         else:
-            x_fig_size = self._figure_size
-            y_fig_size = self._figure_size / self._aspect
-
-        if hasattr(self, "_unit_aspect"):
-            y_fig_size = y_fig_size * self._unit_aspect
+            x_fig_size = y_fig_size = self._figure_size
+            scaling = self._aspect / unit_aspect
+            if scaling < 1:
+                x_fig_size *= scaling
+            else:
+                y_fig_size /= scaling
 
         if self._draw_colorbar:
             cb_size = self._cb_size


### PR DESCRIPTION
## PR Summary

fix #3632
Running the script therein I get:
![zy](https://user-images.githubusercontent.com/14075922/139578862-fcfc3cb6-6b56-4ce3-b1a5-ce2c788790b7.png)

I expect this to fail CI because we surely have a couple images whose size is going to change, and unfortunately I don't think our testing infra is currently able to manage this properly (see #3602)

