### PR TITLE
Format error string

### DIFF
--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -293,7 +293,8 @@ class FieldInfoContainer(dict):
         acceptable_samplings = ("cell", "particle", "local")
         if sampling_type not in acceptable_samplings:
             raise ValueError(
-                f'Invalid sampling type {sampling_type}. Valid sampling types are {", ".join(acceptable_samplings)}'
+                f"Received invalid sampling type {sampling_type!r}. "
+                f"Expected any of {acceptable_samplings}"
             )
         return sampling_type
 

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -293,9 +293,7 @@ class FieldInfoContainer(dict):
         acceptable_samplings = ("cell", "particle", "local")
         if sampling_type not in acceptable_samplings:
             raise ValueError(
-                "Invalid sampling type %s. Valid sampling types are %s",
-                sampling_type,
-                ", ".join(acceptable_samplings),
+                f'Invalid sampling type {sampling_type}. Valid sampling types are {", ".join(acceptable_samplings)}'
             )
         return sampling_type
 


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

The string to denote the error message seems to not be formatted here:

https://github.com/yt-project/yt/blob/23e65e19700b3892bdabea0d918b8274fb8aa1ff/yt/fields/field_info_container.py#L295

which gives the output:

```py
ValueError: ('Invalid sampling type %s. Valid sampling types are %s', 'discrete', 'cell, particle, local')
```

if an incorrect `sampling_type` is input to the `@yt.derived_field` decorator.

This small change formats the string to get a, hopefully, better output.

Thanks!