### PR TITLE
Updating the linthresh guessing

### DIFF
--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -1001,8 +1001,9 @@ One can switch to `symlog
 <https://matplotlib.org/stable/api/_as_gen/matplotlib.colors.SymLogNorm.html?highlight=symlog#matplotlib.colors.SymLogNorm>`_
 by providing a "linear threshold" (``linthresh``) value.
 With ``linthresh="auto"`` yt will switch to symlog norm and guess an appropriate value
-automatically. Specifically the minimum absolute value in the image is used
-unless it's zero, in which case yt uses 1/1000 of the maximum value.
+automatically, with different behavior depending on the dynamic range of the data.
+When the dynamic range of the symlog scale is less than 15 orders of magnitude, the
+linthresh value will be the minimum absolute nonzero value, as in
 
 .. python-script::
 
@@ -1013,9 +1014,10 @@ unless it's zero, in which case yt uses 1/1000 of the maximum value.
    slc.set_log(("gas", "density"), linthresh="auto")
    slc.save()
 
-
-In some cases, you might find that the automatically selected linear threshold is not
-really suited to your dataset, for instance
+When the dynamic range of the symlog scale exceeds 15 orders of magnitude, the
+linthresh value is calculated as 1/10\ :sup:`15` of the maximum nonzero value in
+order to avoid possible floating point precision issues. The following plot
+triggers the dynamic range cutoff
 
 .. python-script::
 
@@ -1026,7 +1028,9 @@ really suited to your dataset, for instance
    p.set_log(("gas", "density"), linthresh="auto")
    p.save()
 
-An explicit value can be passed instead
+In the previous example, it is actually safe to expand the dynamic range and in
+other cases you may find that the selected linear threshold is not well suited to
+your dataset. To pass an explicit value instead
 
 .. python-script::
 

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -171,10 +171,10 @@ answer_tests:
   local_axialpix_009: # PR 3818
     - yt/geometry/coordinates/tests/test_axial_pixelization.py:test_axial_pixelization
 
-  local_cylindrical_background_014:  # PR 3818
+  local_cylindrical_background_015:  # PR 3818, 3986
     - yt/geometry/coordinates/tests/test_cylindrical_coordinates.py:test_noise_plots
 
-  local_spherical_background_008:  # PR 3818
+  local_spherical_background_009:  # PR 3818, 3986
     - yt/geometry/coordinates/tests/test_spherical_coordinates.py:test_noise_plots
 
   #local_particle_trajectory_001:

--- a/yt/visualization/_handlers.py
+++ b/yt/visualization/_handlers.py
@@ -373,13 +373,13 @@ class NormHandler:
         # the starting guess is the absolute value of the point closest to 0
         # (remember: neg_max is closer to 0 than neg_min)
         if has_pos and has_neg:
-            linthresh = np.min((np.abs(neg_max), pos_min))
+            linthresh = np.min((-neg_max, pos_min))
         elif has_pos:
             linthresh = pos_min
         elif has_neg:
-            linthresh = np.abs(neg_max)
+            linthresh = -neg_max
         else:
-            # this condition should handled before here in get_norm
+            # this condition should be handled before here in get_norm
             raise RuntimeError("No negative or positive values")
 
         log10_linthresh = np.log10(linthresh)
@@ -387,15 +387,15 @@ class NormHandler:
         # if either the pos or neg ranges exceed cutoff_sigdigs, then
         # linthresh is shifted to decrease the range to avoid floating point
         # precision errors in the normalization.
-        cutoff_sigdigs = 15.0  # max allowable range in significant digits
+        cutoff_sigdigs = 15  # max allowable range in significant digits
         if has_pos and np.log10(pos_max) - log10_linthresh > cutoff_sigdigs:
             linthresh = pos_max / (10.0**cutoff_sigdigs)
             log10_linthresh = np.log10(linthresh)
 
-        if has_neg and np.log10(np.abs(neg_min)) - log10_linthresh > cutoff_sigdigs:
+        if has_neg and np.log10(-neg_min) - log10_linthresh > cutoff_sigdigs:
             linthresh = np.abs(neg_min) / (10.0**cutoff_sigdigs)
 
-        if hasattr(linthresh, "units"):
+        if isinstance(linthresh, unyt_quantity):
             # if the original plot_data has units, linthresh will have units here
             return self.to_float(linthresh)
 

