### PR TITLE
BUG: fix for composite volume rendering with octree sources

### DIFF
--- a/yt/utilities/lib/image_samplers.pyx
+++ b/yt/utilities/lib/image_samplers.pyx
@@ -267,7 +267,7 @@ cdef class ImageSampler:
                     continue
 
                 for i in range(Nch):
-                    idata.rgba[i] = 0
+                    idata.rgba[i] = self.image[vi, vj, i]
                 for i in range(8):
                     vc.mask[i] = 1
 


### PR DESCRIPTION
## PR Summary

Changes the octree sampler to initialize image pixel values to the initial image rather than 0 so that any already rendered sources (like points) will show up. 

The following works as expected now:

```python
import numpy as np

import yt
from yt.units import kpc
from yt.visualization.volume_rendering.api import PointSource

ds=yt.load_sample("output_00080")  # output_00080or "ramses_star_formation" or 

sc = yt.create_scene(ds, field=("gas","density"), lens_type="perspective")

# Random particle positions
np.random.seed(1234567)
npoints = 1000
vertices = np.random.random([npoints, 3])
colors = np.ones([npoints, 4])
colors[:,3]=0.01
points = PointSource(vertices, colors=colors, radii=np.full((npoints,), 2))
sc.add_source(points)

sc.show(sigma_clip=2)
```

![image](https://user-images.githubusercontent.com/22038879/178592084-97dab77c-6ee3-47a4-8515-bb72d9237920.png)

for reference, here is the output of the above code before this change:

![image](https://user-images.githubusercontent.com/22038879/178593093-d8cbf633-f37c-448b-9d49-4435cc5ee5ad.png)



Closes #4010


