### PR TITLE
BLD: Explicitly cast np.argsort() result to target data type

### DIFF
--- a/yt/geometry/particle_oct_container.pyx
+++ b/yt/geometry/particle_oct_container.pyx
@@ -746,9 +746,11 @@ cdef class ParticleBitmap:
         # Loop over positions skipping those outside the domain
         cdef np.ndarray[np.uint64_t, ndim=1, cast=True] sorted_order
         if hsml is None:
-            sorted_order = np.argsort(morton_indices)
+            # casting to uint64 for compatibility with 32 bits systems
+            # see https://github.com/yt-project/yt/issues/3656
+            sorted_order = np.argsort(morton_indices).astype(np.uint64, copy=False)
         else:
-            sorted_order = np.argsort(hsml)[::-1]
+            sorted_order = np.argsort(hsml)[::-1].astype(np.uint64, copy=False)
         for sorted_ind in range(sorted_order.shape[0]):
             p = sorted_order[sorted_ind]
             skip = 0

--- a/yt/utilities/lib/geometry_utils.pyx
+++ b/yt/utilities/lib/geometry_utils.pyx
@@ -1044,7 +1044,9 @@ def knn_direct(np.ndarray[np.float64_t, ndim=2] P, np.uint64_t k, np.uint64_t i,
         for m in range(3):
             jpos[m] = P[idx[j],m]
         dist[j] = euclidean_distance(ipos, jpos)
-    sort_fwd = np.argsort(dist, kind='mergesort')[:k]
+    # casting to uint64 for compatibility with 32 bits systems
+    # see https://github.com/yt-project/yt/issues/3656
+    sort_fwd = np.argsort(dist, kind='mergesort')[:k].astype(np.int64, copy=False)
     if return_dist:
         return np.array(idx)[sort_fwd], np.array(dist)[sort_fwd]
     elif return_rad:


### PR DESCRIPTION
## PR Summary

On 32 bit machines (i386), argsort returns an `int32`, which is not automatically casted to the `uint64` target data type by Cython, so it raises an exception. This PR adds an explicit `.astype(np.uint64, copy=False)`

Closes: #3656 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
