### PR TITLE
MNT: revert a patch that was written in support to a now unsupported use case

### DIFF
--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -29,17 +29,6 @@ from .particle_fields import (
 )
 
 
-def tupleize(inp):
-    if isinstance(inp, tuple):
-        return inp
-    # prepending with a '?' ensures that the sort order is the same in py2 and
-    # py3, since names of field types shouldn't begin with punctuation
-    return (
-        "?",
-        inp,
-    )
-
-
 class FieldInfoContainer(dict):
     """
     This is a generic field container.  It contains a list of potential derived
@@ -404,7 +393,7 @@ class FieldInfoContainer(dict):
         self.ds.field_dependencies.update(deps)
         # Note we may have duplicated
         dfl = set(self.ds.derived_field_list).union(deps.keys())
-        self.ds.derived_field_list = list(sorted(dfl, key=tupleize))
+        self.ds.derived_field_list = sorted(dfl)
         return loaded, unavailable
 
     def add_output_field(self, name, sampling_type, **kwargs):
@@ -628,7 +617,7 @@ class FieldInfoContainer(dict):
         # now populate the derived field list with results
         # this violates isolation principles and should be refactored
         dfl = set(self.ds.derived_field_list).union(deps.keys())
-        dfl = list(sorted(dfl, key=tupleize))
+        dfl = sorted(dfl)
 
         if not hasattr(self.ds.index, "meshes"):
             # the meshes attribute characterizes an unstructured-mesh data structure

--- a/yt/geometry/grid_geometry_handler.py
+++ b/yt/geometry/grid_geometry_handler.py
@@ -339,7 +339,7 @@ class GridIndex(Index, abc.ABC):
                 _gsort = _grid_sort_mixed
             else:
                 _gsort = _grid_sort_id
-            grids = list(sorted(self.grids[gi], key=_gsort))
+            grids = sorted(self.grids[gi], key=_gsort)
             dobj._chunk_info = np.empty(len(grids), dtype="object")
             for i, g in enumerate(grids):
                 dobj._chunk_info[i] = g

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -831,7 +831,7 @@ def load_hexahedral_mesh(
     sfh.update({"connectivity": connectivity, "coordinates": coordinates, 0: data})
     # Simple check for axis length correctness
     if len(data) > 0:
-        fn = list(sorted(data))[0]
+        fn = sorted(data)[0]
         array_values = data[fn]
         if array_values.size != connectivity.shape[0]:
             mylog.error(


### PR DESCRIPTION
## PR Summary
revert 2ffd0a246c83dd846f988eefbeb38e37d18c0f24
for context, this patch was intended to answer https://github.com/yt-project/yt/issues/1053
but the example given in the issue is currently invalid and fails with
```python-traceback
TypeError: Expected a 2-tuple of strings formatted as
(field or particle type, field name)
Received invalid field key: dust_density, with type <class 'str'>
```
This failure is intentional and aligns with the overarching goal of dropping support for single-string field ids in yt 4.1

I hope reverting the patch doesn't break anything else, but the intended use case has clearly not been tested continuously for a while.
edit: looks like not !
