### PR TITLE
[WIP] Track blockless particles

### DIFF
--- a/yt/frontends/flash/data_structures.py
+++ b/yt/frontends/flash/data_structures.py
@@ -99,6 +99,9 @@ class FLASHHierarchy(GridIndex):
         self.grid_dimensions[:] *= (nxb, nyb, nzb)
         try:
             self.grid_particle_count[:] = f_part["/localnp"][:][:, None]
+            self._blockless_particle_count = (
+                f_part["/tracer particles"].shape[0] - self.grid_particle_count.sum()
+            )
         except KeyError:
             self.grid_particle_count[:] = 0.0
         self._particle_indices = np.zeros(self.num_grids + 1, dtype="int64")


### PR DESCRIPTION
This is a first step at tracking blockless particles, as noted in #3681.  It needs two things before it can go in:

 - [ ] Whatever we end up with in `_read_particle_coords` (which I'm hoping someone will have suggestions to improve) needs to be mirrored in `_read_particle_fields`.
 - [ ] We need to add a test dataset to catch and verify this behavior.
