### PR TITLE
TMP: pin unyt to 2.8.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     pyparsing>0.0  # hard dependency to MPL. We require it (unconstrained) in case MPL drops it in the future
     tomli-w>=0.4.0
     tqdm>=3.4.0
-    unyt>=2.8.0
+    unyt==2.8.0
     tomli>=1.2.3;python_version < '3.11'
 python_requires = >=3.7,<3.12
 include_package_data = True


### PR DESCRIPTION
## PR Summary
Going to use this to try and identify the root cause of #4023 (unyt 2.9.0 is the main suspect, though I suspect it's not an actual regression), and potential fixes.
Opening the branch with an empty commit to show that tests fail even on the main branch.
