### PR TITLE
Do not load plugins if ftype is None.

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -610,7 +610,6 @@ class Dataset(abc.ABC):
                 if nfields == 0:
                     mylog.debug("zero common fields, skipping particle union 'nbody'")
         self.field_info.setup_extra_union_fields()
-        mylog.debug("Loading field plugins.")
         self.field_info.load_all_plugins(self.default_fluid_type)
         deps, unloaded = self.field_info.check_derived_fields()
         self.field_dependencies.update(deps)

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -378,7 +378,10 @@ class FieldInfoContainer(dict):
         else:
             self[name] = DerivedField(name, sampling_type, function, **kwargs)
 
-    def load_all_plugins(self, ftype="gas"):
+    def load_all_plugins(self, ftype: Optional[str] = "gas"):
+        if ftype is None:
+            return
+        mylog.debug("Loading field plugins for field type: %s.", ftype)
         loaded = []
         for n in sorted(field_plugins):
             loaded += self.load_plugin(n, ftype)

--- a/yt/fields/tests/test_fields.py
+++ b/yt/fields/tests/test_fields.py
@@ -551,3 +551,13 @@ def test_ion_field_labels():
     for f in fields:
         label = getattr(fobj, f).get_latex_display_name()
         assert_equal(label, pm_labels[f])
+
+
+def test_default_fluid_type_None():
+    """
+    Check for bad behavior when default_fluid_type is None.
+    See PR #3710.
+    """
+    ds = fake_amr_ds()
+    ds.default_fluid_type = None
+    ds.field_list


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

This PR skips loading plugins if the `ftype` kwarg is None. This came up recently in an external frontend I maintain where the default field type (`default_fluid_type`) is None. Prior to PR #3433, we were silently loading plugins with a `None` field type. PR #3433 causes this to fail, which is probably the right thing, but I argue that we do not (and should not) explicitly disallow setting `default_fluid_type=None` and so should avoid loading the default fluid type plugins in this case. I've also moved the debug print into the function where it seemed to belong more. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
