### PR TITLE
Refactors oref to equal the number of zones along each dimension

### DIFF
--- a/yt/data_objects/index_subobjects/octree_subset.py
+++ b/yt/data_objects/index_subobjects/octree_subset.py
@@ -44,10 +44,10 @@ class OctreeSubset(YTSelectionContainer):
     _block_order = "C"
 
     def __init__(
-        self, base_region, domain, ds, over_refine_factor=1, num_ghost_zones=0
+        self, base_region, domain, ds, over_refine_factor=2, num_ghost_zones=0
     ):
         super().__init__(ds, None)
-        self._num_zones = 1 << (over_refine_factor)
+        self._num_zones = over_refine_factor
         self._num_ghost_zones = num_ghost_zones
         self._oref = over_refine_factor
         self.domain = domain
@@ -443,7 +443,7 @@ class OctreeSubset(YTSelectionContainer):
             [1, 1, 1],
             self.ds.domain_left_edge,
             self.ds.domain_right_edge,
-            over_refine=1,
+            over_refine=2,
         )
         particle_octree.n_ref = nneighbors * 2
         particle_octree.add(morton)
@@ -671,7 +671,7 @@ class YTPositionArray(unyt_array):
         morton = compute_morton(self[:, 0], self[:, 1], self[:, 2], LE, RE)
         return morton
 
-    def to_octree(self, over_refine_factor=1, dims=(1, 1, 1), n_ref=64):
+    def to_octree(self, over_refine_factor=2, dims=(1, 1, 1), n_ref=64):
         mi = self.morton
         mi.sort()
         eps = np.finfo(self.dtype).eps

--- a/yt/data_objects/tests/test_covering_grid.py
+++ b/yt/data_objects/tests/test_covering_grid.py
@@ -205,7 +205,7 @@ def test_arbitrary_grid():
 
 
 def test_octree_cg():
-    ds = fake_octree_ds(over_refine_factor=0, partial_coverage=0)
+    ds = fake_octree_ds(over_refine_factor=1, partial_coverage=0)
     cgrid = ds.covering_grid(
         0, left_edge=ds.domain_left_edge, dims=ds.domain_dimensions
     )

--- a/yt/frontends/adaptahop/data_structures.py
+++ b/yt/frontends/adaptahop/data_structures.py
@@ -66,7 +66,7 @@ class AdaptaHOPDataset(Dataset):
         filename,
         dataset_type="adaptahop_binary",
         n_ref=16,
-        over_refine_factor=1,
+        over_refine_factor=2,
         units_override=None,
         unit_system="cgs",
         parent_ds=None,
@@ -145,7 +145,7 @@ class AdaptaHOPDataset(Dataset):
         # Domain related things
         self.filename_template = self.parameter_filename
         self.file_count = 1
-        nz = 1 << self.over_refine_factor
+        nz = self.over_refine_factor
         self.domain_dimensions = np.ones(3, "int32") * nz
 
         # Set things up

--- a/yt/frontends/ahf/data_structures.py
+++ b/yt/frontends/ahf/data_structures.py
@@ -59,7 +59,7 @@ class AHFHalosDataset(Dataset):
         filename,
         dataset_type="ahf",
         n_ref=16,
-        over_refine_factor=1,
+        over_refine_factor=2,
         units_override=None,
         unit_system="cgs",
         hubble_constant=1.0,
@@ -98,7 +98,7 @@ class AHFHalosDataset(Dataset):
         # Set up geometrical information.
         self.refine_by = 2
         self.dimensionality = 3
-        nz = 1 << self.over_refine_factor
+        nz = self.over_refine_factor
         self.domain_dimensions = np.ones(self.dimensionality, "int32") * nz
         self.domain_left_edge = np.array([0.0, 0.0, 0.0])
         # Note that boxsize is in Mpc but particle positions are in kpc.

