### PR TITLE
ENH: uniformize API for "center" argument for plot windows

### DIFF
--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -164,13 +164,17 @@ If supplied without units, the center is assumed by in code units.  There are al
 the following alternative options for the ``center`` keyword:
 
 * ``"center"``, ``"c"``: the domain center
+* ``"left"``, ``"l"``, ``"right"`` ``"r"``: the domain's left/right edge along the normal direction
+* ``"min"``: the position of the minimum density
 * ``"max"``, ``"m"``: the position of the maximum density
+* ``"min/max_<field name>"``: the position of the minimum/maximum in the first field matching field name
 * ``("min", field)``: the position of the minimum of ``field``
 * ``("max", field)``: the position of the maximum of ``field``
 
 where for the last two objects any spatial field, such as ``"density"``,
 ``"velocity_z"``,
 etc., may be used, e.g. ``center=("min", ("gas", "temperature"))``.
+``"left"`` and ``"right"`` are not allowed for off-axis slices.
 
 The effective resolution of the plot (i.e. the number of resolution elements
 in the image itself) can be controlled with the ``buff_size`` argument:

--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -165,6 +165,7 @@ the following alternative options for the ``center`` keyword:
 
 * ``"center"``, ``"c"``: the domain center
 * ``"left"``, ``"l"``, ``"right"`` ``"r"``: the domain's left/right edge along the normal direction
