### PR TITLE
ENH: avoid storing relative paths in Dataset attributes

### DIFF
--- a/yt/frontends/art/data_structures.py
+++ b/yt/frontends/art/data_structures.py
@@ -164,7 +164,6 @@ class ARTDataset(Dataset):
         self._file_particle_data = file_particle_data
         self._file_particle_stars = file_particle_stars
         self._find_files(filename)
-        self.parameter_filename = filename
         self.skip_particles = skip_particles
         self.skip_stars = skip_stars
         self.limit_level = limit_level
@@ -449,7 +448,6 @@ class DarkMatterARTDataset(ARTDataset):
         self._file_particle = filename
         self._file_particle_header = file_particle_header
         self._find_files(filename)
-        self.parameter_filename = filename
         self.skip_stars = skip_stars
         self.spread_age = spread_age
         Dataset.__init__(

--- a/yt/frontends/athena/data_structures.py
+++ b/yt/frontends/athena/data_structures.py
@@ -494,11 +494,9 @@ class AthenaDataset(Dataset):
             unit_system=unit_system,
             default_species_fields=default_species_fields,
         )
-        self.filename = filename
         if storage_filename is None:
-            storage_filename = f"{filename.split('/')[-1]}.yt"
+            storage_filename = self.basename + ".yt"
         self.storage_filename = storage_filename
-        self.backup_filename = self.filename[:-4] + "_backup.gdf"
         # Unfortunately we now have to mandate that the index gets
         # instantiated so that we can make sure we have the correct left
         # and right domain edges.

--- a/yt/frontends/athena_pp/data_structures.py
+++ b/yt/frontends/athena_pp/data_structures.py
@@ -266,11 +266,9 @@ class AthenaPPDataset(Dataset):
             unit_system=unit_system,
             default_species_fields=default_species_fields,
         )
-        self.filename = filename
         if storage_filename is None:
-            storage_filename = f"{filename.split('/')[-1]}.yt"
+            storage_filename = self.basename + ".yt"
         self.storage_filename = storage_filename
-        self.backup_filename = self.filename[:-4] + "_backup.gdf"
 
     def _set_code_unit_attributes(self):
         """
@@ -361,7 +359,7 @@ class AthenaPPDataset(Dataset):
     @classmethod
     def _is_valid(cls, filename, *args, **kwargs):
         try:
-            if filename.endswith("athdf"):
+            if filename.endswith(".athdf"):
                 return True
         except Exception:
             pass

--- a/yt/frontends/chombo/data_structures.py
+++ b/yt/frontends/chombo/data_structures.py
@@ -93,7 +93,7 @@ class ChomboHierarchy(GridIndex):
         self.dataset = weakref.proxy(ds)
         # for now, the index file is the dataset!
         self.index_filename = os.path.abspath(self.dataset.parameter_filename)
-        self.directory = ds.fullpath
+        self.directory = ds.directory
         self._handle = ds._handle
 
         self._levels = [key for key in self._handle.keys() if key.startswith("level")]

--- a/yt/frontends/exodus_ii/data_structures.py
+++ b/yt/frontends/exodus_ii/data_structures.py
@@ -139,17 +139,22 @@ class ExodusIIDataset(Dataset):
         ... )
 
         """
-        self.parameter_filename = filename
-        self.fluid_types += self._get_fluid_types()
         self.step = step
         if displacements is None:
             self.displacements = {}
         else:
             self.displacements = displacements
-        super().__init__(filename, dataset_type, units_override=units_override)
-        self.index_filename = filename
         self.storage_filename = storage_filename
+
+        super().__init__(filename, dataset_type, units_override=units_override)
+
+        self.fluid_types += self._get_fluid_types()
         self.default_field = [f for f in self.field_list if f[0] == "connect1"][-1]
+
+    @property
+    def index_filename(self):
+        # historic alias
+        return self.filename
 
     def _set_code_unit_attributes(self):
         # This is where quantities are created that represent the various

--- a/yt/frontends/gdf/data_structures.py
+++ b/yt/frontends/gdf/data_structures.py
@@ -171,7 +171,6 @@ class GDFDataset(Dataset):
             default_species_fields=default_species_fields,
         )
         self.storage_filename = storage_filename
-        self.filename = filename
 
     def _set_code_unit_attributes(self):
         """

--- a/yt/frontends/moab/data_structures.py
+++ b/yt/frontends/moab/data_structures.py
@@ -68,7 +68,6 @@ class MoabHex8Dataset(Dataset):
             unit_system=unit_system,
         )
         self.storage_filename = storage_filename
-        self.filename = filename
         self._handle = HDF5FileHandler(filename)
 
     def _set_code_unit_attributes(self):
@@ -169,7 +168,6 @@ class PyneMoabHex8Dataset(Dataset):
             unit_system=unit_system,
         )
         self.storage_filename = storage_filename
-        self.filename = filename
 
     def _set_code_unit_attributes(self):
         # Almost everything is regarded as dimensionless in MOAB, so these will

--- a/yt/frontends/nc4_cm1/data_structures.py
+++ b/yt/frontends/nc4_cm1/data_structures.py
@@ -90,7 +90,6 @@ class CM1Dataset(Dataset):
             unit_system=unit_system,
         )
         self.storage_filename = storage_filename
-        self.filename = filename
 
     def _setup_coordinate_handler(self):
         # ensure correct ordering of axes so plots aren't rotated (z should always be

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -291,8 +291,11 @@ class StreamDataset(Dataset):
             default_species_fields=default_species_fields,
         )
 
+    @property
+    def filename(self):
+        return self.stream_handler.name
+
     def _parse_parameter_file(self):
-        self.basename = self.stream_handler.name
         self.parameters["CurrentTimeIdentifier"] = time.time()
         self.unique_identifier = self.parameters["CurrentTimeIdentifier"]
         self.domain_left_edge = self.stream_handler.domain_left_edge.copy()

--- a/yt/frontends/swift/data_structures.py
+++ b/yt/frontends/swift/data_structures.py
@@ -35,8 +35,6 @@ class SwiftDataset(SPHDataset):
         default_species_fields=None,
     ):
 
-        self.filename = filename
-
         super().__init__(
             filename,
             dataset_type,

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -41,7 +41,9 @@ from yt.utilities.on_demand_imports import _pooch as pooch, _ratarmount as ratar
 # --- Loaders for known data formats ---
 
 
-def load(fn, *args, hint: Optional[str] = None, **kwargs):
+def load(
+    fn: Union[str, "os.PathLike[str]"], *args, hint: Optional[str] = None, **kwargs
+):
     """
     Load a Dataset or DatasetSeries object.
     The data format is automatically discovered, and the exact return type is the
