### PR TITLE
ENH: upgrade cached_properties, uniformize Dataset.unique_identifier

### DIFF
--- a/yt/data_objects/index_subobjects/octree_subset.py
+++ b/yt/data_objects/index_subobjects/octree_subset.py
@@ -1,3 +1,4 @@
+import sys
 from contextlib import contextmanager
 from itertools import product, repeat
 from typing import Tuple
@@ -19,6 +20,11 @@ from yt.utilities.exceptions import (
 )
 from yt.utilities.lib.geometry_utils import compute_morton
 from yt.utilities.logger import ytLogger as mylog
+
+if sys.version_info >= (3, 8):
+    from functools import cached_property
+else:
+    from yt._maintenance.backports import cached_property
 
 
 def cell_count_cache(func):
@@ -100,8 +106,6 @@ class OctreeSubset(YTSelectionContainer):
         arr = arr.reshape(new_shape, order="F")
         return arr
 
-    _domain_ind = None
-
     def mask_refinement(self, selector):
         mask = self.oct_handler.mask(selector, domain_id=self.domain_id)
         return mask
@@ -125,12 +129,9 @@ class OctreeSubset(YTSelectionContainer):
             return np.empty(0, "f8"), np.empty(0, "f8")
         return np.concatenate(dts), np.concatenate(ts)
 
-    @property
+    @cached_property
     def domain_ind(self):
-        if self._domain_ind is None:
-            di = self.oct_handler.domain_ind(self.selector)
-            self._domain_ind = di
-        return self._domain_ind
+        return self.oct_handler.domain_ind(self.selector)
 
     def deposit(self, positions, fields=None, method=None, kernel_name="cubic"):
         r"""Operate on the mesh, in a particle-against-mesh fashion, with

--- a/yt/data_objects/region_expression.py
+++ b/yt/data_objects/region_expression.py
@@ -1,3 +1,4 @@
+import sys
 import weakref
 
 from yt.funcs import obj_length
@@ -7,18 +8,19 @@ from yt.visualization.line_plot import LineBuffer
 
 from .data_containers import _get_ipython_key_completion
 
+if sys.version_info >= (3, 8):
+    from functools import cached_property
+else:
+    from yt._maintenance.backports import cached_property
+
 
 class RegionExpression:
-    _all_data = None
-
     def __init__(self, ds):
         self.ds = weakref.proxy(ds)
 
-    @property
+    @cached_property
     def all_data(self):
-        if self._all_data is None:
-            self._all_data = self.ds.all_data()
-        return self._all_data
+        return self.ds.all_data()
 
     def __getitem__(self, item):
         # At first, we will only implement this as accepting a slice that is

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1,5 +1,6 @@
 import abc
 import functools
+import hashlib
 import itertools
 import os
 import pickle
@@ -57,6 +58,11 @@ from yt.utilities.minimal_representation import MinimalDataset
 from yt.utilities.object_registries import data_object_registry, output_type_registry
 from yt.utilities.parallel_tools.parallel_analysis_interface import parallel_root_only
 from yt.utilities.parameter_file_storage import NoParameterShelf, ParameterFileStore
+
+if sys.version_info >= (3, 8):
+    from functools import cached_property
+else:
+    from yt._maintenance.backports import cached_property
 
 if sys.version_info >= (3, 9):
     from collections.abc import MutableMapping
@@ -153,7 +159,6 @@ class Dataset(abc.ABC):
     derived_field_list = requires_index("derived_field_list")
     fields = requires_index("fields")
     _instantiated = False
-    _unique_identifier: Optional[Union[str, int]] = None
     _particle_type_counts = None
     _proj_type = "quad_proj"
     _ionization_label_format = "roman_numeral"
@@ -306,17 +311,12 @@ class Dataset(abc.ABC):
         name, _ext = os.path.splitext(self.filename)
         return name + "_backup.gdf"
 
-    @property
-    def unique_identifier(self):
-        if self._unique_identifier is None:
-            self._unique_identifier = int(os.stat(self.parameter_filename)[ST_CTIME])
-            name_as_bytes = bytearray(map(ord, self.parameter_filename))
-            self._unique_identifier += fnv_hash(name_as_bytes)
-        return self._unique_identifier
-
-    @unique_identifier.setter
-    def unique_identifier(self, value):
-        self._unique_identifier = value
+    @cached_property
+    def unique_identifier(self) -> str:
+        retv = int(os.stat(self.parameter_filename)[ST_CTIME])
+        name_as_bytes = bytearray(map(ord, self.parameter_filename))
+        retv += fnv_hash(name_as_bytes)
+        return str(retv)
 
     @property
     def periodicity(self):
@@ -387,16 +387,9 @@ class Dataset(abc.ABC):
 
     def _hash(self):
         s = f"{self.basename};{self.current_time};{self.unique_identifier}"
-        try:
-            import hashlib
+        return hashlib.md5(s.encode("utf-8")).hexdigest()
 
-            return hashlib.md5(s.encode("utf-8")).hexdigest()
-        except ImportError:
-            return s.replace(";", "*")
-
-    _checksum = None
-
-    @property
+    @cached_property
     def checksum(self):
         """
         Computes md5 sum of a dataset.
