### PR TITLE
MNT: matplotlib 3.5 compat

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -92,7 +92,7 @@ answer_tests:
     - yt/frontends/owls/tests/test_outputs.py:test_snapshot_033
     - yt/frontends/owls/tests/test_outputs.py:test_OWLS_particlefilter
 
-  local_pw_040:  # PR 3441
+  local_pw_041:  # PR 3670
     - yt/visualization/tests/test_plotwindow.py:test_attributes
     - yt/visualization/tests/test_particle_plot.py:test_particle_projection_answers
     - yt/visualization/tests/test_particle_plot.py:test_particle_projection_filter
@@ -167,10 +167,10 @@ answer_tests:
   local_axialpix_007:
     - yt/geometry/coordinates/tests/test_axial_pixelization.py:test_axial_pixelization
 
-  local_cylindrical_background_010:  # PR 3520
+  local_cylindrical_background_011:  # PR 3670
     - yt/geometry/coordinates/tests/test_cylindrical_coordinates.py:test_noise_plots
 
-  local_spherical_background_003:  # PR 3618
+  local_spherical_background_004:  # PR 3670
     - yt/geometry/coordinates/tests/test_spherical_coordinates.py:test_noise_plots
 
   #local_particle_trajectory_001:

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -92,11 +92,9 @@ class PlotMPL:
         if figure_manager is not None:
             self.manager = figure_manager(self.canvas, 1)
 
-        for which in ["major", "minor"]:
-            for axis in "xy":
-                self.axes.tick_params(
-                    which=which, axis=axis, direction="in", top=True, right=True
-                )
+        self.axes.tick_params(
+            which="both", axis="both", direction="in", top=True, right=True
+        )
 
     def _create_axes(self, axrect):
         self.axes = self.figure.add_axes(axrect)
@@ -337,8 +335,7 @@ class ImagePlotMPL(PlotMPL):
             self.cb.set_ticks(yticks)
         else:
             self.cb = self.figure.colorbar(self.image, self.cax)
-        for which in ["major", "minor"]:
-            self.cax.tick_params(which=which, axis="y", direction="in")
+        self.cax.tick_params(which="both", axis="y", direction="in")
 
     def _get_best_layout(self):
 

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -418,7 +418,7 @@ class PlotWindow(ImagePlotContainer):
 
         """
         if len(deltas) != 2:
-            raise RuntimeError(
+            raise TypeError(
                 f"The pan function accepts a two-element sequence.\nReceived {deltas}."
             )
         if isinstance(deltas[0], Number) and isinstance(deltas[1], Number):
@@ -434,7 +434,7 @@ class PlotWindow(ImagePlotContainer):
         elif isinstance(deltas[0], YTQuantity) and isinstance(deltas[1], YTQuantity):
             pass
         else:
-            raise RuntimeError(
+            raise TypeError(
                 "The arguments of the pan function must be a sequence of floats,\n"
                 "quantities, or (float, unit) tuples. Received %s." % (deltas,)
             )

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -1630,3 +1630,5 @@ class PhasePlotMPL(ImagePlotMPL):
             self.cb.formatter.set_scientific(True)
             self.cb.formatter.set_powerlimits((-2, 3))
             self.cb.update_ticks()
+
+        self.cax.tick_params(which="both", axis="y", direction="in")


### PR DESCRIPTION
## PR Summary

I'm fixing a couple error messages here as an excuse to trigger CI so that I can update the answer store.
This PR will be a blocker unless it turns out that no update is needed.

goal ? fix #3558
why now ? matplotlib 3.5.0 just came out. I'm hoping that my work with the release candidate was enough to make this update pretty transparent
but I still expect we're going to see some small changes in our test images, at a level that will bother CI but not humans 🤞🏻 

