### PR TITLE
MNT: loose exact Python runtime requirement in pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,12 +15,6 @@ yt/extern\
 ci:
     autofix_prs: false
 
-default_language_version:
-  # setup default Python runtime version for Python hooks
-  # that don't specify their own (e.g. black)
-  # 3.9 is the most supported version as of 09/19/2021
-  python: python3.9
-
 repos:
 -   repo: https://github.com/asottile/setup-cfg-fmt
     rev: v1.19.0


### PR DESCRIPTION
## PR Summary

This requirement apparently prevents devs that don't have the specific Python version to use pre-commit,
so let's just drop it.
