### PR TITLE
WIP: particle file transactions and refactoring

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1872,6 +1872,21 @@ class ParticleFile(abc.ABC):
     def __hash__(self):
         return hash((self.filename, self.file_id, self.start, self.end))
 
+    def _nonzero_ptf(self, ptf):
+        for ptype, field_list in sorted(ptf.items()):
+            if self.total_particles[ptype] == 0:
+                continue
+            yield ptype, field_list, self.total_particles[ptype]
+
+    def _nonzero_ptypes(self, ptypes=None):
+        if ptypes is None:
+            ptypes = self.total_particles.keys()
+
+        for ptype in sorted(ptypes):
+            if self.total_particles[ptype] == 0:
+                continue
+            yield ptype, self.total_particles[ptype]
+
 
 class ParticleDataset(Dataset):
     _unit_base = None

--- a/yt/frontends/adaptahop/io.py
+++ b/yt/frontends/adaptahop/io.py
@@ -36,15 +36,13 @@ class IOHandlerAdaptaHOPBinary(BaseParticleIOHandler):
 
     def _read_particle_coords(self, chunks, ptf):
         # This will read chunks and yield the results.
-        chunks = list(chunks)
-        data_files = set()
+
         # Only support halo reading for now.
         assert len(ptf) == 1
         assert list(ptf.keys())[0] == "halos"
         ptype = "halos"
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
+
+        data_files = self._data_files_set(chunks)
         for data_file in sorted(data_files, key=attrgetter("filename")):
             pcount = (
                 data_file.ds.parameters["nhalos"] + data_file.ds.parameters["nsubs"]
@@ -56,14 +54,9 @@ class IOHandlerAdaptaHOPBinary(BaseParticleIOHandler):
 
     def _read_particle_fields(self, chunks, ptf, selector):
         # Now we have all the sizes, and we can allocate
-        chunks = list(chunks)
-        data_files = set()
         # Only support halo reading for now.
         assert len(ptf) == 1
         assert list(ptf.keys())[0] == "halos"
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
 
         def iterate_over_attributes(attr_list):
             for attr, *_ in attr_list:
@@ -73,9 +66,8 @@ class IOHandlerAdaptaHOPBinary(BaseParticleIOHandler):
                     yield attr
 
         halo_attributes = self.ds._halo_attributes
-
         attr_pos = partial(_find_attr_position, halo_attributes=halo_attributes)
-
+        data_files = self._data_files_set(chunks)
         for data_file in sorted(data_files, key=attrgetter("filename")):
             pcount = (
                 data_file.ds.parameters["nhalos"] + data_file.ds.parameters["nsubs"]

--- a/yt/frontends/ahf/io.py
+++ b/yt/frontends/ahf/io.py
@@ -72,10 +72,5 @@ class IOHandlerAHFHalos(BaseParticleIOHandler):
         assert len(ptf) == 1
         assert list(ptf.keys())[0] == "halos"
         # Get data_files
-        chunks = list(chunks)
-        data_files = set()
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
-        data_files = sorted(data_files, key=attrgetter("filename"))
-        yield from data_files
+        data_files = self._data_files_set(chunks)
+        yield from sorted(data_files, key=attrgetter("filename"))

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -565,14 +565,14 @@ class GadgetDataset(SPHDataset):
 
 class GadgetHDF5File(ParticleFile):
 
-    _fields_with_cols = ["Metallicity_", "PassiveScalars_", "Chemistry_", "GFM_Metals_"]
+    _fields_with_cols = ("Metallicity_", "PassiveScalars_", "Chemistry_", "GFM_Metals_")
 
     def _read_field(self, ptype, field_name, handle=None):
 
         field_name, col = self._sanitize_field_col(field_name)
 
         if self.total_particles[ptype] == 0:
-            # consider returning an empty array here instead of None
+            # TODO: consider returning an empty array here instead of None
             return
 
         if not handle:

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -590,9 +590,9 @@ class GadgetHDF5File(ParticleFile):
     def _sanitize_field_col(self, field_name: str):
 
         if any(field_name.startswith(c) for c in self.fields_with_cols):
-            rc = field_name.split("_")
+            rc = field_name.rsplit("_", 1)
             col = int(rc[-1])
-            rfield = rc[0]
+            rfield = rc[:-1]
 
             if rfield == "Chemistry":
                 rfield = rfield + "Abundances"

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -565,7 +565,7 @@ class GadgetDataset(SPHDataset):
 
 class GadgetHDF5File(ParticleFile):
 
-    fields_with_cols = ["Metallicity_", "PassiveScalars_", "Chemistry_", "GFM_Metals_"]
+    _fields_with_cols = ["Metallicity_", "PassiveScalars_", "Chemistry_", "GFM_Metals_"]
 
     def _read_field(self, ptype, field_name, handle=None):
 
@@ -589,12 +589,12 @@ class GadgetHDF5File(ParticleFile):
 
     def _sanitize_field_col(self, field_name: str):
 
-        if any(field_name.startswith(c) for c in self.fields_with_cols):
+        if any(field_name.startswith(c) for c in self._fields_with_cols):
             rc = field_name.rsplit("_", 1)
             col = int(rc[-1])
             rfield = rc[:-1]
 
-            if rfield == "Chemistry":
+            if rfield.startswith("Chemistry"):
                 rfield = rfield + "Abundances"
 
             return rfield, col

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -581,7 +581,7 @@ class GadgetHDF5File(ParticleFile):
         else:
             v = handle[f"/{ptype}/{field_name}"][self.start : self.end, ...]
 
-        if col:
+        if col is not None:
             # extract the column if appropriate for this field
             v = v[:, col]
 

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -156,7 +156,6 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
             if ds is None:
                 return np.empty(0, dtype=position_dtype)
 
-        # ds may be None
         dt = ds.dtype.newbyteorder("N")  # Native
         if position_dtype is not None and dt < position_dtype:
             # Sometimes positions are stored in double precision
@@ -188,7 +187,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
                     )
                     if ptype == "PartType0":
                         hsmls = self._get_smoothing_length(
-                            data_file, coords.dtype, coords.shape
+                            data_file, coords.dtype, coords.shape, handle
                         ).astype("float64")
                     else:
                         hsmls = 0.0
@@ -219,6 +218,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
                                 data_file,
                                 coords.dtype,
                                 coords.shape,
+                                handle,
                             ).astype("float64")
                         data = hsmls[mask]
                     else:

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -411,7 +411,7 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
             for ptype, count in data_file.total_particles.items():
                 if count == 0:
                     continue
