### PR TITLE
RFC: refactor plot callbacks registration

### DIFF
--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -533,7 +533,7 @@ class FixedResolutionBuffer:
                 @wraps(FilterMaker)
                 def method(*args, **kwargs):
                     # We need to also do it here as "invalidate_plot"
-                    # and "apply_callback" require the functions'
+                    # requires the functions'
                     # __name__ in order to work properly
                     @wraps(FilterMaker)
                     def cb(self, *a, **kwa):

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -1,9 +1,9 @@
 import weakref
-from functools import wraps
-from typing import Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 import numpy as np
 
+from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.data_objects.image_array import ImageArray
 from yt.frontends.ytdata.utilities import save_as_dataset
 from yt.funcs import get_output_filename, iter_fields, mylog
@@ -15,12 +15,10 @@ from yt.utilities.lib.api import (  # type: ignore
 from yt.utilities.lib.pixelization_routines import pixelize_cylinder
 from yt.utilities.on_demand_imports import _h5py as h5py
 
-from .fixed_resolution_filters import (
-    FixedResolutionBufferFilter,
-    apply_filter,
-    filter_registry,
-)
 from .volume_rendering.api import off_axis_projection
+
+if TYPE_CHECKING:
+    from yt.visualization.fixed_resolution_filters import FixedResolutionBufferFilter
 
 
 class FixedResolutionBuffer:
@@ -105,7 +103,7 @@ class FixedResolutionBuffer:
         antialias=True,
         periodic=False,
         *,
-        filters: Optional[List[FixedResolutionBufferFilter]] = None,
+        filters: Optional[List["FixedResolutionBufferFilter"]] = None,
     ):
         self.data_source = data_source
         self.ds = data_source.ds
@@ -113,11 +111,18 @@ class FixedResolutionBuffer:
         self.buff_size = (int(buff_size[0]), int(buff_size[1]))
         self.antialias = antialias
         self.data: Dict[str, np.ndarray] = {}
-        self._filters = []
         self.axis = data_source.axis
         self.periodic = periodic
         self._data_valid = False
-        self._filters = filters if filters is not None else []
+
+        # import type here to avoid import cycles
+        from yt.visualization.fixed_resolution_filters import (
+            FixedResolutionBufferFilter,
+        )
+
+        self._filters: List[FixedResolutionBufferFilter] = (
+            filters if filters is not None else []
+        )
 
         ds = getattr(data_source, "ds", None)
         if ds is not None:
@@ -133,8 +138,6 @@ class FixedResolutionBuffer:
             yax = self.ds.coordinates.y_axis[axis]
             self._period = (DD[xax], DD[yax])
             self._edges = ((DLE[xax], DRE[xax]), (DLE[yax], DRE[yax]))
-
-        self.setup_filters()
 
     def keys(self):
         return self.data.keys()
@@ -166,8 +169,7 @@ class FixedResolutionBuffer:
             int(self.antialias),
         )
 
-        for name, (args, kwargs) in self._filters:
-            buff = filter_registry[name](*args, **kwargs).apply(buff)
+        buff = self._apply_filters(buff)
 
         # FIXME FIXME FIXME we shouldn't need to do this for projections
         # but that will require fixing data object access for particle
@@ -185,6 +187,11 @@ class FixedResolutionBuffer:
         self.data[item] = ia
         self._data_valid = True
         return self.data[item]
+
+    def _apply_filters(self, buffer: np.ndarray) -> np.ndarray:
+        for f in self._filters:
+            buffer = f(buffer)
+        return buffer
 
     def __setitem__(self, item, val):
         self.data[item] = val
@@ -522,33 +529,10 @@ class FixedResolutionBuffer:
         return rv
 
     def setup_filters(self):
