### PR TITLE
REL: upgrade cuilbuildwheel (2.3.0 -> 2.4.0)

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -7,6 +7,9 @@ on:
       - stable
     tags:
       - 'yt-*'
+  pull_request:
+    paths:
+      - '.github/workflows/wheels.yaml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -39,7 +39,7 @@ jobs:
           CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-*"
           CIBW_SKIP: "*-musllinux_*"  #  numpy doesn't have wheels for musllinux so we can't build some quickly and without bloating
           CIBW_ARCHS_LINUX: "x86_64"
-          CIBW_ARCHS_MACOS: "x86_64"
+          CIBW_ARCHS_MACOS: x86_64 arm64
           CIBW_ARCHS_WINDOWS: "auto"
           CIBW_ENVIRONMENT: "LDFLAGS='-static-libstdc++'"
           CIBW_BUILD_VERBOSITY: 1

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build wheels for CPython
-        uses: pypa/cibuildwheel@v2.3.0
+        uses: pypa/cibuildwheel@v2.4.0
         with:
           output-dir: dist
         env:


### PR DESCRIPTION
## PR Summary

Simple one line patch so we can use the current version of cibuildwheel for our next release

the one patch that I think is relevant to us is: https://github.com/pypa/cibuildwheel/pull/975

see complete release notes : https://github.com/pypa/cibuildwheel/releases


A test job is running on my fork for this branch: https://github.com/neutrinoceros/yt/actions/runs/2140271185