### PR TITLE
ENH: Projections of a field's standard deviation

### DIFF
--- a/doc/source/analyzing/objects.rst
+++ b/doc/source/analyzing/objects.rst
@@ -609,7 +609,7 @@ This is equivalent to:
    proj = ds.proj(("gas", "density"), "x", data_source=reg, method="min")
    proj.plot()
 
-You can also compute the ``mean`` value, which accepts a field, axis and weight
+You can also compute the ``mean`` value, which accepts a field, axis, and weight
 function.  If the axis is not specified, it will return the average value of
 the specified field, weighted by the weight argument.  The weight argument
 defaults to ``ones``, which performs an arithmetic average.  For instance:
@@ -636,6 +636,34 @@ If an axis is provided, it will project along that axis and return it to you:
 
    rho_proj = reg.mean(("gas", "temperature"), axis="y", weight=("gas", "density"))
    rho_proj.plot()
+
+You can also compute the ``std`` (standard deviation), which accepts a field,
+axis, and weight function. If the axis is not specified, it will
+return the standard deviation of the specified field, weighted by the weight
+argument.  The weight argument defaults to ``ones``. For instance:
+
+.. code-block:: python
+
+   std_rho = reg.std(("gas", "density"))
+   std_rho_by_vol = reg.std(("gas", "density"), weight=("gas", "cell_volume"))
+
+This is equivalent to:
+
+.. code-block:: python
+
+   std_rho = reg.quantities.weighted_standard_deviation(
+       ("gas", "density"), weight_field=("index", "ones")
+   )
+   std_rho_by_vol = reg.quantities.weighted_standard_deviation(
+       ("gas", "density"), weight_field=("gas", "cell_volume")
+   )
+
+If an axis is provided, it will project along that axis and return it to you:
+
+.. code-block:: python
+
+   vy_std = reg.std(("gas", "velocity_y"), axis="y", weight=("gas", "density"))
+   vy_std.plot()
 
 The ``sum`` function will add all the values in the data object.  It accepts a
 field and, optionally, an axis.  If the axis is left unspecified, it will sum

--- a/doc/source/analyzing/objects.rst
+++ b/doc/source/analyzing/objects.rst
@@ -591,11 +591,23 @@ This is equivalent to:
 
 .. code-block:: python
 
-   proj = ds.proj(("gas", "density"), "x", data_source=reg, method="mip")
+   proj = ds.proj(("gas", "density"), "x", data_source=reg, method="max")
    proj.plot()
 
-The ``min`` operator does not do this, however, as a minimum intensity
-projection is not currently implemented.
+The same can be done with the ``min`` operation, computing a minimum
+intensity projection:
+
+.. code-block:: python
+
+   proj = reg.min(("gas", "density"), axis="x")
+   proj.plot()
+
+This is equivalent to:
+
+.. code-block:: python
+
+   proj = ds.proj(("gas", "density"), "x", data_source=reg, method="min")
+   proj.plot()
 
 You can also compute the ``mean`` value, which accepts a field, axis and weight
 function.  If the axis is not specified, it will return the average value of

--- a/doc/source/cookbook/simple_plots.rst
+++ b/doc/source/cookbook/simple_plots.rst
@@ -34,12 +34,21 @@ See :ref:`projection-plots` for more information.
 .. yt_cookbook:: simple_projection_weighted.py
 
 Simple Projections (Methods)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 And here we illustrate different methods for projection plots (integrate,
 minimum, maximum).
 
 .. yt_cookbook:: simple_projection_methods.py
+
+Simple Projections (Weighted Standard Deviation)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+And here we produce a density-weighted projection (weighted line integral)
+of the line-of-sight velocity from the same dataset (see :ref:`projection-plots`
+for more information).
+
+.. yt_cookbook:: simple_projection_stddev.py
 
 Simple Phase Plots
 ~~~~~~~~~~~~~~~~~~

--- a/doc/source/cookbook/simple_projection_stddev.py
+++ b/doc/source/cookbook/simple_projection_stddev.py
@@ -1,0 +1,16 @@
+import yt
+
+# Load the dataset.
+ds = yt.load("GalaxyClusterMerger/fiducial_1to3_b0.273d_hdf5_plt_cnt_0175")
+
+# Create density-weighted projections of standard deviation of the velocity
+# (weighted line integrals)
+
+for normal in "xyz":
+    yt.ProjectionPlot(
+        ds,
+        normal,
+        ("gas", f"velocity_{normal}"),
+        weight_field=("gas", "density"),
+        moment=2,
+    ).save()

--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -394,10 +394,16 @@ field is mathematically given by:
 in order to make a weighted projection of the standard deviation of a field
 along a line of sight, the ``moment`` keyword argument should be set to 2.
 
-``mip``:
+``max``:
 ++++++++
 
 This method picks out the maximum value of a field along the line of
+sight given by the axis parameter.
+
+``min``:
+++++++++
+
+This method picks out the minimum value of a field along the line of
 sight given by the axis parameter.
 
 ``sum``:

--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -343,46 +343,73 @@ Types of Projections
 """"""""""""""""""""
 
 There are several different methods of projections that can be made either
-when creating a projection with ds.proj() or when making a ProjectionPlot.
+when creating a projection with :meth:`~yt.static_output.Dataset.proj` or
+when making a :class:`~yt.visualization.plot_window.ProjectionPlot`.
 In either construction method, set the ``method`` keyword to be one of the
 following:
 
-``integrate`` (unweighted)
-    This is the default projection method. It simply integrates the
-    requested field  :math:`f(x)` along a line of sight  :math:`\hat{n}` ,
-    given by the axis parameter (e.g. :math:`\hat{i},\hat{j},` or
-    :math:`\hat{k}`).  The units of the projected field
-    :math:`g(X)` will be the units of the unprojected field  :math:`f(x)`
-    multiplied by the appropriate length unit, e.g., density in
-    :math:`\mathrm{g\ cm^{-3}}` will be projected to  :math:`\mathrm{g\ cm^{-2}}`.
+``integrate`` (unweighted):
++++++++++++++++++++++++++++
+
+This is the default projection method. It simply integrates the
+requested field :math:`f({\bf x})` along a line of sight :math:`\hat{\bf n}` ,
+given by the axis parameter (e.g. :math:`\hat{\bf i},\hat{\bf j},` or
+:math:`\hat{\bf k}`). The units of the projected field
+:math:`g({\bf X})` will be the units of the unprojected field :math:`f({\bf x})`
+multiplied by the appropriate length unit, e.g., density in
+:math:`\mathrm{g\ cm^{-3}}` will be projected to  :math:`\mathrm{g\ cm^{-2}}`.
 
 .. math::
 
-    g(X) = {\int\ {f(x)\hat{n}\cdot{dx}}}
+    g({\bf X}) = {\int\ {f({\bf x})\hat{\bf n}\cdot{d{\bf x}}}}
 
-``integrate`` (weighted)
-    When using the ``integrate``  method, a ``weight_field`` argument may also
-    be specified, which will produce a weighted projection.  :math:`w(x)`
-    is the field used as a weight. One common example would
-    be to weight the "temperature" field by the "density" field. In this case,
-    the units of the projected field are the same as the unprojected field.
+``integrate`` (weighted):
++++++++++++++++++++++++++
+
+When using the ``integrate``  method, a ``weight_field`` argument may also
+be specified, which will produce a weighted projection. :math:`w({\bf x})`
+is the field used as a weight. One common example would
+be to weight the "temperature" field by the "density" field. In this case,
+the units of the projected field are the same as the unprojected field.
 
 .. math::
 
-    g(X) = \frac{\int\ {f(x)w(x)\hat{n}\cdot{dx}}}{\int\ {w(x)\hat{n}\cdot{dx}}}
+    g({\bf X}) = \int\ {f({\bf x})\tilde{w}({\bf x})\hat{\bf n}\cdot{d{\bf x}}}
 
-``mip``
-    This method picks out the maximum value of a field along the line of
-    sight given by the axis parameter.
+where the "~" over :math:`w({\bf x})` reflects the fact that it has been normalized
+like so:
 