-        for key in filter_registry:
-            filtername = filter_registry[key]._filter_name
-
-            # We need to wrap to create a closure so that
-            # FilterMaker is bound to the wrapped method.
-            def closure():
-                FilterMaker = filter_registry[key]
-
-                @wraps(FilterMaker)
-                def method(*args, **kwargs):
-                    # We need to also do it here as "invalidate_plot"
-                    # requires the functions'
-                    # __name__ in order to work properly
-                    @wraps(FilterMaker)
-                    def cb(self, *a, **kwa):
-                        # We construct the callback method
-                        # skipping self
-                        return FilterMaker(*a, **kwa)
-
-                    # Create callback
-                    cb = apply_filter(cb)
-
-                    return cb(self, *args, **kwargs)
-
-                return method
-
-            self.__dict__["apply_" + filtername] = closure()
+        issue_deprecation_warning(
+            "The FixedResolutionBuffer.setup_filters method is now a no-op. ",
+            since="4.1.0",
+        )
 
 
 class CylindricalFixedResolutionBuffer(FixedResolutionBuffer):

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -116,6 +116,10 @@ class FixedResolutionBuffer:
         self._data_valid = False
 
         # import type here to avoid import cycles
+        # note that this import statement is actually crucial at runtime:
+        # the filter methods for the present class are defined only when
+        # fixed_resolution_filters is imported, so we need to guarantee
+        # that it happens no later than instanciation
         from yt.visualization.fixed_resolution_filters import (
             FixedResolutionBufferFilter,
         )

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -13,6 +13,7 @@ from matplotlib.cm import get_cmap
 from matplotlib.font_manager import FontProperties
 from more_itertools.more import always_iterable
 
+from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.config import ytcfg
 from yt.data_objects.time_series import DatasetSeries
 from yt.funcs import dictWithFactory, ensure_dir, is_sequence, iter_fields, mylog
@@ -36,6 +37,13 @@ latex_prefixes = {
 
 
 def apply_callback(f):
+    issue_deprecation_warning(
+        "The apply_callback decorator is not used in yt any more and "
+        "will be removed in a future version. "
+        "Please do not use it.",
+        since="4.1",
+    )
+
     @wraps(f)
     def newfunc(*args, **kwargs):
         args[0]._callbacks.append((f.__name__, (args, kwargs)))

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -803,19 +803,19 @@ class ContourCallback(PlotCallback):
 
     def __init__(
         self,
-        field,
+        field: Union[Tuple[str, str], str],
         levels: int = 5,
         *,
         factor: Union[Tuple[int, int], int] = 4,
         clim: Optional[Tuple[float, float]] = None,
-        label=False,
-        take_log=None,
-        data_source=None,
-        plot_args=None,
-        label_args=None,
-        text_args=None,
+        label: bool = False,
+        take_log: Optional[bool] = None,
+        data_source: YTDataContainer = None,
+        plot_args: Optional[Dict[str, Any]] = None,
+        label_args: Optional[Dict[str, Any]] = None,
+        text_args: Optional[Dict[str, Any]] = None,
         ncont: Optional[int] = None,  # deprecated
-    ):
+    ) -> None:
         def_plot_args = {"colors": "k", "linestyles": "solid"}
         def_text_args = {"colors": "w"}
         if ncont is not None:

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1,6 +1,5 @@
 import abc
 from collections import defaultdict
-from functools import wraps
 from numbers import Number
 from typing import List, Optional, Type, Union
 
@@ -27,13 +26,13 @@ from yt.utilities.exceptions import (
     YTInvalidFieldType,
     YTPlotCallbackError,
     YTUnitNotRecognized,
-    YTUnsupportedPlotCallback,
 )
 from yt.utilities.math_utils import ortho_find
 from yt.utilities.orientation import Orientation
+from yt.visualization.base_plot_types import CallbackWrapper
 
 from ._commons import MPL_VERSION, _swap_axes_extents
