### PR TITLE
Allow for different normalizations of magnetic fields in CGS

### DIFF
--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -333,6 +333,23 @@ This means that the yt fields, e.g. ``("gas","density")``,
 ``("athena","density")``, ``("athena","velocity_x")``,
 ``("athena","cell_centered_B_x")``, will be in code units.
 
+The default normalization for various magnetic-related quantities such as
+magnetic pressure, Alfven speed, etc., as well as the conversion between
+magnetic code units and other units, is Gaussian/CGS, meaning that factors
+of :math:`4\pi` or :math:`\sqrt{4\pi}` will appear in these quantities, e.g.
+:math:`p_B = B^2/8\pi`. To use the Lorentz-Heaviside normalization instead,
+in which the factors of :math:`4\pi` are dropped (:math:`p_B = B^2/2), for
+example), set ``magnetic_normalization="lorentz_heaviside"`` in the call to
+``yt.load``:
+
+.. code-block:: python
+
+    ds = yt.load(
+        "id0/cluster_merger.0250.vtk",
+        units_override=units_override,
+        magnetic_normalization="lorentz_heaviside",
+    )
+
 Some 3D Athena outputs may have large grids (especially parallel datasets
 subsequently joined with the ``join_vtk`` script), and may benefit from being
 subdivided into "virtual grids". For this purpose, one can pass in the
@@ -429,6 +446,23 @@ This means that the yt fields, e.g. ``("gas","density")``,
 (or whatever unit system was specified), but the Athena fields, e.g.,
 ``("athena_pp","density")``, ``("athena_pp","vel1")``, ``("athena_pp","Bcc1")``,
 will be in code units.
+
+The default normalization for various magnetic-related quantities such as
+magnetic pressure, Alfven speed, etc., as well as the conversion between
+magnetic code units and other units, is Gaussian/CGS, meaning that factors
+of :math:`4\pi` or :math:`\sqrt{4\pi}` will appear in these quantities, e.g.
+:math:`p_B = B^2/8\pi`. To use the Lorentz-Heaviside normalization instead,
+in which the factors of :math:`4\pi` are dropped (:math:`p_B = B^2/2), for
+example), set ``magnetic_normalization="lorentz_heaviside"`` in the call to
+``yt.load``:
+
+.. code-block:: python
+
+    ds = yt.load(
+        "AM06/AM06.out1.00400.athdf",
+        units_override=units_override,
+        magnetic_normalization="lorentz_heaviside",
+    )
 
 Alternative values for the following simulation parameters may be specified
 using a ``parameters`` dict, accepting the following keys:

--- a/yt/fields/magnetic_field.py
+++ b/yt/fields/magnetic_field.py
@@ -24,7 +24,7 @@ def setup_magnetic_field_fields(registry, ftype="gas", slice_info=None):
 
     def mag_factors(dims):
         if dims == dimensions.magnetic_field_cgs:
-            return 4.0 * np.pi
+            return getattr(ds, "mag_factor", 4.0 * np.pi)
         elif dims == dimensions.magnetic_field_mks:
             return ds.units.physical_constants.mu_0
 

--- a/yt/fields/magnetic_field.py
+++ b/yt/fields/magnetic_field.py
@@ -10,6 +10,15 @@ from .field_plugin_registry import register_field_plugin
 cgs_normalizations = {"gaussian": 4.0 * np.pi, "lorentz_heaviside": 1.0}
 
 
+def get_magnetic_normalization(key: str) -> float:
+    if key not in cgs_normalizations:
+        raise ValueError(
+            "Unknown magnetic normalization convention. "
+            f"Got {key!r}, expected one of {tuple(cgs_normalizations)}"
+        )
+    return cgs_normalizations[key]
+
+
 @register_field_plugin
 def setup_magnetic_field_fields(registry, ftype="gas", slice_info=None):
     ds = registry.ds

--- a/yt/fields/magnetic_field.py
+++ b/yt/fields/magnetic_field.py
@@ -7,6 +7,8 @@ from yt.utilities.math_utils import get_sph_phi_component, get_sph_theta_compone
 
 from .field_plugin_registry import register_field_plugin
 
+cgs_normalizations = {"gaussian": 4.0 * np.pi, "lorentz_heaviside": 1.0}
+
 
 @register_field_plugin
 def setup_magnetic_field_fields(registry, ftype="gas", slice_info=None):
@@ -24,7 +26,7 @@ def setup_magnetic_field_fields(registry, ftype="gas", slice_info=None):
 
     def mag_factors(dims):
         if dims == dimensions.magnetic_field_cgs:
