### PR TITLE
BLD: require setuptools>=59 (partial migration out of distutils)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "setuptools>=19.6",
+  "setuptools>=59",
   # see https://github.com/numpy/numpy/pull/18389
   "wheel>=0.36.2",
 

--- a/setupext.py
+++ b/setupext.py
@@ -10,13 +10,13 @@ from textwrap import dedent
 from concurrent.futures import ThreadPoolExecutor
 from distutils import log
 from distutils.ccompiler import CCompiler, new_compiler
-from distutils.errors import CompileError, LinkError
 from distutils.sysconfig import customize_compiler
 from subprocess import PIPE, Popen
 from sys import platform as _platform
 
 from pkg_resources import resource_filename
 from setuptools.command.build_ext import build_ext as _build_ext
+from setuptools.errors import CompileError, LinkError
 from setuptools.command.sdist import sdist as _sdist
 
 


### PR DESCRIPTION
## PR Summary
Another incremental step away from distutils, which is targetted for removal from the standard library in Python 3.12 (#3384)
This change requires setuptools 59, see https://setuptools.pypa.io/en/latest/history.html#v59-0-0 and in particular https://github.com/pypa/setuptools/issues/2698
