### PR TITLE
Fix electromagnetic unit conversions (second try)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ png.cfg
 rockstar.cfg
 yt_updater.log
 yt/frontends/artio/_artio_caller.c
+yt/frontends/gamer/cfields.c
 yt/analysis_modules/halo_finding/rockstar/rockstar_groupies.c
 yt/analysis_modules/halo_finding/rockstar/rockstar_interface.c
 yt/analysis_modules/ppv_cube/ppv_utils.c

--- a/doc/source/developing/creating_frontend.rst
+++ b/doc/source/developing/creating_frontend.rst
@@ -32,8 +32,8 @@ If you are interested in adding a new code, be sure to drop us a line on
 `yt-dev <https://mail.python.org/archives/list/yt-dev@python.org/>`_!
 
 
-Boostraping a new frontend
---------------------------
+Bootstrapping a new frontend
+----------------------------
 
 To get started
 

--- a/doc/source/examining/Loading_Generic_Array_Data.ipynb
+++ b/doc/source/examining/Loading_Generic_Array_Data.ipynb
@@ -104,7 +104,7 @@
     "* `mass_unit` : The unit that corresponds to `code_mass`, can be a string, tuple, or floating-point number\n",
     "* `time_unit` : The unit that corresponds to `code_time`, can be a string, tuple, or floating-point number\n",
     "* `velocity_unit` : The unit that corresponds to `code_velocity`\n",
-    "* `magnetic_unit` : The unit that corresponds to `code_magnetic`, i.e. the internal units used to represent magnetic field strengths.\n",
+    "* `magnetic_unit` : The unit that corresponds to `code_magnetic`, i.e. the internal units used to represent magnetic field strengths. NOTE: if you want magnetic field units to be in the SI unit system, you must specify it here, e.g. `magnetic_unit=(1.0, \"T\")`\n",
     "* `periodicity` : A tuple of booleans that determines whether the data will be treated as periodic along each axis\n",
     "\n",
     "This example creates a yt-native dataset `ds` that will treat your array as a\n",

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -29,6 +29,8 @@ answer_tests:
     - yt/frontends/athena/tests/test_outputs.py:test_stripping
 
   local_athena_pp_006:
+    # disabling disk test for now until we have better support
+    # for this dataset
     #- yt/frontends/athena_pp/tests/test_outputs.py:test_disk
     - yt/frontends/athena_pp/tests/test_outputs.py:test_AM06
 

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -28,8 +28,8 @@ answer_tests:
     - yt/frontends/athena/tests/test_outputs.py:test_blast
     - yt/frontends/athena/tests/test_outputs.py:test_stripping
 
-  local_athena_pp_004:
-    - yt/frontends/athena_pp/tests/test_outputs.py:test_disk
+  local_athena_pp_006:
+    #- yt/frontends/athena_pp/tests/test_outputs.py:test_disk
     - yt/frontends/athena_pp/tests/test_outputs.py:test_AM06
 
   local_chombo_005:

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1119,27 +1119,48 @@ class Dataset(abc.ABC):
         return self.refine_by ** (l1 - l0)
 
     def _assign_unit_system(self, unit_system):
-        if unit_system == "cgs":
-            current_mks_unit = None
+        # we need to determine if the requested unit system
+        # is mks-like: i.e., it has a current with the same
+        # dimensions as amperes.
+        mks_system = False
+        if getattr(self, "magnetic_unit", None):
+            mag_dims = self.magnetic_unit.units.dimensions.free_symbols
         else:
-            current_mks_unit = "A"
-        magnetic_unit = getattr(self, "magnetic_unit", None)
-        if magnetic_unit is not None:
-            if unit_system == "mks":
-                if current_mks not in self.magnetic_unit.units.dimensions.free_symbols:
-                    self.magnetic_unit = self.magnetic_unit.to("gauss").to("T")
-                self.unit_registry.modify("code_magnetic", self.magnetic_unit.value)
-            else:
-                # if the magnetic unit is in T, we need to create the code unit
-                # system as an MKS-like system
-                if current_mks in self.magnetic_unit.units.dimensions.free_symbols:
-                    self.magnetic_unit = self.magnetic_unit.to("T").to("gauss")
+            mag_dims = None
+        if unit_system != "code":
+            # if the unit system is known, we can check if it
+            # has a "current_mks" unit
+            us = unit_system_registry[str(unit_system).lower()]
+            mks_system = us.base_units[current_mks] is not None
+        elif mag_dims and current_mks in mag_dims:
+            # if we're using the not-yet defined code unit system,
+            # then we check if the magnetic field unit has a SI
+            # current dimension in it
+            mks_system = True
+        # Now we get to the tricky part. If we have an MKS-like system but
+        # we asked for a conversion to something CGS-like, or vice-versa,
+        # we have to convert the magnetic field
+        if mag_dims is not None:
+            if mks_system:
+                if current_mks not in mag_dims:
+                    self.magnetic_unit = self.quan(
+                        self.magnetic_unit.to_value("gauss") * 1.0e-4, "T"
+                    )
+                    # The following modification ensures that we get the conversion to
+                    # mks correct
+                    self.unit_registry.modify(
+                        "code_magnetic", self.magnetic_unit.value * 1.0e3 * 0.1**-0.5
+                    )
+            elif current_mks in mag_dims:
+                self.magnetic_unit = self.quan(
+                    self.magnetic_unit.to_value("T") * 1.0e4, "gauss"
+                )
                 # The following modification ensures that we get the conversion to
                 # cgs correct
                 self.unit_registry.modify(
-                    "code_magnetic", self.magnetic_unit.value * 0.1**0.5
+                    "code_magnetic", self.magnetic_unit.value * 1.0e-4
                 )
-
+        current_mks_unit = "A" if mks_system else None
         us = create_code_unit_system(
             self.unit_registry, current_mks_unit=current_mks_unit
         )
@@ -1168,6 +1189,7 @@ class Dataset(abc.ABC):
         # Note that the values associated with the code units here will be
         # modified once we actually determine what the code units are from
         # the dataset
+        # NOTE that magnetic fields are not done here yet, see set_code_units
         self.unit_registry = UnitRegistry(unit_system=unit_system)
         # 1 cm = 0.01 m
         self.unit_registry.add("code_length", 0.01, dimensions.length)
@@ -1181,16 +1203,6 @@ class Dataset(abc.ABC):
         )
         # 1 s = 1 s
         self.unit_registry.add("code_time", 1.0, dimensions.time)
-        # Defining code units for magnetic fields are tricky because
-        # they have different dimensions in different unit systems
-        if unit_system == "mks":
-            # 1 T = 1 kg/(A*s**2)
-            self.unit_registry.add("code_magnetic", 1.0, dimensions.magnetic_field)
-        else:
-            # 1 gauss = 1 sqrt(g)/(sqrt(cm)*s) = 0.1**0.5 sqrt(kg)/(sqrt(m)*s)
-            self.unit_registry.add(
-                "code_magnetic", 0.1**0.5, dimensions.magnetic_field_cgs
-            )
         # 1 K = 1 K
         self.unit_registry.add("code_temperature", 1.0, dimensions.temperature)
         # 1 dyn/cm**2 = 0.1 N/m**2
@@ -1303,6 +1315,24 @@ class Dataset(abc.ABC):
         self.unit_registry.modify("code_pressure", pressure_unit)
         self.unit_registry.modify("code_density", density_unit)
         self.unit_registry.modify("code_specific_energy", specific_energy_unit)
+        # Defining code units for magnetic fields are tricky because
+        # they have different dimensions in different unit systems, so we have
+        # to handle them carefully
+        if hasattr(self, "magnetic_unit"):
+            if self.magnetic_unit.units.dimensions == dimensions.magnetic_field_cgs:
+                # We have to cast this explicitly to MKS base units, otherwise
+                # unyt will convert it automatically to Tesla
+                value = self.magnetic_unit.to_value("sqrt(kg)/(sqrt(m)*s)")
+                dims = dimensions.magnetic_field_cgs
+            else:
+                value = self.magnetic_unit.to_value("T")
+                dims = dimensions.magnetic_field_mks
+        else:
+            # Fallback to gauss if no magnetic unit is specified
+            # 1 gauss = 1 sqrt(g)/(sqrt(cm)*s) = 0.1**0.5 sqrt(kg)/(sqrt(m)*s)
+            value = 0.1**0.5
+            dims = dimensions.magnetic_field_cgs
+        self.unit_registry.add("code_magnetic", value, dims)
         # domain_width does not yet exist
         if self.domain_left_edge is not None and self.domain_right_edge is not None:
             DW = self.arr(self.domain_right_edge - self.domain_left_edge, "code_length")

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1170,7 +1170,7 @@ class Dataset(abc.ABC):
         self.unit_registry.add("code_mass", 0.001, dimensions.mass)
         self.unit_registry.add("code_density", 1000.0, dimensions.density)
         self.unit_registry.add(
-            "code_specific_energy", 1.0, dimensions.energy / dimensions.mass
+            "code_specific_energy", 1.0e-4, dimensions.energy / dimensions.mass
         )
         self.unit_registry.add("code_time", 1.0, dimensions.time)
         if unit_system == "mks":

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1141,17 +1141,16 @@ class Dataset(abc.ABC):
         # we asked for a conversion to something CGS-like, or vice-versa,
         # we have to convert the magnetic field
         if mag_dims is not None:
-            if mks_system:
-                if current_mks not in mag_dims:
-                    self.magnetic_unit = self.quan(
-                        self.magnetic_unit.to_value("gauss") * 1.0e-4, "T"
-                    )
-                    # The following modification ensures that we get the conversion to
-                    # mks correct
-                    self.unit_registry.modify(
-                        "code_magnetic", self.magnetic_unit.value * 1.0e3 * 0.1**-0.5
-                    )
-            elif current_mks in mag_dims:
+            if mks_system and current_mks not in mag_dims:
+                self.magnetic_unit = self.quan(
+                    self.magnetic_unit.to_value("gauss") * 1.0e-4, "T"
+                )
+                # The following modification ensures that we get the conversion to
+                # mks correct
+                self.unit_registry.modify(
+                    "code_magnetic", self.magnetic_unit.value * 1.0e3 * 0.1**-0.5
+                )
+            elif not mks_system and current_mks in mag_dims:
                 self.magnetic_unit = self.quan(
                     self.magnetic_unit.to_value("T") * 1.0e4, "gauss"
                 )

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1165,25 +1165,43 @@ class Dataset(abc.ABC):
         # yt assumes a CGS unit system by default (for back compat reasons).
         # Since unyt is MKS by default we specify the MKS values of the base
         # units in the CGS system. So, for length, 1 cm = .01 m. And so on.
+        # Note that the values associated with the code units here will be
+        # modified once we actually determine what the code units are from
+        # the dataset
         self.unit_registry = UnitRegistry(unit_system=unit_system)
+        # 1 cm = 0.01 m
         self.unit_registry.add("code_length", 0.01, dimensions.length)
+        # 1 g = 0.001 kg
         self.unit_registry.add("code_mass", 0.001, dimensions.mass)
+        # 1 g/cm**3 = 1000 kg/m**3
         self.unit_registry.add("code_density", 1000.0, dimensions.density)
+        # 1 erg/g = 1.0e-4 J/kg
         self.unit_registry.add(
             "code_specific_energy", 1.0e-4, dimensions.energy / dimensions.mass
         )
+        # 1 s = 1 s
         self.unit_registry.add("code_time", 1.0, dimensions.time)
+        # Defining code units for magnetic fields are tricky because
+        # they have different dimensions in different unit systems
         if unit_system == "mks":
+            # 1 T = 1 kg/(A*s**2)
             self.unit_registry.add("code_magnetic", 1.0, dimensions.magnetic_field)
         else:
+            # 1 gauss = 1 sqrt(g)/(sqrt(cm)*s) = 0.1**0.5 sqrt(kg)/(sqrt(m)*s)
             self.unit_registry.add(
                 "code_magnetic", 0.1**0.5, dimensions.magnetic_field_cgs
             )
+        # 1 K = 1 K
         self.unit_registry.add("code_temperature", 1.0, dimensions.temperature)
+        # 1 dyn/cm**2 = 0.1 N/m**2
         self.unit_registry.add("code_pressure", 0.1, dimensions.pressure)
+        # 1 cm/s = 0.01 m/s
         self.unit_registry.add("code_velocity", 0.01, dimensions.velocity)
+        # metallicity
         self.unit_registry.add("code_metallicity", 1.0, dimensions.dimensionless)
+        # dimensionless hubble parameter
         self.unit_registry.add("h", 1.0, dimensions.dimensionless, r"h")
+        # cosmological scale factor
         self.unit_registry.add("a", 1.0, dimensions.dimensionless)
 
     def set_units(self):

