### PR TITLE
MNT: cleanup now unneeded option for nbqa pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,9 +69,8 @@ repos:
   rev: 1.3.1
   hooks:
     - id: nbqa-pyupgrade
-      args: [--nbqa-mutate, --py37-plus]
+      args: [--py37-plus]
     - id: nbqa-isort
-      args: [--nbqa-mutate]
     - id: nbqa-flake8
       args: [--extend-ignore=E402]
       additional_dependencies: [


### PR DESCRIPTION
This flag is a no-op and has been deprecated for a year now, see
https://github.com/nbQA-dev/nbQA/pull/629