### PR TITLE
BUG: fix a bug in masking invalid values in line integral convolution callback

### DIFF
--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -3090,7 +3090,8 @@ class LineIntegralConvolutionCallback(PlotCallback):
         vectors = np.concatenate((pixX[..., np.newaxis], pixY[..., np.newaxis]), axis=2)
 
         if self.texture is None:
-            self.texture = np.random.rand(nx, ny).astype(np.double)
+            prng = np.random.RandomState(0x4D3D3D3)
+            self.texture = prng.random_sample((nx, ny))
         elif self.texture.shape != (nx, ny):
             raise ValueError(
                 "'texture' must have the same shape "

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -3104,6 +3104,10 @@ class LineIntegralConvolutionCallback(PlotCallback):
         lic_data = lic_data / lic_data.max()
         lic_data_clip = np.clip(lic_data, self.lim[0], self.lim[1])
 
+        mask = ~(np.isfinite(pixX) & np.isfinite(pixY))
+        lic_data[mask] = np.nan
+        lic_data_clip[mask] = np.nan
+
         if self.const_alpha:
             plot._axes.imshow(
                 lic_data_clip,


### PR DESCRIPTION
## PR Summary
fix #3738

![after](https://user-images.githubusercontent.com/14075922/147707903-47ae7dbf-debc-4b54-9d20-3e69e15af1d0.png)
