### PR TITLE
BUG: fix a regression in (AxisAligned)SlicePlot's API

### DIFF
--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1549,7 +1549,7 @@ class NormalPlot(abc.ABC):
                 raise TypeError("Received incompatible arguments 'axis' and 'normal'")
             normal = axis
 
-        if (normal, fields) == (None, None):
+        if normal is fields is None:
             raise TypeError(
                 "missing 2 required positional arguments: 'normal' and 'fields'"
             )
@@ -1939,7 +1939,7 @@ class AxisAlignedSlicePlot(SlicePlot, PWViewerMPL):
             axis=axis,
             fields=fields,
         )
-
+        normal = self.sanitize_normal_vector(ds, normal)
         # this will handle time series data and controllers
         axis = fix_axis(normal, ds)
         (bounds, center, display_center) = get_window_parameters(
@@ -2160,6 +2160,7 @@ class AxisAlignedProjectionPlot(ProjectionPlot, PWViewerMPL):
     ):
         # TODO: in yt 4.2, remove default values for normal and fields, drop axis kwarg
         normal = self._validate_init_args(normal=normal, fields=fields, axis=axis)
+        normal = self.sanitize_normal_vector(ds, normal)
 
         axis = fix_axis(normal, ds)
         if ds.geometry in (

--- a/yt/visualization/tests/test_normal_plot_api.py
+++ b/yt/visualization/tests/test_normal_plot_api.py
@@ -1,3 +1,6 @@
+from itertools import product
+
+import numpy as np
 import pytest
 
 from yt._maintenance.deprecation import VisibleDeprecationWarning
@@ -78,3 +81,12 @@ def test_error_with_missing_fields_with_positional(ds, plot_cls):
         TypeError, match="missing required positional argument: 'fields'"
     ):
         plot_cls(ds, "z")
+
+
+@pytest.mark.parametrize(
+    "plot_cls, normal",
+    product([SlicePlot, ProjectionPlot], [(0, 0, 1), [0, 0, 1], np.array((0, 0, 1))]),
+)
+def test_normalplot_normal_array(ds, plot_cls, normal):
+    # see regression https://github.com/yt-project/yt/issues/3736
+    plot_cls(ds, normal, fields=("stream", "Density"))


### PR DESCRIPTION
## PR Summary

Fix #3736 

Incidentally add support for array-like normal arguments in (AxisAligned)ProjectionPlot

## PR Checklist

- [ ] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.
