### PR TITLE
BLD: drop wheel building for Python 3.6 and start building for 3.10

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -7,6 +7,7 @@ on:
       - stable
     tags:
       - 'yt-*'
+  workflow_dispatch:
 
 jobs:
   build_wheels:

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/checkout@v2
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==1.9.0
+        run: python -m pip install cibuildwheel==2.2.2
 
       - name: Install dependencies and yt
         shell: bash
@@ -50,7 +50,8 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir dist
         env:
-          CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-*"
+          CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-*"
+          CIBW_SKIP: "*-musllinux_*"  # these fail due to side effects from previous builds
           CIBW_ARCHS_LINUX: "x86_64"
           CIBW_ARCHS_MACOS: "x86_64"
           CIBW_ARCHS_WINDOWS: "auto"


### PR DESCRIPTION
## PR Summary

I believe everything upstream is now ready, so let's start building wheels for Python's latest version.