-from .base_plot_types import CallbackWrapper, ImagePlotMPL
+from .base_plot_types import ImagePlotMPL
 from .fixed_resolution import (
     FixedResolutionBuffer,
     OffAxisProjectionFixedResolutionBuffer,
@@ -41,7 +40,6 @@ from .fixed_resolution import (
 from .geo_plot_utils import get_mpl_transform
 from .plot_container import (
     ImagePlotContainer,
-    apply_callback,
     get_log_minorticks,
     get_symlog_minorticks,
     invalidate_data,
@@ -51,7 +49,6 @@ from .plot_container import (
     log_transform,
     symlog_transform,
 )
-from .plot_modifications import callback_registry
 
 import sys  # isort: skip
 
@@ -270,7 +267,6 @@ class PlotWindow(ImagePlotContainer):
             # Access the dictionary to force the key to be created
             self._units_config[field]
 
-        self.setup_callbacks()
         self._setup_plots()
 
     def __iter__(self):
@@ -922,6 +918,11 @@ class PWViewerMPL(PlotWindow):
         self._frb: Optional[FixedResolutionBuffer] = None
         PlotWindow.__init__(self, *args, **kwargs)
 
+        # import type here to avoid import cycles
+        from yt.visualization.plot_modifications import PlotCallback
+
+        self._callbacks: List[PlotCallback] = []
+
     @property
     def _data_valid(self) -> bool:
         return self._frb is not None and self._frb._data_valid
@@ -1388,88 +1389,21 @@ class PWViewerMPL(PlotWindow):
         self._plot_valid = True
 
     def setup_callbacks(self):
-        ignored = ["PlotCallback"]
-        if self._plot_type.startswith("OffAxis"):
-            ignored += [
-                "ParticleCallback",
-                "ClumpContourCallback",
-                "GridBoundaryCallback",
-            ]
-        if self._plot_type == "OffAxisProjection":
-            ignored += [
-                "VelocityCallback",
-                "MagFieldCallback",
-                "QuiverCallback",
-                "CuttingQuiverCallback",
-                "StreamlineCallback",
-                "LineIntegralConvolutionCallback",
-            ]
-        elif self._plot_type == "Particle":
-            ignored += [
-                "HopCirclesCallback",
-                "HopParticleCallback",
-                "ClumpContourCallback",
-                "GridBoundaryCallback",
-                "VelocityCallback",
-                "MagFieldCallback",
-                "QuiverCallback",
-                "CuttingQuiverCallback",
-                "StreamlineCallback",
-                "ContourCallback",
-            ]
-
-        def missing_callback_closure(cbname):
-            def _(*args, **kwargs):
-                raise YTUnsupportedPlotCallback(
-                    callback=cbname, plot_type=self._plot_type
-                )
-
-            return _
-
-        for key in callback_registry:
-            cbname = callback_registry[key]._type_name
-
-            if key in ignored:
-                self.__dict__["annotate_" + cbname] = missing_callback_closure(cbname)
-                continue
-
-            # We need to wrap to create a closure so that
-            # CallbackMaker is bound to the wrapped method.
-            def closure():
-                CallbackMaker = callback_registry[key]
-
-                @wraps(CallbackMaker)
-                def method(*args, **kwargs):
-                    # We need to also do it here as "invalidate_plot"
-                    # and "apply_callback" require the functions'
-                    # __name__ in order to work properly
-                    @wraps(CallbackMaker)
-                    def cb(self, *a, **kwa):
-                        # We construct the callback method
-                        # skipping self
-                        return CallbackMaker(*a, **kwa)
-
-                    # Create callback
-                    cb = invalidate_plot(apply_callback(cb))
-
-                    return cb(self, *args, **kwargs)
-
-                return method
-
-            self.__dict__["annotate_" + cbname] = closure()
+        issue_deprecation_warning(
+            "The PWViewer.setup_callbacks method is a no-op.", since="4.1.0"
+        )
 
     @invalidate_plot
-    def clear_annotations(self, index=None):
+    def clear_annotations(self, index: Optional[int] = None):
         """
         Clear callbacks from the plot.  If index is not set, clear all
         callbacks.  If index is set, clear that index (ie 0 is the first one
         created, 1 is the 2nd one created, -1 is the last one created, etc.)
         """
         if index is None:
-            self._callbacks = []
+            self._callbacks.clear()
         else:
-            del self._callbacks[index]
-        self.setup_callbacks()
+            self._callbacks.pop(index)
         return self
 
     def list_annotations(self):
@@ -1484,7 +1418,7 @@ class PWViewerMPL(PlotWindow):
     def run_callbacks(self):
         for f in self.fields:
             keys = self.frb.keys()
-            for name, (args, kwargs) in self._callbacks:
+            for callback in self._callbacks:
                 # need to pass _swap_axes and adjust all the callbacks
                 cbw = CallbackWrapper(
                     self,
@@ -1494,8 +1428,6 @@ class PWViewerMPL(PlotWindow):
                     self._font_properties,
                     self._font_color,
                 )
-                CallbackMaker = callback_registry[name]
-                callback = CallbackMaker(*args[1:], **kwargs)
                 try:
                     callback(cbw)
                 except YTDataTypeUnsupported as e:

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -919,6 +919,10 @@ class PWViewerMPL(PlotWindow):
         PlotWindow.__init__(self, *args, **kwargs)
 
         # import type here to avoid import cycles
+        # note that this import statement is actually crucial at runtime:
+        # the filter methods for the present class are defined only when
+        # fixed_resolution_filters is imported, so we need to guarantee
+        # that it happens no later than instanciation
         from yt.visualization.plot_modifications import PlotCallback
 
         self._callbacks: List[PlotCallback] = []

--- a/yt/visualization/tests/test_callbacks.py
+++ b/yt/visualization/tests/test_callbacks.py
@@ -95,7 +95,7 @@ def test_init_signature_error_callback():
         units=["g/cm**3", "m/s", "m/s"],
     )
     p = SlicePlot(ds, "z", ("gas", "density"))
-    assert_raises(TypeError, p.annotate_velocity, {"invalid_argument": 1})
+    assert_raises(TypeError, p.annotate_velocity, invalid_argument=1)
 
 
 def check_axis_manipulation(plot_obj, prefix):
@@ -139,9 +139,7 @@ def test_timestamp_callback():
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
         p = ProjectionPlot(ds, "r", ("gas", "density"))
-        p.annotate_timestamp(coord_system="data")
-        assert_raises(YTDataTypeUnsupported, p.save, prefix)
-        p = ProjectionPlot(ds, "r", ("gas", "density"))
+        assert_raises(YTDataTypeUnsupported, p.annotate_timestamp, coord_system="data")
         p.annotate_timestamp(coord_system="axis")
         assert_fname(p.save(prefix)[0])
 
@@ -189,11 +187,8 @@ def test_scale_callback():
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
         p = ProjectionPlot(ds, "r", ("gas", "density"))
-        p.annotate_scale()
-        assert_raises(YTDataTypeUnsupported, p.save, prefix)
-        p = ProjectionPlot(ds, "r", ("gas", "density"))
-        p.annotate_scale(coord_system="axis")
-        assert_raises(YTDataTypeUnsupported, p.save, prefix)
+        assert_raises(YTDataTypeUnsupported, p.annotate_scale)
+        assert_raises(YTDataTypeUnsupported, p.annotate_scale, coord_system="axis")
 
 
 def test_line_callback():
@@ -221,9 +216,9 @@ def test_line_callback():
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
         p = ProjectionPlot(ds, "r", ("gas", "density"))
-        p.annotate_line([0.1, 0.1, 0.1], [0.5, 0.5, 0.5])
-        assert_raises(YTDataTypeUnsupported, p.save, prefix)
-        p = ProjectionPlot(ds, "r", ("gas", "density"))
+        assert_raises(
+            YTDataTypeUnsupported, p.annotate_line, [0.1, 0.1, 0.1], [0.5, 0.5, 0.5]
+        )
         p.annotate_line([0.1, 0.1], [0.5, 0.5], coord_system="axis")
         assert_fname(p.save(prefix)[0])
 
@@ -259,11 +254,8 @@ def test_ray_callback():
         ray = ds.ray((0.1, 0.2, 0.3), (0.6, 0.8, 0.5))
         oray = ds.ortho_ray(0, (0.3, 0.4))
         p = ProjectionPlot(ds, "r", ("gas", "density"))
-        p.annotate_ray(oray)
-        assert_raises(YTDataTypeUnsupported, p.save, prefix)
-        p = ProjectionPlot(ds, "r", ("gas", "density"))
-        p.annotate_ray(ray)
-        assert_raises(YTDataTypeUnsupported, p.save, prefix)
+        assert_raises(YTDataTypeUnsupported, p.annotate_ray, oray)
+        assert_raises(YTDataTypeUnsupported, p.annotate_ray, ray)
 
 
 def test_arrow_callback():
@@ -306,9 +298,7 @@ def test_arrow_callback():
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
         p = ProjectionPlot(ds, "r", ("gas", "density"))
-        p.annotate_arrow([0.5, 0.5, 0.5])
-        assert_raises(YTDataTypeUnsupported, p.save, prefix)
-        p = ProjectionPlot(ds, "r", ("gas", "density"))
+        assert_raises(YTDataTypeUnsupported, p.annotate_arrow, [0.5, 0.5, 0.5])
         p.annotate_arrow([0.5, 0.5], coord_system="axis")
         assert_fname(p.save(prefix)[0])
 
@@ -346,9 +336,7 @@ def test_marker_callback():
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
         p = ProjectionPlot(ds, "r", ("gas", "density"))
-        p.annotate_marker([0.5, 0.5, 0.5])
-        assert_raises(YTDataTypeUnsupported, p.save, prefix)
-        p = ProjectionPlot(ds, "r", ("gas", "density"))
+        assert_raises(YTDataTypeUnsupported, p.annotate_marker, [0.5, 0.5, 0.5])
         p.annotate_marker([0.5, 0.5], coord_system="axis")
         assert_fname(p.save(prefix)[0])
 
@@ -382,8 +370,7 @@ def test_particles_callback():
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
         p = ProjectionPlot(ds, "r", ("gas", "density"))
-        p.annotate_particles((10, "Mpc"))
-        assert_raises(YTDataTypeUnsupported, p.save, prefix)
+        assert_raises(YTDataTypeUnsupported, p.annotate_particles, (10, "Mpc"))
 
 
 def test_sphere_callback():
@@ -408,9 +395,12 @@ def test_sphere_callback():
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
         p = ProjectionPlot(ds, "r", ("gas", "density"))
-        p.annotate_sphere([0.5, 0.5, 0.5], 0.1)
-        assert_raises(YTDataTypeUnsupported, p.save, prefix)
-        p = ProjectionPlot(ds, "r", ("gas", "density"))
+        assert_raises(
+            YTDataTypeUnsupported,
+            p.annotate_sphere,
+            [0.5, 0.5, 0.5],
+            0.1,
+        )
         p.annotate_sphere([0.5, 0.5], 0.1, coord_system="axis", text="blah")
         assert_fname(p.save(prefix)[0])
 
@@ -439,9 +429,9 @@ def test_text_callback():
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
         p = ProjectionPlot(ds, "r", ("gas", "density"))
-        p.annotate_text([0.5, 0.5, 0.5], "dinosaurs!")
-        assert_raises(YTDataTypeUnsupported, p.save, prefix)
-        p = ProjectionPlot(ds, "r", ("gas", "density"))
+        assert_raises(
+            YTDataTypeUnsupported, p.annotate_text, [0.5, 0.5, 0.5], "dinosaurs!"
+        )
         p.annotate_text(
             [0.5, 0.5], "dinosaurs!", coord_system="axis", text_args={"color": "red"}
         )
@@ -503,8 +493,9 @@ def test_velocity_callback():
             geometry="spherical",
         )
         p = ProjectionPlot(ds, "r", ("gas", "density"))
-        p.annotate_velocity(factor=40, normalize=True)
-        assert_raises(YTDataTypeUnsupported, p.save, prefix)
+        assert_raises(
+            YTDataTypeUnsupported, p.annotate_velocity, factor=40, normalize=True
+        )
 
 
 @requires_file(cyl_2d)
@@ -579,10 +570,8 @@ def test_magnetic_callback():
             geometry="spherical",
         )
         p = ProjectionPlot(ds, "r", ("gas", "density"))
