### PR TITLE
BUG: bring back support to group folder structure in RAMSES

### DIFF
--- a/nose_unit.cfg
+++ b/nose_unit.cfg
@@ -6,5 +6,5 @@ nologcapture=1
 verbosity=2
 where=yt
 with-timer=1
-ignore-files=(test_load_errors.py|test_load_sample.py|test_commons.py|test_ambiguous_fields.py|test_field_access_pytest.py|test_save.py|test_line_annotation_unit.py|test_eps_writer.py|test_registration.py|test_invalid_origin.py|test_outputs_pytest\.py|test_normal_plot_api\.py|test_load_archive\.py|test_stream_particles\.py)
+ignore-files=(test_load_errors.py|test_load_sample.py|test_commons.py|test_ambiguous_fields.py|test_field_access_pytest.py|test_save.py|test_line_annotation_unit.py|test_eps_writer.py|test_registration.py|test_invalid_origin.py|test_outputs_pytest\.py|test_normal_plot_api\.py|test_load_archive\.py|test_stream_particles\.py|test_file_sanitizer\.py)
 exclude-test=yt.frontends.gdf.tests.test_outputs.TestGDF

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -196,6 +196,7 @@ other_tests:
      - "--ignore-files=test_load_archive\\.py"
      - "--ignore-files=test_outputs_pytest\\.py"
      - "--ignore-files=test_normal_plot_api\\.py"
+     - "--ignore-file=test_file_sanitizer\\.py"
      - "--exclude-test=yt.frontends.gdf.tests.test_outputs.TestGDF"
      - "--exclude-test=yt.frontends.adaptahop.tests.test_outputs"
      - "--exclude-test=yt.frontends.stream.tests.test_stream_particles.test_stream_non_cartesian_particles"

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -113,7 +113,7 @@ class RAMSESFileSanitizer:
         # Three cases for path
         # 1. path == output_XXXXX and group_00001 exists
         # 2. path == output_XXXXX and group_00001 does not exist
-        # 2. path == output_XXXXX/group_YYYYYY
+        # 3. path == output_XXXXX/group_YYYYYY
         iout_match = OUTPUT_DIR_RE.match(path.name)
         if iout_match:
             group_dir = path / "group_00001"

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -110,19 +110,25 @@ class RAMSESFileSanitizer:
         path: Path,
     ) -> Tuple[Path, Optional[Path], Optional[str]]:
 
-        # Three cases for path
-        # 1. path == output_XXXXX and group_00001 exists
-        # 2. path == output_XXXXX and group_00001 does not exist
-        # 3. path == output_XXXXX/group_YYYYYY
-        iout_match = OUTPUT_DIR_RE.match(path.name)
-        if iout_match:
-            group_dir = path / "group_00001"
+        # Make sure we work with a directory of the form `output_XXXXX`
+        for p in (path, path.parent):
+            match = OUTPUT_DIR_RE.match(p.name)
 
-            return path, group_dir if group_dir.is_dir() else None, iout_match.group(1)
+            if match:
+                path = p
+                break
+
+        if match is None:
+            return path, None, None
+
+        iout = match.group(1)
+
+        # See whether a folder named `group_YYYYY` exists
+        group_dir = path / "group_00001"
+        if group_dir.is_dir():
+            return path, group_dir, iout
         else:
