### PR TITLE
ENH: cache results from yt.fields.field_functions.get_periodic_rvec

### DIFF
--- a/yt/fields/field_functions.py
+++ b/yt/fields/field_functions.py
@@ -1,3 +1,5 @@
+from functools import lru_cache
+
 import numpy as np
 
 from yt.utilities.lib.misc_utilities import obtain_position_vector
@@ -40,6 +42,7 @@ def get_radius(data, field_prefix, ftype):
     return radius
 
 
+@lru_cache(maxsize=128)
 def get_periodic_rvec(data):
     coords = obtain_position_vector(data).d
     if sum(data.ds.periodicity) == 0:


### PR DESCRIPTION
## PR Summary
Another small performance optimization.
This reduces indexing time by about 10% to 25% for the classic IsolatedGalaxy dataset

Measured very non-scientifically with
```python
from time import monotonic_ns
import yt
ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")

tstart = monotonic_ns()
ds.index
tstop = monotonic_ns()

print(f"Indexing took {(tstop-tstart) / 1e6:.2e} ms")
```
I still get consistent speedups, from 1.2s (average baseline) to 1.0s with this patch (best run)
