### PR TITLE
Add three new derived fields to the AREPO frontend

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -15,10 +15,11 @@ answer_tests:
     - yt/frontends/amrvac/tests/test_outputs.py:test_riemann_cartesian_175D
     - yt/frontends/amrvac/tests/test_outputs.py:test_rmi_cartesian_dust_2D
 
-  local_arepo_008:  # PR 2909
+  local_arepo_009:  # PR 3815
     - yt/frontends/arepo/tests/test_outputs.py:test_arepo_bullet
     - yt/frontends/arepo/tests/test_outputs.py:test_arepo_tng59
     - yt/frontends/arepo/tests/test_outputs.py:test_index_override
+    - yt/frontends/arepo/tests/test_outputs.py:test_arepo_cr
 
   local_artio_004:
     - yt/frontends/artio/tests/test_outputs.py:test_sizmbhloz

--- a/yt/frontends/arepo/data_structures.py
+++ b/yt/frontends/arepo/data_structures.py
@@ -41,6 +41,7 @@ class ArepoHDF5Dataset(GadgetHDF5Dataset):
         # to that of the Voronoi cell to create smoothing lengths.
         self.smoothing_factor = smoothing_factor
         self.gamma = 5.0 / 3.0
+        self.gamma_cr = self.parameters.get("GammaCR", 4.0 / 3.0)
 
     @classmethod
     def _is_valid(cls, filename, *args, **kwargs):

--- a/yt/frontends/arepo/fields.py
+++ b/yt/frontends/arepo/fields.py
@@ -150,7 +150,7 @@ class ArepoFieldInfo(GadgetFieldInfo):
             )
 
             def _cr_pressure(field, data):
-                return data["gas", "cr_energy_density"] / 3.0
+                return (data.ds.gamma_cr - 1.0) * data["gas", "cr_energy_density"]
 
             self.add_field(
                 ("gas", "cr_pressure"),

--- a/yt/frontends/arepo/fields.py
+++ b/yt/frontends/arepo/fields.py
@@ -148,3 +148,13 @@ class ArepoFieldInfo(GadgetFieldInfo):
                 sampling_type="local",
                 units=self.ds.unit_system["pressure"],
             )
+
+            def _cr_pressure(field, data):
+                return data["gas", "cr_energy_density"] / 3.0
+
+            self.add_field(
+                ("gas", "cr_pressure"),
+                _cr_pressure,
+                sampling_type="local",
+                units=self.ds.unit_system["pressure"],
+            )

--- a/yt/frontends/arepo/fields.py
+++ b/yt/frontends/arepo/fields.py
@@ -45,6 +45,18 @@ class ArepoFieldInfo(GadgetFieldInfo):
     def setup_gas_particle_fields(self, ptype):
         super().setup_gas_particle_fields(ptype)
 
+        # Since the AREPO gas "particles" are Voronoi cells, we can
+        # define a volume here
+        def _volume(field, data):
+            return data[ptype, "mass"] / data[ptype, "density"]
+
+        self.add_field(
+            (ptype, "cell_volume"),
+            function=_volume,
+            sampling_type="particle",
+            units=self.ds.unit_system["volume"],
+        )
+
         if (ptype, "InternalEnergy") in self.field_list:
 
             def _pressure(field, data):
@@ -60,6 +72,8 @@ class ArepoFieldInfo(GadgetFieldInfo):
                 sampling_type="particle",
                 units=self.ds.unit_system["pressure"],
             )
+
+            self.alias((ptype, "pressure"), ("gas", "pressure"))
 
         if (ptype, "GFM_Metals_00") in self.field_list:
             self.nuclei_names = metal_elements

--- a/yt/frontends/arepo/fields.py
+++ b/yt/frontends/arepo/fields.py
@@ -53,7 +53,7 @@ class ArepoFieldInfo(GadgetFieldInfo):
         self.add_field(
             (ptype, "cell_volume"),
             function=_volume,
-            sampling_type="particle",
+            sampling_type="local",
             units=self.ds.unit_system["volume"],
         )
 

--- a/yt/frontends/arepo/fields.py
+++ b/yt/frontends/arepo/fields.py
@@ -31,7 +31,7 @@ class ArepoFieldInfo(GadgetFieldInfo):
             ("GFM_Metals_08", ("", ["Fe_fraction"], None)),
             (
                 "CosmicRaySpecificEnergy",
-                ("code_specific_energy", ["specific_cr_energy"], None),
+                ("code_specific_energy", ["specific_cosmic_ray_energy"], None),
             ),
         )
         super().__init__(ds, field_list, slice_info=slice_info)