-``sum``
-    This method is the same as ``integrate``, except that it does not
-    multiply by a path length when performing the integration, and is just a
-    straight summation of the field along the given axis. The units of the
-    projected field will be the same as those of the unprojected field. This
-    method is typically only useful for datasets such as 3D FITS cubes where
-    the third axis of the dataset is something like velocity or frequency, and
-    should _only_ be used with fixed-resolution grid-based datasets.
+.. math::
+
+    \tilde{w}({\bf x}) = \frac{w({\bf x})}{\int\ {w({\bf x})\hat{\bf n}\cdot{d{\bf x}}}}
+
+For weighted projections using the ``integrate`` method, it is also possible
+to project the standard deviation of a field. In this case, the projected
+field is mathematically given by:
+
+.. math::
+
+    g({\bf X}) = \left[\int\ {f({\bf x})^2\tilde{w}({\bf x})\hat{\bf n}\cdot{d{\bf x}}} - \left(\int\ {f({\bf x})\tilde{w}({\bf x})\hat{\bf n}\cdot{d{\bf x}}}\right)^2\right]^{1/2}
+
+in order to make a weighted projection of the standard deviation of a field
+along a line of sight, the ``moment`` keyword argument should be set to 2.
+
+``mip``:
+++++++++
+
+This method picks out the maximum value of a field along the line of
+sight given by the axis parameter.
+
+``sum``:
+++++++++
+
+This method is the same as ``integrate``, except that it does not
+multiply by a path length when performing the integration, and is just a
+straight summation of the field along the given axis. The units of the
+projected field will be the same as those of the unprojected field. This
+method is typically only useful for datasets such as 3D FITS cubes where
+the third axis of the dataset is something like velocity or frequency, and
+should *only* be used with fixed-resolution grid-based datasets.
 
 .. _off-axis-projections:
 
@@ -444,8 +471,11 @@ to project along, and a field to project.  For example:
 
 ``OffAxisProjectionPlot`` objects can also be created with a number of
 keyword arguments, as described in
-:class:`~yt.visualization.plot_window.OffAxisProjectionPlot`
+:class:`~yt.visualization.plot_window.OffAxisProjectionPlot`.
 
+Like on-axis projections, the projection of the standard deviation
+of a weighted field can be created by setting ``moment=2`` in the call
+to :class:`~yt.visualization.plot_window.ProjectionPlot`.
 
 .. _slices-and-projections-in-spherical-geometry:
 

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -513,6 +513,10 @@ class YTQuadTreeProj(YTProj):
     field_parameters : dict of items
         Values to be passed as field parameters that can be
         accessed by generated fields.
+    moment : integer, optional
+        for a weighted projection, moment = 1 (the default) corresponds to a
+        weighted average. moment = 2 corresponds to a weighted standard
+        deviation.
 
     Examples
     --------

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -439,8 +439,8 @@ class YTParticleProj(YTProj):
         method="integrate",
         field_parameters=None,
         max_level=None,
-        moment=1,
         *,
+        moment=1,
         style=None,
     ):
         super().__init__(
@@ -539,8 +539,8 @@ class YTQuadTreeProj(YTProj):
         method="integrate",
         field_parameters=None,
         max_level=None,
-        moment=1,
         *,
+        moment=1,
         style=None,
     ):
         super().__init__(

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -352,9 +352,8 @@ class YTProj(YTSelectionContainer2D):
             self[i] = data.pop(i)
         mylog.info("Projection completed")
         if self.moment == 2:
-            for field in fields:
-                if field[1].startswith("tmp_") and field[1].endswith("_squared"):
-                    self.ds.field_info.pop(field)
+            for field in sfields:
+                self.ds.field_info.pop(field)
         self.tree = tree
 
     def to_pw(self, fields=None, center="c", width=None, origin="center-window"):

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -53,6 +53,7 @@ from yt.utilities.lib.pixelization_routines import (
     pixelize_sph_kernel_arbitrary_grid,
 )
 from yt.utilities.lib.quad_tree import QuadTree
+from yt.utilities.math_utils import compute_stddev_image
 from yt.utilities.minimal_representation import MinimalProjectionData
 from yt.utilities.parallel_tools.parallel_analysis_interface import (
     communication_system,
@@ -349,7 +350,7 @@ class YTProj(YTSelectionContainer2D):
             input_units = self._projected_units[field]
             fvals = field_data[fi].ravel()
             if self.moment == 2:
-                fvals = np.sqrt(field_data[fi + nfields].ravel() - fvals * fvals)
+                fvals = compute_stddev_image(field_data[fi + nfields].ravel(), fvals)
             self[field] = self.ds.arr(fvals, input_units)
         for i in list(data.keys()):
             self[i] = data.pop(i)

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -21,7 +21,14 @@ from yt.data_objects.selection_objects.data_selection_objects import (
 )
 from yt.fields.field_exceptions import NeedsGridType, NeedsOriginalGrid
 from yt.frontends.sph.data_structures import ParticleDataset
-from yt.funcs import get_memory_usage, is_sequence, iter_fields, mylog, only_on_root
+from yt.funcs import (
+    get_memory_usage,
+    is_sequence,
+    iter_fields,
+    mylog,
+    only_on_root,
+    validate_moment,
+)
 from yt.geometry import particle_deposit as particle_deposit
 from yt.geometry.coordinates.cartesian_coordinates import all_data
 from yt.loaders import load_uniform_grid
@@ -209,11 +216,7 @@ class YTProj(YTSelectionContainer2D):
             self.func = np.sum  # for the future
         else:
             raise NotImplementedError(self.method)
-        if moment == 2 and weight_field is None:
-            raise RuntimeError(
-                "Cannot compute the second moment of a projection "
-                "if weight_field=None!"
-            )
+        validate_moment(moment, weight_field)
         self.moment = moment
         self._set_center(center)
         self._projected_units = {}

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -182,8 +182,8 @@ class YTProj(YTSelectionContainer2D):
         method="integrate",
         field_parameters=None,
         max_level=None,
-        moment=1,
         *,
+        moment=1,
         style=None,
     ):
         super().__init__(axis, ds, field_parameters)
@@ -455,7 +455,7 @@ class YTParticleProj(YTProj):
             method,
             field_parameters,
             max_level,
-            moment,
+            moment=moment,
             style=style,
         )
 
@@ -555,7 +555,7 @@ class YTQuadTreeProj(YTProj):
             method,
             field_parameters,
             max_level,
-            moment,
+            moment=moment,
             style=style,
         )
 

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -3,9 +3,10 @@ import io
 import os
 import warnings
 import zipfile
-from functools import wraps
+from functools import partial, wraps
 from re import finditer
 from tempfile import NamedTemporaryFile, TemporaryFile
+from typing import Tuple
 
 import numpy as np
 from more_itertools import always_iterable
@@ -254,21 +255,18 @@ class YTProj(YTSelectionContainer2D):
         sfields = []
         if self.moment == 2:
 
-            def make_sq_field(fname):
-                def _sq_field(field, data):
-                    return data[fname] ** 2
+            def _sq_field(field, data, fname: Tuple[str, str]):
+                return data[fname] ** 2
 
-                return _sq_field
-
-            for field in fields:
-                fd = self.ds._get_field_info(*field)
+            for fname in fields:
+                fd = self.ds._get_field_info(*fname)
                 self.ds.add_field(
-                    (field[0], f"tmp_{field[1]}_squared"),
-                    make_sq_field(field),
+                    (fname[0], f"tmp_{fname[1]}_squared"),
+                    partial(_sq_field, fname=fname),
                     sampling_type=fd.sampling_type,
                     units=f"({fd.units})*({fd.units})",
                 )
-                sfields.append((field[0], f"tmp_{field[1]}_squared"))
+                sfields.append((fname[0], f"tmp_{fname[1]}_squared"))
         nfields = len(fields)
         nsfields = len(sfields)
         # We need a new tree for every single set of fields we add

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1014,7 +1014,8 @@ class YTDataContainer(abc.ABC):
         r"""Compute the minimum of a field.
 
         This will, in a parallel-aware fashion, compute the minimum of the
-        given field.  Supplying an axis is not currently supported.  If the max
+        given field. Supplying an axis will result in a return value of a
+        YTProjection, with method 'min' for minimum intensity.  If the min
         has already been requested, it will use the cached extrema value.
 
         Parameters
@@ -1026,12 +1027,13 @@ class YTDataContainer(abc.ABC):
 
         Returns
         -------
-        Scalar.
+        Either a scalar or a YTProjection.
 
         Examples
         --------
 
         >>> min_temp = reg.min(("gas", "temperature"))
+        >>> min_temp_proj = reg.min(("gas", "temperature"), axis=("index", "x"))
         """
         if axis is None:
             rv = tuple(self._compute_extrema(f)[0] for f in iter_fields(field))

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1257,7 +1257,7 @@ class YTDataContainer(abc.ABC):
             raise NotImplementedError(f"Unknown axis {axis}")
         return r
 
