### PR TITLE
EXP: limit image buffer to single precision

### DIFF
--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -163,6 +163,7 @@ class FixedResolutionBuffer:
         except (KeyError, AttributeError):
             units = self.data_source[item].units
 
+        buff = buff.astype("float32", copy=False)
         ia = ImageArray(buff, units=units, info=self._get_info(item))
         self.data[item] = ia
         return self.data[item]


### PR DESCRIPTION
## PR Summary

This patch is a candidate solution to #3895, but I expect it'd have to be opt-in rather than locked-in
Opening as an experiment: I want to check how big of a break (as measured in test failures) would making FRB images single precision cause.
