### PR TITLE
RFC: simplify test skipper decorators

### DIFF
--- a/yt/data_objects/tests/test_glue.py
+++ b/yt/data_objects/tests/test_glue.py
@@ -8,7 +8,7 @@ def setup_func():
     ytcfg["yt", "internals", "within_testing"] = True
 
 
-@requires_module("glue.core")
+@requires_module("glue")
 @nose.with_setup(setup_func)
 def test_glue_data_object():
     ds = fake_random_ds(16)

--- a/yt/fields/tests/test_sph_fields.py
+++ b/yt/fields/tests/test_sph_fields.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 
 import yt
-from yt.testing import assert_array_almost_equal, assert_equal, requires_file
+from yt.testing import assert_array_almost_equal, assert_equal, requires_file, skip
 
 isothermal_h5 = "IsothermalCollapse/snap_505.hdf5"
 isothermal_bin = "IsothermalCollapse/snap_505"
@@ -34,6 +34,7 @@ gas_fields_to_particle_fields = {
 }
 
 
+@skip(reason="See https://github.com/yt-project/yt/issues/3909")
 @requires_file(isothermal_bin)
 @requires_file(isothermal_h5)
 @requires_file(snap_33)

--- a/yt/frontends/ytdata/tests/test_old_outputs.py
+++ b/yt/frontends/ytdata/tests/test_old_outputs.py
@@ -23,7 +23,7 @@ from yt.frontends.ytdata.tests.test_outputs import (
     YTDataFieldTest,
     compare_unit_attributes,
 )
-from yt.testing import assert_allclose_units, assert_array_equal, requires_file
+from yt.testing import assert_allclose_units, assert_array_equal, requires_file, skip
 from yt.units.yt_array import YTArray
 from yt.utilities.answer_testing.framework import data_dir_load, requires_ds
 from yt.visualization.profile_plotter import PhasePlot, ProfilePlot
@@ -32,6 +32,7 @@ enzotiny = "enzo_tiny_cosmology/DD0046/DD0046"
 ytdata_dir = "ytdata_test"
 
 
+@skip(reason="See https://github.com/yt-project/yt/issues/3909")
 @requires_ds(enzotiny)
 @requires_file(os.path.join(ytdata_dir, "DD0046_sphere.h5"))
 @requires_file(os.path.join(ytdata_dir, "DD0046_cut_region.h5"))
@@ -53,6 +54,7 @@ def test_old_datacontainer_data():
     assert (cr[("gas", "temperature")] == cr_ds.data[("gas", "temperature")]).all()
 
 
+@skip(reason="See https://github.com/yt-project/yt/issues/3909")
 @requires_ds(enzotiny)
 @requires_file(os.path.join(ytdata_dir, "DD0046_covering_grid.h5"))
 @requires_file(os.path.join(ytdata_dir, "DD0046_arbitrary_grid.h5"))
@@ -89,6 +91,7 @@ def test_old_grid_datacontainer_data():
     yield YTDataFieldTest(full_fn, ("gas", "density"), geometric=False)
 
 
+@skip(reason="See https://github.com/yt-project/yt/issues/3909")
 @requires_ds(enzotiny)
 @requires_file(os.path.join(ytdata_dir, "DD0046_proj.h5"))
 def test_old_spatial_data():
@@ -101,6 +104,7 @@ def test_old_spatial_data():
     yield YTDataFieldTest(full_fn, ("gas", "density"), geometric=False)
 
 
+@skip(reason="See https://github.com/yt-project/yt/issues/3909")
 @requires_ds(enzotiny)
 @requires_file(os.path.join(ytdata_dir, "DD0046_Profile1D.h5"))
 @requires_file(os.path.join(ytdata_dir, "DD0046_Profile2D.h5"))
@@ -163,6 +167,7 @@ def test_old_profile_data():
     shutil.rmtree(tmpdir)
 
 
+@skip(reason="See https://github.com/yt-project/yt/issues/3909")
 @requires_ds(enzotiny)
 @requires_file(os.path.join(ytdata_dir, "test_data.h5"))
 @requires_file(os.path.join(ytdata_dir, "random_data.h5"))

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -1,6 +1,4 @@
-import functools
 import hashlib
-import importlib
 import itertools as it
 import os
 import pickle
@@ -8,7 +6,10 @@ import shutil
 import sys
 import tempfile
 import unittest
+from functools import wraps
+from importlib.util import find_spec
 from shutil import which
+from unittest import SkipTest
 
 import matplotlib
 import numpy as np
@@ -858,19 +859,27 @@ def expand_keywords(keywords, full=False):
     return list_of_kwarg_dicts
 
 
