### PR TITLE
ENH: reduce import time by avoiding top-level expensive imports

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,11 +1,10 @@
 import os
 import shutil
+import sys
 import tempfile
 from importlib.util import find_spec
 from pathlib import Path
 
-import matplotlib
-import numpy
 import pytest
 import yaml
 from packaging.version import Version
@@ -20,8 +19,14 @@ from yt.utilities.answer_testing.testing_utilities import (
     data_dir_load,
 )
 
-MPL_VERSION = Version(matplotlib.__version__)
-NUMPY_VERSION = Version(numpy.__version__)
+if sys.version_info >= (3, 8):
+    from importlib.metadata import version
+else:
+    from importlib_metadata import version
+
+MPL_VERSION = Version(version("matplotlib"))
+NUMPY_VERSION = Version(version("numpy"))
+PILLOW_VERSION = Version(version("pillow"))
 
 
 def pytest_addoption(parser):
@@ -118,31 +123,18 @@ def pytest_configure(config):
             ),
         )
 
-    if MPL_VERSION < Version("3.5.2"):
-        if MPL_VERSION < Version("3.3"):
-            try:
-                import PIL
-            except ImportError:
-                PILLOW_INSTALLED = False
-            else:
-                PILLOW_INSTALLED = True
-        else:
-            # pillow became a hard dependency in matplotlib 3.3
-            import PIL
-
-            PILLOW_INSTALLED = True
-        if PILLOW_INSTALLED and Version(PIL.__version__) >= Version("9.1"):
-            # see https://github.com/matplotlib/matplotlib/pull/22766
-            config.addinivalue_line(
-                "filterwarnings",
-                r"ignore:NONE is deprecated and will be removed in Pillow 10 \(2023-07-01\)\. "
-                r"Use Resampling\.NEAREST or Dither\.NONE instead\.:DeprecationWarning",
-            )
-            config.addinivalue_line(
-                "filterwarnings",
-                r"ignore:ADAPTIVE is deprecated and will be removed in Pillow 10 \(2023-07-01\)\. "
-                r"Use Palette\.ADAPTIVE instead\.:DeprecationWarning",
-            )
+    if MPL_VERSION < Version("3.5.2") and PILLOW_VERSION >= Version("9.1"):
+        # see https://github.com/matplotlib/matplotlib/pull/22766
+        config.addinivalue_line(
+            "filterwarnings",
+            r"ignore:NONE is deprecated and will be removed in Pillow 10 \(2023-07-01\)\. "
+            r"Use Resampling\.NEAREST or Dither\.NONE instead\.:DeprecationWarning",
+        )
+        config.addinivalue_line(
+            "filterwarnings",
+            r"ignore:ADAPTIVE is deprecated and will be removed in Pillow 10 \(2023-07-01\)\. "
+            r"Use Palette\.ADAPTIVE instead\.:DeprecationWarning",
+        )
 
     if NUMPY_VERSION < Version("1.19") and MPL_VERSION < Version("3.3"):
         # This warning is triggered from matplotlib in exactly one test at the time of writing

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     numpy>=1.14.5
     packaging>=20.9
     pillow>=6.2.0 # transitive dependency via MPL (>=3.3)
-    pyparsing>=2.0.1  # transitive dependency via MPL(>=2.2.3)
+    pyparsing>=2.0.2  # transitive dependency via packaging and MPL
     tomli-w>=0.4.0
     tqdm>=3.4.0
     unyt>=2.8.0
@@ -105,6 +105,7 @@ minimal =
     more-itertools==8.4
     numpy==1.14.5
     pillow==6.2.0
+    pyparsing==2.0.2
     tomli-w==0.4.0
     unyt==2.8.0
     importlib-metadata==1.4;python_version < '3.8'

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ install_requires =
     tomli-w>=0.4.0
     tqdm>=3.4.0
     unyt>=2.8.0
+    importlib-metadata>=1.4;python_version < '3.8'
     tomli>=1.2.3;python_version < '3.11'
 python_requires = >=3.7,<3.12
 include_package_data = True
@@ -103,8 +104,10 @@ minimal =
     matplotlib==2.2.3
     more-itertools==8.4
     numpy==1.14.5
+    pillow==6.2.0
     tomli-w==0.4.0
     unyt==2.8.0
+    importlib-metadata==1.4;python_version < '3.8'
     tomli==1.2.3;python_version < '3.11'
 test =
     codecov~=2.0.15

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,8 @@ install_requires =
     more-itertools>=8.4
     numpy>=1.14.5
     packaging>=20.9