-                if needed_ptype is not None and ptype != needed_ptype:
+                if needed_ptype and ptype != needed_ptype:
                     continue
                 pp = data_file._read_field(ptype, self._coord_name, handle=f)
                 yield ptype, pp

--- a/yt/frontends/gadget_fof/io.py
+++ b/yt/frontends/gadget_fof/io.py
@@ -19,12 +19,7 @@ class IOHandlerGadgetFOFHDF5(BaseParticleIOHandler):
 
     def _read_particle_coords(self, chunks, ptf):
         # This will read chunks and yield the results.
-        chunks = list(chunks)
-        data_files = set()
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
-        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+        for data_file in self._sorted_chunk_iterator(chunks):
             with h5py.File(data_file.filename, mode="r") as f:
                 for ptype in sorted(ptf):
                     coords = data_file._get_particle_positions(ptype, f=f)
@@ -69,12 +64,7 @@ class IOHandlerGadgetFOFHDF5(BaseParticleIOHandler):
 
     def _read_particle_fields(self, chunks, ptf, selector):
         # Now we have all the sizes, and we can allocate
-        chunks = list(chunks)
-        data_files = set()
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
-        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+        for data_file in self._sorted_chunk_iterator(chunks):
             si, ei = data_file.start, data_file.end
             with h5py.File(data_file.filename, mode="r") as f:
                 for ptype, field_list in sorted(ptf.items()):

--- a/yt/frontends/gadget_fof/io.py
+++ b/yt/frontends/gadget_fof/io.py
@@ -20,7 +20,7 @@ class IOHandlerGadgetFOFHDF5(BaseParticleIOHandler):
     def _read_particle_coords(self, chunks, ptf):
         # This will read chunks and yield the results.
         for data_file in self._sorted_chunk_iterator(chunks):
-            with h5py.File(data_file.filename, mode="r") as f:
+            with data_file.transaction() as f:
                 for ptype in sorted(ptf):
                     coords = data_file._get_particle_positions(ptype, f=f)
                     if coords is None:
@@ -32,9 +32,9 @@ class IOHandlerGadgetFOFHDF5(BaseParticleIOHandler):
 
     def _yield_coordinates(self, data_file):
         ptypes = self.ds.particle_types_raw
-        with h5py.File(data_file.filename, mode="r") as f:
+        with data_file.transaction() as f:
             for ptype, pcount in data_file._nonzero_ptypes(ptypes):
-                coords = f[ptype][f"{ptype}Pos"][()].astype("float64")
+                coords = data_file._read_particle_positions(ptype, f=f)
                 coords = np.resize(coords, (pcount, 3))
                 yield ptype, coords
 
@@ -46,54 +46,48 @@ class IOHandlerGadgetFOFHDF5(BaseParticleIOHandler):
         )
         for offset_file in data_file.offset_files:
             if fh.filename == offset_file.filename:
-                ofh = fh
+                data = data_file._read_field("Subhalo", field, handle=fh)
             else:
-                ofh = h5py.File(offset_file.filename, mode="r")
+                data = offset_file._read_field("Subhalo", field)
             subindex = np.arange(offset_file.total_offset) + offset_file.offset_start
             substart = max(fofindex[0] - subindex[0], 0)
             subend = min(fofindex[-1] - subindex[0], subindex.size - 1)
             fofstart = substart + subindex[0] - fofindex[0]
             fofend = subend + subindex[0] - fofindex[0]
-            field_data[fofstart : fofend + 1] = ofh["Subhalo"][field][
-                substart : subend + 1
-            ]
+            field_data[fofstart : fofend + 1] = data[substart : subend + 1]
         return field_data
 
