### PR TITLE
TYP: improve type checking around calls to is_sized (alias is_sequence)

### DIFF
--- a/doc/source/reference/api/api.rst
+++ b/doc/source/reference/api/api.rst
@@ -735,6 +735,7 @@ Function List
    ~yt.funcs.insert_ipython
    ~yt.funcs.is_root
    ~yt.funcs.is_sequence
+   ~yt.funcs.is_sized
    ~yt.funcs.iter_fields
    ~yt.funcs.just_one
    ~yt.funcs.only_on_root

--- a/doc/source/reference/api/api.rst
+++ b/doc/source/reference/api/api.rst
@@ -734,6 +734,7 @@ Function List
    ~yt.funcs.humanize_time
    ~yt.funcs.insert_ipython
    ~yt.funcs.is_root
+   ~yt.funcs.is_scalar
    ~yt.funcs.is_sequence
    ~yt.funcs.is_sized
    ~yt.funcs.iter_fields

--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -164,13 +164,17 @@ If supplied without units, the center is assumed by in code units.  There are al
 the following alternative options for the ``center`` keyword:
 
 * ``"center"``, ``"c"``: the domain center
+* ``"left"``, ``"l"``, ``"right"`` ``"r"``: the domain's left/right edge along the normal direction
+* ``"min"``: the position of the minimum density
 * ``"max"``, ``"m"``: the position of the maximum density
+* ``"min/max_<field name>"``: the position of the minimum/maximum in the first field matching field name
 * ``("min", field)``: the position of the minimum of ``field``
 * ``("max", field)``: the position of the maximum of ``field``
 
 where for the last two objects any spatial field, such as ``"density"``,
 ``"velocity_z"``,
 etc., may be used, e.g. ``center=("min", ("gas", "temperature"))``.
+``"left"`` and ``"right"`` are not allowed for off-axis slices.
 
 The effective resolution of the plot (i.e. the number of resolution elements
 in the image itself) can be controlled with the ``buff_size`` argument:

--- a/nose_unit.cfg
+++ b/nose_unit.cfg
@@ -6,5 +6,5 @@ nologcapture=1
 verbosity=2
 where=yt
 with-timer=1
-ignore-files=(test_load_errors.py|test_load_sample.py|test_commons.py|test_ambiguous_fields.py|test_field_access_pytest.py|test_save.py|test_line_annotation_unit.py|test_eps_writer.py|test_registration.py|test_invalid_origin.py|test_outputs_pytest\.py|test_normal_plot_api\.py|test_load_archive\.py|test_stream_particles\.py|test_file_sanitizer\.py|test_version\.py|\test_on_demand_imports\.py|test_set_zlim\.py|test_add_field\.py)
+ignore-files=(test_load_errors.py|test_load_sample.py|test_commons.py|test_ambiguous_fields.py|test_field_access_pytest.py|test_save.py|test_line_annotation_unit.py|test_eps_writer.py|test_registration.py|test_invalid_origin.py|test_outputs_pytest\.py|test_normal_plot_api\.py|test_load_archive\.py|test_stream_particles\.py|test_file_sanitizer\.py|test_version\.py|\test_on_demand_imports\.py|test_set_zlim\.py|test_add_field\.py|test_sanitize_center\.py)
 exclude-test=yt.frontends.gdf.tests.test_outputs.TestGDF

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -218,6 +218,7 @@ other_tests:
      - "--ignore-files=test_version\\.py"
      - "--ignore-files=test_set_zlim\\.py"
      - "--ignore-file=test_add_field\\.py"
+     - "--ignore-files=test_sanitize_center\\.py"
      - "--exclude-test=yt.frontends.gdf.tests.test_outputs.TestGDF"
      - "--exclude-test=yt.frontends.adaptahop.tests.test_outputs"
      - "--exclude-test=yt.frontends.stream.tests.test_stream_particles.test_stream_non_cartesian_particles"