+  (``SlicePlot``'s second argument). Remaining axes use their respective domain center values.
 * ``"min"``: the position of the minimum density
 * ``"max"``, ``"m"``: the position of the maximum density
 * ``"min/max_<field name>"``: the position of the minimum/maximum in the first field matching field name

--- a/nose_unit.cfg
+++ b/nose_unit.cfg
@@ -6,5 +6,5 @@ nologcapture=1
 verbosity=2
 where=yt
 with-timer=1
-ignore-files=(test_load_errors.py|test_load_sample.py|test_commons.py|test_ambiguous_fields.py|test_field_access_pytest.py|test_save.py|test_line_annotation_unit.py|test_eps_writer.py|test_registration.py|test_invalid_origin.py|test_outputs_pytest\.py|test_normal_plot_api\.py|test_load_archive\.py|test_stream_particles\.py|test_file_sanitizer\.py|test_version\.py|\test_on_demand_imports\.py|test_set_zlim\.py|test_add_field\.py|test_glue\.py|test_geometries\.py|test_firefly\.py|test_callable_grids\.py|test_external_frontends\.py|test_stream_stretched\.py)
+ignore-files=(test_load_errors.py|test_load_sample.py|test_commons.py|test_ambiguous_fields.py|test_field_access_pytest.py|test_save.py|test_line_annotation_unit.py|test_eps_writer.py|test_registration.py|test_invalid_origin.py|test_outputs_pytest\.py|test_normal_plot_api\.py|test_load_archive\.py|test_stream_particles\.py|test_file_sanitizer\.py|test_version\.py|\test_on_demand_imports\.py|test_set_zlim\.py|test_add_field\.py|test_glue\.py|test_geometries\.py|test_firefly\.py|test_callable_grids\.py|test_external_frontends\.py|test_stream_stretched\.py|test_sanitize_center\.py)
 exclude-test=yt.frontends.gdf.tests.test_outputs.TestGDF

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -231,6 +231,7 @@ other_tests:
      - "--ignore-file=test_callable_grids\\.py"
      - "--ignore-file=test_external_frontends\\.py"
      - "--ignore-file=test_stream_stretched\\.py"
+     - "--ignore-files=test_sanitize_center\\.py"
      - "--exclude-test=yt.frontends.gdf.tests.test_outputs.TestGDF"
      - "--exclude-test=yt.frontends.adaptahop.tests.test_outputs"
      - "--exclude-test=yt.frontends.stream.tests.test_stream_particles.test_stream_non_cartesian_particles"

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -350,7 +350,7 @@ class YTProj(YTSelectionContainer2D):
                 self.ds.field_info.pop(field)
         self.tree = tree
 
-    def to_pw(self, fields=None, center="c", width=None, origin="center-window"):
+    def to_pw(self, fields=None, center="center", width=None, origin="center-window"):
         r"""Create a :class:`~yt.visualization.plot_window.PWViewerMPL` from this
         object.
 

--- a/yt/data_objects/selection_objects/slices.py
+++ b/yt/data_objects/selection_objects/slices.py
@@ -212,7 +212,7 @@ class YTCuttingPlane(YTSelectionContainer2D):
         validate_object(ds, Dataset)
         validate_object(field_parameters, dict)
         validate_object(data_source, YTSelectionContainer)
-        YTSelectionContainer2D.__init__(self, 4, ds, field_parameters, data_source)
+        YTSelectionContainer2D.__init__(self, None, ds, field_parameters, data_source)
         self._set_center(center)
         self.set_field_parameter("center", center)
         # Let's set up our plane equation

--- a/yt/data_objects/selection_objects/slices.py
+++ b/yt/data_objects/selection_objects/slices.py
@@ -104,7 +104,7 @@ class YTSlice(YTSelectionContainer2D):
     def _mrep(self):
         return MinimalSliceData(self)
 
-    def to_pw(self, fields=None, center="c", width=None, origin="center-window"):
+    def to_pw(self, fields=None, center="center", width=None, origin="center-window"):
         r"""Create a :class:`~yt.visualization.plot_window.PWViewerMPL` from this
         object.
 
@@ -275,7 +275,7 @@ class YTCuttingPlane(YTSelectionContainer2D):
         else:
             raise KeyError(field)
 
-    def to_pw(self, fields=None, center="c", width=None, axes_unit=None):
+    def to_pw(self, fields=None, center="center", width=None, axes_unit=None):
         r"""Create a :class:`~yt.visualization.plot_window.PWViewerMPL` from this
         object.
 

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -26,6 +26,7 @@ from typing import (
 )
 
 import numpy as np
+import unyt as un
 from more_itertools import unzip
 from sympy import Symbol
 from unyt import Unit, UnitSystem, unyt_quantity
@@ -2036,6 +2037,18 @@ class Dataset(abc.ABC):
             prefixable=prefixable,
             registry=self.unit_registry,
         )
+
+    def _is_within_domain(self, point) -> bool:
+        assert len(point) == len(self.domain_left_edge)
+        assert point.units.dimensions == un.dimensions.length
+        for i, x in enumerate(point):
+            if self.periodicity[i]:
+                continue
+            if x < self.domain_left_edge[i]:
+                return False
+            if x > self.domain_right_edge[i]:
+                return False
+        return True
 
 
 def _reconstruct_ds(*args, **kwargs):

--- a/yt/data_objects/tests/test_cutting_plane.py
+++ b/yt/data_objects/tests/test_cutting_plane.py
@@ -43,7 +43,7 @@ def test_cutting_plane():
                 fi = ds._get_field_info(cut_field)
                 data = frb[cut_field]
                 assert_equal(data.info["data_source"], cut.__str__())
-                assert_equal(data.info["axis"], 4)
+                assert_equal(data.info["axis"], None)
                 assert_equal(data.info["field"], str(cut_field))
                 assert_equal(data.units, Unit(fi.units))
                 assert_equal(data.info["xlim"], frb.bounds[:2])

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -1254,8 +1254,7 @@ def parse_center_array(center, ds, axis: Optional[int] = None):
                 else:
                     raise YTFieldNotFound(match["field"], ds)
             else:
-                # mypy erroneously marks this line as unreachable
-                ftype, fname = ("gas", "density")  # type: ignore [unreachable]
+                ftype, fname = ("gas", "density")
 
             center = (match["extremum"], (ftype, fname))
 

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -17,7 +17,7 @@ import urllib
 from collections import UserDict
 from functools import lru_cache, wraps
 from numbers import Number as numeric_type
-from typing import Any, Callable, Type
+from typing import Any, Callable, Optional, Type
 
 import numpy as np
 from more_itertools import always_iterable, collapse, first
@@ -26,7 +26,7 @@ from packaging.version import Version
 from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.config import ytcfg
 from yt.units import YTArray, YTQuantity
-from yt.utilities.exceptions import YTInvalidWidthError
+from yt.utilities.exceptions import YTFieldNotFound, YTInvalidWidthError
 from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.on_demand_imports import _requests as requests
 
@@ -1178,6 +1178,15 @@ def validate_field_key(key):
     )
 
 
+def is_valid_field_key(key):
+    try:
+        validate_field_key(key)
+    except TypeError:
+        return False
+    else:
+        return True
+
+
 def validate_object(obj, data_type):
     if obj is not None and not isinstance(obj, data_type):
         raise TypeError(
@@ -1217,6 +1226,119 @@ def validate_center(center):
             "list/tuple/np.ndarray/YTArray/YTQuantity, "
             "received '%s'." % str(type(center)).split("'")[1]
         )
+
+
+def parse_center_array(center, ds, axis: Optional[int] = None):
+    known_shortnames = {"m": "max", "c": "center", "l": "left", "r": "right"}
+    valid_single_str_values = ("center", "left", "right")
+    valid_field_loc_str_values = ("min", "max")
+    valid_str_values = valid_single_str_values + valid_field_loc_str_values
+    default_error_message = (
+        "Expected any of the following\n"
+        "- 'c', 'center', 'l', 'left', 'r', 'right', 'm', 'max', or 'min'\n"
+        "- 'min' or 'max', followed by a field identifier\n"
+        "- a 3 element unyt_array with length dimensions"
+    )
+
+    if isinstance(center, str):
+        centerl = center.lower()
+        if centerl in known_shortnames:
+            centerl = known_shortnames[centerl]
+
+        match = re.match(r"^(?P<extremum>(min|max))(_(?P<field>[\w_]+))?", centerl)
+        if match is not None:
+            if match["field"] is not None:
+                for ftype, fname in ds.derived_field_list:  # noqa: B007
+                    if fname == match["field"]:
+                        break
+                else:
+                    raise YTFieldNotFound(match["field"], ds)
+            else:
+                # mypy erroneously marks this line as unreachable
+                ftype, fname = ("gas", "density")  # type: ignore [unreachable]
+
+            center = (match["extremum"], (ftype, fname))
+
+        elif centerl in ("center", "left", "right"):
+            # domain_left_edge and domain_right_edge might not be
+            # initialized until we create the index, so create it
+            ds.index
+            center = ds.domain_center.copy()
+            if centerl in ("left", "right") and axis is None:
+                raise ValueError(f"center={center!r} is not valid with axis=None")
+            if centerl == "left":
+                center = ds.domain_center.copy()
+                center[axis] = ds.domain_left_edge[axis]
+            elif centerl == "right":
+                # note that the right edge of a grid is excluded by slice selector
+                # which is why we offset the region center by the smallest distance possible
+                center = ds.domain_center.copy()
+                center[axis] = (
+                    ds.domain_right_edge[axis] - center.uq * np.finfo(center.dtype).eps
+                )
+
+        elif centerl not in valid_str_values:
+            raise ValueError(
+                f"Received unknown center single string value {center!r}. "
+                + default_error_message
+            )
+
+    if is_sequence(center):
+        if (
+            len(center) == 2
+            and isinstance(center[0], str)
+            and (is_valid_field_key(center[1]) or isinstance(center[1], str))
+        ):
+            center0l = center[0].lower()
+
+            if center0l not in valid_str_values:
+                raise ValueError(
+                    f"Received unknown string value {center[0]!r}. "
+                    f"Expected one of {valid_field_loc_str_values} (case insensitive)"
+                )
+            field_key = center[1]
+            if center0l == "min":
+                v, center = ds.find_min(field_key)
+            else:
+                assert center0l == "max"
+                v, center = ds.find_max(field_key)
+            center = ds.arr(center, "code_length")
+        elif len(center) == 2 and is_sequence(center[0]) and isinstance(center[1], str):
+            center = ds.arr(center[0], center[1])
+        elif len(center) == 3 and all(isinstance(_, YTQuantity) for _ in center):
+            center = ds.arr([c.copy() for c in center], dtype="float64")
+        elif len(center) == 3:
+            center = ds.arr(center, "code_length")
+
+    if isinstance(center, np.ndarray) and center.ndim > 1:
+        mylog.debug("Removing singleton dimensions from 'center'.")
+        center = np.squeeze(center)
+
+    if not isinstance(center, YTArray):
+        raise TypeError(f"Invalid center value {center!r}. " + default_error_message)
+
+    if center.shape != (3,):
+        raise TypeError(f"Expected an array with size 3, got {center.size}. ")
+
+    # make sure the return value shares all
+    # unit symbols with ds.unit_registry
+    center = ds.arr(center)
+    # we rely on unyt to invalidate unit dimensionality here
+    center.convert_to_units("code_length")
+
+    if not ds._is_within_domain(center):
+        mylog.warning(
+            "Requested center at %s is outside of data domain with "
+            "left edge = %s, "
+            "right edge = %s, "
+            "periodicity = %s",
+            center,
+            ds.domain_left_edge,
+            ds.domain_right_edge,
+            ds.periodicity,
+        )
+
+    return center.astype("float64")
 
 
 def sglob(pattern):

--- a/yt/geometry/coordinates/cartesian_coordinates.py
+++ b/yt/geometry/coordinates/cartesian_coordinates.py
@@ -218,7 +218,7 @@ class CartesianCoordinateHandler(CoordinateHandler):
             # re-order the array and squeeze out the dummy dim
             return np.squeeze(np.transpose(img, (yax, xax, ax)))
 
-        elif self.axis_id.get(dimension, dimension) < 3:
+        elif self.axis_id.get(dimension, dimension) is not None:
             return self._ortho_pixelize(
                 data_source, field, bounds, size, antialias, dimension, periodic
             )

--- a/yt/geometry/coordinates/tests/test_sanitize_center.py
+++ b/yt/geometry/coordinates/tests/test_sanitize_center.py
@@ -1,0 +1,114 @@
+import re
+
+import pytest
+from unyt import unyt_array
+from unyt.exceptions import UnitConversionError
+
+from yt.testing import fake_amr_ds
+
+
+@pytest.fixture(scope="module")
+def reusable_fake_dataset():
+    ds = fake_amr_ds(
+        fields=[("gas", "density")],
+        units=["g/cm**3"],
+    )
+    return ds
+
+
+valid_single_str_values = ("center",)
+valid_field_loc_str_values = ("min", "max")
+
+DEFAUT_ERROR_MESSAGE = (
+    "Expected any of the following\n"
+    "- 'c', 'center', 'l', 'left', 'r', 'right', 'm', 'max', or 'min'\n"
+    "- 'min' or 'max', followed by a field identifier\n"
+    "- a 3 element unyt_array with length dimensions"
+)
+
+
+@pytest.mark.parametrize(
+    "user_input",
+    (
+        # second element can be a single str or a field tuple (2 str), but not three
+        (("max", ("not", "a", "field"))),
+        # a 1-tuple is also not a valid field key
+        (("max", ("notafield",))),
+        # both elements need to be str
+        (("max", (0, "invalid_field_type"))),
+        (("max", ("invalid_field_type", 1))),
+    ),
+)
+def test_invalid_center_type_default_error(reusable_fake_dataset, user_input):
+    ds = reusable_fake_dataset
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            f"Invalid center value {user_input!r}. " + DEFAUT_ERROR_MESSAGE
+        ),
+    ):
+        # at the time of writing `axis` is an unused parameter of the base
+        # sanitize center method, which is used directly for cartesian coordinate handlers
+        # this probably hints that a refactor would make sense to separaet center sanitizing
+        # and display_center calculation
+        ds.coordinates.sanitize_center(user_input, axis=None)
+
+
+@pytest.mark.parametrize(
+    "user_input, error_type, error_message",
+    (
+        (
+            "bad_str",
+            ValueError,
+            re.escape(
+                "Received unknown center single string value 'bad_str'. "
+                + DEFAUT_ERROR_MESSAGE
+            ),
+        ),
+        (
+            ("bad_str", ("gas", "density")),
+            ValueError,
+            re.escape(
+                "Received unknown string value 'bad_str'. "
+                f"Expected one of {valid_field_loc_str_values} (case insensitive)"
+            ),
+        ),
+        (
+            ("bad_str", "density"),
+            ValueError,
+            re.escape(
+                "Received unknown string value 'bad_str'. "
+                "Expected one of ('min', 'max') (case insensitive)"
+            ),
+        ),
+        # even with exactly three elements, the dimension should be length
+        (
+            unyt_array([0.5] * 3, "kg"),
+            UnitConversionError,
+            "...",  # don't match the exact error message since it's unyt's responsability
+        ),
+        # only validate 3 elements unyt_arrays
+        (
+            unyt_array([0.5] * 2, "cm"),
+            TypeError,
+            re.escape("Expected an array with size 3, got 2."),
+        ),
+        (
+            unyt_array([0.5] * 4, "cm"),
+            TypeError,
+            re.escape("Expected an array with size 3, got 4."),
+        ),
+        (
+            # check that the whole shape is used in validation, not just the length (number of rows)
+            unyt_array([0.5] * 6, "cm").reshape(3, 2),
+            TypeError,
+            re.escape("Expected an array with size 3, got 6."),
+        ),
+    ),
+)
+def test_invalid_center_special_cases(
+    reusable_fake_dataset, user_input, error_type, error_message
+):
+    ds = reusable_fake_dataset
+    with pytest.raises(error_type, match=error_message):
+        ds.coordinates.sanitize_center(user_input, axis=None)

--- a/yt/geometry/coordinates/tests/test_sanitize_center.py
+++ b/yt/geometry/coordinates/tests/test_sanitize_center.py
@@ -22,8 +22,8 @@ valid_field_loc_str_values = ("min", "max")
 DEFAUT_ERROR_MESSAGE = (
     "Expected any of the following\n"
     "- 'c', 'center', 'l', 'left', 'r', 'right', 'm', 'max', or 'min'\n"
-    "- 'min' or 'max', followed by a field identifier\n"
-    "- a 3 element unyt_array with length dimensions"
+    "- a 2 element tuple with 'min' or 'max' as the first element, followed by a field identifier\n"
+    "- a 3 element array-like: for a unyt_array, expects length dimensions, otherwise code_lenght is assumed"
 )
 
 

--- a/yt/geometry/coordinates/tests/test_sanitize_center.py
+++ b/yt/geometry/coordinates/tests/test_sanitize_center.py
@@ -43,9 +43,8 @@ def test_invalid_center_type_default_error(reusable_fake_dataset, user_input):
     ds = reusable_fake_dataset
     with pytest.raises(
         TypeError,
-        match=re.escape(
-            f"Invalid center value {user_input!r}. " + DEFAUT_ERROR_MESSAGE
-        ),
+        match=re.escape(f"Received {user_input!r}, ")
+        + r"but failed to transform to a unyt_array \(obtained .+\)\.",
     ):
         # at the time of writing `axis` is an unused parameter of the base
         # sanitize center method, which is used directly for cartesian coordinate handlers
@@ -91,18 +90,22 @@ def test_invalid_center_type_default_error(reusable_fake_dataset, user_input):
         (
             unyt_array([0.5] * 2, "cm"),
             TypeError,
-            re.escape("Expected an array with size 3, got 2."),
+            re.escape("Received unyt_array([0.5, 0.5], 'cm')"),
         ),
         (
             unyt_array([0.5] * 4, "cm"),
             TypeError,
-            re.escape("Expected an array with size 3, got 4."),
+            # don't attempt to match error message as details of how
+            # a unyt array with more than a couple elements is displayed are out of our control
+            "...",
         ),
         (
             # check that the whole shape is used in validation, not just the length (number of rows)
             unyt_array([0.5] * 6, "cm").reshape(3, 2),
             TypeError,
-            re.escape("Expected an array with size 3, got 6."),
+            # don't attempt to match error message as details of how
+            # a unyt array with more than a couple elements is displayed are out of our control
+            "...",
         ),
     ),
 )

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -58,7 +58,7 @@ class CallbackWrapper:
             if viewer._has_swapped_axes:
                 # store the original un-transposed shape
                 self.raw_image_shape = self.raw_image_shape[1], self.raw_image_shape[0]
-        if frb.axis < 3:
+        if frb.axis is not None:
             DD = frb.ds.domain_width
             xax = frb.ds.coordinates.x_axis[frb.axis]
             yax = frb.ds.coordinates.y_axis[frb.axis]

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -974,19 +974,31 @@ class FITSSlice(FITSImageData):
         Specify the resolution of the resulting image. A single value will be
         used for both axes, whereas a tuple of values will be used for the
         individual axes. Default: 512
-    center : A sequence of floats, a string, or a tuple.
-        The coordinate of the center of the image. If set to 'c', 'center' or
-        left blank, the plot is centered on the middle of the domain. If set
-        to 'max' or 'm', the center will be located at the maximum of the
-        ('gas', 'density') field. Centering on the max or min of a specific
-        field is supported by providing a tuple such as ("min","temperature")
-        or ("max","dark_matter_density"). Units can be specified by passing in
-        *center* as a tuple containing a coordinate and string unit name or by
-        passing in a YTArray. If a list or unitless array is supplied, code
-        units are assumed.
+    center : 'center', 'c', 'left', 'l', 'right', 'r' id of a global extremum, or array-like
+        The coordinate of the selection's center.
+        Defaults to the 'center', i.e. center of the domain.
+
+        Centering on the min or max of a field is supported by passing a tuple
+        such as ('min', ('gas', 'density')) or ('max', ('gas', 'temperature'). A
+        single string may also be used (e.g. "min_density" or
+        "max_temperature"), though it's not as flexible and does not allow to
+        select an exact field/particle type. With this syntax, the first field
+        matching the provided name is selected.
+        'max' or 'm' can be used as a shortcut for ('max', ('gas', 'density'))
+        'min' can be used as a shortcut for ('min', ('gas', 'density'))
+
+        One can also select an exact point as a 3 element coordinate sequence,
+        e.g. [0.5, 0.5, 0]
+        Units can be specified by passing in *center* as a tuple containing a
+        3-element coordinate sequence and string unit name, e.g. ([0, 0.5, 0.5], "cm"),
+        or by passing in a YTArray. Code units are assumed if unspecified.
+
+        The domain edges along the selected *axis* can be selected with
+        'left'/'l' and 'right'/'r' respectively.
+
     width : tuple or a float.
-        Width can have four different formats to support variable
-        x and y widths.  They are:
+        Width can have four different formats to support variable x and y
+        widths.  They are:
 
         ==================================     =======================
         format                                 example
@@ -997,12 +1009,12 @@ class FITSSlice(FITSImageData):
         (float, float)                         (0.2, 0.3)
         ==================================     =======================
 
-        For example, (10, 'kpc') specifies a width that is 10 kiloparsecs
-        wide in the x and y directions, ((10,'kpc'),(15,'kpc')) specifies a
-        width that is 10 kiloparsecs wide along the x axis and 15
-        kiloparsecs wide along the y axis.  In the other two examples, code
-        units are assumed, for example (0.2, 0.3) specifies a width that has an
-        x width of 0.2 and a y width of 0.3 in code units.
+        For example, (10, 'kpc') specifies a width that is 10 kiloparsecs wide
+        in the x and y directions, ((10,'kpc'),(15,'kpc')) specifies a width
+        that is 10 kiloparsecs wide along the x axis and 15 kiloparsecs wide
+        along the y axis.  In the other two examples, code units are assumed,
+        for example (0.2, 0.3) specifies a width that has an x width of 0.2 and
+        a y width of 0.3 in code units.
     length_unit : string, optional
         the length units that the coordinates are written in. The default
         is to use the default length unit of the dataset.
@@ -1019,7 +1031,7 @@ class FITSSlice(FITSImageData):
         axis,
         fields,
         image_res=512,
-        center="c",
+        center="center",
         width=None,
         length_unit=None,
         *,
@@ -1059,16 +1071,27 @@ class FITSProjection(FITSImageData):
         Specify the resolution of the resulting image. A single value will be
         used for both axes, whereas a tuple of values will be used for the
         individual axes. Default: 512
-    center : A sequence of floats, a string, or a tuple.
-        The coordinate of the center of the image. If set to 'c', 'center' or
-        left blank, the plot is centered on the middle of the domain. If set
-        to 'max' or 'm', the center will be located at the maximum of the
-        ('gas', 'density') field. Centering on the max or min of a specific
-        field is supported by providing a tuple such as ("min","temperature")
-        or ("max","dark_matter_density"). Units can be specified by passing in
-        *center* as a tuple containing a coordinate and string unit name or by
-        passing in a YTArray. If a list or unitless array is supplied, code
-        units are assumed.
+    center : 'center', 'c', 'left', 'l', 'right', 'r' id of a global extremum, or array-like
+        The coordinate of the selection's center.
+        Defaults to the 'center', i.e. center of the domain.
+
+        Centering on the min or max of a field is supported by passing a tuple
+        such as ('min', ('gas', 'density')) or ('max', ('gas', 'temperature'). A
+        single string may also be used (e.g. "min_density" or
+        "max_temperature"), though it's not as flexible and does not allow to
+        select an exact field/particle type. With this syntax, the first field
+        matching the provided name is selected.
+        'max' or 'm' can be used as a shortcut for ('max', ('gas', 'density'))
+        'min' can be used as a shortcut for ('min', ('gas', 'density'))
+
+        One can also select an exact point as a 3 element coordinate sequence,
+        e.g. [0.5, 0.5, 0]
+        Units can be specified by passing in *center* as a tuple containing a
+        3-element coordinate sequence and string unit name, e.g. ([0, 0.5, 0.5], "cm"),
+        or by passing in a YTArray. Code units are assumed if unspecified.
+
+        The domain edges along the selected *axis* can be selected with
+        'left'/'l' and 'right'/'r' respectively.
     width : tuple or a float.
         Width can have four different formats to support variable
         x and y widths.  They are:
@@ -1110,7 +1133,7 @@ class FITSProjection(FITSImageData):
         axis,
         fields,
         image_res=512,
-        center="c",
+        center="center",
         width=None,
         weight_field=None,
         length_unit=None,
@@ -1155,16 +1178,27 @@ class FITSParticleProjection(FITSImageData):
         Specify the resolution of the resulting image. A single value will be
         used for both axes, whereas a tuple of values will be used for the
         individual axes. Default: 512
-    center : A sequence of floats, a string, or a tuple.
-        The coordinate of the center of the image. If set to 'c', 'center' or
-        left blank, the plot is centered on the middle of the domain. If set
-        to 'max' or 'm', the center will be located at the maximum of the
-        ('gas', 'density') field. Centering on the max or min of a specific
-        field is supported by providing a tuple such as ("min","temperature")
-        or ("max","dark_matter_density"). Units can be specified by passing in
-        *center* as a tuple containing a coordinate and string unit name or by
-        passing in a YTArray. If a list or unitless array is supplied, code
-        units are assumed.
+    center : 'center', 'c', 'left', 'l', 'right', 'r' id of a global extremum, or array-like
+        The coordinate of the selection's center.
+        Defaults to the 'center', i.e. center of the domain.
+
+        Centering on the min or max of a field is supported by passing a tuple
+        such as ('min', ('gas', 'density')) or ('max', ('gas', 'temperature'). A
+        single string may also be used (e.g. "min_density" or
+        "max_temperature"), though it's not as flexible and does not allow to
+        select an exact field/particle type. With this syntax, the first field
+        matching the provided name is selected.
+        'max' or 'm' can be used as a shortcut for ('max', ('gas', 'density'))
+        'min' can be used as a shortcut for ('min', ('gas', 'density'))
+
+        One can also select an exact point as a 3 element coordinate sequence,
+        e.g. [0.5, 0.5, 0]
+        Units can be specified by passing in *center* as a tuple containing a
+        3-element coordinate sequence and string unit name, e.g. ([0, 0.5, 0.5], "cm"),
+        or by passing in a YTArray. Code units are assumed if unspecified.
+
+        The domain edges along the selected *axis* can be selected with
+        'left'/'l' and 'right'/'r' respectively.
     width : tuple or a float.
         Width can have four different formats to support variable
         x and y widths.  They are:
@@ -1219,7 +1253,7 @@ class FITSParticleProjection(FITSImageData):
         axis,
         fields,
         image_res=512,
-        center="c",
+        center="center",
         width=None,
         depth=(1, "1"),
         weight_field=None,
@@ -1274,16 +1308,25 @@ class FITSOffAxisSlice(FITSImageData):
         Specify the resolution of the resulting image. A single value will be
         used for both axes, whereas a tuple of values will be used for the
         individual axes. Default: 512
-    center : A sequence of floats, a string, or a tuple.
-        The coordinate of the center of the image. If set to 'c', 'center' or
-        left blank, the plot is centered on the middle of the domain. If set
-        to 'max' or 'm', the center will be located at the maximum of the
-        ('gas', 'density') field. Centering on the max or min of a specific
-        field is supported by providing a tuple such as ("min","temperature")
-        or ("max","dark_matter_density"). Units can be specified by passing in
-        *center* as a tuple containing a coordinate and string unit name or by
-        passing in a YTArray. If a list or unitless array is supplied, code
-        units are assumed.
+    center : 'center', 'c', id of a global extremum, or array-like
+        The coordinate of the selection's center.
+        Defaults to the 'center', i.e. center of the domain.
+
+        Centering on the min or max of a field is supported by passing a tuple
+        such as ('min', ('gas', 'density')) or ('max', ('gas', 'temperature'). A
+        single string may also be used (e.g. "min_density" or
+        "max_temperature"), though it's not as flexible and does not allow to
+        select an exact field/particle type. With this syntax, the first field
+        matching the provided name is selected.
+        'max' or 'm' can be used as a shortcut for ('max', ('gas', 'density'))
+        'min' can be used as a shortcut for ('min', ('gas', 'density'))
+
+        One can also select an exact point as a 3 element coordinate sequence,
+        e.g. [0.5, 0.5, 0]
+        Units can be specified by passing in *center* as a tuple containing a
+        3-element coordinate sequence and string unit name, e.g. ([0, 0.5, 0.5], "cm"),
+        or by passing in a YTArray. Code units are assumed if unspecified.
+
     width : tuple or a float.
         Width can have four different formats to support variable
         x and y widths.  They are:
@@ -1318,13 +1361,13 @@ class FITSOffAxisSlice(FITSImageData):
         normal,
         fields,
         image_res=512,
-        center="c",
+        center="center",
         width=None,
         north_vector=None,
         length_unit=None,
     ):
         fields = list(iter_fields(fields))
-        center, dcenter = ds.coordinates.sanitize_center(center, 4)
+        center, dcenter = ds.coordinates.sanitize_center(center, axis=None)
         cut = ds.cutting(normal, center, north_vector=north_vector)
         center = ds.arr([0.0] * 2, "code_length")
         w, frb, lunit = construct_image(
@@ -1350,16 +1393,24 @@ class FITSOffAxisProjection(FITSImageData):
         Specify the resolution of the resulting image. A single value will be
         used for both axes, whereas a tuple of values will be used for the
         individual axes. Default: 512
-    center : A sequence of floats, a string, or a tuple.
-        The coordinate of the center of the image. If set to 'c', 'center' or
-        left blank, the plot is centered on the middle of the domain. If set
-        to 'max' or 'm', the center will be located at the maximum of the
-        ('gas', 'density') field. Centering on the max or min of a specific
-        field is supported by providing a tuple such as ("min","temperature")
-        or ("max","dark_matter_density"). Units can be specified by passing in
-        *center* as a tuple containing a coordinate and string unit name or by
-        passing in a YTArray. If a list or unitless array is supplied, code
-        units are assumed.
+    center : 'center', 'c', id of a global extremum, or array-like
+        The coordinate of the selection's center.
+        Defaults to the 'center', i.e. center of the domain.
+
+        Centering on the min or max of a field is supported by passing a tuple
+        such as ('min', ('gas', 'density')) or ('max', ('gas', 'temperature'). A
+        single string may also be used (e.g. "min_density" or
+        "max_temperature"), though it's not as flexible and does not allow to
+        select an exact field/particle type. With this syntax, the first field
+        matching the provided name is selected.
+        'max' or 'm' can be used as a shortcut for ('max', ('gas', 'density'))
+        'min' can be used as a shortcut for ('min', ('gas', 'density'))
+
+        One can also select an exact point as a 3 element coordinate sequence,
+        e.g. [0.5, 0.5, 0]
+        Units can be specified by passing in *center* as a tuple containing a
+        3-element coordinate sequence and string unit name, e.g. ([0, 0.5, 0.5], "cm"),
+        or by passing in a YTArray. Code units are assumed if unspecified.
     width : tuple or a float.
         Width can have four different formats to support variable
         x and y widths.  They are:
@@ -1420,7 +1471,7 @@ class FITSOffAxisProjection(FITSImageData):
         ds,
         normal,
         fields,
-        center="c",
+        center="center",
         width=(1.0, "unitary"),
         weight_field=None,
         image_res=512,
@@ -1433,7 +1484,8 @@ class FITSOffAxisProjection(FITSImageData):
         moment=1,
     ):
         validate_moment(moment, weight_field)
-        center, dcenter = ds.coordinates.sanitize_center(center, 4)
+        center, dcenter = ds.coordinates.sanitize_center(center, axis=None)
+        fields = list(iter_fields(fields))
         buf = {}
         width = ds.coordinates.sanitize_width(normal, width, depth)
         wd = tuple(el.in_units("code_length").v for el in width)

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -974,7 +974,7 @@ class FITSSlice(FITSImageData):
         Specify the resolution of the resulting image. A single value will be
         used for both axes, whereas a tuple of values will be used for the
         individual axes. Default: 512
-    center : 'center', 'c', 'left', 'l', 'right', 'r' id of a global extremum, or array-like
+    center : 'center', 'c', 'left', 'l', 'right', 'r', id of a global extremum, or array-like
         The coordinate of the selection's center.
         Defaults to the 'center', i.e. center of the domain.
 
@@ -1071,7 +1071,7 @@ class FITSProjection(FITSImageData):
         Specify the resolution of the resulting image. A single value will be
         used for both axes, whereas a tuple of values will be used for the
         individual axes. Default: 512
-    center : 'center', 'c', 'left', 'l', 'right', 'r' id of a global extremum, or array-like
+    center : 'center', 'c', 'left', 'l', 'right', 'r', id of a global extremum, or array-like
         The coordinate of the selection's center.
         Defaults to the 'center', i.e. center of the domain.
 
@@ -1178,7 +1178,7 @@ class FITSParticleProjection(FITSImageData):
         Specify the resolution of the resulting image. A single value will be
         used for both axes, whereas a tuple of values will be used for the
         individual axes. Default: 512
-    center : 'center', 'c', 'left', 'l', 'right', 'r' id of a global extremum, or array-like
+    center : 'center', 'c', 'left', 'l', 'right', 'r', id of a global extremum, or array-like
         The coordinate of the selection's center.
         Defaults to the 'center', i.e. center of the domain.
 

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -136,7 +136,7 @@ class FixedResolutionBuffer:
             ds.plots.append(weakref.proxy(self))
 
         # Handle periodicity, just in case
-        if self.data_source.axis < 3:
+        if self.data_source.axis is not None:
             DLE = self.ds.domain_left_edge
             DRE = self.ds.domain_right_edge
             DD = float(self.periodic) * (DRE - DLE)

--- a/yt/visualization/particle_plots.py
+++ b/yt/visualization/particle_plots.py
@@ -106,7 +106,7 @@ class ParticleProjectionPlot(PWViewerMPL):
          The color that will indicate the particle locations
          on the mesh. This argument is ignored if z_fields is
          not None. Default is 'b'.
-    center : 'center', 'c', 'left', 'l', 'right', 'r' id of a global extremum, or array-like
+    center : 'center', 'c', 'left', 'l', 'right', 'r', id of a global extremum, or array-like
         The coordinate of the selection's center.
         Defaults to the 'center', i.e. center of the domain.
 
@@ -483,7 +483,7 @@ def ParticlePlot(ds, x_field, y_field, z_fields=None, color="b", *args, **kwargs
     data_source : YTSelectionContainer Object
          Object to be used for data selection.  Defaults to a region covering
          the entire simulation.
-    center : 'center', 'c', 'left', 'l', 'right', 'r' id of a global extremum, or array-like
+    center : 'center', 'c', 'left', 'l', 'right', 'r', id of a global extremum, or array-like
         The coordinate of the selection's center.
         Defaults to the 'center', i.e. center of the domain.
 

--- a/yt/visualization/particle_plots.py
+++ b/yt/visualization/particle_plots.py
@@ -106,16 +106,27 @@ class ParticleProjectionPlot(PWViewerMPL):
          The color that will indicate the particle locations
          on the mesh. This argument is ignored if z_fields is
          not None. Default is 'b'.
-    center : A sequence of floats, a string, or a tuple.
-         The coordinate of the center of the image. If set to 'c', 'center' or
-         left blank, the plot is centered on the middle of the domain. If set to
-         'max' or 'm', the center will be located at the maximum of the
-         ('gas', 'density') field. Centering on the max or min of a specific
-         field is supported by providing a tuple such as ("min","temperature") or
-         ("max","dark_matter_density"). Units can be specified by passing in *center*
-         as a tuple containing a coordinate and string unit name or by passing
-         in a YTArray. If a list or unitless array is supplied, code units are
-         assumed.
+    center : 'center', 'c', 'left', 'l', 'right', 'r' id of a global extremum, or array-like
+        The coordinate of the selection's center.
+        Defaults to the 'center', i.e. center of the domain.
+
+        Centering on the min or max of a field is supported by passing a tuple
+        such as ('min', ('gas', 'density')) or ('max', ('gas', 'temperature'). A
+        single string may also be used (e.g. "min_density" or
+        "max_temperature"), though it's not as flexible and does not allow to
+        select an exact field/particle type. With this syntax, the first field
+        matching the provided name is selected.
+        'max' or 'm' can be used as a shortcut for ('max', ('gas', 'density'))
+        'min' can be used as a shortcut for ('min', ('gas', 'density'))
+
+        One can also select an exact point as a 3 element coordinate sequence,
+        e.g. [0.5, 0.5, 0]
+        Units can be specified by passing in *center* as a tuple containing a
+        3-element coordinate sequence and string unit name, e.g. ([0, 0.5, 0.5], "cm"),
+        or by passing in a YTArray. Code units are assumed if unspecified.
+
+        The domain edges along the selected *axis* can be selected with
+        'left'/'l' and 'right'/'r' respectively.
     width : tuple or a float.
          Width can have four different formats to support windows with variable
          x and y widths.  They are:
@@ -219,7 +230,7 @@ class ParticleProjectionPlot(PWViewerMPL):
         axis,
         fields=None,
         color="b",
-        center="c",
+        center="center",
         width=None,
         depth=(1, "1"),
         weight_field=None,
@@ -472,16 +483,29 @@ def ParticlePlot(ds, x_field, y_field, z_fields=None, color="b", *args, **kwargs
     data_source : YTSelectionContainer Object
          Object to be used for data selection.  Defaults to a region covering
          the entire simulation.
-    center : A sequence of floats, a string, or a tuple.
-         The coordinate of the center of the image. If set to 'c', 'center' or
-         left blank, the plot is centered on the middle of the domain. If set to
-         'max' or 'm', the center will be located at the maximum of the
-         ('gas', 'density') field. Centering on the max or min of a specific
-         field is supported by providing a tuple such as ("min","temperature") or
-         ("max","dark_matter_density"). Units can be specified by passing in *center*
-         as a tuple containing a coordinate and string unit name or by passing
-         in a YTArray. If a list or unitless array is supplied, code units are
-         assumed. This argument is only accepted by ``ParticleProjectionPlot``.
+    center : 'center', 'c', 'left', 'l', 'right', 'r' id of a global extremum, or array-like
+        The coordinate of the selection's center.
+        Defaults to the 'center', i.e. center of the domain.
+
+        Centering on the min or max of a field is supported by passing a tuple
+        such as ('min', ('gas', 'density')) or ('max', ('gas', 'temperature'). A
+        single string may also be used (e.g. "min_density" or
+        "max_temperature"), though it's not as flexible and does not allow to
+        select an exact field/particle type. With this syntax, the first field
+        matching the provided name is selected.
+        'max' or 'm' can be used as a shortcut for ('max', ('gas', 'density'))
+        'min' can be used as a shortcut for ('min', ('gas', 'density'))
+
+        One can also select an exact point as a 3 element coordinate sequence,
+        e.g. [0.5, 0.5, 0]
+        Units can be specified by passing in *center* as a tuple containing a
+        3-element coordinate sequence and string unit name, e.g. ([0, 0.5, 0.5], "cm"),
+        or by passing in a YTArray. Code units are assumed if unspecified.
+
+        The domain edges along the selected *axis* can be selected with
+        'left'/'l' and 'right'/'r' respectively.
+
+        This argument is only accepted by ``ParticleProjectionPlot``.
     width : tuple or a float.
          Width can have four different formats to support windows with variable
          x and y widths.  They are:

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -159,7 +159,7 @@ class PlotCallback(ABC):
             # if this is an off-axis project or slice (ie cutting plane)
             # we have to calculate where the data coords fall in the projected
             # plane
-            elif ax is None:
+            else:
                 # transpose is just to get [[x1,x2,...],[y1,y2,...],[z1,z2,...]]
                 # in the same order as plot.data.center for array arithmetic
                 coord_vectors = coord_copy.transpose() - plot.data.center
@@ -168,8 +168,6 @@ class PlotCallback(ABC):
                 # Transpose into image coords. Due to VR being not a
                 # right-handed coord system
                 ret_coord = (y, x)
-            else:
-                raise ValueError("Object being plotted must have a `data.axis` defined")
 
         # if the position is already two-coords, it is expected to be
         # in the proper projected orientation

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -149,7 +149,7 @@ class PlotCallback(ABC):
             ax = plot.data.axis
             # if this is an on-axis projection or slice, then
             # just grab the appropriate 2 coords for the on-axis view
-            if ax >= 0 and ax <= 2:
+            if ax is not None:
                 (xi, yi) = (
                     plot.data.ds.coordinates.x_axis[ax],
                     plot.data.ds.coordinates.y_axis[ax],
@@ -159,7 +159,7 @@ class PlotCallback(ABC):
             # if this is an off-axis project or slice (ie cutting plane)
             # we have to calculate where the data coords fall in the projected
             # plane
-            elif ax == 4:
+            elif ax is None:
                 # transpose is just to get [[x1,x2,...],[y1,y2,...],[z1,z2,...]]
                 # in the same order as plot.data.center for array arithmetic
                 coord_vectors = coord_copy.transpose() - plot.data.center

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -78,7 +78,7 @@ def get_window_parameters(axis, center, width, ds):
 
 
 def get_oblique_window_parameters(normal, center, width, ds, depth=None):
-    display_center, center = ds.coordinates.sanitize_center(center, 4)
+    center, display_center = ds.coordinates.sanitize_center(center, axis=None)
     width = ds.coordinates.sanitize_width(normal, width, depth)
 
     if len(width) == 2:

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1466,16 +1466,27 @@ class SlicePlot(NormalPlot):
     Keyword Arguments
     -----------------
 
-    center : A sequence floats, a string, or a tuple.
-         The coordinate of the center of the image. If set to 'c', 'center' or
-         left blank, the plot is centered on the middle of the domain. If set to
-         'max' or 'm', the center will be located at the maximum of the
-         ('gas', 'density') field. Centering on the max or min of a specific
-         field is supported by providing a tuple such as ("min","temperature") or
-         ("max","dark_matter_density"). Units can be specified by passing in *center*
-         as a tuple containing a coordinate and string unit name or by passing
-         in a YTArray. If a list or unitless array is supplied, code units are
-         assumed.
+    center : 'center', 'c', 'left', 'l', 'right', 'r' id of a global extremum, or array-like
+        The coordinate of the selection's center.
+        Defaults to the 'center', i.e. center of the domain.
+
+        Centering on the min or max of a field is supported by passing a tuple
+        such as ('min', ('gas', 'density')) or ('max', ('gas', 'temperature'). A
+        single string may also be used (e.g. "min_density" or
+        "max_temperature"), though it's not as flexible and does not allow to
+        select an exact field/particle type. With this syntax, the first field
+        matching the provided name is selected.
+        'max' or 'm' can be used as a shortcut for ('max', ('gas', 'density'))
+        'min' can be used as a shortcut for ('min', ('gas', 'density'))
+
+        One can also select an exact point as a 3 element coordinate sequence,
+        e.g. [0.5, 0.5, 0]
+        Units can be specified by passing in *center* as a tuple containing a
+        3-element coordinate sequence and string unit name, e.g. ([0, 0.5, 0.5], "cm"),
+        or by passing in a YTArray. Code units are assumed if unspecified.
+
+        The domain edges along the selected *axis* can be selected with
+        'left'/'l' and 'right'/'r' respectively.
     width : tuple or a float.
          Width can have four different formats to support windows with variable
          x and y widths.  They are:
@@ -1668,16 +1679,27 @@ class AxisAlignedSlicePlot(SlicePlot, PWViewerMPL):
          or the axis name itself
     fields : string
          The name of the field(s) to be plotted.
-    center : A sequence of floats, a string, or a tuple.
-         The coordinate of the center of the image. If set to 'c', 'center' or
-         left blank, the plot is centered on the middle of the domain. If set to
-         'max' or 'm', the center will be located at the maximum of the
-         ('gas', 'density') field. Centering on the max or min of a specific
-         field is supported by providing a tuple such as ("min","temperature") or
-         ("max","dark_matter_density"). Units can be specified by passing in *center*
-         as a tuple containing a coordinate and string unit name or by passing
-         in a YTArray. If a list or unitless array is supplied, code units are
-         assumed.
+    center : 'center', 'c', 'left', 'l', 'right', 'r' id of a global extremum, or array-like
+        The coordinate of the selection's center.
+        Defaults to the 'center', i.e. center of the domain.
+
+        Centering on the min or max of a field is supported by passing a tuple
+        such as ('min', ('gas', 'density')) or ('max', ('gas', 'temperature'). A
+        single string may also be used (e.g. "min_density" or
+        "max_temperature"), though it's not as flexible and does not allow to
+        select an exact field/particle type. With this syntax, the first field
+        matching the provided name is selected.
+        'max' or 'm' can be used as a shortcut for ('max', ('gas', 'density'))
+        'min' can be used as a shortcut for ('min', ('gas', 'density'))
+
+        One can also select an exact point as a 3 element coordinate sequence,
+        e.g. [0.5, 0.5, 0]
+        Units can be specified by passing in *center* as a tuple containing a
+        3-element coordinate sequence and string unit name, e.g. ([0, 0.5, 0.5], "cm"),
+        or by passing in a YTArray. Code units are assumed if unspecified.
+
+        The domain edges along the selected *axis* can be selected with
+        'left'/'l' and 'right'/'r' respectively.
     width : tuple or a float.
          Width can have four different formats to support windows with variable
          x and y widths.  They are:
@@ -1768,7 +1790,7 @@ class AxisAlignedSlicePlot(SlicePlot, PWViewerMPL):
         ds,
         normal,
         fields,
-        center="c",
+        center="center",
         width=None,
         axes_unit=None,
         origin="center-window",
@@ -1850,16 +1872,27 @@ class AxisAlignedProjectionPlot(ProjectionPlot, PWViewerMPL):
         or the axis name itself
     fields : string
         The name of the field(s) to be plotted.
-    center : A sequence of floats, a string, or a tuple.
-        The coordinate of the center of the image. If set to 'c', 'center' or
-        left blank, the plot is centered on the middle of the domain. If set to
-        'max' or 'm', the center will be located at the maximum of the
-        ('gas', 'density') field. Centering on the max or min of a specific
-        field is supported by providing a tuple such as ("min","temperature") or
-        ("max","dark_matter_density"). Units can be specified by passing in *center*
-        as a tuple containing a coordinate and string unit name or by passing
-        in a YTArray. If a list or unitless array is supplied, code units are
-        assumed.
+    center : 'center', 'c', 'left', 'l', 'right', 'r' id of a global extremum, or array-like
+        The coordinate of the selection's center.
+        Defaults to the 'center', i.e. center of the domain.
+
+        Centering on the min or max of a field is supported by passing a tuple
+        such as ('min', ('gas', 'density')) or ('max', ('gas', 'temperature'). A
+        single string may also be used (e.g. "min_density" or
+        "max_temperature"), though it's not as flexible and does not allow to
+        select an exact field/particle type. With this syntax, the first field
+        matching the provided name is selected.
+        'max' or 'm' can be used as a shortcut for ('max', ('gas', 'density'))
+        'min' can be used as a shortcut for ('min', ('gas', 'density'))
+
+        One can also select an exact point as a 3 element coordinate sequence,
+        e.g. [0.5, 0.5, 0]
+        Units can be specified by passing in *center* as a tuple containing a
+        3-element coordinate sequence and string unit name, e.g. ([0, 0.5, 0.5], "cm"),
+        or by passing in a YTArray. Code units are assumed if unspecified.
+
+        The domain edges along the selected *axis* can be selected with
+        'left'/'l' and 'right'/'r' respectively.
     width : tuple or a float.
         Width can have four different formats to support windows with variable
         x and y widths.  They are:
@@ -1983,7 +2016,7 @@ class AxisAlignedProjectionPlot(ProjectionPlot, PWViewerMPL):
         ds,
         normal,
         fields,
-        center="c",
+        center="center",
         width=None,
         axes_unit=None,
         weight_field=None,
@@ -2084,16 +2117,24 @@ class OffAxisSlicePlot(SlicePlot, PWViewerMPL):
          The vector normal to the slicing plane.
     fields : string
          The name of the field(s) to be plotted.
-    center : A sequence of floats, a string, or a tuple.
-         The coordinate of the center of the image. If set to 'c', 'center' or
-         left blank, the plot is centered on the middle of the domain. If set to
-         'max' or 'm', the center will be located at the maximum of the
-         ('gas', 'density') field. Centering on the max or min of a specific
-         field is supported by providing a tuple such as ("min","temperature") or
-         ("max","dark_matter_density"). Units can be specified by passing in *center*
-         as a tuple containing a coordinate and string unit name or by passing
-         in a YTArray. If a list or unitless array is supplied, code units are
-         assumed.
+    center : 'center', 'c' id of a global extremum, or array-like
+        The coordinate of the selection's center.
+        Defaults to the 'center', i.e. center of the domain.
+
+        Centering on the min or max of a field is supported by passing a tuple
+        such as ('min', ('gas', 'density')) or ('max', ('gas', 'temperature'). A
+        single string may also be used (e.g. "min_density" or
+        "max_temperature"), though it's not as flexible and does not allow to
+        select an exact field/particle type. With this syntax, the first field
+        matching the provided name is selected.
+        'max' or 'm' can be used as a shortcut for ('max', ('gas', 'density'))
+        'min' can be used as a shortcut for ('min', ('gas', 'density'))
+
+        One can also select an exact point as a 3 element coordinate sequence,
+        e.g. [0.5, 0.5, 0]
+        Units can be specified by passing in *center* as a tuple containing a
+        3-element coordinate sequence and string unit name, e.g. ([0, 0.5, 0.5], "cm"),
+        or by passing in a YTArray. Code units are assumed if unspecified.
     width : tuple or a float.
          Width can have four different formats to support windows with variable
          x and y widths.  They are:
@@ -2146,7 +2187,7 @@ class OffAxisSlicePlot(SlicePlot, PWViewerMPL):
         ds,
         normal,
         fields,
-        center="c",
+        center="center",
         width=None,
         axes_unit=None,
         north_vector=None,
@@ -2279,16 +2320,24 @@ class OffAxisProjectionPlot(ProjectionPlot, PWViewerMPL):
         The vector normal to the slicing plane.
     fields : string
         The name of the field(s) to be plotted.
-    center : A sequence of floats, a string, or a tuple.
-        The coordinate of the center of the image. If set to 'c', 'center' or
-        left blank, the plot is centered on the middle of the domain. If set to
-        'max' or 'm', the center will be located at the maximum of the
-        ('gas', 'density') field. Centering on the max or min of a specific
-        field is supported by providing a tuple such as ("min","temperature") or
-        ("max","dark_matter_density"). Units can be specified by passing in *center*
-        as a tuple containing a coordinate and string unit name or by passing
-        in a YTArray. If a list or unitless array is supplied, code units are
-        assumed.
+    center : 'center', 'c', id of a global extremum, or array-like
+        The coordinate of the selection's center.
+        Defaults to the 'center', i.e. center of the domain.
+
+        Centering on the min or max of a field is supported by passing a tuple
+        such as ('min', ('gas', 'density')) or ('max', ('gas', 'temperature'). A
+        single string may also be used (e.g. "min_density" or
+        "max_temperature"), though it's not as flexible and does not allow to
+        select an exact field/particle type. With this syntax, the first field
+        matching the provided name is selected.
+        'max' or 'm' can be used as a shortcut for ('max', ('gas', 'density'))
+        'min' can be used as a shortcut for ('min', ('gas', 'density'))
+
+        One can also select an exact point as a 3 element coordinate sequence,
+        e.g. [0.5, 0.5, 0]
+        Units can be specified by passing in *center* as a tuple containing a
+        3-element coordinate sequence and string unit name, e.g. ([0, 0.5, 0.5], "cm"),
+        or by passing in a YTArray. Code units are assumed if unspecified.
     width : tuple or a float.
         Width can have four different formats to support windows with variable
         x and y widths. They are:
@@ -2363,7 +2412,7 @@ class OffAxisProjectionPlot(ProjectionPlot, PWViewerMPL):
         ds,
         normal,
         fields,
-        center="c",
+        center="center",
         width=None,
         depth=(1, "1"),
         axes_unit=None,
@@ -2500,7 +2549,7 @@ class WindowPlotMPL(ImagePlotMPL):
 def plot_2d(
     ds,
     fields,
-    center="c",
+    center="center",
     width=None,
     axes_unit=None,
     origin="center-window",
@@ -2525,16 +2574,26 @@ def plot_2d(
          simulation output to be plotted.
     fields : string
          The name of the field(s) to be plotted.
-    center : A sequence of floats, a string, or a tuple.
-         The coordinate of the center of the image. If set to 'c', 'center' or
-         left blank, the plot is centered on the middle of the domain. If set to
-         'max' or 'm', the center will be located at the maximum of the
-         ('gas', 'density') field. Centering on the max or min of a specific
-         field is supported by providing a tuple such as ("min","temperature") or
-         ("max","dark_matter_density"). Units can be specified by passing in *center*
-         as a tuple containing a coordinate and string unit name or by passing
-         in a YTArray. If a list or unitless array is supplied, code units are
-         assumed. For plot_2d, this keyword accepts a coordinate in two dimensions.
+    center : 'center', 'c', id of a global extremum, or array-like
+        The coordinate of the selection's center.
+        Defaults to the 'center', i.e. center of the domain.
+
+        Centering on the min or max of a field is supported by passing a tuple
+        such as ('min', ('gas', 'density')) or ('max', ('gas', 'temperature'). A
+        single string may also be used (e.g. "min_density" or
+        "max_temperature"), though it's not as flexible and does not allow to
+        select an exact field/particle type. With this syntax, the first field
+        matching the provided name is selected.
+        'max' or 'm' can be used as a shortcut for ('max', ('gas', 'density'))
+        'min' can be used as a shortcut for ('min', ('gas', 'density'))
+
+        One can also select an exact point as a 3 element coordinate sequence,
+        e.g. [0.5, 0.5, 0]
+        Units can be specified by passing in *center* as a tuple containing a
+        3-element coordinate sequence and string unit name, e.g. ([0, 0.5, 0.5], "cm"),
+        or by passing in a YTArray. Code units are assumed if unspecified.
+
+        plot_2d also accepts a coordinate in two dimensions.
     width : tuple or a float.
          Width can have four different formats to support windows with variable
          x and y widths.  They are:

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -2219,7 +2219,7 @@ class OffAxisSlicePlot(SlicePlot, PWViewerMPL):
 
         if isinstance(ds, YTSpatialPlotDataset):
             cutting = ds.all_data()
-            cutting.axis = 4
+            cutting.axis = None
             cutting._inv_mat = ds.parameters["_inv_mat"]
         else:
             cutting = ds.cutting(
@@ -2275,7 +2275,7 @@ class OffAxisProjectionDummyDataSource:
         validate_moment(moment, weight)
         self.center = center
         self.ds = ds
-        self.axis = 4  # always true for oblique data objects
+        self.axis = None  # always true for oblique data objects
         self.normal_vector = normal_vector
         self.width = width
         if data_source is None:

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1466,7 +1466,7 @@ class SlicePlot(NormalPlot):
     Keyword Arguments
     -----------------
 
-    center : 'center', 'c', 'left', 'l', 'right', 'r' id of a global extremum, or array-like
+    center : 'center', 'c', 'left', 'l', 'right', 'r', id of a global extremum, or array-like
         The coordinate of the selection's center.
         Defaults to the 'center', i.e. center of the domain.
 
@@ -1679,7 +1679,7 @@ class AxisAlignedSlicePlot(SlicePlot, PWViewerMPL):
          or the axis name itself
     fields : string
          The name of the field(s) to be plotted.
-    center : 'center', 'c', 'left', 'l', 'right', 'r' id of a global extremum, or array-like
+    center : 'center', 'c', 'left', 'l', 'right', 'r', id of a global extremum, or array-like
         The coordinate of the selection's center.
         Defaults to the 'center', i.e. center of the domain.
 
@@ -1872,7 +1872,7 @@ class AxisAlignedProjectionPlot(ProjectionPlot, PWViewerMPL):
         or the axis name itself
     fields : string
         The name of the field(s) to be plotted.
-    center : 'center', 'c', 'left', 'l', 'right', 'r' id of a global extremum, or array-like
+    center : 'center', 'c', 'left', 'l', 'right', 'r', id of a global extremum, or array-like
         The coordinate of the selection's center.
         Defaults to the 'center', i.e. center of the domain.
 

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -83,13 +83,17 @@ CENTER_SPECS = (
     "M",
     "max",
     "Max",
-    "c",
-    "C",
+    "min",
+    "Min",
     "center",
     "Center",
+    "left",
+    "right",
     [0.5, 0.5, 0.5],
     [[0.2, 0.3, 0.4], "cm"],
     YTArray([0.3, 0.4, 0.7], "cm"),
+    ("max", ("gas", "density")),
+    ("min", ("gas", "density")),
 )
 
 WIDTH_SPECS = {

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -85,6 +85,8 @@ CENTER_SPECS = (
     "Max",
     "min",
     "Min",
+    "c",
+    "C",
     "center",
     "Center",
     "left",


### PR DESCRIPTION
## PR Summary

Original goal: make errors much more informative than the current `RuntimeError(f'center keyword "{center}" not recognized')` raised by `PlotWindows.sanitize_center`, and improve the discoverability of the rich API that's actually implemented via error messages.
I've extended the goal to providing a more uniform API between plot windows and data selectors (which also have a "center" argument), because there was a lot of similar-yet different code basically accomplishing the same task there, as well as a couple things that worked with one but not the other.

I've added extensive tests for `CoordinateHandler.sanitize_center` and made the following changes:
- add much more verbose error message in case of invalid data type or incorrect value
- invalidate `center=YTArray(...)` if the array has an incorrect shape or unit dimension (previously any YTArray would pass)
- ~deprecate `center="c"` and `center="m"` because this encourages user code that's less clear, and reserving `"m"` for "max" doesn't leave any room for an equivalent "min" shortened keyword.~ edit: withdrawn
- ~deprecate `center="max"` (where the `("gas", "density)` field is implicitly queried) because it's not explicit as well as brittle (not every dataset has a `("gas", "density")` field)~ edit: withdrawn
- ~updated docs and tests to avoid showing off deprecated usages~ edit: withdrawn

I'm also using this to experiment with new possible special values, akin to `center="center"`, such as `center="left"` and `center="right"`, which I'm sure are useful to easily visualise domain boundaries / box "faces". This may be separated from this PR depending on how #3828 evolves.


## PR Checklist

- [x] Tests for invalid user input
- [x] Tests for deprecated user input
- [x] Tests for valid user input
- [x] Document `center="left"` and `center="right"`
- [x] Uniformize API for `yt.funcs.validate_center` and `YTDataContainer._set_center` (with minimal or no breaking changes)
- [x] make sure docstrings are in sync and up to date