### PR TITLE
DOC: fixup deprecated API in docs

### DIFF
--- a/doc/cheatsheet.tex
+++ b/doc/cheatsheet.tex
@@ -258,7 +258,7 @@ Plot callbacks are functions itemized in a registry that is attached to every pl
 \texttt{velocity(\textit{factor=},\textit{scale=},\textit{scale\_units=}, \textit{normalize=})} \textemdash\ Uses field "x-velocity" to draw quivers\\
 \texttt{magnetic\_field(\textit{factor=},\textit{scale=},\textit{scale\_units=}, \textit{normalize=})} \textemdash\ Uses field "Bx" to draw quivers\\
 \texttt{quiver(\textit{field\_x},\textit{field\_y},\textit{factor=},\textit{scale=},\textit{scale\_units=}, \textit{normalize=})} \\
-\texttt{contour(\textit{field=},\textit{ncont=},\textit{factor=},\textit{clim=},\textit{take\_log=}, \textit{additional parameters})} \textemdash Plots a number of contours \textit{ncont} to interpolate \textit{field} optionally using \textit{take\_log}, upper and lower \textit{c}ontour\textit{lim}its and \textit{factor} number of points in the interpolation.\\
+\texttt{contour(\textit{field=},\textit{levels=},\textit{factor=},\textit{clim=},\textit{take\_log=}, \textit{additional parameters})} \textemdash Plots a number of contours \textit{ncont} to interpolate \textit{field} optionally using \textit{take\_log}, upper and lower \textit{c}ontour\textit{lim}its and \textit{factor} number of points in the interpolation.\\
 \texttt{grids(\textit{alpha=}, \textit{draw\_ids=}, \textit{periodic=}, \textit{min\_level=}, \textit{max\_level=})} \textemdash Add grid boundaries. \\
 \texttt{streamlines(\textit{field\_x},\textit{field\_y},\textit{factor=},\textit{density=})}\\
 \texttt{clumps(\textit{clumplist})} \textemdash\ Generate \textit{clumplist} using the clump finder and plot. \\

--- a/doc/source/analyzing/filtering.rst
+++ b/doc/source/analyzing/filtering.rst
@@ -313,7 +313,7 @@ distributed throughout the dataset.
     )
 
     # Mark the center with a big X
-    prj.annotate_marker(center, "x", plot_args={"s": 100})
+    prj.annotate_marker(center, "x", s=100)
 
     prj.show()
 

--- a/doc/source/cookbook/annotations.py
+++ b/doc/source/cookbook/annotations.py
@@ -9,11 +9,9 @@ p.annotate_sphere(
     coord_system="data",
     circle_args={"color": "green", "linewidth": 4, "linestyle": "dashed"},
 )
-p.annotate_arrow([0.87, 0.59, 0.2], coord_system="data", plot_args={"color": "red"})
+p.annotate_arrow([0.87, 0.59, 0.2], coord_system="data", color="red")
 p.annotate_text([10, 20], "Some halos", coord_system="plot")
-p.annotate_marker(
-    [0.45, 0.1, 0.4], coord_system="data", plot_args={"color": "yellow", "s": 500}
-)
+p.annotate_marker([0.45, 0.1, 0.4], coord_system="data", color="yellow", s=500)
 p.annotate_line([0.2, 0.4], [0.3, 0.9], coord_system="axis")
 p.annotate_timestamp(redshift=True)
 p.annotate_scale()

