### PR TITLE
MNT: readd glueviz to [full] env (optional deps) on Python 3.10 following the release of glue-core 1.2.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -76,6 +76,7 @@ full =
     f90nml>=1.1.2
     fastcache>=1.0.2
     firefly-vis>=2.0.4,<3.0.0
+    glueviz>=0.13.3
     h5py>=3.1.0,<4.0.0
     libconf>=1.0.1
     miniballcpp>=0.2.1
@@ -90,7 +91,6 @@ full =
     requests>=2.20.0
     scipy>=1.5.0
     xarray>=0.16.1
-    glueviz>=0.13.3;python_version < '3.10' # FUTURE: lift this limitation when glueviz has Python 3.10 compatibility
 mapserver =
     bottle
 minimal =


### PR DESCRIPTION
## PR Summary

problem resolved upstream, see
https://github.com/glue-viz/glue/issues/2257
