### PR TITLE
BUG: fix a bug in pixelize_cylinder where buffer shape was read backwards

### DIFF
--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -534,8 +534,8 @@ def pixelize_cylinder(np.float64_t[:,:] buff,
     rmax = radius[imax] + dradius[imax]
 
     x0, x1, y0, y1 = extents
-    dx = (x1 - x0) / buff.shape[1]
-    dy = (y1 - y0) / buff.shape[0]
+    dx = (x1 - x0) / buff.shape[0]
+    dy = (y1 - y0) / buff.shape[1]
     cdef np.float64_t rbounds[2]
     cdef np.float64_t corners[8]
     # Find our min and max r


### PR DESCRIPTION
## PR Summary
Welp, that was easy.
Fix #3794

Just to make it flagrant I'll make an even more drastic version of the script therein
```python
import numpy as np
import yt

shape = (32, 16, 1)
a = np.linspace(1, 100, 16)
b = np.ones((32, 16))
c = np.reshape(a * b, shape)
data = {("gas", "density"): c}

ds = yt.load_uniform_grid(
    data,
    shape,
    bbox=np.array([[0.0, 5.0], [np.pi / 2 - 0.2, np.pi / 2 + 0.2], [-0.1, +0.1]]),
    geometry="spherical",
)

p = yt.SlicePlot(ds, "phi", "density")
p.save("/tmp/buff_default.png")
p.set_buff_size((10, 800))
p.save("/tmp/buff_10_800.png")

p.set_buff_size((10, 10))
p.save("/tmp/buff_10_10.png")
```

![buff_default](https://user-images.githubusercontent.com/14075922/153083225-4ff2b741-bb77-4cda-a3d9-bb12d4fb9a00.png)
![buff_10_800](https://user-images.githubusercontent.com/14075922/153083230-09ebbd39-f542-4a86-bf69-93669e576fad.png)
![buff_10_10](https://user-images.githubusercontent.com/14075922/153083235-7dbe1590-9945-42bc-965d-c88222d77e87.png)