@@ -407,36 +400,29 @@ class Dataset(abc.ABC):
         :py:attr:`~parameter_file` is a directory, checksum of all files inside
         the directory is calculated.
         """
-        if self._checksum is None:
-            try:
-                import hashlib
-            except ImportError:
-                self._checksum = "nohashlib"
-                return self._checksum
 
-            def generate_file_md5(m, filename, blocksize=2**20):
-                with open(filename, "rb") as f:
-                    while True:
-                        buf = f.read(blocksize)
-                        if not buf:
-                            break
-                        m.update(buf)
+        def generate_file_md5(m, filename, blocksize=2**20):
+            with open(filename, "rb") as f:
+                while True:
+                    buf = f.read(blocksize)
+                    if not buf:
+                        break
+                    m.update(buf)
 
-            m = hashlib.md5()
-            if os.path.isdir(self.parameter_filename):
-                for root, _, files in os.walk(self.parameter_filename):
-                    for fname in files:
-                        fname = os.path.join(root, fname)
-                        generate_file_md5(m, fname)
-            elif os.path.isfile(self.parameter_filename):
-                generate_file_md5(m, self.parameter_filename)
-            else:
-                m = "notafile"
+        m = hashlib.md5()
+        if os.path.isdir(self.parameter_filename):
+            for root, _, files in os.walk(self.parameter_filename):
+                for fname in files:
+                    fname = os.path.join(root, fname)
+                    generate_file_md5(m, fname)
+        elif os.path.isfile(self.parameter_filename):
+            generate_file_md5(m, self.parameter_filename)
+        else:
+            m = "notafile"
 
-            if hasattr(m, "hexdigest"):
-                m = m.hexdigest()
-            self._checksum = m
-        return self._checksum
+        if hasattr(m, "hexdigest"):
+            m = m.hexdigest()
+        return m
 
     @property
     def _mrep(self):

--- a/yt/fields/field_type_container.py
+++ b/yt/fields/field_type_container.py
@@ -3,10 +3,16 @@ A proxy object for field descriptors, usually living as ds.fields.
 """
 
 import inspect
+import sys
 import textwrap
 import weakref
 
 from yt.fields.derived_field import DerivedField
+
+if sys.version_info >= (3, 8):
+    from functools import cached_property
+else:
+    from yt._maintenance.backports import cached_property
 
 
 def _fill_values(values):
@@ -36,13 +42,9 @@ class FieldTypeContainer:
             return self.__getattribute__(attr)
         return fnc
 
-    _field_types = None
-
-    @property
+    @cached_property
     def field_types(self):