-            iout_match = OUTPUT_DIR_RE.match(path.parent.name)
-
-            return path.parent, path, iout_match.group(1) if iout_match else None
+            return path, None, iout
 
     @classmethod
     def test_with_folder_name(

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -75,10 +75,10 @@ class RAMSESFileSanitizer:
         filename: str = os.path.expanduser(self.original_filename)
 
         if not os.path.exists(filename):
-            raise FileNotFoundError(f"No such file or directory {filename!r}")
+            raise FileNotFoundError(rf"No such file or directory '{filename!s}'")
         if self.root_folder is None:
             raise ValueError(
-                f"Could not determine output directory from {filename!r}\n"
+                f"Could not determine output directory from '{filename!s}'\n"
                 f"Expected a directory name of form {OUTPUT_DIR_EXP!r} "
                 "containing an info_*.txt file and amr_* files."
             )
@@ -87,7 +87,7 @@ class RAMSESFileSanitizer:
         # If/when this bug is fixed upstream, mypy will warn that the unused
         # 'type: ignore' comment can be removed
         if self.info_fname is None:  # type: ignore [unreachable]
-            raise ValueError(f"Failed to detect info file from {filename!r}")
+            raise ValueError(f"Failed to detect info file from '{filename!s}'")
 
     @property
     def is_valid(self) -> bool:

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -79,7 +79,8 @@ class RAMSESFileSanitizer:
         if self.root_folder is None:
             raise ValueError(
                 f"Could not determine output directory from {filename!r}\n"
-                f"Expected a directory name of form {OUTPUT_DIR_EXP!r}"
+                f"Expected a directory name of form {OUTPUT_DIR_EXP!r} "
+                "containing an info_*.txt file and amr_* files."
             )
 
         # This last case is (erroneously ?) marked as unreachable by mypy

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -140,8 +140,9 @@ class RAMSESFileSanitizer:
         info_fname: Optional[Path]
 
         if ok:
-            ok &= cls.check_standard_files(group_dir or output_dir, iout)
-            info_fname = (group_dir or output_dir) / f"info_{iout}.txt"
+            parent_dir = group_dir or output_dir
+            ok &= cls.check_standard_files(parent_dir, iout)
+            info_fname = parent_dir / f"info_{iout}.txt"
         else:
             info_fname = None
 
@@ -161,8 +162,9 @@ class RAMSESFileSanitizer:
         info_fname: Optional[Path]
 
         if ok:
-            ok &= cls.check_standard_files(group_dir or output_dir, iout)
-            info_fname = (group_dir or output_dir) / f"info_{iout}.txt"
+            parent_dir = group_dir or output_dir
+            ok &= cls.check_standard_files(parent_dir, iout)
+            info_fname = parent_dir / f"info_{iout}.txt"
         else:
             info_fname = None
 

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -112,6 +112,10 @@ class RAMSESFileSanitizer:
     @classmethod
     def test_with_folder_name(cls, output_dir):
         iout_match = OUTPUT_DIR_RE.match(output_dir.name)
+        # If we have structure like output_XXXXX/group_YYYYY/
+        # go up one level to find output number
+        if iout_match and iout_match.group(1) == "group":
+            iout_match = OUTPUT_DIR_RE.match(output_dir.parent.name)
         ok = output_dir.is_dir() and iout_match is not None
         if ok:
             iout = iout_match.group(2)

--- a/yt/frontends/ramses/definitions.py
+++ b/yt/frontends/ramses/definitions.py
@@ -53,7 +53,7 @@ VERSION_RE = re.compile(r"# version: *(\d+)")
 # on the left hand side
 VAR_DESC_RE = re.compile(r"\s*([^\s]+),\s*([^\s]+),\s*([^\s]+)")
 
-OUTPUT_DIR_EXP = r"(output|group)_(\d{5})"
+OUTPUT_DIR_EXP = r"output_(\d{5})"
 OUTPUT_DIR_RE = re.compile(OUTPUT_DIR_EXP)
 STANDARD_FILE_RE = re.compile(r"((amr|hydro|part|grav)_\d{5}\.out\d{5}|info_\d{5}.txt)")
 

--- a/yt/frontends/ramses/tests/test_file_sanitizer.py
+++ b/yt/frontends/ramses/tests/test_file_sanitizer.py
@@ -80,7 +80,7 @@ def test_invalid_sanitizing(valid_path_tuples, invalid_path_tuples):
         if path.exists():
             expected_error = ValueError
             expected_error_message = (
-                f"Could not determine output directory from '{str(path)}'\n"
+                "Could not determine output directory from '.*'\n"
                 "Expected a directory name of form .* "
                 "containing an info_\\*.txt file and amr_\\* files."
             )
@@ -99,7 +99,7 @@ def test_invalid_sanitizing(valid_path_tuples, invalid_path_tuples):
         with pytest.raises(FileNotFoundError, match=expected_error_message):
             sanitizer.validate()
 
-    expected_error_message = "No such file or directory '/this/does/not/exist'"
-    sanitizer = RAMSESFileSanitizer("/this/does/not/exist")
+    expected_error_message = "No such file or directory '.*'"
+    sanitizer = RAMSESFileSanitizer(Path("this") / "does" / "not" / "exist")
     with pytest.raises(FileNotFoundError, match=expected_error_message):
         sanitizer.validate()

--- a/yt/frontends/ramses/tests/test_file_sanitizer.py
+++ b/yt/frontends/ramses/tests/test_file_sanitizer.py
@@ -1,0 +1,105 @@
+import tempfile
+from collections import namedtuple
+from itertools import chain
+from pathlib import Path
+
+import pytest
+
+from yt.frontends.ramses.data_structures import RAMSESFileSanitizer
+
+PathTuple = namedtuple(
+    "PathTuple", ("output_dir", "group_dir_name", "info_file", "paths_to_try")
+)
+
+
+def generate_paths(create):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_dir = Path(tmpdir) / "output_00123"
+        output_dir.mkdir()
+        amr_file = output_dir / "amr_00123.out00001"
+        if create:
+            amr_file.touch()
+        info_file = output_dir / "info_00123.txt"
+        if create:
+            info_file.touch()
+
+        # Test with regular structure
+        output_dir2 = Path(tmpdir) / "output_00124"
+        output_dir2.mkdir()
+
+        group_dir2 = output_dir2 / "group_00001"
+        group_dir2.mkdir()
+        info_file2 = group_dir2 / "info_00124.txt"
+        if create:
+            info_file2.touch()
+        amr_file2 = group_dir2 / "amr_00124.out00001"
+        if create:
+            amr_file2.touch()
+
+        yield (
+            PathTuple(
+                output_dir=output_dir,
+                group_dir_name=None,
+                info_file=info_file,
+                paths_to_try=(output_dir, info_file, amr_file),
+            ),
+            PathTuple(
+                output_dir=output_dir2,
+                group_dir_name=group_dir2.name,
+                info_file=info_file2,
+                paths_to_try=(output_dir2, info_file2, group_dir2, amr_file2),
+            ),
+        )
+
+
+@pytest.fixture
+def valid_path_tuples():
+    yield from generate_paths(create=True)
+
+
+@pytest.fixture
+def invalid_path_tuples():
+    yield from generate_paths(create=False)
+
+
+def test_valid_sanitizing(valid_path_tuples):
+    for answer in valid_path_tuples:
+        for path in answer.paths_to_try:
+            sanitizer = RAMSESFileSanitizer(path)
+            sanitizer.validate()
+
+            assert sanitizer.root_folder == answer.output_dir
+            assert sanitizer.group_name == answer.group_dir_name
+            assert sanitizer.info_fname == answer.info_file
+
+
+def test_invalid_sanitizing(valid_path_tuples, invalid_path_tuples):
+    for path in chain(*(pt.paths_to_try for pt in invalid_path_tuples)):
+        sanitizer = RAMSESFileSanitizer(path)
+
+        if path.exists():
+            expected_error = ValueError
+            expected_error_message = (
+                f"Could not determine output directory from '{str(path)}'\n"
+                "Expected a directory name of form .* "
+                "containing an info_\\*.txt file and amr_\\* files."
+            )
+        else:
+            expected_error = FileNotFoundError
+            expected_error_message = f"No such file or directory '{str(path)}'"
+
+        with pytest.raises(expected_error, match=expected_error_message):
+            sanitizer.validate()
+
+    for path in chain(*(pt.paths_to_try for pt in valid_path_tuples)):
+        expected_error_message = (
+            f"No such file or directory '{str(path)}/does_not_exist.txt'"
+        )
+        sanitizer = RAMSESFileSanitizer(path / "does_not_exist.txt")
+        with pytest.raises(FileNotFoundError, match=expected_error_message):
+            sanitizer.validate()
+
+    expected_error_message = "No such file or directory '/this/does/not/exist'"
+    sanitizer = RAMSESFileSanitizer("/this/does/not/exist")
+    with pytest.raises(FileNotFoundError, match=expected_error_message):
+        sanitizer.validate()

--- a/yt/frontends/ramses/tests/test_file_sanitizer.py
+++ b/yt/frontends/ramses/tests/test_file_sanitizer.py
@@ -1,3 +1,4 @@
+import re
 import tempfile
 from collections import namedtuple
 from itertools import chain
@@ -86,14 +87,16 @@ def test_invalid_sanitizing(valid_path_tuples, invalid_path_tuples):
             )
         else:
             expected_error = FileNotFoundError
