### PR TITLE
BUG: fix plot bounds for slices in cylindrical coordinates

### DIFF
--- a/yt/geometry/coordinates/cylindrical_coordinates.py
+++ b/yt/geometry/coordinates/cylindrical_coordinates.py
@@ -167,7 +167,7 @@ class CylindricalCoordinateHandler(CoordinateHandler):
         # non-Cartesian coordinates, we usually want to override these for
         # Cartesian coordinates, since we transform them.
         rv = {
-            self.axis_id["r"]: ("theta", "z"),
+            self.axis_id["r"]: ("\\theta", "z"),
             self.axis_id["z"]: ("x", "y"),
             self.axis_id["theta"]: ("r", "z"),
         }

--- a/yt/geometry/coordinates/cylindrical_coordinates.py
+++ b/yt/geometry/coordinates/cylindrical_coordinates.py
@@ -1,10 +1,18 @@
+import sys
+
 import numpy as np
 
 from yt.utilities.lib.pixelization_routines import pixelize_cartesian, pixelize_cylinder
 
+if sys.version_info >= (3, 8):
+    from functools import cached_property
+else:
+    from yt._maintenance.backports import cached_property
+
 from .coordinate_handler import (
     CoordinateHandler,
     _get_coord_fields,
+    _get_polar_bounds,
     _setup_dummy_cartesian_coords_and_widths,
     _setup_polar_coordinates,
     cartesian_to_cylindrical,
@@ -94,6 +102,13 @@ class CylindricalCoordinateHandler(CoordinateHandler):
                 data_source, field, bounds, size, antialias, dimension, periodic
             )
         elif ax_name == "z":
+            # This is admittedly a very hacky way to resolve a bug
+            # it's very likely that the *right* fix would have to
+            # be applied upstream of this function, *but* this case
+            # has never worked properly so maybe it's still preferable to
+            # not having a solution ?
+            # see https://github.com/yt-project/yt/pull/3533
+            bounds = (*bounds[2:4], *bounds[:2])
             return self._cyl_pixelize(data_source, field, bounds, size, antialias)
         else:
             # Pixelizing along a cylindrical surface is a bit tricky
@@ -184,6 +199,10 @@ class CylindricalCoordinateHandler(CoordinateHandler):
     def period(self):
         return np.array([0.0, 0.0, 2.0 * np.pi])
 
