### PR TITLE
BUG: fix a bug where PlotWindow origin parameter wasn't handled correctly in non-cartesian geometries

### DIFF
--- a/yt/data_objects/selection_objects/data_selection_objects.py
+++ b/yt/data_objects/selection_objects/data_selection_objects.py
@@ -536,6 +536,7 @@ class YTSelectionContainer2D(YTSelectionContainer):
             origin=origin,
             frb_generator=frb,
             plot_type=plot_type,
+            geometry=self.ds.geometry,
         )
         pw._setup_plots()
         return pw

--- a/yt/visualization/particle_plots.py
+++ b/yt/visualization/particle_plots.py
@@ -293,6 +293,7 @@ class ParticleProjectionPlot(PWViewerMPL):
             window_size=window_size,
             aspect=aspect,
             splat_color=splat_color,
+            geometry=ds.geometry,
         )
 
         self.set_axes_unit(axes_unit)

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -195,6 +195,8 @@ class PlotWindow(ImagePlotContainer):
         fontsize=18,
         aspect=None,
         setup=False,
+        *,
+        geometry="cartesian",
     ):
         self.center = None
         self._periodic = periodic
@@ -216,6 +218,20 @@ class PlotWindow(ImagePlotContainer):
         super().__init__(data_source, window_size, fontsize)
 
         self._set_window(bounds)  # this automatically updates the data and plot
+        if (
+            geometry
+            in (
+                "spherical",
+                "cylindrical",
+                "geographic",
+                "internal_geographic",
+                "polar",
+            )
+            and origin != "native"
+        ):
+            mylog.info("Setting origin='native' for %s geometry.", geometry)
+            origin = "native"
+
         self.origin = origin
         if self.data_source.center is not None and not oblique:
             ax = self.data_source.axis
@@ -1947,16 +1963,6 @@ class AxisAlignedSlicePlot(SlicePlot, PWViewerMPL):
         if field_parameters is None:
             field_parameters = {}
 
-        if ds.geometry in (
-            "spherical",
-            "cylindrical",
-            "geographic",
-            "internal_geographic",
-            "polar",
-        ):
-            mylog.info("Setting origin='native' for %s geometry.", ds.geometry)
-            origin = "native"
-
         if isinstance(ds, YTSpatialPlotDataset):
             slc = ds.all_data()
             slc.axis = axis
@@ -1983,6 +1989,7 @@ class AxisAlignedSlicePlot(SlicePlot, PWViewerMPL):
             aspect=aspect,
             right_handed=right_handed,
             buff_size=buff_size,
+            geometry=ds.geometry,
         )
         if axes_unit is None:
             axes_unit = get_axes_unit(width, ds)
@@ -2163,15 +2170,6 @@ class AxisAlignedProjectionPlot(ProjectionPlot, PWViewerMPL):
         normal = self.sanitize_normal_vector(ds, normal)
 
         axis = fix_axis(normal, ds)
-        if ds.geometry in (
-            "spherical",
-            "cylindrical",
-            "geographic",
-            "internal_geographic",
-            "polar",
-        ):
-            mylog.info("Setting origin='native' for %s geometry.", ds.geometry)
-            origin = "native"
         # If a non-weighted integral projection, assure field-label reflects that
         if weight_field is None and method == "integrate":
             self.projected = True
@@ -2220,6 +2218,7 @@ class AxisAlignedProjectionPlot(ProjectionPlot, PWViewerMPL):
             window_size=window_size,
             aspect=aspect,
             buff_size=buff_size,
+            geometry=ds.geometry,
         )
         if axes_unit is None:
             axes_unit = get_axes_unit(width, ds)


### PR DESCRIPTION
## PR Summary
fix #3862 by moving the responsibility of switching to `origin="native"` from `AxisAlignedSlicePlot` an `AxisAlignedProjectionPlot` to `PlotWindow`. Note that I'm not making any change to `OffAxis...Plot` classes, because they don't have support for non-cartesian geometries anyway, and they also don't expose the origin keyword argument.