-        p.annotate_magnetic_field(
-            factor=8, scale=0.5, scale_units="inches", normalize=True
-        )
-        assert_raises(YTDataTypeUnsupported, p.save, prefix)
+        kwargs = dict(factor=8, scale=0.5, scale_units="inches", normalize=True)
+        assert_raises(YTDataTypeUnsupported, p.annotate_magnetic_field, **kwargs)
 
 
 @requires_file(cyl_2d)
@@ -647,9 +636,11 @@ def test_quiver_callback():
             geometry="spherical",
         )
         p = ProjectionPlot(ds, "r", ("gas", "density"))
-        p.annotate_quiver(
+        args = (
             ("gas", "velocity_theta"),
             ("gas", "velocity_phi"),
+        )
+        kwargs = dict(
             factor=8,
             scale=0.5,
             scale_units="inches",
@@ -657,7 +648,7 @@ def test_quiver_callback():
             bv_x=0.5 * u.cm / u.s,
             bv_y=0.5 * u.cm / u.s,
         )
-        assert_raises(YTDataTypeUnsupported, p.save, prefix)
+        assert_raises(YTDataTypeUnsupported, p.annotate_quiver, *args, **kwargs)
 
 
 @requires_file(cyl_2d)
@@ -728,8 +719,7 @@ def test_contour_callback():
             geometry="spherical",
         )
         p = SlicePlot(ds, "r", ("gas", "density"))