--- a/yt/visualization/_handlers.py
+++ b/yt/visualization/_handlers.py
@@ -7,6 +7,7 @@ import numpy as np
 import unyt as un
 from matplotlib.colors import Colormap, LogNorm, Normalize, SymLogNorm
 from packaging.version import Version
+from unyt import unyt_quantity
 
 from yt._typing import Quantity, Unit
 from yt.config import ytcfg
@@ -329,11 +330,9 @@ class NormHandler:
             if kw["vmin"] == kw["vmax"] or not np.any(finite_values_mask):
                 norm_type = Normalize
             elif kw["vmin"] <= 0:
-                # note: matplotlib >= 3.5.2 could use LogNorm here if vmin==0
-                # if we do the following: set vmin to the min nonzero value and
-                # supply the interpolation_stage='rgba' keyword arg to imshow.
-                # this would, however, change default behavior and break answer
-                # tests, so needs a wider discussion.
+                # note: see issue 3944 (and PRs and issues linked therein) for a
+                # discussion on when to switch to SymLog and related questions
+                # of how to calculate a default linthresh value.
                 norm_type = SymLogNorm
             else:
                 norm_type = LogNorm
@@ -380,7 +379,7 @@ class NormHandler:
             linthresh = -neg_max
         else:
             # this condition should be handled before here in get_norm
-            raise RuntimeError("No negative or positive values")
+            raise RuntimeError("No finite data points.")
 
         log10_linthresh = np.log10(linthresh)
 

--- a/yt/visualization/_handlers.py
+++ b/yt/visualization/_handlers.py
@@ -342,7 +342,7 @@ class NormHandler:
             if self.linthresh is not None:
                 linthresh = self.to_float(self.linthresh)
             else:
-                linthresh = self._guess_linthresh(data)
+                linthresh = self._guess_linthresh(data[finite_values_mask])
 
             kw.setdefault("linthresh", linthresh)
             if MPL_VERSION >= Version("3.2"):
@@ -353,7 +353,7 @@ class NormHandler:
 
         return norm_type(*args, **kw)
 
-    def _guess_linthresh(self, plot_data):
+    def _guess_linthresh(self, finite_plot_data):
         # data is an ImageArray or ColorbarHandler data
 
         # get the extrema for the negative and positive values separately
@@ -363,8 +363,8 @@ class NormHandler:
                 return np.nanmin(data), np.nanmax(data)
             return None, None
 
-        pos_min, pos_max = get_minmax(plot_data[plot_data > 0])
-        neg_min, neg_max = get_minmax(plot_data[plot_data < 0])
+        pos_min, pos_max = get_minmax(finite_plot_data[finite_plot_data > 0])
+        neg_min, neg_max = get_minmax(finite_plot_data[finite_plot_data < 0])
 
         has_pos = pos_min is not None
         has_neg = neg_min is not None

--- a/yt/visualization/_handlers.py
+++ b/yt/visualization/_handlers.py
@@ -354,7 +354,8 @@ class NormHandler:
         return norm_type(*args, **kw)
 
     def _guess_linthresh(self, finite_plot_data):
-        # data is an ImageArray or ColorbarHandler data
+        # finite_plot_data is the ImageArray or ColorbarHandler data, already
+        # filtered to be finite values
 
         # get the extrema for the negative and positive values separately
         # neg_min -> neg_max -> 0 -> pos_min -> pos_max
@@ -369,7 +370,8 @@ class NormHandler:
         has_pos = pos_min is not None
         has_neg = neg_min is not None
 
-        # the starting guess is the absolute value of the point closest to 0:
+        # the starting guess is the absolute value of the point closest to 0
+        # (remember: neg_max is closer to 0 than neg_min)
         if has_pos and has_neg:
             linthresh = np.min((np.abs(neg_max), pos_min))
         elif has_pos:

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -768,15 +768,57 @@ def test_symlog_min_zero():
 def test_symlog_extremely_small_vals():
     # check that the plot can be constructed without crashing
     # see https://github.com/yt-project/yt/issues/3858
+    # and https://github.com/yt-project/yt/issues/3944
     shape = (64, 64, 1)
     arr = np.full(shape, 5.0e-324)
     arr[0, 0] = -1e12
     arr[1, 1] = 200
