### PR TITLE
TST: fix a deprecation warning from scipy 1.8

### DIFF
--- a/yt/visualization/volume_rendering/tests/test_off_axis_SPH.py
+++ b/yt/visualization/volume_rendering/tests/test_off_axis_SPH.py
@@ -270,7 +270,7 @@ def test_center_3():
 @requires_module("scipy")
 def find_compare_maxima(expected_maxima, buf, resolution, width):
     buf_ndarray = buf.ndarray_view()
-    max_filter_buf = ndimage.filters.maximum_filter(buf_ndarray, size=5)
+    max_filter_buf = ndimage.maximum_filter(buf_ndarray, size=5)
     maxima = np.isclose(max_filter_buf, buf_ndarray, rtol=1e-09)
 
     # ignore contributions from zones of no smoothing


### PR DESCRIPTION
## PR Summary
Fix a deprecation warning from [scipy 1.8](https://github.com/scipy/scipy/releases/tag/v1.8.0) that's breaking CI.

The warning reads as follow:
```
E       DeprecationWarning: Please use `maximum_filter` from the `scipy.ndimage` namespace, the `scipy.ndimage.filters` namespace is deprecated.
```

it can be reproduced using SciPy 1.8 and running
```
pytest yt/visualization/volume_rendering/tests/test_off_axis_SPH.py::test_center_3
```
