### PR TITLE
New "preserve_symlinks" keyword for the RAMSES frontend.

### DIFF
--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -40,9 +40,12 @@ class RAMSESFileSanitizer:
     info_fname = None  # Path | None: path to the info file
     group_name = None  # str | None: name of the first group folder (if any)
 
-    def __init__(self, filename):
+    def __init__(self, filename, preserve_symlinks=False):
+
+        filename = Path(filename)
         # Resolve so that it works with symlinks
-        filename = Path(filename).resolve()
+        if not preserve_symlinks:
+            filename = Path(filename).resolve()
 
         self.original_filename = filename
 
@@ -656,6 +659,7 @@ class RAMSESDataset(Dataset):
         max_level=None,
         max_level_convention=None,
         default_species_fields=None,
+        preserve_symlinks=False,
     ):
         # Here we want to initiate a traceback, if the reader is not built.
         if isinstance(fields, str):
@@ -672,6 +676,9 @@ class RAMSESDataset(Dataset):
         cosmological:
         If set to None, automatically detect cosmological simulation.
         If a boolean, force its value.
+
+        preserve_symlinks:
+        If set to True, does not resolve the symlinks in the filenames.
         """
 
         self._fields_in_file = fields
@@ -685,7 +692,7 @@ class RAMSESDataset(Dataset):
             max_level, max_level_convention
         )
 
-        file_handler = RAMSESFileSanitizer(filename)
+        file_handler = RAMSESFileSanitizer(filename, preserve_symlinks=preserve_symlinks)
 
         # This should not happen, but let's check nonetheless.
         if not file_handler.is_valid:
@@ -983,4 +990,5 @@ class RAMSESDataset(Dataset):
 
     @classmethod
     def _is_valid(cls, filename, *args, **kwargs):
-        return RAMSESFileSanitizer(filename).is_valid
+        preserve_symlinks = kwargs.get("preserve_symlinks", False)
+        return RAMSESFileSanitizer(filename, preserve_symlinks).is_valid


### PR DESCRIPTION
The extra keyword in the loader for the RAMSES frontend makes sure that the symlinks are not resolved by the `RAMSESFileSanitizer`. This is particularly helpful if the file structure is actually a set of links to the files, for instance to bypass the fact that `RAMSESFileSanitizer` doesn't deal well with outputs including "groups".


## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

With yt 4, the RAMSES loader does not recognize the "groups" output structure (`/path/to/output/files/output_XXXXX/group_YYYYY/info_XXXXX.txt`). One relatively easy way to bypass that, in principle, is to do link all the output files in a separate folder without the nested "group" structure (`/path/to/linked/files/output_XXXXX/info_XXXXX.txt`). Beyond yt, this can be needed/useful for other analysis tools that are less flexible.

However, doing so does not work if the symlinks are resolved to their original location. This PR fixes this by adding an extra keyword `preserve_symlinks` to ensure that said links are preserved by the `RAMSESFileSainitizer`.
This is `False` by default, so it should not break any code.

This partially fixes issue #3785.

## PR Checklist
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