--- a/yt/__init__.py
+++ b/yt/__init__.py
@@ -45,6 +45,7 @@ from yt.funcs import (
     insert_ipython,
     is_root,
     is_sequence,
+    is_sized,
     memory_checker,
     only_on_root,
     parallel_profile,

--- a/yt/__init__.py
+++ b/yt/__init__.py
@@ -44,6 +44,7 @@ from yt.funcs import (
     get_yt_version,
     insert_ipython,
     is_root,
+    is_scalar,
     is_sequence,
     is_sized,
     memory_checker,

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -21,7 +21,7 @@ from yt.data_objects.selection_objects.data_selection_objects import (
 )
 from yt.fields.field_exceptions import NeedsGridType, NeedsOriginalGrid
 from yt.frontends.sph.data_structures import ParticleDataset
-from yt.funcs import get_memory_usage, is_sequence, iter_fields, mylog, only_on_root
+from yt.funcs import get_memory_usage, is_sized, iter_fields, mylog, only_on_root
 from yt.geometry import particle_deposit as particle_deposit
 from yt.geometry.coordinates.cartesian_coordinates import all_data
 from yt.loaders import load_uniform_grid
@@ -781,7 +781,7 @@ class YTCoveringGrid(YTSelectionContainer3D):
             self._data_source.set_field_parameter(name, val)
 
     def _sanitize_dims(self, dims):
-        if not is_sequence(dims):
+        if not is_sized(dims):
             dims = [dims] * len(self.ds.domain_left_edge)
         if len(dims) != len(self.ds.domain_left_edge):
             raise RuntimeError(
@@ -790,7 +790,7 @@ class YTCoveringGrid(YTSelectionContainer3D):
         return np.array(dims, dtype="int32")
 
     def _sanitize_edge(self, edge):
-        if not is_sequence(edge):
+        if not is_sized(edge):
             edge = [edge] * len(self.ds.domain_left_edge)
         if len(edge) != len(self.ds.domain_left_edge):
             raise RuntimeError(
@@ -1019,7 +1019,7 @@ class YTCoveringGrid(YTSelectionContainer3D):
             "int64"
         ) * self.ds.relative_refinement(0, self.level)
         refine_by = self.ds.refine_by
-        if not is_sequence(self.ds.refine_by):
+        if not is_sized(self.ds.refine_by):
             refine_by = [refine_by, refine_by, refine_by]
         refine_by = np.array(refine_by, dtype="i8")
         for chunk in parallel_objects(self._data_source.chunks(fields, "io")):
@@ -1405,7 +1405,7 @@ class YTSmoothedCoveringGrid(YTCoveringGrid):
         # NOTE: This usage of "refine_by" is actually *okay*, because it's
         # being used with respect to iref, which is *already* scaled!
         refine_by = self.ds.refine_by
-        if not is_sequence(self.ds.refine_by):
+        if not is_sized(self.ds.refine_by):
             refine_by = [refine_by, refine_by, refine_by]
         refine_by = np.array(refine_by, dtype="i8")
 
@@ -2825,7 +2825,7 @@ class YTOctree(YTSelectionContainer3D):
     def _sanitize_edge(self, edge, default):
         if edge is None:
             return default.copy()
-        if not is_sequence(edge):
+        if not is_sized(edge):
             edge = [edge] * len(self.ds.domain_left_edge)
         if len(edge) != len(self.ds.domain_left_edge):
             raise RuntimeError(

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -21,7 +21,7 @@ from yt.data_objects.selection_objects.data_selection_objects import (
 )
 from yt.fields.field_exceptions import NeedsGridType, NeedsOriginalGrid
 from yt.frontends.sph.data_structures import ParticleDataset
-from yt.funcs import get_memory_usage, is_sized, iter_fields, mylog, only_on_root
+from yt.funcs import get_memory_usage, is_scalar, iter_fields, mylog, only_on_root
 from yt.geometry import particle_deposit as particle_deposit
 from yt.geometry.coordinates.cartesian_coordinates import all_data
 from yt.loaders import load_uniform_grid
@@ -781,7 +781,7 @@ class YTCoveringGrid(YTSelectionContainer3D):
             self._data_source.set_field_parameter(name, val)
 
     def _sanitize_dims(self, dims):
-        if not is_sized(dims):
+        if is_scalar(dims):
             dims = [dims] * len(self.ds.domain_left_edge)
         if len(dims) != len(self.ds.domain_left_edge):
             raise RuntimeError(
@@ -790,7 +790,7 @@ class YTCoveringGrid(YTSelectionContainer3D):
         return np.array(dims, dtype="int32")
 
     def _sanitize_edge(self, edge):
-        if not is_sized(edge):
+        if is_scalar(edge):
             edge = [edge] * len(self.ds.domain_left_edge)
         if len(edge) != len(self.ds.domain_left_edge):
             raise RuntimeError(
@@ -1019,7 +1019,7 @@ class YTCoveringGrid(YTSelectionContainer3D):
             "int64"
         ) * self.ds.relative_refinement(0, self.level)
         refine_by = self.ds.refine_by
-        if not is_sized(self.ds.refine_by):
+        if is_scalar(self.ds.refine_by):
             refine_by = [refine_by, refine_by, refine_by]
         refine_by = np.array(refine_by, dtype="i8")
         for chunk in parallel_objects(self._data_source.chunks(fields, "io")):
@@ -1405,7 +1405,7 @@ class YTSmoothedCoveringGrid(YTCoveringGrid):
         # NOTE: This usage of "refine_by" is actually *okay*, because it's
         # being used with respect to iref, which is *already* scaled!
         refine_by = self.ds.refine_by
-        if not is_sized(self.ds.refine_by):
+        if is_scalar(self.ds.refine_by):
             refine_by = [refine_by, refine_by, refine_by]
         refine_by = np.array(refine_by, dtype="i8")
 
@@ -2825,7 +2825,7 @@ class YTOctree(YTSelectionContainer3D):
     def _sanitize_edge(self, edge, default):
         if edge is None:
             return default.copy()
-        if not is_sized(edge):
+        if is_scalar(edge):
             edge = [edge] * len(self.ds.domain_left_edge)
         if len(edge) != len(self.ds.domain_left_edge):
             raise RuntimeError(

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -323,7 +323,7 @@ class YTProj(YTSelectionContainer2D):
         mylog.info("Projection completed")
         self.tree = tree
 
-    def to_pw(self, fields=None, center="c", width=None, origin="center-window"):
+    def to_pw(self, fields=None, center="center", width=None, origin="center-window"):
         r"""Create a :class:`~yt.visualization.plot_window.PWViewerMPL` from this
         object.
 

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -13,7 +13,7 @@ from yt.fields.field_exceptions import NeedsGridType
 from yt.frontends.ytdata.utilities import save_as_dataset
 from yt.funcs import (
     get_output_filename,
-    is_sequence,
+    is_sized,
     iter_fields,
     mylog,
     parse_center_array,
@@ -1359,7 +1359,7 @@ class YTDataContainer(abc.ABC):
         except AttributeError:
             pass
 
-        if is_sequence(field) and not isinstance(field, str):
+        if is_sized(field) and not isinstance(field, str):
             try:
                 ftype, fname = field
                 if not all(isinstance(_, str) for _ in field):

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -11,8 +11,14 @@ from yt.data_objects.field_data import YTFieldData
 from yt.data_objects.profiles import create_profile
 from yt.fields.field_exceptions import NeedsGridType
 from yt.frontends.ytdata.utilities import save_as_dataset
-from yt.funcs import get_output_filename, is_sequence, iter_fields, mylog
-from yt.units.yt_array import YTArray, YTQuantity, uconcatenate  # type: ignore
+from yt.funcs import (
+    get_output_filename,
+    is_sequence,
+    iter_fields,
+    mylog,
+    parse_center_array,
+)
+from yt.units.yt_array import uconcatenate  # type: ignore
 from yt.utilities.amr_kdtree.api import AMRKDTree
 from yt.utilities.exceptions import (
     YTCouldNotGenerateField,
@@ -170,43 +176,10 @@ class YTDataContainer(abc.ABC):
         if center is None:
             self.center = None
             return
-        elif isinstance(center, YTArray):
-            self.center = self.ds.arr(center.astype("float64"))
-            self.center.convert_to_units("code_length")
-        elif isinstance(center, (list, tuple, np.ndarray)):
-            if isinstance(center[0], YTQuantity):
-                self.center = self.ds.arr([c.copy() for c in center], dtype="float64")
-                self.center.convert_to_units("code_length")
-            else:
-                self.center = self.ds.arr(center, "code_length", dtype="float64")
-        elif isinstance(center, str):
-            if center.lower() in ("c", "center"):
-                self.center = self.ds.domain_center
-            # is this dangerous for race conditions?
-            elif center.lower() in ("max", "m"):
-                self.center = self.ds.find_max(("gas", "density"))[1]
-            elif center.startswith("max_"):
-                field = self._first_matching_field(center[4:])
-                self.center = self.ds.find_max(field)[1]
-            elif center.lower() == "min":
-                self.center = self.ds.find_min(("gas", "density"))[1]
-            elif center.startswith("min_"):
-                field = self._first_matching_field(center[4:])
-                self.center = self.ds.find_min(field)[1]
         else:
-            self.center = self.ds.arr(center, "code_length", dtype="float64")
-
-        if self.center.ndim > 1:
-            mylog.debug("Removing singleton dimensions from 'center'.")
-            self.center = np.squeeze(self.center)
-            if self.center.ndim > 1:
-                msg = (
-                    "center array must be 1 dimensional, supplied center has "
-                    f"{self.center.ndim} dimensions with shape {self.center.shape}."
-                )
-                raise YTException(msg)
-
-        self.set_field_parameter("center", self.center)
+            axis = getattr(self, "axis", None)
+            self.center = parse_center_array(center, ds=self.ds, axis=axis)
+            self.set_field_parameter("center", self.center)
 
     def get_field_parameter(self, name, default=None):
         """

--- a/yt/data_objects/index_subobjects/grid_patch.py
+++ b/yt/data_objects/index_subobjects/grid_patch.py
@@ -9,7 +9,7 @@ from yt.config import ytcfg
 from yt.data_objects.selection_objects.data_selection_objects import (
     YTSelectionContainer,
 )
-from yt.funcs import is_sequence
+from yt.funcs import is_sized
 from yt.geometry.selection_routines import convert_mask_to_indices
 from yt.units.yt_array import YTArray
 from yt.utilities.exceptions import (
@@ -170,7 +170,7 @@ class AMRGridPatch(YTSelectionContainer):
         # This can be expensive so we allow people to disable this behavior
         # via a config option
         if ytcfg.get("yt", "reconstruct_index"):
-            if is_sequence(self.Parent) and len(self.Parent) > 0:
+            if is_sized(self.Parent) and len(self.Parent) > 0:
                 p = self.Parent[0]
             else:
                 p = self.Parent

--- a/yt/data_objects/index_subobjects/grid_patch.py
+++ b/yt/data_objects/index_subobjects/grid_patch.py
@@ -9,7 +9,7 @@ from yt.config import ytcfg
 from yt.data_objects.selection_objects.data_selection_objects import (
     YTSelectionContainer,
 )
-from yt.funcs import is_sized
+from yt.funcs import obj_length
 from yt.geometry.selection_routines import convert_mask_to_indices
 from yt.units.yt_array import YTArray
 from yt.utilities.exceptions import (
@@ -170,7 +170,7 @@ class AMRGridPatch(YTSelectionContainer):
         # This can be expensive so we allow people to disable this behavior
         # via a config option
         if ytcfg.get("yt", "reconstruct_index"):
-            if is_sized(self.Parent) and len(self.Parent) > 0:
+            if obj_length(self.Parent) > 0:
                 p = self.Parent[0]
             else:
                 p = self.Parent

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -4,7 +4,7 @@ from more_itertools import collapse
 from yt.data_objects.field_data import YTFieldData
 from yt.fields.derived_field import DerivedField
 from yt.frontends.ytdata.utilities import save_as_dataset
-from yt.funcs import get_output_filename, is_sized, iter_fields, mylog
+from yt.funcs import get_output_filename, is_scalar, is_sequence, iter_fields, mylog
 from yt.units.unit_object import Unit  # type: ignore
 from yt.units.yt_array import YTQuantity, array_like_field
 from yt.utilities.exceptions import (
@@ -1335,9 +1335,9 @@ def create_profile(
         wf = data_source.ds._get_field_info(weight_field)
         if not wf.sampling_type == "particle":
             weight_field = None
-    if not is_sized(n_bins):
+    if is_scalar(n_bins):
         n_bins = [n_bins] * len(bin_fields)
-    if not is_sized(accumulation):
+    if is_scalar(accumulation):
         accumulation = [accumulation] * len(bin_fields)
     if logs is None:
         logs = {}
@@ -1405,10 +1405,10 @@ def create_profile(
                     fe = data_source.ds.arr(field_ex, bf_units)
             fe.convert_to_units(bf_units)
             field_ex = [fe[0].v, fe[1].v]
-            if is_sized(field_ex[0]):
+            if is_sequence(field_ex[0], check_access=True):
                 field_ex[0] = data_source.ds.quan(field_ex[0][0], field_ex[0][1])
                 field_ex[0] = field_ex[0].in_units(bf_units)
-            if is_sized(field_ex[1]):
+            if is_sequence(field_ex[1], check_access=True):
                 field_ex[1] = data_source.ds.quan(field_ex[1][0], field_ex[1][1])
                 field_ex[1] = field_ex[1].in_units(bf_units)
             ex.append(field_ex)

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -4,7 +4,7 @@ from more_itertools import collapse
 from yt.data_objects.field_data import YTFieldData
 from yt.fields.derived_field import DerivedField
 from yt.frontends.ytdata.utilities import save_as_dataset
-from yt.funcs import get_output_filename, is_sequence, iter_fields, mylog
+from yt.funcs import get_output_filename, is_sized, iter_fields, mylog
 from yt.units.unit_object import Unit  # type: ignore
 from yt.units.yt_array import YTQuantity, array_like_field
 from yt.utilities.exceptions import (
@@ -1335,9 +1335,9 @@ def create_profile(
         wf = data_source.ds._get_field_info(weight_field)
         if not wf.sampling_type == "particle":
             weight_field = None
-    if not is_sequence(n_bins):
+    if not is_sized(n_bins):
         n_bins = [n_bins] * len(bin_fields)
-    if not is_sequence(accumulation):
+    if not is_sized(accumulation):
         accumulation = [accumulation] * len(bin_fields)
     if logs is None:
         logs = {}
@@ -1405,10 +1405,10 @@ def create_profile(
                     fe = data_source.ds.arr(field_ex, bf_units)
             fe.convert_to_units(bf_units)
             field_ex = [fe[0].v, fe[1].v]
-            if is_sequence(field_ex[0]):
+            if is_sized(field_ex[0]):
                 field_ex[0] = data_source.ds.quan(field_ex[0][0], field_ex[0][1])
                 field_ex[0] = field_ex[0].in_units(bf_units)
-            if is_sequence(field_ex[1]):
+            if is_sized(field_ex[1]):
                 field_ex[1] = data_source.ds.quan(field_ex[1][0], field_ex[1][1])
                 field_ex[1] = field_ex[1].in_units(bf_units)
             ex.append(field_ex)

--- a/yt/data_objects/selection_objects/data_selection_objects.py
+++ b/yt/data_objects/selection_objects/data_selection_objects.py
@@ -13,7 +13,7 @@ from yt.data_objects.data_containers import YTDataContainer
 from yt.data_objects.derived_quantities import DerivedQuantityCollection
 from yt.data_objects.field_data import YTFieldData
 from yt.fields.field_exceptions import NeedsGridType
-from yt.funcs import fix_axis, is_sized, iter_fields, validate_width_tuple
+from yt.funcs import fix_axis, is_scalar, is_sized, iter_fields, validate_width_tuple
 from yt.geometry.selection_routines import compose_selector
 from yt.units import YTArray
 from yt.utilities.exceptions import (
@@ -629,7 +629,7 @@ class YTSelectionContainer2D(YTSelectionContainer):
             height = self.ds.quan(h, units=u)
         elif not isinstance(height, YTArray):
             height = self.ds.quan(height, "code_length")
-        if not is_sized(resolution):
+        if is_scalar(resolution):
             resolution = (resolution, resolution)
         from yt.visualization.fixed_resolution import FixedResolutionBuffer
 

--- a/yt/data_objects/selection_objects/data_selection_objects.py
+++ b/yt/data_objects/selection_objects/data_selection_objects.py
@@ -13,7 +13,7 @@ from yt.data_objects.data_containers import YTDataContainer
 from yt.data_objects.derived_quantities import DerivedQuantityCollection
 from yt.data_objects.field_data import YTFieldData
 from yt.fields.field_exceptions import NeedsGridType
-from yt.funcs import fix_axis, is_sequence, iter_fields, validate_width_tuple
+from yt.funcs import fix_axis, is_sized, iter_fields, validate_width_tuple
 from yt.geometry.selection_routines import compose_selector
 from yt.units import YTArray
 from yt.utilities.exceptions import (
@@ -603,7 +603,7 @@ class YTSelectionContainer2D(YTSelectionContainer):
             )
 
             validate_width_tuple(width)
-            if is_sequence(resolution):
+            if is_sized(resolution):
                 resolution = max(resolution)
             frb = CylindricalFixedResolutionBuffer(self, width, resolution)
             return frb
@@ -612,9 +612,9 @@ class YTSelectionContainer2D(YTSelectionContainer):
             center = self.center
             if center is None:
                 center = (self.ds.domain_right_edge + self.ds.domain_left_edge) / 2.0
-        elif is_sequence(center) and not isinstance(center, YTArray):
+        elif is_sized(center) and not isinstance(center, YTArray):
             center = self.ds.arr(center, "code_length")
-        if is_sequence(width):
+        if is_sized(width):
             w, u = width
             if isinstance(w, tuple) and isinstance(u, tuple):
                 height = u
@@ -624,12 +624,12 @@ class YTSelectionContainer2D(YTSelectionContainer):
             width = self.ds.quan(width, "code_length")
         if height is None:
             height = width
-        elif is_sequence(height):
+        elif is_sized(height):
             h, u = height
             height = self.ds.quan(h, units=u)
         elif not isinstance(height, YTArray):
             height = self.ds.quan(height, "code_length")
-        if not is_sequence(resolution):
+        if not is_sized(resolution):
             resolution = (resolution, resolution)
         from yt.visualization.fixed_resolution import FixedResolutionBuffer
 

--- a/yt/data_objects/selection_objects/slices.py
+++ b/yt/data_objects/selection_objects/slices.py
@@ -6,7 +6,8 @@ from yt.data_objects.selection_objects.data_selection_objects import (
 )
 from yt.data_objects.static_output import Dataset
 from yt.funcs import (
-    is_sized,
+    is_scalar,
+    is_sequence,
     iter_fields,
     validate_3d_array,
     validate_axis,
@@ -353,15 +354,15 @@ class YTCuttingPlane(YTSelectionContainer2D):
         >>> frb = cutting.to_frb((1.0, "pc"), 1024)
         >>> write_image(np.log10(frb[("gas", "density")]), "density_1pc.png")
         """
-        if is_sized(width):
+        if is_sequence(width, check_access=True):
             validate_width_tuple(width)
             width = self.ds.quan(width[0], width[1])
         if height is None:
             height = width
-        elif is_sized(height):
+        elif is_sequence(height, check_access=True):
             validate_width_tuple(height)
             height = self.ds.quan(height[0], height[1])
-        if not is_sized(resolution):
+        if is_scalar(resolution):
             resolution = (resolution, resolution)
         from yt.visualization.fixed_resolution import FixedResolutionBuffer
 

--- a/yt/data_objects/selection_objects/slices.py
+++ b/yt/data_objects/selection_objects/slices.py
@@ -212,7 +212,7 @@ class YTCuttingPlane(YTSelectionContainer2D):
         validate_object(ds, Dataset)
         validate_object(field_parameters, dict)
         validate_object(data_source, YTSelectionContainer)
-        YTSelectionContainer2D.__init__(self, 4, ds, field_parameters, data_source)
+        YTSelectionContainer2D.__init__(self, None, ds, field_parameters, data_source)
         self._set_center(center)
         self.set_field_parameter("center", center)
         # Let's set up our plane equation

--- a/yt/data_objects/selection_objects/slices.py
+++ b/yt/data_objects/selection_objects/slices.py
@@ -6,7 +6,7 @@ from yt.data_objects.selection_objects.data_selection_objects import (
 )
 from yt.data_objects.static_output import Dataset
 from yt.funcs import (
-    is_sequence,
+    is_sized,
     iter_fields,
     validate_3d_array,
     validate_axis,
@@ -353,15 +353,15 @@ class YTCuttingPlane(YTSelectionContainer2D):
         >>> frb = cutting.to_frb((1.0, "pc"), 1024)
         >>> write_image(np.log10(frb[("gas", "density")]), "density_1pc.png")
         """
-        if is_sequence(width):
+        if is_sized(width):
             validate_width_tuple(width)
             width = self.ds.quan(width[0], width[1])
         if height is None:
             height = width
-        elif is_sequence(height):
+        elif is_sized(height):
             validate_width_tuple(height)
             height = self.ds.quan(height[0], height[1])
-        if not is_sequence(resolution):
+        if not is_sized(resolution):
             resolution = (resolution, resolution)
         from yt.visualization.fixed_resolution import FixedResolutionBuffer
 

--- a/yt/data_objects/selection_objects/slices.py
+++ b/yt/data_objects/selection_objects/slices.py
@@ -104,7 +104,7 @@ class YTSlice(YTSelectionContainer2D):
     def _mrep(self):
         return MinimalSliceData(self)
 
-    def to_pw(self, fields=None, center="c", width=None, origin="center-window"):
+    def to_pw(self, fields=None, center="center", width=None, origin="center-window"):
         r"""Create a :class:`~yt.visualization.plot_window.PWViewerMPL` from this
         object.
 
@@ -275,7 +275,7 @@ class YTCuttingPlane(YTSelectionContainer2D):
         else:
             raise KeyError(field)
 
-    def to_pw(self, fields=None, center="c", width=None, axes_unit=None):
+    def to_pw(self, fields=None, center="center", width=None, axes_unit=None):
         r"""Create a :class:`~yt.visualization.plot_window.PWViewerMPL` from this
         object.
 

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -26,7 +26,7 @@ from yt.data_objects.region_expression import RegionExpression
 from yt.fields.derived_field import ValidateSpatial
 from yt.fields.field_type_container import FieldTypeContainer
 from yt.fields.fluid_fields import setup_gradient_fields
-from yt.funcs import is_sequence, iter_fields, mylog, set_intersection, setdefaultattr
+from yt.funcs import is_sized, iter_fields, mylog, set_intersection, setdefaultattr
 from yt.geometry.coordinates.api import (
     CartesianCoordinateHandler,
     CoordinateHandler,
@@ -2049,7 +2049,7 @@ class ParticleDataset(Dataset):
 def validate_index_order(index_order):
     if index_order is None:
         index_order = (6, 2)
-    elif not is_sequence(index_order):
+    elif not is_sized(index_order):
         index_order = (int(index_order), 1)
     else:
         if len(index_order) != 2:

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -26,7 +26,7 @@ from yt.data_objects.region_expression import RegionExpression
 from yt.fields.derived_field import ValidateSpatial
 from yt.fields.field_type_container import FieldTypeContainer
 from yt.fields.fluid_fields import setup_gradient_fields
-from yt.funcs import is_sized, iter_fields, mylog, set_intersection, setdefaultattr
+from yt.funcs import is_scalar, iter_fields, mylog, set_intersection, setdefaultattr
 from yt.geometry.coordinates.api import (
     CartesianCoordinateHandler,
     CoordinateHandler,
@@ -2049,7 +2049,7 @@ class ParticleDataset(Dataset):
 def validate_index_order(index_order):
     if index_order is None:
         index_order = (6, 2)
-    elif not is_sized(index_order):
+    elif is_scalar(index_order):
         index_order = (int(index_order), 1)
     else:
         if len(index_order) != 2:

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -14,6 +14,7 @@ from stat import ST_CTIME
 from typing import DefaultDict, Dict, List, Optional, Set, Tuple, Type, Union
 
 import numpy as np
+import unyt as un
 from more_itertools import unzip
 from unyt.exceptions import UnitConversionError, UnitParseError
 
@@ -1950,6 +1951,18 @@ class Dataset(abc.ABC):
             prefixable=prefixable,
             registry=self.unit_registry,
         )
+
+    def _is_within_domain(self, point) -> bool:
+        assert len(point) == len(self.domain_left_edge)
+        assert point.units.dimensions == un.dimensions.length
+        for i, x in enumerate(point):
+            if self.periodicity[i]:
+                continue
+            if x < self.domain_left_edge[i]:
+                return False
+            if x > self.domain_right_edge[i]:
+                return False
+        return True
 
 
 def _reconstruct_ds(*args, **kwargs):

--- a/yt/data_objects/tests/test_cutting_plane.py
+++ b/yt/data_objects/tests/test_cutting_plane.py
@@ -43,7 +43,7 @@ def test_cutting_plane():
                 fi = ds._get_field_info("unknown", cut_field)
                 data = frb[cut_field]
                 assert_equal(data.info["data_source"], cut.__str__())
-                assert_equal(data.info["axis"], 4)
+                assert_equal(data.info["axis"], None)
                 assert_equal(data.info["field"], str(cut_field))
                 assert_equal(data.units, Unit(fi.units))
                 assert_equal(data.info["xlim"], frb.bounds[:2])

--- a/yt/data_objects/tests/test_disks.py
+++ b/yt/data_objects/tests/test_disks.py
@@ -42,7 +42,7 @@ def test_bad_disk_input():
             (20, "kpc"),
             fields=YTQuantity(1, "kpc"),
         )
-    desired = "Expected an iterable object, received 'unyt.array.unyt_quantity'"
+    desired = "Expected an object with length, received scalar unyt_quantity(1, 'kpc')"
     assert_equal(str(ex.exception), desired)
 
     # Test invalid object

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -12,7 +12,7 @@ from more_itertools import always_iterable
 from yt.config import ytcfg
 from yt.data_objects.analyzer_objects import AnalysisTask, create_quantity_proxy
 from yt.data_objects.particle_trajectories import ParticleTrajectories
-from yt.funcs import is_sequence, mylog
+from yt.funcs import is_sized, mylog
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.exceptions import YTException
 from yt.utilities.object_registries import (
@@ -174,7 +174,7 @@ class DatasetSeries:
     ):
         # This is needed to properly set _pre_outputs for Simulation subclasses.
         self._mixed_dataset_types = mixed_dataset_types
-        if is_sequence(outputs) and not isinstance(outputs, str):
+        if is_sized(outputs) and not isinstance(outputs, str):
             self._pre_outputs = outputs[:]
         self.tasks = AnalysisTaskProxy(self)
         self.params = TimeSeriesParametersContainer(self)

--- a/yt/fields/local_fields.py
+++ b/yt/fields/local_fields.py
@@ -1,7 +1,7 @@
 from functools import partial
 from typing import Any, Callable, TypeVar
 
-from yt.funcs import is_sized
+from yt.funcs import is_scalar
 from yt.utilities.logger import ytLogger as mylog
 
 from .field_info_container import FieldInfoContainer
@@ -20,7 +20,7 @@ class LocalFieldInfoContainer(FieldInfoContainer):
         from yt.fields.field_functions import validate_field_function
 
         validate_field_function(function)
-        if isinstance(name, str) or not is_sized(name):
+        if isinstance(name, str) or is_scalar(name):
             # the base method only accepts proper tuple field keys
             # and is only used internally, while this method is exposed to users
             # and is documented as usable with single strings as name

--- a/yt/fields/local_fields.py
+++ b/yt/fields/local_fields.py
@@ -1,7 +1,7 @@
 from functools import partial
 from typing import Any, Callable, TypeVar
 
-from yt.funcs import is_sequence
+from yt.funcs import is_sized
 from yt.utilities.logger import ytLogger as mylog
 
 from .field_info_container import FieldInfoContainer
@@ -20,7 +20,7 @@ class LocalFieldInfoContainer(FieldInfoContainer):
         from yt.fields.field_functions import validate_field_function
 
         validate_field_function(function)
-        if isinstance(name, str) or not is_sequence(name):
+        if isinstance(name, str) or not is_sized(name):
             # the base method only accepts proper tuple field keys
             # and is only used internally, while this method is exposed to users
             # and is documented as usable with single strings as name

--- a/yt/fields/vector_operations.py
+++ b/yt/fields/vector_operations.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from yt.funcs import is_sequence, just_one
+from yt.funcs import is_sized, just_one
 from yt.geometry.geometry_handler import is_curvilinear
 from yt.utilities.lib.misc_utilities import obtain_relative_velocity_vector
 from yt.utilities.math_utils import (
@@ -105,7 +105,7 @@ def create_los_field(registry, basename, field_units, ftype="gas", slice_info=No
         else:
             fns = field_comps
         ax = data.get_field_parameter("axis")
-        if is_sequence(ax):
+        if is_sized(ax):
             # Make sure this is a unit vector
             ax /= np.sqrt(np.dot(ax, ax))
             ret = data[fns[0]] * ax[0] + data[fns[1]] * ax[1] + data[fns[2]] * ax[2]

--- a/yt/fields/vector_operations.py
+++ b/yt/fields/vector_operations.py
@@ -107,7 +107,7 @@ def create_los_field(registry, basename, field_units, ftype="gas", slice_info=No
         ax = data.get_field_parameter("axis")
         if is_sized(ax):
             # Make sure this is a unit vector
-            ax /= np.sqrt(np.dot(ax, ax))
+            ax = np.asanyarray(ax) / np.sqrt(np.dot(ax, ax))
             ret = data[fns[0]] * ax[0] + data[fns[1]] * ax[1] + data[fns[2]] * ax[2]
         elif ax in [0, 1, 2]:
             ret = data[fns[ax]]

--- a/yt/frontends/stream/definitions.py
+++ b/yt/frontends/stream/definitions.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 
 import numpy as np
 
-from yt.funcs import is_sequence
+from yt.funcs import is_sized
 from yt.geometry.grid_container import GridTree, MatchPointsToGrids
 from yt.utilities.exceptions import (
     YTInconsistentGridFieldShape,
@@ -169,7 +169,7 @@ def process_data(data, grid_dims=None):
                 raise RuntimeError("The data dict appears to be invalid.\n" + str(e))
 
         # val is a list of data to be turned into an array
-        elif is_sequence(val):
+        elif is_sized(val):
             field_units[field] = ""
             new_data[field] = np.asarray(val)
 

--- a/yt/geometry/coordinates/cartesian_coordinates.py
+++ b/yt/geometry/coordinates/cartesian_coordinates.py
@@ -218,7 +218,7 @@ class CartesianCoordinateHandler(CoordinateHandler):
             # re-order the array and squeeze out the dummy dim
             return np.squeeze(np.transpose(img, (yax, xax, ax)))
 
-        elif self.axis_id.get(dimension, dimension) < 3:
+        elif self.axis_id.get(dimension, dimension) is not None:
             return self._ortho_pixelize(
                 data_source, field, bounds, size, antialias, dimension, periodic
             )

--- a/yt/geometry/coordinates/coordinate_handler.py
+++ b/yt/geometry/coordinates/coordinate_handler.py
@@ -6,7 +6,7 @@ from typing import Tuple
 import numpy as np
 from packaging.version import Version
 
-from yt.funcs import fix_unitary, is_sequence, parse_center_array, validate_width_tuple
+from yt.funcs import fix_unitary, is_sized, parse_center_array, validate_width_tuple
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.exceptions import YTCoordinateNotImplemented, YTInvalidWidthError
 from yt.visualization._commons import MPL_VERSION
@@ -277,7 +277,7 @@ class CoordinateHandler(abc.ABC):
         pass
 
     def sanitize_depth(self, depth):
-        if is_sequence(depth):
+        if is_sized(depth):
             validate_width_tuple(depth)
             depth = (self.ds.quan(depth[0], fix_unitary(depth[1])),)
         elif isinstance(depth, Number):
@@ -295,7 +295,7 @@ class CoordinateHandler(abc.ABC):
             # initialize the index if it is not already initialized
             self.ds.index
             # Default to code units
-            if not is_sequence(axis):
+            if not is_sized(axis):
                 xax = self.x_axis[axis]
                 yax = self.y_axis[axis]
                 w = self.ds.domain_width[np.array([xax, yax])]
@@ -305,7 +305,7 @@ class CoordinateHandler(abc.ABC):
                 mi = np.argmin(self.ds.domain_width)
                 w = self.ds.domain_width[np.array((mi, mi))]
             width = (w[0], w[1])
-        elif is_sequence(width):
+        elif is_sized(width):
             width = validate_sequence_width(width, self.ds)
         elif isinstance(width, YTQuantity):
             width = (width, width)

--- a/yt/geometry/coordinates/coordinate_handler.py
+++ b/yt/geometry/coordinates/coordinate_handler.py
@@ -6,7 +6,13 @@ from typing import Tuple
 import numpy as np
 from packaging.version import Version
 
-from yt.funcs import fix_unitary, is_sized, parse_center_array, validate_width_tuple
+from yt.funcs import (
+    fix_unitary,
+    is_scalar,
+    is_sized,
+    parse_center_array,
+    validate_width_tuple,
+)
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.exceptions import YTCoordinateNotImplemented, YTInvalidWidthError
 from yt.visualization._commons import MPL_VERSION
@@ -295,7 +301,7 @@ class CoordinateHandler(abc.ABC):
             # initialize the index if it is not already initialized
             self.ds.index
             # Default to code units
-            if not is_sized(axis):
+            if is_scalar(axis):
                 xax = self.x_axis[axis]
                 yax = self.y_axis[axis]
                 w = self.ds.domain_width[np.array([xax, yax])]

--- a/yt/geometry/coordinates/coordinate_handler.py
+++ b/yt/geometry/coordinates/coordinate_handler.py
@@ -6,7 +6,7 @@ from typing import Tuple
 import numpy as np
 from packaging.version import Version
 
-from yt.funcs import fix_unitary, is_sequence, validate_width_tuple
+from yt.funcs import fix_unitary, is_sequence, parse_center_array, validate_width_tuple
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.exceptions import YTCoordinateNotImplemented, YTInvalidWidthError
 from yt.visualization._commons import MPL_VERSION
@@ -322,34 +322,7 @@ class CoordinateHandler(abc.ABC):
         return width
 
     def sanitize_center(self, center, axis):
-        if isinstance(center, str):
-            if center.lower() == "m" or center.lower() == "max":
-                v, center = self.ds.find_max(("gas", "density"))
-                center = self.ds.arr(center, "code_length")
-            elif center.lower() == "c" or center.lower() == "center":
-                # domain_left_edge and domain_right_edge might not be
-                # initialized until we create the index, so create it
-                self.ds.index
-                center = (self.ds.domain_left_edge + self.ds.domain_right_edge) / 2
-            else:
-                raise RuntimeError(f'center keyword "{center}" not recognized')
-        elif isinstance(center, YTArray):
-            return self.ds.arr(center), self.convert_to_cartesian(center)
-        elif is_sequence(center):
-            if isinstance(center[0], str) and isinstance(center[1], str):
-                if center[0].lower() == "min":
-                    v, center = self.ds.find_min(center[1])
-                elif center[0].lower() == "max":
-                    v, center = self.ds.find_max(center[1])
-                else:
-                    raise RuntimeError(f'center keyword "{center}" not recognized')
-                center = self.ds.arr(center, "code_length")
-            elif is_sequence(center[0]) and isinstance(center[1], str):
-                center = self.ds.arr(center[0], center[1])
-            else:
-                center = self.ds.arr(center, "code_length")
-        else:
-            raise RuntimeError(f'center keyword "{center}" not recognized')
+        center = parse_center_array(center, ds=self.ds, axis=axis)
         # This has to return both a center and a display_center
         display_center = self.convert_to_cartesian(center)
         return center, display_center

--- a/yt/geometry/coordinates/tests/test_sanitize_center.py
+++ b/yt/geometry/coordinates/tests/test_sanitize_center.py
@@ -1,0 +1,114 @@
+import re
+
+import pytest
+from unyt import unyt_array
+from unyt.exceptions import UnitConversionError
+
+from yt.testing import fake_amr_ds
+
+
+@pytest.fixture(scope="module")
+def reusable_fake_dataset():
+    ds = fake_amr_ds(
+        fields=[("gas", "density")],
+        units=["g/cm**3"],
+    )
+    return ds
+
+
+valid_single_str_values = ("center",)
+valid_field_loc_str_values = ("min", "max")
+
+DEFAUT_ERROR_MESSAGE = (
+    "Expected any of the following\n"
+    "- 'c', 'center', 'l', 'left', 'r', 'right', 'm', 'max', or 'min'\n"
+    "- 'min' or 'max', followed by a field identifier\n"
+    "- a 3 element unyt_array with length dimensions"
+)
+
+
+@pytest.mark.parametrize(
+    "user_input",
+    (
+        # second element can be a single str or a field tuple (2 str), but not three
+        (("max", ("not", "a", "field"))),
+        # a 1-tuple is also not a valid field key
+        (("max", ("notafield",))),
+        # both elements need to be str
+        (("max", (0, "invalid_field_type"))),
+        (("max", ("invalid_field_type", 1))),
+    ),
+)
+def test_invalid_center_type_default_error(reusable_fake_dataset, user_input):
+    ds = reusable_fake_dataset
+    with pytest.raises(
+        TypeError,
+        match=re.escape(
+            f"Invalid center value {user_input!r}. " + DEFAUT_ERROR_MESSAGE
+        ),
+    ):
+        # at the time of writing `axis` is an unused parameter of the base
+        # sanitize center method, which is used directly for cartesian coordinate handlers
+        # this probably hints that a refactor would make sense to separaet center sanitizing
+        # and display_center calculation
+        ds.coordinates.sanitize_center(user_input, axis=None)
+
+
+@pytest.mark.parametrize(
+    "user_input, error_type, error_message",
+    (
+        (
+            "bad_str",
+            ValueError,
+            re.escape(
+                "Received unknown center single string value 'bad_str'. "
+                + DEFAUT_ERROR_MESSAGE
+            ),
+        ),
+        (
+            ("bad_str", ("gas", "density")),
+            ValueError,
+            re.escape(
+                "Received unknown string value 'bad_str'. "
+                f"Expected one of {valid_field_loc_str_values} (case insensitive)"
+            ),
+        ),
+        (
+            ("bad_str", "density"),
+            ValueError,
+            re.escape(
+                "Received unknown string value 'bad_str'. "
+                "Expected one of ('min', 'max') (case insensitive)"
+            ),
+        ),
+        # even with exactly three elements, the dimension should be length
+        (
+            unyt_array([0.5] * 3, "kg"),
+            UnitConversionError,
+            "...",  # don't match the exact error message since it's unyt's responsability
+        ),
+        # only validate 3 elements unyt_arrays
+        (
+            unyt_array([0.5] * 2, "cm"),
+            TypeError,
+            re.escape("Expected an array with size 3, got 2."),
+        ),
+        (
+            unyt_array([0.5] * 4, "cm"),
+            TypeError,
+            re.escape("Expected an array with size 3, got 4."),
+        ),
+        (
+            # check that the whole shape is used in validation, not just the length (number of rows)
+            unyt_array([0.5] * 6, "cm").reshape(3, 2),
+            TypeError,
+            re.escape("Expected an array with size 3, got 6."),
+        ),
+    ),
+)
+def test_invalid_center_special_cases(
+    reusable_fake_dataset, user_input, error_type, error_message
+):
+    ds = reusable_fake_dataset
+    with pytest.raises(error_type, match=error_message):
+        ds.coordinates.sanitize_center(user_input, axis=None)

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -20,7 +20,7 @@ from unyt.exceptions import UnitOperationError
 
 from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.config import ytcfg
-from yt.funcs import is_sequence
+from yt.funcs import is_sized
 from yt.loaders import load
 from yt.units.yt_array import YTArray, YTQuantity
 
@@ -231,11 +231,11 @@ def fake_random_ds(
     from yt.loaders import load_uniform_grid
 
     prng = RandomState(0x4D3D3D3)
-    if not is_sequence(ndims):
+    if not is_sized(ndims):
         ndims = [ndims, ndims, ndims]
     else:
         assert len(ndims) == 3
-    if not is_sequence(negative):
+    if not is_sized(negative):
         if fields:
             negative = [negative for f in fields]
         else:
@@ -376,7 +376,7 @@ def fake_particle_ds(
     from yt.loaders import load_particles
 
     prng = RandomState(0x4D3D3D3)
-    if negative is not None and not is_sequence(negative):
+    if negative is not None and not is_sized(negative):
         negative = [negative for f in fields]
 
     fields, units, negative = _check_field_unit_args_helper(

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -20,7 +20,7 @@ from unyt.exceptions import UnitOperationError
 
 from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.config import ytcfg
-from yt.funcs import is_sized
+from yt.funcs import is_scalar
 from yt.loaders import load
 from yt.units.yt_array import YTArray, YTQuantity
 
@@ -231,11 +231,11 @@ def fake_random_ds(
     from yt.loaders import load_uniform_grid
 
     prng = RandomState(0x4D3D3D3)
-    if not is_sized(ndims):
+    if is_scalar(ndims):
         ndims = [ndims, ndims, ndims]
     else:
         assert len(ndims) == 3
-    if not is_sized(negative):
+    if is_scalar(negative):
         if fields:
             negative = [negative for f in fields]
         else:
@@ -376,7 +376,7 @@ def fake_particle_ds(
     from yt.loaders import load_particles
 
     prng = RandomState(0x4D3D3D3)
-    if negative is not None and not is_sized(negative):
+    if negative is not None and is_scalar(negative):
         negative = [negative for f in fields]
 
     fields, units, negative = _check_field_unit_args_helper(

--- a/yt/utilities/amr_kdtree/amr_kdtree.py
+++ b/yt/utilities/amr_kdtree/amr_kdtree.py
@@ -2,7 +2,7 @@ import operator
 
 import numpy as np
 
-from yt.funcs import is_sized, mylog
+from yt.funcs import is_scalar, mylog
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.utilities.amr_kdtree.amr_kdtools import (
     receive_and_reduce,
@@ -214,7 +214,7 @@ class AMRKDTree(ParallelAnalysisInterface):
             or self.fields != new_fields
             or force
         )
-        if not is_sized(log_fields):
+        if is_scalar(log_fields):
             log_fields = [log_fields]
         new_log_fields = list(log_fields)
         self.tree.trunk.set_dirty(regenerate_data)

--- a/yt/utilities/amr_kdtree/amr_kdtree.py
+++ b/yt/utilities/amr_kdtree/amr_kdtree.py
@@ -2,7 +2,7 @@ import operator
 
 import numpy as np
 
-from yt.funcs import is_sequence, mylog
+from yt.funcs import is_sized, mylog
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.utilities.amr_kdtree.amr_kdtools import (
     receive_and_reduce,
@@ -214,7 +214,7 @@ class AMRKDTree(ParallelAnalysisInterface):
             or self.fields != new_fields
             or force
         )
-        if not is_sequence(log_fields):
+        if not is_sized(log_fields):
             log_fields = [log_fields]
         new_log_fields = list(log_fields)
         self.tree.trunk.set_dirty(regenerate_data)

--- a/yt/utilities/minimal_representation.py
+++ b/yt/utilities/minimal_representation.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 
 import numpy as np
 
-from yt.funcs import compare_dicts, is_sequence
+from yt.funcs import compare_dicts, is_sized
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.on_demand_imports import _h5py as h5py
 
@@ -48,7 +48,7 @@ def _deserialize_from_h5(g, ds):
         if item == "chunks":
             continue
         if "units" in g[item].attrs:
-            if is_sequence(g[item]):
+            if is_sized(g[item]):
                 result[item] = ds.arr(g[item][:], g[item].attrs["units"])
             else:
                 result[item] = ds.quan(g[item][()], g[item].attrs["units"])

--- a/yt/utilities/parallel_tools/parallel_analysis_interface.py
+++ b/yt/utilities/parallel_tools/parallel_analysis_interface.py
@@ -13,7 +13,7 @@ from more_itertools import always_iterable
 import yt.utilities.logger
 from yt.config import ytcfg
 from yt.data_objects.image_array import ImageArray
-from yt.funcs import is_sequence
+from yt.funcs import is_sized
 from yt.units.unit_registry import UnitRegistry  # type: ignore
 from yt.units.yt_array import YTArray
 from yt.utilities.exceptions import YTNoDataInObjectError
@@ -419,7 +419,7 @@ class ProcessorPool:
         pool = cls()
         rank = pool.comm.rank
         for i, size in enumerate(always_iterable(sizes)):
-            if is_sequence(size):
+            if is_sized(size):
                 size, name = size
             else:
                 name = "workgroup_%02i" % i

--- a/yt/visualization/_handlers.py
+++ b/yt/visualization/_handlers.py
@@ -10,7 +10,7 @@ from packaging.version import Version
 
 from yt._typing import Quantity, Unit
 from yt.config import ytcfg
-from yt.funcs import get_brewer_cmap, is_sequence, mylog
+from yt.funcs import get_brewer_cmap, is_sized, mylog
 from yt.visualization._commons import MPL_VERSION
 from yt.visualization.color_maps import _get_cmap
 
@@ -122,7 +122,7 @@ class NormHandler:
         if isinstance(val, un.unyt_quantity):
             return self.ds.quan(val)
         elif (
-            is_sequence(val)
+            is_sized(val)
             and len(val) == 2
             and isinstance(val[0], Real)
             and isinstance(val[1], (str, un.Unit))
@@ -426,7 +426,7 @@ class ColorbarHandler:
             self._cmap = newval
         elif isinstance(newval, str):
             self._cmap = _get_cmap(newval)
-        elif is_sequence(newval):
+        elif is_sized(newval):
             # tuple colormaps are from palettable (or brewer2mpl)
             self._cmap = get_brewer_cmap(newval)
         else:

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -12,7 +12,13 @@ from matplotlib.figure import Figure
 from matplotlib.ticker import LogFormatterMathtext
 from packaging.version import Version
 
-from yt.funcs import get_interactivity, is_sized, matplotlib_style_context, mylog
+from yt.funcs import (
+    get_interactivity,
+    is_scalar,
+    matplotlib_style_context,
+    mylog,
+    obj_length,
+)
 from yt.visualization._handlers import ColorbarHandler, NormHandler
 
 from ._commons import (
@@ -99,7 +105,7 @@ class PlotMPL:
 
         self._plot_valid = True
         if figure is None:
-            if not is_sized(fsize):
+            if is_scalar(fsize):
                 fsize = (fsize, fsize)
             self.figure = matplotlib.figure.Figure(figsize=fsize, frameon=True)
         else:
@@ -403,16 +409,20 @@ class ImagePlotMPL(PlotMPL, ABC):
 
         # Ensure the figure size along the long axis is always equal to _figure_size
         unit_aspect = getattr(self, "_unit_aspect", 1)
-        if is_sized(self._figure_size):
+        if obj_length(self._figure_size) == 2:
             x_fig_size, y_fig_size = self._figure_size
             y_fig_size *= unit_aspect
-        else:
+        elif is_scalar(self._figure_size):
             x_fig_size = y_fig_size = self._figure_size
             scaling = self._aspect / unit_aspect
             if scaling < 1:
                 x_fig_size *= scaling
             else:
                 y_fig_size /= scaling
+        else:
+            raise RuntimeError(
+                "Got invalid _figure_size attr (need a scalar or a two-element sequence)"
+            )
 
         if self.colorbar_handler.draw_cbar:
             cb_size = self._cb_size

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -56,7 +56,7 @@ class CallbackWrapper:
             if viewer._has_swapped_axes:
                 # store the original un-transposed shape
                 self.raw_image_shape = self.raw_image_shape[1], self.raw_image_shape[0]
-        if frb.axis < 3:
+        if frb.axis is not None:
             DD = frb.ds.domain_width
             xax = frb.ds.coordinates.x_axis[frb.axis]
             yax = frb.ds.coordinates.y_axis[frb.axis]

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -12,7 +12,7 @@ from matplotlib.figure import Figure
 from matplotlib.ticker import LogFormatterMathtext
 from packaging.version import Version
 
-from yt.funcs import get_interactivity, is_sequence, matplotlib_style_context, mylog
+from yt.funcs import get_interactivity, is_sized, matplotlib_style_context, mylog
 from yt.visualization._handlers import ColorbarHandler, NormHandler
 
 from ._commons import (
@@ -99,7 +99,7 @@ class PlotMPL:
 
         self._plot_valid = True
         if figure is None:
-            if not is_sequence(fsize):
+            if not is_sized(fsize):
                 fsize = (fsize, fsize)
             self.figure = matplotlib.figure.Figure(figsize=fsize, frameon=True)
         else:
@@ -403,7 +403,7 @@ class ImagePlotMPL(PlotMPL, ABC):
 
         # Ensure the figure size along the long axis is always equal to _figure_size
         unit_aspect = getattr(self, "_unit_aspect", 1)
-        if is_sequence(self._figure_size):
+        if is_sized(self._figure_size):
             x_fig_size, y_fig_size = self._figure_size
             y_fig_size *= unit_aspect
         else:

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -962,19 +962,31 @@ class FITSSlice(FITSImageData):
         Specify the resolution of the resulting image. A single value will be
         used for both axes, whereas a tuple of values will be used for the
         individual axes. Default: 512
-    center : A sequence of floats, a string, or a tuple.
-        The coordinate of the center of the image. If set to 'c', 'center' or
-        left blank, the plot is centered on the middle of the domain. If set
-        to 'max' or 'm', the center will be located at the maximum of the
-        ('gas', 'density') field. Centering on the max or min of a specific
-        field is supported by providing a tuple such as ("min","temperature")
-        or ("max","dark_matter_density"). Units can be specified by passing in
-        *center* as a tuple containing a coordinate and string unit name or by
-        passing in a YTArray. If a list or unitless array is supplied, code
-        units are assumed.
+    center : 'center', 'c', 'left', 'l', 'right', 'r' id of a global extremum, or array-like
+        The coordinate of the selection's center.
+        Defaults to the 'center', i.e. center of the domain.
+
+        Centering on the min or max of a field is supported by passing a tuple
+        such as ('min', ('gas', 'density')) or ('max', ('gas', 'temperature'). A
+        single string may also be used (e.g. "min_density" or
+        "max_temperature"), though it's not as flexible and does not allow to
+        select an exact field/particle type. With this syntax, the first field
+        matching the provided name is selected.
+        'max' or 'm' can be used as a shortcut for ('max', ('gas', 'density'))
+        'min' can be used as a shortcut for ('min', ('gas', 'density'))
+
+        One can also select an exact point as a 3 element coordinate sequence,
+        e.g. [0.5, 0.5, 0]
+        Units can be specified by passing in *center* as a tuple containing a
+        3-element coordinate sequence and string unit name, e.g. ([0, 0.5, 0.5], "cm"),
+        or by passing in a YTArray. Code units are assumed if unspecified.
+
+        The domain edges along the selected *axis* can be selected with
+        'left'/'l' and 'right'/'r' respectively.
+
     width : tuple or a float.
-        Width can have four different formats to support variable
-        x and y widths.  They are:
+        Width can have four different formats to support variable x and y
+        widths.  They are:
 
         ==================================     =======================
         format                                 example
@@ -985,15 +997,15 @@ class FITSSlice(FITSImageData):
         (float, float)                         (0.2, 0.3)
         ==================================     =======================
 
-        For example, (10, 'kpc') specifies a width that is 10 kiloparsecs
-        wide in the x and y directions, ((10,'kpc'),(15,'kpc')) specifies a
-        width that is 10 kiloparsecs wide along the x axis and 15
-        kiloparsecs wide along the y axis.  In the other two examples, code
-        units are assumed, for example (0.2, 0.3) specifies a width that has an
-        x width of 0.2 and a y width of 0.3 in code units.
+        For example, (10, 'kpc') specifies a width that is 10 kiloparsecs wide
+        in the x and y directions, ((10,'kpc'),(15,'kpc')) specifies a width
+        that is 10 kiloparsecs wide along the x axis and 15 kiloparsecs wide
+        along the y axis.  In the other two examples, code units are assumed,
+        for example (0.2, 0.3) specifies a width that has an x width of 0.2 and
+        a y width of 0.3 in code units.
     length_unit : string, optional
-        the length units that the coordinates are written in. The default
-        is to use the default length unit of the dataset.
+        the length units that the coordinates are written in. The default is to
+        use the default length unit of the dataset.
     """
 
     def __init__(
@@ -1002,7 +1014,7 @@ class FITSSlice(FITSImageData):
         axis,
         fields,
         image_res=512,
-        center="c",
+        center="center",
         width=None,
         length_unit=None,
         **kwargs,
@@ -1033,16 +1045,27 @@ class FITSProjection(FITSImageData):
         Specify the resolution of the resulting image. A single value will be
         used for both axes, whereas a tuple of values will be used for the
         individual axes. Default: 512
-    center : A sequence of floats, a string, or a tuple.
-        The coordinate of the center of the image. If set to 'c', 'center' or
-        left blank, the plot is centered on the middle of the domain. If set
-        to 'max' or 'm', the center will be located at the maximum of the
-        ('gas', 'density') field. Centering on the max or min of a specific
-        field is supported by providing a tuple such as ("min","temperature")
-        or ("max","dark_matter_density"). Units can be specified by passing in
-        *center* as a tuple containing a coordinate and string unit name or by
-        passing in a YTArray. If a list or unitless array is supplied, code
-        units are assumed.
+    center : 'center', 'c', 'left', 'l', 'right', 'r' id of a global extremum, or array-like
+        The coordinate of the selection's center.
+        Defaults to the 'center', i.e. center of the domain.
+
+        Centering on the min or max of a field is supported by passing a tuple
+        such as ('min', ('gas', 'density')) or ('max', ('gas', 'temperature'). A
+        single string may also be used (e.g. "min_density" or
+        "max_temperature"), though it's not as flexible and does not allow to
+        select an exact field/particle type. With this syntax, the first field
+        matching the provided name is selected.
+        'max' or 'm' can be used as a shortcut for ('max', ('gas', 'density'))
+        'min' can be used as a shortcut for ('min', ('gas', 'density'))
+
+        One can also select an exact point as a 3 element coordinate sequence,
+        e.g. [0.5, 0.5, 0]
+        Units can be specified by passing in *center* as a tuple containing a
+        3-element coordinate sequence and string unit name, e.g. ([0, 0.5, 0.5], "cm"),
+        or by passing in a YTArray. Code units are assumed if unspecified.
+
+        The domain edges along the selected *axis* can be selected with
+        'left'/'l' and 'right'/'r' respectively.
     width : tuple or a float.
         Width can have four different formats to support variable
         x and y widths.  They are:
@@ -1075,7 +1098,7 @@ class FITSProjection(FITSImageData):
         axis,
         fields,
         image_res=512,
-        center="c",
+        center="center",
         width=None,
         weight_field=None,
         length_unit=None,
@@ -1108,16 +1131,27 @@ class FITSParticleProjection(FITSImageData):
         Specify the resolution of the resulting image. A single value will be
         used for both axes, whereas a tuple of values will be used for the
         individual axes. Default: 512
-    center : A sequence of floats, a string, or a tuple.
-        The coordinate of the center of the image. If set to 'c', 'center' or
-        left blank, the plot is centered on the middle of the domain. If set
-        to 'max' or 'm', the center will be located at the maximum of the
-        ('gas', 'density') field. Centering on the max or min of a specific
-        field is supported by providing a tuple such as ("min","temperature")
-        or ("max","dark_matter_density"). Units can be specified by passing in
-        *center* as a tuple containing a coordinate and string unit name or by
-        passing in a YTArray. If a list or unitless array is supplied, code
-        units are assumed.
+    center : 'center', 'c', 'left', 'l', 'right', 'r' id of a global extremum, or array-like
+        The coordinate of the selection's center.
+        Defaults to the 'center', i.e. center of the domain.
+
+        Centering on the min or max of a field is supported by passing a tuple
+        such as ('min', ('gas', 'density')) or ('max', ('gas', 'temperature'). A
+        single string may also be used (e.g. "min_density" or
+        "max_temperature"), though it's not as flexible and does not allow to
+        select an exact field/particle type. With this syntax, the first field
+        matching the provided name is selected.
+        'max' or 'm' can be used as a shortcut for ('max', ('gas', 'density'))
+        'min' can be used as a shortcut for ('min', ('gas', 'density'))
+
+        One can also select an exact point as a 3 element coordinate sequence,
+        e.g. [0.5, 0.5, 0]
+        Units can be specified by passing in *center* as a tuple containing a
+        3-element coordinate sequence and string unit name, e.g. ([0, 0.5, 0.5], "cm"),
+        or by passing in a YTArray. Code units are assumed if unspecified.
+
+        The domain edges along the selected *axis* can be selected with
+        'left'/'l' and 'right'/'r' respectively.
     width : tuple or a float.
         Width can have four different formats to support variable
         x and y widths.  They are:
@@ -1167,7 +1201,7 @@ class FITSParticleProjection(FITSImageData):
         axis,
         fields,
         image_res=512,
-        center="c",
+        center="center",
         width=None,
         depth=(1, "1"),
         weight_field=None,
@@ -1220,16 +1254,25 @@ class FITSOffAxisSlice(FITSImageData):
         Specify the resolution of the resulting image. A single value will be
         used for both axes, whereas a tuple of values will be used for the
         individual axes. Default: 512
-    center : A sequence of floats, a string, or a tuple.
-        The coordinate of the center of the image. If set to 'c', 'center' or
-        left blank, the plot is centered on the middle of the domain. If set
-        to 'max' or 'm', the center will be located at the maximum of the
-        ('gas', 'density') field. Centering on the max or min of a specific
-        field is supported by providing a tuple such as ("min","temperature")
-        or ("max","dark_matter_density"). Units can be specified by passing in
-        *center* as a tuple containing a coordinate and string unit name or by
-        passing in a YTArray. If a list or unitless array is supplied, code
-        units are assumed.
+    center : 'center', 'c', id of a global extremum, or array-like
+        The coordinate of the selection's center.
+        Defaults to the 'center', i.e. center of the domain.
+
+        Centering on the min or max of a field is supported by passing a tuple
+        such as ('min', ('gas', 'density')) or ('max', ('gas', 'temperature'). A
+        single string may also be used (e.g. "min_density" or
+        "max_temperature"), though it's not as flexible and does not allow to
+        select an exact field/particle type. With this syntax, the first field
+        matching the provided name is selected.
+        'max' or 'm' can be used as a shortcut for ('max', ('gas', 'density'))
+        'min' can be used as a shortcut for ('min', ('gas', 'density'))
+
+        One can also select an exact point as a 3 element coordinate sequence,
+        e.g. [0.5, 0.5, 0]
+        Units can be specified by passing in *center* as a tuple containing a
+        3-element coordinate sequence and string unit name, e.g. ([0, 0.5, 0.5], "cm"),
+        or by passing in a YTArray. Code units are assumed if unspecified.
+
     width : tuple or a float.
         Width can have four different formats to support variable
         x and y widths.  They are:
@@ -1264,13 +1307,13 @@ class FITSOffAxisSlice(FITSImageData):
         normal,
         fields,
         image_res=512,
-        center="c",
+        center="center",
         width=None,
         north_vector=None,
         length_unit=None,
     ):
         fields = list(iter_fields(fields))
-        center, dcenter = ds.coordinates.sanitize_center(center, 4)
+        center, dcenter = ds.coordinates.sanitize_center(center, axis=None)
         cut = ds.cutting(normal, center, north_vector=north_vector)
         center = ds.arr([0.0] * 2, "code_length")
         w, frb, lunit = construct_image(
@@ -1296,16 +1339,24 @@ class FITSOffAxisProjection(FITSImageData):
         Specify the resolution of the resulting image. A single value will be
         used for both axes, whereas a tuple of values will be used for the
         individual axes. Default: 512
-    center : A sequence of floats, a string, or a tuple.
-        The coordinate of the center of the image. If set to 'c', 'center' or
-        left blank, the plot is centered on the middle of the domain. If set
-        to 'max' or 'm', the center will be located at the maximum of the
-        ('gas', 'density') field. Centering on the max or min of a specific
-        field is supported by providing a tuple such as ("min","temperature")
-        or ("max","dark_matter_density"). Units can be specified by passing in
-        *center* as a tuple containing a coordinate and string unit name or by
-        passing in a YTArray. If a list or unitless array is supplied, code
-        units are assumed.
+    center : 'center', 'c', id of a global extremum, or array-like
+        The coordinate of the selection's center.
+        Defaults to the 'center', i.e. center of the domain.
+
+        Centering on the min or max of a field is supported by passing a tuple
+        such as ('min', ('gas', 'density')) or ('max', ('gas', 'temperature'). A
+        single string may also be used (e.g. "min_density" or
+        "max_temperature"), though it's not as flexible and does not allow to
+        select an exact field/particle type. With this syntax, the first field
+        matching the provided name is selected.
+        'max' or 'm' can be used as a shortcut for ('max', ('gas', 'density'))
+        'min' can be used as a shortcut for ('min', ('gas', 'density'))
+
+        One can also select an exact point as a 3 element coordinate sequence,
+        e.g. [0.5, 0.5, 0]
+        Units can be specified by passing in *center* as a tuple containing a
+        3-element coordinate sequence and string unit name, e.g. ([0, 0.5, 0.5], "cm"),
+        or by passing in a YTArray. Code units are assumed if unspecified.
     width : tuple or a float.
         Width can have four different formats to support variable
         x and y widths.  They are:
@@ -1362,7 +1413,7 @@ class FITSOffAxisProjection(FITSImageData):
         ds,
         normal,
         fields,
-        center="c",
+        center="center",
         width=(1.0, "unitary"),
         weight_field=None,
         image_res=512,
@@ -1373,7 +1424,7 @@ class FITSOffAxisProjection(FITSImageData):
         length_unit=None,
     ):
         fields = list(iter_fields(fields))
-        center, dcenter = ds.coordinates.sanitize_center(center, 4)
+        center, dcenter = ds.coordinates.sanitize_center(center, axis=None)
         buf = {}
         width = ds.coordinates.sanitize_width(normal, width, depth)
         wd = tuple(el.in_units("code_length").v for el in width)

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -9,7 +9,7 @@ from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.data_objects.construction_data_containers import YTCoveringGrid
 from yt.data_objects.image_array import ImageArray
 from yt.fields.derived_field import DerivedField
-from yt.funcs import fix_axis, is_sequence, iter_fields, mylog
+from yt.funcs import fix_axis, is_sized, iter_fields, mylog
 from yt.units import dimensions
 from yt.units.unit_object import Unit  # type: ignore
 from yt.units.yt_array import YTArray, YTQuantity
@@ -322,7 +322,7 @@ class FITSImageData:
             else:
                 # If img_data is just an array we use the width and img_ctr
                 # parameters to determine the cell widths
-                if not is_sequence(width):
+                if not is_sized(width):
                     width = [width] * self.dimensionality
                 if isinstance(width[0], YTQuantity):
                     cdelt = [
@@ -866,7 +866,7 @@ def construct_image(ds, axis, data_source, center, image_res, width, length_unit
     else:
         width = ds.coordinates.sanitize_width(axis, width, None)
         unit = str(width[0].units)
-    if is_sequence(image_res):
+    if is_sized(image_res):
         nx, ny = image_res
     else:
         nx, ny = image_res, image_res
@@ -885,12 +885,12 @@ def construct_image(ds, axis, data_source, center, image_res, width, length_unit
     cunit = [length_unit] * 2
     ctype = ["LINEAR"] * 2
     cdelt = [dx.in_units(length_unit), dy.in_units(length_unit)]
-    if is_sequence(axis):
+    if is_sized(axis):
         crval = center.in_units(length_unit)
     else:
         crval = [center[idx].in_units(length_unit) for idx in axis_wcs[axis]]
     if hasattr(data_source, "to_frb"):
-        if is_sequence(axis):
+        if is_sized(axis):
             frb = data_source.to_frb(width[0], (nx, ny), height=width[1])
         else:
             frb = data_source.to_frb(width[0], (nx, ny), center=center, height=width[1])
@@ -1428,7 +1428,7 @@ class FITSOffAxisProjection(FITSImageData):
         buf = {}
         width = ds.coordinates.sanitize_width(normal, width, depth)
         wd = tuple(el.in_units("code_length").v for el in width)
-        if not is_sequence(image_res):
+        if not is_sized(image_res):
             image_res = (image_res, image_res)
         res = (image_res[0], image_res[1])
         if data_source is None:

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -133,7 +133,7 @@ class FixedResolutionBuffer:
             ds.plots.append(weakref.proxy(self))
 
         # Handle periodicity, just in case
-        if self.data_source.axis < 3:
+        if self.data_source.axis is not None:
             DLE = self.ds.domain_left_edge
             DRE = self.ds.domain_right_edge
             DD = float(self.periodic) * (DRE - DLE)

--- a/yt/visualization/line_plot.py
+++ b/yt/visualization/line_plot.py
@@ -4,7 +4,7 @@ from typing import Optional
 import numpy as np
 from matplotlib.colors import LogNorm, Normalize, SymLogNorm
 
-from yt.funcs import is_sequence, mylog
+from yt.funcs import is_sized, mylog
 from yt.units.unit_object import Unit  # type: ignore
 from yt.units.yt_array import YTArray
 from yt.visualization.plot_container import (
@@ -203,7 +203,7 @@ class LinePlot(BaseLinePlot):
         y_axis_size = 0.7 * fontscale
         right_buff_size = 0.2 * fontscale
 
-        if is_sequence(self.figure_size):
+        if is_sized(self.figure_size):
             figure_size = self.figure_size
         else:
             figure_size = (self.figure_size, self.figure_size)
@@ -425,7 +425,7 @@ class LinePlot(BaseLinePlot):
 
 
 def _validate_point(point, ds, start=False):
-    if not is_sequence(point):
+    if not is_sized(point):
         raise RuntimeError("Input point must be array-like")
     if not isinstance(point, YTArray):
         point = ds.arr(point, "code_length", dtype=np.float64)

--- a/yt/visualization/line_plot.py
+++ b/yt/visualization/line_plot.py
@@ -4,7 +4,7 @@ from typing import Optional
 import numpy as np
 from matplotlib.colors import LogNorm, Normalize, SymLogNorm
 
-from yt.funcs import is_sized, mylog
+from yt.funcs import is_scalar, is_sized, mylog
 from yt.units.unit_object import Unit  # type: ignore
 from yt.units.yt_array import YTArray
 from yt.visualization.plot_container import (
@@ -425,7 +425,7 @@ class LinePlot(BaseLinePlot):
 
 
 def _validate_point(point, ds, start=False):
-    if not is_sized(point):
+    if is_scalar(point):
         raise RuntimeError("Input point must be array-like")
     if not isinstance(point, YTArray):
         point = ds.arr(point, "code_length", dtype=np.float64)

--- a/yt/visualization/particle_plots.py
+++ b/yt/visualization/particle_plots.py
@@ -105,16 +105,27 @@ class ParticleProjectionPlot(PWViewerMPL):
          The color that will indicate the particle locations
          on the mesh. This argument is ignored if z_fields is
          not None. Default is 'b'.
-    center : A sequence of floats, a string, or a tuple.
-         The coordinate of the center of the image. If set to 'c', 'center' or
-         left blank, the plot is centered on the middle of the domain. If set to
-         'max' or 'm', the center will be located at the maximum of the
-         ('gas', 'density') field. Centering on the max or min of a specific
-         field is supported by providing a tuple such as ("min","temperature") or
-         ("max","dark_matter_density"). Units can be specified by passing in *center*
-         as a tuple containing a coordinate and string unit name or by passing
-         in a YTArray. If a list or unitless array is supplied, code units are
-         assumed.
+    center : 'center', 'c', 'left', 'l', 'right', 'r' id of a global extremum, or array-like
+        The coordinate of the selection's center.
+        Defaults to the 'center', i.e. center of the domain.
+
+        Centering on the min or max of a field is supported by passing a tuple
+        such as ('min', ('gas', 'density')) or ('max', ('gas', 'temperature'). A
+        single string may also be used (e.g. "min_density" or
+        "max_temperature"), though it's not as flexible and does not allow to
+        select an exact field/particle type. With this syntax, the first field
+        matching the provided name is selected.
+        'max' or 'm' can be used as a shortcut for ('max', ('gas', 'density'))
+        'min' can be used as a shortcut for ('min', ('gas', 'density'))
+
+        One can also select an exact point as a 3 element coordinate sequence,
+        e.g. [0.5, 0.5, 0]
+        Units can be specified by passing in *center* as a tuple containing a
+        3-element coordinate sequence and string unit name, e.g. ([0, 0.5, 0.5], "cm"),
+        or by passing in a YTArray. Code units are assumed if unspecified.
+
+        The domain edges along the selected *axis* can be selected with
+        'left'/'l' and 'right'/'r' respectively.
     width : tuple or a float.
          Width can have four different formats to support windows with variable
          x and y widths.  They are:
@@ -218,7 +229,7 @@ class ParticleProjectionPlot(PWViewerMPL):
         axis,
         fields=None,
         color="b",
-        center="c",
+        center="center",
         width=None,
         depth=(1, "1"),
         weight_field=None,
@@ -470,16 +481,29 @@ def ParticlePlot(ds, x_field, y_field, z_fields=None, color="b", *args, **kwargs
     data_source : YTSelectionContainer Object
          Object to be used for data selection.  Defaults to a region covering
          the entire simulation.
-    center : A sequence of floats, a string, or a tuple.
-         The coordinate of the center of the image. If set to 'c', 'center' or
-         left blank, the plot is centered on the middle of the domain. If set to
-         'max' or 'm', the center will be located at the maximum of the
-         ('gas', 'density') field. Centering on the max or min of a specific
-         field is supported by providing a tuple such as ("min","temperature") or
-         ("max","dark_matter_density"). Units can be specified by passing in *center*
-         as a tuple containing a coordinate and string unit name or by passing
-         in a YTArray. If a list or unitless array is supplied, code units are
-         assumed. This argument is only accepted by ``ParticleProjectionPlot``.
+    center : 'center', 'c', 'left', 'l', 'right', 'r' id of a global extremum, or array-like
+        The coordinate of the selection's center.
+        Defaults to the 'center', i.e. center of the domain.
+
+        Centering on the min or max of a field is supported by passing a tuple
+        such as ('min', ('gas', 'density')) or ('max', ('gas', 'temperature'). A
+        single string may also be used (e.g. "min_density" or
+        "max_temperature"), though it's not as flexible and does not allow to
+        select an exact field/particle type. With this syntax, the first field
+        matching the provided name is selected.
+        'max' or 'm' can be used as a shortcut for ('max', ('gas', 'density'))
+        'min' can be used as a shortcut for ('min', ('gas', 'density'))
+
+        One can also select an exact point as a 3 element coordinate sequence,
+        e.g. [0.5, 0.5, 0]
+        Units can be specified by passing in *center* as a tuple containing a
+        3-element coordinate sequence and string unit name, e.g. ([0, 0.5, 0.5], "cm"),
+        or by passing in a YTArray. Code units are assumed if unspecified.
+
+        The domain edges along the selected *axis* can be selected with
+        'left'/'l' and 'right'/'r' respectively.
+
+        This argument is only accepted by ``ParticleProjectionPlot``.
     width : tuple or a float.
          Width can have four different formats to support windows with variable
          x and y widths.  They are:

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -17,7 +17,7 @@ from yt._maintenance.deprecation import issue_deprecation_warning
 from yt._typing import Quantity
 from yt.config import ytcfg
 from yt.data_objects.time_series import DatasetSeries
-from yt.funcs import ensure_dir, is_sequence, is_sized, iter_fields
+from yt.funcs import ensure_dir, is_scalar, is_sequence, iter_fields
 from yt.units.unit_object import Unit  # type: ignore
 from yt.utilities.definitions import formatted_length_unit_names
 from yt.utilities.exceptions import YTConfigurationError, YTNotInsideNotebook
@@ -325,7 +325,7 @@ class PlotContainer(abc.ABC):
 
     def _initialize_dataset(self, ts):
         if not isinstance(ts, DatasetSeries):
-            if not is_sized(ts):
+            if is_scalar(ts):
                 ts = [ts]
             ts = DatasetSeries(ts)
         return ts

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -17,7 +17,7 @@ from yt._maintenance.deprecation import issue_deprecation_warning
 from yt._typing import Quantity
 from yt.config import ytcfg
 from yt.data_objects.time_series import DatasetSeries
-from yt.funcs import ensure_dir, is_sequence, iter_fields
+from yt.funcs import ensure_dir, is_sequence, is_sized, iter_fields
 from yt.units.unit_object import Unit  # type: ignore
 from yt.utilities.definitions import formatted_length_unit_names
 from yt.utilities.exceptions import YTConfigurationError, YTNotInsideNotebook
@@ -325,7 +325,7 @@ class PlotContainer(abc.ABC):
 
     def _initialize_dataset(self, ts):
         if not isinstance(ts, DatasetSeries):
-            if not is_sequence(ts):
+            if not is_sized(ts):
                 ts = [ts]
             ts = DatasetSeries(ts)
         return ts

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -17,7 +17,7 @@ from yt._maintenance.deprecation import issue_deprecation_warning
 from yt._typing import Quantity
 from yt.config import ytcfg
 from yt.data_objects.time_series import DatasetSeries
-from yt.funcs import ensure_dir, is_scalar, is_sequence, iter_fields
+from yt.funcs import ensure_dir, is_scalar, is_sized, iter_fields
 from yt.units.unit_object import Unit  # type: ignore
 from yt.utilities.definitions import formatted_length_unit_names
 from yt.utilities.exceptions import YTConfigurationError, YTNotInsideNotebook
@@ -464,7 +464,7 @@ class PlotContainer(abc.ABC):
     def _set_figure_size(self, size):
         if size is None:
             self.figure_size = self.__class__._default_figure_size
-        elif is_sequence(size):
+        elif is_sized(size):
             if len(size) != 2:
                 raise TypeError(f"Expected a single float or a pair, got {size}")
             self.figure_size = float(size[0]), float(size[1])

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -138,7 +138,7 @@ class PlotCallback(ABC):
             ax = plot.data.axis
             # if this is an on-axis projection or slice, then
             # just grab the appropriate 2 coords for the on-axis view
-            if ax >= 0 and ax <= 2:
+            if ax is not None:
                 (xi, yi) = (
                     plot.data.ds.coordinates.x_axis[ax],
                     plot.data.ds.coordinates.y_axis[ax],
@@ -148,7 +148,7 @@ class PlotCallback(ABC):
             # if this is an off-axis project or slice (ie cutting plane)
             # we have to calculate where the data coords fall in the projected
             # plane
-            elif ax == 4:
+            elif ax is None:
                 # transpose is just to get [[x1,x2,...],[y1,y2,...],[z1,z2,...]]
                 # in the same order as plot.data.center for array arithmetic
                 coord_vectors = coord_copy.transpose() - plot.data.center

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -15,7 +15,7 @@ from yt.data_objects.level_sets.clump_handling import Clump
 from yt.data_objects.selection_objects.cut_region import YTCutRegion
 from yt.data_objects.static_output import Dataset
 from yt.frontends.ytdata.data_structures import YTClumpContainer
-from yt.funcs import is_sized, mylog, validate_width_tuple
+from yt.funcs import is_sequence, is_sized, mylog, validate_width_tuple
 from yt.geometry.geometry_handler import is_curvilinear
 from yt.geometry.unstructured_mesh_handler import UnstructuredIndex
 from yt.units import dimensions
@@ -40,11 +40,12 @@ callback_registry: Dict[str, Type["PlotCallback"]] = {}
 
 def _validate_factor_tuple(factor) -> Tuple[int, int]:
     if (
-        is_sized(factor)
+        is_sequence(factor, check_access=True)
         and len(factor) == 2
         and all(isinstance(_, Integral) for _ in factor)
     ):
-        # - checking for "is_sized" allows lists, numpy arrays and other containers
+        # - checking for "is_sized" validates that len(factor) is supported
+        # - checking for Sequence abc validates item access, necessary for the 4th check
         # - checking for Integral type allows numpy integer types
         # in any case we return a with strict typing
         return (int(factor[0]), int(factor[1]))

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -15,7 +15,7 @@ from yt.data_objects.level_sets.clump_handling import Clump
 from yt.data_objects.selection_objects.cut_region import YTCutRegion
 from yt.data_objects.static_output import Dataset
 from yt.frontends.ytdata.data_structures import YTClumpContainer
-from yt.funcs import is_sequence, is_sized, mylog, validate_width_tuple
+from yt.funcs import is_sized, mylog, validate_width_tuple
 from yt.geometry.geometry_handler import is_curvilinear
 from yt.geometry.unstructured_mesh_handler import UnstructuredIndex
 from yt.units import dimensions
@@ -40,7 +40,7 @@ callback_registry: Dict[str, Type["PlotCallback"]] = {}
 
 def _validate_factor_tuple(factor) -> Tuple[int, int]:
     if (
-        is_sequence(factor, check_access=True)
+        is_sized(factor, check_access=True)
         and len(factor) == 2
         and all(isinstance(_, Integral) for _ in factor)
     ):

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -15,7 +15,7 @@ from yt.data_objects.level_sets.clump_handling import Clump
 from yt.data_objects.selection_objects.cut_region import YTCutRegion
 from yt.data_objects.static_output import Dataset
 from yt.frontends.ytdata.data_structures import YTClumpContainer
-from yt.funcs import is_sequence, mylog, validate_width_tuple
+from yt.funcs import is_sized, mylog, validate_width_tuple
 from yt.geometry.geometry_handler import is_curvilinear
 from yt.geometry.unstructured_mesh_handler import UnstructuredIndex
 from yt.units import dimensions
@@ -40,11 +40,11 @@ callback_registry: Dict[str, Type["PlotCallback"]] = {}
 
 def _validate_factor_tuple(factor) -> Tuple[int, int]:
     if (
-        is_sequence(factor)
+        is_sized(factor)
         and len(factor) == 2
         and all(isinstance(_, Integral) for _ in factor)
     ):
-        # - checking for "is_sequence" allows lists, numpy arrays and other containers
+        # - checking for "is_sized" allows lists, numpy arrays and other containers
         # - checking for Integral type allows numpy integer types
         # in any case we return a with strict typing
         return (int(factor[0]), int(factor[1]))
@@ -1710,7 +1710,7 @@ class ArrowCallback(PlotCallback):
                 since="3.2",
                 removal="4.2",
             )
-            if is_sequence(self.code_size):
+            if is_sized(self.code_size):
                 self.code_size = plot.data.ds.quan(self.code_size[0], self.code_size[1])
                 self.code_size = np.float64(self.code_size.in_units(plot.xlim[0].units))
             self.code_size = self.code_size * self._pixel_scale(plot)[0]
@@ -1933,7 +1933,7 @@ class SphereCallback(PlotCallback):
     def __call__(self, plot):
         from matplotlib.patches import Circle
 
-        if is_sequence(self.radius):
+        if is_sized(self.radius):
             self.radius = plot.data.ds.quan(self.radius[0], self.radius[1])
             self.radius = np.float64(self.radius.in_units(plot.xlim[0].units))
         if isinstance(self.radius, YTQuantity):
@@ -2427,7 +2427,7 @@ class ParticleCallback(PlotCallback):
 
     def __call__(self, plot):
         data = plot.data
-        if is_sequence(self.width):
+        if is_sized(self.width):
             validate_width_tuple(self.width)
             self.width = plot.data.ds.quan(self.width[0], self.width[1])
         elif isinstance(self.width, YTQuantity):

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -2279,7 +2279,7 @@ class OffAxisSlicePlot(SlicePlot, PWViewerMPL):
 
         if isinstance(ds, YTSpatialPlotDataset):
             cutting = ds.all_data()
-            cutting.axis = 4
+            cutting.axis = None
             cutting._inv_mat = ds.parameters["_inv_mat"]
         else:
             cutting = ds.cutting(
@@ -2333,7 +2333,7 @@ class OffAxisProjectionDummyDataSource:
     ):
         self.center = center
         self.ds = ds
-        self.axis = 4  # always true for oblique data objects
+        self.axis = None  # always true for oblique data objects
         self.normal_vector = normal_vector
         self.width = width
         if data_source is None:

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -12,7 +12,7 @@ from unyt.exceptions import UnitConversionError
 from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.data_objects.image_array import ImageArray
 from yt.frontends.ytdata.data_structures import YTSpatialPlotDataset
-from yt.funcs import fix_axis, fix_unitary, is_sequence, iter_fields, mylog, obj_length
+from yt.funcs import fix_axis, fix_unitary, is_sized, iter_fields, mylog, obj_length
 from yt.units.unit_object import Unit  # type: ignore
 from yt.units.unit_registry import UnitParseError  # type: ignore
 from yt.units.yt_array import YTArray, YTQuantity
@@ -86,10 +86,10 @@ def get_axes_unit(width, ds):
     """
     if ds.no_cgs_equiv_length:
         return ("code_length",) * 2
-    if is_sequence(width):
+    if is_sized(width):
         if isinstance(width[1], str):
             axes_unit = (width[1], width[1])
-        elif is_sequence(width[1]):
+        elif is_sized(width[1]):
             axes_unit = (width[0][1], width[1][1])
         elif isinstance(width[0], YTArray):
             axes_unit = (str(width[0].units), str(width[1].units))
@@ -722,7 +722,7 @@ class PlotWindow(ImagePlotContainer, abc.ABC):
         )
         if new_center is None:
             self.center = None
-        elif is_sequence(new_center):
+        elif is_sized(new_center):
             if len(new_center) != 2:
                 raise error
             for el in new_center:
@@ -756,7 +756,7 @@ class PlotWindow(ImagePlotContainer, abc.ABC):
             The number of data elements in the buffer on the x and y axes.
             If a scalar is provided,  then the buffer is assumed to be square.
         """
-        if is_sequence(size):
+        if is_sized(size):
             self.buff_size = size
         else:
             self.buff_size = (size, size)
@@ -1405,7 +1405,7 @@ class NormalPlot(abc.ABC):
                 )
             return axis_names[normal]
 
-        if not is_sequence(normal):
+        if not is_sized(normal):
             raise TypeError(
                 f"{normal} is not a valid normal vector identifier. "
                 "Expected a string, integer or sequence of 3 floats."
@@ -2581,7 +2581,7 @@ class WindowPlotMPL(ImagePlotMPL):
         if fontscale < 1.0:
             fontscale = np.sqrt(fontscale)
 
-        if is_sequence(figure_size):
+        if is_sized(figure_size):
             self._cb_size = 0.0375 * figure_size[0]
         else:
             self._cb_size = 0.0375 * figure_size

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -12,7 +12,15 @@ from unyt.exceptions import UnitConversionError
 from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.data_objects.image_array import ImageArray
 from yt.frontends.ytdata.data_structures import YTSpatialPlotDataset
-from yt.funcs import fix_axis, fix_unitary, is_sized, iter_fields, mylog, obj_length
+from yt.funcs import (
+    fix_axis,
+    fix_unitary,
+    is_scalar,
+    is_sized,
+    iter_fields,
+    mylog,
+    obj_length,
+)
 from yt.units.unit_object import Unit  # type: ignore
 from yt.units.unit_registry import UnitParseError  # type: ignore
 from yt.units.yt_array import YTArray, YTQuantity
@@ -1405,7 +1413,7 @@ class NormalPlot(abc.ABC):
                 )
             return axis_names[normal]
 
-        if not is_sized(normal):
+        if is_scalar(normal):
             raise TypeError(
                 f"{normal} is not a valid normal vector identifier. "
                 "Expected a string, integer or sequence of 3 floats."

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1497,16 +1497,27 @@ class SlicePlot(NormalPlot):
     Keyword Arguments
     -----------------
 
-    center : A sequence floats, a string, or a tuple.
-         The coordinate of the center of the image. If set to 'c', 'center' or
-         left blank, the plot is centered on the middle of the domain. If set to
-         'max' or 'm', the center will be located at the maximum of the
-         ('gas', 'density') field. Centering on the max or min of a specific
-         field is supported by providing a tuple such as ("min","temperature") or
-         ("max","dark_matter_density"). Units can be specified by passing in *center*
-         as a tuple containing a coordinate and string unit name or by passing
-         in a YTArray. If a list or unitless array is supplied, code units are
-         assumed.
+    center : 'center', 'c', 'left', 'l', 'right', 'r' id of a global extremum, or array-like
+        The coordinate of the selection's center.
+        Defaults to the 'center', i.e. center of the domain.
+
+        Centering on the min or max of a field is supported by passing a tuple
+        such as ('min', ('gas', 'density')) or ('max', ('gas', 'temperature'). A
+        single string may also be used (e.g. "min_density" or
+        "max_temperature"), though it's not as flexible and does not allow to
+        select an exact field/particle type. With this syntax, the first field
+        matching the provided name is selected.
+        'max' or 'm' can be used as a shortcut for ('max', ('gas', 'density'))
+        'min' can be used as a shortcut for ('min', ('gas', 'density'))
+
+        One can also select an exact point as a 3 element coordinate sequence,
+        e.g. [0.5, 0.5, 0]
+        Units can be specified by passing in *center* as a tuple containing a
+        3-element coordinate sequence and string unit name, e.g. ([0, 0.5, 0.5], "cm"),
+        or by passing in a YTArray. Code units are assumed if unspecified.
+
+        The domain edges along the selected *axis* can be selected with
+        'left'/'l' and 'right'/'r' respectively.
     width : tuple or a float.
          Width can have four different formats to support windows with variable
          x and y widths.  They are:
@@ -1705,16 +1716,27 @@ class AxisAlignedSlicePlot(SlicePlot, PWViewerMPL):
          or the axis name itself
     fields : string
          The name of the field(s) to be plotted.
-    center : A sequence of floats, a string, or a tuple.
-         The coordinate of the center of the image. If set to 'c', 'center' or
-         left blank, the plot is centered on the middle of the domain. If set to
-         'max' or 'm', the center will be located at the maximum of the
-         ('gas', 'density') field. Centering on the max or min of a specific
-         field is supported by providing a tuple such as ("min","temperature") or
-         ("max","dark_matter_density"). Units can be specified by passing in *center*
-         as a tuple containing a coordinate and string unit name or by passing
-         in a YTArray. If a list or unitless array is supplied, code units are
-         assumed.
+    center : 'center', 'c', 'left', 'l', 'right', 'r' id of a global extremum, or array-like
+        The coordinate of the selection's center.
+        Defaults to the 'center', i.e. center of the domain.
+
+        Centering on the min or max of a field is supported by passing a tuple
+        such as ('min', ('gas', 'density')) or ('max', ('gas', 'temperature'). A
+        single string may also be used (e.g. "min_density" or
+        "max_temperature"), though it's not as flexible and does not allow to
+        select an exact field/particle type. With this syntax, the first field
+        matching the provided name is selected.
+        'max' or 'm' can be used as a shortcut for ('max', ('gas', 'density'))
+        'min' can be used as a shortcut for ('min', ('gas', 'density'))
+
+        One can also select an exact point as a 3 element coordinate sequence,
+        e.g. [0.5, 0.5, 0]
+        Units can be specified by passing in *center* as a tuple containing a
+        3-element coordinate sequence and string unit name, e.g. ([0, 0.5, 0.5], "cm"),
+        or by passing in a YTArray. Code units are assumed if unspecified.
+
+        The domain edges along the selected *axis* can be selected with
+        'left'/'l' and 'right'/'r' respectively.
     width : tuple or a float.
          Width can have four different formats to support windows with variable
          x and y widths.  They are:
@@ -1810,7 +1832,7 @@ class AxisAlignedSlicePlot(SlicePlot, PWViewerMPL):
         ds,
         normal=None,
         fields=None,
-        center="c",
+        center="center",
         width=None,
         axes_unit=None,
         origin="center-window",
@@ -1901,16 +1923,27 @@ class AxisAlignedProjectionPlot(ProjectionPlot, PWViewerMPL):
          or the axis name itself
     fields : string
          The name of the field(s) to be plotted.
-    center : A sequence of floats, a string, or a tuple.
-         The coordinate of the center of the image. If set to 'c', 'center' or
-         left blank, the plot is centered on the middle of the domain. If set to
-         'max' or 'm', the center will be located at the maximum of the
-         ('gas', 'density') field. Centering on the max or min of a specific
-         field is supported by providing a tuple such as ("min","temperature") or
-         ("max","dark_matter_density"). Units can be specified by passing in *center*
-         as a tuple containing a coordinate and string unit name or by passing
-         in a YTArray. If a list or unitless array is supplied, code units are
-         assumed.
+    center : 'center', 'c', 'left', 'l', 'right', 'r' id of a global extremum, or array-like
+        The coordinate of the selection's center.
+        Defaults to the 'center', i.e. center of the domain.
+
+        Centering on the min or max of a field is supported by passing a tuple
+        such as ('min', ('gas', 'density')) or ('max', ('gas', 'temperature'). A
+        single string may also be used (e.g. "min_density" or
+        "max_temperature"), though it's not as flexible and does not allow to
+        select an exact field/particle type. With this syntax, the first field
+        matching the provided name is selected.
+        'max' or 'm' can be used as a shortcut for ('max', ('gas', 'density'))
+        'min' can be used as a shortcut for ('min', ('gas', 'density'))
+
+        One can also select an exact point as a 3 element coordinate sequence,
+        e.g. [0.5, 0.5, 0]
+        Units can be specified by passing in *center* as a tuple containing a
+        3-element coordinate sequence and string unit name, e.g. ([0, 0.5, 0.5], "cm"),
+        or by passing in a YTArray. Code units are assumed if unspecified.
+
+        The domain edges along the selected *axis* can be selected with
+        'left'/'l' and 'right'/'r' respectively.
     width : tuple or a float.
          Width can have four different formats to support windows with variable
          x and y widths.  They are:
@@ -2035,7 +2068,7 @@ class AxisAlignedProjectionPlot(ProjectionPlot, PWViewerMPL):
         ds,
         normal=None,
         fields=None,
-        center="c",
+        center="center",
         width=None,
         axes_unit=None,
         weight_field=None,
@@ -2138,16 +2171,24 @@ class OffAxisSlicePlot(SlicePlot, PWViewerMPL):
          The vector normal to the slicing plane.
     fields : string
          The name of the field(s) to be plotted.
-    center : A sequence of floats, a string, or a tuple.
-         The coordinate of the center of the image. If set to 'c', 'center' or
-         left blank, the plot is centered on the middle of the domain. If set to
-         'max' or 'm', the center will be located at the maximum of the
-         ('gas', 'density') field. Centering on the max or min of a specific
-         field is supported by providing a tuple such as ("min","temperature") or
-         ("max","dark_matter_density"). Units can be specified by passing in *center*
-         as a tuple containing a coordinate and string unit name or by passing
-         in a YTArray. If a list or unitless array is supplied, code units are
-         assumed.
+    center : 'center', 'c' id of a global extremum, or array-like
+        The coordinate of the selection's center.
+        Defaults to the 'center', i.e. center of the domain.
+
+        Centering on the min or max of a field is supported by passing a tuple
+        such as ('min', ('gas', 'density')) or ('max', ('gas', 'temperature'). A
+        single string may also be used (e.g. "min_density" or
+        "max_temperature"), though it's not as flexible and does not allow to
+        select an exact field/particle type. With this syntax, the first field
+        matching the provided name is selected.
+        'max' or 'm' can be used as a shortcut for ('max', ('gas', 'density'))
+        'min' can be used as a shortcut for ('min', ('gas', 'density'))
+
+        One can also select an exact point as a 3 element coordinate sequence,
+        e.g. [0.5, 0.5, 0]
+        Units can be specified by passing in *center* as a tuple containing a
+        3-element coordinate sequence and string unit name, e.g. ([0, 0.5, 0.5], "cm"),
+        or by passing in a YTArray. Code units are assumed if unspecified.
     width : tuple or a float.
          Width can have four different formats to support windows with variable
          x and y widths.  They are:
@@ -2205,7 +2246,7 @@ class OffAxisSlicePlot(SlicePlot, PWViewerMPL):
         ds,
         normal,
         fields,
-        center="c",
+        center="center",
         width=None,
         axes_unit=None,
         north_vector=None,
@@ -2336,16 +2377,24 @@ class OffAxisProjectionPlot(ProjectionPlot, PWViewerMPL):
         The vector normal to the slicing plane.
     fields : string
         The name of the field(s) to be plotted.
-    center : A sequence of floats, a string, or a tuple.
-         The coordinate of the center of the image. If set to 'c', 'center' or
-         left blank, the plot is centered on the middle of the domain. If set to
-         'max' or 'm', the center will be located at the maximum of the
-         ('gas', 'density') field. Centering on the max or min of a specific
-         field is supported by providing a tuple such as ("min","temperature") or
-         ("max","dark_matter_density"). Units can be specified by passing in *center*
-         as a tuple containing a coordinate and string unit name or by passing
-         in a YTArray. If a list or unitless array is supplied, code units are
-         assumed.
+    center : 'center', 'c', id of a global extremum, or array-like
+        The coordinate of the selection's center.
+        Defaults to the 'center', i.e. center of the domain.
+
+        Centering on the min or max of a field is supported by passing a tuple
+        such as ('min', ('gas', 'density')) or ('max', ('gas', 'temperature'). A
+        single string may also be used (e.g. "min_density" or
+        "max_temperature"), though it's not as flexible and does not allow to
+        select an exact field/particle type. With this syntax, the first field
+        matching the provided name is selected.
+        'max' or 'm' can be used as a shortcut for ('max', ('gas', 'density'))
+        'min' can be used as a shortcut for ('min', ('gas', 'density'))
+
+        One can also select an exact point as a 3 element coordinate sequence,
+        e.g. [0.5, 0.5, 0]
+        Units can be specified by passing in *center* as a tuple containing a
+        3-element coordinate sequence and string unit name, e.g. ([0, 0.5, 0.5], "cm"),
+        or by passing in a YTArray. Code units are assumed if unspecified.
     width : tuple or a float.
          Width can have four different formats to support windows with variable
          x and y widths.  They are:
@@ -2421,7 +2470,7 @@ class OffAxisProjectionPlot(ProjectionPlot, PWViewerMPL):
         ds,
         normal,
         fields,
-        center="c",
+        center="center",
         width=None,
         depth=(1, "1"),
         axes_unit=None,
@@ -2556,7 +2605,7 @@ class WindowPlotMPL(ImagePlotMPL):
 def plot_2d(
     ds,
     fields,
-    center="c",
+    center="center",
     width=None,
     axes_unit=None,
     origin="center-window",
@@ -2581,16 +2630,26 @@ def plot_2d(
          simulation output to be plotted.
     fields : string
          The name of the field(s) to be plotted.
-    center : A sequence of floats, a string, or a tuple.
-         The coordinate of the center of the image. If set to 'c', 'center' or
-         left blank, the plot is centered on the middle of the domain. If set to
-         'max' or 'm', the center will be located at the maximum of the
-         ('gas', 'density') field. Centering on the max or min of a specific
-         field is supported by providing a tuple such as ("min","temperature") or
-         ("max","dark_matter_density"). Units can be specified by passing in *center*
-         as a tuple containing a coordinate and string unit name or by passing
-         in a YTArray. If a list or unitless array is supplied, code units are
-         assumed. For plot_2d, this keyword accepts a coordinate in two dimensions.
+    center : 'center', 'c', id of a global extremum, or array-like
+        The coordinate of the selection's center.
+        Defaults to the 'center', i.e. center of the domain.
+
+        Centering on the min or max of a field is supported by passing a tuple
+        such as ('min', ('gas', 'density')) or ('max', ('gas', 'temperature'). A
+        single string may also be used (e.g. "min_density" or
+        "max_temperature"), though it's not as flexible and does not allow to
+        select an exact field/particle type. With this syntax, the first field
+        matching the provided name is selected.
+        'max' or 'm' can be used as a shortcut for ('max', ('gas', 'density'))
+        'min' can be used as a shortcut for ('min', ('gas', 'density'))
+
+        One can also select an exact point as a 3 element coordinate sequence,
+        e.g. [0.5, 0.5, 0]
+        Units can be specified by passing in *center* as a tuple containing a
+        3-element coordinate sequence and string unit name, e.g. ([0, 0.5, 0.5], "cm"),
+        or by passing in a YTArray. Code units are assumed if unspecified.
+
+        plot_2d also accepts a coordinate in two dimensions.
     width : tuple or a float.
          Width can have four different formats to support windows with variable
          x and y widths.  They are:

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -64,7 +64,7 @@ def get_window_parameters(axis, center, width, ds):
 
 
 def get_oblique_window_parameters(normal, center, width, ds, depth=None):
-    display_center, center = ds.coordinates.sanitize_center(center, 4)
+    center, display_center = ds.coordinates.sanitize_center(center, axis=None)
     width = ds.coordinates.sanitize_width(normal, width, depth)
 
     if len(width) == 2:

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -84,13 +84,17 @@ CENTER_SPECS = (
     "M",
     "max",
     "Max",
-    "c",
-    "C",
+    "min",
+    "Min",
     "center",
     "Center",
+    "left",
+    "right",
     [0.5, 0.5, 0.5],
     [[0.2, 0.3, 0.4], "cm"],
     YTArray([0.3, 0.4, 0.7], "cm"),
+    ("max", ("gas", "density")),
+    ("min", ("gas", "density")),
 )
 
 WIDTH_SPECS = {

--- a/yt/visualization/volume_rendering/camera.py
+++ b/yt/visualization/volume_rendering/camera.py
@@ -3,7 +3,7 @@ from numbers import Number as numeric_type
 
 import numpy as np
 
-from yt.funcs import ensure_numpy_array, is_sized
+from yt.funcs import ensure_numpy_array, is_scalar, is_sized
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.math_utils import get_rotation_matrix
 from yt.utilities.orientation import Orientation
@@ -325,7 +325,7 @@ class Camera(Orientation):
             width = data_source.ds.quan(width[0], units=width[1])
             # Now convert back to code length for subsequent manipulation
             width = width.in_units("code_length")  # .value
-        if not is_sized(width):
+        if is_scalar(width):
             width = data_source.ds.arr([width, width, width], units="code_length")
             # left/right, top/bottom, front/back
         if not isinstance(width, YTArray):

--- a/yt/visualization/volume_rendering/camera.py
+++ b/yt/visualization/volume_rendering/camera.py
@@ -3,7 +3,7 @@ from numbers import Number as numeric_type
 
 import numpy as np
 
-from yt.funcs import ensure_numpy_array, is_sequence
+from yt.funcs import ensure_numpy_array, is_sized
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.math_utils import get_rotation_matrix
 from yt.utilities.orientation import Orientation
@@ -13,7 +13,7 @@ from .utils import data_source_or_all
 
 
 def _sanitize_camera_property_units(value, scene):
-    if is_sequence(value):
+    if is_sized(value):
         if len(value) == 1:
             return _sanitize_camera_property_units(value[0], scene)
         elif isinstance(value, YTArray) and len(value) == 3:
@@ -25,7 +25,7 @@ def _sanitize_camera_property_units(value, scene):
         ):
             return scene.arr([scene.arr(value[0], value[1]).in_units("unitary")] * 3)
         if len(value) == 3:
-            if all([is_sequence(v) for v in value]):
+            if all([is_sized(v) for v in value]):
                 if all(
                     [
                         isinstance(v[0], numeric_type) and isinstance(v[1], str)
@@ -249,7 +249,7 @@ class Camera(Orientation):
 
     @resolution.setter
     def resolution(self, value):
-        if is_sequence(value):
+        if is_sized(value):
             if len(value) != 2:
                 raise RuntimeError
         else:
@@ -321,11 +321,11 @@ class Camera(Orientation):
         width = np.sqrt((xma - xmi) ** 2 + (yma - ymi) ** 2 + (zma - zmi) ** 2)
         focus = data_source.get_field_parameter("center")
 
-        if is_sequence(width) and len(width) > 1 and isinstance(width[1], str):
+        if is_sized(width) and len(width) > 1 and isinstance(width[1], str):
             width = data_source.ds.quan(width[0], units=width[1])
             # Now convert back to code length for subsequent manipulation
             width = width.in_units("code_length")  # .value
-        if not is_sequence(width):
+        if not is_sized(width):
             width = data_source.ds.arr([width, width, width], units="code_length")
             # left/right, top/bottom, front/back
         if not isinstance(width, YTArray):

--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from yt.data_objects.api import ImageArray
-from yt.funcs import is_sequence, mylog
+from yt.funcs import is_sized, mylog
 from yt.units.unit_object import Unit  # type: ignore
 from yt.utilities.lib.partitioned_grid import PartitionedGrid
 from yt.utilities.lib.pixelization_routines import (
@@ -337,10 +337,10 @@ def off_axis_projection(
     vol.set_transfer_function(ptf)
     camera = sc.add_camera(data_source)
     camera.set_width(width)
-    if not is_sequence(resolution):
+    if not is_sized(resolution):
         resolution = [resolution] * 2
     camera.resolution = resolution
-    if not is_sequence(width):
+    if not is_sized(width):
         width = data_source.ds.arr([width] * 3)
     normal = np.array(normal_vector)
     normal = normal / np.linalg.norm(normal)

--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from yt.data_objects.api import ImageArray
-from yt.funcs import is_sized, mylog
+from yt.funcs import is_scalar, mylog
 from yt.units.unit_object import Unit  # type: ignore
 from yt.utilities.lib.partitioned_grid import PartitionedGrid
 from yt.utilities.lib.pixelization_routines import (
@@ -337,10 +337,10 @@ def off_axis_projection(
     vol.set_transfer_function(ptf)
     camera = sc.add_camera(data_source)
     camera.set_width(width)
-    if not is_sized(resolution):
+    if is_scalar(resolution):
         resolution = [resolution] * 2
     camera.resolution = resolution
-    if not is_sized(width):
+    if is_scalar(width):
         width = data_source.ds.arr([width] * 3)
     normal = np.array(normal_vector)
     normal = normal / np.linalg.norm(normal)

--- a/yt/visualization/volume_rendering/old_camera.py
+++ b/yt/visualization/volume_rendering/old_camera.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from yt.config import ytcfg
 from yt.data_objects.api import ImageArray
-from yt.funcs import ensure_numpy_array, get_num_threads, get_pbar, is_sequence, mylog
+from yt.funcs import ensure_numpy_array, get_num_threads, get_pbar, is_sized, mylog
 from yt.units.yt_array import YTArray
 from yt.utilities.amr_kdtree.api import AMRKDTree
 from yt.utilities.exceptions import YTNotInsideNotebook
@@ -169,16 +169,16 @@ class Camera(ParallelAnalysisInterface):
         ParallelAnalysisInterface.__init__(self)
         if ds is not None:
             self.ds = ds
-        if not is_sequence(resolution):
+        if not is_sized(resolution):
             resolution = (resolution, resolution)
         self.resolution = resolution
         self.sub_samples = sub_samples
         self.rotation_vector = north_vector
-        if is_sequence(width) and len(width) > 1 and isinstance(width[1], str):
+        if is_sized(width) and len(width) > 1 and isinstance(width[1], str):
             width = self.ds.quan(width[0], units=width[1])
             # Now convert back to code length for subsequent manipulation
             width = width.in_units("code_length").value
-        if not is_sequence(width):
+        if not is_sized(width):
             width = (width, width, width)  # left/right, top/bottom, front/back
         if not isinstance(width, YTArray):
             width = self.ds.arr(width, units="code_length")
@@ -629,7 +629,7 @@ class Camera(ParallelAnalysisInterface):
         """
         if width is None:
             width = self.width
-        if not is_sequence(width):
+        if not is_sized(width):
             width = (width, width, width)  # left/right, tom/bottom, front/back
         self.width = width
         if center is not None:
@@ -1009,7 +1009,7 @@ class Camera(ParallelAnalysisInterface):
             final = self.ds.arr(final, units="code_length")
         if exponential:
             if final_width is not None:
-                if not is_sequence(final_width):
+                if not is_sized(final_width):
                     final_width = [final_width, final_width, final_width]
                 if not isinstance(final_width, YTArray):
                     final_width = self.ds.arr(final_width, units="code_length")
@@ -1024,7 +1024,7 @@ class Camera(ParallelAnalysisInterface):
             dx = position_diff ** (1.0 / n_steps)
         else:
             if final_width is not None:
-                if not is_sequence(final_width):
+                if not is_sized(final_width):
                     final_width = [final_width, final_width, final_width]
                 if not isinstance(final_width, YTArray):
                     final_width = self.ds.arr(final_width, units="code_length")
@@ -1698,7 +1698,7 @@ class FisheyeCamera(Camera):
         self.center = np.array(center, dtype="float64")
         self.radius = radius
         self.fov = fov
-        if is_sequence(resolution):
+        if is_sized(resolution):
             raise RuntimeError("Resolution must be a single int")
         self.resolution = resolution
         if transfer_function is None:
@@ -1813,13 +1813,13 @@ class MosaicCamera(Camera):
         self.procs_per_wg = procs_per_wg
         if ds is not None:
             self.ds = ds
-        if not is_sequence(resolution):
+        if not is_sized(resolution):
             resolution = (int(resolution / nimx), int(resolution / nimy))
         self.resolution = resolution
         self.nimx = nimx
         self.nimy = nimy
         self.sub_samples = sub_samples
-        if not is_sequence(width):
+        if not is_sized(width):
             width = (width, width, width)  # front/back, left/right, top/bottom
         self.width = np.array([width[0], width[1], width[2]])
         self.center = center

--- a/yt/visualization/volume_rendering/old_camera.py
+++ b/yt/visualization/volume_rendering/old_camera.py
@@ -6,7 +6,14 @@ import numpy as np
 
 from yt.config import ytcfg
 from yt.data_objects.api import ImageArray
-from yt.funcs import ensure_numpy_array, get_num_threads, get_pbar, is_sized, mylog
+from yt.funcs import (
+    ensure_numpy_array,
+    get_num_threads,
+    get_pbar,
+    is_scalar,
+    is_sized,
+    mylog,
+)
 from yt.units.yt_array import YTArray
 from yt.utilities.amr_kdtree.api import AMRKDTree
 from yt.utilities.exceptions import YTNotInsideNotebook
@@ -169,7 +176,7 @@ class Camera(ParallelAnalysisInterface):
         ParallelAnalysisInterface.__init__(self)
         if ds is not None:
             self.ds = ds
-        if not is_sized(resolution):
+        if is_scalar(resolution):
             resolution = (resolution, resolution)
         self.resolution = resolution
         self.sub_samples = sub_samples
@@ -178,7 +185,7 @@ class Camera(ParallelAnalysisInterface):
             width = self.ds.quan(width[0], units=width[1])
             # Now convert back to code length for subsequent manipulation
             width = width.in_units("code_length").value
-        if not is_sized(width):
+        if is_scalar(width):
             width = (width, width, width)  # left/right, top/bottom, front/back
         if not isinstance(width, YTArray):
             width = self.ds.arr(width, units="code_length")
@@ -629,7 +636,7 @@ class Camera(ParallelAnalysisInterface):
         """
         if width is None:
             width = self.width
-        if not is_sized(width):
+        if is_scalar(width):
             width = (width, width, width)  # left/right, tom/bottom, front/back
         self.width = width
         if center is not None:
@@ -1009,7 +1016,7 @@ class Camera(ParallelAnalysisInterface):
             final = self.ds.arr(final, units="code_length")
         if exponential:
             if final_width is not None:
-                if not is_sized(final_width):
+                if is_scalar(final_width):
                     final_width = [final_width, final_width, final_width]
                 if not isinstance(final_width, YTArray):
                     final_width = self.ds.arr(final_width, units="code_length")
@@ -1024,7 +1031,7 @@ class Camera(ParallelAnalysisInterface):
             dx = position_diff ** (1.0 / n_steps)
         else:
             if final_width is not None:
-                if not is_sized(final_width):
+                if is_scalar(final_width):
                     final_width = [final_width, final_width, final_width]
                 if not isinstance(final_width, YTArray):
                     final_width = self.ds.arr(final_width, units="code_length")
@@ -1813,13 +1820,13 @@ class MosaicCamera(Camera):
         self.procs_per_wg = procs_per_wg
         if ds is not None:
             self.ds = ds
-        if not is_sized(resolution):
+        if is_scalar(resolution):
             resolution = (int(resolution / nimx), int(resolution / nimy))
         self.resolution = resolution
         self.nimx = nimx
         self.nimy = nimy
         self.sub_samples = sub_samples
-        if not is_sized(width):
+        if is_scalar(width):
             width = (width, width, width)  # front/back, left/right, top/bottom
         self.width = np.array([width[0], width[1], width[2]])
         self.center = center

--- a/yt/visualization/volume_rendering/render_source.py
+++ b/yt/visualization/volume_rendering/render_source.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from yt.config import ytcfg
 from yt.data_objects.image_array import ImageArray
-from yt.funcs import ensure_numpy_array, is_sized, mylog
+from yt.funcs import ensure_numpy_array, is_scalar, mylog
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.geometry.oct_geometry_handler import OctreeIndex
 from yt.utilities.amr_kdtree.api import AMRKDTree
@@ -994,7 +994,7 @@ class PointSource(OpaqueSource):
         if colors is not None:
             assert colors.ndim == 2 and colors.shape[1] == 4
             assert colors.shape[0] == positions.shape[0]
-        if not is_sized(radii):
+        if is_scalar(radii):
             if radii is not None:  # broadcast the value
                 radii = radii * np.ones(positions.shape[0], dtype="int64")
             else:  # default radii to 0 pixels (i.e. point is 1 pixel wide)

--- a/yt/visualization/volume_rendering/render_source.py
+++ b/yt/visualization/volume_rendering/render_source.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from yt.config import ytcfg
 from yt.data_objects.image_array import ImageArray
-from yt.funcs import ensure_numpy_array, is_sequence, mylog
+from yt.funcs import ensure_numpy_array, is_sized, mylog
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.geometry.oct_geometry_handler import OctreeIndex
 from yt.utilities.amr_kdtree.api import AMRKDTree
@@ -994,7 +994,7 @@ class PointSource(OpaqueSource):
         if colors is not None:
             assert colors.ndim == 2 and colors.shape[1] == 4
             assert colors.shape[0] == positions.shape[0]
-        if not is_sequence(radii):
+        if not is_sized(radii):
             if radii is not None:  # broadcast the value
                 radii = radii * np.ones(positions.shape[0], dtype="int64")
             else:  # default radii to 0 pixels (i.e. point is 1 pixel wide)


### PR DESCRIPTION
## PR Summary
`typing.TypeGuard` (new in Pyhton 3.10, backported to older versions via `typing-extensions`) makes is possible to mark a function such as `yt.funcs.is_sequence` such that type checkers (mypy) can narrow down types where the function is called.
Using this type annotation helped me discover a bug, fixed in the second commit.

Because `collections.abc.Sequence` is a actually more contraining than what we mean in `is_squence`, I'm aliasing it to a `is_sized`, which better fits Python's typing vocabulary.

⚠️ the final scope of this PR is not fully defined yet. Right now it's based on top of #3827 to avoid future conflicts.

- deprecated previous behaviour for `is_sequence` because it doesn't actually check for `collections.abc.Sequence` (the standard lib's definition of a "sequence" in Python)
- previous behaviour is now aliased to a new `is_sized` functions. This one is marked as able to narrow down it's input type with `typing.TypeGuard` (see https://docs.python.org/3/library/typing.html#typing.TypeGuard)
- added a `is_scalar` function, which is a shortcut for `not is_sized`, which I think improves readability
- edited a lot of places where `if is_sized(obj) and len(obj) == n` was used when we have a perfectly good encapsulation for this already in `yt.funcs`: `if obj_length(obj) == n`. Also edited a lot of places where `is_sized` was used but we actually needed `is_sequence`.