-        p.annotate_contour(
-            ("gas", "temperature"),
+        kwargs = dict(
             ncont=10,
             factor=8,
             take_log=False,
@@ -738,7 +728,9 @@ def test_contour_callback():
             label=True,
             text_args={"fontsize": "x-large"},
         )
-        assert_raises(YTDataTypeUnsupported, p.save, prefix)
+        assert_raises(
+            YTDataTypeUnsupported, p.annotate_contour, ("gas", "temperature"), **kwargs
+        )
 
 
 @requires_file(cyl_2d)
@@ -782,7 +774,7 @@ def test_grids_callback():
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
         p = SlicePlot(ds, "r", ("gas", "density"))
-        p.annotate_grids(
+        kwargs = dict(
             alpha=0.7,
             min_pix=10,
             min_pix_ids=30,
@@ -793,7 +785,7 @@ def test_grids_callback():
             max_level=3,
             cmap="gist_stern",
         )
-        assert_raises(YTDataTypeUnsupported, p.save, prefix)
+        assert_raises(YTDataTypeUnsupported, p.annotate_grids, **kwargs)
 
 
 @requires_file(cyl_2d)
@@ -827,8 +819,7 @@ def test_cell_edges_callback():
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
         p = SlicePlot(ds, "r", ("gas", "density"))
-        p.annotate_cell_edges()
-        assert_raises(YTDataTypeUnsupported, p.save, prefix)
+        assert_raises(YTDataTypeUnsupported, p.annotate_cell_edges)
 
 
 def test_mesh_lines_callback():
@@ -937,8 +928,12 @@ def test_streamline_callback():
             geometry="spherical",
         )
         p = SlicePlot(ds, "r", ("gas", "density"))
-        p.annotate_streamlines(("gas", "velocity_theta"), ("gas", "velocity_phi"))
-        assert_raises(YTDataTypeUnsupported, p.save, prefix)
+        assert_raises(
+            YTDataTypeUnsupported,
+            p.annotate_streamlines,
+            ("gas", "velocity_theta"),
+            ("gas", "velocity_phi"),
+        )
 
 
 @requires_file(cyl_2d)
@@ -1014,10 +1009,12 @@ def test_line_integral_convolution_callback():
             geometry="spherical",
         )
         p = SlicePlot(ds, "r", ("gas", "density"))
