### PR TITLE
BUG: deactivate antialising in pixelize_cartesian when data is uniform

### DIFF
--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -128,6 +128,8 @@ def pixelize_cartesian(np.float64_t[:,:] buff,
        px.shape[0] != pdy.shape[0] or \
        px.shape[0] != data.shape[0]:
         raise YTPixelizeError("Arrays are not of correct shape.")
+    if np.nanmax(data) == np.nanmin(data):
+        antialias = 0
     xiter[0] = yiter[0] = 0
     xiterv[0] = yiterv[0] = 0.0
     # Here's a basic outline of what we're going to do here.  The xiter and


### PR DESCRIPTION
## PR Summary
Fix #3895
I'm not 100% sure that calling `np.nanmin` and `np.nanmax` isn't calling the Python API, which would make this patch potentially hurtful to performance.