+    @cached_property
+    def _polar_bounds(self):
+        return _get_polar_bounds(self, axes=("r", "theta"))
+
     def sanitize_center(self, center, axis):
         center, display_center = super().sanitize_center(center, axis)
         display_center = [
@@ -202,6 +221,11 @@ class CylindricalCoordinateHandler(CoordinateHandler):
             # use existing center value
             for idx in (r_ax, z_ax):
                 display_center[idx] = center[idx]
+        elif ax_name == "z":
+            xxmin, xxmax, yymin, yymax = self._polar_bounds
+            xc = (xxmin + xxmax) / 2
+            yc = (yymin + yymax) / 2
+            display_center = (xc, yc, 0 * xc)
         return center, display_center
 
     def sanitize_width(self, axis, width, depth):
@@ -214,12 +238,12 @@ class CylindricalCoordinateHandler(CoordinateHandler):
         # Note: regardless of axes, these are set up to give consistent plots
         # when plotted, which is not strictly a "right hand rule" for axes.
         elif name == "r":  # soup can label
-            width = [2.0 * np.pi * self.ds.domain_width.uq, self.ds.domain_width[z_ax]]
+            width = [self.ds.domain_width[theta_ax], self.ds.domain_width[z_ax]]
         elif name == "theta":
             width = [self.ds.domain_width[r_ax], self.ds.domain_width[z_ax]]
         elif name == "z":
-            width = [
-                2.0 * self.ds.domain_right_edge[r_ax],
-                2.0 * self.ds.domain_right_edge[r_ax],
-            ]
+            xxmin, xxmax, yymin, yymax = self._polar_bounds
+            xw = xxmax - xxmin
+            yw = yymax - yymin
+            width = [xw, yw]
         return width

--- a/yt/geometry/coordinates/spherical_coordinates.py
+++ b/yt/geometry/coordinates/spherical_coordinates.py
@@ -7,6 +7,7 @@ from yt.utilities.lib.pixelization_routines import pixelize_aitoff, pixelize_cyl
 from .coordinate_handler import (
     CoordinateHandler,
     _get_coord_fields,
+    _get_polar_bounds,
     _setup_dummy_cartesian_coords_and_widths,
     _setup_polar_coordinates,
 )
@@ -275,50 +276,7 @@ class SphericalCoordinateHandler(CoordinateHandler):
 
     @cached_property
     def _conic_bounds(self):
-        ri = self.axis_id["r"]
-        pi = self.axis_id["phi"]
-        rmin = self.ds.domain_left_edge[ri]
-        rmax = self.ds.domain_right_edge[ri]
-        phimin = self.ds.domain_left_edge[pi]
-        phimax = self.ds.domain_right_edge[pi]
-        corners = [
-            (rmin, phimin),
-            (rmin, phimax),
-            (rmax, phimin),
-            (rmax, phimax),
-        ]
-
-        def to_conic_plane(r, phi):
-            x = r * np.cos(phi)
-            y = r * np.sin(phi)
-            return x, y
-
-        conic_corner_coords = [to_conic_plane(*corner) for corner in corners]
-
-        phimin = phimin.d
-        phimax = phimax.d
-
-        if phimin <= np.pi <= phimax:
-            xxmin = -rmax
-        else:
-            xxmin = min(xx for xx, yy in conic_corner_coords)
-
-        if phimin <= 0 <= phimax:
-            xxmax = rmax
-        else:
-            xxmax = max(xx for xx, yy in conic_corner_coords)
-
-        if phimin <= 3 * np.pi / 2 <= phimax:
-            yymin = -rmax
-        else:
-            yymin = min(yy for xx, yy in conic_corner_coords)
-
-        if phimin <= np.pi / 2 <= phimax:
-            yymax = rmax
-        else:
-            yymax = max(yy for xx, yy in conic_corner_coords)
-
-        return xxmin, xxmax, yymin, yymax
+        return _get_polar_bounds(self, axes=("r", "phi"))
 
     @cached_property
     def _aitoff_bounds(self):

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1952,6 +1952,7 @@ class AxisAlignedSlicePlot(SlicePlot, PWViewerMPL):
             "cylindrical",
             "geographic",
             "internal_geographic",
+            "polar",
         ):
             mylog.info("Setting origin='native' for %s geometry.", ds.geometry)
             origin = "native"
@@ -2167,6 +2168,7 @@ class AxisAlignedProjectionPlot(ProjectionPlot, PWViewerMPL):
             "cylindrical",
             "geographic",
             "internal_geographic",
+            "polar",
         ):
             mylog.info("Setting origin='native' for %s geometry.", ds.geometry)
             origin = "native"


### PR DESCRIPTION
## PR Summary
Reutilizing some bits from #3533, fix #3819
Opening as a draft because there's a secondary problem to solve. Namely, axes ticks are incorrect (0, 0) should always be the origin, not the display center

```python
import numpy as np
import yt
from yt.testing import fake_amr_ds, add_noise_fields

shape = (32, 64, 128)
ds = yt.load_uniform_grid(
    {},
    shape,
    bbox=np.array([[1, 5], [0.1, np.pi / 2 - 0.1], [0, 1]]),
    geometry="polar",
)
add_noise_fields(ds)
p = yt.SlicePlot(ds, "z", "noise1")
p.save("/tmp/")
```
![UniformGridData_Slice_z_noise1](https://user-images.githubusercontent.com/14075922/154838672-b69f9330-a805-423a-8cb9-aebce8c94290.png)