-        p.annotate_line_integral_convolution(
-            ("gas", "velocity_theta"), ("gas", "velocity_phi")
+        assert_raises(
+            YTDataTypeUnsupported,
+            p.annotate_line_integral_convolution,
+            ("gas", "velocity_theta"),
+            ("gas", "velocity_phi"),
         )
-        assert_raises(YTDataTypeUnsupported, p.save, prefix)
 
 
 def test_accepts_all_fields_decorator():

--- a/yt/visualization/tests/test_callbacks.py
+++ b/yt/visualization/tests/test_callbacks.py
@@ -95,7 +95,8 @@ def test_init_signature_error_callback():
         units=["g/cm**3", "m/s", "m/s"],
     )
     p = SlicePlot(ds, "z", ("gas", "density"))
-    assert_raises(TypeError, p.annotate_velocity, invalid_argument=1)
+    # annotate_velocity accepts only one positional argument
+    assert_raises(TypeError, p.annotate_velocity, 1, 2, 3)
 
 
 def check_axis_manipulation(plot_obj, prefix):
@@ -207,9 +208,7 @@ def test_line_callback():
         assert_fname(p.save(prefix)[0])
         # Now we'll check a few additional minor things
         p = SlicePlot(ds, "x", ("gas", "density"))
-        p.annotate_line(
-            [0.1, 0.1], [0.5, 0.5], coord_system="axis", plot_args={"color": "red"}
-        )
+        p.annotate_line([0.1, 0.1], [0.5, 0.5], coord_system="axis", color="red")
         p.save(prefix)
         check_axis_manipulation(p, prefix)
 