--- a/yt/fields/fluid_fields.py
+++ b/yt/fields/fluid_fields.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from yt.units.dimensions import current_mks  # type: ignore
 from yt.units.unit_object import Unit  # type: ignore
 from yt.utilities.chemical_formulas import compute_mu
 from yt.utilities.lib.misc_utilities import obtain_relative_velocity_vector
@@ -31,7 +32,7 @@ def setup_fluid_fields(registry, ftype="gas", slice_info=None):
 
     unit_system = registry.ds.unit_system
 
-    if unit_system.name == "cgs":
+    if unit_system.base_units[current_mks] is None:
         mag_units = "magnetic_field_cgs"
     else:
         mag_units = "magnetic_field_mks"

--- a/yt/fields/tests/test_magnetic_fields.py
+++ b/yt/fields/tests/test_magnetic_fields.py
@@ -23,18 +23,22 @@ def test_magnetic_fields():
     for field in data1:
         data2[field] = (data1[field][0] * 1.0e4, "gauss")
 
-    ds1 = load_uniform_grid(data1, ddims, unit_system="cgs")
+    ds1 = load_uniform_grid(data1, ddims, magnetic_unit=(1.0, "T"), unit_system="cgs")
     ds2 = load_uniform_grid(data2, ddims, unit_system="mks")
     # For this test dataset, code units are cgs units
     ds3 = load_uniform_grid(data2, ddims, unit_system="code")
+    # For this test dataset, code units are SI units
+    ds4 = load_uniform_grid(data1, ddims, magnetic_unit=(1.0, "T"), unit_system="code")
 
     ds1.index
     ds2.index
     ds3.index
+    ds4.index
 
     dd1 = ds1.all_data()
     dd2 = ds2.all_data()
     dd3 = ds3.all_data()
+    dd4 = ds4.all_data()
 
     assert ds1.fields.gas.magnetic_field_strength.units == "G"
     assert ds1.fields.gas.magnetic_field_poloidal.units == "G"
@@ -45,6 +49,9 @@ def test_magnetic_fields():
     assert ds3.fields.gas.magnetic_field_strength.units == "code_magnetic"
     assert ds3.fields.gas.magnetic_field_poloidal.units == "code_magnetic"
     assert ds3.fields.gas.magnetic_field_toroidal.units == "code_magnetic"
+    assert ds4.fields.gas.magnetic_field_strength.units == "code_magnetic"
+    assert ds4.fields.gas.magnetic_field_poloidal.units == "code_magnetic"
+    assert ds4.fields.gas.magnetic_field_toroidal.units == "code_magnetic"
 
     emag1 = (
         dd1[("gas", "magnetic_field_x")] ** 2
@@ -64,16 +71,26 @@ def test_magnetic_fields():
         dd3[("gas", "magnetic_field_x")] ** 2
         + dd3[("gas", "magnetic_field_y")] ** 2
         + dd3[("gas", "magnetic_field_z")] ** 2
-    ) / (2.0 * mu_0)
+    ) / (8.0 * np.pi)
     emag3.convert_to_units("code_pressure")
+
+    emag4 = (
+        dd4[("gas", "magnetic_field_x")] ** 2
+        + dd4[("gas", "magnetic_field_y")] ** 2
+        + dd4[("gas", "magnetic_field_z")] ** 2
+    ) / (2.0 * mu_0)
+    emag4.convert_to_units("code_pressure")
 
     assert_almost_equal(emag1, dd1[("gas", "magnetic_energy_density")])
     assert_almost_equal(emag2, dd2[("gas", "magnetic_energy_density")])
     assert_almost_equal(emag3, dd3[("gas", "magnetic_energy_density")])
+    assert_almost_equal(emag4, dd4[("gas", "magnetic_energy_density")])
 
     assert str(emag1.units) == str(dd1[("gas", "magnetic_energy_density")].units)
     assert str(emag2.units) == str(dd2[("gas", "magnetic_energy_density")].units)
     assert str(emag3.units) == str(dd3[("gas", "magnetic_energy_density")].units)
+    assert str(emag4.units) == str(dd4[("gas", "magnetic_energy_density")].units)
 
     assert_almost_equal(emag1.in_cgs(), emag2.in_cgs())
     assert_almost_equal(emag1.in_cgs(), emag3.in_cgs())
