### PR TITLE
Dask minimal particle reader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,4 @@ doc/source/quickstart/.ipynb_checkpoints/
 dist
 .python-version
 answer_nosetests.xml
+dask-worker-space/*

--- a/conftest.py
+++ b/conftest.py
@@ -19,6 +19,7 @@ from yt.utilities.answer_testing.testing_utilities import (
     _streamline_for_io,
     data_dir_load,
 )
+from yt.utilities.on_demand_imports import _dask as dask
 
 MPL_VERSION = Version(matplotlib.__version__)
 NUMPY_VERSION = Version(numpy.__version__)
@@ -64,6 +65,16 @@ def pytest_addoption(parser):
         "test_data_dir",
         default=ytcfg.get("yt", "test_data_dir"),
         help="Directory where data for tests is stored.",
+    )
+    # Dask options. Defaults are chosen for github actions.
+    parser.addoption(
+        "--dask_workers", action="store", default=2, help="number of dask workers"
+    )
+    parser.addoption(
+        "--dask_threads_pw",
+        action="store",
+        default=1,
+        help="number of threads per worker",
     )
 
 
@@ -458,3 +469,24 @@ def Npart(request):
     Needed because indirect=True is used for loading the datasets.
     """
     return request.param
+
+
+@pytest.fixture(scope="session")
+def dask_client_fixture(request):
+    """
+    Fixture for spinning up a dask LocalCluster and Client
+    """
+
+    # there are a number of options, including using some of the internal dask
+    # functions for testing, but this seems the simplest way to ensure only a
+    # single cluster is spun up during testing. Some useful discussion here:
+    # https://github.com/dask/distributed/issues/4479#issuecomment-772119435
+    # also note that if running pytest in parallel, this fixture will need
+    # modification (e.g., pytest-xdist would execute this fixture multiple times)
+
+    n_workers = int(request.config.getoption("--dask_workers"))
+    tpw = int(request.config.getoption("--dask_threads_pw"))
+    lc = dask.distributed.LocalCluster
+    with lc(n_workers=n_workers, threads_per_worker=tpw) as cluster:
+        with dask.distributed.Client(cluster) as client:
+            yield client

--- a/nose_unit.cfg
+++ b/nose_unit.cfg
@@ -6,5 +6,5 @@ nologcapture=1
 verbosity=2
 where=yt
 with-timer=1
-ignore-files=(test_load_errors.py|test_load_sample.py|test_commons.py|test_ambiguous_fields.py|test_field_access_pytest.py|test_save.py|test_line_annotation_unit.py|test_eps_writer.py|test_registration.py|test_invalid_origin.py|test_outputs_pytest\.py|test_normal_plot_api\.py|test_load_archive\.py|test_stream_particles\.py|test_file_sanitizer\.py|test_version\.py|\test_on_demand_imports\.py)
+ignore-files=(test_load_errors.py|test_load_sample.py|test_commons.py|test_ambiguous_fields.py|test_field_access_pytest.py|test_save.py|test_line_annotation_unit.py|test_eps_writer.py|test_registration.py|test_invalid_origin.py|test_outputs_pytest\.py|test_normal_plot_api\.py|test_load_archive\.py|test_stream_particles\.py|test_file_sanitizer\.py|test_version\.py|\test_on_demand_imports\.py|\test_dask_helper\.py)
 exclude-test=yt.frontends.gdf.tests.test_outputs.TestGDF

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,8 @@ doc =
     sphinx-rtd-theme
 full =
     astropy>=4.0.1,<6.0.0
+    dask[array]
+    dask[distributed]
     f90nml>=1.1.2
     fastcache>=1.0.2
     firefly-vis>=2.0.4,<3.0.0
@@ -108,6 +110,8 @@ minimal =
 test =
     codecov~=2.0.15
     coverage~=4.5.1
+    dask[array]
+    dask[distributed]
     nose~=1.3.7
     nose-exclude
     nose-timer~=1.0.0

--- a/yt/config.py
+++ b/yt/config.py
@@ -54,8 +54,7 @@ ytcfg_defaults["yt"] = dict(
         topcomm_parallel_rank=0,
         topcomm_parallel_size=1,
         command_line=False,
-        dask_enabled=True,  # long term user option
-        dask_allowed=True,  # temporary for testing
+        dask_enabled=False,
     ),
 )
 

--- a/yt/config.py
+++ b/yt/config.py
@@ -54,6 +54,8 @@ ytcfg_defaults["yt"] = dict(
         topcomm_parallel_rank=0,
         topcomm_parallel_size=1,
         command_line=False,
+        dask_enabled=True,  # long term user option
+        dask_allowed=True,  # temporary for testing
     ),
 )
 

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -35,6 +35,7 @@ class IOHandlerGadgetHDF5(IOHandlerSPH):
     )
 
     _coord_name = "Coordinates"
+    _dask_enabled = True
 
     @property
     def var_mass(self):

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -336,6 +336,7 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
 
     _var_mass = None
     _format = None
+    _dask_enabled = True
 
     def __init__(self, ds, *args, **kwargs):
         self._fields = ds._field_spec

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -6,6 +6,7 @@ import shutil
 import sys
 import tempfile
 import unittest
+from contextlib import contextmanager
 from functools import wraps
 from importlib.util import find_spec
 from shutil import which
@@ -1479,3 +1480,20 @@ class ParticleSelectionComparison:
             (0.0 + LE[2], "unitary") : (0.1 + LE[2], "unitary"),
         ]
         self.compare_dobj_selection(reg3)
+
+
+@contextmanager
+def config_toggle_context(newvalue, *keys, metadata=None):
+    # a context manager that caches the value of a config option and sets the
+    # config to the new provided value during setup. During teardown the
+    # config option is reset to the original value.
+    # note: with pytest, can use a fixture instead of this. But the answer tests
+    # running with nosetest need a slightly different approach.
+    set_back_to = keys + (ytcfg.get(*keys),)
+    config_args_for_test = keys + (newvalue,)
+    ytcfg.set(*config_args_for_test, metadata=metadata)
+
+    try:
+        yield  # yield nothing, the code using the generator runs here
+    finally:
+        ytcfg.set(*set_back_to, metadata=metadata)

--- a/yt/utilities/io_handler.py
+++ b/yt/utilities/io_handler.py
@@ -13,9 +13,9 @@ else:
 import numpy as np
 
 from yt._typing import ParticleCoordinateTuple
-from yt.config import ytcfg
 from yt.geometry.selection_routines import GridSelector
 from yt.utilities.on_demand_imports import _h5py as h5py
+from yt.utilities.parallel_tools.dask_helper import compute, dask_delay_wrapper
 
 io_registry = {}
 
@@ -174,22 +174,9 @@ class BaseIOHandler:
         self, chunks, selector, fields: List[Tuple[str, str]]
     ) -> Dict[Tuple[str, str], np.ndarray]:
 
-        if ytcfg.get("yt", "internals", "dask_allowed"):
-            return self._read_particle_selection_dask(chunks, selector, fields)
-        else:
-            return self._read_particle_selection_plain(chunks, selector, fields)
-
-    def _read_particle_selection_dask(
-        self, chunks, selector, fields: List[Tuple[str, str]]
-    ) -> Dict[Tuple[str, str], np.ndarray]:
         # this particle reader constructs a dask-delayed graph and immediately
         # computes. If dask is not enabled, all dask operations are passthrough
         # functions that have no effect.
-
-        from yt.utilities.parallel_tools.dask_helper import (
-            dask_compute,
-            dask_delay_wrapper,
-        )
 
         # re-organize the fields to read
         ptf, field_maps = self._get_particle_field_containers(fields)
@@ -207,7 +194,7 @@ class BaseIOHandler:
 
         # since we are returning in-mem arrays with this function, we immediately compute
         # if dask is not enabled, this will pass through the chunks without modification
-        data_by_chunk = dask_compute(*delayed_chunks)
+        data_by_chunk = compute(*delayed_chunks)
 
         # convert from a list of dicts to dict of lists in order to concatenate
         for chunk in data_by_chunk:
@@ -238,7 +225,7 @@ class BaseIOHandler:
         return rv
 
     def _get_particle_field_containers(self, fields: List[Tuple[str, str]]):
-
+        # returns ptf and field_maps:
         # ptf (particle field types) maps particle type to list of on-disk fields to read
         # field_maps stores fields, accounting for field unions
 
@@ -263,42 +250,6 @@ class BaseIOHandler:
                 field_maps[field].append(field)
 
         return ptf, field_maps
-
-    def _read_particle_selection_plain(
-        self, chunks, selector, fields: List[Tuple[str, str]]
-    ) -> Dict[Tuple[str, str], np.ndarray]:
-        data: Dict[Tuple[str, str], List[np.ndarray]] = {}
-
-        # re-organize the fields to read
-        ptf, field_maps = self._get_particle_field_containers(fields)
-
-        # What we need is a mapping from particle types to return types
-        for field in fields:
-            data[field] = []
-
-        # Now we read.
-        for field_r, vals in self._read_particle_fields(chunks, ptf, selector):
-            # Note that we now need to check the mappings
-            for field_f in field_maps[field_r]:
-                data[field_f].append(vals)
-
-        rv: Dict[Tuple[str, str], np.ndarray] = {}  # the return dictionary
-        fields = list(data.keys())
-        for field_f in fields:
-            # We need to ensure the arrays have the right shape if there are no
-            # particles in them.
-            total = sum(_.size for _ in data[field_f])
-            if total > 0:
-                vals = data.pop(field_f)
-                rv[field_f] = np.concatenate(vals, axis=0).astype("float64")
-            else:
-                shape = [0]
-                if field[1] in self._vector_fields:
-                    shape.append(self._vector_fields[field[1]])
-                elif field[1] in self._array_fields:
-                    shape.append(self._array_fields[field[1]])
-                rv[field_f] = np.empty(shape, dtype="float64")
-        return rv
 
     def _read_particle_fields(self, chunks, ptf, selector):
         # Now we have all the sizes, and we can allocate

--- a/yt/utilities/on_demand_imports.py
+++ b/yt/utilities/on_demand_imports.py
@@ -451,3 +451,32 @@ class ratarmount_imports(OnDemand):
 
 
 _ratarmount = ratarmount_imports()
+
+
+class dask_imports(OnDemand):
+    @safe_import
+    def distributed(self):
+        from dask import distributed
+
+        return distributed
+
+    @safe_import
+    def compute(self):
+        from dask import compute
+
+        return compute
+
+    @safe_import
+    def delayed(self):
+        from dask import delayed
+
+        return delayed
+
+    @safe_import
+    def array(self):
+        from dask import array
+
+        return array
+
+
+_dask = dask_imports()

--- a/yt/utilities/parallel_tools/dask_helper.py
+++ b/yt/utilities/parallel_tools/dask_helper.py
@@ -1,0 +1,158 @@
+from dask import array as dask_array, compute as dask_compute, delayed
+from dask.distributed import Client
+
+from yt.utilities.logger import ytLogger as mylog
+
+# a couple of warning messages used in several places
+here_be_dragons = (
+    "You have chosen to attempt multi-threading. Many frontends are not"
+    " thread-safe and many yt functions are built for single-threading so "
+    "you will likely encounter bugs (including silent failures and hangs)."
+    "Good luck!"
+)
+
+thread_override = (
+    "multi-threading is prohibited by default. Supply allow_threads=True "
+    "to start_client() to override if you really want to (you probably "
+    "dont want to)."
+)
+
+
+class ClientContainer:
+    """
+    a container to help with managing dask clients for yt. Enforces
+    single-threading for new clients and allows us to easily track if a client
+    is open.
+
+    Intentionally does NOT spin up a dask client on instantiation so that
+    a user is responsible for starting their own client. With no client,
+    the wrapper functions in dask_helper assume one single-threaded processor.
+    """
+
+    def __init__(self):
+        self.client = None
+
+    def start_client(self, *args, allow_threads=False, **kwargs):
+        """spins up a new dask.distributed.Client and stores in self.client
+
+        Parameters
+        ----------
+        *args :
+            all *args passed to dask.distributed.Client
+        allow_threads : bool
+            if False (default), prevents multithreading. Switch to True at your
+            own risk (multithreading is not supported but might work for some
+            operations if you are lucky).
+        **kwargs :
+            all **kwargs are passed to dask.distributed.Client with some
+            exceptions.
+
+            The following **kwargs have defaults set here that differ from the
+            defaults of dask.distributed.Client to enforce singlethreaded, single
+            processor execution by default. These kwargs and their defaults are:
+
+            threads_per_worker = 1
+            n_workers = 1
+            proccesses = False
+
+            see dask.distributed.Client for descriptions of arguments.
+
+        Example Usage
+        -------------
+
+        To start a default client:
+        from yt.utilities.parallel_tools.dask_helper import dask_client
+
+        dask_client.start_client()
+        print(dask_client.client)
+        print(dask_client.client.status)
+        print(dask_client.client.dashboard_link)
+
+        ds = yt.load_sample("snapshot_033")
+        reg = ds.region(ds.domain_center,ds.domain_right_edge*0.25, ds.domain_right_edge*0.75)
+        si = reg[('PartType4','Silicon')]
+        """
+
+        # some sanitizing and defaults different from dask's normal defaults
+        # for dask.distributed.Client:
+        tpw = self._sanitize_threading(allow_threads, **kwargs)
+        nw = kwargs.pop("n_workers", 1)
+        pr = kwargs.pop("processes", False)
+
+        # spin up the Client:
+        self.client = Client(
+            *args, threads_per_worker=tpw, n_workers=nw, processes=pr, **kwargs
+        )
+
+    def _sanitize_threading(self, allow_threads, **kwargs):
+        tpw = kwargs.pop("threads_per_worker", 1)
+        if tpw > 1:
+            if allow_threads:
+                mylog.warning(here_be_dragons)
+            else:
+                mylog.warning(thread_override)
+                tpw = 1
+        return tpw
+
+    def close(self):
+        if self.client:
+            self.client.close()
+            self.client = None
+
+
+dask_client = ClientContainer()
+
+
+def compute(*args, allow_threads=False, **kwargs):
+    """direct wrapper of dask.compute. If there is not an active `dask_client`,
+    will enforce single-threaded computation. Primarily used by yt internally,
+    but may be public uses once dask objects can be returned.
+
+    Parameters
+    ----------
+    *args : passed to dask.compute()
+    allow_threads : bool
+        if False (default), prevents multithreading. Switch to True at your
+        own risk (multithreading is not supported but might work for some
+        operations if you are lucky).
+    **kwargs : passed to dask.compute()
+
+    If no dask_client is active, the `scheduler` kwarg is forced to be "singe-threaded"
+
+    Returns
+    -------
+    output from dask.compute()
+
+    """
+
+    if dask_client.client is None:
+        sch = kwargs.pop("scheduler", "single-threaded")
+        safe_sch = ["single-threaded", "processes"]
+        if sch not in safe_sch:
+            if allow_threads:
+                mylog.warning(here_be_dragons)
+            else:
+                mylog.warning(thread_override)
+                sch = "single-threaded"
+        return dask_compute(*args, scheduler=sch, **kwargs)
+    else:
+        # sanitization already taken care of by dask_client.
+        return dask_compute(*args, **kwargs)
+
+
+def is_delayed(obj):
+    """checks if obj is a dask array (or a unyt-dask array)"""
+    return isinstance(obj, dask_array.Array)
+
+
+dask_enabled = False
+
+def dask_delay_wrapper(func):
+    def call_func(*args, **kwargs):
+        if dask_enabled:
+            # if dask is enabled, we delay
+            return delayed(func)(*args, **kwargs)
+        else:
+            # if dask is not enabled, immediately execute and return result
+            return func(*args, **kwargs)
+    return call_func

--- a/yt/utilities/parallel_tools/dask_helper.py
+++ b/yt/utilities/parallel_tools/dask_helper.py
@@ -2,7 +2,7 @@ from yt.config import ytcfg
 from yt.utilities.on_demand_imports import _dask as dask
 
 
-def is_delayed(obj):
+def is_dask_array(obj):
     """checks if obj is a dask array (or a unyt-dask array)"""
     return isinstance(obj, dask.array.Array)
 

--- a/yt/utilities/parallel_tools/dask_helper.py
+++ b/yt/utilities/parallel_tools/dask_helper.py
@@ -1,6 +1,7 @@
 from dask import array as dask_array, compute as dask_compute, delayed
 from dask.distributed import Client
 
+from yt.config import ytcfg
 from yt.utilities.logger import ytLogger as mylog
 
 # a couple of warning messages used in several places
@@ -145,14 +146,13 @@ def is_delayed(obj):
     return isinstance(obj, dask_array.Array)
 
 
-dask_enabled = False
-
 def dask_delay_wrapper(func):
     def call_func(*args, **kwargs):
-        if dask_enabled:
+        if ytcfg.get("yt", "internals", "dask_enabled"):
             # if dask is enabled, we delay
             return delayed(func)(*args, **kwargs)
         else:
             # if dask is not enabled, immediately execute and return result
             return func(*args, **kwargs)
+
     return call_func

--- a/yt/utilities/parallel_tools/dask_helper.py
+++ b/yt/utilities/parallel_tools/dask_helper.py
@@ -1,155 +1,5 @@
 from yt.config import ytcfg
-from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.on_demand_imports import _dask as dask
-
-# a couple of warning messages used in several places
-here_be_dragons = (
-    "You have chosen to attempt multi-threading. Many frontends are not"
-    " thread-safe and many yt functions are built for single-threading so "
-    "you will likely encounter bugs (including silent failures and hangs)."
-    "Good luck!"
-)
-
-thread_override = (
-    "multi-threading is prohibited by default. Supply allow_threads=True "
-    "to start_client() to override if you really want to (you probably "
-    "dont want to)."
-)
-
-
-class ClientContainer:
-    """
-    a container to help with managing dask clients for yt. Enforces
-    single-threading for new clients and allows us to easily track if a client
-    is open.
-
-    Intentionally does NOT spin up a dask client on instantiation so that
-    a user is responsible for starting their own client. With no client,
-    the wrapper functions in dask_helper assume one single-threaded processor.
-    """
-
-    def __init__(self):
-        self.client = None
-
-    @property
-    def _dask_enabled(self):
-        # always check config in case user has changed it dynamically
-        return ytcfg.get("yt", "internals", "dask_enabled")
-
-    def start_client(self, *args, allow_threads=False, **kwargs):
-        """spins up a new dask.distributed.Client and stores in self.client
-
-        Parameters
-        ----------
-        *args :
-            all *args passed to dask.distributed.Client
-        allow_threads : bool
-            if False (default), prevents multithreading. Switch to True at your
-            own risk (multithreading is not supported but might work for some
-            operations if you are lucky).
-        **kwargs :
-            all **kwargs are passed to dask.distributed.Client with some
-            exceptions.
-
-            The following **kwargs have defaults set here that differ from the
-            defaults of dask.distributed.Client to enforce singlethreaded, single
-            processor execution by default. These kwargs and their defaults are:
-
-            threads_per_worker = 1
-            n_workers = 1
-            proccesses = False
-
-            see dask.distributed.Client for descriptions of arguments.
-
-        Example Usage
-        -------------
-
-        To start a default client:
-        from yt.utilities.parallel_tools.dask_helper import dask_client
-
-        dask_client.start_client()
-        print(dask_client.client)
-        print(dask_client.client.status)
-        print(dask_client.client.dashboard_link)
-
-        ds = yt.load_sample("snapshot_033")
-        reg = ds.region(ds.domain_center,ds.domain_right_edge*0.25, ds.domain_right_edge*0.75)
-        si = reg[('PartType4','Silicon')]
-        """
-
-        if self._dask_enabled is False:
-            raise RuntimeError(
-                "To use dask with yt, please set the dask_enabled "
-                "config option to True."
-            )
-
-        # some sanitizing and defaults different from dask's normal defaults
-        # for dask.distributed.Client:
-        tpw = self._sanitize_threading(allow_threads, **kwargs)
-        nw = kwargs.pop("n_workers", 1)
-        pr = kwargs.pop("processes", False)
-
-        # spin up the Client:
-        self.client = dask.distributed.Client(
-            *args, threads_per_worker=tpw, n_workers=nw, processes=pr, **kwargs
-        )
-
-    def _sanitize_threading(self, allow_threads, **kwargs):
-        tpw = kwargs.pop("threads_per_worker", 1)
-        if tpw > 1:
-            if allow_threads:
-                mylog.warning(here_be_dragons)
-            else:
-                mylog.warning(thread_override)
-                tpw = 1
-        return tpw
-
-    def close(self):
-        if self.client:
-            self.client.close()
-            self.client = None
-
-
-dask_client = ClientContainer()
-
-
-def compute(*args, allow_threads=False, **kwargs):
-    """direct wrapper of dask.compute. If there is not an active `dask_client`,
-    will enforce single-threaded computation. Primarily used by yt internally,
-    but may be public uses once dask objects can be returned.
-
-    Parameters
-    ----------
-    *args : passed to dask.compute()
-    allow_threads : bool
-        if False (default), prevents multithreading. Switch to True at your
-        own risk (multithreading is not supported but might work for some
-        operations if you are lucky).
-    **kwargs : passed to dask.compute()
-
-    If no dask_client is active, the `scheduler` kwarg is forced to be "singe-threaded"
-
-    Returns
-    -------
-    output from dask.compute()
-
-    """
-
-    if not ytcfg.get("yt", "internals", "dask_enabled"):
-        return args
-    elif dask_client.client is None:
-        sch = kwargs.pop("scheduler", "single-threaded")
-        safe_sch = ["single-threaded", "processes"]
-        if sch not in safe_sch:
-            if allow_threads:
-                mylog.warning(here_be_dragons)
-            else:
-                mylog.warning(thread_override)
-                sch = "single-threaded"
-        return dask.compute(*args, scheduler=sch, **kwargs)
-    else:
-        # sanitization already taken care of by dask_client.
-        return dask.compute(*args, **kwargs)
 
 
 def is_delayed(obj):
@@ -157,14 +7,26 @@ def is_delayed(obj):
     return isinstance(obj, dask.array.Array)
 
 
-def dask_delay_wrapper(func):
+def _empty_decorator(func):
     def call_func(*args, **kwargs):
-        # note: the dask_enabled switch is a permanent config option
-        if ytcfg.get("yt", "internals", "dask_enabled"):
-            # if dask is enabled, we delay
-            return dask.delayed(func)(*args, **kwargs)
-        else:
-            # if dask is not enabled, immediately execute and return result
-            return func(*args, **kwargs)
+        return func(*args, **kwargs)
 
     return call_func
+
+
+def _passthrough_function(*args, **kwargs):
+    return args
+
+
+def _get_dask_delayed(use_dask: bool):
+    if use_dask and ytcfg.get("yt", "internals", "dask_enabled"):
+        return dask.delayed  # contains additional internal config checks
+    else:
+        return _empty_decorator
+
+
+def _get_dask_compute(use_dask: bool):
+    if use_dask and ytcfg.get("yt", "internals", "dask_enabled"):
+        return dask.compute
+    else:
+        return _passthrough_function

--- a/yt/utilities/parallel_tools/tests/test_dask_helper.py
+++ b/yt/utilities/parallel_tools/tests/test_dask_helper.py
@@ -1,0 +1,80 @@
+import numpy as np
+import pytest
+
+from yt.config import ytcfg
+from yt.testing import assert_array_equal, assert_equal
+from yt.utilities.on_demand_imports import _dask as dask
+from yt.utilities.parallel_tools import dask_helper as dh
+
+
+@pytest.fixture(autouse=True)
+def run_before_and_after_tests():
+    # Fixture to execute set dask_enabled config to standard value then reset.
+    # ensures that these tests will work even if default value for dask_enabled
+    # changes while ensuring other tests will retain the default value even
+    # if a test here changes the config value.
+
+    # Setup:
+    original_config = ytcfg.get("yt", "internals", "dask_enabled")
+    ytcfg.set("yt", "internals", "dask_enabled", False)
+
+    yield  # test will run here
+
+    # Teardown:
+    ytcfg.set("yt", "internals", "dask_enabled", original_config)
+
+
+def test_compute_helper():
+    ytcfg.set("yt", "internals", "dask_enabled", True)  # make sure its enabled
+    # ensure that results returned by dask_helper.compute match those
+    # returned by standard dask compute methods.
+    f = dask.array.random.random((1000, 5), chunks=500)
+    meanval = f.mean()
+    # standard compute methods:
+    r_orig = meanval.compute()
+    r_orig2 = dask.compute(meanval)[0]
+
+    # wrapped method
+    new = dh.compute(meanval)[0]
+
+    assert_equal(r_orig, new)
+    assert_equal(r_orig2, new)
+
+
+def test_client_spin_up_down():
+    c = dh.dask_client
+    # first check that we catch dask_enabled=False
+    with pytest.raises(RuntimeError):
+        c.start_client()
+
+    # check that updating dask_enabled works
+    ytcfg.set("yt", "internals", "dask_enabled", True)
+    assert c._dask_enabled
+
+    # now starting should work
+    c.start_client()
+    assert_equal("running", c.client.status)
+    c.close()
+    assert_equal(None, c.client)
+
+
+def test_dask_config_options():
+
+    # when not enabled, helper functions will pass through arguments or calls
+    def delay_func(vals_list):
+        results = [vals.min() for vals in vals_list]
+        return np.array(results)
+
+    x = [np.linspace(1, 10, 5), np.linspace(2, 30, 5)]
+    expected = np.array((1.0, 2.0))
+    actual = dh.dask_delay_wrapper(delay_func)(x)  # will compute immediately
+    assert_array_equal(expected, actual)
+
+    result = dh.compute(*x)  # will return arguments immediately
+    for expected, actual in zip(x, result):
+        assert_array_equal(expected, actual)
+
+    # the dh.compute should match dask.compute for non-delayed values
+    normal_compute = dask.compute(*x)
+    for expected, actual in zip(normal_compute, result):
+        assert_array_equal(expected, actual)

--- a/yt/utilities/parallel_tools/tests/test_dask_helper.py
+++ b/yt/utilities/parallel_tools/tests/test_dask_helper.py
@@ -4,27 +4,25 @@ import pytest
 from yt.config import ytcfg
 from yt.testing import assert_array_equal, assert_equal
 from yt.utilities.on_demand_imports import _dask as dask
-from yt.utilities.parallel_tools import dask_helper as dh
+from yt.utilities.parallel_tools import dask_helper
 
 
 @pytest.fixture(autouse=True)
 def run_before_and_after_tests():
-    # Fixture to execute set dask_enabled config to standard value then reset.
+    # Fixture to set dask_enabled config to standard value then reset.
     # ensures that these tests will work even if default value for dask_enabled
-    # changes while ensuring other tests will retain the default value even
-    # if a test here changes the config value.
+    # changes while ensuring the config value gets reset to the default value
+    # after a test runs.
 
-    # Setup:
     original_config = ytcfg.get("yt", "internals", "dask_enabled")
     ytcfg.set("yt", "internals", "dask_enabled", False)
 
     yield  # test will run here
 
-    # Teardown:
     ytcfg.set("yt", "internals", "dask_enabled", original_config)
 
 
-def test_compute_helper():
+def test_compute_helper(dask_client_fixture):
     ytcfg.set("yt", "internals", "dask_enabled", True)  # make sure its enabled
     # ensure that results returned by dask_helper.compute match those
     # returned by standard dask compute methods.
@@ -34,47 +32,62 @@ def test_compute_helper():
     r_orig = meanval.compute()
     r_orig2 = dask.compute(meanval)[0]
 
-    # wrapped method
-    new = dh.compute(meanval)[0]
-
+    # check the wrapped version
+    dask_helper_compute = dask_helper._get_dask_compute(True)
+    new = dask_helper_compute(meanval)[0]
     assert_equal(r_orig, new)
     assert_equal(r_orig2, new)
 
+    # when passing compute a non-delayed object, compute just returns the *args,
+    # ignoring any kwargs. This checks that we get back compute from dask_helper
+    # when expected and also tests that the passthrough function returns the
+    # *args just like compute.
+    expected = dask.compute(1, 2, 3, this_will_be_dropped=2)
+    dask_helper_compute = dask_helper._get_dask_compute(True)
+    assert dask_helper_compute == dask.compute
+    actual = dask_helper_compute(1, 2, 3, this_will_be_dropped=2)
+    assert actual == expected
+    dask_helper_compute = dask_helper._get_dask_compute(False)
+    assert dask_helper_compute == dask_helper._passthrough_function
+    actual = dask_helper_compute(1, 2, 3, this_will_be_dropped=2)
+    assert actual == expected
 
-def test_client_spin_up_down():
-    c = dh.dask_client
-    # first check that we catch dask_enabled=False
-    with pytest.raises(RuntimeError):
-        c.start_client()
-
-    # check that updating dask_enabled works
-    ytcfg.set("yt", "internals", "dask_enabled", True)
-    assert c._dask_enabled
-
-    # now starting should work
-    c.start_client()
-    assert_equal("running", c.client.status)
-    c.close()
-    assert_equal(None, c.client)
+    # check that if dask is not enabled we get back the passthrough function
+    ytcfg.set("yt", "internals", "dask_enabled", False)
+    dask_helper_compute = dask_helper._get_dask_compute(True)
+    assert dask_helper_compute == dask_helper._passthrough_function
 
 
-def test_dask_config_options():
+def test_delay_helper(dask_client_fixture):
 
-    # when not enabled, helper functions will pass through arguments or calls
+    # a function to delay (or not)
     def delay_func(vals_list):
         results = [vals.min() for vals in vals_list]
         return np.array(results)
 
     x = [np.linspace(1, 10, 5), np.linspace(2, 30, 5)]
     expected = np.array((1.0, 2.0))
-    actual = dh.dask_delay_wrapper(delay_func)(x)  # will compute immediately
+
+    # when dask is not enabled, get an empty decorator that calls the function
+    # immediately
+    delay = dask_helper._get_dask_delayed(True)
+    assert delay == dask_helper._empty_decorator
+    actual = delay(delay_func)(x)
     assert_array_equal(expected, actual)
 
-    result = dh.compute(*x)  # will return arguments immediately
-    for expected, actual in zip(x, result):
-        assert_array_equal(expected, actual)
+    # check that the right functions are selected
+    ytcfg.set("yt", "internals", "dask_enabled", True)
+    delay = dask_helper._get_dask_delayed(False)
+    assert delay == dask_helper._empty_decorator
+    delay = dask_helper._get_dask_delayed(True)
+    assert delay == dask.delayed
 
-    # the dh.compute should match dask.compute for non-delayed values
-    normal_compute = dask.compute(*x)
-    for expected, actual in zip(normal_compute, result):
-        assert_array_equal(expected, actual)
+    # check that a delayed operation behaves as expected
+    x = [
+        dask.array.random.random((1000,), chunks=1000),
+        dask.array.random.random((1000,), chunks=1000),
+    ]
+    assert dask_helper.is_dask_array(x[0])
+    expected = dask.delayed(delay_func)(x).compute()
+    actual = delay(delay_func)(x).compute()
+    assert_array_equal(expected, actual)


### PR DESCRIPTION
This is the first refactor and splitting of #3511 

It includes: 
* a minimal particle reader that is dask-optional that immediately reads into memory (no dask-unyt arrays here)
* a global `dask_enabled` config option (default False, for now?) and a by-frontend `_dask_enabled` attribute in the io handler that turns dask on/off for a frontend.
* some minimal dask helper functions to facilitate the dask-optional behavior
* testing infrastructure updates

Dask here is an optional dependency. 

Here's a minimal example that will utilize dask:

```python
import yt
from yt.config import ytcfg
ytcfg.set("yt", "internals", "dask_enabled", True)
ds = yt.load("MagneticumCluster/snap_132")
ad = ds.all_data()
ad[("gas", "density")]
```

