### PR TITLE
ENH: Update to fields used in Enzo answer testing

### DIFF
--- a/yt/frontends/enzo/answer_testing_support.py
+++ b/yt/frontends/enzo/answer_testing_support.py
@@ -96,7 +96,6 @@ class ShockTubeTest:
     def __call__(self):
         # Read in the ds
         ds = load(self.data_file)
-        ds.setup_deprecated_fields()
         exact = self.get_analytical_solution()
 
         ad = ds.all_data()

--- a/yt/frontends/enzo/answer_testing_support.py
+++ b/yt/frontends/enzo/answer_testing_support.py
@@ -100,7 +100,7 @@ class ShockTubeTest:
         exact = self.get_analytical_solution()
 
         ad = ds.all_data()
-        position = ad["x"]
+        position = ad[("index", "x")]
         for k in self.fields:
             field = ad[k].d
             for xmin, xmax in zip(self.left_edges, self.right_edges):
@@ -122,8 +122,8 @@ class ShockTubeTest:
         pos, dens, vel, pres, inte = np.loadtxt(self.solution_file, unpack=True)
         exact = {}
         exact["pos"] = pos
-        exact["Density"] = dens
-        exact["x-velocity"] = vel
-        exact["Pressure"] = pres
-        exact["ThermalEnergy"] = inte
+        exact[("gas", "density")] = dens
+        exact[("gas", "velocity_x")] = vel
+        exact[("gas", "pressure")] = pres
+        exact[("gas", "specific_thermal_energy")] = inte
         return exact

--- a/yt/utilities/cosmology.py
+++ b/yt/utilities/cosmology.py
@@ -83,6 +83,7 @@ class Cosmology:
         self.omega_radiation = float(omega_radiation)
         self.omega_lambda = float(omega_lambda)
         self.omega_curvature = float(omega_curvature)
+        hubble_constant = float(hubble_constant)
         if unit_registry is None:
             unit_registry = UnitRegistry(unit_system=unit_system)
             unit_registry.add("h", hubble_constant, dimensions.dimensionless, r"h")


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

This PR updates the field names to be tuples in the answer testing of the Enzo frontend. The `hubble_constant` parameter is also not necessarily always written as a float (i.e. 1), so it is read as an int, which causes problems in unyt downstream. Forcing it to be float at initialization.

<!--If it fixes an open issue, please link to the issue here.-->

<!-- Note that some of these check boxes may not apply to all pull requests -->

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