-        if self._field_types is None:
-            self._field_types = {t for t, n in self.ds.field_info}
-        return self._field_types
+        return {t for t, n in self.ds.field_info}
 
     def __dir__(self):
         return list(self.field_types)

--- a/yt/frontends/_skeleton/data_structures.py
+++ b/yt/frontends/_skeleton/data_structures.py
@@ -150,8 +150,6 @@ class SkeletonDataset(Dataset):
         #   self.hubble_constant            <= float
 
         # optional (the following have default implementations)
-        #   self.unique_identifier      <= unique identifier for the dataset
-        #                                  being read (e.g., UUID or ST_CTIME) (int)
         #
         #   self.geometry  <= a lower case string
         #                     ("cartesian", "polar", "cylindrical"...)

--- a/yt/frontends/adaptahop/data_structures.py
+++ b/yt/frontends/adaptahop/data_structures.py
@@ -9,7 +9,6 @@ Data structures for AdaptaHOP frontend.
 
 import os
 import re
-import stat
 from itertools import product
 from typing import Optional
 
@@ -141,7 +140,6 @@ class AdaptaHOPDataset(Dataset):
         with FortranFile(self.parameter_filename) as fpu:
             params = fpu.read_attrs(self._header_attributes)
         self.dimensionality = 3
-        self.unique_identifier = int(os.stat(self.parameter_filename)[stat.ST_CTIME])
         # Domain related things
         self.filename_template = self.parameter_filename
         self.file_count = 1

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -5,7 +5,6 @@ AMRVAC data structures
 
 """
 import os
-import stat
 import struct
 import sys
 import warnings
@@ -317,7 +316,6 @@ class AMRVACDataset(Dataset):
     def _parse_parameter_file(self):
         """Parse input datfile's header. Apply geometry_override if specified."""
         # required method
-        self.unique_identifier = int(os.stat(self.parameter_filename)[stat.ST_CTIME])
 
         # populate self.parameters with header data
         with open(self.parameter_filename, "rb") as istream:

--- a/yt/frontends/athena/data_structures.py
+++ b/yt/frontends/athena/data_structures.py
@@ -581,7 +581,6 @@ class AthenaDataset(Dataset):
             raise RuntimeError("Virtual grids are only supported for 3D outputs!")
         self.dimensionality = dimensionality
         self.current_time = grid["time"]
-        self.unique_identifier = self.parameter_filename.__hash__()
         self.cosmological_simulation = False
         self.num_ghost_zones = 0
         self.field_ordering = "fortran"

--- a/yt/frontends/athena_pp/data_structures.py
+++ b/yt/frontends/athena_pp/data_structures.py
@@ -331,7 +331,6 @@ class AthenaPPDataset(Dataset):
             dimensionality = 1
         self.dimensionality = dimensionality
         self.current_time = self._handle.attrs["Time"]
-        self.unique_identifier = self.parameter_filename.__hash__()
         self.cosmological_simulation = False
         self.num_ghost_zones = 0
         self.field_ordering = "fortran"

--- a/yt/frontends/enzo/data_structures.py
+++ b/yt/frontends/enzo/data_structures.py
@@ -1,6 +1,7 @@
 import os
 import re
 import string
+import sys
 import time
 import weakref
 from collections import defaultdict
@@ -19,6 +20,11 @@ from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.on_demand_imports import _h5py as h5py, _libconf as libconf
 
 from .fields import EnzoFieldInfo
+
+if sys.version_info >= (3, 8):
+    from functools import cached_property
+else:
+    from yt._maintenance.backports import cached_property
 
 
 class EnzoGrid(AMRGridPatch):
@@ -542,15 +548,12 @@ class EnzoHierarchy(GridIndex):
 class EnzoHierarchyInMemory(EnzoHierarchy):
 
     grid = EnzoGridInMemory
-    _enzo = None
 
-    @property
+    @cached_property
     def enzo(self):
-        if self._enzo is None:
-            import enzo
+        import enzo
 
