### PR TITLE
BUG: fixup FieldInfoContainer.add_field

### DIFF
--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -296,7 +296,9 @@ class FieldInfoContainer(dict):
             )
         return sampling_type
 
-    def add_field(self, name, function, sampling_type, **kwargs):
+    def add_field(
+        self, name, function, sampling_type, *, force_override=False, **kwargs
+    ):
         """
         Add a new field, along with supplemental metadata, to the list of
         available fields.  This respects a number of arguments, all of which
@@ -313,6 +315,8 @@ class FieldInfoContainer(dict):
            arguments (field, data)
         sampling_type: str
            "cell" or "particle" or "local"
+        force_override: bool
+           If False (default), an error will be raised if a field of the same name already exists.
         units : str
            A plain text string encoding the unit.  Powers must be in
            python syntax (** instead of ^). If set to "auto" the units
@@ -327,9 +331,8 @@ class FieldInfoContainer(dict):
            A name used in the plots
 
         """
-        override = kwargs.pop("force_override", False)
         # Handle the case where the field has already been added.
-        if not override and name in self:
+        if not force_override and name in self:
             # See below.
             if function is None:
 

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -332,6 +332,10 @@ class FieldInfoContainer(dict):
         """
         # Handle the case where the field has already been added.
         if not force_override and name in self:
+            mylog.warning(
+                "Field %s already exists. To override use `force_override=True`.",
+                name,
+            )
             # See below.
             if function is None:
 

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -282,8 +282,6 @@ class FieldInfoContainer(dict):
         ------
         ValueError
             For unsupported values in sampling_type
-        RuntimeError
-            If conflicting parameters are passed.
         """
         try:
             sampling_type = sampling_type.lower()
@@ -359,9 +357,7 @@ class FieldInfoContainer(dict):
             self[name] = DerivedField(name, sampling_type, function, **kwargs)
             return
 
-        sampling_type = self._sanitize_sampling_type(
-            sampling_type, particle_type=kwargs.get("particle_type")
-        )
+        sampling_type = self._sanitize_sampling_type(sampling_type)
 
         if sampling_type == "particle":
             ftype = "all"

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -267,7 +267,7 @@ class FieldInfoContainer(dict):
                 self.alias((ftype, alias), field)
 
     @staticmethod
-    def _sanitize_sampling_type(sampling_type):
+    def _sanitize_sampling_type(sampling_type: str) -> str:
         """Detect conflicts between deprecated and new parameters to specify the
         sampling type in a new field.
 
@@ -283,11 +283,10 @@ class FieldInfoContainer(dict):
         ValueError
             For unsupported values in sampling_type
         """
-        try:
-            sampling_type = sampling_type.lower()
-        except AttributeError as e:
-            raise TypeError("sampling_type should be a string.") from e
+        if not isinstance(sampling_type, str):
+            raise TypeError("sampling_type should be a string.")
 
+        sampling_type = sampling_type.lower()
         acceptable_samplings = ("cell", "particle", "local")
         if sampling_type not in acceptable_samplings:
             raise ValueError(

--- a/yt/fields/local_fields.py
+++ b/yt/fields/local_fields.py
@@ -6,7 +6,9 @@ from .field_plugin_registry import register_field_plugin
 
 
 class LocalFieldInfoContainer(FieldInfoContainer):
-    def add_field(self, name, function, sampling_type, **kwargs):
+    def add_field(
+        self, name, function, sampling_type, *, force_override=False, **kwargs
+    ):
 
         sampling_type = self._sanitize_sampling_type(sampling_type)
 
@@ -25,7 +27,9 @@ class LocalFieldInfoContainer(FieldInfoContainer):
                 name,
             )
 
-        return super().add_field(name, function, sampling_type, **kwargs)
+        return super().add_field(
+            name, function, sampling_type, force_override=force_override, **kwargs
+        )
 
 
 # Empty FieldInfoContainer


### PR DESCRIPTION
## PR Summary
A couple fixes for this method. Most importantly fixes some broken leftovers from https://github.com/yt-project/yt/pull/3240

- BUG: fix a broken internal function call
- ENH: clarify FieldInfoContainer.add_field's signature (add missing force_override kwarg)
- ENH: avoid confusing exception chaining in sanitizer method


The bug this fixes isn't present on the backport branch so this gets triaged to 4.1