-            return getattr(ds, "mag_factor", 4.0 * np.pi)
+            return getattr(ds, "_magnetic_factor", 4.0 * np.pi)
         elif dims == dimensions.magnetic_field_mks:
             return ds.units.physical_constants.mu_0
 

--- a/yt/frontends/athena/data_structures.py
+++ b/yt/frontends/athena/data_structures.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from yt.data_objects.index_subobjects.grid_patch import AMRGridPatch
 from yt.data_objects.static_output import Dataset
-from yt.fields.magnetic_field import cgs_normalizations
+from yt.fields.magnetic_field import get_magnetic_normalization
 from yt.funcs import mylog, sglob
 from yt.geometry.geometry_handler import YTDataChunk
 from yt.geometry.grid_geometry_handler import GridIndex
@@ -488,7 +488,8 @@ class AthenaDataset(Dataset):
         self.specified_parameters = parameters.copy()
         if units_override is None:
             units_override = {}
-        self._magnetic_factor = cgs_normalizations[magnetic_normalization]
+        self._magnetic_factor = get_magnetic_normalization(magnetic_normalization)
+
         Dataset.__init__(
             self,
             filename,

--- a/yt/frontends/athena/data_structures.py
+++ b/yt/frontends/athena/data_structures.py
@@ -478,6 +478,7 @@ class AthenaDataset(Dataset):
         nprocs=1,
         unit_system="cgs",
         default_species_fields=None,
+        mag_factor="gaussian",
     ):
         self.fluid_types += ("athena",)
         self.nprocs = nprocs
@@ -486,6 +487,9 @@ class AthenaDataset(Dataset):
         self.specified_parameters = parameters.copy()
         if units_override is None:
             units_override = {}