-    def integrate(self, field, weight=None, axis=None):
+    def integrate(self, field, weight=None, axis=None, moment=1):
         r"""Compute the integral (projection) of a field along an axis.
 
         This projects a field along an axis.
@@ -1285,7 +1285,9 @@ class YTDataContainer(abc.ABC):
         else:
             weight_field = None
         if axis in self.ds.coordinates.axis_name:
-            r = self.ds.proj(field, axis, data_source=self, weight_field=weight_field)
+            r = self.ds.proj(
+                field, axis, data_source=self, weight_field=weight_field, moment=moment
+            )
         else:
             raise NotImplementedError(f"Unknown axis {axis}")
         return r

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1257,7 +1257,7 @@ class YTDataContainer(abc.ABC):
             raise NotImplementedError(f"Unknown axis {axis}")
         return r
 
-    def integrate(self, field, weight=None, axis=None, moment=1):
+    def integrate(self, field, weight=None, axis=None, *, moment=1):
         r"""Compute the integral (projection) of a field along an axis.
 
         This projects a field along an axis.

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1270,6 +1270,10 @@ class YTDataContainer(abc.ABC):
             The field to weight the projection by
         axis : string
             The axis to project along.
+        moment : integer, optional
+            for a weighted projection, moment = 1 (the default) corresponds to a
+            weighted average. moment = 2 corresponds to a weighted standard
+            deviation.
 
         Returns
         -------

--- a/yt/data_objects/tests/test_projection.py
+++ b/yt/data_objects/tests/test_projection.py
@@ -127,9 +127,9 @@ def test_projection(pf):
             assert_rel_equal(v1, v2.in_units(v1.units), 10)
 
         # Test moment projections
-        def make_vsq_field(an):
+        def make_vsq_field(aname):
             def _vsquared(field, data):
-                return data["gas", f"velocity_{an}"] ** 2
+                return data["gas", f"velocity_{aname}"] ** 2
 
             return _vsquared
 

--- a/yt/data_objects/tests/test_projection.py
+++ b/yt/data_objects/tests/test_projection.py
@@ -125,6 +125,38 @@ def test_projection(pf):
             v1 = proj[("gas", "density")].sum()
             v2 = (dd[("gas", "density")] * dd[("index", f"d{an}")]).sum()
             assert_rel_equal(v1, v2.in_units(v1.units), 10)
+
+        # Test moment projections
+        def make_vsq_field(an):
+            def _vsquared(field, data):
+                return data["gas", f"velocity_{an}"] ** 2
+
+            return _vsquared
+
+        for ax, an in enumerate("xyz"):
+            ds.add_field(
+                ("gas", f"velocity_{an}_squared"),
+                make_vsq_field(an),
+                sampling_type="local",
+                units="cm**2/s**2",
+            )
+            proj1 = ds.proj(
+                [("gas", f"velocity_{an}"), ("gas", f"velocity_{an}_squared")],
+                ax,
+                weight_field=("gas", "density"),
+                moment=1,
+            )
+            proj2 = ds.proj(
+                ("gas", f"velocity_{an}"), ax, weight_field=("gas", "density"), moment=2
+            )
+            assert_rel_equal(
+                np.sqrt(
+                    proj1["gas", f"velocity_{an}_squared"]
+                    - proj1["gas", f"velocity_{an}"] ** 2
+                ),
+                proj2["gas", f"velocity_{an}"],
+                10,
+            )
     teardown_func(fns)
 
 

--- a/yt/fields/vector_operations.py
+++ b/yt/fields/vector_operations.py
@@ -121,6 +121,7 @@ def create_los_field(registry, basename, field_units, ftype="gas", slice_info=No
         function=_los_field,
         units=field_units,
         validators=validators,
+        display_name=r"\mathrm{Line of Sight %s}" % basename.capitalize(),
     )
 
 

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -1336,11 +1336,11 @@ def levenshtein_distance(seq1, seq2, max_dist=None):
 
 def validate_moment(moment, weight_field):
     if moment == 2 and weight_field is None:
-        raise RuntimeError(
-            "Cannot compute the second moment of a projection " "if weight_field=None!"
+        raise ValueError(
+            "Cannot compute the second moment of a projection if weight_field=None!"
         )
     if moment not in [1, 2]:
-        raise RuntimeError(
+        raise ValueError(
             "Weighted projections can only be made of averages "
             "(moment = 1) or standard deviations (moment = 2)!"
         )

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -1332,3 +1332,15 @@ def levenshtein_distance(seq1, seq2, max_dist=None):
         if matrix[x].min() > max_dist:
             return max_dist + 1
     return matrix[size_x - 1, size_y - 1]
+
+
+def validate_moment(moment, weight_field):
+    if moment == 2 and weight_field is None:
+        raise RuntimeError(
+            "Cannot compute the second moment of a projection " "if weight_field=None!"
+        )
+    if moment not in [1, 2]:
+        raise RuntimeError(
+            "Weighted projections can only be made of averages "
+            "(moment = 1) or standard deviations (moment = 2)!"
+        )

--- a/yt/geometry/coordinates/cartesian_coordinates.py
+++ b/yt/geometry/coordinates/cartesian_coordinates.py
@@ -14,6 +14,7 @@ from yt.utilities.lib.pixelization_routines import (
     pixelize_sph_kernel_projection,
     pixelize_sph_kernel_slice,
 )
+from yt.utilities.math_utils import compute_stddev_image
 from yt.utilities.nodal_data_utils import get_nodal_data
 
 from .coordinate_handler import (
@@ -451,7 +452,7 @@ class CartesianCoordinateHandler(CoordinateHandler):
                                 weight_field=chunk[weight].in_units(wounits),
                             )
                         normalization_2d_utility(buff2, weight_buff)
-                        buff = np.sqrt(buff2 - buff * buff)
+                        buff = compute_stddev_image(buff2, buff)
             elif isinstance(data_source, YTSlice):
                 smoothing_style = getattr(self.ds, "sph_smoothing_style", "scatter")
                 normalize = getattr(self.ds, "use_sph_normalization", True)

--- a/yt/geometry/coordinates/tests/test_sph_pixelization.py
+++ b/yt/geometry/coordinates/tests/test_sph_pixelization.py
@@ -1,0 +1,38 @@
+import yt
+from yt.testing import assert_rel_equal, requires_file
+from yt.utilities.math_utils import compute_stddev_image
+
+magneticum = "MagneticumCluster/snap_132"
+
+mag_kwargs = dict(
+    long_ids=True,
+    field_spec="magneticum_box2_hr",
+)
+
+
+@requires_file(magneticum)
+def test_sph_moment():
+    ds = yt.load(magneticum, **mag_kwargs)
+
+    def _vysq(field, data):
+        return data["gas", "velocity_y"] ** 2
+
+    ds.add_field(("gas", "vysq"), _vysq, sampling_type="local", units="cm**2/s**2")
+    prj1 = yt.ProjectionPlot(
+        ds,
+        "y",
+        [("gas", "velocity_y"), ("gas", "vysq")],
+        weight_field=("gas", "density"),
+        moment=1,
+        buff_size=(400, 400),
+    )
+    prj2 = yt.ProjectionPlot(
+        ds,
+        "y",
+        ("gas", "velocity_y"),
+        moment=2,
+        weight_field=("gas", "density"),
+        buff_size=(400, 400),
+    )
+    sigy = compute_stddev_image(prj1.frb["gas", "vysq"], prj1.frb["gas", "velocity_y"])
+    assert_rel_equal(sigy, prj2.frb["gas", "velocity_y"].d, 10)

--- a/yt/utilities/math_utils.py
+++ b/yt/utilities/math_utils.py
@@ -1544,6 +1544,32 @@ def get_sph_theta_component(vectors, theta, phi, normal):
 
 
 def compute_stddev_image(buff2, buff):
+    """
+    This function computes the standard deviation of a weighted projection.
+    It defines the standard deviation as sigma^2 = <v^2>-<v>^2, where the
+    brackets indicate averages (with the weight) and v is the field in
+    question.
+
+    There is the possibility that if the projection at a particular location
+    is of a constant or a single cell/particle, then <v^2> = <v>^2 and instead
+    of getting zero one gets roundoff error that results in sigma^2 < 0,
+    which is unphysical.
+
+    We handle this here by performing the subtraction and checking that any
+    and all negative values of sigma^2 can be attributed to roundoff and
+    thus be safely set to zero. We error out if this is not the case. There
+    are ways of computing the standard deviation that are designed to avoid
+    this catastrophic cancellation, but this would require rather substantial
+    and invasive changes to the projection machinery so for the time being
+    it is avoided.
+
+    Parameters
+    ----------
+    buff2 : ImageArray
+        The image of the weighted averge of the field squared
+    buff : ImageArray
+        The image of the weighted averge of the field
+    """
     buff1 = buff * buff
     y = buff2 - buff1
     close_negs = np.isclose(np.asarray(buff2), np.asarray(buff1))[y < 0.0]

--- a/yt/utilities/math_utils.py
+++ b/yt/utilities/math_utils.py
@@ -1541,3 +1541,17 @@ def get_sph_theta_component(vectors, theta, phi, normal):
     )
 
     return np.sum(vectors * thetahat, axis=0)
+
+
+def compute_stddev_image(buff2, buff):
+    buff1 = buff * buff
+    y = buff2 - buff1
+    close_negs = np.isclose(np.asarray(buff2), np.asarray(buff1))[y < 0.0]
+    if close_negs.all():
+        y[y < 0.0] = 0.0
+    else:
+        raise ValueError(
+            "Something went wrong, there are significant negative "
+            "variances in the standard deviation image!"
+        )
+    return np.sqrt(y)

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -1397,7 +1397,7 @@ class FITSOffAxisProjection(FITSImageData):
             image_res = (image_res, image_res)
         res = (image_res[0], image_res[1])
         if data_source is None:
-            source = ds
+            source = ds.all_data()
         else:
             source = data_source
         fields = source._determine_fields(list(iter_fields(fields)))

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -9,7 +9,7 @@ from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.data_objects.construction_data_containers import YTCoveringGrid
 from yt.data_objects.image_array import ImageArray
 from yt.fields.derived_field import DerivedField
-from yt.funcs import fix_axis, is_sequence, iter_fields, mylog
+from yt.funcs import fix_axis, is_sequence, iter_fields, mylog, validate_moment
 from yt.units import dimensions
 from yt.units.unit_object import Unit  # type: ignore
 from yt.units.yt_array import YTArray, YTQuantity
@@ -1384,11 +1384,7 @@ class FITSOffAxisProjection(FITSImageData):
         length_unit=None,
         moment=1,
     ):
