### PR TITLE
DEPR: fix a broken deprecation warning (missing stacklevel)

### DIFF
--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -183,6 +183,7 @@ class YTProj(YTSelectionContainer2D):
                 "Please use method directly.",
                 since="3.2",
                 removal="4.2",
+                stacklevel=4,
             )
             method = style
         if method == "sum":


### PR DESCRIPTION
## PR Summary
Fix #3941
There are a dozen deprecation warnings in `plot_modifications.py` that are currently impossible to fix because of how plot callbacks' init is delayed until the plot is actually setup.
I'll see if I can refactor this slightly so we at least validate arguments when they are passed.
