### PR TITLE
Drop a comment that was treated as a part of key=value

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = yt
-version = 4.1.dev0  # keep in sync with yt/_version.__version__
+version = 4.1.dev0
 description = An analysis and visualization toolkit for volumetric data
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
## PR Summary

Hopefully fixes:

```
Building wheels for collected packages: yt
  Building wheel for yt (pyproject.toml): started
  Building wheel for yt (pyproject.toml): finished with status 'done'
  Created wheel for yt: filename=yt-4.1.dev0.._.keep.in.sync.with.yt_version._version_-cp38-cp38-linux_x86_64.whl size=14904256 sha256=541f863de95e286b2b1715bb05e42af01bf9907e929fa58e03e8231c24db28b3
  Stored in directory: /tmp/pip-ephem-wheel-cache-721ymkwl/wheels/cb/e3/d4/d236de7552d18e164ff4dc42cb58a5ecaa7380e764833058b8
  WARNING: Built wheel for yt is invalid: Metadata 1.2 mandates PEP 440 version, but '4.1.dev0..-.keep.in.sync.with.yt-version.-version-' is not
Failed to build yt
ERROR: Could not build wheels for yt, which is required to install pyproject.toml-based projects
Build step 'Virtualenv Builder' marked build as failure
Skipped archiving because build is not successful
```