-            self._enzo = enzo
-        return self._enzo
+        return enzo
 
     def __init__(self, ds, dataset_type=None):
         self.dataset_type = dataset_type

--- a/yt/frontends/exodus_ii/data_structures.py
+++ b/yt/frontends/exodus_ii/data_structures.py
@@ -176,7 +176,6 @@ class ExodusIIDataset(Dataset):
             self._read_glo_var()
             self.dimensionality = ds.variables["coor_names"].shape[0]
             self.parameters["info_records"] = self._load_info_records()
-            self.unique_identifier = self._get_unique_identifier()
             self.num_steps = len(ds.variables["time_whole"])
             self.current_time = self._get_current_time()
             self.parameters["num_meshes"] = ds.variables["eb_status"].shape[0]
@@ -233,9 +232,6 @@ class ExodusIIDataset(Dataset):
             except (KeyError, TypeError):
                 mylog.warning("No info_records found")
                 return []
-
-    def _get_unique_identifier(self):
-        return self.parameter_filename
 
     def _get_current_time(self):
         with self._handle.open_ds() as ds:

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 import uuid
 import warnings
@@ -31,6 +32,10 @@ from yt.utilities.on_demand_imports import NotAModule, _astropy
 
 from .fields import FITSFieldInfo, WCSFITSFieldInfo, YTFITSFieldInfo
 
+if sys.version_info >= (3, 8):
+    from functools import cached_property
+else:
+    from yt._maintenance.backports import cached_property
 lon_prefixes = ["X", "RA", "GLON", "LINEAR"]
 lat_prefixes = ["Y", "DEC", "GLAT", "LINEAR"]
 
@@ -429,13 +434,17 @@ class FITSDataset(Dataset):
         self.magnetic_unit.convert_to_units("gauss")
         self.velocity_unit = self.length_unit / self.time_unit
 
+    @cached_property
+    def unique_identifier(self) -> str:
+        if self.parameter_filename.startswith("InMemory"):
+            return str(time.time())
+        else:
+            return super().unique_identifier
+
     def _parse_parameter_file(self):
 
         self._determine_structure()
         self._determine_axes()
-
-        if self.parameter_filename.startswith("InMemory"):
-            self.unique_identifier = time.time()
 
         # Determine dimensionality
 

--- a/yt/frontends/flash/io.py
+++ b/yt/frontends/flash/io.py
@@ -1,3 +1,4 @@
+import sys
 from itertools import groupby
 
 import numpy as np
@@ -5,6 +6,10 @@ import numpy as np
 from yt.geometry.selection_routines import AlwaysSelector
 from yt.utilities.io_handler import BaseIOHandler
 
+if sys.version_info >= (3, 8):
+    from functools import cached_property
+else:
+    from yt._maintenance.backports import cached_property
 
 # http://stackoverflow.com/questions/2361945/detecting-consecutive-integers-in-a-list
 def particle_sequences(grids):
@@ -284,11 +289,11 @@ class IOHandlerFLASHParticle(BaseIOHandler):
         assert len(ptf) == 1
         yield from super()._read_particle_fields(chunks, ptf, selector)
 
-    _pcount = None
+    @cached_property
+    def _pcount(self):
+        return self._handle["/localnp"][:].sum()
 
     def _count_particles(self, data_file):
-        if self._pcount is None:
-            self._pcount = self._handle["/localnp"][:].sum()
         si, ei = data_file.start, data_file.end
         pcount = self._pcount
         if None not in (si, ei):

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -1,5 +1,4 @@
 import os
-import stat
 import struct
 from typing import Type
 
@@ -645,7 +644,6 @@ class GadgetHDF5Dataset(GadgetDataset):
         self.dimensionality = 3
         self.refine_by = 2
         self.parameters["HydroMethod"] = "sph"