@@ -51,7 +53,7 @@ def load(fn, *args, hint: Optional[str] = None, **kwargs):
 
     Parameters
     ----------
-    fn : str, os.Pathlike, or byte (types supported by os.path.expandusers)
+    fn : str, os.Pathlike[str]
         A path to the data location. This can be a file name, directory name, a glob
         pattern, or a url (for data types that support it).
 

--- a/yt/utilities/io_handler.py
+++ b/yt/utilities/io_handler.py
@@ -89,7 +89,7 @@ class BaseIOHandler:
         # check backup file first. if field not found,
         # call frontend-specific io method
         backup_filename = grid.ds.backup_filename
-        if not grid.ds.read_from_backup:
+        if not os.path.exists(backup_filename):
             return self._read_data(grid, field)
         elif self._field_in_backup(grid, backup_filename, field):
             fhandle = h5py.File(backup_filename, mode="r")

--- a/yt/utilities/parameter_file_storage.py
+++ b/yt/utilities/parameter_file_storage.py
@@ -101,7 +101,7 @@ class ParameterFileStore:
         """This turns a dataset into a CSV entry."""
         return dict(
             bn=ds.basename,
-            fp=ds.fullpath,
+            fp=ds.directory,
             tt=ds.current_time,
             ctid=ds.unique_identifier,
             class_name=ds.__class__.__name__,
@@ -138,7 +138,7 @@ class ParameterFileStore:
             return
         ds_dict = self._records[hash]
         self._records[hash]["last_seen"] = ds._instantiated
-        if ds_dict["bn"] != ds.basename or ds_dict["fp"] != ds.fullpath:
+        if ds_dict["bn"] != ds.basename or ds_dict["fp"] != ds.directory:
             self.wipe_hash(hash)
             self.insert_ds(ds)
 

--- a/yt/visualization/volume_rendering/old_camera.py
+++ b/yt/visualization/volume_rendering/old_camera.py
@@ -825,7 +825,7 @@ class Camera(ParallelAnalysisInterface):
             "north_vector": self.orienter.unit_vectors[1],
             "normal_vector": self.orienter.unit_vectors[2],
             "width": self.width,
-            "dataset": self.ds.fullpath,
+            "dataset": self.ds.directory,
         }
         return info_dict
 
@@ -1568,7 +1568,7 @@ class HEALpixCamera(Camera):
             "type": self.__class__.__name__,
             "center": self.center,
             "radius": self.radius,
-            "dataset": self.ds.fullpath,
+            "dataset": self.ds.directory,
         }
         return info_dict
 


### PR DESCRIPTION
## PR Summary

Initial motivation:
I found that storing relative paths attributes can lead to bugs, see downstream issues in an externally maintained frontend
https://github.com/neutrinoceros/yt_idefix/issues/88 and https://github.com/neutrinoceros/yt_idefix/issues/91, with the associated fixes https://github.com/neutrinoceros/yt_idefix/pull/89 then https://github.com/neutrinoceros/yt_idefix/pull/92

Indeed the way path attributes are set in the `Dataset` base class (as of current main branch) is unreliable because path data can be destroyed.

Let's reproduce the reference implementation in a self-contained example to illustrate the problem
```python
import os

def get_paths_attrs(filename):
    parameter_filename = os.path.expanduser(filename)

    basename = os.path.basename(filename)
    directory = os.path.dirname(filename)
    fullpath = os.path.abspath(directory)
    return parameter_filename, basename, directory, fullpath

print(get_paths_attrs(".."))
```
Running this in my `/tmp/` dir for illustration
```
('..', '..', '', '/private/tmp')
```

So I'm proposing here we resolve absolute paths instead of using the raw user-value as input here. I don't expect that this change would break anyone, so hopefully it's okay.

A consequence of this proposed change is that `Dataset.fullpath` becomes redundant with `Dataset.directory`, so I'm deprecating the former as I think the name is a bit less clear.

In order to implement this, I found it was useful to make these attribute read-only properties, which allowed me to harmonise their setup in a couple frontends with some custom logic, and I was able to discover and fix a handful of small bugs there.

I am also slightly changing filenames for the `backup_filename` attributes, where on main, we just append a suffix to the original filename, and here I'm stripping out the extension first, generalizing (and fixing) a custom behaviour that was implemented in the Athena frontend. Maybe this part is controversial since it's not backwards compatible with existing backup files for any dataset that's not Athena. I honestly do not know wether this is acceptable or not, but I can easily revert that if it isn't.


Incidentally, this fixes #3774 as well as #3777. 

