### PR TITLE
MNT: remove pyyaml and IPython from install_requires as they are both de facto optional dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,13 +38,11 @@ project_urls =
 packages = find:
 install_requires =
     cmyt>=0.2.2
-    ipython>=2.0.0
     matplotlib!=3.4.2,>=2.2.3  # keep in sync with tests/windows_conda_requirements.txt
     more-itertools>=8.4
     numpy>=1.14.5
     packaging>=20.9
     pyparsing>0.0  # hard dependency to MPL. We require it (unconstrained) in case MPL drops it in the future
-    pyyaml>=4.2b1
     setuptools>=19.6
     sympy!=1.9,>=1.2  # see https://github.com/sympy/sympy/issues/22241
     tomli>=1.2.3
@@ -81,6 +79,7 @@ full =
     firefly-vis>=2.0.4,<3.0.0
     glueviz>=0.13.3
     h5py>=3.1.0,<4.0.0
+    ipython>=2.0.0
     libconf>=1.0.1
     miniballcpp>=0.2.1
     mpi4py>=3.0.3
@@ -100,7 +99,6 @@ mapserver =
     bottle
 minimal =
     cmyt==0.2.2
-    ipython==2.0.0
     matplotlib==2.2.3
     more-itertools==8.4
     numpy==1.14.5
@@ -113,6 +111,7 @@ test =
     nose~=1.3.7
     nose-exclude
     nose-timer~=1.0.0
+    pyaml>=17.10.0
     pytest>=6.1
     pytest-xdist~=2.1.0
 typecheck =


### PR DESCRIPTION
## PR Summary
Follow up to the discussion in #3830, let's experiment with making IPython actually optional as a dependency.
I expect CI could fail at first because we haven't been using on_demand_import.py for IPython.

I note that there's also something weird with yaml support, where we currently require `pyyaml` in `install_deps` but `pyyaml` in the optional `full` environment.