@@ -139,21 +139,41 @@ class ArepoFieldInfo(GadgetFieldInfo):
 
         if (ptype, "CosmicRaySpecificEnergy") in self.field_list:
 
+            self.alias(
+                (ptype, "specific_cosmic_ray_energy"),
+                ("gas", "specific_cosmic_ray_energy"),
+            )
+
             def _cr_energy_density(field, data):
-                return data["PartType0", "specific_cr_energy"] * data["gas", "density"]
+                return (
+                    data["PartType0", "specific_cosmic_ray_energy"]
+                    * data["gas", "density"]
+                )
 
             self.add_field(
-                ("gas", "cr_energy_density"),
+                ("gas", "cosmic_ray_energy_density"),
                 _cr_energy_density,
                 sampling_type="local",
                 units=self.ds.unit_system["pressure"],
+            )
+
+            self.alias(
+                ("PartType0", "specific_cr_energy"),
+                ("PartType0", "specific_cosmic_ray_energy"),
+                deprecate=("4.1.0", "4.2.0"),
+            )
+
+            self.alias(
+                ("gas", "cr_energy_density"),
+                ("gas", "cosmic_ray_energy_density"),
+                deprecate=("4.1.0", "4.2.0"),
             )
 
             def _cr_pressure(field, data):
                 return (data.ds.gamma_cr - 1.0) * data["gas", "cr_energy_density"]
 
             self.add_field(
-                ("gas", "cr_pressure"),
+                ("gas", "cosmic_ray_pressure"),
                 _cr_pressure,
                 sampling_type="local",
                 units=self.ds.unit_system["pressure"],

--- a/yt/frontends/arepo/tests/test_outputs.py
+++ b/yt/frontends/arepo/tests/test_outputs.py
@@ -9,6 +9,7 @@ from yt.utilities.answer_testing.framework import data_dir_load, requires_ds, sp
 bullet_h5 = "ArepoBullet/snapshot_150.hdf5"
 tng59_h5 = "TNGHalo/halo_59.hdf5"
 _tng59_bbox = [[45135.0, 51343.0], [51844.0, 56184.0], [60555.0, 63451.0]]
+cr_h5 = "ArepoCosmicRays/snapshot_039.hdf5"
 
 
 @requires_file(bullet_h5)
@@ -80,3 +81,21 @@ def test_arepo_tng59_selection():
     ds = data_dir_load(tng59_h5, kwargs={"bounding_box": _tng59_bbox})
     psc = ParticleSelectionComparison(ds)
     psc.run_defaults()
+
+
+cr_fields = OrderedDict(
+    [
+        (("gas", "density"), None),
+        (("gas", "cosmic_ray_energy_density"), None),
+        (("gas", "cosmic_ray_pressure"), None),
+    ]
+)
+
+
+@requires_ds(cr_h5)
+def test_arepo_cr():
+    ds = data_dir_load(cr_h5)
+    assert ds.gamma_cr == ds.parameters["GammaCR"]
+    for test in sph_answer(ds, "snapshot_039", 28313510, cr_fields):
+        test_arepo_cr.__name__ = test.description
+        yield test

--- a/yt/sample_data_registry.json
+++ b/yt/sample_data_registry.json
@@ -29,6 +29,12 @@
     "load_name": "snapshot_150.hdf5",
     "url": "https://yt-project.org/data/ArepoBullet.tar.gz"
   },
+  "ArepoCosmicRays.tar.gz": {
+    "hash": "e664ea7f634fff778511e9ae7b2e375ba9c5099e427f7c037d48bba9944388f4",
+    "load_kwargs": {},
+    "load_name": "snapshot_039.hdf5",
+    "url": "https://yt-project.org/data/ArepoCosmicRays.tar.gz"
+  },
   "BigEndianGadgetBinary.tar.gz": {
     "hash": "0ab8d69b7c0c1a74282c567823916cc947f9ead7ab54b749a38a17c158b371c9",
     "load_kwargs": {},


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

* Alias the `("PartType0","pressure")` field to `("gas","pressure")` (not sure why this wasn't already one
* Create a `"cell_volume"` field
* Create a `"cosmic_ray_pressure"` field
* Rename `"cr_energy_density"` and `"specific_cr_energy"` to `"cosmic_ray_energy_density"` and `"specific_cosmic_ray_energy"`

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
