### PR TITLE
TST: add constraint to forbid sympy 1.10.0 in tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,6 @@ install_requires =
     pyparsing>0.0  # hard dependency to MPL. We require it (unconstrained) in case MPL drops it in the future
     pyyaml>=4.2b1
     setuptools>=19.6
-    sympy!=1.9,>=1.2  # see https://github.com/sympy/sympy/issues/22241
     tomli>=1.2.3
     tomli-w>=0.4.0
     tqdm>=3.4.0
@@ -115,6 +114,7 @@ test =
     nose-timer~=1.0.0
     pytest>=6.1
     pytest-xdist~=2.1.0
+    sympy!=1.10,!=1.9 # see https://github.com/sympy/sympy/issues/22241
 typecheck =
     mypy==0.910
     types-PyYAML==5.4.10


### PR DESCRIPTION
## PR Summary

Context: sympy 1.9 broke unpickling of unyt_array instance that were pickled with older versions (https://github.com/sympy/sympy/issues/22241)

Sympy 1.10 was released yesterday but unfortunately the fix it shipped didn't completely resolve the problem. Now we have good reasons to think the next release will be usable again in yt's CI (see discussion upstream), but for now we need a hotfix to stabilize tests.

Because this issue is purely with our testing framework and infrastructure, I'm moving these constraints away from `install_requires` since we don't want our need to constraint users.

Also note that I'm removing the `>=1.2` constraint since it's already imposed by unyt itself and we don't actually use sympy directly in yt.