--- a/yt/frontends/art/data_structures.py
+++ b/yt/frontends/art/data_structures.py
@@ -440,7 +440,7 @@ class DarkMatterARTDataset(ARTDataset):
         units_override=None,
         unit_system="cgs",
     ):
-        self.over_refine_factor = 1
+        self.over_refine_factor = 2
         self.n_ref = 64
         self.particle_types += ("all",)
         if fields is None:

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -346,7 +346,7 @@ class RAMSESDomainSubset(OctreeSubset):
         base_region,
         domain,
         ds,
-        over_refine_factor=1,
+        over_refine_factor=2,
         num_ghost_zones=0,
         base_grid=None,
     ):

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -666,10 +666,10 @@ class StreamOctreeSubset(OctreeSubset):
     _domain_offset = 1
 
     def __init__(
-        self, base_region, ds, oct_handler, over_refine_factor=1, num_ghost_zones=0
+        self, base_region, ds, oct_handler, over_refine_factor=2, num_ghost_zones=0
     ):
         self._over_refine_factor = over_refine_factor
-        self._num_zones = 1 << (over_refine_factor)
+        self._num_zones = over_refine_factor
         self.field_data = YTFieldData()
         self.field_parameters = {}
         self.ds = ds

--- a/yt/frontends/stream/tests/test_stream_octree.py
+++ b/yt/frontends/stream/tests/test_stream_octree.py
@@ -44,7 +44,7 @@ def test_octree():
         octree_mask=octree_mask,
         data=quantities,
         bbox=bbox,
-        over_refine_factor=0,
+        over_refine_factor=1,
         partial_coverage=0,
     )
 

--- a/yt/geometry/_selection_routines/selector_object.pxi
+++ b/yt/geometry/_selection_routines/selector_object.pxi
@@ -156,7 +156,7 @@ cdef class SelectorObject:
                             visitor.pos[1] = (visitor.pos[1] >> 1)
                             visitor.pos[2] = (visitor.pos[2] >> 1)
                             visitor.level -= 1
