### PR TITLE
DEPR: deprecate yt.testing.run_nose and wrap it in the yt namespace

### DIFF
--- a/yt/__init__.py
+++ b/yt/__init__.py
@@ -89,7 +89,17 @@ from yt.loaders import (
     load_uniform_grid,
     load_unstructured_mesh,
 )
-from yt.testing import run_nose
+
+
+def run_nose(*args, **kwargs):
+    # we hide this function behind a closure so we
+    # don't make pytest a hard dependency for end users
+    # see https://github.com/yt-project/yt/issues/3771
+    from yt.testing import run_nose
+
+    return run_nose(*args, **kwargs)
+
+
 from yt.units.unit_systems import UnitSystem, unit_system_registry  # type: ignore
 
 # Import some helpful math utilities

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -17,6 +17,7 @@ from more_itertools import always_iterable
 from numpy.random import RandomState
 from unyt.exceptions import UnitOperationError
 
+from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.config import ytcfg
 from yt.funcs import is_sequence
 from yt.loaders import load
@@ -1190,6 +1191,12 @@ def run_nose(
     call_pdb=False,
     module=None,
 ):
+    issue_deprecation_warning(
+        "yt.run_nose (aka yt.testing.run_nose) is deprecated. "
+        "Please do not rely on this function as it will be removed "
+        "in the process of migrating yt tests from nose to pytest.",
+        since="4.1.0",
+    )
     import sys
 
     from yt.utilities.logger import ytLogger as mylog


### PR DESCRIPTION
## PR Summary
fix #3771
Opening as a draft because this will surely break CI until I refactor a couple imports
