### PR TITLE
ENH: cleanup legacy Python, now noop, __new__ method

### DIFF
--- a/yt/frontends/enzo/data_structures.py
+++ b/yt/frontends/enzo/data_structures.py
@@ -1004,11 +1004,6 @@ class EnzoDatasetInMemory(EnzoDataset):
     _index_class = EnzoHierarchyInMemory
     _dataset_type = "enzo_inline"
 
-    def __new__(cls, *args, **kwargs):
-        obj = object.__new__(cls)
-        obj.__init__(*args, **kwargs)
-        return obj
-
     def __init__(self, parameter_override=None, conversion_override=None):
         self.fluid_types += ("enzo",)
         if parameter_override is None:


### PR DESCRIPTION
## PR Summary
This was implemented 11yrs ago, when Python 2 was obviously still a thing. It looks like a way to selectively inherit a cool `__new__` method from `object`, but this is redundant in Python 3 where all classes inherit from `object`.
