### PR TITLE
[BUG] volume rendering: sigma_clip normalization 

### DIFF
--- a/yt/data_objects/image_array.py
+++ b/yt/data_objects/image_array.py
@@ -332,10 +332,8 @@ class ImageArray(unyt_array):
             sigma_clip = clip_ratio
 
         if sigma_clip is not None:
-            nz = out[:, :, :3][out[:, :, :3].nonzero()]
-            return write_bitmap(
-                out.swapaxes(0, 1), filename, nz.mean() + sigma_clip * nz.std()
-            )
+            clip_value = self._clipping_value(sigma_clip, im=out)
+            return write_bitmap(out.swapaxes(0, 1), filename, clip_value)
         else:
             return write_bitmap(out.swapaxes(0, 1), filename)
 
@@ -443,3 +441,11 @@ class ImageArray(unyt_array):
             if not filename.endswith(".h5"):
                 filename = filename + ".h5"
             self.write_hdf5(filename, dataset_name)
+
+    def _clipping_value(self, sigma_clip, im=None):
+        # return the max value to clip with given a sigma_clip value. If im
+        # is None, the current instance is used
+        if im is None:
+            im = self
+        nz = im[:, :, :3][im[:, :, :3].nonzero()]
+        return nz.mean() + sigma_clip * nz.std()

--- a/yt/data_objects/tests/test_image_array.py
+++ b/yt/data_objects/tests/test_image_array.py
@@ -135,6 +135,18 @@ class TestImageArray(unittest.TestCase):
         im_arr.write_image("with_cmap", cmap_name="hot")
         im_arr.write_image("channel_1.png", channel=1)
 
+    def test_clipping_value(self):
+        im_arr = ImageArray(dummy_image(10.0, 4))
+        clip_val1 = im_arr._clipping_value(1)
+        clip_val2 = im_arr._clipping_value(1, im=im_arr)
+        assert clip_val2 == clip_val1
+
+        clip_val3 = im_arr._clipping_value(6)
+        assert clip_val3 > clip_val2
+
+        im_arr[:] = 1.0  # std will be 0, mean will be 1, so clip value will be 1
+        assert im_arr._clipping_value(1) == 1.0
+
     def tearDown(self):
         os.chdir(self.curdir)
         # clean up

--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -349,7 +349,7 @@ class Scene:
             ax = fig.add_axes([0, 0, 1, 1])
             ax.set_axis_off()
             out = self._last_render
-            if sigma_clip:
+            if sigma_clip is not None:
                 max_val = out._clipping_value(sigma_clip)
             else:
                 max_val = out[:, :, :3].max()

--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -351,8 +351,10 @@ class Scene:
             out = self._last_render
             if sigma_clip:
                 max_val = out._clipping_value(sigma_clip)
-                out = np.clip(out[:, :, :3] / max_val, 0.0, 1.0) * 255
+            else:
+                max_val = out[:, :, :3].max()
             alpha = 255 * out[:, :, 3].astype("uint8")
+            out = np.clip(out[:, :, :3] / max_val, 0.0, 1.0) * 255
             out = np.concatenate([out.astype("uint8"), alpha[..., None]], axis=-1)
             # not sure why we need rot90, but this makes the orientation
             # match the png writer

--- a/yt/visualization/volume_rendering/tests/test_save_render.py
+++ b/yt/visualization/volume_rendering/tests/test_save_render.py
@@ -40,4 +40,8 @@ class SaveRenderTest(TestCase):
         sc.save(os.path.join(self.tmpdir, "clip_2.png"), sigma_clip=2.0, render=False)
         sc.save(os.path.join(self.tmpdir, "clip_4.png"), sigma_clip=4.0, render=False)
 
+        # save a different format with/without sigma clips
+        sc.save(os.path.join(self.tmpdir, "no_clip.jpg"), render=False)
+        sc.save(os.path.join(self.tmpdir, "clip_2.jpg"), sigma_clip=2, render=False)
+
         return sc


### PR DESCRIPTION
This closes #3979 and fixes an unreported bug in which not providing a `sigma_clip` value while trying to save a non-png results in a crash. 

There were several spots where `sigma_clip` was used to calculated a clipping value, the version in `save_annotated` incorrectly included the alpha channel in the calculation. I added a `ImageArray._clipping_value` method to cut down on some of the duplicate code.

Here's a script based on the cookbook example mentioned in #3979 

```python
import yt
ds = yt.load("Enzo_64/DD0043/data0043")
sc = yt.create_scene(ds, lens_type="perspective")
source = sc[0]
source.set_field(("gas", "density"))
source.set_log(True)
# Set up the camera parameters: focus, width, resolution, and image orientation
sc.camera.focus = ds.domain_center
sc.camera.resolution = 800
sc.camera.north_vector = [0, 0, 1]
sc.camera.position = [1.7, 1.7, 1.7]
sc.annotate_axes(alpha=0.02)
sc.annotate_domain(ds, color=[1, 1, 1, 0.01])
text_string = f"T = {float(ds.current_time.to('Gyr'))} Gyr"

sc.save_annotated("vol_annotated_6.png", sigma_clip=6, text_annotate=[[(0.1, 0.95), text_string]])
sc.save("vol_save_6.png", sigma_clip=6, render=False)
sc.save("vol_save_6.jpg", sigma_clip=6, render=False)
sc.save("vol_save.jpg", render=False)  # this one errors on main!
```

The `save_annotated` and `save` versions now match:

![vol_annotated_6](https://user-images.githubusercontent.com/22038879/175165758-67b601f2-2491-462d-98d8-11563b702a6c.png)
![vol_save_6](https://user-images.githubusercontent.com/22038879/175165759-13dd4bbc-527b-46d5-9850-016b7a42d43a.png)




