### PR TITLE
TYP: add py.typed marker file to improve downstream type-checking

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -22,6 +22,7 @@ prune .tours
 recursive-include yt/visualization/volume_rendering/shaders *.fragmentshader *.vertexshader
 include yt/sample_data_registry.json
 include conftest.py
+include yt/py.typed
 prune yt/frontends/_skeleton
 recursive-include yt/frontends/amrvac *.par
 exclude .codecov.yml .coveragerc .git-blame-ignore-revs .gitmodules .hgchurn .mailmap

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ ignore = [
 
 [tool.mypy]
 python_version = 3.7
+show_error_codes = true
 ignore_missing_imports = true
 warn_unused_configs = true
 warn_unused_ignores = true


### PR DESCRIPTION
## PR Summary

Add an empty marker file that's required by type-checkers declare our inline-type annotations
This is necessary to make downstream type-checking able to rely on existing annotations in yt.

See
https://mypy.readthedocs.io/en/latest/installed_packages.html#creating-pep-561-compatible-packages


as an example here's how adding this file changes Mypy's report for https://github.com/neutrinoceros/yt_idefix

with main
```
yt_idefix/fields.py:1: error: Skipping analyzing "yt.fields.field_info_container": module is installed, but missing library stubs or py.typed marker
yt_idefix/fields.py:2: error: Skipping analyzing "yt.fields.magnetic_field": module is installed, but missing library stubs or py.typed marker
yt_idefix/io.py:6: error: Skipping analyzing "yt.utilities.io_handler": module is installed, but missing library stubs or py.typed marker
yt_idefix/data_structures.py:13: error: Skipping analyzing "yt.data_objects.index_subobjects.grid_patch": module is installed, but missing library stubs or py.typed marker
yt_idefix/data_structures.py:13: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
yt_idefix/data_structures.py:14: error: Skipping analyzing "yt.data_objects.static_output": module is installed, but missing library stubs or py.typed marker
yt_idefix/data_structures.py:15: error: Skipping analyzing "yt.funcs": module is installed, but missing library stubs or py.typed marker
yt_idefix/data_structures.py:16: error: Skipping analyzing "yt.geometry.grid_geometry_handler": module is installed, but missing library stubs or py.typed marker
yt_idefix/loaders.py:7: error: Skipping analyzing "yt": module is installed, but missing library stubs or py.typed marker
Found 8 errors in 4 files (checked 13 source files)
```

with this marker
```
yt_idefix/data_structures.py: note: In member "__init__" of class "IdefixDataset":
yt_idefix/data_structures.py:124: error: "Type[IdefixDataset]" has no attribute "_dataset_type"
yt_idefix/data_structures.py:127: error: Incompatible types in assignment (expression has type "Optional[str]", variable has type "str")
yt_idefix/data_structures.py: note: In class "IdefixVtkDataset":
yt_idefix/data_structures.py:229: error: Signature of "_is_valid" incompatible with supertype "Dataset"
yt_idefix/data_structures.py:229: note:      Superclass:
yt_idefix/data_structures.py:229: note:          @classmethod
yt_idefix/data_structures.py:229: note:          def _is_valid(cls, filename: Any, *args: Any, **kwargs: Any) -> Any
yt_idefix/data_structures.py:229: note:      Subclass:
yt_idefix/data_structures.py:229: note:          @classmethod
yt_idefix/data_structures.py:229: note:          def _is_valid(cls, fn: Any, *args: Any, **kwargs: Any) -> bool
Found 3 errors in 1 file (checked 13 source files)
```