### PR TITLE
MNT: bump maximal supported Matplotlib version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ packages = find:
 install_requires =
     cmyt>=0.2.2,<2.0.0
     ipython>=2.0.0
-    matplotlib!=3.4.2,>=2.2.3,<3.6  # keep in sync with tests/windows_conda_requirements.txt
+    matplotlib!=3.4.2,>=2.2.3,<3.7  # keep in sync with tests/windows_conda_requirements.txt
     more-itertools>=8.4
     numpy>=1.14.5
     packaging>=20.9

--- a/tests/windows_conda_requirements.txt
+++ b/tests/windows_conda_requirements.txt
@@ -2,5 +2,5 @@ numpy>=1.19.4
 cython>=0.29.21,<3.0
 cartopy~=0.18.0
 h5py~=3.1.0
-matplotlib!=3.4.2,>=2.2.3,<3.6  # keep in sync with setup.cfg
+matplotlib!=3.4.2,>=2.2.3,<3.7  # keep in sync with setup.cfg
 scipy~=1.5.0


### PR DESCRIPTION
## PR Summary
Fix #3712