-    d = {"scalar": arr}
+
+    arr2 = np.full(shape, 5.0e-324)
+    arr2[0, 0] = -1e12
+
+    arr3 = arr.copy()
+    arr3[4, 4] = 0.0
+
+    d = {"scalar_spans_0": arr, "tiny_vmax": arr2, "scalar_tiny_with_0": arr3}
 
     ds = load_uniform_grid(d, shape)
-    p = SlicePlot(ds, "z", ("stream", "scalar"))
-    p["stream", "scalar"]
+    for field in d.keys():
+        p = SlicePlot(ds, "z", field)
+        p["stream", field]
+
+
+def test_symlog_linthresh_gt_vmax():
+    # check that some more edge cases do not crash
+
+    # linthresh will end up being larger than vmax here. This is OK.
+    shape = (64, 64, 1)
+    arr = np.full(shape, -1e30)
+    arr[1, 1] = -1e27
+    arr[2, 2] = 1e-12
+    arr[3, 3] = 1e-10
+
+    arr2 = -1 * arr.copy()  # also check the reverse
+    d = {"linthresh_gt_vmax": arr, "linthresh_lt_vmin": arr2}
+
+    ds = load_uniform_grid(d, shape)
+    for field in d.keys():
+        p = SlicePlot(ds, "z", field)
+        p["stream", field]
+
+
+def test_symlog_symmetric():
+    # should run ok when abs(min negative) == abs(pos max)
+    shape = (64, 64, 1)
+    arr = np.full(shape, -1e30)
+    arr[1, 1] = -1e27
+    arr[2, 2] = 1e10
+    arr[3, 3] = 1e30
+    d = {"linthresh_symmetric": arr}
+
+    ds = load_uniform_grid(d, shape)
+    p = SlicePlot(ds, "z", "linthresh_symmetric")
+    p["stream", "linthresh_symmetric"]
 
 
 def test_nan_data():

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -783,7 +783,7 @@ def test_symlog_extremely_small_vals():
     d = {"scalar_spans_0": arr, "tiny_vmax": arr2, "scalar_tiny_with_0": arr3}
 
     ds = load_uniform_grid(d, shape)
-    for field in d.keys():
+    for field in d:
         p = SlicePlot(ds, "z", field)
         p["stream", field]
 
@@ -802,7 +802,7 @@ def test_symlog_linthresh_gt_vmax():
     d = {"linthresh_gt_vmax": arr, "linthresh_lt_vmin": arr2}
 
     ds = load_uniform_grid(d, shape)
-    for field in d.keys():
+    for field in d:
         p = SlicePlot(ds, "z", field)
         p["stream", field]
 


### PR DESCRIPTION
This is an attempt at updating how the linthresh value is calculated for SymLogNorms when not provided. Note that I based it off of #3849 , so I'm submitting in draft mode until that one is cleared. The changes here are simple enough that it should be easy to update this PR after #3849 is fully reviewed. 

IMO the linthresh calculation here nicely handles all of the concerns of #3944 without too much complexity. I need to update/add some tests and the docs would need a little updating, but it'd be great to get some feedback on the approach. 

Conceptually, the calculation here uses the minimum absolute nonzero value as a starting guess at linthresh (as in  #3295) but then limits the dynamic range of the symlog scale when necessary to avoid the floating point precision issues that caused the errors in #3858. The limiting is sensitive to the data so it does a decent job for a range of data distributions (and should not error for any).  

Some images:

```python
fn = 'FIRE_M12i_ref11/snapshot_600.hdf5'
ds = yt.load(fn)
p = yt.ProjectionPlot(ds, 'x', ('gas', 'density'), width=(30, 'Mpc'))
p.show()
```
![image](https://user-images.githubusercontent.com/22038879/175715226-8459a578-dbeb-4e33-941a-70904a429ca9.png)

And using the sample data from #3858 
```python
import yt

ds = yt.load('symlogsets/yt_bug_reproducer/plt04000')
slc = yt.SlicePlot(ds, "z", ("boxlib", "scalar"))
slc.show()
```

![image](https://user-images.githubusercontent.com/22038879/175718420-9e66cdcd-0e55-4d1c-9578-0ee1768db0a0.png)
