### PR TITLE
BUG: Take into account endianness when reading Gadget binary files

### DIFF
--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -452,6 +452,8 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
     def _yield_coordinates(self, data_file, needed_ptype=None):
         self._float_type = data_file.ds._header.float_type
         self._field_size = np.dtype(self._float_type).itemsize
+        dt = np.dtype(self._endian + self._float_type)
+        dt_native = dt.newbyteorder("N")
         with open(data_file.filename, "rb") as f:
             # We add on an additionally 4 for the first record.
             f.seek(data_file._position_offset + 4)
@@ -461,7 +463,9 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
                 if needed_ptype is not None and ptype != needed_ptype:
                     continue
                 # The first total_particles * 3 values are positions
-                pp = np.fromfile(f, dtype=self._float_type, count=count * 3)
+                pp = np.fromfile(f, dtype=dt, count=count * 3).astype(
+                    dt_native, copy=False
+                )
                 pp.shape = (count, 3)
                 yield ptype, pp
 

--- a/yt/geometry/particle_oct_container.pyx
+++ b/yt/geometry/particle_oct_container.pyx
@@ -587,11 +587,11 @@ cdef class ParticleBitmap:
             for i in range(3):
                 axiter[i][1] = 999
                 # Skip particles outside the domain
-                if pos[p,i] >= RE[i] or pos[p,i] < LE[i]:
+                if not (LE[i] <= pos[p, i] < RE[i]):
                     skip = 1
                     break
                 ppos[i] = pos[p,i]
-            if skip==1: continue
+            if skip == 1: continue
             mi = bounded_morton_split_dds(ppos[0], ppos[1], ppos[2], LE,
                                           dds, mi_split)
             mask[mi] = 1
@@ -756,11 +756,11 @@ cdef class ParticleBitmap:
             skip = 0
             for i in range(3):
                 axiter[i][1] = 999
-                if pos[p,i] >= RE[i] or pos[p,i] < LE[i]:
+                if not (LE[i] <= pos[p, i] < RE[i]):
                     skip = 1
                     break
                 ppos[i] = pos[p,i]
-            if skip==1: continue
+            if skip == 1: continue
             # Only look if collision at coarse index
             mi1 = bounded_morton_split_dds(ppos[0], ppos[1], ppos[2], LE,
                                            dds1, mi_split1)


### PR DESCRIPTION
The computation of the morton index only makes sense when dealing with positions within the bounding box. This particularly excludes non-normal (e.g. `inf` or `NaN`).
This should fix #3676 .

However, due to the way the logic was coded in `particle_oct_container.pyx`, non-normal value would happily be passed to compute the morton index... which would then be used to index an array.


## PR Summary

The fix is simple: formulate the boundary check in a way that caught non-normal values!
In more details, even though they seem to be equivalent, the following two lines of codes differ!
```python
import numpy as np
LE, RE, pos = 0, 1, np.nan
pos >= RE or pos < LE  # is False!
# yet...
not (LE <= pos < RE)   # is True!
```