### PR TITLE
OWLS Electron number density field should return a value

### DIFF
--- a/yt/frontends/owls/fields.py
+++ b/yt/frontends/owls/fields.py
@@ -202,6 +202,7 @@ class OWLSFieldInfo(SPHFieldInfo):
                 n_e = data[ptype, "H_p1_number_density"]
                 n_e += data[ptype, "He_p1_number_density"]
                 n_e += 2.0 * data[ptype, "He_p2_number_density"]
+                return n_e
 
             self.add_field(
                 (ptype, "El_number_density"),


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

The `("PartType0","El_number_density")` field function in the OWLS frontend is not returning a value. This fixes that.

Fixes issue #3838.
 
<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->