### PR TITLE
Fix bug in bitmap index for particle datasets

### DIFF
--- a/yt/geometry/particle_oct_container.pyx
+++ b/yt/geometry/particle_oct_container.pyx
@@ -72,7 +72,7 @@ import struct
 
 # If set to 1, ghost cells are added at the refined level regardless of if the
 # coarse cell containing it is refined in the selector.
-# If set to 0, ghost cells are only added at the refined level of the coarse
+# If set to 0, ghost cells are only added at the refined level if the coarse
 # index for the ghost cell is refined in the selector.
 DEF RefinedExternalGhosts = 1
 
@@ -874,7 +874,6 @@ cdef class ParticleBitmap:
                                            np.float64_t dds1[3], np.uint64_t xex, np.uint64_t yex, np.uint64_t zex,
                                            np.float64_t dds2[3], bool_array &refined_set) except -1:
         cdef int i
-        cdef np.uint64_t new_nsub = 0
         cdef np.uint64_t bounds_l[3], bounds_r[3]
         cdef np.uint64_t miex2, miex2_min, miex2_max
         cdef np.float64_t clip_pos_l[3]
@@ -883,6 +882,7 @@ cdef class ParticleBitmap:
         cdef np.uint64_t ex1[3]
         cdef np.uint64_t xiex_min, yiex_min, ziex_min
         cdef np.uint64_t xiex_max, yiex_max, ziex_max
+        cdef np.uint64_t old_nsub = refined_set.numberOfOnes()
         ex1[0] = xex
         ex1[1] = yex
         ex1[2] = zex
@@ -921,8 +921,7 @@ cdef class ParticleBitmap:
             if (miex2 & zex_max) < (ziex_min): continue
             if (miex2 & zex_max) > (ziex_max): continue
             refined_set.set(miex2)
-            new_nsub += 1
-        return refined_set.numberOfOnes()
+        return refined_set.numberOfOnes() - old_nsub
 
     @cython.boundscheck(False)
     @cython.wraparound(False)


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

This PR fixes a bug where __fill_refined_ranges in ParticleBitmap was returning the total number of refined cells for a coarse cell instead of the number of new refined cells. This bug caused coarse cells to be marked as fully refined on subsequent passes and so they were not actually refined and resulted in some files not being identified as selected, particularly for selectors that rely on the refined index (e.g. slice selector).

<!--If it fixes an open issue, please link to the issue here.-->

This fixes #3672 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
