### PR TITLE
BUG: fix a regression where calling annotate_timestamp on a plot from a dataset with code units would crash

### DIFF
--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -2629,11 +2629,7 @@ class TimestampCallback(PlotCallback):
                 # here the time unit will be in brackets on the annotation.
                 un = self.time_unit.latex_representation()
                 time_unit = r"$\ \ (" + un + r")$"
-            except AttributeError as err:
-                if plot.ds._uses_code_time_unit:
-                    raise RuntimeError(
-                        "The time unit str repr didn't match expectations, something is wrong."
-                    ) from err
+            except AttributeError:
                 time_unit = str(self.time_unit).replace("_", " ")
             self.text += self.time_format.format(time=float(t), units=time_unit)
 

--- a/yt/visualization/tests/test_callbacks.py
+++ b/yt/visualization/tests/test_callbacks.py
@@ -92,6 +92,15 @@ def test_timestamp_callback():
         assert_fname(p.save(prefix)[0])
 
 
+def test_timestamp_callback_code_units():
+    # see https://github.com/yt-project/yt/issues/3869
+    with _cleanup_fname() as prefix:
+        ds = fake_random_ds(2, unit_system="code")
+        p = SlicePlot(ds, "z", ("gas", "density"))
+        p.annotate_timestamp()
+        assert_fname(p.save(prefix)[0])
+
+
 def test_scale_callback():
     with _cleanup_fname() as prefix:
         ax = "z"


### PR DESCRIPTION
## PR Summary
Fix #3869
Turns out that the custom error reraising introduced in #2728 is apparently not necessary since #3618, and combining both created a regression

```python
import yt
from yt.testing import fake_random_ds

ds = fake_random_ds(64, unit_system="code")
p = yt.SlicePlot(ds,"x",("gas", "density"))
p.annotate_timestamp(draw_inset_box=True)
p.save("timestamp.png")
```
![timestamp](https://user-images.githubusercontent.com/14075922/160706643-3aabe276-e620-4b29-af33-2fe44d44ca52.png)

