### PR TITLE
BUG: restore compatibility with latest version of cartopy (0.20)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -140,19 +140,8 @@ def pytest_configure(config):
         )
 
     if find_spec("cartopy") is not None:
-        # cartopy still triggers this numpy warning
-        # last checked with cartopy 0.19.0
-        config.addinivalue_line(
-            "filterwarnings",
-            (
-                "ignore:`np.float` is a deprecated alias for the builtin `float`. "
-                "To silence this warning, use `float` by itself. "
-                "Doing this will not modify any behavior and is safe. "
-                "If you specifically wanted the numpy scalar type, use `np.float64` here."
-                ":DeprecationWarning: "
-            ),
-        )
-        # this warning *still* shows up on cartopy 0.19 so we'll ignore it
+        # This can be removed when cartopy 0.21 is released
+        # see https://github.com/SciTools/cartopy/pull/1957
         config.addinivalue_line(
             "filterwarnings",
             (

--- a/tests/cartopy_requirements.txt
+++ b/tests/cartopy_requirements.txt
@@ -1,5 +1,0 @@
-# cartopy and its dependencies are non trivial to install
-# so we can't easily put these specs into setup.cfg
-shapely
---no-binary=shapely
-cartopy~=0.18.0

--- a/tests/ci_install.sh
+++ b/tests/ci_install.sh
@@ -16,13 +16,7 @@ osx|macOS)
     sudo mkdir -p /usr/local/man
     sudo chown -R "${USER}:admin" /usr/local/man
     brew update
-    # proj can be unpinned when upstream incompatibility issue is resolved. See
-    # https://github.com/SciTools/cartopy/issues/1140
-    export LDFLAGS="$LDFLAGS -L/usr/local/opt/proj@7/lib"
-    export CPPFLAGS="$CPPFLAGS -I/usr/local/opt/proj@7/include"
-    export CFLAGS="$CFLAGS -I/usr/local/opt/proj@7/include"
-    export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/proj@7/lib/pkgconfig"
-    HOMEBREW_NO_AUTO_UPDATE=1 brew install hdf5 proj@7 geos open-mpi netcdf ccache
+    HOMEBREW_NO_AUTO_UPDATE=1 brew install hdf5 proj geos open-mpi netcdf ccache
     ;;
 esac
 

--- a/tests/windows_conda_requirements.txt
+++ b/tests/windows_conda_requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.19.4
 cython>=0.29.21,<3.0
-cartopy~=0.18.0
+cartopy>=0.20.1
 h5py~=3.1.0
 matplotlib!=3.4.2,>=2.2.3,<3.6  # keep in sync with setup.cfg
 scipy~=1.5.0

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -269,7 +269,16 @@ class ImagePlotMPL(PlotMPL):
             # instances.  It is left as a historical note because we will
             # eventually need some form of it.
             # self.axes.set_extent(extent)
-            pass
+
+            # possibly related issue (operation order dependency)
+            # https://github.com/SciTools/cartopy/issues/1468
+
+            # in cartopy 0.19 (or 0.20), some intented behaviour changes produced an
+            # incompatibility here where default values for extent would lead to a crash.
+            # A solution is to let the transform object set the image extents internally
+            # see https://github.com/SciTools/cartopy/issues/1955
+            extent = None
+
         self.image = self.axes.imshow(
             data.to_ndarray(),
             origin="lower",


### PR DESCRIPTION
## PR Summary
Fix #3705 using the relevant bits of #3706
I'm cleaning a bunch of temporary measures that were recently taken to mitigate incompatibility issues, but the main patch, which consist in setting `extent=None`, was suggested by @greglucas, who I kindly invite to review this PR, particularly yt/visualization/base_plot_types.py

