### PR TITLE
BUG: fix a regression where @yt.derived_field decorator would crash

### DIFF
--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -1889,7 +1889,7 @@ class YTSurface(YTSelectionContainer3D):
         ...         * np.sqrt(data[("gas", "temperature")])
         ...     )
         >>> ds.add_field(
-        ...     "emissivity",
+        ...     ("gas", "emissivity"),
         ...     function=_Emissivity,
         ...     sampling_type="cell",
         ...     units=r"g**2*sqrt(K)/cm**6",
@@ -2224,7 +2224,7 @@ class YTSurface(YTSelectionContainer3D):
         ...         * data[("gas", "density")]
         ...         * np.sqrt(data[("gas", "temperature")])
         ...     )
-        >>> ds.add_field("emissivity", function=_Emissivity, units="g / cm**6")
+        >>> ds.add_field(("gas", "emissivity"), function=_Emissivity, units="g / cm**6")
         >>> for i, r in enumerate(rhos):
         ...     surf = ds.surface(sp, "density", r)
         ...     surf.export_obj(

--- a/yt/data_objects/tests/test_add_field.py
+++ b/yt/data_objects/tests/test_add_field.py
@@ -2,6 +2,8 @@ from functools import partial
 
 import pytest
 
+from yt import derived_field
+from yt.fields import local_fields
 from yt.testing import fake_random_ds
 
 
@@ -92,4 +94,18 @@ def test_add_field_keyword_only():
             ("bacon", "spam"),
             _spam,
             sampling_type="cell",
+        )
+
+
+def test_derived_field(monkeypatch):
+
+    tmp_field_info = local_fields.LocalFieldInfoContainer(None, [], None)
+    monkeypatch.setattr(local_fields, "local_fields", tmp_field_info)
+
+    @derived_field(name="pressure", sampling_type="cell", units="dyne/cm**2")
+    def _pressure(field, data):
+        return (
+            (data.ds.gamma - 1.0)
+            * data["gas", "density"]
+            * data["gas", "specific_thermal_energy"]
         )

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -315,12 +315,12 @@ class FieldInfoContainer(dict):
 
     def add_field(
         self,
-        name,
+        name: Tuple[str, str],
         function: Callable,
-        sampling_type,
+        sampling_type: str,
         *,
         alias: Optional[DerivedField] = None,
-        force_override=False,
+        force_override: bool = False,
         **kwargs,
     ):
         """
@@ -332,8 +332,8 @@ class FieldInfoContainer(dict):
         Parameters
         ----------
 
-        name : str
-           is the name of the field.
+        name : tuple[str, str]
+           field (or particle) type, field name
         function : callable
            A function handle that defines the field.  Should accept
            arguments (field, data)
@@ -403,22 +403,8 @@ class FieldInfoContainer(dict):
             self[name] = DerivedField(
                 name, sampling_type, function, alias=alias, **kwargs
             )
-            return
-
-        if sampling_type == "particle":
-            ftype = "all"
         else:
-            ftype = self.ds.default_fluid_type
-
-        if (ftype, name) not in self:
-            tuple_name = (ftype, name)
-            self[tuple_name] = DerivedField(
-                tuple_name, sampling_type, function, alias=alias, **kwargs
-            )
-        else:
-            self[name] = DerivedField(
-                name, sampling_type, function, alias=alias, **kwargs
-            )
+            raise ValueError(f"Expected name to be a tuple[str, str], got {name}")
 
     def load_all_plugins(self, ftype: Optional[str] = "gas"):
         if ftype is None:


### PR DESCRIPTION
## PR Summary
Closes #4001 and adds a basic test to avoid this regression comes back
I found that the `derived_field` decorator was not tested at all, and the way it's implemented right now is evidently fragile, so I may attempt a refactor to make it more maintainable in the future, but for this PR I'm just focusing on getting it in a working state again.