-def skip_case(*, reason: str):
-    """
-    An adapter test skipping function that should work with both test runners
-    (nosetest or pytest) and with any Python version.
-    """
-    if sys.version_info >= (3, 10):
-        # nose isn't compatible with Python 3.10 so we can't import it here
-        pytest.skip(reason)
-    else:
-        # pytest.skip() isn't recognized by nosetest (but nose.SkipTest works in pytest !)
-        from nose import SkipTest
+def skip(reason: str):
+    # a drop-in replacement for pytest.mark.skip decorator with nose-compatibility
+    def dec(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            raise SkipTest(reason)
 
-        raise SkipTest(reason)
+        return wrapper
+
+    return dec
+
+
+def skipif(condition: bool, reason: str):
+    # a drop-in replacement for pytest.mark.skipif decorator with nose-compatibility
+    def dec(func):
+        if condition:
+            return skip(reason)(func)
+        else:
+            return func
+
+    return dec
 
 
 def requires_module(module):
@@ -881,27 +890,7 @@ def requires_module(module):
     being imported will not fail if the module is not installed on the testing
     platform.
     """
-
-    def ffalse(func):
-        @functools.wraps(func)
-        def false_wrapper(*args, **kwargs):
-            skip_case(reason=f"Missing required module {module}")
-
-        return false_wrapper
-
-    def ftrue(func):
-        @functools.wraps(func)
-        def true_wrapper(*args, **kwargs):
-            return func(*args, **kwargs)
-
-        return true_wrapper
-
-    try:
-        importlib.import_module(module)
-    except ImportError:
-        return ffalse
-    else:
-        return ftrue
+    return skipif(find_spec(module) is None, reason=f"Missing required module {module}")
 
 
 def requires_module_pytest(*module_names):
@@ -934,7 +923,7 @@ def requires_module_pytest(*module_names):
             missing,
             reason=f"missing requirement(s): {', '.join(missing)}",
         )
-        @functools.wraps(func)
+        @wraps(func)
         def inner_func(*args, **kwargs):
             return func(*args, **kwargs)
 
@@ -944,35 +933,16 @@ def requires_module_pytest(*module_names):
 
 
 def requires_file(req_file):
-    path = ytcfg.get("yt", "test_data_dir")
-
-    def ffalse(func):
-        @functools.wraps(func)
-        def false_wrapper(*args, **kwargs):
-            if ytcfg.get("yt", "internals", "strict_requires"):
-                raise FileNotFoundError(req_file)
-            skip_case(reason=f"Missing required file {req_file}")
-
-        return false_wrapper
-
-    def ftrue(func):
-        @functools.wraps(func)
-        def true_wrapper(*args, **kwargs):
-            return func(*args, **kwargs)
-
-        return true_wrapper
-
-    if os.path.exists(req_file):
-        return ftrue
-    else:
-        if os.path.exists(os.path.join(path, req_file)):
-            return ftrue
-        else:
-            return ffalse
+    condition = (
+        not os.path.exists(req_file)
+        and not os.path.exists(os.path.join(ytcfg.get("yt", "test_data_dir"), req_file))
+        and not ytcfg.get("yt", "internals", "strict_requires")
+    )
+    return skipif(condition, reason=f"Missing required file {req_file}")
 
 
 def disable_dataset_cache(func):
-    @functools.wraps(func)
+    @wraps(func)
     def newfunc(*args, **kwargs):
         restore_cfg_state = False
         if not ytcfg.get("yt", "skip_dataset_cache"):
@@ -1107,7 +1077,7 @@ def check_results(func):
     """
 
     def compute_results(func):
-        @functools.wraps(func)
+        @wraps(func)
         def _func(*args, **kwargs):
             name = kwargs.pop("result_basename", func.__name__)
             rv = func(*args, **kwargs)
@@ -1135,7 +1105,7 @@ def check_results(func):
         return compute_results(func)
 
     def compare_results(func):
-        @functools.wraps(func)
+        @wraps(func)
         def _func(*args, **kwargs):
             name = kwargs.pop("result_basename", func.__name__)
             rv = func(*args, **kwargs)
@@ -1198,7 +1168,6 @@ def run_nose(
         "in the process of migrating yt tests from nose to pytest.",
         since="4.1.0",
     )
-    import sys
 
     from yt.utilities.logger import ytLogger as mylog
     from yt.utilities.on_demand_imports import _nose
@@ -1367,8 +1336,9 @@ def requires_backend(backend):
         # needed since None is no longer returned, so we check for the skip
         # exception in the xfail case for that test
         def skip(*args, **kwargs):
-            msg = f"`{backend}` backend not in use, skipping: `{func.__name__}`"
-            skip_case(reason=msg)
+            raise SkipTest(
+                f"`{backend}` backend not in use, skipping: `{func.__name__}`"
+            )
 
         if ytcfg.get("yt", "internals", "within_pytest"):
             return skip
@@ -1395,7 +1365,7 @@ def requires_external_executable(*names):
             missing,
             reason=f"missing external executable(s): {', '.join(missing)}",
         )
-        @functools.wraps(func)
+        @wraps(func)
         def inner_func(*args, **kwargs):
             return func(*args, **kwargs)
 

--- a/yt/tests/test_testing.py
+++ b/yt/tests/test_testing.py
@@ -1,3 +1,5 @@
+from unittest import SkipTest
+
 import matplotlib
 
 from yt.testing import requires_backend
