### PR TITLE
TST: ignore a deprecation warning from glueviz

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -166,6 +166,16 @@ def pytest_configure(config):
             ),
         )
 
+    if find_spec("glue"):
+        config.addinivalue_line(
+            "filterwarnings",
+            (
+                r"ignore:Error loading config file .*"
+                r"the load_module\(\) method is deprecated and slated for removal in Python 3\.12; "
+                r"use exec_module\(\) instead:DeprecationWarning"
+            ),
+        )
+
 
 def pytest_collection_modifyitems(config, items):
     r"""


### PR DESCRIPTION
## PR Summary

Ignore a new warning emitted on Python 3.10 with the latest version of glue-core released yesterday (https://pypi.org/project/glue-core/1.2.4/)
This warning is failing CI, so I'll mark this as a blocker.
