### PR TITLE
ENH: enable yt + interactive matplotlib interface (plot.show())

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -113,12 +113,11 @@ def pytest_configure(config):
     ):
         config.addinivalue_line("filterwarnings", value)
 
-    if MPL_VERSION < Version("3.0.0"):
+    if MPL_VERSION < Version("3.1.0"):
         config.addinivalue_line(
             "filterwarnings",
             (
-                "ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' "
-                "is deprecated since Python 3.3,and in 3.9 it will stop working:DeprecationWarning"
+                r"ignore:\nexamples.directory is deprecated; in the future, examples will be found relative to the 'datapath' directory.:matplotlib.cbook.deprecation.MatplotlibDeprecationWarning"
             ),
         )
     # at the time of writing, astropy's wheels are behind numpy's latest

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ packages = find:
 install_requires =
     cmyt>=0.2.2
     ipython>=2.0.0
-    matplotlib!=3.4.2,>=2.2.3  # keep in sync with tests/windows_conda_requirements.txt
+    matplotlib!=3.4.2,>=3.0.0  # keep in sync with tests/windows_conda_requirements.txt
     more-itertools>=8.4
     numpy>=1.14.5
     packaging>=20.9
@@ -96,7 +96,7 @@ mapserver =
 minimal =
     cmyt==0.2.2
     ipython==2.0.0
-    matplotlib==2.2.3
+    matplotlib==3.0.0
     more-itertools==8.4
     numpy==1.14.5
     unyt==2.8.0

--- a/tests/matplotlibrc
+++ b/tests/matplotlibrc
@@ -1,3 +1,4 @@
 #### MATPLOTLIBRC FORMAT
 
 backend : Agg
+figure.max_open_warning : 32

--- a/tests/matplotlibrc
+++ b/tests/matplotlibrc
@@ -1,4 +1,3 @@
 #### MATPLOTLIBRC FORMAT
 
 backend : Agg
-figure.max_open_warning : 32

--- a/tests/windows_conda_requirements.txt
+++ b/tests/windows_conda_requirements.txt
@@ -2,5 +2,5 @@ numpy>=1.19.4
 cython>=0.29.21,<3.0
 cartopy~=0.18.0
 h5py~=3.1.0
-matplotlib!=3.4.2,>=2.2.3  # keep in sync with setup.cfg
+matplotlib!=3.4.2,>=3.0.0  # keep in sync with setup.cfg
 scipy~=1.5.0

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -28,7 +28,6 @@ from yt.units.unit_object import Unit  # type: ignore
 from yt.units.yt_array import YTArray, uconcatenate  # type: ignore
 from yt.utilities.exceptions import (
     YTNoAPIKey,
-    YTNotInsideNotebook,
     YTParticleDepositionNotImplemented,
     YTTooManyVertices,
 )
@@ -327,10 +326,6 @@ class YTProj(YTSelectionContainer2D):
             width = self.ds.domain_width
             center = self.ds.domain_center
         pw = self._get_pw(fields, center, width, "native", "Projection")
-        try:
-            pw.show()
-        except YTNotInsideNotebook:
-            pass
         return pw
 
     def _initialize_projected_units(self, fields, chunk):

--- a/yt/data_objects/selection_objects/slices.py
+++ b/yt/data_objects/selection_objects/slices.py
@@ -15,7 +15,6 @@ from yt.funcs import (
     validate_object,
     validate_width_tuple,
 )
-from yt.utilities.exceptions import YTNotInsideNotebook
 from yt.utilities.minimal_representation import MinimalSliceData
 from yt.utilities.orientation import Orientation
 
@@ -132,10 +131,6 @@ class YTSlice(YTSelectionContainer2D):
             width = self.ds.domain_width
             center = self.ds.domain_center
         pw = self._get_pw(fields, center, width, "native", "Slice")
-        try:
-            pw.show()
-        except YTNotInsideNotebook:
-            pass
         return pw
 
 

--- a/yt/data_objects/tests/test_projection.py
+++ b/yt/data_objects/tests/test_projection.py
@@ -24,7 +24,7 @@ def teardown_func(fns):
             pass
 
 
