### PR TITLE
BUG: Use format string 'd' not 'i' in grids

### DIFF
--- a/yt/data_objects/index_subobjects/grid_patch.py
+++ b/yt/data_objects/index_subobjects/grid_patch.py
@@ -143,7 +143,7 @@ class AMRGridPatch(YTSelectionContainer):
 
     def __repr__(self):
         cls_name = self.__class__.__name__
-        return f"{cls_name}_{self.id:04i} ({self.ActiveDimensions})"
+        return f"{cls_name}_{self.id:04d} ({self.ActiveDimensions})"
 
     def __int__(self):
         return self.id


### PR DESCRIPTION
The current behavior results in an error:

```
File "/home/mturk/yt/yt/yt/data_objects/index_subobjects/grid_patch.py", line 146, in __repr__                                                                                                                        return f"{cls_name}_{self.id:04i} ({self.ActiveDimensions})"                                                                                                                                                    ValueError: Unknown format code 'i' for object of type 'int'
```

This fixes that error.