-        if moment == 2 and weight_field is None:
-            raise RuntimeError(
-                "Cannot compute the second moment of a projection "
-                "if weight_field=None!"
-            )
+        validate_moment(moment, weight_field)
         center, dcenter = ds.coordinates.sanitize_center(center, 4)
         buf = {}
         width = ds.coordinates.sanitize_width(normal, width, depth)

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -1086,6 +1086,7 @@ class FITSProjection(FITSImageData):
         width=None,
         weight_field=None,
         length_unit=None,
+        *,
         moment=1,
         **kwargs,
     ):
@@ -1401,14 +1402,14 @@ class FITSOffAxisProjection(FITSImageData):
         else:
             source = data_source
         fields = source._determine_fields(list(iter_fields(fields)))
-        for fname in fields:
-            buf[fname] = off_axis_projection(
+        for item in fields:
+            buf[item] = off_axis_projection(
                 source,
                 center,
                 normal,
                 wd,
                 res,
-                fname,
+                item,
                 north_vector=north_vector,
                 method=method,
                 weight=weight_field,
@@ -1416,16 +1417,16 @@ class FITSOffAxisProjection(FITSImageData):
 
             if moment == 2:
 
-                def _sq_field(field, data, fname: Tuple[str, str]):
-                    return data[fname] ** 2
+                def _sq_field(field, data, item: Tuple[str, str]):
+                    return data[item] ** 2
 
-                fd = ds._get_field_info(*fname)
+                fd = ds._get_field_info(*item)
 
-                field_sq = (fname[0], f"tmp_{fname[1]}_squared")
+                field_sq = (item[0], f"tmp_{item[1]}_squared")
 
                 ds.add_field(
                     field_sq,
-                    partial(_sq_field, fname=fname),
+                    partial(_sq_field, item=item),
                     sampling_type=fd.sampling_type,
                     units=f"({fd.units})*({fd.units})",
                 )
@@ -1442,7 +1443,7 @@ class FITSOffAxisProjection(FITSImageData):
                     weight=weight_field,
                 ).swapaxes(0, 1)
 
-                buf[fname] = compute_stddev_image(buff2, buf[fname])
+                buf[item] = compute_stddev_image(buff2, buf[item])
 
                 ds.field_info.pop(field_sq)
 

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -1382,6 +1382,7 @@ class FITSOffAxisProjection(FITSImageData):
         depth=(1.0, "unitary"),
         method="integrate",
         length_unit=None,
+        *,
         moment=1,
     ):
         validate_moment(moment, weight_field)

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -13,6 +13,7 @@ from yt.funcs import fix_axis, is_sequence, iter_fields, mylog, validate_moment
 from yt.units import dimensions
 from yt.units.unit_object import Unit  # type: ignore
 from yt.units.yt_array import YTArray, YTQuantity
+from yt.utilities.math_utils import compute_stddev_image
 from yt.utilities.on_demand_imports import _astropy
 from yt.utilities.parallel_tools.parallel_analysis_interface import parallel_root_only
 from yt.visualization.fixed_resolution import FixedResolutionBuffer, ParticleImageBuffer
@@ -1442,7 +1443,7 @@ class FITSOffAxisProjection(FITSImageData):
                     weight=weight_field,
                 ).swapaxes(0, 1)
 
-                buf[field] = np.sqrt(buff2 - buf[field] * buf[field])
+                buf[field] = compute_stddev_image(buff2, buf[field])
 
                 ds.field_info.pop(field_sq)
 

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -13,6 +13,7 @@ from yt.utilities.lib.api import (  # type: ignore
     add_points_to_greyscale_image,
 )
 from yt.utilities.lib.pixelization_routines import pixelize_cylinder
+from yt.utilities.math_utils import compute_stddev_image
 from yt.utilities.on_demand_imports import _h5py as h5py
 
 from .volume_rendering.api import off_axis_projection
@@ -646,7 +647,7 @@ class OffAxisProjectionFixedResolutionBuffer(FixedResolutionBuffer):
                 north_vector=dd.north_vector,
                 method=dd.method,
             )
-            buff = np.sqrt(buff2 - buff * buff)
+            buff = compute_stddev_image(buff2, buff)
 
             self.ds.field_info.pop(item_sq)
 

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -646,7 +646,6 @@ class OffAxisProjectionFixedResolutionBuffer(FixedResolutionBuffer):
                 north_vector=dd.north_vector,
                 method=dd.method,
             )
-            self.ds.field_info.pop(item_sq)
             buff = np.sqrt(buff2 - buff * buff)
 
             self.ds.field_info.pop(item_sq)

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -614,6 +614,41 @@ class OffAxisProjectionFixedResolutionBuffer(FixedResolutionBuffer):
             north_vector=dd.north_vector,
             method=dd.method,
         )
+        if self.data_source.moment == 2:
+
+            def make_sq_field(fname):
+                def _sq_field(field, data):
+                    return data[fname] ** 2
+
+                return _sq_field
+
+            fd = self.ds._get_field_info(*item)
+
+            item_sq = (item[0], f"tmp_{item[1]}_squared")
+            self.ds.add_field(
+                item_sq,
+                make_sq_field(item),
+                sampling_type=fd.sampling_type,
+                units=f"({fd.units})*({fd.units})",
+            )
+
+            buff2 = off_axis_projection(
+                dd.dd,
+                dd.center,
+                dd.normal_vector,
+                width,
+                self.buff_size,
+                item,
+                weight=dd.weight_field,
+                volume=dd.volume,
+                no_ghost=dd.no_ghost,
+                interpolated=dd.interpolated,
+                north_vector=dd.north_vector,
+                method=dd.method,
+            )
+            self.ds.field_info.pop(item_sq)
+            buff = np.sqrt(buff2 - buff * buff)
+
         ia = ImageArray(buff.swapaxes(0, 1), info=self._get_info(item))
         self[item] = ia
         return ia

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -618,15 +618,15 @@ class OffAxisProjectionFixedResolutionBuffer(FixedResolutionBuffer):
         )
         if self.data_source.moment == 2:
 
-            def _sq_field(field, data, fname: Tuple[str, str]):
-                return data[fname] ** 2
+            def _sq_field(field, data, item: Tuple[str, str]):
+                return data[item] ** 2
 
             fd = self.ds._get_field_info(*item)
 
             item_sq = (item[0], f"tmp_{item[1]}_squared")
             self.ds.add_field(
                 item_sq,
-                partial(_sq_field, fname=item),
+                partial(_sq_field, item=item),
                 sampling_type=fd.sampling_type,
                 units=f"({fd.units})*({fd.units})",
             )

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -1,5 +1,6 @@
 import weakref
-from typing import TYPE_CHECKING, Dict, List, Optional
+from functools import partial
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 import numpy as np
 