+    assert_almost_equal(emag1.in_cgs(), emag4.in_cgs())

--- a/yt/fields/tests/test_magnetic_fields.py
+++ b/yt/fields/tests/test_magnetic_fields.py
@@ -23,6 +23,7 @@ def test_magnetic_fields():
     for field in data1:
         data2[field] = (data1[field][0] * 1.0e4, "gauss")
 
+    ds0 = load_uniform_grid(data1, ddims, unit_system="cgs")
     ds1 = load_uniform_grid(data1, ddims, magnetic_unit=(1.0, "T"), unit_system="cgs")
     ds2 = load_uniform_grid(data2, ddims, unit_system="mks")
     # For this test dataset, code units are cgs units
@@ -30,16 +31,19 @@ def test_magnetic_fields():
     # For this test dataset, code units are SI units
     ds4 = load_uniform_grid(data1, ddims, magnetic_unit=(1.0, "T"), unit_system="code")
 
+    ds0.index
     ds1.index
     ds2.index
     ds3.index
     ds4.index
 
+    dd0 = ds0.all_data()
     dd1 = ds1.all_data()
     dd2 = ds2.all_data()
     dd3 = ds3.all_data()
     dd4 = ds4.all_data()
 
+    assert ds0.fields.gas.magnetic_field_strength.units == "G"
     assert ds1.fields.gas.magnetic_field_strength.units == "G"
     assert ds1.fields.gas.magnetic_field_poloidal.units == "G"
     assert ds1.fields.gas.magnetic_field_toroidal.units == "G"
@@ -52,6 +56,13 @@ def test_magnetic_fields():
     assert ds4.fields.gas.magnetic_field_strength.units == "code_magnetic"
     assert ds4.fields.gas.magnetic_field_poloidal.units == "code_magnetic"
     assert ds4.fields.gas.magnetic_field_toroidal.units == "code_magnetic"
+
+    emag0 = (
+        dd0[("gas", "magnetic_field_x")] ** 2
+        + dd0[("gas", "magnetic_field_y")] ** 2
+        + dd0[("gas", "magnetic_field_z")] ** 2
+    ) / (8.0 * np.pi)
+    emag0.convert_to_units("dyne/cm**2")
 
     emag1 = (
         dd1[("gas", "magnetic_field_x")] ** 2
@@ -81,16 +92,22 @@ def test_magnetic_fields():
     ) / (2.0 * mu_0)
     emag4.convert_to_units("code_pressure")
 
+    # note that "magnetic_energy_density" and "magnetic_pressure" are aliased
+
+    assert_almost_equal(emag0, dd0[("gas", "magnetic_energy_density")])
     assert_almost_equal(emag1, dd1[("gas", "magnetic_energy_density")])
     assert_almost_equal(emag2, dd2[("gas", "magnetic_energy_density")])
     assert_almost_equal(emag3, dd3[("gas", "magnetic_energy_density")])
     assert_almost_equal(emag4, dd4[("gas", "magnetic_energy_density")])
 
+    assert str(emag0.units) == str(dd0[("gas", "magnetic_energy_density")].units)
     assert str(emag1.units) == str(dd1[("gas", "magnetic_energy_density")].units)
     assert str(emag2.units) == str(dd2[("gas", "magnetic_energy_density")].units)
     assert str(emag3.units) == str(dd3[("gas", "magnetic_energy_density")].units)
     assert str(emag4.units) == str(dd4[("gas", "magnetic_energy_density")].units)
 
+    assert_almost_equal(emag1.in_cgs(), emag0.in_cgs())
+    assert_almost_equal(emag2.in_cgs(), emag0.in_cgs())
     assert_almost_equal(emag1.in_cgs(), emag2.in_cgs())
     assert_almost_equal(emag1.in_cgs(), emag3.in_cgs())
     assert_almost_equal(emag1.in_cgs(), emag4.in_cgs())

--- a/yt/frontends/_skeleton/data_structures.py
+++ b/yt/frontends/_skeleton/data_structures.py
@@ -114,6 +114,10 @@ class SkeletonDataset(Dataset):
         # These can also be set:
         # self.velocity_unit = self.quan(1.0, "cm/s")
         # self.magnetic_unit = self.quan(1.0, "gauss")