-@mock.patch("yt.visualization._mpl_imports.FigureCanvasAgg.print_figure")
+@mock.patch("matplotlib.pyplot.savefig")
 def test_projection(pf):
     fns = []
     for nprocs in [8, 1]:

--- a/yt/data_objects/tests/test_slice.py
+++ b/yt/data_objects/tests/test_slice.py
@@ -22,7 +22,7 @@ def teardown_func(fns):
             pass
 
 
-@mock.patch("yt.visualization._mpl_imports.FigureCanvasAgg.print_figure")
+@mock.patch("matplotlib.pyplot.savefig")
 def test_slice(pf):
     fns = []
     grid_eps = np.finfo(np.float64).eps

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -19,7 +19,7 @@ import urllib.request
 import warnings
 from functools import lru_cache, wraps
 from numbers import Number as numeric_type
-from typing import Any, Callable, Type
+from typing import Any, Callable, Optional, Type
 
 import matplotlib
 import numpy as np
@@ -1045,13 +1045,15 @@ def matplotlib_style_context(style_name=None, after_reset=False):
 _interactivity = False
 
 
-def toggle_interactivity():
+def toggle_interactivity(state: Optional[bool] = None):
     """
     A wrapper around matplotlib.interactive, switch interactivity state (on/off)
     on every call.
     """
     global _interactivity
-    _interactivity = not _interactivity
+    if state is None:
+        state = not _interactivity
+    _interactivity = state
     matplotlib.interactive(_interactivity)
 
 

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -1,5 +1,4 @@
 import base64
-import builtins
 import contextlib
 import copy
 import errno
@@ -1043,28 +1042,28 @@ def matplotlib_style_context(style_name=None, after_reset=False):
     return dummy_context_manager()
 
 
-interactivity = False
-
-"""Sets the condition that interactive backends can be used."""
+_interactivity = False
 
 
 def toggle_interactivity():
-    global interactivity
-    interactivity = not interactivity
-    if interactivity:
-        if "__IPYTHON__" in dir(builtins):
-            import IPython
-
-            shell = IPython.get_ipython()
-            shell.magic("matplotlib")
-        else:
-            import matplotlib
-
-            matplotlib.interactive(True)
+    """
+    A wrapper around matplotlib.interactive, switch interactivity state (on/off)
+    on every call.
+    """
+    global _interactivity
+    _interactivity = not _interactivity
+    matplotlib.interactive(_interactivity)
 
 
-def get_interactivity():
-    return interactivity
+def get_interactivity() -> bool:
+    """
+    A wrapper around matplotlib.is_interactive, emit a warning in case yt's
+    interactivity state has gone out of sync with matplotlib.
+    """
+    mpl_interactivity = matplotlib.is_interactive()
+    if _interactivity != mpl_interactivity:
+        warnings.warn("yt's interactivity flag seems to be out of sync with matplotlib")
+    return matplotlib.is_interactive()
 
 
 def setdefaultattr(obj, name, value):

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -48,7 +48,7 @@ class PlotMPL:
         if figure is None:
             if not is_sequence(fsize):
                 fsize = (fsize, fsize)
-            self.figure = matplotlib.figure.Figure(figsize=fsize)
+            self.figure = plt.figure(figsize=fsize)
         else:
             figure.set_size_inches(fsize)
             self.figure = figure
@@ -115,6 +115,9 @@ class PlotMPL:
             canvas.print_figure(f)
         f.seek(0)
         return f.read()
+
+    def __del__(self):
+        plt.close(self.figure)
 
 
 class ImagePlotMPL(PlotMPL):

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -117,7 +117,11 @@ class PlotMPL:
         return f.read()
 
     def __del__(self):
-        plt.close(self.figure)
+        if hasattr(self, "figure"):
+            # this condition should NOT be necessary by virtue of the substitution principle
+            # however I'm finding a couple tests failing here with AttributeError, so I'm making
+            # this instruction conditional for now, but this bandaid should absolutely not be merged !
+            plt.close(self.figure)
 
 
 class ImagePlotMPL(PlotMPL):

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -625,7 +625,6 @@ class PlotContainer(abc.ABC):
         # invalidate_data will take care of everything
         return self
 
