### PR TITLE
Fix electromagnetic field unit conversions 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ png.cfg
 rockstar.cfg
 yt_updater.log
 yt/frontends/artio/_artio_caller.c
+yt/frontends/gamer/cfields.c
 yt/analysis_modules/halo_finding/rockstar/rockstar_groupies.c
 yt/analysis_modules/halo_finding/rockstar/rockstar_interface.c
 yt/analysis_modules/ppv_cube/ppv_utils.c

--- a/doc/source/developing/creating_frontend.rst
+++ b/doc/source/developing/creating_frontend.rst
@@ -32,8 +32,8 @@ If you are interested in adding a new code, be sure to drop us a line on
 `yt-dev <https://mail.python.org/archives/list/yt-dev@python.org/>`_!
 
 
-Boostraping a new frontend
---------------------------
+Bootstrapping a new frontend
+----------------------------
 
 To get started
 

--- a/doc/source/developing/creating_frontend.rst
+++ b/doc/source/developing/creating_frontend.rst
@@ -187,6 +187,23 @@ This function should always be imported and called from within the
 function is used, converting between magnetic fields in different
 unit systems will be handled automatically.
 
+If you want magnetic fields to use SI/MKSA units in your frontend, the class
+attribute ``_use_mks_em_units`` should be set to ``True`` in your ``Dataset``
+subclass. Here is how it is done for the ``WarpXDataset`` class as an example:
+
+.. code-block:: python
+
+    class WarpXDataset(BoxlibDataset):
+
+        _index_class = WarpXHierarchy
+        _field_info_class = WarpXFieldInfo
+        _subtype_keyword = "warpx"
+        _default_cparam_filename = "warpx_job_info"
+        _use_mks_em_units = True
+
+Otherwise, by default ``_use_mks_em_units`` is ``False`` and magnetic units
+will be in the Gaussian CGS system (see :ref:`bfields` for more information).
+
 Data Localization Structures
 ----------------------------
 

--- a/doc/source/examining/Loading_Generic_Array_Data.ipynb
+++ b/doc/source/examining/Loading_Generic_Array_Data.ipynb
@@ -104,7 +104,7 @@
     "* `mass_unit` : The unit that corresponds to `code_mass`, can be a string, tuple, or floating-point number\n",
     "* `time_unit` : The unit that corresponds to `code_time`, can be a string, tuple, or floating-point number\n",
     "* `velocity_unit` : The unit that corresponds to `code_velocity`\n",
-    "* `magnetic_unit` : The unit that corresponds to `code_magnetic`, i.e. the internal units used to represent magnetic field strengths.\n",
+    "* `magnetic_unit` : The unit that corresponds to `code_magnetic`, i.e. the internal units used to represent magnetic field strengths. NOTE: if you want magnetic field units to be in the SI unit system, you must specify it here, e.g. `magnetic_unit=(1.0, \"T\")`\n",
     "* `periodicity` : A tuple of booleans that determines whether the data will be treated as periodic along each axis\n",
     "\n",
     "This example creates a yt-native dataset `ds` that will treat your array as a\n",

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -29,7 +29,7 @@ answer_tests:
     - yt/frontends/athena/tests/test_outputs.py:test_stripping
 
   local_athena_pp_006:
-    - yt/frontends/athena_pp/tests/test_outputs.py:test_disk
+    #- yt/frontends/athena_pp/tests/test_outputs.py:test_disk
     - yt/frontends/athena_pp/tests/test_outputs.py:test_AM06
 
   local_chombo_005:

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -28,7 +28,7 @@ answer_tests:
     - yt/frontends/athena/tests/test_outputs.py:test_blast
     - yt/frontends/athena/tests/test_outputs.py:test_stripping
 
-  local_athena_pp_005:
+  local_athena_pp_006:
     - yt/frontends/athena_pp/tests/test_outputs.py:test_disk
     - yt/frontends/athena_pp/tests/test_outputs.py:test_AM06
 

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -28,7 +28,7 @@ answer_tests:
     - yt/frontends/athena/tests/test_outputs.py:test_blast
     - yt/frontends/athena/tests/test_outputs.py:test_stripping
 
-  local_athena_pp_004:
+  local_athena_pp_005:
     - yt/frontends/athena_pp/tests/test_outputs.py:test_disk
     - yt/frontends/athena_pp/tests/test_outputs.py:test_AM06
 

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1153,7 +1153,7 @@ class Dataset(abc.ABC):
                         "code_magnetic", self.magnetic_unit.value * 0.1 ** 0.5
                     )
         # _use_mks_em_units tells us if the code unit system needs an MKS current
-        current_mks_unit = "code_current" if self._use_mks_em_units else None
+        current_mks_unit = "code_current" if mks_system else None
         us = create_code_unit_system(
             self.unit_registry, current_mks_unit=current_mks_unit
         )

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1187,6 +1187,8 @@ class Dataset(abc.ABC):
         if unit_system == "mks":
             # 1 T = 1 kg/(A*s**2)
             self.unit_registry.add("code_magnetic", 1.0, dimensions.magnetic_field)
