### PR TITLE
Pin jinja2 for docs build

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,7 @@ nose.plugins.0.10 =
 doc =
     alabaster
     bottle
+    jinja2<3.1.0  # see https://github.com/readthedocs/readthedocs.org/issues/9037
     jupyter-client<7.0
     nbconvert==5.6.1
     pyregion


### PR DESCRIPTION
Some deprecated features were removed in jinja2==3.1.0.

For details see e.g. https://github.com/pallets/jinja/issues/1626 and
https://github.com/readthedocs/readthedocs.org/issues/9037
We should probably update sphinx instead, but that breaks other
things...