### PR TITLE
BUG: fix internal warning bleeding

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1638,6 +1638,11 @@ class Dataset(abc.ABC):
                 "force_override is only meant to be used with "
                 "derived fields, not on-disk fields."
             )
+        if not force_override and name in self.field_info:
+            mylog.warning(
+                "Field %s already exists. To override use `force_override=True`.",
+                name,
+            )
 
         self.field_info.add_field(
             name, function, sampling_type, force_override=force_override, **kwargs

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -350,10 +350,6 @@ class FieldInfoContainer(dict):
         """
         # Handle the case where the field has already been added.
         if not force_override and name in self:
-            mylog.warning(
-                "Field %s already exists. To override use `force_override=True`.",
-                name,
-            )
             # See below.
             if function is None:
 

--- a/yt/fields/local_fields.py
+++ b/yt/fields/local_fields.py
@@ -19,9 +19,8 @@ class LocalFieldInfoContainer(FieldInfoContainer):
                 ftype = "gas"
             name = (ftype, name)
 
-        override = kwargs.get("force_override", False)
         # Handle the case where the field has already been added.
-        if not override and name in self:
+        if not force_override and name in self:
             mylog.warning(
                 "Field %s already exists. To override use `force_override=True`.",
                 name,


### PR DESCRIPTION
## PR Summary
closes #3933, also fix a sibling issue introduced in #3919

- BUG: fix internal warning bleeding (partially revert https://github.com/yt-project/yt/pull/3919)
- BUG: fix an error where a warning was unreachable