-    def _read_particle_fields(self, chunks, ptf, selector):
-        # Now we have all the sizes, and we can allocate
-        for data_file in self._sorted_chunk_iterator(chunks):
-            si, ei = data_file.start, data_file.end
-            with h5py.File(data_file.filename, mode="r") as f:
-                for ptype, field_list, pcount in data_file._nonzero_ptf(ptf):
-                    coords = data_file._get_particle_positions(ptype, f=f)
-                    x = coords[:, 0]
-                    y = coords[:, 1]
-                    z = coords[:, 2]
-                    mask = selector.select_points(x, y, z, 0.0)
-                    del x, y, z
-                    if mask is None:
-                        continue
-                    for field in field_list:
-                        if field in self.offset_fields:
-                            field_data = self._read_offset_particle_field(
-                                field, data_file, f
-                            )
-                        else:
-                            if field == "particle_identifier":
-                                field_data = (
-                                    np.arange(pcount) + data_file.index_start[ptype]
-                                )
-                            elif field in f[ptype]:
-                                field_data = f[ptype][field][()].astype("float64")
-                            else:
-                                fname = field[: field.rfind("_")]
-                                field_data = f[ptype][fname][()].astype("float64")
-                                my_div = field_data.size / pcount
-                                if my_div > 1:
-                                    findex = int(field[field.rfind("_") + 1 :])
-                                    field_data = field_data[:, findex]
-                        data = field_data[si:ei][mask]
-                        yield (ptype, field), data
+    def _read_particle_data_file(self, data_file, ptf, selector):
+        data_return = {}
+        si, ei = data_file.start, data_file.end
+        with data_file.transaction() as f:
+            for ptype, field_list, pcount in data_file._nonzero_ptf(ptf):
+                coords = data_file._get_particle_positions(ptype, f=f)
+                x = coords[:, 0]
+                y = coords[:, 1]
+                z = coords[:, 2]
+                mask = selector.select_points(x, y, z, 0.0)
+                del x, y, z
+                if mask is None:
+                    continue
+                for field in field_list:
+                    if field in self.offset_fields:
+                        field_data = self._read_offset_particle_field(
+                            field, data_file, f
+                        )[si:ei]
+                    elif field == "particle_identifier":
+                        field_data = np.arange(pcount) + data_file.index_start[ptype]
+                    elif field in f[ptype]:
+                        field_data = data_file._read_field(ptype, field, handle=f)
+                    else:
+                        fname = field[: field.rfind("_")]
+                        field_data = data_file._read_field(ptype, fname, handle=f)
+                        my_div = field_data.size / pcount
+                        if my_div > 1:
+                            findex = int(field[field.rfind("_") + 1 :])
+                            field_data = field_data[:, findex]
+                    data_return[(ptype, field)] = field_data[mask]
+        return data_return
 
     def _count_particles(self, data_file):
         si, ei = data_file.start, data_file.end
@@ -111,7 +105,7 @@ class IOHandlerGadgetFOFHDF5(BaseParticleIOHandler):
         pcount = data_file.total_particles
         if sum(pcount.values()) == 0:
             return fields, {}
-        with h5py.File(data_file.filename, mode="r") as f:
+        with data_file.transaction() as f:
             for ptype in self.ds.particle_types_raw:
                 if data_file.total_particles[ptype] == 0:
                     continue

--- a/yt/frontends/halo_catalog/io.py
+++ b/yt/frontends/halo_catalog/io.py
@@ -17,17 +17,12 @@ class IOHandlerYTHaloCatalog(BaseParticleIOHandler):
 
     def _read_particle_coords(self, chunks, ptf):
         # This will read chunks and yield the results.
-        chunks = list(chunks)
-        data_files = set()
         # Only support halo reading for now.
         assert len(ptf) == 1
         assert list(ptf.keys())[0] == "halos"
         ptype = "halos"
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
         pn = "particle_position_%s"
-        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+        for data_file in self._sorted_chunk_iterator(chunks):
             with h5py.File(data_file.filename, mode="r") as f:
                 units = parse_h5_attr(f[pn % "x"], "units")
                 pos = data_file._get_particle_positions(ptype, f=f)
@@ -47,16 +42,11 @@ class IOHandlerYTHaloCatalog(BaseParticleIOHandler):
 
     def _read_particle_fields(self, chunks, ptf, selector):
         # Now we have all the sizes, and we can allocate
-        chunks = list(chunks)
-        data_files = set()
         # Only support halo reading for now.
         assert len(ptf) == 1
         assert list(ptf.keys())[0] == "halos"
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
         pn = "particle_position_%s"
-        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+        for data_file in self._sorted_chunk_iterator(chunks):
             si, ei = data_file.start, data_file.end
             with h5py.File(data_file.filename, mode="r") as f:
                 for ptype, field_list in sorted(ptf.items()):

--- a/yt/frontends/http_stream/io.py
+++ b/yt/frontends/http_stream/io.py
@@ -33,12 +33,7 @@ class IOHandlerHTTPStream(BaseParticleIOHandler):
         return f, {}
 
     def _read_particle_coords(self, chunks, ptf):
