### PR TITLE
Broadcast missing attribute

### DIFF
--- a/yt/frontends/enzo_e/data_structures.py
+++ b/yt/frontends/enzo_e/data_structures.py
@@ -276,12 +276,15 @@ class EnzoEHierarchy(GridIndex):
             grid = self.grids[0]
             field_list, ptypes = self.io._read_field_names(grid)
             mylog.debug("Grid %s has: %s", grid.id, field_list)
+            sample_pfields = self.io.sample_pfields
         else:
             field_list = None
             ptypes = None
+            sample_pfields = None
         self.field_list = list(self.comm.mpi_bcast(field_list))
         self.dataset.particle_types = list(self.comm.mpi_bcast(ptypes))
         self.dataset.particle_types_raw = self.dataset.particle_types[:]
+        self.io.sample_pfields = self.comm.mpi_bcast(sample_pfields)
 
 
 class EnzoEDataset(Dataset):


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

This fixes a bug where the `sample_pfields` attribute on the io handler wasn't getting set for all non-root processes. This only comes up when querying particle fields in parallel.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
