### PR TITLE
BUG: use tight layout by default when saving matplotlib figures

### DIFF
--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -13,6 +13,7 @@ import sys
 import tempfile
 import time
 import urllib
+import warnings
 import zlib
 from collections import defaultdict
 
@@ -806,6 +807,32 @@ def dump_images(new_result, old_result, decimals=10):
         sys.stderr.write("\n")
 
 
+def ensure_image_comparability(a, b):
+    # pad nans to the right and the bottom of two images to make them comparable
+    # via matplotlib if they do not have the same shape
+    if a.shape == b.shape:
+        return a, b
+
+    assert a.shape[2:] == b.shape[2:]
+
+    warnings.warn(
+        f"Images have different shapes {a.shape} and {b.shape}. "
+        "Padding nans to make them comparable."
+    )
+    smallest_containing_shape = (
+        max(a.shape[0], b.shape[0]),
+        max(a.shape[1], b.shape[1]),
+        *a.shape[2:],
+    )
+    pa = np.full(smallest_containing_shape, np.nan)
+    pa[: a.shape[0], : a.shape[1], ...] = a
+
+    pb = np.full(smallest_containing_shape, np.nan)
+    pb[: b.shape[0], : b.shape[1], ...] = b
+
+    return pa, pb
+
+
 def compare_image_lists(new_result, old_result, decimals):
     fns = []
     for _ in range(2):
@@ -815,8 +842,12 @@ def compare_image_lists(new_result, old_result, decimals):
     num_images = len(old_result)
     assert num_images > 0
     for i in range(num_images):
-        mpimg.imsave(fns[0], np.loads(zlib.decompress(old_result[i])))
-        mpimg.imsave(fns[1], np.loads(zlib.decompress(new_result[i])))
+        expected = np.loads(zlib.decompress(old_result[i]))
+        actual = np.loads(zlib.decompress(new_result[i]))
+        expected, actual = ensure_image_comparability(expected, actual)
+
+        mpimg.imsave(fns[0], expected)
+        mpimg.imsave(fns[1], actual)
         results = compare_images(fns[0], fns[1], 10 ** (-decimals))
         if results is not None:
             if os.environ.get("JENKINS_HOME") is not None:

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -343,12 +343,12 @@ class ImagePlotMPL(PlotMPL):
     def _get_best_layout(self):
 
         # Ensure the figure size along the long axis is always equal to _figure_size
-        if is_sequence(self._figure_size):
-            x_fig_size = self._figure_size[0]
-            y_fig_size = self._figure_size[1]
-        else:
-            x_fig_size = self._figure_size
-            y_fig_size = self._figure_size / self._aspect
+        if not is_sequence(self._figure_size):
+            self._figure_size = (self._figure_size, self._figure_size / self._aspect)
+        if self._aspect < 1:
+            self._figure_size = tuple(_ * self._aspect for _ in self._figure_size)
+
+        x_fig_size, y_fig_size = self._figure_size
 
         if hasattr(self, "_unit_aspect"):
             y_fig_size = y_fig_size * self._unit_aspect

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -138,6 +138,7 @@ class PlotMPL:
         ):
             mpl_kwargs["papertype"] = "auto"
 
+        mpl_kwargs.setdefault("bbox_inches", "tight")
         name = validate_image_name(name)
 
         try:


### PR DESCRIPTION
## PR Summary

This is a second a second attempt to fix #3601, reusing the patch from #3602
combined with the test framework modifications from #3633 to enable comparisons
for images of different sizes.
Opening as a draft to indicate #3633 takes priority over this.
