### PR TITLE
BUG: fix compatibility with gadget 2 files using '*.gad.*' template

### DIFF
--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -427,7 +427,15 @@ class GadgetDataset(SPHDataset):
         )
 
         if hvals["NumFiles"] > 1:
-            self.filename_template = f"{prefix}.%(num)s{self._suffix}"
+            for t in (
+                f"{prefix}.%(num)s{self._suffix}",
+                f"{prefix}.gad.%(num)s{self._suffix}",
+            ):
+                if os.path.isfile(t % {"num": 0}):
+                    self.filename_template = t
+                    break
+            else:
+                raise RuntimeError("Could not determine correct data file template.")
         else:
             self.filename_template = self.parameter_filename
 


### PR DESCRIPTION
## PR Summary
This fixes an issue where some Gadget2 files can't be loaded because their names aren't compatible with the filename template we have.
This problem was reported on Slack by @Gustav-Madsen. Here's an example dataset to test this on http://skun.iaa.es/SUsimulations/UchuuDR1/ShinUchuu/SamplingParticle/snapdir_070/
I was able to make a simple plot of this dataset, only downloading the first 3 files

```python
import yt

ds = yt.load("snapdir_070")
yt.ParticleProjectionPlot(ds, "z", ("all", "Mass")).save("/tmp/")
```
![SU140_070_samp0p015625_Particle_z_Mass](https://user-images.githubusercontent.com/14075922/164103066-d61dec77-7cc1-4cb5-9bff-4225afd01326.png)

