### PR TITLE
DOC: Fix typo in Gadget notebook

### DIFF
--- a/doc/source/cookbook/yt_gadget_analysis.ipynb
+++ b/doc/source/cookbook/yt_gadget_analysis.ipynb
@@ -219,7 +219,7 @@
    },
    "outputs": [],
    "source": [
-    "print([tm.in_units(\"Msun\") for tm in ad.quantities.total_mass()])"
+    "print([tm.in_units(\"Msun\") for tm in ad2.quantities.total_mass()])"
    ]
   },
   {


### PR DESCRIPTION
This fixes a typo in the Gadget notebook (and thus in the Gadget cookbook) where we create a new object, `ad2`, and then say we will use it, but we *don't*.  Thanks to @EwanBJones98 for spotting it and letting me know!
