### PR TITLE
DOC: don't pin a specific yt version in a badge that appears on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # The yt Project
 
 [![PyPI](https://img.shields.io/pypi/v/yt)](https://pypi.org/project/yt)
-[![Supported Python Versions](https://img.shields.io/pypi/pyversions/yt/4.0.0)](https://pypi.org/project/yt/)
+[![Supported Python Versions](https://img.shields.io/pypi/pyversions/yt)](https://pypi.org/project/yt/)
 [![Latest Documentation](https://img.shields.io/badge/docs-latest-brightgreen.svg)](http://yt-project.org/docs/dev/)
 [![Users' Mailing List](https://img.shields.io/badge/Users-List-lightgrey.svg)](https://mail.python.org/archives/list/yt-users@python.org//)
 [![Devel Mailing List](https://img.shields.io/badge/Devel-List-lightgrey.svg)](https://mail.python.org/archives/list/yt-dev@python.org//)


### PR DESCRIPTION
## PR Summary
We forgot to update this version string for yt 4.0.2, now the badge displays support for Python 3.6 to 3.9 (it should be 3.6 to 3.10). On second thought I don't think it's worth pinning there because ultimately it's just one more mistake we can make in the release process, so I'm going for the easy fix here that can be safely backported for 4.0.3 as is
