### PR TITLE
MNT: remove 2 unused internal functions

### DIFF
--- a/yt/visualization/color_maps.py
+++ b/yt/visualization/color_maps.py
@@ -16,18 +16,6 @@ from ._commons import MPL_VERSION
 yt_colormaps = {}
 
 
-def is_colormap(cmap):
-    return isinstance(cmap, cc.Colormap)
-
-
-def check_color(name):
-    try:
-        cc.colorConverter.to_rgb(name)
-        return True
-    except ValueError:
-        return False
-
-
 def add_colormap(name, cdict):
     """
     Adds a colormap to the colormaps available in yt for this session


### PR DESCRIPTION
## PR Summary
These are not used anywhere. I don't think `yt.visualization.color_maps` is considered public API so I just removed them.
If anyone argues that it _is_ public (nothing actually signals privacy), I'm happy to deprecate them instead