-        chunks = list(chunks)
-        data_files = set()
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
-        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+        for data_file in self._sorted_chunk_iterator(chunks):
             for ptype in ptf:
                 s = self._open_stream(data_file, (ptype, "Coordinates"))
                 c = np.frombuffer(s, dtype="float64")
@@ -47,11 +42,7 @@ class IOHandlerHTTPStream(BaseParticleIOHandler):
 
     def _read_particle_fields(self, chunks, ptf, selector):
         # Now we have all the sizes, and we can allocate
-        data_files = set()
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
-        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+        for data_file in self._sorted_chunk_iterator(chunks):
             for ptype, field_list in sorted(ptf.items()):
                 s = self._open_stream(data_file, (ptype, "Coordinates"))
                 c = np.frombuffer(s, dtype="float64")

--- a/yt/frontends/owls_subfind/io.py
+++ b/yt/frontends/owls_subfind/io.py
@@ -20,12 +20,7 @@ class IOHandlerOWLSSubfindHDF5(BaseParticleIOHandler):
 
     def _read_particle_coords(self, chunks, ptf):
         # This will read chunks and yield the results.
-        chunks = list(chunks)
-        data_files = set()
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
-        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+        for data_file in self._sorted_chunk_iterator(chunks):
             with h5py.File(data_file.filename, mode="r") as f:
                 for ptype in sorted(ptf):
                     pcount = data_file.total_particles[ptype]
@@ -67,12 +62,7 @@ class IOHandlerOWLSSubfindHDF5(BaseParticleIOHandler):
 
     def _read_particle_fields(self, chunks, ptf, selector):
         # Now we have all the sizes, and we can allocate
-        chunks = list(chunks)
-        data_files = set()
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
-        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+        for data_file in self._sorted_chunk_iterator(chunks):
             with h5py.File(data_file.filename, mode="r") as f:
                 for ptype, field_list in sorted(ptf.items()):
                     pcount = data_file.total_particles[ptype]

--- a/yt/frontends/owls_subfind/io.py
+++ b/yt/frontends/owls_subfind/io.py
@@ -60,10 +60,7 @@ class IOHandlerOWLSSubfindHDF5(BaseParticleIOHandler):
         # Now we have all the sizes, and we can allocate
         for data_file in self._sorted_chunk_iterator(chunks):
             with data_file.transaction() as f:
-                for ptype, field_list in sorted(ptf.items()):
-                    pcount = data_file.total_particles[ptype]
-                    if pcount == 0:
-                        continue
+                for ptype, field_list, pcount in data_file._nonzero_ptf(ptf):
                     coords = data_file._read_field(ptype, self._position_name, handle=f)
                     coords = np.resize(coords, (pcount, 3))
                     x = coords[:, 0]
@@ -81,8 +78,7 @@ class IOHandlerOWLSSubfindHDF5(BaseParticleIOHandler):
                         else:
                             if field == "particle_identifier":
                                 field_data = (
-                                    np.arange(data_file.total_particles[ptype])
-                                    + data_file.index_start[ptype]
+                                    np.arange(pcount) + data_file.index_start[ptype]
                                 )
                             elif field in f[ptype]:
                                 field_data = data_file._read_field(ptype, field)

--- a/yt/frontends/rockstar/io.py
+++ b/yt/frontends/rockstar/io.py
@@ -19,16 +19,11 @@ class IOHandlerRockstarBinary(BaseParticleIOHandler):
 
     def _read_particle_coords(self, chunks, ptf):
         # This will read chunks and yield the results.
-        chunks = list(chunks)
-        data_files = set()
         # Only support halo reading for now.
         assert len(ptf) == 1
         assert list(ptf.keys())[0] == "halos"
         ptype = "halos"
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
-        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+        for data_file in self._sorted_chunk_iterator(chunks):
             pcount = data_file.header["num_halos"]
             if pcount == 0:
                 continue
@@ -38,15 +33,10 @@ class IOHandlerRockstarBinary(BaseParticleIOHandler):
 
     def _read_particle_fields(self, chunks, ptf, selector):
         # Now we have all the sizes, and we can allocate
-        chunks = list(chunks)
-        data_files = set()
         # Only support halo reading for now.
         assert len(ptf) == 1
         assert list(ptf.keys())[0] == "halos"
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
-        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+        for data_file in self._sorted_chunk_iterator(chunks):
             si, ei = data_file.start, data_file.end
             pcount = data_file.header["num_halos"]
             if pcount == 0:

--- a/yt/frontends/sdf/io.py
+++ b/yt/frontends/sdf/io.py
@@ -14,16 +14,15 @@ class IOHandlerSDF(BaseParticleIOHandler):
     def _read_fluid_selection(self, chunks, selector, fields, size):
         raise NotImplementedError
 
+    def _sorted_chunk_iterator(self, chunks):
+        data_files = list(super()._sorted_chunk_iterator(chunks))
+        assert len(data_files) == 1
+        yield from data_files
+
     def _read_particle_coords(self, chunks, ptf):
