### PR TITLE
ENH: don't error out in the face of ambiguity for pixel fields

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -81,12 +81,6 @@ def pytest_configure(config):
     for value in (
         # treat most warnings as errors
         "error",
-        # >>> internal deprecation warnings with no obvious solution
-        # see https://github.com/yt-project/yt/issues/3381
-        (
-            r"ignore:The requested field name 'pd?[xyz]' is ambiguous and corresponds "
-            "to any one of the following field types.*:yt._maintenance.deprecation.VisibleDeprecationWarning"
-        ),
         # >>> warnings emitted by testing frameworks, or in testing contexts
         # we still have some yield-based tests, awaiting for transition into pytest
         "ignore::pytest.PytestCollectionWarning",

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -863,6 +863,11 @@ class Dataset(abc.ABC):
     def _get_field_info(self, ftype, fname=None):
         field_info, is_ambiguous = self._get_field_info_helper(ftype, fname)
 
+        if field_info.name[1] in ("px", "py", "pz", "pdx", "pdy", "pdz"):
+            # escape early as as bandaid solution to
+            # https://github.com/yt-project/yt/issues/3381
+            return field_info
+
         if is_ambiguous:
             ft, fn = field_info.name
             msg = (


### PR DESCRIPTION
## PR Summary
This is a possible solution to #3381, which is critical to the next feature release.
It's not ideal but I couldn't find another way around it, and at least it's a very small and self-contained patch.
