### PR TITLE
BUG: don't install IPython 8 for docs build with hopes it fixes the build

### DIFF
--- a/doc/source/developing/deprecating_features.rst
+++ b/doc/source/developing/deprecating_features.rst
@@ -21,7 +21,7 @@ Here's an example call.
         issue_deprecation_warning(
             "`old_function` is deprecated, use `replacement_function` instead."
             since="4.0.0",
-            removal="4.1.0"
+            removal="4.1.0",
         )
         ...
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,7 @@ nose.plugins.0.10 =
 doc =
     alabaster
     bottle
+    ipython<8.0
     nbconvert==5.6.1
     pyregion
     pyx>=0.15


### PR DESCRIPTION
## PR Summary
Lazy attempt to fix #3768, assuming the culprit is IPython 8, which is currently my only suspect.
I made an insignificant change to a doc source file to trigger the docs build.