### PR TITLE
TYP: upgrade mypy to 0.930 (enable TypeAlias)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ install_requires =
     toml>=0.10.2
     tqdm>=3.4.0
     unyt>=2.8.0
+    typing-extensions>=4.0.1;python_version < "3.10"
 python_requires = >=3.7,<3.12
 include_package_data = True
 scripts = scripts/iyt
@@ -100,6 +101,7 @@ minimal =
     more-itertools==8.4
     numpy==1.14.5
     unyt==2.8.0
+    typing-extensions==4.0.1;python_version < "3.10"
 test =
     codecov~=2.0.15
     coverage~=4.5.1
@@ -109,7 +111,7 @@ test =
     pytest>=6.1
     pytest-xdist~=2.1.0
 typecheck =
-    mypy==0.910
+    mypy==0.930
     types-PyYAML==5.4.10
     types-chardet==4.0.0
     types-requests==2.25.9

--- a/yt/_typing.py
+++ b/yt/_typing.py
@@ -1,4 +1,11 @@
+import sys
 from typing import List, Optional, Tuple
 
-FieldDescT = Tuple[str, Tuple[str, List[str], Optional[str]]]
-KnownFieldsT = Tuple[FieldDescT, ...]
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
+
+
+FieldDescT: TypeAlias = Tuple[str, Tuple[str, List[str], Optional[str]]]
+KnownFieldsT: TypeAlias = Tuple[FieldDescT, ...]

--- a/yt/frontends/gadget_fof/fields.py
+++ b/yt/frontends/gadget_fof/fields.py
@@ -74,7 +74,8 @@ _particle_fields = (
 
 
 class GadgetFOFFieldInfo(FieldInfoContainer):
-    known_particle_fields = _particle_fields
+    # https://github.com/python/mypy/issues/11836
+    known_particle_fields = _particle_fields  # type: ignore
 
     # these are extra fields to be created for the "all" particle type
     extra_union_fields = (
@@ -91,4 +92,5 @@ class GadgetFOFFieldInfo(FieldInfoContainer):
 
 
 class GadgetFOFHaloFieldInfo(FieldInfoContainer):
-    known_particle_fields = _particle_fields + (("ID", ("", ["member_ids"], None)),)
+    # https://github.com/python/mypy/issues/11836
+    known_particle_fields = _particle_fields + (("ID", ("", ["member_ids"], None)),)  # type: ignore

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1688,7 +1688,9 @@ class SlicePlot(NormalPlot):
             else:
                 cls = OffAxisSlicePlot
         self = object.__new__(cls)
-        return self
+
+        # https://github.com/python/mypy/issues/11835
+        return self  # type: ignore
 
 
 class ProjectionPlot(NormalPlot):
@@ -1749,7 +1751,9 @@ class ProjectionPlot(NormalPlot):
             else:
                 cls = OffAxisProjectionPlot
         self = object.__new__(cls)
-        return self
+
+        # https://github.com/python/mypy/issues/11835
+        return self  # type: ignore
 
 
 class AxisAlignedSlicePlot(SlicePlot, PWViewerMPL):


### PR DESCRIPTION
## PR Summary
Upgrading mypy to 0.930 enables using `typing.TypeAlias`, which I think come in handy in #3526
I'm opening as a draft because the new version has a couple regressions affecting us. I reported them upstream as
https://github.com/python/mypy/issues/11836 and https://github.com/python/mypy/issues/11836
In case they are resolved quickly we can avoid adding temporary `type: ignore` comments here
