### PR TITLE
Backport #3543 to yt-4.0.x (MNT: add explicit support for Python 3.10 on UNIX)

### DIFF
--- a/.github/workflows/build-test-pytest.yaml
+++ b/.github/workflows/build-test-pytest.yaml
@@ -14,8 +14,12 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-18.04]
-        python-version: [3.9]
+        os: [
+          macos-latest,
+          windows-latest,
+          ubuntu-latest,
+        ]
+        python-version: ['3.10']
         dependencies: [full]
         tests-type: [unit]
         include:
@@ -23,6 +27,12 @@ jobs:
             python-version: 3.6
             dependencies: minimal
             tests-type: unit
+          # temporary: Python 3.10 is not available on conda, so we pin this job to Python 3.9
+          - os: windows-latest
+            python-version: '3.9'
+        exclude:
+          - os: windows-latest
+            python-version: '3.10'
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Scientific/Engineering :: Astronomy
     Topic :: Scientific/Engineering :: Physics
     Topic :: Scientific/Engineering :: Visualization
@@ -72,24 +73,25 @@ doc =
     sphinx-bootstrap-theme
     sphinx-rtd-theme
 full =
-    astropy>=4.0.1,<5.0.0
+    astropy>=4.0.1,<6.0.0
     f90nml>=1.1.2
-    fastcache~=1.0.2
-    glueviz~=0.13.3
+    fastcache>=1.0.2
+    firefly-vis>=2.0.4,<3.0.0
     h5py>=3.1.0,<4.0.0
-    libconf~=1.0.1
+    libconf>=1.0.1
     miniballcpp>=0.2.1
-    mpi4py~=3.0.3
-    netCDF4~=1.5.3
-    pandas~=1.1.2
+    mpi4py>=3.0.3
+    netCDF4>=1.5.3
+    pandas>=1.1.2
     pooch>=0.7.0
-    pyaml~=17.10.0
-    pykdtree~=1.3.1
-    pyqt5~=5.15.2
-    pyx~=0.15
-    requests~=2.20.0
-    scipy~=1.5.0
-    xarray~=0.16.1
+    pyaml>=17.10.0
+    pykdtree>=1.3.1
+    pyqt5>=5.15.2
+    pyx>=0.15
+    requests>=2.20.0
+    scipy>=1.5.0
+    xarray>=0.16.1
+    glueviz>=0.13.3;python_version < '3.10' # FUTURE: lift this limitation when glueviz has Python 3.10 compatibility
 mapserver =
     bottle
 minimal =


### PR DESCRIPTION
## PR Summary
Manual backport because of a couple conflicts, actually easy to resolve.
