### PR TITLE
[BUG] adjust CFRadial's _is_valid

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -186,17 +186,6 @@ def pytest_configure(config):
             ),
         )
 
-    if find_spec("xarray") is not None:
-        # this can be removed when the related fix is published
-        # https://github.com/pydata/xarray/issues/6514
-        config.addinivalue_line(
-            "filterwarnings",
-            (
-                "ignore: SelectableGroups dict interface is deprecated. "
-                "Use select.:DeprecationWarning"
-            ),
-        )
-
 
 def pytest_collection_modifyitems(config, items):
     r"""

--- a/yt/frontends/cf_radial/data_structures.py
+++ b/yt/frontends/cf_radial/data_structures.py
@@ -16,9 +16,9 @@ from yt.data_objects.index_subobjects.grid_patch import AMRGridPatch
 from yt.data_objects.static_output import Dataset
 from yt.funcs import mylog
 from yt.geometry.grid_geometry_handler import GridIndex
+from yt.utilities.file_handler import NetCDF4FileHandler, warn_netcdf
 from yt.utilities.on_demand_imports import _xarray as xr
 
-from ...utilities.file_handler import NetCDF4FileHandler, warn_netcdf
 from .fields import CFRadialFieldInfo
 
 

--- a/yt/frontends/cf_radial/data_structures.py
+++ b/yt/frontends/cf_radial/data_structures.py
@@ -308,6 +308,7 @@ class CFRadialDataset(Dataset):
                 for c in [con, con.lower()]:
                     if hasattr(ds, c):
                         cons += getattr(ds, c)
+                        break
                 is_cfrad = "CF/Radial" in cons
         except (OSError, AttributeError, ImportError):
             return False

--- a/yt/frontends/cf_radial/data_structures.py
+++ b/yt/frontends/cf_radial/data_structures.py
@@ -308,7 +308,6 @@ class CFRadialDataset(Dataset):
                 for c in [con, con.lower()]:
                     if hasattr(ds, c):
                         cons += getattr(ds, c)
-                        break
                 is_cfrad = "CF/Radial" in cons
         except (OSError, AttributeError, ImportError):
             return False


### PR DESCRIPTION
This switches CFRadial's `_is_valid` method to use yt's  `NetCDF4FileHandler` instead of xarray following the nc4_cm1 frontend. xarray is still used for opening and loading data after the dataset is identified as a CFRadial dataset. 

Closes #3987 