@@ -245,7 +244,7 @@ def test_ray_callback():
         # Now we'll check a few additional minor things
         p = SlicePlot(ds, "x", ("gas", "density"))
         p.annotate_ray(oray)
-        p.annotate_ray(ray, plot_args={"color": "red"})
+        p.annotate_ray(ray, color="red")
         p.save(prefix)
         check_axis_manipulation(p, prefix)
 
@@ -671,7 +670,7 @@ def test_contour_callback():
         p = SlicePlot(ds, "x", ("gas", "density"))
         p.annotate_contour(
             ("gas", "temperature"),
-            ncont=10,
+            levels=10,
             factor=8,
             take_log=False,
             clim=(0.4, 0.6),
@@ -685,7 +684,7 @@ def test_contour_callback():
         s2 = ds.slice(0, 0.2)
         p.annotate_contour(
             ("gas", "temperature"),
-            ncont=10,
+            levels=10,
             factor=8,
             take_log=False,
             clim=(0.4, 0.6),
@@ -701,7 +700,7 @@ def test_contour_callback():
         slc = SlicePlot(ds, "theta", ("gas", "plasma_beta"))
         slc.annotate_contour(
             ("gas", "plasma_beta"),
-            ncont=2,
+            levels=2,
             factor=7,
             take_log=False,
             clim=(1.0e-1, 1.0e1),
@@ -720,7 +719,7 @@ def test_contour_callback():
         )
         p = SlicePlot(ds, "r", ("gas", "density"))
         kwargs = dict(
-            ncont=10,
+            levels=10,
             factor=8,
             take_log=False,
             clim=(0.4, 0.6),
@@ -828,13 +827,13 @@ def test_mesh_lines_callback():
         ds = fake_hexahedral_ds()
         for field in ds.field_list:
             sl = SlicePlot(ds, 1, field)
-            sl.annotate_mesh_lines(plot_args={"color": "black"})
+            sl.annotate_mesh_lines(color="black")
             assert_fname(sl.save(prefix)[0])
 
         ds = fake_tetrahedral_ds()
         for field in ds.field_list:
             sl = SlicePlot(ds, 1, field)
-            sl.annotate_mesh_lines(plot_args={"color": "black"})
+            sl.annotate_mesh_lines(color="black")
             assert_fname(sl.save(prefix)[0])
         check_axis_manipulation(sl, prefix)  # only test the final field
 
@@ -889,10 +888,8 @@ def test_streamline_callback():
                 ("gas", "velocity_y"),
                 field_color=("stream", "magvel"),
                 display_threshold=0.5,
-                plot_args={
-                    "cmap": ytcfg.get("yt", "default_colormap"),
-                    "arrowstyle": "->",
-                },
+                cmap="viridis",
+                arrowstyle="->",
             )
             assert_fname(p.save(prefix)[0])
 

--- a/yt/visualization/tests/test_callbacks.py
+++ b/yt/visualization/tests/test_callbacks.py
@@ -1,4 +1,5 @@
 import contextlib
+import inspect
 import shutil
 import tempfile
 
@@ -69,6 +70,32 @@ def _cleanup_fname():
     tmpdir = tempfile.mkdtemp()
     yield tmpdir
     shutil.rmtree(tmpdir)
+
+
+def test_method_signature():
+    ds = fake_amr_ds(
+        fields=[("gas", "density"), ("gas", "velocity_x"), ("gas", "velocity_y")],
+        units=["g/cm**3", "m/s", "m/s"],
+    )
+    p = SlicePlot(ds, "z", ("gas", "density"))
+    sig = inspect.signature(p.annotate_velocity)
+    # checking the first few arguments rather than the whole signature
+    # we just want to validate that method wrapping works
+    assert list(sig.parameters.keys())[:4] == [
+        "factor",
+        "scale",
+        "scale_units",
+        "normalize",
+    ]
+
+
+def test_init_signature_error_callback():
+    ds = fake_amr_ds(
+        fields=[("gas", "density"), ("gas", "velocity_x"), ("gas", "velocity_y")],
+        units=["g/cm**3", "m/s", "m/s"],
+    )
+    p = SlicePlot(ds, "z", ("gas", "density"))
+    assert_raises(TypeError, p.annotate_velocity, {"invalid_argument": 1})
 
 
 def check_axis_manipulation(plot_obj, prefix):


### PR DESCRIPTION
## PR Summary
Fix #3945
Right now this is a proof of concept, there's still work to do, but I think it's promising so I'm opening to see how many tests are currently broken.
It should backwards compatible, and retain compatibility with externally defined plot callbacks (such as `HaloCatalogCallback` from `yt_astro_analysis`).

If I can manage to get it 100% complete while keeping a reasonable diff size, I'll propose this for yt 4.1

Note: I ended up cleaning up a lot of signatures in `PlotCallback` subclasses `__init__` methods (making most arguments keyword only). This change is technically not backward compatible. It is motivated by future compatibility concerns: some arguments are already deprecated, but sometimes occupy early positions, so there is *no* way to actually remove them in the future without breaking backward compatibility. Making them keyword only now is the least painful route I can see.
This wasn't the original goal of this PR, however it turned out that to be a requirement to keep this as tidy as possible, I'm happy to discuss it in more detail upon request.

In short, here's what works on the main branch but not here:

```python
import yt

ds = yt.load_sample("IsolatedGalaxy")
p = yt.SlicePlot(ds, "z", ("gas", "density"))
p.annotate_contour(("gas", "density"), 5, 4, (1e-28, 1e-25))
p.save("/tmp/test_contour.png")
```

on this branch it will raise a TypeError (this is 100% by design)
```python-traceback
Traceback (most recent call last):
  File "/Users/robcleme/dev/yt-project/yt/t_callback_validation.py", line 5, in <module>
    p.annotate_contour(("gas", "density"),5,4, (1e-28, 1e-25))
  File "/Users/robcleme/dev/yt-project/yt/yt/visualization/plot_modifications.py", line 103, in closure
    self._callbacks.append(cls(*args, **kwargs))
TypeError: ContourCallback.__init__() takes from 2 to 3 positional arguments but 5 were given
```
The fix is simply to use keyword arguments instead of positional:
```python
p.annotate_contour(("gas", "density"), levels=5, factor=4, clim=(1e-28, 1e-25))
```
(in this particular example, the second argument, `levels`, main still be passed positionally)
Hopefully this is not too concerning of a change, since most arguments were _desinged_ to be used as keyword rather than positional, and that's how they've always been demonstrated in docs. The main reason why they were not already implemented as keyword only is that this wasn't a thing in Python 2, but it's been around since Python 3.0


TODO:

- [x] proof of concept for `PlotCallback` subclasses
- [x] generalize to FRB filters
- [x] validate CI
- [x] move geometry checking responsability from `__call__` to `__init__`
- [x] reimplement mechanism to detect unsupported callbacks according to plot type
- [x] check that `annotate_halos` from yt_astro_analysis still works as expected (checked with https://yt-astro-analysis.readthedocs.io/en/latest/halo_plot_callbacks.html?highlight=annotate_halo#annotate_halos)


## PR Checklist

- [N/A] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.