@@ -617,18 +618,15 @@ class OffAxisProjectionFixedResolutionBuffer(FixedResolutionBuffer):
         )
         if self.data_source.moment == 2:
 
-            def make_sq_field(fname):
-                def _sq_field(field, data):
-                    return data[fname] ** 2
-
-                return _sq_field
+            def _sq_field(field, data, fname: Tuple[str, str]):
+                return data[fname] ** 2
 
             fd = self.ds._get_field_info(*item)
 
             item_sq = (item[0], f"tmp_{item[1]}_squared")
             self.ds.add_field(
                 item_sq,
-                make_sq_field(item),
+                partial(_sq_field, fname=item),
                 sampling_type=fd.sampling_type,
                 units=f"({fd.units})*({fd.units})",
             )

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -638,7 +638,7 @@ class OffAxisProjectionFixedResolutionBuffer(FixedResolutionBuffer):
                 dd.normal_vector,
                 width,
                 self.buff_size,
-                item,
+                item_sq,
                 weight=dd.weight_field,
                 volume=dd.volume,
                 no_ghost=dd.no_ghost,
@@ -648,6 +648,8 @@ class OffAxisProjectionFixedResolutionBuffer(FixedResolutionBuffer):
             )
             self.ds.field_info.pop(item_sq)
             buff = np.sqrt(buff2 - buff * buff)
+
+            self.ds.field_info.pop(item_sq)
 
         ia = ImageArray(buff.swapaxes(0, 1), info=self._get_info(item))
         self[item] = ia

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -559,11 +559,14 @@ class PlotContainer(abc.ABC):
         else:
             axis = None
         weight = None
+        stddev = None
         plot_type = self._plot_type
         if plot_type in ["Projection", "OffAxisProjection"]:
             weight = self.data_source.weight_field
             if weight is not None:
                 weight = weight[1].replace(" ", "_")
+            if self.data_source.moment == 2:
+                stddev = "standard_deviation"
         if "Cutting" in self.data_source.__class__.__name__:
             plot_type = "OffAxisSlice"
 
@@ -582,7 +585,8 @@ class PlotContainer(abc.ABC):
             name_elements.append(k.replace(" ", "_"))
             if weight:
                 name_elements.append(weight)
-
+            if stddev:
+                name_elements.append(stddev)
             name = "_".join(name_elements) + suffix
             names.append(v.save(name, mpl_kwargs))
         return names

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -565,7 +565,7 @@ class PlotContainer(abc.ABC):
             weight = self.data_source.weight_field
             if weight is not None:
                 weight = weight[1].replace(" ", "_")
-            if self.data_source.moment == 2:
+            if getattr(self.data_source, "moment", 1) == 2:
                 stddev = "standard_deviation"
         if "Cutting" in self.data_source.__class__.__name__:
             plot_type = "OffAxisSlice"

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1198,6 +1198,8 @@ class PWViewerMPL(PlotWindow):
 
             if colorbar_label is None:
                 colorbar_label = image.info["label"]
+                if hasattr(self, "moment"):
+                    colorbar_label = "%s Standard Deviation" % colorbar_label
                 if hasattr(self, "projected"):
                     colorbar_label = "$\\rm{Projected }$ %s" % colorbar_label
                 if units is None or units == "":
@@ -2049,6 +2051,7 @@ class AxisAlignedProjectionPlot(ProjectionPlot, PWViewerMPL):
         window_size=8.0,
         buff_size=(800, 800),
         aspect=None,
+        moment=1,
         *,
         axis=None,
     ):
@@ -2100,6 +2103,7 @@ class AxisAlignedProjectionPlot(ProjectionPlot, PWViewerMPL):
                 field_parameters=field_parameters,
                 method=method,
                 max_level=max_level,
+                moment=moment,
             )
         PWViewerMPL.__init__(
             self,
@@ -2117,6 +2121,7 @@ class AxisAlignedProjectionPlot(ProjectionPlot, PWViewerMPL):
         if axes_unit is None:
             axes_unit = get_axes_unit(width, ds)
         self.set_axes_unit(axes_unit)
+        self.moment = moment
 
 
 class OffAxisSlicePlot(SlicePlot, PWViewerMPL):

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1198,7 +1198,7 @@ class PWViewerMPL(PlotWindow):
 
             if colorbar_label is None:
                 colorbar_label = image.info["label"]
-                if hasattr(self, "moment"):
+                if getattr(self, "moment", 1) == 2:
                     colorbar_label = "%s Standard Deviation" % colorbar_label
                 if hasattr(self, "projected"):
                     colorbar_label = "$\\rm{Projected }$ %s" % colorbar_label
@@ -2105,6 +2105,7 @@ class AxisAlignedProjectionPlot(ProjectionPlot, PWViewerMPL):
                 max_level=max_level,
                 moment=moment,
             )
+        self.moment = moment
         PWViewerMPL.__init__(
             self,
             proj,
@@ -2121,7 +2122,6 @@ class AxisAlignedProjectionPlot(ProjectionPlot, PWViewerMPL):
         if axes_unit is None:
             axes_unit = get_axes_unit(width, ds)
         self.set_axes_unit(axes_unit)
-        self.moment = moment
 
 
 class OffAxisSlicePlot(SlicePlot, PWViewerMPL):
@@ -2496,6 +2496,8 @@ class OffAxisProjectionPlot(ProjectionPlot, PWViewerMPL):
         # reflects that
         if weight_field is None and OffAxisProj.method == "integrate":
             self.projected = True
+
+        self.moment = moment
 
         # Hard-coding the origin keyword since the other two options
         # aren't well-defined for off-axis data objects

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -2296,6 +2296,11 @@ class OffAxisProjectionDummyDataSource:
         data_source=None,
         moment=1,
     ):
+        if moment == 2 and weight is None:
+            raise RuntimeError(
+                "Cannot compute the second moment of a projection "
+                "if weight_field=None!"
+            )
         self.center = center
         self.ds = ds
         self.axis = 4  # always true for oblique data objects

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1899,78 +1899,78 @@ class AxisAlignedProjectionPlot(ProjectionPlot, PWViewerMPL):
         This is the dataset object corresponding to the
         simulation output to be plotted.
     normal : int or one of 'x', 'y', 'z'
-         An int corresponding to the axis to slice along (0=x, 1=y, 2=z)
-         or the axis name itself
+        An int corresponding to the axis to slice along (0=x, 1=y, 2=z)
+        or the axis name itself
     fields : string
-         The name of the field(s) to be plotted.
+        The name of the field(s) to be plotted.
     center : A sequence of floats, a string, or a tuple.
-         The coordinate of the center of the image. If set to 'c', 'center' or
-         left blank, the plot is centered on the middle of the domain. If set to
-         'max' or 'm', the center will be located at the maximum of the
-         ('gas', 'density') field. Centering on the max or min of a specific
-         field is supported by providing a tuple such as ("min","temperature") or
-         ("max","dark_matter_density"). Units can be specified by passing in *center*
-         as a tuple containing a coordinate and string unit name or by passing
-         in a YTArray. If a list or unitless array is supplied, code units are
-         assumed.
+        The coordinate of the center of the image. If set to 'c', 'center' or
+        left blank, the plot is centered on the middle of the domain. If set to
+        'max' or 'm', the center will be located at the maximum of the
+        ('gas', 'density') field. Centering on the max or min of a specific
+        field is supported by providing a tuple such as ("min","temperature") or
+        ("max","dark_matter_density"). Units can be specified by passing in *center*
+        as a tuple containing a coordinate and string unit name or by passing
+        in a YTArray. If a list or unitless array is supplied, code units are
+        assumed.
     width : tuple or a float.
-         Width can have four different formats to support windows with variable
-         x and y widths.  They are:
+        Width can have four different formats to support windows with variable
+        x and y widths.  They are:
 
-         ==================================     =======================
-         format                                 example
-         ==================================     =======================
-         (float, string)                        (10,'kpc')
-         ((float, string), (float, string))     ((10,'kpc'),(15,'kpc'))
-         float                                  0.2
-         (float, float)                         (0.2, 0.3)
-         ==================================     =======================
+        ==================================     =======================
+        format                                 example
+        ==================================     =======================
+        (float, string)                        (10,'kpc')
+        ((float, string), (float, string))     ((10,'kpc'),(15,'kpc'))
+        float                                  0.2
+        (float, float)                         (0.2, 0.3)
+        ==================================     =======================
 