-        self.unique_identifier = int(os.stat(self.parameter_filename)[stat.ST_CTIME])
 
         self._unit_base = self._get_uvals()
         self._unit_base["cmcm"] = 1.0 / self._unit_base["UnitLength_in_cm"]

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -1,5 +1,7 @@
 import os
+import sys
 from collections import defaultdict
+from typing import Tuple
 
 import numpy as np
 
@@ -11,12 +13,16 @@ from yt.utilities.on_demand_imports import _h5py as h5py
 
 from .definitions import SNAP_FORMAT_2_OFFSET, gadget_hdf5_ptypes
 
+if sys.version_info >= (3, 8):
+    from functools import cached_property
+else:
+    from yt._maintenance.backports import cached_property
+
 
 class IOHandlerGadgetHDF5(IOHandlerSPH):
     _dataset_type = "gadget_hdf5"
     _vector_fields = ("Coordinates", "Velocity", "Velocities", "MagneticField")
     _known_ptypes = gadget_hdf5_ptypes
-    _var_mass = None
     _element_names = (
         "Hydrogen",
         "Helium",
@@ -31,15 +37,13 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
 
     _coord_name = "Coordinates"
 
-    @property
-    def var_mass(self):
-        if self._var_mass is None:
-            vm = []
-            for i, v in enumerate(self.ds["Massarr"]):
-                if v == 0:
-                    vm.append(self._known_ptypes[i])
-            self._var_mass = tuple(vm)
-        return self._var_mass
+    @cached_property
+    def var_mass(self) -> Tuple[str, ...]:
+        vm = []
+        for i, v in enumerate(self.ds["Massarr"]):
+            if v == 0:
+                vm.append(self._known_ptypes[i])
+        return tuple(vm)
 
     def _read_fluid_selection(self, chunks, selector, fields, size):
         raise NotImplementedError
@@ -328,7 +332,6 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
     #   ENDT    (only if enabled in makefile)
     #   TSTP    (only if enabled in makefile)
 
-    _var_mass = None
     _format = None
 
     def __init__(self, ds, *args, **kwargs):
@@ -342,15 +345,13 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
         self._endian = endianswap
         super().__init__(ds, *args, **kwargs)
 
-    @property
-    def var_mass(self):
-        if self._var_mass is None:
-            vm = []
-            for i, v in enumerate(self.ds["Massarr"]):
-                if v == 0:
-                    vm.append(self._ptypes[i])
-            self._var_mass = tuple(vm)
-        return self._var_mass
+    @cached_property
+    def var_mass(self) -> Tuple[str, ...]:
+        vm = []
+        for i, v in enumerate(self.ds["Massarr"]):
+            if v == 0:
+                vm.append(self._ptypes[i])
+        return tuple(vm)
 
     def _read_fluid_selection(self, chunks, selector, fields, size):
         raise NotImplementedError

--- a/yt/frontends/gadget_fof/data_structures.py
+++ b/yt/frontends/gadget_fof/data_structures.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import weakref
 from collections import defaultdict
 from functools import partial
@@ -17,6 +18,11 @@ from yt.geometry.particle_geometry_handler import ParticleIndex
 from yt.utilities.cosmology import Cosmology
 from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.on_demand_imports import _h5py as h5py
+
+if sys.version_info >= (3, 8):
+    from functools import cached_property
+else:
+    from yt._maintenance.backports import cached_property
 
 
 class GadgetFOFParticleIndex(ParticleIndex):
@@ -182,13 +188,9 @@ class GadgetFOFDataset(ParticleDataset):
     def halos_derived_field_list(self):
         return self._halos_ds.derived_field_list
 
-    _instantiated_halo_ds = None
-
-    @property
+    @cached_property
     def _halos_ds(self):
-        if self._instantiated_halo_ds is None:
-            self._instantiated_halo_ds = GadgetFOFHaloDataset(self)
-        return self._instantiated_halo_ds
+        return GadgetFOFHaloDataset(self)
 
     def _setup_classes(self):
         super()._setup_classes()

--- a/yt/frontends/halo_catalog/data_structures.py
+++ b/yt/frontends/halo_catalog/data_structures.py
@@ -1,4 +1,5 @@
 import glob
+import sys
 import weakref
 from collections import defaultdict
 from functools import partial
@@ -19,6 +20,11 @@ from yt.geometry.particle_geometry_handler import ParticleIndex
 from yt.utilities.on_demand_imports import _h5py as h5py
 
 from .fields import YTHaloCatalogFieldInfo, YTHaloCatalogHaloFieldInfo
+
+if sys.version_info >= (3, 8):
+    from functools import cached_property
+else:
+    from yt._maintenance.backports import cached_property
 
 
 class HaloCatalogFile(ParticleFile):
@@ -141,13 +147,9 @@ class YTHaloCatalogDataset(SavedDataset):
     def halos_derived_field_list(self):
         return self._halos_ds.derived_field_list
 
-    _instantiated_halo_ds = None
-
-    @property
+    @cached_property
     def _halos_ds(self):
-        if self._instantiated_halo_ds is None:
-            self._instantiated_halo_ds = YTHaloDataset(self)
-        return self._instantiated_halo_ds
+        return YTHaloDataset(self)
 
     def _setup_classes(self):
         super()._setup_classes()
@@ -304,6 +306,7 @@ class YTHaloParticleIndex(ParticleIndex):
         super()._setup_data_io()
         if self.real_ds._instantiated_index is None:
             self.real_ds.index
+        self.real_ds.index
 
         # inherit some things from parent index
         self._data_files = self.real_ds.index.data_files
@@ -434,37 +437,21 @@ class HaloContainer(YTSelectionContainer):
         # starting and ending indices for each file containing particles
         self._set_field_indices()
 
-    _mass = None
-
-    @property
+    @cached_property
     def mass(self):
-        if self._mass is None:
-            self._mass = self[self.ptype, "particle_mass"][0]
-        return self._mass
+        return self[self.ptype, "particle_mass"][0]
 
-    _radius = None
-
-    @property
+    @cached_property
     def radius(self):
-        if self._radius is None:
-            self._radius = self[self.ptype, "virial_radius"][0]
-        return self._radius
+        return self[self.ptype, "virial_radius"][0]
 
-    _position = None
-
-    @property
+    @cached_property
     def position(self):
-        if self._position is None:
-            self._position = self[self.ptype, "particle_position"][0]
-        return self._position
+        return self[self.ptype, "particle_position"][0]
 
-    _velocity = None
-
-    @property
+    @cached_property
     def velocity(self):
-        if self._velocity is None:
-            self._velocity = self[self.ptype, "particle_velocity"][0]
-        return self._velocity
+        return self[self.ptype, "particle_velocity"][0]
 
     def _set_io_data(self):
         halo_fields = self._get_member_fieldnames()

--- a/yt/frontends/http_stream/data_structures.py
+++ b/yt/frontends/http_stream/data_structures.py
@@ -1,4 +1,5 @@
 import json
+import sys
 import time
 
 import numpy as np
@@ -7,6 +8,11 @@ from yt.data_objects.static_output import ParticleDataset, ParticleFile
 from yt.frontends.sph.fields import SPHFieldInfo
 from yt.geometry.particle_geometry_handler import ParticleIndex
 from yt.utilities.on_demand_imports import _requests as requests
+
+if sys.version_info >= (3, 8):
+    from functools import cached_property
+else:
+    from yt._maintenance.backports import cached_property
 
 
 class HTTPParticleFile(ParticleFile):
@@ -42,6 +48,10 @@ class HTTPStreamDataset(ParticleDataset):
     def __str__(self):
         return self.base_url
 
+    @cached_property
+    def unique_identifier(self) -> str:
+        return str(self.parameters.get("unique_identifier", time.time()))
+
     def _parse_parameter_file(self):
         self.dimensionality = 3
         self.refine_by = 2
@@ -64,7 +74,6 @@ class HTTPStreamDataset(ParticleDataset):
         self._periodicity = (True, True, True)
 
         self.current_time = header["current_time"]
-        self.unique_identifier = header.get("unique_identifier", time.time())
         self.cosmological_simulation = int(header["cosmological_simulation"])
         for attr in (
             "current_redshift",

--- a/yt/frontends/moab/data_structures.py
+++ b/yt/frontends/moab/data_structures.py
@@ -86,7 +86,6 @@ class MoabHex8Dataset(Dataset):
         self.refine_by = 2
         self.dimensionality = len(self.domain_dimensions)
         self.current_time = 0.0
-        self.unique_identifier = self.parameter_filename
         self.cosmological_simulation = False
         self.num_ghost_zones = 0
         self.current_redshift = 0.0
@@ -185,7 +184,6 @@ class PyneMoabHex8Dataset(Dataset):
         self.refine_by = 2
         self.dimensionality = len(self.domain_dimensions)
         self.current_time = 0.0
-        self.unique_identifier = self.parameter_filename
         self.cosmological_simulation = False
         self.num_ghost_zones = 0
         self.current_redshift = 0.0

--- a/yt/frontends/nc4_cm1/data_structures.py
+++ b/yt/frontends/nc4_cm1/data_structures.py
@@ -1,5 +1,4 @@
 import os
-import stat
 import weakref
 from collections import OrderedDict
 
@@ -116,10 +115,7 @@ class CM1Dataset(Dataset):
         # assumed to be in code units; domain_left_edge and domain_right_edge
         # will be converted to YTArray automatically at a later time.
         # This includes the cosmological parameters.
-        #
-        #   self.unique_identifier      <= unique identifier for the dataset
-        #                                  being read (e.g., UUID or ST_CTIME)
-        self.unique_identifier = int(os.stat(self.parameter_filename)[stat.ST_CTIME])
+
         self.parameters = {}  # code-specific items
         with self._handle.open_ds() as _handle:
             # _handle here is a netcdf Dataset object, we need to parse some metadata

--- a/yt/frontends/open_pmd/data_structures.py
+++ b/yt/frontends/open_pmd/data_structures.py
@@ -550,7 +550,6 @@ class OpenPMDDataset(Dataset):
         bp = self.base_path
         mp = self.meshes_path
 
-        self.unique_identifier = 0
         self.parameters = 0
         self._periodicity = np.zeros(3, dtype="bool")
         self.refine_by = 1

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 import uuid
 import weakref
@@ -37,6 +38,11 @@ from yt.utilities.logger import ytLogger as mylog
 
 from .definitions import process_data, set_particle_types
 from .fields import StreamFieldInfo
+
+if sys.version_info >= (3, 8):
+    from functools import cached_property
+else:
+    from yt._maintenance.backports import cached_property
 
 
 class StreamGrid(AMRGridPatch):
@@ -295,9 +301,12 @@ class StreamDataset(Dataset):
     def filename(self):
         return self.stream_handler.name
 
+    @cached_property
+    def unique_identifier(self) -> str:
+        return str(self.parameters["CurrentTimeIdentifier"])
+
     def _parse_parameter_file(self):
         self.parameters["CurrentTimeIdentifier"] = time.time()
-        self.unique_identifier = self.parameters["CurrentTimeIdentifier"]
         self.domain_left_edge = self.stream_handler.domain_left_edge.copy()
         self.domain_right_edge = self.stream_handler.domain_right_edge.copy()
         self.refine_by = self.stream_handler.refine_by

--- a/yt/frontends/swift/data_structures.py
+++ b/yt/frontends/swift/data_structures.py
@@ -1,5 +1,3 @@
-from uuid import uuid4
-
 import numpy as np
 
 from yt.data_objects.static_output import ParticleFile
@@ -96,9 +94,6 @@ class SwiftDataset(SPHDataset):
         The header information from the HDF5 file is stored in an un-parsed
         format in self.parameters should users wish to use it.
         """
-
-        self.unique_identifier = uuid4()
-
         # Read from the HDF5 file, this gives us all the info we need. The rest
         # of this function is just parsing.
         header = self._get_info_attributes("Header")

--- a/yt/frontends/ytdata/data_structures.py
+++ b/yt/frontends/ytdata/data_structures.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import weakref
 from collections import defaultdict
 from numbers import Number as numeric_type
@@ -31,6 +32,10 @@ from yt.utilities.tree_container import TreeContainer
 
 from .fields import YTDataContainerFieldInfo, YTGridFieldInfo
 
+if sys.version_info >= (3, 8):
+    from functools import cached_property
+else:
+    from yt._maintenance.backports import cached_property
 _grid_data_containers = ["arbitrary_grid", "covering_grid", "smoothed_covering_grid"]
 _set_attrs = {"periodicity": "_periodicity"}
 
@@ -274,31 +279,25 @@ class YTDataContainerDataset(YTDataset):
         # cover the field_list.
         self.field_info.alias(("gas", "cell_volume"), ("grid", "cell_volume"))
 
-    _data_obj = None
-
-    @property
+    @cached_property
     def data(self):
         """
         Return a data container configured like the original used to
         create this dataset.
         """
 
-        if self._data_obj is None:
-            # Some data containers can't be reconstructed in the same way
-            # since this is now particle-like data.
-            data_type = self.parameters.get("data_type")
-            container_type = self.parameters.get("container_type")
-            ex_container_type = ["cutting", "quad_proj", "ray", "slice", "cut_region"]
-            if data_type == "yt_light_ray" or container_type in ex_container_type:
-                mylog.info("Returning an all_data data container.")
-                return self.all_data()
+        # Some data containers can't be reconstructed in the same way
+        # since this is now particle-like data.
+        data_type = self.parameters.get("data_type")
+        container_type = self.parameters.get("container_type")
+        ex_container_type = ["cutting", "quad_proj", "ray", "slice", "cut_region"]
+        if data_type == "yt_light_ray" or container_type in ex_container_type:
+            mylog.info("Returning an all_data data container.")
+            return self.all_data()
 
-            my_obj = getattr(self, self.parameters["container_type"])
-            my_args = [
-                self.parameters[con_arg] for con_arg in self.parameters["con_args"]
-            ]
-            self._data_obj = my_obj(*my_args)
-        return self._data_obj
+        my_obj = getattr(self, self.parameters["container_type"])
+        my_args = [self.parameters[con_arg] for con_arg in self.parameters["con_args"]]
+        return my_obj(*my_args)
 
     @classmethod
     def _is_valid(cls, filename, *args, **kwargs):
@@ -955,16 +954,9 @@ class YTClumpTreeDataset(YTNonspatialDataset):
                 parent = my_tree[clump.parent_id]
                 parent.add_child(clump)
 
-    _leaves = None
-
-    @property
+    @cached_property
     def leaves(self):
-        if self._leaves is None:
-            self._leaves = []
-            for clump in self.tree:
-                if clump.children is None:
-                    self._leaves.append(clump)
-        return self._leaves
+        return [clump for clump in self.tree if clump.children is None]
 
     @classmethod
     def _is_valid(cls, filename, *args, **kwargs):


### PR DESCRIPTION
## PR Summary
Some systematic (but manual) upgrade of all places where `functools.cached_property` is relevant but currently not used.
`functools.cached_property` is only available since Python 3.8 but we already vendor a backport for Python 3.7 that can be used transparently. The boilerplate code will eventually be auto-cleaned with pre-commit + pyupgrade when we drop support for Python 3.7

Content:
- ENH: use functools' @cached_property decorator where appropriate to simplify code
- ENH: cleanup all implementations of the Dataset.unique_identifier property (guarantee str type, drop unneeded frontend-specific, historic implementations)
