### PR TITLE
BUG: fix heuristic to switch from log scale to symlog scale

### DIFF
--- a/yt/visualization/line_plot.py
+++ b/yt/visualization/line_plot.py
@@ -335,7 +335,7 @@ class LinePlot(PlotContainer):
 
                 # apply log transforms if requested
                 if self._field_transform[field] != linear_transform:
-                    if (y < 0).any():
+                    if (y <= 0).any():
                         plot.axes.set_yscale("symlog")
                     else:
                         plot.axes.set_yscale("log")

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1056,7 +1056,7 @@ class PWViewerMPL(PlotWindow):
                     use_symlog = True
                 elif not np.any(np.isfinite(image)):
                     msg = f"Plotting {f}: All values = NaN."
-                elif np.nanmax(image) > 0.0 and np.nanmin(image) < 0:
+                elif np.nanmax(image) > 0.0 and np.nanmin(image) <= 0:
                     msg = (
                         f"Plotting {f}: Both positive and negative values. "
                         f"Min = {np.nanmin(image)}, Max = {np.nanmax(image)}."


### PR DESCRIPTION
## PR Summary
Fix #3791

Here's a simpler demo
```python
import numpy as np
import yt

shape = (32, 16, 1)
a = np.linspace(0, 1, 16)
b = np.ones((32, 16))
c = np.reshape(a*b, shape)
data = {("gas", "density"): c}

ds = yt.load_uniform_grid(
    data,
    shape,
    bbox=np.array([[0.0, 5.0], [0, 1], [-0.1, +0.1]]),
)

p = yt.SlicePlot(ds, "z", "density")
p.save("/tmp/branch.png")
```

on main
![main](https://user-images.githubusercontent.com/14075922/152986772-02062d11-fbec-4cfd-aadb-f09bf264d484.png)


this branch
![branch](https://user-images.githubusercontent.com/14075922/152986723-a53dfa87-74ac-4010-b9f4-3a1ddf6ad001.png)

While the original issue was only about 2D plots, I'm also fixing a similar bug in line plots that I found on the way
