### PR TITLE
BUG: Make sure Boxlib DLE/DRE are correct index

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -142,7 +142,7 @@ answer_tests:
     - yt/frontends/boxlib/tests/test_outputs.py:test_units_override
     - yt/frontends/boxlib/tests/test_outputs.py:test_raw_fields
 
-  local_boxlib_particles_009:
+  local_boxlib_particles_010:
     - yt/frontends/boxlib/tests/test_outputs.py:test_LyA
     - yt/frontends/boxlib/tests/test_outputs.py:test_nyx_particle_io
     - yt/frontends/boxlib/tests/test_outputs.py:test_castro_particle_io

--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -372,7 +372,7 @@ class BoxlibHierarchy(GridIndex):
             if self.dimensionality < 2:
                 dx[i].append(DRE[1] - DLE[1])
             if self.dimensionality < 3:
-                dx[i].append(DRE[2] - DLE[1])
+                dx[i].append(DRE[2] - DLE[2])
         self.level_dds = np.array(dx, dtype="float64")
         next(header_file)
         if self.ds.geometry == "cartesian":


### PR DESCRIPTION
Fixes #3993.

This change uses the correct index for the z dimension when setting less-than-three-dimension boundaries.

The cascading set of things that happen as a result of this include the dds[2] set to 2.0, rather than 1.0, which in the particular cases identified by @NeilZaim set our point/grid selection to exclude the underlying grid.  With this change, we correctly set the grid *cell* size to not exceed the *domain* size, and now the selection process works OK.

The reason this was caught by the specific instance identified in the reproducer script was that we called the grid selector for setting the base chunk for `ad_particles` in that script, but then used `particle_select` rather than grid select, so the cached mask was incorrect.  When using the covering grid selection, we select based on integer indexes, which normally work, *unless* the mask is set to "none included" which was the case here.