-         For example, (10, 'kpc') requests a plot window that is 10 kiloparsecs
-         wide in the x and y directions, ((10,'kpc'),(15,'kpc')) requests a
-         window that is 10 kiloparsecs wide along the x axis and 15
-         kiloparsecs wide along the y axis.  In the other two examples, code
-         units are assumed, for example (0.2, 0.3) requests a plot that has an
-         x width of 0.2 and a y width of 0.3 in code units.  If units are
-         provided the resulting plot axis labels will use the supplied units.
+        For example, (10, 'kpc') requests a plot window that is 10 kiloparsecs
+        wide in the x and y directions, ((10,'kpc'),(15,'kpc')) requests a
+        window that is 10 kiloparsecs wide along the x axis and 15
+        kiloparsecs wide along the y axis.  In the other two examples, code
+        units are assumed, for example (0.2, 0.3) requests a plot that has an
+        x width of 0.2 and a y width of 0.3 in code units.  If units are
+        provided the resulting plot axis labels will use the supplied units.
     axes_unit : string
-         The name of the unit for the tick labels on the x and y axes.
-         Defaults to None, which automatically picks an appropriate unit.
-         If axes_unit is '1', 'u', or 'unitary', it will not display the
-         units, and only show the axes name.
+        The name of the unit for the tick labels on the x and y axes.
+        Defaults to None, which automatically picks an appropriate unit.
+        If axes_unit is '1', 'u', or 'unitary', it will not display the
+        units, and only show the axes name.
     origin : string or length 1, 2, or 3 sequence.
-         The location of the origin of the plot coordinate system. This
-         is typically represented by a '-' separated string or a tuple of
-         strings. In the first index the y-location is given by 'lower',
-         'upper', or 'center'. The second index is the x-location, given as
-         'left', 'right', or 'center'. Finally, whether the origin is
-         applied in 'domain' space, plot 'window' space or 'native'
-         simulation coordinate system is given. For example, both
-         'upper-right-domain' and ['upper', 'right', 'domain'] place the
-         origin in the upper right hand corner of domain space. If x or y
-         are not given, a value is inferred. For instance, 'left-domain'
-         corresponds to the lower-left hand corner of the simulation domain,
-         'center-domain' corresponds to the center of the simulation domain,
-         or 'center-window' for the center of the plot window. In the event
-         that none of these options place the origin in a desired location,
-         a sequence of tuples and a string specifying the
-         coordinate space can be given. If plain numeric types are input,
-         units of `code_length` are assumed. Further examples:
+        The location of the origin of the plot coordinate system. This
+        is typically represented by a '-' separated string or a tuple of
+        strings. In the first index the y-location is given by 'lower',
+        'upper', or 'center'. The second index is the x-location, given as
+        'left', 'right', or 'center'. Finally, whether the origin is
+        applied in 'domain' space, plot 'window' space or 'native'
+        simulation coordinate system is given. For example, both
+        'upper-right-domain' and ['upper', 'right', 'domain'] place the
+        origin in the upper right hand corner of domain space. If x or y
+        are not given, a value is inferred. For instance, 'left-domain'
+        corresponds to the lower-left hand corner of the simulation domain,
+        'center-domain' corresponds to the center of the simulation domain,
+        or 'center-window' for the center of the plot window. In the event
+        that none of these options place the origin in a desired location,
+        a sequence of tuples and a string specifying the
+        coordinate space can be given. If plain numeric types are input,
+        units of `code_length` are assumed. Further examples:
 
-         =============================================== ===============================
-         format                                          example
-         =============================================== ===============================
-         '{space}'                                       'domain'
-         '{xloc}-{space}'                                'left-window'
-         '{yloc}-{space}'                                'upper-domain'
-         '{yloc}-{xloc}-{space}'                         'lower-right-window'
-         ('{space}',)                                    ('window',)
-         ('{xloc}', '{space}')                           ('right', 'domain')
-         ('{yloc}', '{space}')                           ('lower', 'window')
-         ('{yloc}', '{xloc}', '{space}')                 ('lower', 'right', 'window')
-         ((yloc, '{unit}'), (xloc, '{unit}'), '{space}') ((0, 'm'), (.4, 'm'), 'window')
-         (xloc, yloc, '{space}')                            (0.23, 0.5, 'domain')
-         =============================================== ===============================
+        =============================================== ===============================
+        format                                          example
+        =============================================== ===============================
+        '{space}'                                       'domain'
+        '{xloc}-{space}'                                'left-window'
+        '{yloc}-{space}'                                'upper-domain'
+        '{yloc}-{xloc}-{space}'                         'lower-right-window'
+        ('{space}',)                                    ('window',)
+        ('{xloc}', '{space}')                           ('right', 'domain')
+        ('{yloc}', '{space}')                           ('lower', 'window')
+        ('{yloc}', '{xloc}', '{space}')                 ('lower', 'right', 'window')
+        ((yloc, '{unit}'), (xloc, '{unit}'), '{space}') ((0, 'm'), (.4, 'm'), 'window')
+        (xloc, yloc, '{space}')                            (0.23, 0.5, 'domain')
+        =============================================== ===============================
 
     right_handed : boolean
         Depreceated, please use flip_horizontal callback.
@@ -1978,45 +1978,49 @@ class AxisAlignedProjectionPlot(ProjectionPlot, PWViewerMPL):
         handed coordinate system with a north vector and the normal vector, the
         direction of the 'window' into the data.
     data_source : YTSelectionContainer Object
-         Object to be used for data selection.  Defaults to a region covering
-         the entire simulation.
+        Object to be used for data selection.  Defaults to a region covering
+        the entire simulation.
     weight_field : string
-         The name of the weighting field.  Set to None for no weight.
+        The name of the weighting field.  Set to None for no weight.
     max_level: int
-         The maximum level to project to.
+        The maximum level to project to.
     fontsize : integer
-         The size of the fonts for the axis, colorbar, and tick labels.
+        The size of the fonts for the axis, colorbar, and tick labels.
     method : string
-         The method of projection.  Valid methods are:
+        The method of projection.  Valid methods are:
 
-         "integrate" with no weight_field specified : integrate the requested
-         field along the line of sight.
+        "integrate" with no weight_field specified : integrate the requested
+        field along the line of sight.
 
-         "integrate" with a weight_field specified : weight the requested
-         field by the weighting field and integrate along the line of sight.
+        "integrate" with a weight_field specified : weight the requested
+        field by the weighting field and integrate along the line of sight.
 
-         "max" : pick out the maximum value of the field in the line of sight.
-         "min" : pick out the minimum value of the field in the line of sight.
+        "max" : pick out the maximum value of the field in the line of sight.
+        "min" : pick out the minimum value of the field in the line of sight.
 
-         "sum" : This method is the same as integrate, except that it does not
-         multiply by a path length when performing the integration, and is
-         just a straight summation of the field along the given axis. WARNING:
-         This should only be used for uniform resolution grid datasets, as other
-         datasets may result in unphysical images.
+        "sum" : This method is the same as integrate, except that it does not
+        multiply by a path length when performing the integration, and is
+        just a straight summation of the field along the given axis. WARNING:
+        This should only be used for uniform resolution grid datasets, as other
+        datasets may result in unphysical images.
     window_size : float
-         The size of the window in inches. Set to 8 by default.
+        The size of the window in inches. Set to 8 by default.
     aspect : float
-         The aspect ratio of the plot.  Set to None for 1.
+        The aspect ratio of the plot.  Set to None for 1.
     field_parameters : dictionary
-         A dictionary of field parameters than can be accessed by derived
-         fields.
+        A dictionary of field parameters than can be accessed by derived
+        fields.
     data_source: YTSelectionContainer object
-         Object to be used for data selection. Defaults to ds.all_data(), a
-         region covering the full domain
+        Object to be used for data selection. Defaults to ds.all_data(), a
+        region covering the full domain
     buff_size: length 2 sequence
-         Size of the buffer to use for the image, i.e. the number of resolution elements
-         used.  Effectively sets a resolution limit to the image if buff_size is
-         smaller than the finest gridding.
+        Size of the buffer to use for the image, i.e. the number of resolution elements
+        used. Effectively sets a resolution limit to the image if buff_size is
+        smaller than the finest gridding.
+    moment : integer, optional
+        for a weighted projection, moment = 1 (the default) corresponds to a
+        weighted average. moment = 2 corresponds to a weighted standard
+        deviation.
 
     Examples
     --------

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1207,7 +1207,7 @@ class PWViewerMPL(PlotWindow):
             if colorbar_label is None:
                 colorbar_label = image.info["label"]
                 if getattr(self, "moment", 1) == 2:
-                    colorbar_label = "%s Standard Deviation" % colorbar_label
+                    colorbar_label = "%s \\rm{Standard Deviation}" % colorbar_label
                 if hasattr(self, "projected"):
                     colorbar_label = "$\\rm{Projected }$ %s" % colorbar_label
                 if units is None or units == "":
@@ -2063,8 +2063,8 @@ class AxisAlignedProjectionPlot(ProjectionPlot, PWViewerMPL):
         window_size=8.0,
         buff_size=(800, 800),
         aspect=None,
-        moment=1,
         *,
+        moment=1,
         axis=None,
     ):
         if method == "mip":
@@ -2306,6 +2306,7 @@ class OffAxisProjectionDummyDataSource:
         north_vector=None,
         method="integrate",
         data_source=None,
+        *,
         moment=1,
     ):
         validate_moment(moment, weight)

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -2294,6 +2294,7 @@ class OffAxisProjectionDummyDataSource:
         north_vector=None,
         method="integrate",
         data_source=None,
+        moment=1,
     ):
         self.center = center
         self.ds = ds
@@ -2317,6 +2318,7 @@ class OffAxisProjectionDummyDataSource:
         self.north_vector = north_vector
         self.method = method
         self.orienter = Orientation(normal_vector, north_vector=north_vector)
+        self.moment = moment
 
     def _determine_fields(self, *args):
         return self.dd._determine_fields(*args)
@@ -2441,6 +2443,7 @@ class OffAxisProjectionPlot(ProjectionPlot, PWViewerMPL):
         interpolated=False,
         fontsize=18,
         method="integrate",
+        moment=1,
         data_source=None,
         buff_size=(800, 800),
     ):
@@ -2472,6 +2475,7 @@ class OffAxisProjectionPlot(ProjectionPlot, PWViewerMPL):
             north_vector=north_vector,
             method=method,
             data_source=data_source,
+            moment=moment,
         )
 
         validate_mesh_fields(OffAxisProj, fields)

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -2349,80 +2349,84 @@ class OffAxisProjectionPlot(ProjectionPlot, PWViewerMPL):
     fields : string
         The name of the field(s) to be plotted.
     center : A sequence of floats, a string, or a tuple.
-         The coordinate of the center of the image. If set to 'c', 'center' or
-         left blank, the plot is centered on the middle of the domain. If set to
-         'max' or 'm', the center will be located at the maximum of the
-         ('gas', 'density') field. Centering on the max or min of a specific
-         field is supported by providing a tuple such as ("min","temperature") or
-         ("max","dark_matter_density"). Units can be specified by passing in *center*
-         as a tuple containing a coordinate and string unit name or by passing
-         in a YTArray. If a list or unitless array is supplied, code units are
-         assumed.
+        The coordinate of the center of the image. If set to 'c', 'center' or
+        left blank, the plot is centered on the middle of the domain. If set to
+        'max' or 'm', the center will be located at the maximum of the
+        ('gas', 'density') field. Centering on the max or min of a specific
+        field is supported by providing a tuple such as ("min","temperature") or
+        ("max","dark_matter_density"). Units can be specified by passing in *center*
+        as a tuple containing a coordinate and string unit name or by passing
+        in a YTArray. If a list or unitless array is supplied, code units are
+        assumed.
     width : tuple or a float.
-         Width can have four different formats to support windows with variable
-         x and y widths.  They are:
+        Width can have four different formats to support windows with variable
+        x and y widths. They are:
 
-         ==================================     =======================
-         format                                 example
-         ==================================     =======================
-         (float, string)                        (10,'kpc')
-         ((float, string), (float, string))     ((10,'kpc'),(15,'kpc'))
-         float                                  0.2
-         (float, float)                         (0.2, 0.3)
-         ==================================     =======================
+        ==================================     =======================
+        format                                 example
+        ==================================     =======================
+        (float, string)                        (10,'kpc')
+        ((float, string), (float, string))     ((10,'kpc'),(15,'kpc'))
+        float                                  0.2
+        (float, float)                         (0.2, 0.3)
+        ==================================     =======================
 
-         For example, (10, 'kpc') requests a plot window that is 10 kiloparsecs
-         wide in the x and y directions, ((10,'kpc'),(15,'kpc')) requests a
-         window that is 10 kiloparsecs wide along the x axis and 15
-         kiloparsecs wide along the y axis.  In the other two examples, code
-         units are assumed, for example (0.2, 0.3) requests a plot that has an
-         x width of 0.2 and a y width of 0.3 in code units.  If units are
-         provided the resulting plot axis labels will use the supplied units.
+        For example, (10, 'kpc') requests a plot window that is 10 kiloparsecs
+        wide in the x and y directions, ((10,'kpc'),(15,'kpc')) requests a
+        window that is 10 kiloparsecs wide along the x axis and 15
+        kiloparsecs wide along the y axis.  In the other two examples, code
+        units are assumed, for example (0.2, 0.3) requests a plot that has an
+        x width of 0.2 and a y width of 0.3 in code units.  If units are
+        provided the resulting plot axis labels will use the supplied units.
     depth : A tuple or a float
-         A tuple containing the depth to project through and the string
-         key of the unit: (width, 'unit').  If set to a float, code units
-         are assumed
+        A tuple containing the depth to project through and the string
+        key of the unit: (width, 'unit'). If set to a float, code units
+        are assumed
     weight_field : string
-         The name of the weighting field.  Set to None for no weight.
+        The name of the weighting field.  Set to None for no weight.
     max_level: int
-         The maximum level to project to.
+        The maximum level to project to.
     axes_unit : string
-         The name of the unit for the tick labels on the x and y axes.
-         Defaults to None, which automatically picks an appropriate unit.
-         If axes_unit is '1', 'u', or 'unitary', it will not display the
-         units, and only show the axes name.
+        The name of the unit for the tick labels on the x and y axes.
+        Defaults to None, which automatically picks an appropriate unit.
+        If axes_unit is '1', 'u', or 'unitary', it will not display the
+        units, and only show the axes name.
     north_vector : a sequence of floats
-         A vector defining the 'up' direction in the plot.  This
-         option sets the orientation of the slicing plane.  If not
-         set, an arbitrary grid-aligned north-vector is chosen.
+        A vector defining the 'up' direction in the plot. This
+        option sets the orientation of the slicing plane. If not
+        set, an arbitrary grid-aligned north-vector is chosen.
     right_handed : boolean
         Depreceated, please use flip_horizontal callback.
         Whether the implicit east vector for the image generated is set to make a right
         handed coordinate system with a north vector and the normal vector, the
         direction of the 'window' into the data.
     fontsize : integer
-         The size of the fonts for the axis, colorbar, and tick labels.
+        The size of the fonts for the axis, colorbar, and tick labels.
     method : string
-         The method of projection.  Valid methods are:
+        The method of projection. Valid methods are:
 
-         "integrate" with no weight_field specified : integrate the requested
-         field along the line of sight.
+        "integrate" with no weight_field specified : integrate the requested
+        field along the line of sight.
 
-         "integrate" with a weight_field specified : weight the requested
-         field by the weighting field and integrate along the line of sight.
+        "integrate" with a weight_field specified : weight the requested
+        field by the weighting field and integrate along the line of sight.
 
-         "sum" : This method is the same as integrate, except that it does not
-         multiply by a path length when performing the integration, and is
-         just a straight summation of the field along the given axis. WARNING:
-         This should only be used for uniform resolution grid datasets, as other
-         datasets may result in unphysical images.
+        "sum" : This method is the same as integrate, except that it does not
+        multiply by a path length when performing the integration, and is
+        just a straight summation of the field along the given axis. WARNING:
+        This should only be used for uniform resolution grid datasets, as other
+        datasets may result in unphysical images.
+    moment : integer, optional
+        for a weighted projection, moment = 1 (the default) corresponds to a
+        weighted average. moment = 2 corresponds to a weighted standard
+        deviation.
     data_source: YTSelectionContainer object
-         Object to be used for data selection. Defaults to ds.all_data(), a
-         region covering the full domain
+        Object to be used for data selection. Defaults to ds.all_data(), a
+        region covering the full domain
     buff_size: length 2 sequence
