### PR TITLE
MNT: housekeeping

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -192,17 +192,6 @@ def pytest_configure(config):
             ),
         )
 
-    if find_spec("xarray") is not None:
-        # this can be removed when upstream issue is closed and a fix published
-        # https://github.com/pydata/xarray/issues/6092
-        config.addinivalue_line(
-            "filterwarnings",
-            (
-                "ignore:distutils Version classes are deprecated. "
-                "Use packaging.version instead.:DeprecationWarning"
-            ),
-        )
-
 
 def pytest_collection_modifyitems(config, items):
     r"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-  "setuptools>=19.6",
+  "setuptools>=59.0.1",
   # see https://github.com/numpy/numpy/pull/18389
   "wheel>=0.36.2",
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,6 @@ install_requires =
     numpy>=1.14.5
     packaging>=20.9
     pyparsing>0.0  # hard dependency to MPL. We require it (unconstrained) in case MPL drops it in the future
-    setuptools>=19.6
     tomli>=1.2.3
     tomli-w>=0.4.0
     tqdm>=3.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -121,7 +121,6 @@ typecheck =
     types-chardet==4.0.0
     types-requests==2.25.9
     types-setuptools==57.4.0
-    types-toml==0.10.0
 
 [flake8]
 max-line-length = 88

--- a/setupext.py
+++ b/setupext.py
@@ -1,5 +1,6 @@
 import contextlib
 import glob
+import logging
 import os
 import platform
 import shutil
@@ -8,9 +9,7 @@ import sys
 import tempfile
 from textwrap import dedent
 from concurrent.futures import ThreadPoolExecutor
-from distutils import log
 from distutils.ccompiler import CCompiler, new_compiler
-from distutils.errors import CompileError, LinkError
 from distutils.sysconfig import customize_compiler
 from subprocess import PIPE, Popen
 from sys import platform as _platform
@@ -18,7 +17,9 @@ from sys import platform as _platform
 from pkg_resources import resource_filename
 from setuptools.command.build_ext import build_ext as _build_ext
 from setuptools.command.sdist import sdist as _sdist
+from setuptools.errors import CompileError, LinkError
 
+log = logging.getLogger("setupext")
 
 @contextlib.contextmanager
 def stdchannel_redirected(stdchannel, dest_filename):
@@ -114,14 +115,14 @@ def check_for_openmp():
             if len(output) == nthreads:
                 using_openmp = True
             else:
-                log.warn(
+                log.warning(
                     "Unexpected number of lines from output of test "
                     "OpenMP program (output was %s)",
                     output,
                 )
                 using_openmp = False
         else:
-            log.warn(
+            log.warning(
                 "Unexpected output from test OpenMP program (output was %s)", output
             )
             using_openmp = False
@@ -132,9 +133,9 @@ def check_for_openmp():
         os.chdir(start_dir)
 
     if using_openmp:
-        log.warn("Using OpenMP to compile parallel extensions")
+        log.warning("Using OpenMP to compile parallel extensions")
     else:
-        log.warn(
+        log.warning(
             "Unable to compile OpenMP test program so Cython\n"
             "extensions will be compiled without parallel support"
         )
@@ -193,7 +194,7 @@ def check_CPP14_flags(possible_compile_flags):
         if check_CPP14_flag([flags]):
             return flags
 
-    log.warn(
+    log.warning(
         "Your compiler seems to be too old to support C++14. "
         "yt may not be able to compile. Please use a newer version."
     )
@@ -294,18 +295,18 @@ def read_embree_location():
         exit_code = p.returncode
 
         if exit_code != 0:
-            log.warn(
+            log.warning(
                 "Pyembree is installed, but I could not compile Embree test code."
             )
-            log.warn("The error message was: ")
-            log.warn(err)
-            log.warn(fail_msg)
+            log.warning("The error message was: ")
+            log.warning(err)
+            log.warning(fail_msg)
 
         # Clean up
         file.close()
 
     except OSError:
-        log.warn(
+        log.warning(
             "read_embree_location() could not find your C compiler. "
             "Attempted to use '%s'.",
             compiler,


### PR DESCRIPTION
## PR Summary

- remove unused optional `toml-types` dep (not needed since https://github.com/yt-project/yt/pull/3831)
- remove unused temporary warning filter in `conftest.py` (the simple fact that test pass validate that we don't need it anymore)
- partial migration away from distutils (see #3384): 
  - `logging` is the official recommended replacement for `disutils.log`[source](https://setuptools.pypa.io/en/latest/deprecated/distutils-legacy.html?highlight=distutils#prefer-setuptools)
  - `distutils.errors` is re-exported within `setuptools.errors` since `setuptools 59.0.0` (see https://github.com/pypa/setuptools/pull/2858)
- remove `setuptools` from runtime dependency (this is a left over from an old misunderstanding: setuptools was in fact never a runtime dependency)