### PR TITLE
BUG: add missing MPL version check to a temporary hack introduced in #3161

### DIFF
--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1062,7 +1062,11 @@ class PWViewerMPL(PlotWindow):
                         f"Min = {np.nanmin(image)}, Max = {np.nanmax(image)}."
                     )
                     use_symlog = True
-                elif np.nanmax(image) > 0.0 and np.nanmin(image) == 0:
+                elif (
+                    (Version("3.3") <= MPL_VERSION < Version("3.5"))
+                    and np.nanmax(image) > 0.0
+                    and np.nanmin(image) == 0
+                ):
                     # normally, a LogNorm scaling would still be OK here because
                     # LogNorm will mask 0 values when calculating vmin. But
                     # due to a bug in matplotlib's imshow, if the data range


### PR DESCRIPTION
## PR Summary
This is a proposal to close #3170 by adding a version check for MPL so that the "hack" introduced in #3161 is only applied when strictly necessary (with matplotlib from 3.3 to 3.4)

Taking the example from the original issue #2890 for reference
```python
import yt

ds = yt.load_sample("FIRE_M12i_ref11/snapshot_600.hdf5")
yt.ProjectionPlot(ds, "x", ("gas", "density")).save()
```

Here are the results:

### Main branch
#### w/ Matplotlib 3.2 to 3.4
![3 4 3_main](https://user-images.githubusercontent.com/14075922/150327811-280867d8-a885-4fa8-bab0-9901603c4ac3.png)

#### w/ Matplotlib 3.5
![3 5 1_main](https://user-images.githubusercontent.com/14075922/150327872-68a1dc39-6315-4045-94fe-11f4e27562fb.png)
(the one difference is that minor colorbar ticks are drawn, due to unrelated changes upstream)


### This branch

#### w/ Matplotlib 3.2
![3 2 2_branch](https://user-images.githubusercontent.com/14075922/150327979-b3476a2b-f98c-4d00-86c2-6e08cc54197d.png)

#### w/ Matplotlib 3.4
![3 4 3_branch](https://user-images.githubusercontent.com/14075922/150328025-f0acf283-769a-475a-a662-688c5546ae72.png)


#### w/ Matplotlib 3.5
![3 5 1_branch](https://user-images.githubusercontent.com/14075922/150328038-8c110d8f-3036-4f7c-928a-7d77545d7608.png)

So my main motivation here is to make it clear when (if) we can drop the hack introduced in #3161 in the future, but
I also think the behaviour observed with this patch + Matplotlib 3.5 is more desirable from the user's standpoint.
I acknowledged that a counter argument would be that the current behaviour (main branch) is preferred because it's more consistent across matplotlib versions.
So I'd like to ask @chummels @jzuhone and @chrishavlin to weigh in and decide if this patch is desirable or if we should just close #3170 without a code change.
Of course everyone else is also welcome to provide feedback

