### PR TITLE
ENH: Update Enzo-E particle mass/density distinction

### DIFF
--- a/yt/frontends/enzo_e/data_structures.py
+++ b/yt/frontends/enzo_e/data_structures.py
@@ -354,6 +354,14 @@ class EnzoEDataset(Dataset):
         if os.path.exists(lcfn):
             with open(lcfn) as lf:
                 self.parameters = libconf.load(lf)
+
+            # Determine if particle masses are actually densities by the
+            # existence of the "mass_is_mass" particles parameter.
+            mass_flag = nested_dict_get(
+                self.parameters, ("Particle", "mass_is_mass"),
+                default=None)
+            self._particle_mass_is_mass = mass_flag is not None
+
             cosmo = nested_dict_get(self.parameters, ("Physics", "cosmology"))
             if cosmo is not None:
                 self.cosmological_simulation = 1

--- a/yt/frontends/enzo_e/data_structures.py
+++ b/yt/frontends/enzo_e/data_structures.py
@@ -355,13 +355,6 @@ class EnzoEDataset(Dataset):
             with open(lcfn) as lf:
                 self.parameters = libconf.load(lf)
 
-            # Determine if particle masses are actually densities by the
-            # existence of the "mass_is_mass" particles parameter.
-            mass_flag = nested_dict_get(
-                self.parameters, ("Particle", "mass_is_mass"), default=None
-            )
-            self._particle_mass_is_mass = mass_flag is not None
-
             cosmo = nested_dict_get(self.parameters, ("Physics", "cosmology"))
             if cosmo is not None:
                 self.cosmological_simulation = 1

--- a/yt/frontends/enzo_e/fields.py
+++ b/yt/frontends/enzo_e/fields.py
@@ -4,7 +4,9 @@ from yt._typing import KnownFieldsT
 from yt.fields.field_info_container import FieldInfoContainer
 from yt.fields.magnetic_field import setup_magnetic_field_aliases
 from yt.fields.particle_fields import add_union_field
-from yt.frontends.enzo_e.misc import nested_dict_get
+from yt.frontends.enzo_e.misc import \
+    get_particle_mass_correction, \
+    nested_dict_get
 
 rho_units = "code_mass / code_length**3"
 vel_units = "code_velocity"
@@ -149,12 +151,8 @@ class EnzoEFieldInfo(FieldInfoContainer):
             return
 
         val = constants[names.index("mass")][2] * self.ds.mass_unit
-        if not getattr(self.ds, "_particle_mass_is_mass", False):
-            val = (
-                val
-                * (self.ds.domain_width / self.ds.domain_dimensions).prod()
-                / self.ds.length_unit**3
-            )
+        if not self.ds.index.io._particle_mass_is_mass:
+            val = val * get_particle_mass_correction(self.ds)
 
         def _pmass(field, data):
             return val * data[ptype, "particle_ones"]

--- a/yt/frontends/enzo_e/fields.py
+++ b/yt/frontends/enzo_e/fields.py
@@ -4,9 +4,7 @@ from yt._typing import KnownFieldsT
 from yt.fields.field_info_container import FieldInfoContainer
 from yt.fields.magnetic_field import setup_magnetic_field_aliases
 from yt.fields.particle_fields import add_union_field
-from yt.frontends.enzo_e.misc import \
-    get_particle_mass_correction, \
-    nested_dict_get
+from yt.frontends.enzo_e.misc import get_particle_mass_correction, nested_dict_get
 
 rho_units = "code_mass / code_length**3"
 vel_units = "code_velocity"

--- a/yt/frontends/enzo_e/fields.py
+++ b/yt/frontends/enzo_e/fields.py
@@ -143,7 +143,7 @@ class EnzoEFieldInfo(FieldInfoContainer):
                 constants = (constants,)
             names = [c[0] for c in constants]
 
