### PR TITLE
BUG: fix pixelize_cylinder

### DIFF
--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -525,7 +525,8 @@ def pixelize_cylinder(np.float64_t[:,:] buff,
 
     cdef np.float64_t x, y, dx, dy, r0, theta0
     cdef np.float64_t rmax, x0, y0, x1, y1
-    cdef np.float64_t r_i, theta_i, dr_i, dtheta_i, dthetamin
+    cdef np.float64_t r_i, theta_i, dr_i, dtheta_i
+    cdef np.float64_t r_inc, theta_inc
     cdef np.float64_t costheta, sintheta
     cdef int i, pi, pj
 
@@ -558,9 +559,9 @@ def pixelize_cylinder(np.float64_t[:,:] buff,
         rbounds[0] = 0.0
     if y0 < 0 and y1 > 0:
         rbounds[0] = 0.0
-    dthetamin = dx / rmax
-    for i in range(radius.shape[0]):
+    r_inc = 0.5 * fmin(dx, dy)
 
+    for i in range(radius.shape[0]):
         r0 = radius[i]
         theta0 = theta[i]
         dr_i = dradius[i]
@@ -569,15 +570,15 @@ def pixelize_cylinder(np.float64_t[:,:] buff,
         if r0 + dr_i < rbounds[0] or r0 - dr_i > rbounds[1]:
             continue
         theta_i = theta0 - dtheta_i
-        # Buffer of 0.5 here
-        dthetamin = 0.5*dx/(r0 + dr_i)
+        theta_inc = r_inc / (r0 + dr_i)
+
         while theta_i < theta0 + dtheta_i:
             r_i = r0 - dr_i
             costheta = math.cos(theta_i)
             sintheta = math.sin(theta_i)
             while r_i < r0 + dr_i:
                 if rmax <= r_i:
-                    r_i += 0.5*dx
+                    r_i += r_inc
                     continue
                 y = r_i * costheta
                 x = r_i * sintheta
@@ -586,8 +587,8 @@ def pixelize_cylinder(np.float64_t[:,:] buff,
                 if pi >= 0 and pi < buff.shape[0] and \
                    pj >= 0 and pj < buff.shape[1]:
                     buff[pi, pj] = field[i]
-                r_i += 0.5*dx
-            theta_i += dthetamin
+                r_i += r_inc
+            theta_i += theta_inc
 
 cdef int aitoff_Lambda_btheta_to_xy(np.float64_t Lambda, np.float64_t btheta,
                                np.float64_t *x, np.float64_t *y) except -1:

--- a/yt/visualization/volume_rendering/tests/test_off_axis_SPH.py
+++ b/yt/visualization/volume_rendering/tests/test_off_axis_SPH.py
@@ -270,7 +270,7 @@ def test_center_3():
 @requires_module("scipy")
 def find_compare_maxima(expected_maxima, buf, resolution, width):
     buf_ndarray = buf.ndarray_view()
-    max_filter_buf = ndimage.filters.maximum_filter(buf_ndarray, size=5)
+    max_filter_buf = ndimage.maximum_filter(buf_ndarray, size=5)
     maxima = np.isclose(max_filter_buf, buf_ndarray, rtol=1e-09)
 
     # ignore contributions from zones of no smoothing


### PR DESCRIPTION
## PR Summary
Fix #3781
I found that the actual problem was that the jumps in r and theta were constrained only by `dx` (horizontal pixel size) when they needed to be constained by `dy` too.

Using a variation of the script from the issue to show the change

```python
import numpy as np
import yt

shape = (32, 64, 1)
a = np.linspace(0, 1, 64)
b = np.ones((32, 64))
c = np.reshape(a*b, shape)
data = {("gas", "density"): c}

theta_min = np.pi / 2 - 0.1

ds = yt.load_uniform_grid(
    data,
    shape,
    bbox=np.array([[0.5, 5.0], [theta_min, theta_min+0.1], [-0.1, +0.1]]),
    geometry="spherical",
)

yt.SlicePlot(ds, "phi", "density").save("/tmp/")
```

on the main branch

![main](https://user-images.githubusercontent.com/14075922/152702711-627e606a-a5f7-4715-a21e-ab7c52a9e5f2.png)

this branch
![patch](https://user-images.githubusercontent.com/14075922/152702717-3481d91c-05f6-4a46-8591-64a568e0e051.png)