### PR TITLE
BUG: Use cm_per_mpc instead of 3.08e24 #3867

### DIFF
--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -18,6 +18,7 @@ from yt.utilities.cython_fortran_utils import FortranFile as fpu
 from yt.utilities.lib.cosmology_time import friedman
 from yt.utilities.on_demand_imports import _f90nml as f90nml
 from yt.utilities.physical_constants import kb, mp
+from yt.utilities.physical_ratios import cm_per_mpc
 
 from .definitions import (
     OUTPUT_DIR_EXP,
@@ -973,7 +974,7 @@ class RAMSESDataset(Dataset):
 
                 self.current_time = (
                     (self.time_tot + self.time_simu)
-                    / (self.hubble_constant * 1e7 / 3.08e24)
+                    / (self.hubble_constant * 1e7 / cm_per_mpc)
                     / self.parameters["unit_t"]
                 )
             except IndexError:

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -119,10 +119,15 @@ def test_unit_cosmo():
     for force_cosmo in [True, None]:
         ds = yt.load(ramsesCosmo, cosmological=force_cosmo)
 
-        expected_raw_time = 1.119216564055017  # in ramses unit
+        # NOTE: these are the old test values, which used 3.08e24 as
+        # the Mpc to cm conversion factor
+        # expected_raw_time = 1.119216564055017 # in ramses unit
+        # expected_time = 3.756241729312462e17 # in seconds
+
+        expected_raw_time = 1.121279694787743 # in ramses unit
         assert_equal(ds.current_time.value, expected_raw_time)
 
-        expected_time = 3.756241729312462e17  # in seconds
+        expected_time = 3.7631658742904595e17 # in seconds
         assert_equal(ds.current_time.in_units("s").value, expected_time)
 
 

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -124,10 +124,10 @@ def test_unit_cosmo():
         # expected_raw_time = 1.119216564055017 # in ramses unit
         # expected_time = 3.756241729312462e17 # in seconds
 
-        expected_raw_time = 1.121279694787743 # in ramses unit
+        expected_raw_time = 1.121279694787743  # in ramses unit
         assert_equal(ds.current_time.value, expected_raw_time)
 
-        expected_time = 3.7631658742904595e17 # in seconds
+        expected_time = 3.7631658742904595e17  # in seconds
         assert_equal(ds.current_time.in_units("s").value, expected_time)
 
 


### PR DESCRIPTION
Fix for #3867.

## PR Summary

Use `cm_per_mpc` instead of 3.08e24 for conversion from Mpc to cm. Also partly addresses #2098:

```
ds = yt.load('output_00080/info_00080.txt')
tA = ds.current_time.to('Myr')
tB = ds.cosmology.t_from_z(ds.current_redshift).to('Myr')

print(tA-tB)
```
where `tA-tB` is now `-0.5628994599301222 Myr` where it was `-22.47323433951169 Myr`.