### PR TITLE
BUG: fix a typesetting bug with fractionnal units in colorbar labels for volume rendering

### DIFF
--- a/yt/fields/derived_field.py
+++ b/yt/fields/derived_field.py
@@ -327,7 +327,7 @@ class DerivedField:
                 units = Unit(self.units)
         # Add unit label
         if not units.is_dimensionless:
-            data_label += r"\ \ (%s)" % (units.latex_representation())
+            data_label += r"\ \ \left(%s\right)" % (units.latex_representation())
 
         data_label += r"$"
         return data_label


### PR DESCRIPTION
## PR Summary
Similar to #3282 and #3637, this time for volume rendering.
We might want to refactor this someday to avoid fixing the same mistake 3 times.