### PR TITLE
BUG: fix a bug in SliceSelector where domain right edge was excluded from any selection

### DIFF
--- a/yt/geometry/_selection_routines/slice_selector.pxi
+++ b/yt/geometry/_selection_routines/slice_selector.pxi
@@ -97,7 +97,7 @@ cdef class SliceSelector(SelectorObject):
                                np.float64_t right_edge[3]) nogil:
         if self.reduced_dimensionality == 1:
             return 1
-        if left_edge[self.axis] - grid_eps <= self.coord < right_edge[self.axis]:
+        if left_edge[self.axis] - grid_eps <= self.coord <= right_edge[self.axis]:
             return 1
         return 0
 
@@ -108,7 +108,7 @@ cdef class SliceSelector(SelectorObject):
                                np.float64_t right_edge[3]) nogil:
         if self.reduced_dimensionality == 1:
             return 2
-        if left_edge[self.axis] - grid_eps <= self.coord < right_edge[self.axis]:
+        if left_edge[self.axis] - grid_eps <= self.coord <= right_edge[self.axis]:
             return 2 # a box with non-zero volume can't be inside a plane
         return 0
 

--- a/yt/geometry/_selection_routines/slice_selector.pxi
+++ b/yt/geometry/_selection_routines/slice_selector.pxi
@@ -108,7 +108,7 @@ cdef class SliceSelector(SelectorObject):
                                np.float64_t right_edge[3]) nogil:
         if self.reduced_dimensionality == 1:
             return 2
-        if left_edge[self.axis] - grid_eps <= self.coord <= right_edge[self.axis]:
+        if left_edge[self.axis] - grid_eps <= self.coord < right_edge[self.axis]:
             return 2 # a box with non-zero volume can't be inside a plane
         return 0
 


### PR DESCRIPTION
## PR Summary
Fixes #3828
Both examples I gave in the issue now work as expected (fake data and `"IsolatedGalaxy"`)
Note: I'm note sure which of these two lines _needs_ a change to fix the issue I'm addressing here, but I'm assuming they both need to be kept in sync.
