### PR TITLE
DOC: add notes that only certain data types have support for off-axis operation

### DIFF
--- a/doc/source/cookbook/simple_plots.rst
+++ b/doc/source/cookbook/simple_plots.rst
@@ -59,6 +59,9 @@ See :ref:`manual-line-plots` for more information.
 
 .. yt_cookbook:: simple_1d_line_plot.py
 
+.. note:: Not every data types have support for ``yt.LinePlot`` yet.
+   Currently, this operation is supported for grid based data with cartesian geometry.
+
 Simple Probability Distribution Functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -289,6 +289,7 @@ of the image plane.
 
 .. note:: Not every data types have support for off-axis slices yet.
    Currently, this operation is supported for grid based data with cartesian geometry.
+   In some cases (like SPH data) an off-axis projection over a thin region might be used instead.
 
 .. _projection-plots:
 

--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -287,6 +287,9 @@ In this case, a normal vector for the cutting plane is supplied in the second
 argument. Optionally, a ``north_vector`` can be specified to fix the orientation
 of the image plane.
 
+.. note:: Not every data types have support for off-axis slices yet.
+   Currently, this operation is supported for grid based data with cartesian geometry.
+
 .. _projection-plots:
 
 Projection Plots
@@ -328,6 +331,10 @@ class description.
 If you want to project through a subset of the full dataset volume,
 you can use the ``data_source`` keyword with a :ref:`data object <data-objects>`.
 The :ref:`thin-slice-projections` recipes demonstrates this functionality.
+
+.. note:: Not every data types have support for off-axis projections yet.
+   Currently, this operation is supported for grid based data with cartesian geometry,
+   as well as SPH particles data.
 
 .. _projection-types:
 

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -603,9 +603,13 @@ class YTNonIndexedDataContainer(YTException):
         self.cont = cont
 
     def __str__(self):
+        class_name = self.cont.__class__.__name__
         return (
-            f"The data container type ({type(self.cont)}) is an unindexed type. "
-            "Operations such as ires, icoords, fcoords and fwidth will not work on it."
+            f"The data container type ({class_name}) is an unindexed type. "
+            "Operations such as ires, icoords, fcoords and fwidth will not work on it.\n"
+            "Did you just attempt to perform an off-axis operation ? "
+            "Be sure to consult the latest documentation to see whether the operation "
+            "you tried is actually supported for your data type."
         )
 
 


### PR DESCRIPTION
## PR Summary

Closes #4035

- DOC: add notes that only certain data types have support for off-axis operation
- UX: add information to error message