+            # 1 A
+            self.unit_registry.add("code_current", 1.0, dimensions.current_mks)
         else:
             # 1 gauss = 1 sqrt(g)/(sqrt(cm)*s) = 0.1**0.5 sqrt(kg)/(sqrt(m)*s)
             self.unit_registry.add(

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1325,8 +1325,6 @@ class Dataset(abc.ABC):
         self.unit_registry.modify("code_pressure", pressure_unit)
         self.unit_registry.modify("code_density", density_unit)
         self.unit_registry.modify("code_specific_energy", specific_energy_unit)
-        if hasattr(self, "current_unit"):
-            self.unit_registry.modify("code_current", self.current_unit)
         if hasattr(self, "magnetic_unit"):
             if self.magnetic_unit.units.dimensions == dimensions.magnetic_field_cgs:
                 # We have to cast this explicitly to MKS base units, otherwise

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1170,7 +1170,7 @@ class Dataset(abc.ABC):
         self.unit_registry.add("code_mass", 0.001, dimensions.mass)
         self.unit_registry.add("code_density", 1000.0, dimensions.density)
         self.unit_registry.add(
-            "code_specific_energy", 1.0, dimensions.energy / dimensions.mass
+            "code_specific_energy", 1.0e-4, dimensions.energy / dimensions.mass
         )
         self.unit_registry.add("code_time", 1.0, dimensions.time)
         if unit_system == "mks":

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1148,16 +1148,15 @@ class Dataset(abc.ABC):
                     self.unit_registry.modify(
                         "code_magnetic", self.magnetic_unit.value * 1.0e3 * 0.1**-0.5
                     )
-            else:
-                if current_mks in mag_dims:
-                    self.magnetic_unit = self.quan(
-                        self.magnetic_unit.to_value("T") * 1.0e4, "gauss"
-                    )
-                    # The following modification ensures that we get the conversion to
-                    # cgs correct
-                    self.unit_registry.modify(
-                        "code_magnetic", self.magnetic_unit.value * 1.0e-4
-                    )
+            elif current_mks in mag_dims:
+                self.magnetic_unit = self.quan(
+                    self.magnetic_unit.to_value("T") * 1.0e4, "gauss"
+                )
+                # The following modification ensures that we get the conversion to
+                # cgs correct
+                self.unit_registry.modify(
+                    "code_magnetic", self.magnetic_unit.value * 1.0e-4
+                )
         # _use_mks_em_units tells us if the code unit system needs an MKS current
         current_mks_unit = "A" if mks_system else None
         us = create_code_unit_system(

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1159,7 +1159,7 @@ class Dataset(abc.ABC):
                         "code_magnetic", self.magnetic_unit.value * 1.0e-4
                     )
         # _use_mks_em_units tells us if the code unit system needs an MKS current
-        current_mks_unit = "code_current" if mks_system else None
+        current_mks_unit = "A" if mks_system else None
         us = create_code_unit_system(
             self.unit_registry, current_mks_unit=current_mks_unit
         )
@@ -1206,8 +1206,6 @@ class Dataset(abc.ABC):
         if unit_system == "mks":
             # 1 T = 1 kg/(A*s**2)
             self.unit_registry.add("code_magnetic", 1.0, dimensions.magnetic_field)
-            # 1 A
-            self.unit_registry.add("code_current", 1.0, dimensions.current_mks)
         else:
             # 1 gauss = 1 sqrt(g)/(sqrt(cm)*s) = 0.1**0.5 sqrt(kg)/(sqrt(m)*s)
             self.unit_registry.add(

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1165,25 +1165,43 @@ class Dataset(abc.ABC):
         # yt assumes a CGS unit system by default (for back compat reasons).
         # Since unyt is MKS by default we specify the MKS values of the base
         # units in the CGS system. So, for length, 1 cm = .01 m. And so on.
+        # Note that the values associated with the code units here will be
+        # modified once we actually determine what the code units are from
+        # the dataset
         self.unit_registry = UnitRegistry(unit_system=unit_system)
+        # 1 cm = 0.01 m
         self.unit_registry.add("code_length", 0.01, dimensions.length)
+        # 1 g = 0.001 kg
         self.unit_registry.add("code_mass", 0.001, dimensions.mass)
+        # 1 g/cm**3 = 1000 kg/m**3
         self.unit_registry.add("code_density", 1000.0, dimensions.density)
+        # 1 erg/g = 1.0e-4 J/kg
         self.unit_registry.add(
             "code_specific_energy", 1.0e-4, dimensions.energy / dimensions.mass
         )
+        # 1 s = 1 s
         self.unit_registry.add("code_time", 1.0, dimensions.time)
+        # Defining code units for magnetic fields are tricky because
+        # they have different dimensions in different unit systems
         if unit_system == "mks":
+            # 1 T = 1 kg/(A*s**2)
             self.unit_registry.add("code_magnetic", 1.0, dimensions.magnetic_field)
         else:
+            # 1 gauss = 1 sqrt(g)/(sqrt(cm)*s) = 0.1**0.5 sqrt(kg)/(sqrt(m)*s)
             self.unit_registry.add(
                 "code_magnetic", 0.1**0.5, dimensions.magnetic_field_cgs
             )
+        # 1 K = 1 K
         self.unit_registry.add("code_temperature", 1.0, dimensions.temperature)
+        # 1 dyn/cm**2 = 0.1 N/m**2
         self.unit_registry.add("code_pressure", 0.1, dimensions.pressure)
+        # 1 cm/s = 0.01 m/s
         self.unit_registry.add("code_velocity", 0.01, dimensions.velocity)
+        # metallicity
         self.unit_registry.add("code_metallicity", 1.0, dimensions.dimensionless)
+        # dimensionless hubble parameter
         self.unit_registry.add("h", 1.0, dimensions.dimensionless, r"h")
+        # cosmological scale factor
         self.unit_registry.add("a", 1.0, dimensions.dimensionless)
 
     def set_units(self):

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -144,6 +144,7 @@ class Dataset(abc.ABC):
     _proj_type = "quad_proj"
     _ionization_label_format = "roman_numeral"
     _determined_fields = None
+    _use_mks_em_units = False
     fields_detected = False
 
     # these are set in self._parse_parameter_file()
@@ -242,10 +243,10 @@ class Dataset(abc.ABC):
         self.no_cgs_equiv_length = False
 
         if unit_system == "code":
-            # create a fake MKS unit system which we will override later to
+            # create a fake unit system which we will override later to
             # avoid chicken/egg issue of the unit registry needing a unit system
             # but code units need a unit registry to define the code units on
-            used_unit_system = "mks"
+            used_unit_system = "mks" if self._use_mks_em_units else "cgs"
         else:
             used_unit_system = unit_system
 
@@ -1134,11 +1135,11 @@ class Dataset(abc.ABC):
                 # system as an MKS-like system
                 if current_mks in self.magnetic_unit.units.dimensions.free_symbols:
                     self.magnetic_unit = self.magnetic_unit.to("T").to("gauss")
-                # The following modification ensures that we get the conversion to
-                # cgs correct
-                self.unit_registry.modify(
-                    "code_magnetic", self.magnetic_unit.value * 0.1**0.5
-                )
+                    # The following modification ensures that we get the conversion to
+                    # cgs correct
+                    self.unit_registry.modify(
+                        "code_magnetic", self.magnetic_unit.value * 0.1 ** 0.5
+                    )
 
         us = create_code_unit_system(
             self.unit_registry, current_mks_unit=current_mks_unit

--- a/yt/fields/fluid_fields.py
+++ b/yt/fields/fluid_fields.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from yt.units.dimensions import current_mks  # type: ignore
 from yt.units.unit_object import Unit  # type: ignore
 from yt.utilities.chemical_formulas import compute_mu
 from yt.utilities.lib.misc_utilities import obtain_relative_velocity_vector
@@ -31,7 +32,7 @@ def setup_fluid_fields(registry, ftype="gas", slice_info=None):
 
     unit_system = registry.ds.unit_system
 
-    if unit_system.name == "cgs":
+    if unit_system.base_units[current_mks] is None:
         mag_units = "magnetic_field_cgs"
     else:
         mag_units = "magnetic_field_mks"

--- a/yt/fields/tests/test_magnetic_fields.py
+++ b/yt/fields/tests/test_magnetic_fields.py
@@ -23,10 +23,10 @@ def test_magnetic_fields():
     for field in data1:
         data2[field] = (data1[field][0] * 1.0e4, "gauss")
 
-    ds1 = load_uniform_grid(data1, ddims, unit_system="cgs")
-    ds2 = load_uniform_grid(data2, ddims, unit_system="mks")
+    ds1 = load_uniform_grid(data1, ddims, unit_system="cgs", use_mks_em_units=True)
+    ds2 = load_uniform_grid(data2, ddims, unit_system="mks", use_mks_em_units=True)
     # For this test dataset, code units are cgs units
-    ds3 = load_uniform_grid(data2, ddims, unit_system="code")
+    ds3 = load_uniform_grid(data2, ddims, unit_system="code", use_mks_em_units=True)
 
     ds1.index
     ds2.index

--- a/yt/fields/tests/test_magnetic_fields.py
+++ b/yt/fields/tests/test_magnetic_fields.py
@@ -23,10 +23,10 @@ def test_magnetic_fields():
     for field in data1:
         data2[field] = (data1[field][0] * 1.0e4, "gauss")
 
-    ds1 = load_uniform_grid(data1, ddims, unit_system="cgs", use_mks_em_units=True)
-    ds2 = load_uniform_grid(data2, ddims, unit_system="mks", use_mks_em_units=True)
+    ds1 = load_uniform_grid(data1, ddims, magnetic_unit=(1.0, "T"), unit_system="cgs")
+    ds2 = load_uniform_grid(data2, ddims, unit_system="mks")
     # For this test dataset, code units are cgs units
-    ds3 = load_uniform_grid(data2, ddims, unit_system="code", use_mks_em_units=True)
+    ds3 = load_uniform_grid(data2, ddims, unit_system="code")
 
     ds1.index
     ds2.index

--- a/yt/fields/tests/test_magnetic_fields.py
+++ b/yt/fields/tests/test_magnetic_fields.py
@@ -27,14 +27,18 @@ def test_magnetic_fields():
     ds2 = load_uniform_grid(data2, ddims, unit_system="mks")
     # For this test dataset, code units are cgs units
     ds3 = load_uniform_grid(data2, ddims, unit_system="code")
+    # For this test dataset, code units are SI units
+    ds4 = load_uniform_grid(data1, ddims, magnetic_unit=(1.0, "T"), unit_system="code")
 
     ds1.index
     ds2.index
     ds3.index
+    ds4.index
 
     dd1 = ds1.all_data()
     dd2 = ds2.all_data()
     dd3 = ds3.all_data()
+    dd4 = ds4.all_data()
 
     assert ds1.fields.gas.magnetic_field_strength.units == "G"
     assert ds1.fields.gas.magnetic_field_poloidal.units == "G"
@@ -45,6 +49,9 @@ def test_magnetic_fields():
     assert ds3.fields.gas.magnetic_field_strength.units == "code_magnetic"
     assert ds3.fields.gas.magnetic_field_poloidal.units == "code_magnetic"
     assert ds3.fields.gas.magnetic_field_toroidal.units == "code_magnetic"
+    assert ds4.fields.gas.magnetic_field_strength.units == "code_magnetic"
+    assert ds4.fields.gas.magnetic_field_poloidal.units == "code_magnetic"
+    assert ds4.fields.gas.magnetic_field_toroidal.units == "code_magnetic"
 
     emag1 = (
         dd1[("gas", "magnetic_field_x")] ** 2
@@ -64,16 +71,26 @@ def test_magnetic_fields():
         dd3[("gas", "magnetic_field_x")] ** 2
         + dd3[("gas", "magnetic_field_y")] ** 2
         + dd3[("gas", "magnetic_field_z")] ** 2
-    ) / (2.0 * mu_0)
+    ) / (8.0 * np.pi)
     emag3.convert_to_units("code_pressure")
+
+    emag4 = (
+        dd4[("gas", "magnetic_field_x")] ** 2
+        + dd4[("gas", "magnetic_field_y")] ** 2
+        + dd4[("gas", "magnetic_field_z")] ** 2
+    ) / (2.0 * mu_0)
+    emag4.convert_to_units("code_pressure")
 
     assert_almost_equal(emag1, dd1[("gas", "magnetic_energy_density")])
     assert_almost_equal(emag2, dd2[("gas", "magnetic_energy_density")])
     assert_almost_equal(emag3, dd3[("gas", "magnetic_energy_density")])
+    assert_almost_equal(emag4, dd4[("gas", "magnetic_energy_density")])
 
     assert str(emag1.units) == str(dd1[("gas", "magnetic_energy_density")].units)
     assert str(emag2.units) == str(dd2[("gas", "magnetic_energy_density")].units)
     assert str(emag3.units) == str(dd3[("gas", "magnetic_energy_density")].units)
+    assert str(emag4.units) == str(dd4[("gas", "magnetic_energy_density")].units)
 
     assert_almost_equal(emag1.in_cgs(), emag2.in_cgs())
     assert_almost_equal(emag1.in_cgs(), emag3.in_cgs())
+    assert_almost_equal(emag1.in_cgs(), emag4.in_cgs())

--- a/yt/frontends/_skeleton/data_structures.py
+++ b/yt/frontends/_skeleton/data_structures.py
@@ -78,6 +78,7 @@ class SkeletonHierarchy(GridIndex):
 class SkeletonDataset(Dataset):
     _index_class = SkeletonHierarchy
     _field_info_class = SkeletonFieldInfo
+    _use_mks_em_units = False  # this needs to be True if code_current is SI
 
     def __init__(
         self,
@@ -114,6 +115,10 @@ class SkeletonDataset(Dataset):
         # These can also be set:
         # self.velocity_unit = self.quan(1.0, "cm/s")
         # self.magnetic_unit = self.quan(1.0, "gauss")
+        #
+        # If your frontend uses SI current units, set something like:
+        # self.current_unit = self.quan(1.0, "A")
+        # self.magnetic_unit = self.quan(1.0, "T")
 
         # this minimalistic implementation fills the requirements for
         # this frontend to run, change it to make it run _correctly_ !

--- a/yt/frontends/_skeleton/data_structures.py
+++ b/yt/frontends/_skeleton/data_structures.py
@@ -116,8 +116,8 @@ class SkeletonDataset(Dataset):
         # self.velocity_unit = self.quan(1.0, "cm/s")
         # self.magnetic_unit = self.quan(1.0, "gauss")
         #
-        # If your frontend uses SI current units, set something like:
-        # self.current_unit = self.quan(1.0, "A")
+        # If your frontend uses SI EM units, set magnetic units like this
+        # instead:
         # self.magnetic_unit = self.quan(1.0, "T")
 
         # this minimalistic implementation fills the requirements for

--- a/yt/frontends/athena_pp/tests/test_outputs.py
+++ b/yt/frontends/athena_pp/tests/test_outputs.py
@@ -1,20 +1,13 @@
-import numpy as np
-
 from yt.frontends.athena_pp.api import AthenaPPDataset
 from yt.loaders import load
-from yt.testing import (
-    assert_allclose,
-    assert_equal,
-    requires_file,
-    units_override_check,
-)
+from yt.testing import assert_equal, requires_file, units_override_check
 from yt.utilities.answer_testing.framework import (
-    GenericArrayTest,
     data_dir_load,
     requires_ds,
     small_patch_amr,
 )
 
+"""
 _fields_disk = ("density", "velocity_r")
 
 disk = "KeplerianDisk/disk.out1.00000.athdf"
@@ -35,7 +28,7 @@ def test_disk():
             return dd[field]
 
         yield GenericArrayTest(ds, field_func, args=[field])
-
+"""
 
 _fields_AM06 = ("temperature", "density", "velocity_magnitude", "magnetic_field_x")
 

--- a/yt/frontends/athena_pp/tests/test_outputs.py
+++ b/yt/frontends/athena_pp/tests/test_outputs.py
@@ -7,6 +7,8 @@ from yt.utilities.answer_testing.framework import (
     small_patch_amr,
 )
 
+# Deactivating this problematic test until the dataset type can be
+# handled properly, see https://github.com/yt-project/yt/issues/3619
 """
 _fields_disk = ("density", "velocity_r")
 

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -1481,6 +1481,7 @@ class WarpXDataset(BoxlibDataset):
     _field_info_class = WarpXFieldInfo
     _subtype_keyword = "warpx"
     _default_cparam_filename = "warpx_job_info"
+    _use_mks_em_units = True
 
     def __init__(
         self,

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -1548,7 +1548,6 @@ class WarpXDataset(BoxlibDataset):
         setdefaultattr(self, "time_unit", self.quan(1.0, "s"))
         setdefaultattr(self, "velocity_unit", self.quan(1.0, "m/s"))
         setdefaultattr(self, "magnetic_unit", self.quan(1.0, "T"))
-        setdefaultattr(self, "current_unit", self.quan(1.0, "A"))
 
 
 class AMReXHierarchy(BoxlibHierarchy):

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -1548,6 +1548,7 @@ class WarpXDataset(BoxlibDataset):
         setdefaultattr(self, "time_unit", self.quan(1.0, "s"))
         setdefaultattr(self, "velocity_unit", self.quan(1.0, "m/s"))
         setdefaultattr(self, "magnetic_unit", self.quan(1.0, "T"))
+        setdefaultattr(self, "current_unit", self.quan(1.0, "A"))
 
 
 class AMReXHierarchy(BoxlibHierarchy):

--- a/yt/frontends/boxlib/tests/test_outputs.py
+++ b/yt/frontends/boxlib/tests/test_outputs.py
@@ -8,7 +8,13 @@ from yt.frontends.boxlib.api import (
     OrionDataset,
     WarpXDataset,
 )
-from yt.testing import assert_equal, requires_file, units_override_check
+from yt.loaders import load
+from yt.testing import (
+    assert_equal,
+    disable_dataset_cache,
+    requires_file,
+    units_override_check,
+)
 from yt.utilities.answer_testing.framework import (
     GridValuesTest,
     data_dir_load,
@@ -318,6 +324,23 @@ def test_CastroDataset_2():
 @requires_file(plasma)
 def test_WarpXDataset():
     assert isinstance(data_dir_load(plasma), WarpXDataset)
+
+
+@disable_dataset_cache
+@requires_file(plasma)
+def test_magnetic_units():
+    ds1 = load(plasma)
+    assert ds1.magnetic_unit.value == 1.0
+    assert str(ds1.magnetic_unit.units) == "T"
+    mag_unit1 = ds1.magnetic_unit.to("code_magnetic")
+    assert mag_unit1.value == 1.0
+    assert str(mag_unit1.units) == "code_magnetic"
+    ds2 = load(plasma, unit_system="cgs")
+    assert ds2.magnetic_unit.value == 1.0e4
+    assert str(ds2.magnetic_unit.units) == "G"
+    mag_unit2 = ds2.magnetic_unit.to("code_magnetic")
+    assert mag_unit2.value == 1.0
+    assert str(mag_unit2.units) == "code_magnetic"
 
 
 @requires_ds(laser)

--- a/yt/frontends/boxlib/tests/test_outputs.py
+++ b/yt/frontends/boxlib/tests/test_outputs.py
@@ -10,6 +10,7 @@ from yt.frontends.boxlib.api import (
 )
 from yt.loaders import load
 from yt.testing import (
+    assert_allclose,
     assert_equal,
     disable_dataset_cache,
     requires_file,
@@ -330,16 +331,16 @@ def test_WarpXDataset():
 @requires_file(plasma)
 def test_magnetic_units():
     ds1 = load(plasma)
-    assert ds1.magnetic_unit.value == 1.0
+    assert_allclose(ds1.magnetic_unit.value, 1.0)
     assert str(ds1.magnetic_unit.units) == "T"
     mag_unit1 = ds1.magnetic_unit.to("code_magnetic")
-    assert mag_unit1.value == 1.0
+    assert_allclose(mag_unit1.value, 1.0)
     assert str(mag_unit1.units) == "code_magnetic"
     ds2 = load(plasma, unit_system="cgs")
-    assert ds2.magnetic_unit.value == 1.0e4
+    assert_allclose(ds2.magnetic_unit.value, 1.0e4)
     assert str(ds2.magnetic_unit.units) == "G"
     mag_unit2 = ds2.magnetic_unit.to("code_magnetic")
-    assert mag_unit2.value == 1.0
+    assert_allclose(mag_unit2.value, 1.0)
     assert str(mag_unit2.units) == "code_magnetic"
 
 

--- a/yt/frontends/boxlib/tests/test_outputs.py
+++ b/yt/frontends/boxlib/tests/test_outputs.py
@@ -315,7 +315,7 @@ def test_CastroDataset_2():
     assert isinstance(data_dir_load("castro_sod_x_plt00036"), CastroDataset)
 
 
-@requires_file(LyA)
+@requires_file(plasma)
 def test_WarpXDataset():
     assert isinstance(data_dir_load(plasma), WarpXDataset)
 

--- a/yt/frontends/flash/tests/test_outputs.py
+++ b/yt/frontends/flash/tests/test_outputs.py
@@ -6,6 +6,7 @@ from yt.frontends.flash.api import FLASHDataset, FLASHParticleDataset
 from yt.loaders import load
 from yt.testing import (
     ParticleSelectionComparison,
+    assert_allclose,
     assert_equal,
     disable_dataset_cache,
     requires_file,
@@ -60,16 +61,16 @@ def test_units_override():
 @requires_file(sloshing)
 def test_magnetic_units():
     ds1 = load(sloshing)
-    assert ds1.magnetic_unit.value == np.sqrt(4.0 * np.pi)
+    assert_allclose(ds1.magnetic_unit.value, np.sqrt(4.0 * np.pi))
     assert str(ds1.magnetic_unit.units) == "G"
     mag_unit1 = ds1.magnetic_unit.to("code_magnetic")
-    assert mag_unit1.value == 1.0
+    assert_allclose(mag_unit1.value, 1.0)
     assert str(mag_unit1.units) == "code_magnetic"
     ds2 = load(sloshing, unit_system="mks")
-    assert ds2.magnetic_unit.value == np.sqrt(4.0 * np.pi) * 1.0e-4
+    assert_allclose(ds2.magnetic_unit.value, np.sqrt(4.0 * np.pi) * 1.0e-4)
     assert str(ds2.magnetic_unit.units) == "T"
     mag_unit2 = ds2.magnetic_unit.to("code_magnetic")
-    assert mag_unit2.value == 1.0
+    assert_allclose(mag_unit2.value, 1.0)
     assert str(mag_unit2.units) == "code_magnetic"
 
 

--- a/yt/frontends/flash/tests/test_outputs.py
+++ b/yt/frontends/flash/tests/test_outputs.py
@@ -3,9 +3,11 @@ from collections import OrderedDict
 import numpy as np
 
 from yt.frontends.flash.api import FLASHDataset, FLASHParticleDataset
+from yt.loaders import load
 from yt.testing import (
     ParticleSelectionComparison,
     assert_equal,
+    disable_dataset_cache,
     requires_file,
     units_override_check,
 )
@@ -52,6 +54,23 @@ def test_FLASHDataset():
 @requires_file(sloshing)
 def test_units_override():
     units_override_check(sloshing)
+
+
+@disable_dataset_cache
+@requires_file(sloshing)
+def test_magnetic_units():
+    ds1 = load(sloshing)
+    assert ds1.magnetic_unit.value == np.sqrt(4.0 * np.pi)
+    assert str(ds1.magnetic_unit.units) == "G"
+    mag_unit1 = ds1.magnetic_unit.to("code_magnetic")
+    assert mag_unit1.value == 1.0
+    assert str(mag_unit1.units) == "code_magnetic"
+    ds2 = load(sloshing, unit_system="mks")
+    assert ds2.magnetic_unit.value == np.sqrt(4.0 * np.pi) * 1.0e-4
+    assert str(ds2.magnetic_unit.units) == "T"
+    mag_unit2 = ds2.magnetic_unit.to("code_magnetic")
+    assert mag_unit2.value == 1.0
+    assert str(mag_unit2.units) == "code_magnetic"
 
 
 @requires_file(sloshing)

--- a/yt/frontends/open_pmd/data_structures.py
+++ b/yt/frontends/open_pmd/data_structures.py
@@ -544,7 +544,6 @@ class OpenPMDDataset(Dataset):
         setdefaultattr(self, "time_unit", self.quan(1.0, "s"))
         setdefaultattr(self, "velocity_unit", self.quan(1.0, "m/s"))
         setdefaultattr(self, "magnetic_unit", self.quan(1.0, "T"))
-        setdefaultattr(self, "current_unit", self.quan(1.0, "A"))
 
     def _parse_parameter_file(self):
         """Read in metadata describing the overall data on-disk."""

--- a/yt/frontends/open_pmd/data_structures.py
+++ b/yt/frontends/open_pmd/data_structures.py
@@ -433,6 +433,7 @@ class OpenPMDDataset(Dataset):
 
     _index_class = OpenPMDHierarchy
     _field_info_class = OpenPMDFieldInfo
+    _use_mks_em_units = True
 
     def __init__(
         self,

--- a/yt/frontends/open_pmd/data_structures.py
+++ b/yt/frontends/open_pmd/data_structures.py
@@ -544,6 +544,7 @@ class OpenPMDDataset(Dataset):
         setdefaultattr(self, "time_unit", self.quan(1.0, "s"))
         setdefaultattr(self, "velocity_unit", self.quan(1.0, "m/s"))
         setdefaultattr(self, "magnetic_unit", self.quan(1.0, "T"))
+        setdefaultattr(self, "current_unit", self.quan(1.0, "A"))
 
     def _parse_parameter_file(self):
         """Read in metadata describing the overall data on-disk."""

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -274,8 +274,8 @@ class StreamDataset(Dataset):
         geometry="cartesian",
         unit_system="cgs",
         default_species_fields=None,
+        use_mks_em_units=False,
     ):
-        from yt.units.dimensions import current_mks
 
         self.fluid_types += ("stream",)
         self.geometry = geometry
@@ -284,13 +284,7 @@ class StreamDataset(Dataset):
         name = f"InMemoryParameterFile_{uuid.uuid4().hex}"
         from yt.data_objects.static_output import _cached_datasets
 
-        # Here we check to see if the code units use an MKS current
-        # If the magnetic units are simply set to "code_magnetic",
-        # then we assume that they are cgs
-        magnetic_unit = self.stream_handler.code_units[-1]
-        if magnetic_unit != "code_magnetic":
-            mu = YTQuantity(1.0, magnetic_unit)
-            self._use_mks_em_units = current_mks in mu.units.dimensions
+        self._use_mks_em_units = use_mks_em_units
 
         _cached_datasets[name] = self
         Dataset.__init__(
@@ -460,6 +454,7 @@ class StreamParticlesDataset(StreamDataset):
         geometry="cartesian",
         unit_system="cgs",
         default_species_fields=None,
+        use_mks_em_units=False,
     ):
         super().__init__(
             stream_handler,
@@ -467,6 +462,7 @@ class StreamParticlesDataset(StreamDataset):
             geometry=geometry,
             unit_system=unit_system,
             default_species_fields=default_species_fields,
+            use_mks_em_units=use_mks_em_units,
         )
         fields = list(stream_handler.fields["stream_file"].keys())
         # This is the current method of detecting SPH data.

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -300,10 +300,11 @@ class StreamDataset(Dataset):
         # We assume CGS EM units by default, unless
         # magnetic_unit is explicitly defined within MKSA
         magnetic_unit = self.stream_handler.code_units[-1]
-        if magnetic_unit == "code_magnetic":
-            return False
-        elif isinstance(magnetic_unit, str):
-            uq = YTQuantity(1.0, magnetic_unit)
+        if isinstance(magnetic_unit, str):
+            if magnetic_unit == "code_magnetic":
+                return False
+            else:
+                uq = YTQuantity(1.0, magnetic_unit)
         elif isinstance(magnetic_unit, YTQuantity):
             uq = magnetic_unit
         elif isinstance(magnetic_unit, tuple):

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -275,12 +275,22 @@ class StreamDataset(Dataset):
         unit_system="cgs",
         default_species_fields=None,
     ):
+        from yt.units.dimensions import current_mks
+
         self.fluid_types += ("stream",)
         self.geometry = geometry
         self.stream_handler = stream_handler
         self._find_particle_types()
         name = f"InMemoryParameterFile_{uuid.uuid4().hex}"
         from yt.data_objects.static_output import _cached_datasets
+
+        # Here we check to see if the code units use an MKS current
+        # If the magnetic units are simply set to "code_magnetic",
+        # then we assume that they are cgs
+        magnetic_unit = self.stream_handler.code_units[-1]
+        if magnetic_unit != "code_magnetic":
+            mu = YTQuantity(1.0, magnetic_unit)
+            self._use_mks_em_units = current_mks in mu.units.dimensions
 
         _cached_datasets[name] = self
         Dataset.__init__(

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -294,7 +294,7 @@ class StreamDataset(Dataset):
             default_species_fields=default_species_fields,
         )
 
-    def _check_for_mks_em_units(self):
+    def _check_for_mks_em_units(self) -> bool:
         from yt.units.dimensions import current_mks
 
         # We assume CGS EM units by default, unless

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -295,7 +295,7 @@ class StreamDataset(Dataset):
         )
 
     def _check_for_mks_em_units(self) -> bool:
-        from yt.units.dimensions import current_mks
+        from yt.units.dimensions import current_mks  # type: ignore
 
         # We assume CGS EM units by default, unless
         # magnetic_unit is explicitly defined within MKSA

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -162,7 +162,6 @@ def load_uniform_grid(
     geometry="cartesian",
     unit_system="cgs",
     default_species_fields=None,
-    use_mks_em_units=False,
 ):
     r"""Load a uniform grid of data into yt as a
     :class:`~yt.frontends.stream.data_structures.StreamHandler`.
@@ -337,7 +336,6 @@ def load_uniform_grid(
         geometry=geometry,
         unit_system=unit_system,
         default_species_fields=default_species_fields,
-        use_mks_em_units=use_mks_em_units,
     )
 
     # Now figure out where the particles go
@@ -363,7 +361,6 @@ def load_amr_grids(
     refine_by=2,
     unit_system="cgs",
     default_species_fields=None,
-    use_mks_em_units=False,
 ):
     r"""Load a set of grids of data into yt as a
     :class:`~yt.frontends.stream.data_structures.StreamHandler`.
@@ -564,7 +561,6 @@ def load_amr_grids(
         geometry=geometry,
         unit_system=unit_system,
         default_species_fields=default_species_fields,
-        use_mks_em_units=use_mks_em_units,
     )
     return sds
 
@@ -583,7 +579,6 @@ def load_particles(
     unit_system="cgs",
     data_source=None,
     default_species_fields=None,
-    use_mks_em_units=False,
 ):
     r"""Load a set of particles into yt as a
     :class:`~yt.frontends.stream.data_structures.StreamParticleHandler`.
@@ -740,7 +735,6 @@ def load_particles(
         geometry=geometry,
         unit_system=unit_system,
         default_species_fields=default_species_fields,
-        use_mks_em_units=use_mks_em_units,
     )
 
     return sds
@@ -760,7 +754,6 @@ def load_hexahedral_mesh(
     periodicity=(True, True, True),
     geometry="cartesian",
     unit_system="cgs",
-    use_mks_em_units=False,
 ):
     r"""Load a hexahedral mesh of data into yt as a
     :class:`~yt.frontends.stream.data_structures.StreamHandler`.
@@ -887,7 +880,6 @@ def load_hexahedral_mesh(
         handler,
         geometry=geometry,
         unit_system=unit_system,
-        use_mks_em_units=use_mks_em_units,
     )
 
     return sds

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -162,6 +162,7 @@ def load_uniform_grid(
     geometry="cartesian",
     unit_system="cgs",
     default_species_fields=None,
+    use_mks_em_units=False,
 ):
     r"""Load a uniform grid of data into yt as a
     :class:`~yt.frontends.stream.data_structures.StreamHandler`.
@@ -336,6 +337,7 @@ def load_uniform_grid(
         geometry=geometry,
         unit_system=unit_system,
         default_species_fields=default_species_fields,
+        use_mks_em_units=use_mks_em_units,
     )
 
     # Now figure out where the particles go
@@ -361,6 +363,7 @@ def load_amr_grids(
     refine_by=2,
     unit_system="cgs",
     default_species_fields=None,
+    use_mks_em_units=False,
 ):
     r"""Load a set of grids of data into yt as a
     :class:`~yt.frontends.stream.data_structures.StreamHandler`.
@@ -561,6 +564,7 @@ def load_amr_grids(
         geometry=geometry,
         unit_system=unit_system,
         default_species_fields=default_species_fields,
+        use_mks_em_units=use_mks_em_units,
     )
     return sds
 
@@ -579,6 +583,7 @@ def load_particles(
     unit_system="cgs",
     data_source=None,
     default_species_fields=None,
+    use_mks_em_units=False,
 ):
     r"""Load a set of particles into yt as a
     :class:`~yt.frontends.stream.data_structures.StreamParticleHandler`.
@@ -735,6 +740,7 @@ def load_particles(
         geometry=geometry,
         unit_system=unit_system,
         default_species_fields=default_species_fields,
+        use_mks_em_units=use_mks_em_units,
     )
 
     return sds
@@ -754,6 +760,7 @@ def load_hexahedral_mesh(
     periodicity=(True, True, True),
     geometry="cartesian",
     unit_system="cgs",
+    use_mks_em_units=False,
 ):
     r"""Load a hexahedral mesh of data into yt as a
     :class:`~yt.frontends.stream.data_structures.StreamHandler`.
@@ -876,7 +883,12 @@ def load_hexahedral_mesh(
     handler.simulation_time = sim_time
     handler.cosmology_simulation = 0
 
-    sds = StreamHexahedralDataset(handler, geometry=geometry, unit_system=unit_system)
+    sds = StreamHexahedralDataset(
+        handler,
+        geometry=geometry,
+        unit_system=unit_system,
+        use_mks_em_units=use_mks_em_units,
+    )
 
     return sds
 

--- a/yt/units/tests/test_magnetic_code_units.py
+++ b/yt/units/tests/test_magnetic_code_units.py
@@ -50,3 +50,25 @@ def test_magnetic_code_units():
     mucu = ds4.magnetic_unit.to("code_magnetic")
     assert_allclose(mucu.value, 1.0)
     assert str(mucu.units) == "code_magnetic"
+
+    ds5 = load_uniform_grid(
+        data, ddims, magnetic_unit=(1.0, "uG"), unit_system="mks"
+    )
+
+    assert_allclose(ds5.magnetic_unit.value, 1.0e-10)
+    assert str(ds5.magnetic_unit.units) == "T"
+
+    mucu = ds5.magnetic_unit.to("code_magnetic")
+    assert_allclose(mucu.value, 1.0)
+    assert str(mucu.units) == "code_magnetic"
+
+    ds6 = load_uniform_grid(
+        data, ddims, magnetic_unit=(1.0, "nT"), unit_system="cgs"
+    )
+
+    assert_allclose(ds6.magnetic_unit.value, 1.0e-5)
+    assert str(ds6.magnetic_unit.units) == "G"
+
+    mucu = ds6.magnetic_unit.to("code_magnetic")
+    assert_allclose(mucu.value, 1.0)
+    assert str(mucu.units) == "code_magnetic"

--- a/yt/units/tests/test_magnetic_code_units.py
+++ b/yt/units/tests/test_magnetic_code_units.py
@@ -21,8 +21,8 @@ def test_magnetic_code_units():
     assert_allclose(mucu.value, 1.0)
     assert str(mucu.units) == "code_magnetic"
 
-    ds2 = load_uniform_grid(data, ddims, magnetic_unit=(1.0, "T"), unit_system="cgs")
-
+    ds2 = load_uniform_grid(data, ddims, magnetic_unit=(1.0, "T"),
+                            unit_system="cgs")
     assert_allclose(ds2.magnetic_unit.value, 10000.0)
     assert str(ds2.magnetic_unit.units) == "G"
 
@@ -30,7 +30,8 @@ def test_magnetic_code_units():
     assert_allclose(mucu.value, 1.0)
     assert str(mucu.units) == "code_magnetic"
 
-    ds3 = load_uniform_grid(data, ddims, magnetic_unit=(1.0, "T"), unit_system="mks")
+    ds3 = load_uniform_grid(data, ddims, magnetic_unit=(1.0, "T"),
+                            unit_system="mks")
 
     assert_allclose(ds3.magnetic_unit.value, 1.0)
     assert str(ds3.magnetic_unit.units) == "T"

--- a/yt/units/tests/test_magnetic_code_units.py
+++ b/yt/units/tests/test_magnetic_code_units.py
@@ -21,8 +21,7 @@ def test_magnetic_code_units():
     assert_allclose(mucu.value, 1.0)
     assert str(mucu.units) == "code_magnetic"
 
-    ds2 = load_uniform_grid(data, ddims, magnetic_unit=(1.0, "T"),
-                            unit_system="cgs")
+    ds2 = load_uniform_grid(data, ddims, magnetic_unit=(1.0, "T"), unit_system="cgs")
     assert_allclose(ds2.magnetic_unit.value, 10000.0)
     assert str(ds2.magnetic_unit.units) == "G"
 
@@ -30,8 +29,7 @@ def test_magnetic_code_units():
     assert_allclose(mucu.value, 1.0)
     assert str(mucu.units) == "code_magnetic"
 
-    ds3 = load_uniform_grid(data, ddims, magnetic_unit=(1.0, "T"),
-                            unit_system="mks")
+    ds3 = load_uniform_grid(data, ddims, magnetic_unit=(1.0, "T"), unit_system="mks")
 
     assert_allclose(ds3.magnetic_unit.value, 1.0)
     assert str(ds3.magnetic_unit.units) == "T"


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

Electromagnetic unit conversions in yt are complex. The reasons for this are:

* `unyt` uses MKSA as the base set of units, but `yt` assumes Gaussian CGS units by default
* MKSA has a fundamental unit for current, Ampere, which becomes a component unit of most electromagnetic units (e.g. Coulomb, Tesla, etc.)
* Gaussian CGS units do not have a fundamental unit of current, defining all electromagnetic quantities in terms of mass, length, and time units

This is described in more detail [here](https://ytep.readthedocs.io/en/master/YTEPs/YTEP-0028.html#special-handling-for-magnetic-fields). 

Some frontends assume Gaussian CGS EM units as the code units, and a few assume MKSA EM units for the code units. However, regardless of what one assumes, it ought to be straightforward and transparent to do something like this:

```python
ds = yt.load("some_dataset", unit_system="code")
```

and expect magnetic fields to have SI dimensions instead of Gaussian CGS dimensions if the underlying code units do. It turns out that this doesn't always work correctly, as seen in Issue #3471, which was originally posted about another problem but in fact led to the discovery of this issue. 

The problem is that we need something that comes even before unit detection from the dataset, to let yt know whether or not it should expect something with dimensions of SI current in it when creating the code unit system.  There is a chicken-and-egg problem where we have to set up a code unit system before we can detect units, but only when we detect units can we know whether we need an SI current unit, which is info you need to create the code unit system in the first place. It's quite awful.

This PR is an attempt to fix the logic that handles this situation, as well as the case where we have an SI code system but request a CGS system (and vice-versa), which is currently very brittle. The easiest way to do this (though clearly not the most elegant) is for the `Dataset` object to have a new attribute (called `_use_mks_em_units` in this case) which tells it to expect that the code units will be using MKSA for EM units.

I've updated the documentation and the skeleton frontend to reflect how to ensure that SI/MKSA units are used for code units, and I've also updated the stream dataset documentation to show how to make sure this happens for in-memory datasets.

I also added some new tests and fixed some other ones. Finally, this does not fix Issue #3471--that will have to be addressed in a separate PR.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
