### PR TITLE
MNT: remove upper bound for supported Python version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     tqdm>=3.4.0
     unyt>=2.8.0
     tomli>=1.2.3;python_version < '3.11'
-python_requires = >=3.7,<3.12
+python_requires = >=3.7
 include_package_data = True
 scripts = scripts/iyt
 zip_safe = False


### PR DESCRIPTION
## PR Summary

For context, see https://github.com/yt-project/yt/issues/3384, and https://github.com/pypa/setuptools/issues/2806
