### PR TITLE
REL: manual backports to yt-4.0.x for stability

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -147,6 +147,17 @@ def pytest_configure(config):
             ),
         )
 
+    if find_spec("xarray") is not None:
+        # this can be removed when upstream issue is closed and a fix published
+        # https://github.com/pydata/xarray/issues/6092
+        config.addinivalue_line(
+            "filterwarnings",
+            (
+                "ignore:distutils Version classes are deprecated. "
+                "Use packaging.version instead.:DeprecationWarning"
+            ),
+        )
+
 
 def pytest_collection_modifyitems(config, items):
     r"""

--- a/conftest.py
+++ b/conftest.py
@@ -128,19 +128,8 @@ def pytest_configure(config):
         )
 
     if find_spec("cartopy") is not None:
-        # cartopy still triggers this numpy warning
-        # last checked wtih cartopy 0.19.0
-        config.addinivalue_line(
-            "filterwarnings",
-            (
-                "ignore:`np.float` is a deprecated alias for the builtin `float`. "
-                "To silence this warning, use `float` by itself. "
-                "Doing this will not modify any behavior and is safe. "
-                "If you specifically wanted the numpy scalar type, use `np.float64` here."
-                ":DeprecationWarning: "
-            ),
-        )
-        # this warning *still* shows up on cartopy 0.19 so we'll ignore it
+        # This can be removed when cartopy 0.21 is released
+        # see https://github.com/SciTools/cartopy/pull/1957
         config.addinivalue_line(
             "filterwarnings",
             (

--- a/setup.cfg
+++ b/setup.cfg
@@ -92,6 +92,7 @@ full =
     requests>=2.20.0
     scipy>=1.5.0
     xarray>=0.16.1
+    glue-core!=1.2.4;python_version >= '3.10' # see https://github.com/glue-viz/glue/issues/2263
 mapserver =
     bottle
 minimal =

--- a/tests/cartopy_requirements.txt
+++ b/tests/cartopy_requirements.txt
@@ -1,5 +1,0 @@
-# cartopy and its dependencies are non trivial to install
-# so we can't easily put these specs into setup.cfg
-shapely
---no-binary=shapely
-cartopy~=0.18.0

--- a/tests/ci_install.sh
+++ b/tests/ci_install.sh
@@ -36,6 +36,18 @@ if [[ "${RUNNER_OS}" == "Windows" ]] && [[ ${dependencies} != "minimal" ]]; then
 else
     python -m pip install --upgrade pip
     python -m pip install --upgrade wheel
+
+    # // band aid
+    # TODO: revert https://github.com/yt-project/yt/pull/3733
+    # when the following upstream PR is released
+    # https://github.com/mpi4py/mpi4py/issues/160
+
+    # workaround taken from
+    # https://github.com/mpi4py/mpi4py/issues/157#issuecomment-1001022274
+    export SETUPTOOLS_USE_DISTUTILS=stdlib
+    python -m pip install mpi4py
+    # // end band aid
+
     python -m pip install --upgrade setuptools
 fi
 

--- a/tests/ci_install.sh
+++ b/tests/ci_install.sh
@@ -16,13 +16,7 @@ osx|macOS)
     sudo mkdir -p /usr/local/man
     sudo chown -R "${USER}:admin" /usr/local/man
     brew update
-    # proj can be unpinned when upstream incompatibility issue is resolved. See
-    # https://github.com/SciTools/cartopy/issues/1140
-    export LDFLAGS="$LDFLAGS -L/usr/local/opt/proj@7/lib"
-    export CPPFLAGS="$CPPFLAGS -I/usr/local/opt/proj@7/include"
-    export CFLAGS="$CFLAGS -I/usr/local/opt/proj@7/include"
-    export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/proj@7/lib/pkgconfig"
-    HOMEBREW_NO_AUTO_UPDATE=1 brew install hdf5 proj@7 geos open-mpi netcdf ccache
+    HOMEBREW_NO_AUTO_UPDATE=1 brew install hdf5 proj geos open-mpi netcdf ccache
     ;;
 esac
 

--- a/tests/windows_conda_requirements.txt
+++ b/tests/windows_conda_requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.19.4
 cython>=0.29.21,<3.0
-cartopy~=0.18.0
+cartopy>=0.20.1
 h5py~=3.1.0
 matplotlib!=3.4.2,>=2.1.0  # keep in sync with setup.cfg
 scipy~=1.5.0

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -842,8 +842,8 @@ def compare_image_lists(new_result, old_result, decimals):
     num_images = len(old_result)
     assert num_images > 0
     for i in range(num_images):
-        expected = np.loads(zlib.decompress(old_result[i]))
-        actual = np.loads(zlib.decompress(new_result[i]))
+        expected = pickle.loads(zlib.decompress(old_result[i]))
+        actual = pickle.loads(zlib.decompress(new_result[i]))
         expected_p, actual_p = ensure_image_comparability(expected, actual)
 
         mpimg.imsave(fns[0], expected_p)

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -269,7 +269,16 @@ class ImagePlotMPL(PlotMPL):
             # instances.  It is left as a historical note because we will
             # eventually need some form of it.
             # self.axes.set_extent(extent)
-            pass
+
+            # possibly related issue (operation order dependency)
+            # https://github.com/SciTools/cartopy/issues/1468
+
+            # in cartopy 0.19 (or 0.20), some intented behaviour changes produced an
+            # incompatibility here where default values for extent would lead to a crash.
+            # A solution is to let the transform object set the image extents internally
+            # see https://github.com/SciTools/cartopy/issues/1955
+            extent = None
+
         self.image = self.axes.imshow(
             data.to_ndarray(),
             origin="lower",


### PR DESCRIPTION
## PR Summary
In support to #3765, and in prep for the 4.0.2 release

Manual backports for the following PRs
- #3708
- #3733
- #3743
- #3760

all of which are focused on stabilizing CI