### PR TITLE
MNT: loosen sympy version pinning in dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
     packaging>=20.9
     pyyaml>=4.2b1
     setuptools>=19.6
-    sympy>=1.2,<1.9
+    sympy!=1.9,>=1.2  # see https://github.com/sympy/sympy/issues/22241
     toml>=0.10.2
     tqdm>=3.4.0
     unyt>=2.8.0


### PR DESCRIPTION
## PR Summary
Fix #3559
This should be backported to the 4.0.x branch too.