### PR TITLE
Manual backport #3832 to yt-4.0.x

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,12 +39,10 @@ project_urls =
 packages = find:
 install_requires =
     cmyt>=0.2.2
-    ipython>=2.0.0
     matplotlib!=3.4.2,>=2.1.0 # keep in sync with tests/windows_conda_requirements.txt
     more-itertools>=8.4
     numpy>=1.13.3
     packaging>=20.9
-    pyyaml>=4.2b1
     setuptools>=19.6
     tomli>=1.2.3
     tomli-w>=0.4.0
@@ -81,6 +79,7 @@ full =
     firefly-vis>=2.0.4,<3.0.0
     glueviz>=0.13.3
     h5py>=3.1.0,<4.0.0
+    ipython>=2.0.0
     libconf>=1.0.1
     miniballcpp>=0.2.1
     mpi4py>=3.0.3
@@ -99,7 +98,6 @@ mapserver =
     bottle
 minimal =
     cmyt==0.2.2
-    ipython==2.0.0
     matplotlib==2.1.0
     more-itertools==8.4
     numpy==1.13.3
@@ -113,6 +111,7 @@ test =
     nose~=1.3.7
     nose-exclude
     nose-timer~=1.0.0
+    pyaml>=17.10.0
     pytest>=6.1
     pytest-xdist~=2.1.0
     sympy!=1.10,!=1.9 # see https://github.com/sympy/sympy/issues/22241


### PR DESCRIPTION
## PR Summary

MNT: remove pyyaml and IPython from install_requires as they are both de facto optional dependencies
(cherry picked from commit 7b604073173f976a38a5e7407c3c2ab7af366e6c)
