### PR TITLE
ENH: only validate user-defined field functions (save inspection overhead)

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1677,6 +1677,9 @@ class Dataset(abc.ABC):
            on-disk fields.
 
         """
+        from yt.fields.field_functions import validate_field_function
+
+        validate_field_function(function)
         self.index
         if force_override and name in self.index.field_list:
             raise RuntimeError(

--- a/yt/data_objects/tests/test_add_field.py
+++ b/yt/data_objects/tests/test_add_field.py
@@ -55,9 +55,7 @@ def test_add_field_uncallable():
     class Spam:
         pass
 
-    with pytest.raises(
-        TypeError, match=r"Expected a callable object, got .* with type .*"
-    ):
+    with pytest.raises(TypeError, match=r"(is not a callable object)$"):
         ds.add_field(("bacon", "spam"), Spam(), sampling_type="cell")
 
 

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -1,4 +1,3 @@
-import inspect
 from collections.abc import Callable
 from numbers import Number as numeric_type
 from typing import Optional, Tuple
@@ -362,31 +361,6 @@ class FieldInfoContainer(dict):
             return
 
         kwargs.setdefault("ds", self.ds)
-
-        if not isinstance(function, Callable):  # type: ignore [arg-type]
-            # type-checking is disabled because of https://github.com/python/mypy/issues/11071
-            # this is compatible with lambdas and functools.partial objects
-            raise TypeError(
-                f"Expected a callable object, got {function} with type {type(function)}"
-            )
-
-        # lookup parameters that do not have default values
-        fparams = inspect.signature(function).parameters
-        nodefaults = tuple(p.name for p in fparams.values() if p.default is p.empty)
-        if nodefaults != ("field", "data"):
-            raise TypeError(
-                f"Received field function {function} with invalid signature. "
-                f"Expected exactly 2 positional parameters ('field', 'data'), got {nodefaults!r}"
-            )
-        if any(
-            fparams[name].kind == fparams[name].KEYWORD_ONLY
-            for name in ("field", "data")
-        ):
-            raise TypeError(
-                f"Received field function {function} with invalid signature. "
-                "Parameters 'field' and 'data' must accept positional values "
-                "(they cannot be keyword-only)"
-            )
 
         sampling_type = self._sanitize_sampling_type(sampling_type)
 

--- a/yt/fields/local_fields.py
+++ b/yt/fields/local_fields.py
@@ -17,6 +17,9 @@ class LocalFieldInfoContainer(FieldInfoContainer):
     def add_field(
         self, name, function, sampling_type, *, force_override=False, **kwargs
     ):
+        from yt.fields.field_functions import validate_field_function
+
+        validate_field_function(function)
         if isinstance(name, str) or not is_sequence(name):
             # the base method only accepts proper tuple field keys
             # and is only used internally, while this method is exposed to users


### PR DESCRIPTION
## PR Summary

`inspect.signature` is an expensive function

Using this simple profiling routine
```python
# t.py
import yt
ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
ds.r["gas", "density"]
```
```shell
python -m cProfile -o log.pstats t.py
gprof2dot --colour-nodes-by-selftime log.pstats | dot -Tsvg -o out.svg
```
I was able to measure that ~3.5% of the total runtime is spent validating field functions that are defined internally, so let's restrict its use to user-defined fields to minimise the overhead.

Follow up to #3921
