### PR TITLE
REL: automate wheels publication to PyPI

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Build wheels for CPython
         uses: pypa/cibuildwheel@v2.3.0
+        with:
+          output-dir: dist
         env:
           CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-*"
           CIBW_SKIP: "*-musllinux_*"  #  numpy doesn't have wheels for musllinux so we can't build some quickly and without bloating
@@ -40,4 +42,39 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: wheels
-          path: ./wheelhouse/*.whl
+          path: ./dist/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: tarball
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    # upload to PyPI on every tag starting with 'yt-'
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/yt-')
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: tarball
+          path: dist
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: wheels
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_token }}

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -15,10 +15,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+      # pinning OS versions to oldest versions available
+      # because forward compatibility is much easier to
+      # guarantee than backward compatibility
         os: [
-          macos-latest,
-          windows-latest,
-          ubuntu-18.04,  # has to be the oldest possible for manylinux
+          ubuntu-18.04,
+          windows-2019,
+          macos-10.15,
         ]
       fail-fast: false
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,7 @@ repos:
       args: [--branch, main]
     - id: check-shebang-scripts-are-executable
     - id: check-executables-have-shebangs
+    - id: check-yaml
 -   repo: https://github.com/asottile/pyupgrade
     rev: v2.31.0
     hooks:


### PR DESCRIPTION
## PR Summary
We've been polishing this workflow on yt-astro-analysis and it's now working correctly so here's the port back to yt itself.
This workflow requires that a secret named "PYPI_TOKEN" be added to the repo (the name is arbitrary, that's just the name we've been using for yt-astro), this can be done by a PyPI maintainer.