@@ -6,18 +8,25 @@ active_backend = matplotlib.get_backend()
 inactive_backend = ({"gtkagg", "macosx", "wx", "tkagg"} - {active_backend}).pop()
 
 
-@requires_backend(inactive_backend)
 def test_requires_inactive_backend():
-    # this test cannot pass, check that it's always skipped
-    raise AssertionError("@requires_backend appears to be broken (expected skip)")
+    @requires_backend(inactive_backend)
+    def foo():
+        return
+
+    try:
+        foo()
+    except SkipTest:
+        pass
+    else:
+        raise AssertionError(
+            "@requires_backend appears to be broken (skip was expected)"
+        )
 
 
 def test_requires_active_backend():
-    from unittest import SkipTest
-
     @requires_backend(active_backend)
     def foo():
-        assert True
+        return
 
     try:
         foo()

--- a/yt/tests/test_testing.py
+++ b/yt/tests/test_testing.py
@@ -1,30 +1,27 @@
 import matplotlib
-import numpy as np
-import pytest
 
-from yt.config import ytcfg
-from yt.testing import assert_equal, requires_backend
+from yt.testing import requires_backend
+
+active_backend = matplotlib.get_backend()
+inactive_backend = ({"gtkagg", "macosx", "wx", "tkagg"} - {active_backend}).pop()
 
 
-def test_requires_backend():
-    backend = matplotlib.get_backend().lower()
-    other_backends = {"gtkagg", "macosx", "wx", "tkagg"} - {backend}
+@requires_backend(inactive_backend)
+def test_requires_inactive_backend():
+    # this test cannot pass, check that it's always skipped
+    raise AssertionError("@requires_backend appears to be broken (expected skip)")
 
-    @requires_backend(other_backends.pop())
-    def plot_a():
-        return True
 
-    @requires_backend(backend)
-    def plot_b():
-        return True
+def test_requires_active_backend():
+    from unittest import SkipTest
 
-    assert_equal(plot_b(), True)
-    if not ytcfg.get("yt", "internals", "within_pytest"):
-        assert_equal(plot_a(), None)
-    else:
-        # NOTE: This doesn't actually work. pytest.skip() doesn't actually
-        # raise the exception but rather returns control to the function's
-        # (test_requires_backend) caller, breaking immediately. As such,
-        # this assert_rasies never actually happens. See the comment
-        # in the definition of requires_backend for why pytest.skip is used
-        np.testing.assert_raises(plot_a(), pytest.skip.Exception)
+    @requires_backend(active_backend)
+    def foo():
+        assert True
+
+    try:
+        foo()
+    except SkipTest:
+        raise AssertionError(
+            "@requires_backend appears to be broken (skip was not expected)"
+        )

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -1127,7 +1127,7 @@ def requires_answer_testing():
 
 
 def requires_ds(ds_fn, big_data=False, file_check=False):
-    condition = (not run_big_data and big_data) or not can_run_ds(ds_fn, file_check)
+    condition = (big_data and not run_big_data) or not can_run_ds(ds_fn, file_check)
     return skipif(condition, reason="cannot load dataset")
 
 

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -31,6 +31,7 @@ from yt.testing import (
     assert_almost_equal,
     assert_equal,
     assert_rel_equal,
+    skipif,
 )
 from yt.utilities.exceptions import YTCloudError, YTNoAnswerNameSpecified, YTNoOldAnswer
 from yt.utilities.logger import disable_stream_logging
@@ -1119,47 +1120,15 @@ class AxialPixelizationTest(AnswerTestingTest):
 
 
 def requires_answer_testing():
-    from functools import wraps
-
-    from nose import SkipTest
-
-    def ffalse(func):
-        @wraps(func)
-        def fskip(*args, **kwargs):
-            raise SkipTest
-
-        return fskip
-
-    def ftrue(func):
-        return func
-
-    if AnswerTestingTest.result_storage is not None:
-        return ftrue
-    else:
-        return ffalse
+    return skipif(
+        AnswerTestingTest.result_storage is None,
+        reason="answer testing storage is not properly setup",
+    )
 
 
 def requires_ds(ds_fn, big_data=False, file_check=False):
-    from functools import wraps
-
-    from nose import SkipTest
-
-    def ffalse(func):
-        @wraps(func)
-        def fskip(*args, **kwargs):
-            raise SkipTest
-
-        return fskip
-
-    def ftrue(func):
-        return func
-
-    if not run_big_data and big_data:
-        return ffalse
-    elif not can_run_ds(ds_fn, file_check):
-        return ffalse
-    else:
-        return ftrue
+    condition = (not run_big_data and big_data) or not can_run_ds(ds_fn, file_check)
+    return skipif(condition, reason="cannot load dataset")
 
 
 def small_patch_amr(ds_fn, fields, input_center="max", input_weight=("gas", "density")):


### PR DESCRIPTION
## PR Summary
This is a small step in trying to make the testing framework smaller in size and easier to maintain with the migration from nose to pytest in mind.
The central idea is to systematically use the `unittest.SkipTest` exception to (conditionally) skip tests, because it's supported by all frameworks.