+        #
+        # If your frontend uses SI EM units, set magnetic units like this
+        # instead:
+        # self.magnetic_unit = self.quan(1.0, "T")
 
         # this minimalistic implementation fills the requirements for
         # this frontend to run, change it to make it run _correctly_ !

--- a/yt/frontends/athena_pp/tests/test_outputs.py
+++ b/yt/frontends/athena_pp/tests/test_outputs.py
@@ -1,6 +1,7 @@
 from yt.frontends.athena_pp.api import AthenaPPDataset
 from yt.loaders import load
 from yt.testing import assert_equal, requires_file, units_override_check
+from yt.units import dimensions
 from yt.utilities.answer_testing.framework import (
     data_dir_load,
     requires_ds,
@@ -69,3 +70,10 @@ def test_units_override():
 @requires_file(AM06)
 def test_AthenaPPDataset():
     assert isinstance(data_dir_load(AM06), AthenaPPDataset)
+
+
+@requires_file(AM06)
+def test_magnetic_units():
+    ds = load(AM06, unit_system="code")
+    assert ds.magnetic_unit.units.dimensions == dimensions.magnetic_field_cgs
+    assert (ds.magnetic_unit**2).units.dimensions == dimensions.pressure

--- a/yt/frontends/athena_pp/tests/test_outputs.py
+++ b/yt/frontends/athena_pp/tests/test_outputs.py
@@ -1,20 +1,15 @@
-import numpy as np
-
 from yt.frontends.athena_pp.api import AthenaPPDataset
 from yt.loaders import load
-from yt.testing import (
-    assert_allclose,
-    assert_equal,
-    requires_file,
-    units_override_check,
-)
+from yt.testing import assert_equal, requires_file, units_override_check
 from yt.utilities.answer_testing.framework import (
-    GenericArrayTest,
     data_dir_load,
     requires_ds,
     small_patch_amr,
 )
 
+# Deactivating this problematic test until the dataset type can be
+# handled properly, see https://github.com/yt-project/yt/issues/3619
+"""
 _fields_disk = ("density", "velocity_r")
 
 disk = "KeplerianDisk/disk.out1.00000.athdf"
@@ -35,7 +30,7 @@ def test_disk():
             return dd[field]
 
         yield GenericArrayTest(ds, field_func, args=[field])
-
+"""
 
 _fields_AM06 = ("temperature", "density", "velocity_magnitude", "magnetic_field_x")
 

--- a/yt/frontends/boxlib/tests/test_outputs.py
+++ b/yt/frontends/boxlib/tests/test_outputs.py
@@ -8,7 +8,14 @@ from yt.frontends.boxlib.api import (
     OrionDataset,
     WarpXDataset,
 )
-from yt.testing import assert_equal, requires_file, units_override_check
+from yt.loaders import load
+from yt.testing import (
+    assert_allclose,
+    assert_equal,
+    disable_dataset_cache,
+    requires_file,
+    units_override_check,
+)
 from yt.utilities.answer_testing.framework import (
     GridValuesTest,
     data_dir_load,
@@ -315,9 +322,26 @@ def test_CastroDataset_2():
     assert isinstance(data_dir_load("castro_sod_x_plt00036"), CastroDataset)
 
 
-@requires_file(LyA)
+@requires_file(plasma)
 def test_WarpXDataset():
     assert isinstance(data_dir_load(plasma), WarpXDataset)
+
+
+@disable_dataset_cache
+@requires_file(plasma)
+def test_magnetic_units():
+    ds1 = load(plasma)
+    assert_allclose(ds1.magnetic_unit.value, 1.0)
+    assert str(ds1.magnetic_unit.units) == "T"
+    mag_unit1 = ds1.magnetic_unit.to("code_magnetic")
+    assert_allclose(mag_unit1.value, 1.0)
+    assert str(mag_unit1.units) == "code_magnetic"
+    ds2 = load(plasma, unit_system="cgs")
+    assert_allclose(ds2.magnetic_unit.value, 1.0e4)
+    assert str(ds2.magnetic_unit.units) == "G"
+    mag_unit2 = ds2.magnetic_unit.to("code_magnetic")
+    assert_allclose(mag_unit2.value, 1.0)
+    assert str(mag_unit2.units) == "code_magnetic"
 
 
 @requires_ds(laser)

--- a/yt/frontends/flash/tests/test_outputs.py
+++ b/yt/frontends/flash/tests/test_outputs.py
@@ -3,9 +3,12 @@ from collections import OrderedDict
 import numpy as np
 
 from yt.frontends.flash.api import FLASHDataset, FLASHParticleDataset
+from yt.loaders import load
 from yt.testing import (
     ParticleSelectionComparison,
+    assert_allclose,
     assert_equal,
+    disable_dataset_cache,
     requires_file,
     units_override_check,
 )
@@ -52,6 +55,23 @@ def test_FLASHDataset():
 @requires_file(sloshing)
 def test_units_override():
     units_override_check(sloshing)
+
+
+@disable_dataset_cache
+@requires_file(sloshing)
+def test_magnetic_units():
+    ds1 = load(sloshing)
+    assert_allclose(ds1.magnetic_unit.value, np.sqrt(4.0 * np.pi))
+    assert str(ds1.magnetic_unit.units) == "G"
+    mag_unit1 = ds1.magnetic_unit.to("code_magnetic")
+    assert_allclose(mag_unit1.value, 1.0)
+    assert str(mag_unit1.units) == "code_magnetic"
+    ds2 = load(sloshing, unit_system="mks")
+    assert_allclose(ds2.magnetic_unit.value, np.sqrt(4.0 * np.pi) * 1.0e-4)
+    assert str(ds2.magnetic_unit.units) == "T"
+    mag_unit2 = ds2.magnetic_unit.to("code_magnetic")
+    assert_allclose(mag_unit2.value, 1.0)
+    assert str(mag_unit2.units) == "code_magnetic"
 
 
 @requires_file(sloshing)

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -335,7 +335,12 @@ class StreamDataset(Dataset):
         cgs_units = ("cm", "g", "s", "cm/s", "gauss")
         for unit, attr, cgs_unit in zip(base_units, attrs, cgs_units):
             if isinstance(unit, str):
-                uq = self.quan(1.0, unit)
+                if unit == "code_magnetic":
+                    # If no magnetic unit was explicitly specified
+                    # we skip it now and take care of it at the bottom
+                    continue
+                else:
+                    uq = self.quan(1.0, unit)
             elif isinstance(unit, numeric_type):
                 uq = self.quan(unit, cgs_unit)
             elif isinstance(unit, YTQuantity):
@@ -345,6 +350,10 @@ class StreamDataset(Dataset):
             else:
                 raise RuntimeError(f"{attr} ({unit}) is invalid.")
             setattr(self, attr, uq)
+        if not hasattr(self, "magnetic_unit"):
+            self.magnetic_unit = np.sqrt(
+                4 * np.pi * self.mass_unit / (self.time_unit**2 * self.length_unit)
+            )
 
     @classmethod
     def _is_valid(cls, filename, *args, **kwargs):

--- a/yt/frontends/ytdata/data_structures.py
+++ b/yt/frontends/ytdata/data_structures.py
@@ -81,7 +81,9 @@ class SavedDataset(Dataset):
                 if cu not in self.unit_registry:
                     self.unit_registry.add(cu, 1.0, getattr(dimensions, dim))
             if "code_magnetic" not in self.unit_registry:
-                self.unit_registry.add("code_magnetic", 1.0, dimensions.magnetic_field)
+                self.unit_registry.add(
+                    "code_magnetic", 0.1**0.5, dimensions.magnetic_field_cgs
+                )
 
         # if saved, set unit system
         if "unit_system_name" in self.parameters:

--- a/yt/units/tests/test_magnetic_code_units.py
+++ b/yt/units/tests/test_magnetic_code_units.py
@@ -22,7 +22,6 @@ def test_magnetic_code_units():
     assert str(mucu.units) == "code_magnetic"
 
     ds2 = load_uniform_grid(data, ddims, magnetic_unit=(1.0, "T"), unit_system="cgs")
-
     assert_allclose(ds2.magnetic_unit.value, 10000.0)
     assert str(ds2.magnetic_unit.units) == "G"
 
@@ -47,5 +46,27 @@ def test_magnetic_code_units():
     assert str(ds4.magnetic_unit.units) == "T"
 
     mucu = ds4.magnetic_unit.to("code_magnetic")
+    assert_allclose(mucu.value, 1.0)
+    assert str(mucu.units) == "code_magnetic"
+
+    ds5 = load_uniform_grid(
+        data, ddims, magnetic_unit=(1.0, "uG"), unit_system="mks"
+    )
+
+    assert_allclose(ds5.magnetic_unit.value, 1.0e-10)
+    assert str(ds5.magnetic_unit.units) == "T"
+
+    mucu = ds5.magnetic_unit.to("code_magnetic")
+    assert_allclose(mucu.value, 1.0)
+    assert str(mucu.units) == "code_magnetic"
+
+    ds6 = load_uniform_grid(
+        data, ddims, magnetic_unit=(1.0, "nT"), unit_system="cgs"
+    )
+
+    assert_allclose(ds6.magnetic_unit.value, 1.0e-5)
+    assert str(ds6.magnetic_unit.units) == "G"
+
+    mucu = ds6.magnetic_unit.to("code_magnetic")
     assert_allclose(mucu.value, 1.0)
     assert str(mucu.units) == "code_magnetic"

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -399,20 +399,21 @@ class FITSImageData:
             else:
                 uq = None
 
-            if uq is not None and hasattr(self, "hubble_constant"):
-                # Don't store cosmology units
+            if uq is not None:
                 atoms = {str(a) for a in uq.units.expr.atoms()}
-                if str(uq.units).startswith("cm") or "h" in atoms or "a" in atoms:
+                if hasattr(self, "hubble_constant"):
+                    # Don't store cosmology units
+                    if str(uq.units).startswith("cm") or "h" in atoms or "a" in atoms:
+                        uq.convert_to_cgs()
+                if any(a.startswith("code") for a in atoms):
+                    # Don't store code units
+                    mylog.warning(
+                        "Cannot use code units of '%s' "
+                        "when creating a FITSImageData instance! "
+                        "Converting to a cgs equivalent.",
+                        uq.units,
+                    )
                     uq.convert_to_cgs()
-
-            if uq is not None and uq.units.is_code_unit:
-                mylog.warning(
-                    "Cannot use code units of '%s' "
-                    "when creating a FITSImageData instance! "
-                    "Converting to a cgs equivalent.",
-                    uq.units,
-                )
-                uq.convert_to_cgs()
 
             if attr == "length_unit" and uq.value != 1.0:
                 mylog.warning("Converting length units from %s to %s.", uq, uq.units)


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

(this is an attempt to do better than PR #3787)

Electromagnetic unit conversions in yt are complex. The reasons for this are:

* `unyt` uses MKSA as the base set of units, but `yt` assumes Gaussian CGS units by default
* MKSA has a fundamental unit for current, Ampere, which becomes a component unit of most electromagnetic units (e.g. Coulomb, Tesla, etc.)
* Gaussian CGS units do not have a fundamental unit of current, defining all electromagnetic quantities in terms of mass, length, and time units

This is described in more detail [here](https://ytep.readthedocs.io/en/master/YTEPs/YTEP-0028.html#special-handling-for-magnetic-fields). 

Some frontends assume Gaussian CGS EM units as the code units, and a few assume MKSA EM units for the code units. However, regardless of what one assumes, it ought to be straightforward and transparent to do something like this:

```python
ds = yt.load("some_dataset", unit_system="code")
```

and expect magnetic fields to have SI dimensions instead of Gaussian CGS dimensions if the underlying code units do. It turns out that this doesn't always work correctly, as seen in Issue #3471, which was originally posted about another problem but in fact led to the discovery of this issue. 

The problem is that we need something that comes even before unit detection from the dataset, to let yt know whether or not it should expect something with dimensions of SI current in it when creating the code unit system.  There is a chicken-and-egg problem where we have to set up a code unit system before we can detect units, but only when we detect units can we know whether we need an SI current unit, which is info you need to create the code unit system in the first place. It's quite awful.

This PR is an attempt to fix the logic that handles this situation, as well as the case where we have an SI code system but request a CGS system (and vice-versa), which is currently very brittle. This requires waiting on creating the `code_magnetic` unit until we can be sure about what kind of magnetic dimensions we will have in the dataset. Unlike the previous attempt (PR #3787), this does not require any new class attributes.

I've updated the documentation and the skeleton frontend to reflect how to ensure that SI/MKSA units are used for code units, and I've also updated the stream dataset documentation to show how to make sure this happens for in-memory datasets.

I also added some new tests and fixed some other ones. Finally, this does not fix Issue #3471--that will have to be addressed in a separate PR.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
