### PR TITLE
TST: ignore a new warning emitted from setuptools via xarray

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -170,6 +170,17 @@ def pytest_configure(config):
             ),
         )
 
+    if find_spec("xarray") is not None:
+        # this can be removed when upstream issue is closed and a fix published
+        # https://github.com/pydata/xarray/issues/6092
+        config.addinivalue_line(
+            "filterwarnings",
+            (
+                "ignore:distutils Version classes are deprecated. "
+                "Use packaging.version instead.:DeprecationWarning"
+            ),
+        )
+
 
 def pytest_collection_modifyitems(config, items):
     r"""


### PR DESCRIPTION
## PR Summary

Quick fix to an instability in GHA test workflows, caused by a deprecation in setuptools 60.0 (just released) that xarray depends on
(see for instance #3640 https://github.com/yt-project/yt/runs/4610297736?check_suite_focus=true)
