### PR TITLE
TST: don't update homebrew on MacOS CI (revert #3187)

### DIFF
--- a/tests/ci_install.sh
+++ b/tests/ci_install.sh
@@ -16,7 +16,6 @@ linux|Linux)
 osx|macOS)
     sudo mkdir -p /usr/local/man
     sudo chown -R "${USER}:admin" /usr/local/man
-    brew update
     HOMEBREW_NO_AUTO_UPDATE=1 brew install hdf5 proj geos open-mpi netcdf ccache osxfuse
     ;;
 esac


### PR DESCRIPTION
## PR Summary
This reverts a temporary patch that was introduced in #3187, and closes #3189
I've checked on my fork that updating homebrew isn't necessary anymore and skipping it shaves off ~5 min off MacOS tests jobs.