-        chunks = list(chunks)
-        data_files = set()
         assert len(ptf) == 1
         assert ptf.keys()[0] == "dark_matter"
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
-        assert len(data_files) == 1
-        for _data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+        for _data_file in self._sorted_chunk_iterator(chunks):
             yield "dark_matter", (
                 self._handle["x"],
                 self._handle["y"],
@@ -31,15 +30,9 @@ class IOHandlerSDF(BaseParticleIOHandler):
             ), 0.0
 
     def _read_particle_fields(self, chunks, ptf, selector):
-        chunks = list(chunks)
-        data_files = set()
         assert len(ptf) == 1
         assert ptf.keys()[0] == "dark_matter"
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
-        assert len(data_files) == 1
-        for _data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+        for _data_file in self._sorted_chunk_iterator(chunks):
             for ptype, field_list in sorted(ptf.items()):
                 x = self._handle["x"]
                 y = self._handle["y"]

--- a/yt/frontends/sdf/io.py
+++ b/yt/frontends/sdf/io.py
@@ -4,6 +4,11 @@ from yt.funcs import mylog
 from yt.utilities.io_handler import BaseParticleIOHandler
 
 
+def _check_ptf(ptf):
+    assert len(ptf) == 1
+    assert ptf.keys()[0] == "dark_matter"
+
+
 class IOHandlerSDF(BaseParticleIOHandler):
     _dataset_type = "sdf_particles"
 
@@ -20,8 +25,7 @@ class IOHandlerSDF(BaseParticleIOHandler):
         yield from data_files
 
     def _read_particle_coords(self, chunks, ptf):
-        assert len(ptf) == 1
-        assert ptf.keys()[0] == "dark_matter"
+        _check_ptf(ptf)
         for _data_file in self._sorted_chunk_iterator(chunks):
             yield "dark_matter", (
                 self._handle["x"],
@@ -30,8 +34,7 @@ class IOHandlerSDF(BaseParticleIOHandler):
             ), 0.0
 
     def _read_particle_fields(self, chunks, ptf, selector):
-        assert len(ptf) == 1
-        assert ptf.keys()[0] == "dark_matter"
+        _check_ptf(ptf)
         for _data_file in self._sorted_chunk_iterator(chunks):
             for ptype, field_list in sorted(ptf.items()):
                 x = self._handle["x"]
@@ -69,15 +72,8 @@ class IOHandlerHTTPSDF(IOHandlerSDF):
     _dataset_type = "http_sdf_particles"
 
     def _read_particle_coords(self, chunks, ptf):
-        chunks = list(chunks)
-        data_files = set()
-        assert len(ptf) == 1
-        assert ptf.keys()[0] == "dark_matter"
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
-        assert len(data_files) == 1
-        for _data_file in data_files:
+        _check_ptf(ptf)
+        for _data_file in self._sorted_chunk_iterator(chunks):
             pcount = self._handle["x"].size
             yield "dark_matter", (
                 self._handle["x"][:pcount],
@@ -86,15 +82,8 @@ class IOHandlerHTTPSDF(IOHandlerSDF):
             ), 0.0
 
     def _read_particle_fields(self, chunks, ptf, selector):
-        chunks = list(chunks)
-        data_files = set()
-        assert len(ptf) == 1
-        assert ptf.keys()[0] == "dark_matter"
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
-        assert len(data_files) == 1
-        for _data_file in data_files:
+        _check_ptf(ptf)
+        for _data_file in self._sorted_chunk_iterator(chunks):
             pcount = self._handle["x"].size
             for ptype, field_list in sorted(ptf.items()):
                 x = self._handle["x"][:pcount]

--- a/yt/frontends/stream/io.py
+++ b/yt/frontends/stream/io.py
@@ -97,9 +97,7 @@ class StreamParticleIOHandler(BaseParticleIOHandler):
         super().__init__(ds)
 
     def _read_particle_coords(self, chunks, ptf):
-        for data_file in sorted(
-            self._get_data_files(chunks), key=lambda x: (x.filename, x.start)
-        ):
+        for data_file in self._sorted_chunk_iterator(chunks):
             f = self.fields[data_file.filename]
             # This double-reads
             for ptype in sorted(ptf):
@@ -110,18 +108,9 @@ class StreamParticleIOHandler(BaseParticleIOHandler):
                 ), 0.0
 
     def _read_smoothing_length(self, chunks, ptf, ptype):
-        for data_file in sorted(
-            self._get_data_files(chunks), key=lambda x: (x.filename, x.start)
-        ):
+        for data_file in self._sorted_chunk_iterator(chunks):
             f = self.fields[data_file.filename]
             return f[ptype, "smoothing_length"]
-
-    def _get_data_files(self, chunks):
-        data_files = set()
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
-        return data_files
 
     def _count_particles_chunks(self, psize, chunks, ptf, selector):
         for ptype, (x, y, z), _ in self._read_particle_coords(chunks, ptf):

