### PR TITLE
TST: fix a broken pytest fixture

### DIFF
--- a/yt/visualization/tests/test_save.py
+++ b/yt/visualization/tests/test_save.py
@@ -4,6 +4,7 @@ import re
 import pytest
 
 import yt
+from yt.testing import fake_amr_ds
 
 # avoid testing every supported format as some backends may be buggy on testing platforms
 FORMATS_TO_TEST = [".eps", ".pdf", ".svg"]
@@ -11,7 +12,7 @@ FORMATS_TO_TEST = [".eps", ".pdf", ".svg"]
 
 @pytest.fixture(scope="session")
 def simple_sliceplot():
-    ds = yt.testing.fake_amr_ds()
+    ds = fake_amr_ds()
     p = yt.SlicePlot(ds, "z", "Density")
     yield p
 


### PR DESCRIPTION
## PR Summary
fix a pytest fixture that was broken in #3773
I don't know how this hasn't been caught up to now but the problem can easily be reproduced by invoking

```shell
pytest yt/visualization/tests/test_save.py
```