--- a/doc/source/cookbook/simple_contour_in_slice.py
+++ b/doc/source/cookbook/simple_contour_in_slice.py
@@ -9,7 +9,7 @@ sp = yt.SlicePlot(ds, "x", ("gas", "density"))
 # Overlay the slice plot with thick red contours of density.
 sp.annotate_contour(
     ("gas", "density"),
-    ncont=3,
+    levels=3,
     clim=(1e-2, 1e-1),
     label=True,
     plot_args={"colors": "red", "linewidths": 2},
@@ -18,7 +18,7 @@ sp.annotate_contour(
 # What about some nice temperature contours in blue?
 sp.annotate_contour(
     ("gas", "temperature"),
-    ncont=3,
+    levels=3,
     clim=(1e-8, 1e-6),
     label=True,
     plot_args={"colors": "blue", "linewidths": 2},

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -3112,8 +3112,9 @@ Gridding Behavior
 
 When you load a CfRadial dataset in polar coordinates (elevation, azimuth and
 range), yt will first build a sample by mapping the data onto a cartesian grid
-using the Python-ARM Radar Toolkit (`pyart<https://github.com/ARM-DOE/pyart>`_). Grid points are found by interpolation of all data points within a specified radius of influence. This data, now
-in x, y, z coordiante domain is then saved as a new dataset and subsequent
+using the Python-ARM Radar Toolkit (`pyart <https://github.com/ARM-DOE/pyart>`_).
+Grid points are found by interpolation of all data points within a specified radius of influence.
+This data, now in x, y, z coordiante domain is then saved as a new dataset and subsequent
 loads of the original native CfRadial dataset will use the gridded file.
 Mapping the data from spherical to Cartesian coordinates is useful for 3D volume
 rendering the data using yt.

--- a/doc/source/reference/api/api.rst
+++ b/doc/source/reference/api/api.rst
@@ -454,7 +454,6 @@ Loading Data
 .. autosummary::
 
    ~yt.loaders.load
-   ~yt.loaders.simulation
    ~yt.loaders.load_uniform_grid
    ~yt.loaders.load_amr_grids
    ~yt.loaders.load_particles
@@ -535,7 +534,6 @@ Field Functions
    ~yt.data_objects.static_output.Dataset.add_field
    ~yt.data_objects.static_output.Dataset.add_deposited_particle_field
    ~yt.data_objects.static_output.Dataset.add_mesh_sampling_particle_field
-   ~yt.data_objects.static_output.Dataset.add_smoothed_particle_field
    ~yt.data_objects.static_output.Dataset.add_gradient_fields
    ~yt.frontends.stream.data_structures.StreamParticlesDataset.add_sph_fields
 

--- a/doc/source/visualizing/callbacks.rst
+++ b/doc/source/visualizing/callbacks.rst
@@ -184,8 +184,7 @@ List Currently Applied Callbacks
 Overplot Arrow
 ~~~~~~~~~~~~~~
 
-.. function:: annotate_arrow(self, pos, length=0.03, coord_system='data', \
-                             plot_args=None)
+.. function:: annotate_arrow(self, pos, length=0.03, coord_system='data', **kwargs)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.ArrowCallback`.)
@@ -208,7 +207,7 @@ Overplot Arrow
 Clump Finder Callback
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: annotate_clumps(self, clumps, plot_args=None)
+.. function:: annotate_clumps(self, clumps, **kwargs)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.ClumpContourCallback`.)
@@ -273,8 +272,8 @@ Overplot Quivers
 Axis-Aligned Data Sources
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. function:: annotate_quiver(self, field_x, field_y, field_c=None, factor=16, scale=None, \
-                              scale_units=None, normalize=False, plot_args=None)
+.. function:: annotate_quiver(self, field_x, field_y, field_c=None, *, factor=16, scale=None, \
+                              scale_units=None, normalize=False, **kwargs)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.QuiverCallback`.)
@@ -341,8 +340,8 @@ And now using a continuous colormap
 Off-Axis Data Sources
 ^^^^^^^^^^^^^^^^^^^^^
 
-.. function:: annotate_cquiver(self, field_x, field_y, factor=16, scale=None, \
-                               scale_units=None, normalize=False, plot_args=None)
+.. function:: annotate_cquiver(self, field_x, field_y, field_c=None, *, factor=16, scale=None, \
+                               scale_units=None, normalize=False, **kwargs)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.CuttingQuiverCallback`.)
@@ -431,7 +430,7 @@ Overplot Cell Edges
 Overplot a Straight Line
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: annotate_line(self, p1, p2, coord_system='data', plot_args=None)
+.. function:: annotate_line(self, p1, p2, *, coord_system='data', **kwargs)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.LinePlotCallback`.)
@@ -454,9 +453,9 @@ Overplot a Straight Line
 Overplot Magnetic Field Quivers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: annotate_magnetic_field(self, factor=16, scale=None, \
+.. function:: annotate_magnetic_field(self, factor=16, *, scale=None, \
                                       scale_units=None, normalize=False, \
-                                      plot_args=None)
+                                      **kwargs)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.MagFieldCallback`.)
@@ -490,8 +489,7 @@ Overplot Magnetic Field Quivers
 Annotate a Point With a Marker
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: annotate_marker(self, pos, marker='x', coord_system='data', \
-                              plot_args=None)
+.. function:: annotate_marker(self, pos, marker='x', *, coord_system='data', **kwargs)
 
     (This is a proxy for
     :class:`~yt.visualization.plot_modifications.MarkerAnnotateCallback`.)
@@ -575,9 +573,9 @@ Overplot a Circle on a Plot
 Overplot Streamlines
 ~~~~~~~~~~~~~~~~~~~~
 