--- a/yt/frontends/swift/data_structures.py
+++ b/yt/frontends/swift/data_structures.py
@@ -17,15 +17,12 @@ class SwiftParticleFile(ParticleFile):
         if handle is None:
             with h5py.File(self.filename, mode="r") as handle:
                 yield handle
-            handle.close()
         else:
-            # we have ended up here recursively, so simply yield. The outer
-            # instance will take care of closing the handle.
             yield handle
 
     def _read_field(self, ptype, field_name, handle=None):
 
-        field_name, col = self._sanitize_field_col(field_name)
+        field_name = self._sanitize_field(field_name)
 
         if self.total_particles[ptype] == 0:
             return
@@ -33,16 +30,12 @@ class SwiftParticleFile(ParticleFile):
         with self.transaction(handle) as f:
             v = f[f"/{ptype}/{field_name}"][self.start : self.end, ...]
 
-        if col is not None:
-            # extract the column if appropriate for this field
-            v = v[:, col]
-
         return v
 
-    def _sanitize_field_col(self, fieldname):
-        if fieldname in ("Mass", "Masses"):
-            fieldname = self.ds._particle_mass_name
-        return fieldname, None
+    def _sanitize_field(self, field_name):
+        if field_name in ("Mass", "Masses"):
+            field_name = self.ds._particle_mass_name
+        return field_name
 
 
 class SwiftDataset(SPHDataset):

--- a/yt/frontends/swift/io.py
+++ b/yt/frontends/swift/io.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 from yt.frontends.sph.io import IOHandlerSPH
-from yt.utilities.on_demand_imports import _h5py as h5py
 
 
 class IOHandlerSwift(IOHandlerSPH):
@@ -21,135 +20,112 @@ class IOHandlerSwift(IOHandlerSPH):
         # This will read chunks and yield the results.
         # yt has the concept of sub_files, i.e, we break up big files into
         # virtual sub_files to deal with the chunking system
+        cname = self.ds._particle_coordinates_name
         for sub_file in self._sorted_chunk_iterator(chunks):
-            si, ei = sub_file.start, sub_file.end
-            f = h5py.File(sub_file.filename, mode="r")
-            # This double-reads
-            for ptype in sorted(ptf):
-                if sub_file.total_particles[ptype] == 0:
-                    continue
-                pos = f[f"/{ptype}/Coordinates"][si:ei, :]
-                pos = pos.astype("float64", copy=False)
-                if ptype == self.ds._sph_ptypes[0]:
-                    hsml = self._get_smoothing_length(sub_file)
-                else:
-                    hsml = 0.0
-                yield ptype, (pos[:, 0], pos[:, 1], pos[:, 2]), hsml
-            f.close()
+            with sub_file.transaction() as f:
+                # This does NOT double-read anymore
+                for ptype in sorted(ptf):
+                    if sub_file.total_particles[ptype] == 0:
+                        continue
+                    pos = sub_file._read_field(ptype, cname, handle=f)
+                    pos = pos.astype("float64", copy=False)
+                    if ptype == self.ds._sph_ptypes[0]:
+                        hsml = self._get_smoothing_length(sub_file, handle=f)
+                    else:
+                        hsml = 0.0
+                    yield ptype, (pos[:, 0], pos[:, 1], pos[:, 2]), hsml
 
     def _yield_coordinates(self, sub_file, needed_ptype=None):
-        si, ei = sub_file.start, sub_file.end
-        f = h5py.File(sub_file.filename, mode="r")
-        pcount = f["/Header"].attrs["NumPart_ThisFile"][:].astype("int")
-        np.clip(pcount - si, 0, ei - si, out=pcount)
-        pcount = pcount.sum()
-        for key in f.keys():
-            if (
-                not key.startswith("PartType")
-                or "Coordinates" not in f[key]
-                or needed_ptype
-                and key != needed_ptype
-            ):
-                continue
-            pos = f[key]["Coordinates"][si:ei, ...]
-            pos = pos.astype("float64", copy=False)
-            yield key, pos
-        f.close()
+        cname = self.ds._particle_coordinates_name
+        with sub_file.transaction() as f:
+            for ptype, count in sub_file.total_particles.items():
+                if count == 0:
+                    continue
+                if needed_ptype and ptype != needed_ptype:
+                    continue
+                pos = sub_file._read_field(ptype, cname, handle=f)
+                pos = pos.astype("float64", copy=False)
+                yield ptype, pos
 
-    def _get_smoothing_length(self, sub_file, pdtype=None, pshape=None):
+    def _get_smoothing_length(self, sub_file, pdtype=None, pshape=None, handle=None):
         # We do not need the pdtype and the pshape, but some frontends do so we
         # accept them and then just ignore them
         ptype = self.ds._sph_ptypes[0]
-        ind = int(ptype[-1])
-        si, ei = sub_file.start, sub_file.end
-        with h5py.File(sub_file.filename, mode="r") as f:
-            pcount = f["/Header"].attrs["NumPart_ThisFile"][ind].astype("int")
-            pcount = np.clip(pcount - si, 0, ei - si)
-            # we upscale to float64
-            hsml = f[ptype]["SmoothingLength"][si:ei, ...]
-            hsml = hsml.astype("float64", copy=False)
-            return hsml
+        hsml = sub_file._read_field(ptype, "SmoothingLength", handle=handle)
+        return hsml.astype("float64", copy=False)
 
     def _read_particle_data_file(self, sub_file, ptf, selector=None):
         # note: this frontend uses the variable name and terminology sub_file.
         # other frontends use data_file with the understanding that it may
