### PR TITLE
[BUGFIX] Fix incorrect variable names

### DIFF
--- a/yt/utilities/io_handler.py
+++ b/yt/utilities/io_handler.py
@@ -215,10 +215,10 @@ class BaseIOHandler:
                 rv[field_f] = np.concatenate(vals, axis=0).astype("float64")
             else:
                 shape = [0]
-                if field[1] in self._vector_fields:
-                    shape.append(self._vector_fields[field[1]])
-                elif field[1] in self._array_fields:
-                    shape.append(self._array_fields[field[1]])
+                if field_f[1] in self._vector_fields:
+                    shape.append(self._vector_fields[field_f[1]])
+                elif field_f[1] in self._array_fields:
+                    shape.append(self._array_fields[field_f[1]])
                 rv[field_f] = np.empty(shape, dtype="float64")
         return rv
 


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

This is a bugfix to the recent changes in PR #2416, that resulted in the buggy behavior seen in issue #3975.

Logic was included to ensure that chunks which contain no particle data have the correct shape for particle vector fields, but incorrect variable names were used. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->