+        self.mag_factor = {"gaussian": 4.0 * np.pi, "lorentz_heaviside": 1.0}[
+            mag_factor
+        ]
         Dataset.__init__(
             self,
             filename,
@@ -516,7 +520,7 @@ class AthenaDataset(Dataset):
             mylog.warning("Assuming 1.0 = 1.0 %s", cgs)
             setattr(self, f"{unit}_unit", self.quan(1.0, cgs))
         self.magnetic_unit = np.sqrt(
-            4 * np.pi * self.mass_unit / (self.time_unit**2 * self.length_unit)
+            self.mag_factor * self.mass_unit / (self.time_unit**2 * self.length_unit)
         )
         self.magnetic_unit.convert_to_units("gauss")
         self.velocity_unit = self.length_unit / self.time_unit

--- a/yt/frontends/athena/tests/test_outputs.py
+++ b/yt/frontends/athena/tests/test_outputs.py
@@ -131,7 +131,7 @@ def test_AthenaDataset():
 @requires_file(sloshing)
 @disable_dataset_cache
 def test_mag_factor():
-    ds1 = load(sloshing, units_override=uo_sloshing, mag_factor="gaussian")
+    ds1 = load(sloshing, units_override=uo_sloshing, magnetic_normalization="gaussian")
     assert ds1.magnetic_unit == np.sqrt(
         4.0 * np.pi * ds1.mass_unit / (ds1.time_unit**2 * ds1.length_unit)
     )
@@ -150,7 +150,9 @@ def test_mag_factor():
     pB1b.convert_to_units("dyn/cm**2")
     assert_allclose_units(pB1a, pB1b)
     assert_allclose_units(pB1a, sp1["magnetic_pressure"])
-    ds2 = load(sloshing, units_override=uo_sloshing, mag_factor="lorentz_heaviside")
+    ds2 = load(
+        sloshing, units_override=uo_sloshing, magnetic_normalization="lorentz_heaviside"
+    )
     assert ds2.magnetic_unit == np.sqrt(
         ds2.mass_unit / (ds2.time_unit**2 * ds2.length_unit)
     )

--- a/yt/frontends/athena/tests/test_outputs.py
+++ b/yt/frontends/athena/tests/test_outputs.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from yt.frontends.athena.api import AthenaDataset
 from yt.loaders import load
 from yt.testing import (
@@ -124,3 +126,47 @@ def test_nprocs():
 @requires_file(cloud)
 def test_AthenaDataset():
     assert isinstance(data_dir_load(cloud), AthenaDataset)
+
+
+@requires_file(sloshing)
+@disable_dataset_cache
+def test_mag_factor():
+    ds1 = load(sloshing, units_override=uo_sloshing, mag_factor="gaussian")
+    assert ds1.magnetic_unit == np.sqrt(
+        4.0 * np.pi * ds1.mass_unit / (ds1.time_unit**2 * ds1.length_unit)
+    )
+    sp1 = ds1.sphere("c", (100.0, "kpc"))
+    pB1a = (
+        sp1["athena", "cell_centered_B_x"] ** 2
+        + sp1["athena", "cell_centered_B_y"] ** 2
+        + sp1["athena", "cell_centered_B_z"] ** 2
+    ) / (8.0 * np.pi)
+    pB1b = (
+        sp1["gas", "magnetic_field_x"] ** 2
+        + sp1["gas", "magnetic_field_y"] ** 2
+        + sp1["gas", "magnetic_field_z"] ** 2
+    ) / (8.0 * np.pi)
+    pB1a.convert_to_units("dyn/cm**2")
+    pB1b.convert_to_units("dyn/cm**2")
+    assert_allclose_units(pB1a, pB1b)
+    assert_allclose_units(pB1a, sp1["magnetic_pressure"])
+    ds2 = load(sloshing, units_override=uo_sloshing, mag_factor="lorentz_heaviside")
+    assert ds2.magnetic_unit == np.sqrt(
+        ds2.mass_unit / (ds2.time_unit**2 * ds2.length_unit)
+    )
+    sp2 = ds2.sphere("c", (100.0, "kpc"))
+    pB2a = (
+        sp2["athena", "cell_centered_B_x"] ** 2
+        + sp2["athena", "cell_centered_B_y"] ** 2
+        + sp2["athena", "cell_centered_B_z"] ** 2
+    ) / 2.0
+    pB2b = (
+        sp2["gas", "magnetic_field_x"] ** 2
+        + sp2["gas", "magnetic_field_y"] ** 2
+        + sp2["gas", "magnetic_field_z"] ** 2
+    ) / 2.0
+    pB2a.convert_to_units("dyn/cm**2")
+    pB2b.convert_to_units("dyn/cm**2")
+    assert_allclose_units(pB2a, pB2b)
+    assert_allclose_units(pB2a, sp2["magnetic_pressure"])
+    assert_allclose_units(pB1a, pB2a)

--- a/yt/frontends/athena_pp/data_structures.py
+++ b/yt/frontends/athena_pp/data_structures.py
@@ -7,7 +7,7 @@ import numpy as np
 from yt.data_objects.index_subobjects.grid_patch import AMRGridPatch
 from yt.data_objects.index_subobjects.unstructured_mesh import SemiStructuredMesh
 from yt.data_objects.static_output import Dataset
-from yt.fields.magnetic_field import cgs_normalizations
+from yt.fields.magnetic_field import get_magnetic_normalization
 from yt.funcs import get_pbar, mylog
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.geometry.unstructured_mesh_handler import UnstructuredIndex
@@ -260,7 +260,7 @@ class AthenaPPDataset(Dataset):
         else:
             self._index_class = AthenaPPHierarchy
             self.logarithmic = False
-        self._magnetic_factor = cgs_normalizations[magnetic_normalization]
+        self._magnetic_factor = get_magnetic_normalization(magnetic_normalization)
         Dataset.__init__(
             self,
             filename,

--- a/yt/frontends/athena_pp/data_structures.py
+++ b/yt/frontends/athena_pp/data_structures.py
@@ -241,6 +241,7 @@ class AthenaPPDataset(Dataset):
         units_override=None,
         unit_system="code",
         default_species_fields=None,
+        mag_factor="gaussian",
     ):
         self.fluid_types += ("athena_pp",)
         if parameters is None:
@@ -258,6 +259,9 @@ class AthenaPPDataset(Dataset):
         else:
             self._index_class = AthenaPPHierarchy
             self.logarithmic = False
+        self.mag_factor = {"gaussian": 4.0 * np.pi, "lorentz_heaviside": 1.0}[
+            mag_factor
+        ]
         Dataset.__init__(
             self,
             filename,
@@ -290,7 +294,7 @@ class AthenaPPDataset(Dataset):
             setattr(self, f"{unit}_unit", self.quan(1.0, cgs))
 
         self.magnetic_unit = np.sqrt(
-            4 * np.pi * self.mass_unit / (self.time_unit**2 * self.length_unit)
+            self.mag_factor * self.mass_unit / (self.time_unit**2 * self.length_unit)
         )
         self.magnetic_unit.convert_to_units("gauss")
         self.velocity_unit = self.length_unit / self.time_unit

--- a/yt/frontends/athena_pp/data_structures.py
+++ b/yt/frontends/athena_pp/data_structures.py
@@ -7,6 +7,7 @@ import numpy as np
 from yt.data_objects.index_subobjects.grid_patch import AMRGridPatch
 from yt.data_objects.index_subobjects.unstructured_mesh import SemiStructuredMesh
 from yt.data_objects.static_output import Dataset
+from yt.fields.magnetic_field import cgs_normalizations
 from yt.funcs import get_pbar, mylog
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.geometry.unstructured_mesh_handler import UnstructuredIndex
@@ -241,7 +242,7 @@ class AthenaPPDataset(Dataset):
         units_override=None,
         unit_system="code",
         default_species_fields=None,
-        mag_factor="gaussian",
+        magnetic_normalization="gaussian",
     ):
         self.fluid_types += ("athena_pp",)
         if parameters is None:
@@ -259,9 +260,7 @@ class AthenaPPDataset(Dataset):
         else:
             self._index_class = AthenaPPHierarchy
             self.logarithmic = False
-        self.mag_factor = {"gaussian": 4.0 * np.pi, "lorentz_heaviside": 1.0}[
-            mag_factor
-        ]
+        self._magnetic_factor = cgs_normalizations[magnetic_normalization]
         Dataset.__init__(
             self,
             filename,
@@ -294,7 +293,9 @@ class AthenaPPDataset(Dataset):
             setattr(self, f"{unit}_unit", self.quan(1.0, cgs))
 
         self.magnetic_unit = np.sqrt(
-            self.mag_factor * self.mass_unit / (self.time_unit**2 * self.length_unit)
+            self._magnetic_factor
+            * self.mass_unit
+            / (self.time_unit**2 * self.length_unit)
         )
         self.magnetic_unit.convert_to_units("gauss")
         self.velocity_unit = self.length_unit / self.time_unit

--- a/yt/frontends/athena_pp/tests/test_outputs.py
+++ b/yt/frontends/athena_pp/tests/test_outputs.py
@@ -90,7 +90,7 @@ def test_magnetic_units():
 @requires_file(AM06)
 @disable_dataset_cache
 def test_mag_factor():
-    ds1 = load(AM06, units_override=uo_AM06, mag_factor="gaussian")
+    ds1 = load(AM06, units_override=uo_AM06, magnetic_normalization="gaussian")
     assert ds1.magnetic_unit == np.sqrt(
         4.0 * np.pi * ds1.mass_unit / (ds1.time_unit**2 * ds1.length_unit)
     )
@@ -109,7 +109,7 @@ def test_mag_factor():
     pB1b.convert_to_units("dyn/cm**2")
     assert_allclose_units(pB1a, pB1b)
     assert_allclose_units(pB1a, sp1["magnetic_pressure"])
-    ds2 = load(AM06, units_override=uo_AM06, mag_factor="lorentz_heaviside")
+    ds2 = load(AM06, units_override=uo_AM06, magnetic_normalization="lorentz_heaviside")
     assert ds2.magnetic_unit == np.sqrt(
         ds2.mass_unit / (ds2.time_unit**2 * ds2.length_unit)
     )


### PR DESCRIPTION
## PR Summary

We've been having lots of fun with EM units, so let's have some more!

The relationship between the magnetic field strength and other related quantities, such as magnetic pressure and Alfvén speed, depends on what units are chosen for the magnetic field. For example, the magnetic pressure in CGS is:

![image](https://user-images.githubusercontent.com/1914976/154101299-24272530-53c1-41f9-b715-e308e8176cae.png)

but in SI/MKSA units it is:

![image](https://user-images.githubusercontent.com/1914976/154101514-603e39d6-6a24-444b-a9ee-98bf7e01ec8f.png)

We already take care of both of these cases in yt. However, the CGS convention above is known as the "Gaussian" convention, whereas in many MHD simulations and in some physics areas (such as particle physics/GR) it is more common to use the "Lorentz-Heaviside" convention, which is:

![image](https://user-images.githubusercontent.com/1914976/154101913-ab3c1892-cb95-4264-9217-c3185cc844ea.png)

This was requested in issue #3471 for Athena datasets. This PR addresses that issue by allowing Athena/Athena++ datasets to set the factor for magnetic units in CGS, and then this needs only to be utilized by those fields that need the correct factor to derive other quantities like those mentioned above. In theory this could be implemented for other frontends, but I don't see a pressing need to do so at this time. 

Docs forthcoming. I see this as a feature enhancement, so it should wait until 4.1. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
