### PR TITLE
TST: add a constraint to avoid latest glue-core version in CI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -91,6 +91,7 @@ full =
     requests>=2.20.0
     scipy>=1.5.0
     xarray>=0.16.1
+    glue-core!=1.2.4;python_version >= '3.10' # see https://github.com/glue-viz/glue/issues/2263
     ratarmount~=0.8.1;platform_system!='Windows' and platform_system!='Darwin'
 mapserver =
     bottle


### PR DESCRIPTION
## PR Summary
An alternative solution to (currently failing) #3759

The problem appeared here:
https://github.com/yt-project/yt/runs/4969817599?check_suite_focus=true

and is caused by a new warning emitted on Python 3.10 with the latest version of glue-core released yesterday (https://pypi.org/project/glue-core/1.2.4/)

The issue is reported upstream  glue-viz/glue#2263, and a fix looks to be underway https://github.com/glue-viz/glue/pull/2264