### PR TITLE
BUG: fix an off-by-one error in ColorTransferFunction.to_map_colormap method

### DIFF
--- a/yt/visualization/volume_rendering/transfer_functions.py
+++ b/yt/visualization/volume_rendering/transfer_functions.py
@@ -787,7 +787,7 @@ class ColorTransferFunction(MultiVariateTransferFunction):
             self.nbins * (ma - self.x_bounds[0]) / (self.x_bounds[1] - self.x_bounds[0])
         )
         rel0 = max(rel0, 0)
-        rel1 = min(rel1, self.nbins - 1)
+        rel1 = min(rel1, self.nbins - 1) + 1
         tomap = np.linspace(0.0, 1.0, num=rel1 - rel0)
         cmap = get_cmap(colormap)
         cc = cmap(tomap)


### PR DESCRIPTION
## PR Summary
Fix #3660


rerunning the script therein I obtain:
```
[1. 1. 1. 1. 1. 1. 1. 1.]
[0.96862745 0.8584083  0.73094963 0.53568627 0.32628989 0.16696655
 0.04405998 0.03137255]
[0.98431373 0.91344867 0.83947712 0.74608228 0.61862361 0.48069204
 0.33388697 0.18823529]
[1.         0.96456747 0.92132257 0.86425221 0.80279892 0.72915033
 0.62445213 0.41960784]
 ```
![output](https://user-images.githubusercontent.com/14075922/141104181-1c53df8d-97c5-4aad-8d4c-410b0e8b1eea.png)
