### PR TITLE
Backport PR #3721 (REL: drop overly protective version upper limits for hard dependencies)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,9 +38,9 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    cmyt>=0.2.2,<2.0.0
+    cmyt>=0.2.2
     ipython>=2.0.0
-    matplotlib!=3.4.2,>=2.1.0,<3.6
+    matplotlib!=3.4.2,>=2.1.0 # keep in sync with tests/windows_conda_requirements.txt
     more-itertools>=8.4
     numpy>=1.13.3
     packaging>=20.9

--- a/tests/windows_conda_requirements.txt
+++ b/tests/windows_conda_requirements.txt
@@ -2,5 +2,5 @@ numpy>=1.19.4
 cython>=0.29.21,<3.0
 cartopy~=0.18.0
 h5py~=3.1.0
-matplotlib<3.6
+matplotlib!=3.4.2,>=2.1.0  # keep in sync with setup.cfg
 scipy~=1.5.0


### PR DESCRIPTION
## PR Summary

Manual backport for #3721
