### PR TITLE
ENH: implement hint keyword argument for yt.load to help lifting ambiguities in dataformat

### DIFF
--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -4,6 +4,7 @@ import inspect
 import os
 import weakref
 from functools import wraps
+from typing import Optional
 
 import numpy as np
 from more_itertools import always_iterable
@@ -419,14 +420,14 @@ class DatasetSeries:
 
     _dataset_cls = None
 
-    def _load(self, output_fn, **kwargs):
+    def _load(self, output_fn, *, hint: Optional[str] = None, **kwargs):
         from yt.loaders import load
 
         if self._dataset_cls is not None:
             return self._dataset_cls(output_fn, **kwargs)
         elif self._mixed_dataset_types:
-            return load(output_fn, **kwargs)
-        ds = load(output_fn, **kwargs)
+            return load(output_fn, hint=hint, **kwargs)
+        ds = load(output_fn, hint=hint, **kwargs)
         self._dataset_cls = ds.__class__
         return ds
 

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -51,8 +51,9 @@ class YTAmbiguousDataType(YTUnidentifiedDataType):
         msg += "The following independent classes were detected as valid :\n"
         for c in self.candidates:
             msg += f"{c}\n"
-        msg += "A possible workaround is to directly instantiate one of the above.\n"
-        msg += "Please report this to https://github.com/yt-project/yt/issues/new"
+        msg += (
+            "This degeneracy can be lifted using the `hint` keyword argument in yt.load"
+        )
         return msg
 
 

--- a/yt/utilities/hierarchy_inspection.py
+++ b/yt/utilities/hierarchy_inspection.py
@@ -1,11 +1,11 @@
 import inspect
 from collections import Counter
 from functools import reduce
-from typing import Iterable, List, Optional, Type
+from typing import List, Optional, Type
 
 
 def find_lowest_subclasses(
-    candidates: Iterable[Type], *, hint: Optional[str] = None
+    candidates: List[Type], *, hint: Optional[str] = None
 ) -> List[Type]:
     """
     This function takes a list of classes, and returns only the ones that are
@@ -40,7 +40,7 @@ def find_lowest_subclasses(
     counters = [Counter(mro) for mro in mros]
 
     if len(counters) == 0:
-        return counters
+        return []
 
     count = reduce(lambda x, y: x + y, counters)
 

--- a/yt/utilities/hierarchy_inspection.py
+++ b/yt/utilities/hierarchy_inspection.py
@@ -1,9 +1,12 @@
 import inspect
 from collections import Counter
 from functools import reduce
+from typing import Iterable, List, Optional, Type
 
 
-def find_lowest_subclasses(candidates):
+def find_lowest_subclasses(
+    candidates: Iterable[Type], *, hint: Optional[str] = None
+) -> List[Type]:
     """
     This function takes a list of classes, and returns only the ones that are
     are not super classes of any others in the list. i.e. the ones that are at
@@ -14,6 +17,9 @@ def find_lowest_subclasses(candidates):
     candidates : Iterable
         An iterable object that is a collection of classes to find the lowest
         subclass of.
+
+    hint : str, optional
+        Only keep candidates classes that have `hint` in their name (case insensitive)
 
     Returns
     -------
@@ -38,4 +44,7 @@ def find_lowest_subclasses(candidates):
 
     count = reduce(lambda x, y: x + y, counters)
 
-    return [x for x in count.keys() if count[x] == 1]
+    retv = [x for x in count.keys() if count[x] == 1]
+    if hint is not None:
+        retv = [x for x in retv if hint.lower() in x.__name__.lower()]
+    return retv


### PR DESCRIPTION
## PR Summary

This is based on @mameehan5's work with #3512
fix #3510, fix #3005

I'm opening this as a draft because I want to add some tests, but I believe the functionality in now ready:
```
>>> import yt
>>> yt.load("det_x_plt00000")
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ <ipython-input-2-62a091f562d4>:1 in <module>                                                     │
│                                                                                                  │
│ /Users/robcleme/dev/yt-project/yt/yt/loaders.py:102 in load                                      │
│                                                                                                  │
│     99 │   │   return candidates[0](fn, *args, **kwargs)                                         │
│    100 │                                                                                         │
│    101 │   if len(candidates) > 1:                                                               │
│ ❱  102 │   │   raise YTAmbiguousDataType(fn, candidates)                                         │
│    103 │                                                                                         │
│    104 │   raise YTUnidentifiedDataType(fn, *args, **kwargs)                                     │
│    105                                                                                           │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
YTAmbiguousDataType: Multiple data type candidates for /Users/robcleme/dev/yt-project/test-data-dir/det_x_plt00000
The following independent classes were detected as valid :
<class 'yt.frontends.boxlib.data_structures.CastroDataset'>
<class 'yt.frontends.boxlib.data_structures.AMReXDataset'>
This degeneracy can be lifted using the `hint` keyword argument in yt.load

>>> yt.load("det_x_plt00000", hint="rex")
yt : [INFO     ] 2021-11-12 19:30:21,194 Parameters: current_time              = 0.0
yt : [INFO     ] 2021-11-12 19:30:21,194 Parameters: domain_dimensions         = [256   1   1]
yt : [INFO     ] 2021-11-12 19:30:21,195 Parameters: domain_left_edge          = [0. 0. 0.]
yt : [INFO     ] 2021-11-12 19:30:21,196 Parameters: domain_right_edge         = [1.6384e+05 1.0000e+00 1.0000e+00]
AMReXDataset: /Users/robcleme/dev/yt-project/test-data-dir/det_x_plt00000

>>> yt.load("det_x_plt00000", hint="castro")
yt : [INFO     ] 2021-11-12 19:30:38,908 Parameters: current_time              = 0.0
yt : [INFO     ] 2021-11-12 19:30:38,908 Parameters: domain_dimensions         = [256   1   1]
yt : [INFO     ] 2021-11-12 19:30:38,909 Parameters: domain_left_edge          = [0. 0. 0.]
yt : [INFO     ] 2021-11-12 19:30:38,910 Parameters: domain_right_edge         = [1.6384e+05 1.0000e+00 1.0000e+00]
CastroDataset: /Users/robcleme/dev/yt-project/test-data-dir/det_x_plt00000
```

## PR Checklist

- [ ] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.
