### PR TITLE
DEPR: make some old deprecation warnings user-visible

### DIFF
--- a/yt/data_objects/index_subobjects/grid_patch.py
+++ b/yt/data_objects/index_subobjects/grid_patch.py
@@ -1,10 +1,10 @@
-import warnings
 import weakref
 from typing import List, Tuple
 
 import numpy as np
 
 import yt.geometry.particle_deposit as particle_deposit
+from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.config import ytcfg
 from yt.data_objects.selection_objects.data_selection_objects import (
     YTSelectionContainer,
@@ -277,11 +277,13 @@ class AMRGridPatch(YTSelectionContainer):
     ):
         _old_api = isinstance(fields, (str, tuple))
         if _old_api:
-            message = (
+            issue_deprecation_warning(
                 "get_vertex_centered_data() requires list of fields, rather than "
-                "a single field as an argument."
+                "a single field as an argument.",
+                since="3.4.0",
+                removal="4.2.0",
+                stacklevel=2,
             )
-            warnings.warn(message, DeprecationWarning, stacklevel=2)
             fields = [fields]  # type: ignore
 
         # Make sure the field list has only unique entries

--- a/yt/fields/derived_field.py
+++ b/yt/fields/derived_field.py
@@ -1,12 +1,12 @@
 import contextlib
 import inspect
 import re
-import warnings
 from typing import Optional, Tuple, Union
 
 from more_itertools import always_iterable
 
 import yt.units.dimensions as ytdims
+from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.funcs import iter_fields, validate_field_key
 from yt.units.unit_object import Unit  # type: ignore
 from yt.utilities.exceptions import YTFieldNotFound
@@ -138,10 +138,11 @@ class DerivedField:
         self.not_in_all = not_in_all
         self.display_field = display_field
         if particle_type:
-            warnings.warn(
+            issue_deprecation_warning(
                 "particle_type for derived fields "
                 "has been replaced with sampling_type = 'particle'",
-                DeprecationWarning,
+                since="3.4.0",
+                removal="4.2.0",
             )
             sampling_type = "particle"
         self.sampling_type = sampling_type

--- a/yt/utilities/tests/test_interpolators.py
+++ b/yt/utilities/tests/test_interpolators.py
@@ -3,6 +3,7 @@ import warnings
 import numpy as np
 
 import yt.utilities.linear_interpolators as lin
+from yt._maintenance.deprecation import VisibleDeprecationWarning
 from yt.testing import assert_array_almost_equal, assert_array_equal, fake_random_ds
 from yt.utilities.lib.interpolators import ghost_zone_interpolate
 
@@ -129,13 +130,13 @@ def test_get_vertex_centered_data():
         warnings.simplefilter("always")
         vec_str = g.get_vertex_centered_data(("gas", "density"), no_ghost=True)
         assert len(w) == 1
-        assert issubclass(w[-1].category, DeprecationWarning)
+        assert issubclass(w[-1].category, VisibleDeprecationWarning)
         assert "requires list of fields" in str(w[-1].message)
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         vec_tuple = g.get_vertex_centered_data(("gas", "density"), no_ghost=True)
         assert len(w) == 1
-        assert issubclass(w[-1].category, DeprecationWarning)
+        assert issubclass(w[-1].category, VisibleDeprecationWarning)
         assert (
             "get_vertex_centered_data() requires list of fields, rather than "
             "a single field as an argument."

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -2067,7 +2067,7 @@ class HaloCatalogCallback(PlotCallback):
             "Please update the extension to version 1.1 or newer. "
             "This duplicated functionality will be removed from the main yt package.",
             since="4.1",
-            removal="4.2",
+            removal="4.2.0",
         )
 
         try:


### PR DESCRIPTION
## PR Summary
Found a couple deprecation warnings that use the builtin `DeprecationWarning` class (not visible by default), let's make them visible so we can actually remove the deprecated code at some point.