-            expected_error_message = f"No such file or directory '{str(path)}'"
+            expected_error_message = re.escape(
+                f"No such file or directory '{str(path)}'"
+            )
 
         with pytest.raises(expected_error, match=expected_error_message):
             sanitizer.validate()
 
     for path in chain(*(pt.paths_to_try for pt in valid_path_tuples)):
-        expected_error_message = (
-            f"No such file or directory '{str(path)}/does_not_exist.txt'"
+        expected_error_message = re.escape(
+            f"No such file or directory '{str(path/'does_not_exist.txt')}'"
         )
         sanitizer = RAMSESFileSanitizer(path / "does_not_exist.txt")
         with pytest.raises(FileNotFoundError, match=expected_error_message):


### PR DESCRIPTION
## PR Summary

This brings back support to RAMSES folder structures like `output_XXXXX/group_YYYYY`. Fixes #3785.
In particular, the output number should be read off the `XXXXX` part, not the `YYYYY` part.

## PR Checklist

- [x] Adds a test for any bugs fixed. Adds tests for new features.

Note: I have tested the bugfix on a (massive) simulation with the following script. Unfortunately, we do not have any simulation dataset with the group structure on yt-data so testing would imply more work that I can reasonably put
```python
import yt

yt.mylog.setLevel(40)
eps = 0.0001
bbox = [[0.5-eps]*3, [0.5+eps]*3]

def test_me(path):
    print(f"Testing {path=}")
    ds = yt.load(path, bbox=bbox)
    ds.index

    assert len(ds.index.domains) > 0

    ds.r["density"]
    ds.r["DM", "particle_identity"]

test_me("/data84/obelisk/RHD/OUTPUT_DIR/output_00075")
test_me("/data84/obelisk/RHD/OUTPUT_DIR/output_00075/group_00001/")
test_me("/data84/obelisk/RHD/OUTPUT_DIR/output_00075/group_00001/info_00075.txt")
test_me("/data84/obelisk/RHD/OUTPUTS/output_00075/info_00075.txt")
test_me("/data84/obelisk/RHD/OUTPUTS/output_00075")
```