-                        elif this_level == 1 and visitor.oref > 0:
+                        elif this_level == 1 and visitor.oref > 1:
                             visitor.global_index += increment
                             increment = 0
                             self.visit_oct_cells(root, ch, spos, sdds,
@@ -175,10 +175,10 @@ cdef class SelectorObject:
     cdef void visit_oct_cells(self, Oct *root, Oct *ch,
                               np.float64_t spos[3], np.float64_t sdds[3],
                               OctVisitor visitor, int i, int j, int k):
-        # We can short-circuit the whole process if data.oref == 1.
+        # We can short-circuit the whole process if data.oref == 2.
         # This saves us some funny-business.
         cdef int selected
-        if visitor.oref == 1:
+        if visitor.oref == 2:
             selected = self.select_cell(spos, sdds)
             if ch != NULL:
                 selected *= self.overlap_cells
@@ -196,7 +196,7 @@ cdef class SelectorObject:
         cdef np.float64_t dds[3]
         cdef np.float64_t pos[3]
         cdef int ci, cj, ck
-        cdef int nr = (1 << (visitor.oref - 1))
+        cdef int nr = (self.oref * 0.5)
         for ci in range(3):
             dds[ci] = sdds[ci] / nr
         # Boot strap at the first index.

--- a/yt/geometry/oct_visitors.pxd
+++ b/yt/geometry/oct_visitors.pxd
@@ -39,8 +39,8 @@ cdef class OctVisitor:
     cdef int dims
     cdef np.int32_t domain
     cdef np.int8_t level
-    cdef np.int8_t oref # This is the level of overref.  1 => 8 zones, 2 => 64, etc.
-                        # To calculate nzones, 1 << (oref * 3)
+    cdef np.int8_t oref # This is the level of overref.  1 => 1 zones, 2 => 8, etc.
+                        # To calculate nzones, oref**3
     cdef np.int32_t nz
 
     # There will also be overrides for the memoryviews associated with the
@@ -49,11 +49,11 @@ cdef class OctVisitor:
     cdef void visit(self, Oct*, np.uint8_t selected)
 
     cdef inline int oind(self):
-        cdef int d = (1 << self.oref)
+        cdef int d = self.oref
         return (((self.ind[0]*d)+self.ind[1])*d+self.ind[2])
 
     cdef inline int rind(self):
-        cdef int d = (1 << self.oref)
+        cdef int d = self.oref
         return (((self.ind[2]*d)+self.ind[1])*d+self.ind[0])
 
 cdef class CountTotalOcts(OctVisitor):
@@ -163,7 +163,7 @@ cdef class BaseNeighbourVisitor(OctVisitor):
     cdef void set_neighbour_info(self, Oct *o, int ishift[3])
 
     cdef inline np.uint8_t neighbour_rind(self):
-        cdef int d = (1 << self.oref)
+        cdef int d = self.oref
         return (((self.neigh_ind[2]*d)+self.neigh_ind[1])*d+self.neigh_ind[0])
 
 cdef class NeighbourCellIndexVisitor(BaseNeighbourVisitor):

--- a/yt/geometry/oct_visitors.pyx
+++ b/yt/geometry/oct_visitors.pyx
@@ -35,7 +35,7 @@ cdef class OctVisitor:
         self.domain = domain_id
         self.level = -1
         self.oref = octree.oref
-        self.nz = (1 << (self.oref*3))
+        self.nz = self.oref**3
 
     cdef void visit(self, Oct* o, np.uint8_t selected):
         raise NotImplementedError
@@ -172,7 +172,7 @@ cdef class ICoordsOcts(OctVisitor):
         if selected == 0: return
         cdef int i
         for i in range(3):
-            self.icoords[self.index,i] = (self.pos[i] << self.oref) + self.ind[i]
+            self.icoords[self.index,i] = (self.pos[i] * self.oref) + self.ind[i]
         self.index += 1
 
 # Level
@@ -196,9 +196,9 @@ cdef class FCoordsOcts(OctVisitor):
         if selected == 0: return
         cdef int i
         cdef np.float64_t c, dx
-        dx = 1.0 / ((1 << self.oref) << self.level)
+        dx = 1.0 / ((self.oref) << self.level)
         for i in range(3):
-            c = <np.float64_t> ((self.pos[i] << self.oref ) + self.ind[i])
+            c = <np.float64_t> ((self.pos[i] * self.oref) + self.ind[i])
             self.fcoords[self.index,i] = (c + 0.5) * dx
         self.index += 1
 
@@ -214,7 +214,7 @@ cdef class FWidthOcts(OctVisitor):
         if selected == 0: return
         cdef int i
         cdef np.float64_t dx
-        dx = 1.0 / ((1 << self.oref) << self.level)
+        dx = 1.0 / (self.oref << self.level)
         for i in range(3):
             self.fwidth[self.index,i] = dx
         self.index += 1
@@ -331,7 +331,7 @@ cdef class MortonIndexOcts(OctVisitor):
         cdef np.int64_t coord[3]
         cdef int i
         for i in range(3):
-            coord[i] = (self.pos[i] << self.oref) + self.ind[i]
+            coord[i] = (self.pos[i] * self.oref) + self.ind[i]
             if (coord[i] < 0):
                 raise RuntimeError("Oct coordinate in dimension {} is ".format(i)+
                                    "negative. ({})".format(coord[i]))
@@ -373,12 +373,12 @@ cdef class BaseNeighbourVisitor(OctVisitor):
         cdef Oct *neighbour
         cdef bint local_oct
         cdef bint other_oct
-        dx = 1.0 / ((1 << self.oref) << self.level)
+        dx = 1.0 / (self.oref << self.level)
         local_oct = True
 
         # Compute position of neighbouring cell
         for i in range(3):
-            c = <np.float64_t> (self.pos[i] << self.oref)
+            c = <np.float64_t> (self.pos[i] * self.oref)
             fcoords[i] = (c + 0.5 + ishift[i]) * dx / self.octree.nn[i]
             # Assuming periodicity
             if fcoords[i] < 0:
@@ -395,12 +395,12 @@ cdef class BaseNeighbourVisitor(OctVisitor):
             neighbour = o
             self.oi.level = self.level
             for i in range(3):
-                self.oi.ipos[i] = (self.pos[i] << self.oref) + ishift[i]
+                self.oi.ipos[i] = (self.pos[i] * self.oref) + ishift[i]
 
         # Extra step - compute cell position in neighbouring oct (and store in oi.ipos)
         if self.oi.level == self.level - 1:
             for i in range(3):
-                ipos = (((self.pos[i] << self.oref) + ishift[i])) >> 1
+                ipos = (((self.pos[i] * self.oref) + ishift[i])) >> 1
                 if (self.oi.ipos[i] << 1) == ipos:
                     self.oi.ipos[i] = 0
                 else:

--- a/yt/geometry/particle_deposit.pyx
+++ b/yt/geometry/particle_deposit.pyx
@@ -63,7 +63,7 @@ cdef class ParticleDepositOperation:
         cdef np.float64_t pos[3]
         cdef np.float64_t[:] field_vals = np.empty(nf, dtype="float64")
         cdef int dims[3]
-        dims[0] = dims[1] = dims[2] = (1 << octree.oref)
+        dims[0] = dims[1] = dims[2] = octree.oref
         cdef int nz = dims[0] * dims[1] * dims[2]
         cdef OctInfo oi
         cdef np.int64_t offset, moff

--- a/yt/geometry/particle_oct_container.pyx
+++ b/yt/geometry/particle_oct_container.pyx
@@ -1160,7 +1160,7 @@ cdef class ParticleBitmap:
         # self.index_octree = ParticleOctreeContainer([1,1,1],
         #     [self.left_edge[0], self.left_edge[1], self.left_edge[2]],
         #     [self.right_edge[0], self.right_edge[1], self.right_edge[2]],
-        #     over_refine = 0
+        #     over_refine = 1
         # )
         # self.index_octree.n_ref = 1
         # mi = (<ewah_bool_array*> self.collisions.ewah_keys)[0].toArray()
@@ -1975,7 +1975,7 @@ cdef class ParticleBitmapOctreeContainer(SparseOctreeContainer):
     cdef np.uint64_t[:] _octs_per_root
     cdef public int overlap_cells
     def __init__(self, domain_dimensions, domain_left_edge, domain_right_edge,
-                 int num_root, over_refine = 1):
+                 int num_root, over_refine = 2):
         super(ParticleBitmapOctreeContainer, self).__init__(
             domain_dimensions, domain_left_edge, domain_right_edge,
             over_refine)