-        # actually be a sub_file, hence the super()._read_datafile is called
-        # ._read_datafile instead of ._read_subfile
+        # actually be a sub_file.
         return_data = {}
 
-        si, ei = sub_file.start, sub_file.end
-        f = h5py.File(sub_file.filename, mode="r")
-        for ptype, field_list in sorted(ptf.items()):
-            if sub_file.total_particles[ptype] == 0:
-                continue
-            g = f[f"/{ptype}"]
-            # this should load as float64
-            coords = g["Coordinates"][si:ei]
-            if ptype == "PartType0":
-                hsmls = self._get_smoothing_length(sub_file)
-            else:
-                hsmls = 0.0
-
-            if selector:
-                mask = selector.select_points(
-                    coords[:, 0], coords[:, 1], coords[:, 2], hsmls
-                )
-            del coords
-            if selector and mask is None:
-                continue
-            for field in field_list:
-                if field in ("Mass", "Masses"):
-                    data = g[self.ds._particle_mass_name][si:ei]
-                else:
-                    data = g[field][si:ei]
+        cname = self.ds._particle_coordinates_name
+        with sub_file.transaction() as f:
+            for ptype, field_list in sorted(ptf.items()):
+                if sub_file.total_particles[ptype] == 0:
+                    continue
 
                 if selector:
-                    data = data[mask, ...]
+                    coords = sub_file._read_field(ptype, cname, handle=f)
+                    if ptype == "PartType0":
+                        hsmls = self._get_smoothing_length(sub_file, handle=f)
+                    else:
+                        hsmls = 0.0
+                    mask = selector.select_points(
+                        coords[:, 0], coords[:, 1], coords[:, 2], hsmls
+                    )
+                    del coords
+                    if mask is None:
+                        continue
 
-                data.astype("float64", copy=False)
-
-                return_data[(ptype, field)] = data
-        f.close()
+                for field in field_list:
+                    data = sub_file._read_field(ptype, field, handle=f)
+                    if selector:
+                        data = data[mask, ...]
+                    data.astype("float64", copy=False)
+                    return_data[(ptype, field)] = data
 
         return return_data
 
     def _count_particles(self, data_file):
-        si, ei = data_file.start, data_file.end
-        f = h5py.File(data_file.filename, mode="r")
-        pcount = f["/Header"].attrs["NumPart_ThisFile"][:].astype("int")
-        f.close()
+        with data_file.transaction() as f:
+            pcount = f["/Header"].attrs["NumPart_ThisFile"][:].astype("int")
+
         # if this data_file was a sub_file, then we just extract the region
         # defined by the subfile
+        si, ei = data_file.start, data_file.end
         if None not in (si, ei):
             np.clip(pcount - si, 0, ei - si, out=pcount)
         npart = {f"PartType{i}": v for i, v in enumerate(pcount)}
         return npart
 
     def _identify_fields(self, data_file):
-        f = h5py.File(data_file.filename, mode="r")
-        fields = []
-        cname = self.ds._particle_coordinates_name  # Coordinates
-        mname = self.ds._particle_mass_name  # Coordinates
 
-        for key in f.keys():
-            if not key.startswith("PartType"):
-                continue
+        with data_file.transaction() as f:
 
-            g = f[key]
-            if cname not in g:
-                continue
+            fields = []
+            cname = self.ds._particle_coordinates_name  # Coordinates
+            mname = self.ds._particle_mass_name  # Masses
 
-            ptype = str(key)
-            for k in g.keys():
-                kk = k
-                if str(kk) == mname:
-                    fields.append((ptype, "Mass"))
+            for key in f.keys():
+                if not key.startswith("PartType"):
                     continue
-                if not hasattr(g[kk], "shape"):
-                    continue
-                if len(g[kk].shape) > 1:
-                    self._vector_fields[kk] = g[kk].shape[1]
-                fields.append((ptype, str(kk)))
 
-        f.close()
+                g = f[key]
+                if cname not in g:
+                    continue
+
+                ptype = str(key)
+                for k in g.keys():
+                    kk = k
+                    if str(kk) == mname:
+                        fields.append((ptype, "Mass"))
+                        continue
+                    if not hasattr(g[kk], "shape"):
+                        continue
+                    if len(g[kk].shape) > 1:
+                        self._vector_fields[kk] = g[kk].shape[1]
+                    fields.append((ptype, str(kk)))
+
         return fields, {}

--- a/yt/frontends/swift/io.py
+++ b/yt/frontends/swift/io.py
@@ -105,21 +105,19 @@ class IOHandlerSwift(IOHandlerSPH):
         with data_file.transaction() as f:
 
             fields = []