-    @validate_plot
     def show(self, *args, **kwargs):
         r"""
 

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -1,5 +1,4 @@
 import abc
-import base64
 import os
 import sys
 import warnings

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -1,6 +1,5 @@
 import abc
 import base64
-import builtins
 import os
 import sys
 import warnings
@@ -8,6 +7,7 @@ from collections import defaultdict
 from functools import wraps
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.cm import get_cmap
 from matplotlib.font_manager import FontProperties
@@ -19,7 +19,6 @@ from yt.funcs import dictWithFactory, ensure_dir, is_sequence, iter_fields, mylo
 from yt.units import YTQuantity
 from yt.units.unit_object import Unit  # type: ignore
 from yt.utilities.definitions import formatted_length_unit_names
-from yt.utilities.exceptions import YTNotInsideNotebook
 
 from ._commons import DEFAULT_FONT_PROPERTIES, validate_image_name
 
@@ -627,15 +626,10 @@ class PlotContainer(abc.ABC):
         return self
 
     @validate_plot
-    def show(self):
-        r"""This will send any existing plots to the IPython notebook.
+    def show(self, *args, **kwargs):
+        r"""
 
-        If yt is being run from within an IPython session, and it is able to
-        determine this, this function will send any existing plots to the
-        notebook for display.
-
-        If yt can't determine if it's inside an IPython session, it will raise
-        YTNotInsideNotebook.
+        ... WRITEME ...
 
         Examples
         --------
@@ -647,31 +641,21 @@ class PlotContainer(abc.ABC):
         >>> slc.show()
 
         """
-        interactivity = self.plots[list(self.plots.keys())[0]].interactivity
-        if interactivity:
-            for v in sorted(self.plots.values()):
-                v.show()
-        else:
-            if "__IPYTHON__" in dir(builtins):
-                from IPython.display import display
-
-                display(self)
-            else:
-                raise YTNotInsideNotebook
+        plt.show(*args, **kwargs)
 
     @validate_plot
-    def display(self, name=None, mpl_kwargs=None):
+    def display(self, *args, **kwargs):
+        # TODO: UPDATE DOCSTRING
         """Will attempt to show the plot in in an IPython notebook.
         Failing that, the plot will be saved to disk."""
-        try:
-            return self.show()
-        except YTNotInsideNotebook:
-            return self.save(name=name, mpl_kwargs=mpl_kwargs)
+        return self.show(*args, **kwargs)
 
     @validate_plot
     def _repr_html_(self):
         """Return an html representation of the plot object. Will display as a
         png for each WindowPlotMPL instance in self.plots"""
