### PR TITLE
BUG: tentative fix for #2538

### DIFF
--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -472,6 +472,10 @@ class PlotWindow(ImagePlotContainer):
         for f, u in zip_equal(iter_fields(field), always_iterable(new_unit)):
             self.frb.set_unit(f, u, equivalency, equivalency_kwargs)
             self._equivalencies[f] = (equivalency, equivalency_kwargs)
+            if isinstance(self.plots[f].zmin, YTQuantity):
+                self.plots[f].zmin.convert_to_units(u)
+            if isinstance(self.plots[f].zmax, YTQuantity):
+                self.plots[f].zmax.convert_to_units(u)
         return self
 
     @invalidate_plot


### PR DESCRIPTION
## PR Summary
Fix #2538
So the hard part in fixing this (to me) is to reason about the many interacting classes here.
It seems to me that the easiest way to reconciliate `.set_zlim` and `.set_unit` plot methods in to store `zmin` and `zmax` as unyt_quantity objects instead of floats.
Until now I haven't been able to figure out a way to do that without changing the public API slightly, though my approach should actually make it more flexible as it allows `zmin` or `zmax` to be left unset in `set_zlim`, while on main, both are required.
I'm also not sure how this is going to behave with `PhasePlot` (which descend from `ImagePlotContainer` but don't have a frb attribute), but this needs to be adressed and tested.
For now I'll open as a draft to see if I'm breaking anything that's already exercised in CI.