-            cname = self.ds._particle_coordinates_name  # Coordinates
-            mname = self.ds._particle_mass_name  # Masses
 
             for key in f.keys():
                 if not key.startswith("PartType"):
                     continue
 
                 g = f[key]
-                if cname not in g:
+                if self.ds._particle_coordinates_name not in g:
                     continue
 
                 ptype = str(key)
                 for k in g.keys():
                     kk = k
-                    if str(kk) == mname:
+                    if str(kk) == self.ds._particle_mass_name:
                         fields.append((ptype, "Mass"))
                         continue
                     if not hasattr(g[kk], "shape"):

--- a/yt/frontends/swift/io.py
+++ b/yt/frontends/swift/io.py
@@ -38,9 +38,7 @@ class IOHandlerSwift(IOHandlerSPH):
     def _yield_coordinates(self, sub_file, needed_ptype=None):
         cname = self.ds._particle_coordinates_name
         with sub_file.transaction() as f:
-            for ptype, count in sub_file.total_particles.items():
-                if count == 0:
-                    continue
+            for ptype, _ in sub_file._nonzero_ptypes():
                 if needed_ptype and ptype != needed_ptype:
                     continue
                 pos = sub_file._read_field(ptype, cname, handle=f)
@@ -62,9 +60,7 @@ class IOHandlerSwift(IOHandlerSPH):
 
         cname = self.ds._particle_coordinates_name
         with sub_file.transaction() as f:
-            for ptype, field_list in sorted(ptf.items()):
-                if sub_file.total_particles[ptype] == 0:
-                    continue
+            for ptype, field_list, _ in sub_file._nonzero_ptf(ptf):
 
                 if selector:
                     coords = sub_file._read_field(ptype, cname, handle=f)

--- a/yt/frontends/tipsy/io.py
+++ b/yt/frontends/tipsy/io.py
@@ -86,12 +86,9 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
         return rv
 
     def _read_particle_coords(self, chunks, ptf):
-        data_files = set()
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
+
         chunksize = self.ds.index.chunksize
-        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+        for data_file in self._sorted_chunk_iterator(chunks):
             poff = data_file.field_offsets
             tp = data_file.total_particles
             f = open(data_file.filename, "rb")

--- a/yt/utilities/io_handler.py
+++ b/yt/utilities/io_handler.py
@@ -299,12 +299,16 @@ class BaseIOHandler:
             # to not use an iterator.
             yield from data_file_data.items()
 
-    def _sorted_chunk_iterator(self, chunks):
+    def _data_files_set(self, chunks):
         chunks = list(chunks)
         data_files = set()
         for chunk in chunks:
             for obj in chunk.objs:
                 data_files.update(obj.data_files)
+        return data_files
+
+    def _sorted_chunk_iterator(self, chunks):
+        data_files = self._data_files_set(chunks)
         yield from sorted(data_files, key=lambda x: (x.filename, x.start))
 
 

--- a/yt/utilities/io_handler.py
+++ b/yt/utilities/io_handler.py
@@ -292,22 +292,13 @@ class BaseIOHandler:
 
     def _read_particle_fields(self, chunks, ptf, selector):
         # Now we have all the sizes, and we can allocate
-        data_files = set()
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
-        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
+        for data_file in self._sorted_chunk_iterator(chunks):
             data_file_data = self._read_particle_data_file(data_file, ptf, selector)
             # temporary trickery so it's still an iterator, need to adjust
             # the io_handler.BaseIOHandler.read_particle_selection() method
             # to not use an iterator.
             yield from data_file_data.items()
 
-
-# As a note: we don't *actually* want this to be how it is forever.  There's no
-# reason we need to have the fluid and particle IO handlers separated.  But,
-# for keeping track of which frontend is which, this is a useful abstraction.
-class BaseParticleIOHandler(BaseIOHandler):
     def _sorted_chunk_iterator(self, chunks):
         chunks = list(chunks)
         data_files = set()
@@ -316,6 +307,11 @@ class BaseParticleIOHandler(BaseIOHandler):
                 data_files.update(obj.data_files)
         yield from sorted(data_files, key=lambda x: (x.filename, x.start))
 
+
+# As a note: we don't *actually* want this to be how it is forever.  There's no
+# reason we need to have the fluid and particle IO handlers separated.  But,
+# for keeping track of which frontend is which, this is a useful abstraction.
+class BaseParticleIOHandler(BaseIOHandler):
     def _count_particles_chunks(
         self,
         psize: DefaultDict[str, int],


### PR DESCRIPTION
This is an experimental refactoring of the particle frontends following on #3526. The goal is to simplify and normalize particle reading and selection across frontends in a way that facilitates daskification but also allows creation of a new frontend with less knowledge of yt's chunking and indexing framework. The main structural change is to move the responsibility of opening and reading from a single file to the frontend's `ParticleFile` class. The `io` routines then handle the logic for iterating over the chunks and applying selectors.

If this PR pans out, it might be a sufficient enough change to warrant a YTEP (perhaps on its own or as part of a wider dask-related pr)? But at present, I'd still classify this as experimental. So feel free to peruse and comment with that in mind! 