### PR TITLE
BUG: fix error messages in RAMSESDataset validation

### DIFF
--- a/yt/frontends/ramses/definitions.py
+++ b/yt/frontends/ramses/definitions.py
@@ -53,7 +53,8 @@ VERSION_RE = re.compile(r"# version: *(\d+)")
 # on the left hand side
 VAR_DESC_RE = re.compile(r"\s*([^\s]+),\s*([^\s]+),\s*([^\s]+)")
 
-OUTPUT_DIR_RE = re.compile(r"(output|group)_(\d{5})")
+OUTPUT_DIR_EXP = r"(output|group)_(\d{5})"
+OUTPUT_DIR_RE = re.compile(OUTPUT_DIR_EXP)
 STANDARD_FILE_RE = re.compile(r"((amr|hydro|part|grav)_\d{5}\.out\d{5}|info_\d{5}.txt)")
 
 


### PR DESCRIPTION
## PR Summary
This adresses the surface problem reported in #3800, i.e., I'm demystifying errors raised by `RAMSESDataset` at validation time

### Example 1

```python
from yt.frontends.ramses.api import RAMSESDataset

RAMSESDataset("not_a_file")
```

On main

```python-traceback
ValueError: ('Invalid filename found when building a RAMSESDataset object: %s', 'not_a_file')
```


This branch
```python-traceback
FileNotFoundError: No such file or directory '/Users/robcleme/dev/yt-project/yt/not_a_file'
```

### Example 2

```python
import os
from yt.frontends.ramses.api import RAMSESDataset

RAMSESDataset(os.path.expanduser("~"))
```

On main

```python-traceback
ValueError: ('Invalid filename found when building a RAMSESDataset object: %s', '/Users/robcleme')
```


This branch
```python-traceback
ValueError: Could not determine output directory from '/Users/robcleme'
Expected a directory name of form '(output|group)_(\\d{5})'
```