-.. function:: annotate_streamlines(self, field_x, field_y, factor=16, \
+.. function:: annotate_streamlines(self, field_x, field_y, *, factor=16, \
                                    density=1, display_threshold=None, \
-                                   plot_args=None)
+                                   **kwargs)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.StreamlineCallback`.)
@@ -678,8 +676,8 @@ Add a Title
 Overplot Quivers for the Velocity Field
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: annotate_velocity(self, factor=16, scale=None, scale_units=None, \
-                                normalize=False, plot_args=None)
+.. function:: annotate_velocity(self, factor=16, *, scale=None, scale_units=None, \
+                                normalize=False, **kwargs)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.VelocityCallback`.)
@@ -778,7 +776,7 @@ Add a Physical Scale Bar
 Annotate Triangle Facets Callback
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: annotate_triangle_facets(triangle_vertices, plot_args=None)
+.. function:: annotate_triangle_facets(triangle_vertices, **kwargs)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.TriangleFacetsCallback`.)
@@ -821,7 +819,7 @@ Annotate Triangle Facets Callback
 Annotate Mesh Lines Callback
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: annotate_mesh_lines(plot_args=None)
+.. function:: annotate_mesh_lines(**kwargs)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.MeshLinesCallback`.)
@@ -844,7 +842,7 @@ Annotate Mesh Lines Callback
 Overplot the Path of a Ray
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: annotate_ray(ray, plot_args=None)
+.. function:: annotate_ray(ray, *, arrow=False, **kwargs)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.RayCallback`.)

--- a/doc/source/visualizing/callbacks.rst
+++ b/doc/source/visualizing/callbacks.rst
@@ -81,7 +81,7 @@ of the x-plane (i.e. with axes in the y and z directions):
 
     # Plot marker and text in figure coords
     # N.B. marker will not render outside of axis bounds
-    s.annotate_marker((0.1, 0.2), coord_system="figure", plot_args={"color": "black"})
+    s.annotate_marker((0.1, 0.2), coord_system="figure", color="black")
     s.annotate_text(
         (0.1, 0.2),
         "figure: (0.1, 0.2)",
@@ -200,7 +200,7 @@ Overplot Arrow
 
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
    slc = yt.SlicePlot(ds, "z", ("gas", "density"), width=(10, "kpc"), center="c")
-   slc.annotate_arrow((0.5, 0.5, 0.5), length=0.06, plot_args={"color": "blue"})
+   slc.annotate_arrow((0.5, 0.5, 0.5), length=0.06, color="blue")
    slc.save()
 
 .. _annotate-clumps:
@@ -366,7 +366,7 @@ Off-Axis Data Sources
        ("gas", "cutting_plane_velocity_x"),
        ("gas", "cutting_plane_velocity_y"),
        factor=10,
-       plot_args={"color": "orange"},
+       color="orange",
    )
    s.zoom(1.5)
    s.save()
@@ -482,7 +482,7 @@ Overplot Magnetic Field Quivers
        },
    )
    p = yt.ProjectionPlot(ds, "z", ("gas", "density"), center="c", width=(300, "kpc"))
-   p.annotate_magnetic_field(plot_args={"headlength": 3})
+   p.annotate_magnetic_field(headlength=3)
    p.save()
 
 .. _annotate-marker:
@@ -504,7 +504,7 @@ Annotate a Point With a Marker
 
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
    s = yt.SlicePlot(ds, "z", ("gas", "density"), center="c", width=(10, "kpc"))
-   s.annotate_marker((-2, -2), coord_system="plot", plot_args={"color": "blue", "s": 500})
+   s.annotate_marker((-2, -2), coord_system="plot", color="blue", s=500)
    s.save()
 
 .. _annotate-particles:
@@ -698,7 +698,7 @@ Overplot Quivers for the Velocity Field
 
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
    p = yt.SlicePlot(ds, "z", ("gas", "density"), center="m", width=(10, "kpc"))
-   p.annotate_velocity(plot_args={"headwidth": 4})
+   p.annotate_velocity(headwidth=4)
    p.save()
 
 .. _annotate-timestamp:
@@ -813,7 +813,7 @@ Annotate Triangle Facets Callback
    points = coords[conn - 1]
 
    # Annotate slice-triangle intersection contours to the plot
-   s.annotate_triangle_facets(points, plot_args={"colors": "black"})
+   s.annotate_triangle_facets(points, colors="black")
    s.save()
 
 .. _annotate-mesh-lines:
@@ -836,7 +836,7 @@ Annotate Mesh Lines Callback
 
    ds = yt.load("MOOSE_sample_data/out.e")
    sl = yt.SlicePlot(ds, "z", ("connect1", "nodal_aux"))
-   sl.annotate_mesh_lines(plot_args={"color": "black"})
+   sl.annotate_mesh_lines(color="black")
    sl.save()
 
 .. _annotate-ray:

--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -556,7 +556,7 @@ We can also annotate the mesh lines, as follows:
 
    ds = yt.load("MOOSE_sample_data/out.e-s010")
    sl = yt.SlicePlot(ds, "z", ("connect1", "diffused"))
-   sl.annotate_mesh_lines(plot_args={"color": "black"})
+   sl.annotate_mesh_lines(color="black")
    sl.zoom(0.75)
    sl.save()
 

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -1650,7 +1650,7 @@ class ArrowCallback(PlotCallback):
                 "You can now pass arbitrary keyword arguments instead of a dictionary.",
                 since="4.1.0",
             )
-            plot_args = {**def_plot_args, **plot_args}
+            plot_args = {**def_plot_args, **plot_args, **kwargs}
         else:
             plot_args = def_plot_args
         self.plot_args = plot_args


### PR DESCRIPTION
## PR Summary

This is a follow up to https://github.com/yt-project/yt/pull/3957
fix a bunch of docs using deprecated API + fix a bug in `annotate_arrow` method where `**kwargs` were accepted, but ignored.