-    pyparsing>0.0  # hard dependency to MPL. We require it (unconstrained) in case MPL drops it in the future
+    pillow>=6.2.0 # transitive dependency via MPL (>=3.3)
+    pyparsing>=2.0.1  # transitive dependency via MPL(>=2.2.3)
     tomli-w>=0.4.0
     tqdm>=3.4.0
     unyt>=2.8.0

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -21,7 +21,6 @@ from functools import lru_cache, wraps
 from numbers import Number as numeric_type
 from typing import Any, Callable, Type
 
-import matplotlib
 import numpy as np
 from more_itertools import always_iterable, collapse, first
 from packaging.version import Version
@@ -566,6 +565,8 @@ def get_yt_version():
 
 
 def get_version_stack():
+    import matplotlib
+
     version_info = {}
     version_info["yt"] = get_yt_version()
     version_info["numpy"] = np.version.version

--- a/yt/sample_data/api.py
+++ b/yt/sample_data/api.py
@@ -9,8 +9,6 @@ from pathlib import Path
 from typing import Optional, Union
 from warnings import warn
 
-import pkg_resources
-
 from yt.config import ytcfg
 from yt.funcs import mylog
 from yt.utilities.on_demand_imports import (
@@ -90,6 +88,8 @@ def get_data_registry_table():
 
     The output of this function is cached so it will only generate one request per session.
     """
+
+    import pkg_resources
 
     # it would be nicer to have an actual api on the yt website server,
     # but this will do for now
@@ -183,6 +183,8 @@ def lookup_on_disk_data(fn) -> Path:
 
 @lru_cache(maxsize=128)
 def _get_pooch_instance():
+    import pkg_resources
+
     data_registry = get_data_registry_table()
     cache_storage = _get_test_data_dir_path() / "yt_download_cache"
 

--- a/yt/utilities/png_writer.py
+++ b/yt/utilities/png_writer.py
@@ -1,18 +1,10 @@
 from io import BytesIO
 
+from PIL import Image
+
 
 def call_png_write_png(buffer, fileobj, dpi):
-    try:
-        # matplotlib switched from an internal submodule _png to using pillow (PIL)
-        # between v3.1.0 and v3.3.0
-        # So PIL should be available on any system where matplotlib._png doesn't exist
-        import matplotlib._png as _png
-    except ImportError:
-        from PIL import Image
-    try:
-        _png.write_png(buffer, fileobj, dpi)
-    except NameError:
-        Image.fromarray(buffer).save(fileobj, dpi=(dpi, dpi), format="png")
+    Image.fromarray(buffer).save(fileobj, dpi=(dpi, dpi), format="png")
 
 
 def write_png(buffer, filename, dpi=100):

--- a/yt/utilities/png_writer.py
+++ b/yt/utilities/png_writer.py
@@ -1,15 +1,14 @@
 from io import BytesIO
 
-try:
-    # matplotlib switched from an internal submodule _png to using pillow (PIL)
-    # between v3.1.0 and v3.3.0
-    # So PIL should be available on any system where matplotlib._png doesn't exist
-    import matplotlib._png as _png
-except ImportError:
-    from PIL import Image
-
 
 def call_png_write_png(buffer, fileobj, dpi):
+    try:
+        # matplotlib switched from an internal submodule _png to using pillow (PIL)
+        # between v3.1.0 and v3.3.0
+        # So PIL should be available on any system where matplotlib._png doesn't exist
+        import matplotlib._png as _png
+    except ImportError:
+        from PIL import Image
     try:
         _png.write_png(buffer, fileobj, dpi)
     except NameError:

--- a/yt/visualization/_commons.py
+++ b/yt/visualization/_commons.py
@@ -4,18 +4,23 @@ import warnings
 from functools import wraps
 from typing import TYPE_CHECKING, Optional, Type, TypeVar
 
-import matplotlib
+if sys.version_info >= (3, 8):
+    from importlib.metadata import version
+else:
+    from importlib_metadata import version
+
 from packaging.version import Version
 
 if TYPE_CHECKING:
     from ._mpl_imports import FigureCanvasBase
 
-MPL_VERSION = Version(matplotlib.__version__)
 
 DEFAULT_FONT_PROPERTIES = {
     "family": "stixgeneral",
     "size": 18,
 }
+
+MPL_VERSION = Version(version("matplotlib"))
 
 if MPL_VERSION >= Version("3.4"):
     DEFAULT_FONT_PROPERTIES["math_fontfamily"] = "cm"

--- a/yt/visualization/_mpl_imports.py
+++ b/yt/visualization/_mpl_imports.py
@@ -1,3 +1,5 @@
+# these imports are very expensive so we delay them to until they are requested
+
 import matplotlib
 from matplotlib.backend_bases import FigureCanvasBase
 from matplotlib.backends.backend_agg import FigureCanvasAgg

--- a/yt/visualization/color_maps.py
+++ b/yt/visualization/color_maps.py
@@ -4,7 +4,6 @@ from typing import Tuple, Union
 import cmyt  # noqa: F401
 import numpy as np
 from matplotlib import cm as mcm, colors as cc
-from matplotlib.pyplot import get_cmap
 from packaging.version import Version
 
 from yt.funcs import get_brewer_cmap
@@ -49,17 +48,16 @@ def register_yt_colormaps_from_cmyt():
     For backwards compatibility, register yt colormaps without the "cmyt."
     prefix, but do it in a collision-safe way.
     """
-    from matplotlib.pyplot import get_cmap
 
     for hist_name, alias in _HISTORICAL_ALIASES.items():
         if MPL_VERSION >= Version("3.4.0"):
-            cmap = get_cmap(alias).copy()
+            cmap = mcm.get_cmap(alias).copy()
         else:
-            cmap = deepcopy(get_cmap(alias))
+            cmap = deepcopy(mcm.get_cmap(alias))
         cmap.name = hist_name
         try:
             mcm.register_cmap(cmap=cmap)
-            mcm.register_cmap(cmap=get_cmap(hist_name).reversed())
+            mcm.register_cmap(cmap=mcm.get_cmap(hist_name).reversed())
         except ValueError:
             # Matplotlib 3.4.0 hard-forbids name collisions, but more recent versions
             # will emit a warning instead, so we emulate this behaviour regardless.
@@ -97,7 +95,7 @@ def get_colormap_lut(cmap_id: Union[Tuple[str, str], str]):
     if isinstance(cmap_id, tuple) and len(cmap_id) == 2:
         cmap = get_brewer_cmap(cmap_id)
     elif isinstance(cmap_id, str):
-        cmap = get_cmap(cmap_id)
+        cmap = mcm.get_cmap(cmap_id)
     else:
         raise TypeError(
             "Expected a string or a 2-tuple of strings as a colormap id. "
@@ -184,7 +182,7 @@ def show_colormaps(subset="all", filename=None):
     for i, m in enumerate(maps):
         plt.subplot(1, l, i + 1)
         plt.axis("off")
-        plt.imshow(a, aspect="auto", cmap=plt.get_cmap(m), origin="lower")
+        plt.imshow(a, aspect="auto", cmap=mcm.get_cmap(m), origin="lower")
         plt.title(m, rotation=90, fontsize=10, verticalalignment="bottom")
     if filename is not None:
         plt.savefig(filename, dpi=100, facecolor="gray")

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -4,12 +4,9 @@ from numbers import Number
 from typing import List, Optional, Type, Union
 
 import matplotlib
-import matplotlib.pyplot as plt
 import numpy as np
 from more_itertools import always_iterable
-from mpl_toolkits.axes_grid1 import ImageGrid
 from packaging.version import Version
-from pyparsing import ParseFatalException
 from unyt.exceptions import UnitConversionError
 
 from yt._maintenance.deprecation import issue_deprecation_warning
@@ -1303,6 +1300,8 @@ class PWViewerMPL(PlotWindow):
                     colorbar_label += r"$\ \ \left(" + units + r"\right)$"
 
             parser = MathTextParser("Agg")
+            from pyparsing import ParseFatalException
+
             try:
                 parser.parse(colorbar_label)
             except ParseFatalException as err:
@@ -1495,6 +1494,8 @@ class PWViewerMPL(PlotWindow):
         >>> fig.savefig("test.png")
 
         """
+        import matplotlib.pyplot as plt
+        from mpl_toolkits.axes_grid1 import ImageGrid
 
         fig = plt.figure()
         grid = ImageGrid(

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -19,7 +19,7 @@ from yt.utilities.exceptions import YTNotInsideNotebook
 from yt.utilities.logger import ytLogger as mylog
 
 from ..data_objects.selection_objects.data_selection_objects import YTSelectionContainer
-from ._commons import DEFAULT_FONT_PROPERTIES, validate_image_name
+from ._commons import DEFAULT_FONT_PROPERTIES, MPL_VERSION, validate_image_name
 from .base_plot_types import ImagePlotMPL, PlotMPL
 from .plot_container import (
     ImagePlotContainer,
@@ -30,8 +30,6 @@ from .plot_container import (
     log_transform,
     validate_plot,
 )
-
-MPL_VERSION = Version(matplotlib.__version__)
 
 
 def invalidate_profile(f):


### PR DESCRIPTION
## PR Summary
Reduce yt's import time by 35-60%

This estimation was performed using other optimizations for core dependencies (cmyt and unyt).
To be clear, I'm comparing yt's import time with and without the present patch, but I'm including cmyt and unyt optimizations in both cases.

Here's the command I've used to measure and target main offenders:

```
python -X importtime -c "import yt" 2> tuna.log && tuna tuna.log
```
