### PR TITLE
MNT: cleanup dead function in setupext.py

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -9,7 +9,7 @@ import sys
 import tempfile
 from textwrap import dedent
 from concurrent.futures import ThreadPoolExecutor
-from distutils.ccompiler import CCompiler, new_compiler
+from distutils.ccompiler import new_compiler
 from distutils.sysconfig import customize_compiler
 from subprocess import PIPE, Popen
 from sys import platform as _platform
@@ -334,37 +334,6 @@ def get_cpu_count():
         ) from e
     max_cores = min(cpu_count, user_max_cores)
     return max_cores
-
-
-def install_ccompiler():
-    def _compile(
-        self,
-        sources,
-        output_dir=None,
-        macros=None,
-        include_dirs=None,
-        debug=0,
-        extra_preargs=None,
-        extra_postargs=None,
-        depends=None,
-    ):
-        """Function to monkey-patch distutils.ccompiler.CCompiler"""
-        macros, objects, extra_postargs, pp_opts, build = self._setup_compile(
-            output_dir, macros, include_dirs, sources, depends, extra_postargs
-        )
-        cc_args = self._get_cc_args(pp_opts, debug, extra_preargs)
-
-        for obj in objects:
-            try:
-                src, ext = build[obj]
-            except KeyError:
-                continue
-            self._compile(obj, src, ext, cc_args, extra_postargs, pp_opts)
-
-        # Return *all* object filenames, not just the ones we just built.
-        return objects
-
-    CCompiler.compile = _compile
 
 
 def create_build_ext(lib_exts, cythonize_aliases):


### PR DESCRIPTION
## PR Summary
This is another step to adress #3384 by removing dependencies to `distutils`

It looks to me that this function is never called, and its definition is the only reason why we import `distutils.ccompiler.CCompiler`, so it's should be trivial.

For context, I've also started taking action upstream to get rid of the final ties we have to it (https://github.com/pypa/setuptools/pull/3445)
