### PR TITLE
BUG: ratarmount is broken on MacOS + Python 3.10, making this optional dep linux-only in test envs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -91,7 +91,7 @@ full =
     requests>=2.20.0
     scipy>=1.5.0
     xarray>=0.16.1
-    ratarmount~=0.8.1;platform_system!="Windows"
+    ratarmount>=0.8.1;platform_system!='Windows' and platform_system!='Darwin'
 mapserver =
     bottle
 minimal =

--- a/setup.cfg
+++ b/setup.cfg
@@ -91,7 +91,7 @@ full =
     requests>=2.20.0
     scipy>=1.5.0
     xarray>=0.16.1
-    ratarmount>=0.8.1;platform_system!='Windows' and platform_system!='Darwin'
+    ratarmount~=0.8.1;platform_system!='Windows' and platform_system!='Darwin'
 mapserver =
     bottle
 minimal =


### PR DESCRIPTION
## PR Summary

Alternative PR to #3748
If CI passes and doesn't take forever here I'll simply close the revert PR
