### PR TITLE
BLD: build wheels for 3.10, align workflow file with main branch (yt-4.0.x)

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -7,6 +7,7 @@ on:
       - stable
     tags:
       - 'yt-*'
+  workflow_dispatch:
 
 jobs:
   build_wheels:
@@ -14,7 +15,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, windows-latest, macos-latest]
+        os: [
+          macos-latest,
+          windows-latest,
+          ubuntu-18.04,  # has to be the oldest possible for manylinux
+        ]
       fail-fast: false
 
     steps:
@@ -33,7 +38,7 @@ jobs:
 
       - uses: actions/checkout@v2
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==1.9.0
+        run: python -m pip install cibuildwheel==2.2.2
 
       - name: Install dependencies and yt
         shell: bash
@@ -46,7 +51,8 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir dist
         env:
-          CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-*"
+          CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-* cp310-*"
+          CIBW_SKIP: "*-musllinux_*"  # these fail due to side effects from previous builds
           CIBW_ARCHS_LINUX: "x86_64"
           CIBW_ARCHS_MACOS: "x86_64"
           CIBW_ARCHS_WINDOWS: "auto"


### PR DESCRIPTION
## PR Summary

Similar to #3657 but for the backport branch, in preparation for the 4.0.2 release
A key difference with #3657 is that I'm not dropping wheels building for Python 3.6 on this branch
