### PR TITLE
Add missing ionized species

### DIFF
--- a/yt/frontends/ramses/io.py
+++ b/yt/frontends/ramses/io.py
@@ -1,4 +1,6 @@
 from collections import defaultdict
+from pathlib import Path
+from typing import Union
 
 import numpy as np
 
@@ -209,13 +211,13 @@ class IOHandlerRAMSES(BaseIOHandler):
         return tr
 
 
-def _read_part_file_descriptor(fname):
+def _read_part_file_descriptor(fname: Union[str, Path]):
     """
     Read a file descriptor and returns the array of the fields found.
     """
 
     # Mapping
-    mapping = [
+    mapping_list = [
         ("position_x", "particle_position_x"),
         ("position_y", "particle_position_y"),
         ("position_z", "particle_position_z"),
@@ -229,7 +231,7 @@ def _read_part_file_descriptor(fname):
         ("tag", "particle_tag"),
     ]
     # Convert to dictionary
-    mapping = {k: v for k, v in mapping}
+    mapping = {k: v for k, v in mapping_list}
 
     with open(fname) as f:
         line = f.readline()
@@ -265,23 +267,27 @@ def _read_part_file_descriptor(fname):
     return fields
 
 
-def _read_fluid_file_descriptor(fname):
+def _read_fluid_file_descriptor(fname: Union[str, Path]):
     """
     Read a file descriptor and returns the array of the fields found.
     """
 
     # Mapping
-    mapping = [
+    mapping_list = [
         ("density", "Density"),
         ("velocity_x", "x-velocity"),
         ("velocity_y", "y-velocity"),
         ("velocity_z", "z-velocity"),
         ("pressure", "Pressure"),
         ("metallicity", "Metallicity"),
+        # Add mapping for ionized species
+        ("H_p1_fraction", "HII"),
+        ("He_p1_fraction", "HeII"),
+        ("He_p2_fraction", "HeIII"),
     ]
 
     # Add mapping for magnetic fields
-    mapping += [
+    mapping_list += [
         (key, key)
         for key in (
             f"B_{dim}_{side}" for side in ["left", "right"] for dim in ["x", "y", "z"]
@@ -289,7 +295,7 @@ def _read_fluid_file_descriptor(fname):
     ]
 
     # Convert to dictionary
-    mapping = {k: v for k, v in mapping}
+    mapping = {k: v for k, v in mapping_list}
 
     with open(fname) as f:
         line = f.readline()

--- a/yt/frontends/ramses/io.py
+++ b/yt/frontends/ramses/io.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from pathlib import Path
+import os
 from typing import Union
 
 import numpy as np
@@ -211,7 +211,7 @@ class IOHandlerRAMSES(BaseIOHandler):
         return tr
 
 
-def _read_part_file_descriptor(fname: Union[str, Path]):
+def _read_part_file_descriptor(fname: Union[str, "os.PathLike[str]"]):
     """
     Read a file descriptor and returns the array of the fields found.
     """
@@ -267,7 +267,7 @@ def _read_part_file_descriptor(fname: Union[str, Path]):
     return fields
 
 
-def _read_fluid_file_descriptor(fname: Union[str, Path]):
+def _read_fluid_file_descriptor(fname: Union[str, "os.PathLike[str]"]):
     """
     Read a file descriptor and returns the array of the fields found.
     """

--- a/yt/frontends/ramses/io.py
+++ b/yt/frontends/ramses/io.py
@@ -1,5 +1,5 @@
-from collections import defaultdict
 import os
+from collections import defaultdict
 from typing import Union
 
 import numpy as np
@@ -281,6 +281,12 @@ def _read_fluid_file_descriptor(fname: Union[str, "os.PathLike[str]"]):
         ("pressure", "Pressure"),
         ("metallicity", "Metallicity"),
         # Add mapping for ionized species
+        # Note: we expect internally that these names use the HII, HeII,
+        #       HeIII, ... convention for historical reasons. So we need to map
+        #       the names read from `hydro_file_descriptor.txt` to this
+        #       convention.
+        # This will create fields like ("ramses", "HII") which are mapped
+        # to ("gas", "H_p1_fraction") in fields.py
         ("H_p1_fraction", "HII"),
         ("He_p1_fraction", "HeII"),
         ("He_p2_fraction", "HeIII"),


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

With recent version of RAMSES, which field are present on-disk is documented by a side-car file named `hydro_file_descriptor.txt` which lists which field is which.

Confusingly, yt expects variables to use the old yt convention (e.g. `HII` is ionized hydrogen), while RAMSES moved to follow yt's convention in `hydro_file_descriptor.txt`! The long-term solution would be to migrate everything to yt's convention (`H_p1_fraction` for example) but it would require refactoring a lot of code in the RAMSES frontend.

Instead, I map here the variables read from the file descriptor to the "old" convention used throughout the RAMSES handler, which then maps back to the new yt convention... In other words, yt reads that the n-th variable is `H_p1_fraction`, it reads it into `("ramses", "HII")` which is then aliased to `("gas", "H_p1_fraction")`.