-        group_list  = nested_dict_get(
+        group_list = nested_dict_get(
             self.ds.parameters, ("Particle", ptype, "group_list"), default=()
         )
 
@@ -152,8 +152,9 @@ class EnzoEFieldInfo(FieldInfoContainer):
             # particle masses were stored as densities if the simulation
             # was cosmological.
             pfield = "mass"
-            is_density = "is_gravitating" not in group_list and \
-              self.ds.cosmological_simulation
+            is_density = (
+                "is_gravitating" not in group_list and self.ds.cosmological_simulation
+            )
         elif "density" in names:
             pfield = "density"
             is_density = True

--- a/yt/frontends/enzo_e/fields.py
+++ b/yt/frontends/enzo_e/fields.py
@@ -133,9 +133,7 @@ class EnzoEFieldInfo(FieldInfoContainer):
             add_union_field(self, ptype, fname, "code_mass")
             return
 
-        pdict = nested_dict_get(
-            self.ds.parameters, ("Particle"), default=None
-        )
+        pdict = self.ds.parameters.get("Particle", None)
         if pdict is None:
             return
 

--- a/yt/frontends/enzo_e/fields.py
+++ b/yt/frontends/enzo_e/fields.py
@@ -143,6 +143,8 @@ class EnzoEFieldInfo(FieldInfoContainer):
         if not constants:
             return
 
+        # constants should be a tuple consisting of multiple tuples of (name, type, value).
+        # When there is only one entry, the enclosing tuple gets stripped, so we put it back.
         if not isinstance(constants[0], tuple):
             constants = (constants,)
         names = [c[0] for c in constants]

--- a/yt/frontends/enzo_e/io.py
+++ b/yt/frontends/enzo_e/io.py
@@ -1,5 +1,8 @@
 import numpy as np
 
+from yt.frontends.enzo_e.misc import \
+    get_particle_mass_correction, \
+    nested_dict_get
 from yt.utilities.exceptions import YTException
 from yt.utilities.io_handler import BaseIOHandler
 from yt.utilities.on_demand_imports import _h5py as h5py
@@ -17,6 +20,13 @@ class EnzoEIOHandler(BaseIOHandler):
         self._base = self.ds.dimensionality * (
             slice(self.ds.ghost_zones, -self.ds.ghost_zones),
         )
+
+        # Determine if particle masses are actually densities by the
+        # existence of the "mass_is_mass" particles parameter.
+        mass_flag = nested_dict_get(
+            self.ds.parameters, ("Particle", "mass_is_mass"), default=None
+        )
+        self._particle_mass_is_mass = mass_flag is not None
 
     def _read_field_names(self, grid):
         if grid.filename is None:
@@ -116,13 +126,8 @@ class EnzoEIOHandler(BaseIOHandler):
                         continue
                     for field in field_list:
                         data = np.asarray(group.get(pn % field)[()], "=f8")
-                        if field == "mass" and not getattr(
-                            self.ds, "_particle_mass_is_mass", False
-                        ):
-                            mfac = (
-                                self.ds.domain_width / self.ds.domain_dimensions
-                            ).prod() / self.ds.length_unit**3
-                            data[mask] *= mfac
+                        if field == "mass" and not self._particle_mass_is_mass:
+                            data[mask] *= get_particle_mass_correction(self.ds)
                         yield (ptype, field), data[mask]
             if f:
                 f.close()

--- a/yt/frontends/enzo_e/io.py
+++ b/yt/frontends/enzo_e/io.py
@@ -116,6 +116,11 @@ class EnzoEIOHandler(BaseIOHandler):
                         continue
                     for field in field_list:
                         data = np.asarray(group.get(pn % field)[()], "=f8")
+                        if field == "mass" and not getattr(self.ds, "_particle_mass_is_mass", False):
+                            mfac = (self.ds.domain_width /
+                                    self.ds.domain_dimensions).prod() / \
+                                    self.ds.length_unit**3
+                            data[mask] *= mfac
                         yield (ptype, field), data[mask]
             if f:
                 f.close()

--- a/yt/frontends/enzo_e/io.py
+++ b/yt/frontends/enzo_e/io.py
@@ -1,8 +1,6 @@
 import numpy as np
 
-from yt.frontends.enzo_e.misc import \
-    get_particle_mass_correction, \
-    nested_dict_get
+from yt.frontends.enzo_e.misc import get_particle_mass_correction, nested_dict_get
 from yt.utilities.exceptions import YTException
 from yt.utilities.io_handler import BaseIOHandler
 from yt.utilities.on_demand_imports import _h5py as h5py

--- a/yt/frontends/enzo_e/misc.py
+++ b/yt/frontends/enzo_e/misc.py
@@ -121,3 +121,13 @@ def nested_dict_get(pdict, keys, default=None):
         except KeyError:
             return default
     return val
+
+def get_particle_mass_correction(ds):
+    """
+    Normalize particle masses by the root grid cell volume.
+
+    This correction is used for Enzo-E datasets where particle
+    masses are stored as densities.
+    """
+
+    return (ds.domain_width / ds.domain_dimensions).prod() / ds.length_unit**3

--- a/yt/frontends/enzo_e/misc.py
+++ b/yt/frontends/enzo_e/misc.py
@@ -122,6 +122,7 @@ def nested_dict_get(pdict, keys, default=None):
             return default
     return val
 
+
 def get_particle_mass_correction(ds):
     """
     Normalize particle masses by the root grid cell volume.


### PR DESCRIPTION
## PR Summary

Enzo-E has been updated to include a new way of distinguishing whether particles are saved as masses or densities. This is done using the "mass" or "density" parameter in the parameter file. Previously, particle masses were to be considered as densities if the simulation was cosmological. To preserve backward compatibility, Enzo-E now uses an "is_gravitating" group name that I use to tell if the data was produced before or after this change.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
