### PR TITLE
BUG: fix late-binding errors in closures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
     hooks:
     - id: flake8
       additional_dependencies: [
-        flake8-bugbear==21.9.1,
+        flake8-bugbear==22.7.1,
         flake8-logging-format==0.6.0,
         flake8-2020==1.6.1,
       ]
@@ -75,6 +75,6 @@ repos:
     - id: nbqa-flake8
       args: [--extend-ignore=E402]
       additional_dependencies: [
-        flake8-bugbear==21.9.1,
+        flake8-bugbear==22.7.1,
         flake8-logging-format==0.6.0,
       ]

--- a/yt/data_objects/tests/test_particle_trajectories.py
+++ b/yt/data_objects/tests/test_particle_trajectories.py
@@ -41,7 +41,7 @@ def test_orbit_traj():
     for field in pfields + vfields:
 
         def field_func(name):
-            return traj[field]
+            return traj[field]  # noqa: B023
 
         yield GenericArrayTest(ds, field_func, args=[field])
 
@@ -66,7 +66,7 @@ def test_etc_traj():
     for field in pfields + vfields + [("gas", "density")]:
 
         def field_func(name):
-            return traj[field]
+            return traj[field]  # noqa: B023
 
         yield GenericArrayTest(ds, field_func, args=[field])
 

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -617,7 +617,7 @@ class SimulationTimeSeries(DatasetSeries):
         if not outputs:
             return my_outputs
         for value in values:
-            outputs.sort(key=lambda obj: np.abs(value - obj[key]))
+            outputs.sort(key=lambda obj, value=value: np.abs(value - obj[key]))
             if (
                 tolerance is None or np.abs(value - outputs[0][key]) <= tolerance
             ) and outputs[0] not in my_outputs:

--- a/yt/frontends/exodus_ii/tests/test_outputs.py
+++ b/yt/frontends/exodus_ii/tests/test_outputs.py
@@ -84,6 +84,6 @@ def test_displacement_fields():
         for mesh in ds.index.meshes:
 
             def array_func():
-                return mesh.connectivity_coords
+                return mesh.connectivity_coords  # noqa: B023
 
             yield GenericArrayTest(ds, array_func, 12)

--- a/yt/frontends/ramses/fields.py
+++ b/yt/frontends/ramses/fields.py
@@ -1,4 +1,5 @@
 import os
+from functools import partial
 
 import numpy as np
 
@@ -279,25 +280,25 @@ class RAMSESFieldInfo(FieldInfoContainer):
             function=_temp_IR,
             units=self.ds.unit_system["temperature"],
         )
+
+        def _species_density(field, data, species: str):
+            return data["gas", f"{species}_fraction"] * data["gas", "density"]
+
+        def _species_mass(field, data, species: str):
+            return data["gas", f"{species}_density"] * data["index", "cell_volume"]
+
         for species in ["H_p1", "He_p1", "He_p2"]:
-
-            def _species_density(field, data):
-                return data["gas", f"{species}_fraction"] * data["gas", "density"]
-
             self.add_field(
                 ("gas", species + "_density"),
                 sampling_type="cell",
-                function=_species_density,
+                function=partial(_species_density, species=species),
                 units=self.ds.unit_system["density"],
             )
-
-            def _species_mass(field, data):
-                return data["gas", f"{species}_density"] * data["index", "cell_volume"]
 
             self.add_field(
                 ("gas", species + "_mass"),
                 sampling_type="cell",
-                function=_species_mass,
+                function=partial(_species_mass, species=species),
                 units=self.ds.unit_system["mass"],
             )
 

--- a/yt/frontends/ramses/io.py
+++ b/yt/frontends/ramses/io.py
@@ -130,7 +130,7 @@ class IOHandlerRAMSES(BaseIOHandler):
             # Gather fields by type to minimize i/o operations
             for ft in ftypes:
                 # Get all the fields of the same type
-                field_subs = list(filter(lambda f: f[0] == ft, fields))
+                field_subs = list(filter(lambda f, ft=ft: f[0] == ft, fields))
 
                 # Loop over subsets
                 for subset in chunk.objs:
@@ -213,7 +213,7 @@ class IOHandlerRAMSES(BaseIOHandler):
         for ptype in {f[0] for f in fields}:
 
             # Select relevant files
-            subs_fields = filter(lambda f: f[0] == ptype, fields)
+            subs_fields = filter(lambda f, ptype=ptype: f[0] == ptype, fields)
 
             ok = False
             for ph in subset.domain.particle_handlers:

--- a/yt/frontends/tipsy/io.py
+++ b/yt/frontends/tipsy/io.py
@@ -95,7 +95,7 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
             poff = data_file.field_offsets
             tp = data_file.total_particles
             f = open(data_file.filename, "rb")
-            for ptype in sorted(ptf, key=lambda a: poff.get(a, -1)):
+            for ptype in sorted(ptf, key=lambda a, poff=poff: poff.get(a, -1)):
                 if data_file.total_particles[ptype] == 0:
                     continue
                 f.seek(poff[ptype])

--- a/yt/visualization/volume_rendering/tests/test_vr_orientation.py
+++ b/yt/visualization/volume_rendering/tests/test_vr_orientation.py
@@ -93,7 +93,7 @@ def test_orientation():
         )
 
         def offaxis_image_func(filename_prefix):
-            return image.write_image(filename_prefix)
+            return image.write_image(filename_prefix)  # noqa: B023
 
         test5 = GenericImageTest(ds, offaxis_image_func, decimals)
         test5.prefix = f"oap_orientation_{i}"


### PR DESCRIPTION
## PR Summary

Follow up to #3994
Upgrade flake8-bugbear and fix newly detected gotchas: late-binding errors in closures

If, like me, you didn't know about this problem, here's a helpful blog post to explain what the problem is and its solution(s)
https://docs.python-guide.org/writing/gotchas/#late-binding-closures


Content:

- MNT: manually upgrade flake8-bugbear
- BUG: fix late-binding errors in closures, detected with flake8-bugbear (B023)
- MNT: add noqas to flase positives (B023) in generator based tests
