### PR TITLE
TST: update tests using deprecated pytest api

### DIFF
--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -4,6 +4,7 @@ name: CI (bleeding edge)
 
 # goals: check stability against
 # - dev version of Python, numpy, and matplotlib
+# - pytest pre-releases
 # - building with future pip default options
 
 on:
@@ -42,6 +43,7 @@ jobs:
         python -m pip install git+https://github.com/numpy/numpy.git
         python -m pip install git+https://github.com/matplotlib/matplotlib.git
         python -m pip install cython
+        python -m pip install --upgrade --pre pytest
 
     - name: Build yt
       # --no-build-isolation is used to guarantee that build time dependencies

--- a/yt/fields/tests/test_ambiguous_fields.py
+++ b/yt/fields/tests/test_ambiguous_fields.py
@@ -1,3 +1,4 @@
+import warnings
 from collections import defaultdict
 
 import pytest
@@ -32,13 +33,12 @@ def test_ambiguous_fails():
 
     # Test no warnings are issued for single fname access that aren't ambiguous
     for fname in unambiguous_fnames:
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             ds.r[fname]
-        assert len(record) == 0
 
     # Test no warning are issued for tuple access
     for ftype, fname in ds.field_list:
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             ds.r[(ftype, fname)]
-
-        assert len(record) == 0


### PR DESCRIPTION
Fix #3775, based on pytest's documentation https://docs.pytest.org/en/latest/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests
