### PR TITLE
REL: drop overly protective version upper limits for hard dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,9 +37,9 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    cmyt>=0.2.2,<2.0.0
+    cmyt>=0.2.2
     ipython>=2.0.0
-    matplotlib!=3.4.2,>=2.2.3,<3.6  # keep in sync with tests/windows_conda_requirements.txt
+    matplotlib!=3.4.2,>=2.2.3  # keep in sync with tests/windows_conda_requirements.txt
     more-itertools>=8.4
     numpy>=1.14.5
     packaging>=20.9

--- a/tests/windows_conda_requirements.txt
+++ b/tests/windows_conda_requirements.txt
@@ -2,5 +2,5 @@ numpy>=1.19.4
 cython>=0.29.21,<3.0
 cartopy~=0.18.0
 h5py~=3.1.0
-matplotlib!=3.4.2,>=2.2.3,<3.6  # keep in sync with setup.cfg
+matplotlib!=3.4.2,>=2.2.3  # keep in sync with setup.cfg
 scipy~=1.5.0


### PR DESCRIPTION
## PR Summary
Fix #3712
replaces #3713

Rationale:
I changed my mind about protective version capping after reading this blog post
https://iscinumpy.dev/post/bound-version-constraints/

Essentially, the reason why we're currently capping matplotlib (<3.6) is that we're used to seeing breaking changes in with every matplotlib minor release,
occasionally nasty ones (like the time matplotlib broke yt by erroring on colliding colormap names, see for instance https://github.com/yt-project/yt/issues/3165), _but_ there was always the possibility to fix these problems on the user side by downgrading matplotlib.
The problem with that approach is that by setting upper limits in advance, we just make users unable to use future versions of our dependencies, even when they would probably be fine, and there is no easy workaround on the user side there.
Given that our release cadence is de facto slower than matplotlib's, it doesn't seem like a good long term strategy.

Note that I'm keeping _some_ hard caps:
- in the optional dependencies ([full] env) because it's mostly intended for testing, and not advertised to users so I don't expect anyone to be actually broken by these, and in any case these constraints _can_ be worked around easily on the user side
- still capping Python<3.12 because it's an actual known incompatibility (see #3384), not an overly protective capping as the ones I'm removing here

For reference, we've been having (and occasionally bumping) an upper limit for matplotlib since #3150