--- a/yt/geometry/particle_smooth.pyx
+++ b/yt/geometry/particle_smooth.pyx
@@ -127,7 +127,7 @@ cdef class ParticleSmoothOperation:
             periodicity = (False, False, False)
         else:
             raise NotImplementedError
-        dims[0] = dims[1] = dims[2] = (1 << mesh_octree.oref)
+        dims[0] = dims[1] = dims[2] = mesh_octree.oref
         cdef int nz = dims[0] * dims[1] * dims[2]
         numpart = positions.shape[0]
         # pcount is the number of particles per oct.
@@ -159,7 +159,7 @@ cdef class ParticleSmoothOperation:
         for i in range(3):
             self.DW[i] = (mesh_octree.DRE[i] - mesh_octree.DLE[i])
             self.periodicity[i] = periodicity[i]
-        cdef np.float64_t factor = (1 << (particle_octree.oref))
+        cdef np.float64_t factor = particle_octree.oref
         for i in range(positions.shape[0]):
             for j in range(3):
                 pos[j] = positions[i, j]

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -894,7 +894,7 @@ def load_octree(
     velocity_unit=None,
     magnetic_unit=None,
     periodicity=(True, True, True),
-    over_refine_factor=1,
+    over_refine_factor=2,
     partial_coverage=1,
     unit_system="cgs",
     default_species_fields=None,
@@ -913,7 +913,7 @@ def load_octree(
         This is a depth-first refinement mask for an Octree.  It should be
         of size n_octs * 8 (but see note about the root oct below), where
         each item is 1 for an oct-cell being refined and 0 for it not being
-        refined.  For over_refine_factors != 1, the children count will
+        refined.  For over_refine_factors != 2, the children count will
         still be 8, so there will still be n_octs * 8 entries. Note that if
         the root oct is not refined, there will be only one entry
         for the root, so the size of the mask will be (n_octs - 1)*8 + 1.
@@ -959,7 +959,7 @@ def load_octree(
     ...     octree_mask=octree_mask,
     ...     data=quantities,
     ...     bbox=bbox,
-    ...     over_refine_factor=0,
+    ...     over_refine_factor=1,
     ...     partial_coverage=0,
     ... )
 
@@ -974,7 +974,7 @@ def load_octree(
     if not isinstance(octree_mask, np.ndarray) or octree_mask.dtype != np.uint8:
         raise TypeError("octree_mask should be a Numpy array with type uint8")
 
-    nz = 1 << (over_refine_factor)
+    nz = over_refine_factor
     domain_dimensions = np.array([nz, nz, nz])
     nprocs = 1
     if bbox is None:

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -894,7 +894,7 @@ def load_octree(
     velocity_unit=None,
     magnetic_unit=None,
     periodicity=(True, True, True),
-    over_refine_factor=2,
+    over_refine_factor=1,
     partial_coverage=1,
     unit_system="cgs",
     default_species_fields=None,
@@ -913,7 +913,7 @@ def load_octree(
         This is a depth-first refinement mask for an Octree.  It should be
         of size n_octs * 8 (but see note about the root oct below), where
         each item is 1 for an oct-cell being refined and 0 for it not being
-        refined.  For over_refine_factors != 2, the children count will
+        refined.  For over_refine_factors != 1, the children count will
         still be 8, so there will still be n_octs * 8 entries. Note that if
         the root oct is not refined, there will be only one entry
         for the root, so the size of the mask will be (n_octs - 1)*8 + 1.
@@ -959,7 +959,7 @@ def load_octree(
     ...     octree_mask=octree_mask,
     ...     data=quantities,
     ...     bbox=bbox,
-    ...     over_refine_factor=1,
+    ...     over_refine_factor=0,
     ...     partial_coverage=0,
     ... )
 
@@ -974,7 +974,9 @@ def load_octree(
     if not isinstance(octree_mask, np.ndarray) or octree_mask.dtype != np.uint8:
         raise TypeError("octree_mask should be a Numpy array with type uint8")
 
-    nz = over_refine_factor
+    # nz = 1 << over_refine_factor instead of
+    # nz = over_refine_factor is for backwards compatibility
+    nz = 1 << over_refine_factor
     domain_dimensions = np.array([nz, nz, nz])
     nprocs = 1
     if bbox is None:

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -690,7 +690,7 @@ def fake_octree_ds(
     velocity_unit=None,
     magnetic_unit=None,
     periodicity=(True, True, True),
-    over_refine_factor=1,
+    over_refine_factor=2,
     partial_coverage=1,
     unit_system="cgs",
 ):


### PR DESCRIPTION
Refactors over_refine_factor and oref to equal the number of zones along each dimension, instead of nz equaling oref to the power of two.

To maintain backwards compatibility (although this seems to be primarily used internally) `loaders.load_octree` maintains the old behavior.

Closes #4027 