-         Size of the buffer to use for the image, i.e. the number of resolution elements
-         used.  Effectively sets a resolution limit to the image if buff_size is
-         smaller than the finest gridding.
+        Size of the buffer to use for the image, i.e. the number of resolution elements
+        used. Effectively sets a resolution limit to the image if buff_size is
+        smaller than the finest gridding.
     """
     _plot_type = "OffAxisProjection"
     _frb_generator = OffAxisProjectionFixedResolutionBuffer

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -12,7 +12,15 @@ from unyt.exceptions import UnitConversionError
 from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.data_objects.image_array import ImageArray
 from yt.frontends.ytdata.data_structures import YTSpatialPlotDataset
-from yt.funcs import fix_axis, fix_unitary, is_sequence, iter_fields, mylog, obj_length
+from yt.funcs import (
+    fix_axis,
+    fix_unitary,
+    is_sequence,
+    iter_fields,
+    mylog,
+    obj_length,
+    validate_moment,
+)
 from yt.units.unit_object import Unit  # type: ignore
 from yt.units.unit_registry import UnitParseError  # type: ignore
 from yt.units.yt_array import YTArray, YTQuantity
@@ -2300,11 +2308,7 @@ class OffAxisProjectionDummyDataSource:
         data_source=None,
         moment=1,
     ):
-        if moment == 2 and weight is None:
-            raise RuntimeError(
-                "Cannot compute the second moment of a projection "
-                "if weight_field=None!"
-            )
+        validate_moment(moment, weight)
         self.center = center
         self.ds = ds
         self.axis = 4  # always true for oblique data objects

--- a/yt/visualization/tests/test_fits_image.py
+++ b/yt/visualization/tests/test_fits_image.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import tempfile
 
+import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 
 from yt.loaders import load
@@ -25,11 +26,8 @@ def test_fits_image():
     tmpdir = tempfile.mkdtemp()
     os.chdir(tmpdir)
 
-    fields = ("density", "temperature")
-    units = (
-        "g/cm**3",
-        "K",
-    )
+    fields = ("density", "temperature", "velocity_x", "velocity_y", "velocity_z")
+    units = ("g/cm**3", "K", "cm/s", "cm/s", "cm/s")
     ds = fake_random_ds(
         64, fields=fields, units=units, nprocs=16, length_unit=100.0, particles=10000
     )
@@ -208,6 +206,45 @@ def test_fits_image():
     assert pdfid["particle_mass"].header["BTYPE"] == "particle_mass"
     assert pdfid["particle_mass"].units == "g/cm**2"
 
+    # Test moments for projections
+    def _vysq(field, data):
+        return data["gas", "velocity_y"] ** 2
+
+    ds.add_field(("gas", "vysq"), _vysq, sampling_type="cell", units="cm**2/s**2")
+    fid8 = FITSProjection(
+        ds,
+        "y",
+        [("gas", "velocity_y"), ("gas", "vysq")],
+        moment=1,
+        weight_field=("gas", "density"),
+    )
+    fid9 = FITSProjection(
+        ds, "y", ("gas", "velocity_y"), moment=2, weight_field=("gas", "density")
+    )
+    sigy = np.sqrt(fid8["vysq"].data - fid8["velocity_y"].data ** 2)
+    assert_allclose(sigy, fid9["velocity_y"].data)
+
+    def _vlsq(field, data):
+        return data["gas", "velocity_los"] ** 2
+
+    ds.add_field(("gas", "vlsq"), _vlsq, sampling_type="cell", units="cm**2/s**2")
+    fid10 = FITSOffAxisProjection(
+        ds,
+        [1.0, -1.0, 1.0],
+        [("gas", "velocity_los"), ("gas", "vlsq")],
+        moment=1,
+        weight_field=("gas", "density"),
+    )
+    fid11 = FITSOffAxisProjection(
+        ds,
+        [1.0, -1.0, 1.0],
+        ("gas", "velocity_los"),
+        moment=2,
+        weight_field=("gas", "density"),
+    )
+    sigl = np.sqrt(fid10["vlsq"].data - fid10["velocity_los"].data ** 2)
+    assert_allclose(sigl, fid11["velocity_los"].data)
+
     # We need to manually close all the file descriptors so
     # that windows can delete the folder that contains them.
     ds2.close()
@@ -219,6 +256,8 @@ def test_fits_image():
         fid5,
         fid6,
         fid7,
+        fid8,
+        fid9,
         new_fid1,
         new_fid3,
         pfid,

--- a/yt/visualization/tests/test_fits_image.py
+++ b/yt/visualization/tests/test_fits_image.py
@@ -222,7 +222,7 @@ def test_fits_image():
         ds, "y", ("gas", "velocity_y"), moment=2, weight_field=("gas", "density")
     )
     sigy = np.sqrt(fid8["vysq"].data - fid8["velocity_y"].data ** 2)
-    assert_allclose(sigy, fid9["velocity_y"].data)
+    assert_allclose(sigy, fid9["velocity_y_stddev"].data)
 
     def _vlsq(field, data):
         return data["gas", "velocity_los"] ** 2
@@ -243,7 +243,7 @@ def test_fits_image():
         weight_field=("gas", "density"),
     )
     sigl = np.sqrt(fid10["vlsq"].data - fid10["velocity_los"].data ** 2)
-    assert_allclose(sigl, fid11["velocity_los"].data)
+    assert_allclose(sigl, fid11["velocity_los_stddev"].data)
 
     # We need to manually close all the file descriptors so
     # that windows can delete the folder that contains them.

--- a/yt/visualization/tests/test_offaxisprojection.py
+++ b/yt/visualization/tests/test_offaxisprojection.py
@@ -122,6 +122,7 @@ def test_offaxis_moment():
         [("gas", "velocity_los"), ("gas", "velocity_los_squared")],
         weight_field=("gas", "density"),
         moment=1,
+        buff_size=(400, 400),
     )
     p2 = OffAxisProjectionPlot(
         ds,
@@ -129,6 +130,7 @@ def test_offaxis_moment():
         ("gas", "velocity_los"),
         weight_field=("gas", "density"),
         moment=2,
+        buff_size=(400, 400),
     )
     assert_rel_equal(
         np.sqrt(

--- a/yt/visualization/tests/test_offaxisprojection.py
+++ b/yt/visualization/tests/test_offaxisprojection.py
@@ -8,6 +8,7 @@ import numpy as np
 from yt.testing import (
     assert_equal,
     assert_fname,
+    assert_rel_equal,
     expand_keywords,
     fake_octree_ds,
     fake_random_ds,
@@ -101,3 +102,38 @@ def test_field_cut_off_axis_octree():
     )
     p4rho = p4.frb[("gas", "density")]
     assert_equal(np.nanmin(p4rho[p4rho > 0.0]) >= 0.5, True)
+
+
+def test_offaxis_moment():
+    ds = fake_random_ds(64)
+
+    def _vlos_sq(field, data):
+        return data["gas", "velocity_los"] ** 2
+
+    ds.add_field(
+        ("gas", "velocity_los_squared"),
+        _vlos_sq,
+        sampling_type="local",
+        units="cm**2/s**2",
+    )
+    p1 = OffAxisProjectionPlot(
+        ds,
+        [1, 1, 1],
+        [("gas", "velocity_los"), ("gas", "velocity_los_squared")],
+        weight_field=("gas", "density"),
+        moment=1,
+    )
+    p2 = OffAxisProjectionPlot(
+        ds,
+        [1, 1, 1],
+        ("gas", "velocity_los"),
+        weight_field=("gas", "density"),
+        moment=2,
+    )
+    assert_rel_equal(
+        np.sqrt(
+            p1.frb["gas", "velocity_los_squared"] - p1.frb["gas", "velocity_los"] ** 2
+        ),
+        p2.frb["gas", "velocity_los"],
+        10,
+    )

--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -325,7 +325,10 @@ def off_axis_projection(
             return temp_weightfield
 
         data_source.ds.field_info.add_field(
-            weightfield, sampling_type="cell", function=_make_wf(item, weight)
+            weightfield,
+            sampling_type="cell",
+            function=_make_wf(item, weight),
+            units="",
         )
         # Now we have to tell the dataset to add it and to calculate
         # its dependencies..


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

Weighted projections are essentially averages along the line of sight of a field. For some fields (like velocity), projecting the weighted standard deviation is also a useful quantity. This PR adds that functionality for both on-axis and off-axis projections to yt, including `ProjectionPlot`s and projections to FITS images. The functionality is demonstrated in this notebook: 

https://gist.github.com/388e2b53d1b848fc19a125669d422cec

Still need to add docs ~~and tests~~. When viewing the diff, you may want to turn off changes in whitespace since I fixed the indentation of a bunch of docstrings. 

I'm not entirely crazy about what I had to do in order to take care of cancellations in the computation of the standard deviation in the final map--basically if we end up with a negative difference between the projection of the quantity squared and the square of the projected quantity, and it can be reasonably attributed to roundoff error, we simply set the difference to zero. There are ways to compute the standard deviation which avoids the cancellation, but doing it here would actually be pretty invasive as far as the projection machinery goes. 

I also fixed a number of issues I found with documentation regarding projections. 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