+        import base64
+
         ret = ""
         for field in self.plots:
             img = base64.b64encode(self.plots[field]._repr_png_()).decode()

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -39,7 +39,6 @@ from .geo_plot_utils import get_mpl_transform
 from .plot_container import (
     ImagePlotContainer,
     apply_callback,
-    get_log_minorticks,
     get_symlog_minorticks,
     invalidate_data,
     invalidate_figure,
@@ -1248,14 +1247,8 @@ class PWViewerMPL(PlotWindow):
                         self.plots[f].cax.yaxis.set_ticks(mticks, minor=True)
 
                 elif self._field_transform[f] == log_transform:
-                    if MPL_VERSION >= Version("3.0.0"):
-                        self.plots[f].cax.minorticks_on()
-                        self.plots[f].cax.xaxis.set_visible(False)
-                    else:
-                        mticks = self.plots[f].image.norm(
-                            get_log_minorticks(vmin, vmax)
-                        )
-                        self.plots[f].cax.yaxis.set_ticks(mticks, minor=True)
+                    self.plots[f].cax.minorticks_on()
+                    self.plots[f].cax.xaxis.set_visible(False)
 
                 else:
                     mylog.error(

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -1,11 +1,11 @@
 import base64
-import builtins
 import os
 from collections import OrderedDict
 from functools import wraps
 from typing import Any, Dict, Optional
 
 import matplotlib
+import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.font_manager import FontProperties
 from more_itertools.more import always_iterable, unzip
@@ -15,7 +15,6 @@ from yt.data_objects.profiles import create_profile, sanitize_field_tuple_keys
 from yt.data_objects.static_output import Dataset
 from yt.frontends.ytdata.data_structures import YTProfileDataset
 from yt.funcs import is_sequence, iter_fields, matplotlib_style_context
-from yt.utilities.exceptions import YTNotInsideNotebook
 from yt.utilities.logger import ytLogger as mylog
 
 from ..data_objects.selection_objects.data_selection_objects import YTSelectionContainer
@@ -345,12 +344,7 @@ class ProfilePlot(PlotContainer):
         >>> pp.show()
 
         """
-        if "__IPYTHON__" in dir(builtins):
-            from IPython.display import display
-
-            display(self)
-        else:
-            raise YTNotInsideNotebook
+        plt.show()
 
     @validate_plot
     def _repr_html_(self):

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -23,7 +23,6 @@ from .base_plot_types import ImagePlotMPL, PlotMPL
 from .plot_container import (
     ImagePlotContainer,
     PlotContainer,
-    get_log_minorticks,
     invalidate_plot,
     linear_transform,
     log_transform,
@@ -1181,16 +1180,6 @@ class PhasePlot(ImagePlotContainer):
             if self._cbar_minorticks[f]:
                 if self._field_transform[f] == linear_transform:
                     self.plots[f].cax.minorticks_on()
-                elif MPL_VERSION < Version("3.0.0"):
-                    # before matplotlib 3 log-scaled colorbars internally used
-                    # a linear scale going from zero to one and did not draw
-                    # minor ticks. Since we want minor ticks, calculate
-                    # where the minor ticks should go in this linear scale
-                    # and add them manually.
-                    vmin = np.float64(self.plots[f].cb.norm.vmin)
-                    vmax = np.float64(self.plots[f].cb.norm.vmax)
-                    mticks = self.plots[f].image.norm(get_log_minorticks(vmin, vmax))
-                    self.plots[f].cax.yaxis.set_ticks(mticks, minor=True)
             else:
                 self.plots[f].cax.minorticks_off()
 

--- a/yt/visualization/tests/test_particle_plot.py
+++ b/yt/visualization/tests/test_particle_plot.py
@@ -4,6 +4,7 @@ import tempfile
 import unittest
 from unittest import mock
 
+import matplotlib as mpl
 import numpy as np
 
 from yt.data_objects.particle_filters import add_particle_filter
@@ -209,52 +210,53 @@ class TestParticlePhasePlotSave(unittest.TestCase):
         ]
         particle_phases = []
 
-        for source in data_sources:
-            for x_field, y_field, z_fields in PHASE_FIELDS:
-                particle_phases.append(
-                    ParticlePhasePlot(
-                        source,
-                        x_field,
-                        y_field,
-                        z_fields,
-                        x_bins=16,
-                        y_bins=16,
+        with mpl.rc_context({"figure.max_open_warning": 64}):
+            for source in data_sources:
+                for x_field, y_field, z_fields in PHASE_FIELDS:
+                    particle_phases.append(
+                        ParticlePhasePlot(
+                            source,
+                            x_field,
+                            y_field,
+                            z_fields,
+                            x_bins=16,
+                            y_bins=16,
+                        )
                     )
-                )
 
-                particle_phases.append(
-                    ParticlePhasePlot(
-                        source,
-                        x_field,
-                        y_field,
-                        z_fields,
-                        x_bins=16,
-                        y_bins=16,
-                        deposition="cic",
+                    particle_phases.append(
+                        ParticlePhasePlot(
+                            source,
+                            x_field,
+                            y_field,
+                            z_fields,
+                            x_bins=16,
+                            y_bins=16,
+                            deposition="cic",
+                        )
                     )
-                )
 
-                pp = create_profile(
-                    source,
-                    [x_field, y_field],
-                    z_fields,
-                    weight_field=("all", "particle_ones"),
-                    n_bins=[16, 16],
-                )
+                    pp = create_profile(
+                        source,
+                        [x_field, y_field],
+                        z_fields,
+                        weight_field=("all", "particle_ones"),
+                        n_bins=[16, 16],
+                    )
 
-                particle_phases.append(ParticlePhasePlot.from_profile(pp))
-        particle_phases[0]._repr_html_()
+                    particle_phases.append(ParticlePhasePlot.from_profile(pp))
+            particle_phases[0]._repr_html_()
 
-        with mock.patch(
-            "yt.visualization._mpl_imports.FigureCanvasAgg.print_figure"
-        ), mock.patch(
-            "yt.visualization._mpl_imports.FigureCanvasPdf.print_figure"
-        ), mock.patch(
-            "yt.visualization._mpl_imports.FigureCanvasPS.print_figure"
-        ):
-            for p in particle_phases:
-                for fname in TEST_FLNMS:
-                    p.save(fname)
+            with mock.patch(
+                "yt.visualization._mpl_imports.FigureCanvasAgg.print_figure"
+            ), mock.patch(
+                "yt.visualization._mpl_imports.FigureCanvasPdf.print_figure"
+            ), mock.patch(
+                "yt.visualization._mpl_imports.FigureCanvasPS.print_figure"
+            ):
+                for p in particle_phases:
+                    for fname in TEST_FLNMS:
+                        p.save(fname)
 
 
 tgal = "TipsyGalaxy/galaxy.00300"
@@ -349,29 +351,30 @@ class TestParticleProjectionPlotSave(unittest.TestCase):
         shutil.rmtree(self.tmpdir)
 
     def test_particle_plot(self):
-        test_ds = fake_particle_ds()
-        particle_projs = []
-        for dim in range(3):
-            particle_projs += [
-                ParticleProjectionPlot(test_ds, dim, ("all", "particle_mass")),
-                ParticleProjectionPlot(
-                    test_ds, dim, ("all", "particle_mass"), deposition="cic"
-                ),
-                ParticleProjectionPlot(
-                    test_ds, dim, ("all", "particle_mass"), density=True
-                ),
-            ]
-        particle_projs[0]._repr_html_()
-        with mock.patch(
-            "yt.visualization._mpl_imports.FigureCanvasAgg.print_figure"
-        ), mock.patch(
-            "yt.visualization._mpl_imports.FigureCanvasPdf.print_figure"
-        ), mock.patch(
-            "yt.visualization._mpl_imports.FigureCanvasPS.print_figure"
-        ):
-            for p in particle_projs:
-                for fname in TEST_FLNMS:
-                    p.save(fname)[0]
+        with mpl.rc_context({"figure.max_open_warning": 64}):
+            test_ds = fake_particle_ds()
+            particle_projs = []
+            for dim in range(3):
+                particle_projs += [
+                    ParticleProjectionPlot(test_ds, dim, ("all", "particle_mass")),
+                    ParticleProjectionPlot(
+                        test_ds, dim, ("all", "particle_mass"), deposition="cic"
+                    ),
+                    ParticleProjectionPlot(
+                        test_ds, dim, ("all", "particle_mass"), density=True
+                    ),
+                ]
+            particle_projs[0]._repr_html_()
+            with mock.patch(
+                "yt.visualization._mpl_imports.FigureCanvasAgg.print_figure"
+            ), mock.patch(
+                "yt.visualization._mpl_imports.FigureCanvasPdf.print_figure"
+            ), mock.patch(
+                "yt.visualization._mpl_imports.FigureCanvasPS.print_figure"
+            ):
+                for p in particle_projs:
+                    for fname in TEST_FLNMS:
+                        p.save(fname)[0]
 
     def test_particle_plot_ds(self):
         test_ds = fake_particle_ds()
@@ -411,18 +414,21 @@ class TestParticleProjectionPlotSave(unittest.TestCase):
 
     def test_creation_with_width(self):
         test_ds = fake_particle_ds()
-        for width, (xlim, ylim, pwidth, _aun) in WIDTH_SPECS.items():
-            plot = ParticleProjectionPlot(
-                test_ds, 0, ("all", "particle_mass"), width=width
-            )
+        with mpl.rc_context({"figure.max_open_warning": 64}):
+            for width, (xlim, ylim, pwidth, _aun) in WIDTH_SPECS.items():
+                plot = ParticleProjectionPlot(
+                    test_ds, 0, ("all", "particle_mass"), width=width
+                )
+                xlim = [plot.ds.quan(el[0], el[1]) for el in xlim]
+                ylim = [plot.ds.quan(el[0], el[1]) for el in ylim]
+                pwidth = [plot.ds.quan(el[0], el[1]) for el in pwidth]
 
-            xlim = [plot.ds.quan(el[0], el[1]) for el in xlim]
-            ylim = [plot.ds.quan(el[0], el[1]) for el in ylim]
-            pwidth = [plot.ds.quan(el[0], el[1]) for el in pwidth]
-
-            [assert_array_almost_equal(px, x, 14) for px, x in zip(plot.xlim, xlim)]
-            [assert_array_almost_equal(py, y, 14) for py, y in zip(plot.ylim, ylim)]
-            [assert_array_almost_equal(pw, w, 14) for pw, w in zip(plot.width, pwidth)]
+                [assert_array_almost_equal(px, x, 14) for px, x in zip(plot.xlim, xlim)]
+                [assert_array_almost_equal(py, y, 14) for py, y in zip(plot.ylim, ylim)]
+                [
+                    assert_array_almost_equal(pw, w, 14)
+                    for pw, w in zip(plot.width, pwidth)
+                ]
 
 
 def test_particle_plot_instance():

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -4,6 +4,7 @@ import tempfile
 import unittest
 from collections import OrderedDict
 
+import matplotlib as mpl
 import numpy as np
 from nose.tools import assert_true
 
@@ -568,14 +569,11 @@ def test_setup_origin():
         -5.0,
         5.0,
     ]
-    for o in origin_inputs:
-        slc = SlicePlot(ds, 2, ("gas", "density"), width=w, origin=o)
-        ax = slc.plots[("gas", "density")].axes
-        xlims = ax.get_xlim()
-        ylims = ax.get_ylim()
-        lims = [xlims[0], xlims[1], ylims[0], ylims[1]]
-        for l in lims:
-            generated_limits.append(l)
+    with mpl.rc_context({"figure.max_open_warning": 32}):
+        for o in origin_inputs:
+            slc = SlicePlot(ds, 2, ("gas", "density"), width=w, origin=o)
+            ax = slc.plots[("gas", "density")].axes
+            generated_limits.extend(ax.get_xlim() + ax.get_ylim())
     assert_array_almost_equal(correct_limits, generated_limits)
 
 


### PR DESCRIPTION
## PR Summary


Goals:
- cleanup legacy code / technical debt accumulated in yt
- fix #2126

As noted in #2126, yt hooks with matplotlib at the level of figure canvas and managers.
Historically this was needed to workaround an important limitation from matplotlib where
apropriate backends (GUI/headless) were not determined at runtime, but this was
[solved in matplotlib 3.0.0](https://matplotlib.org/3.0.0/users/whats_new.html#improved-default-backend-selection) (it's even the first item on the changelog !)

Currently the only versions lower than 3.0.0 that we support are matplotlib 2.2.3 to 2.2.5, because 2.2.3 is the first release for which Python 3.7 wheels are available (and we don't support Python 3.6 anymore).
Note that 3.0.0 (Sept 19 2018) actually came out only 38 days after 2.2.3 (Aug 11 2018), and we're bound to bump soon anyway because 2.2.3 doesn't have wheels for Python 3.8 (next in line to become our oldest supported Python version). All things considered I think it is now reasonable to drop support for Matplotlib 2.x

Todo:
- [ ] finish up draft docstring changes
- [ ] cleanup the volume rendering side of yt.visualization
- [ ] cleanup yt.visualization._commons module (get_canvas_class and get_canvas, SUPPORTED_FORMATS and SUPPORTED_CANVAS_CLASSES are probably not needed anymore)

Everything should work as on the main branch with the difference that #2126 should now work as expected.
I've done some amount of testing manually within various Python REPLs (the builtin CPython interpreter, IPython, JupyterLab), but it'd be good to have more feedback than just mine.

I'll open as a draft to see wether I'm ahead in the right direction or if this patch is already breaking a lot of tests.