### PR TITLE
BUG: setting GeoAxes extent

### DIFF
--- a/yt/geometry/coordinates/geographic_coordinates.py
+++ b/yt/geometry/coordinates/geographic_coordinates.py
@@ -367,6 +367,7 @@ class GeographicCoordinateHandler(CoordinateHandler):
 
     @property
     def data_projection(self):
+        # this will control the default projection to use when displaying data
         if self._data_projection is not None:
             return self._data_projection
         dpj = {}
@@ -382,6 +383,7 @@ class GeographicCoordinateHandler(CoordinateHandler):
 
     @property
     def data_transform(self):
+        # this is the coordinate system on which the data is defined (the crs).
         if self._data_transform is not None:
             return self._data_transform
         dtx = {}

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -349,7 +349,13 @@ class ImagePlotMPL(PlotMPL):
         # if the axes are cartopy GeoAxes, this checks that the axes extent
         # is properly set.
 
-        if hasattr(self.axes, "set_extent"):
+        if not "cartopy" in sys.modules:
+            # cartopy isn't already loaded, nothing to do here
+            return
+    
+        from cartopy.mpl.geoaxes import GeoAxes
+ 
+        if isinstance(self.axes, GeoAxes):
             # some projections have trouble when passing extents at or near the
             # limits. So we only set_extent when the plot is a subset of the
             # globe, within the tolerance of the transform.

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -276,33 +276,26 @@ class ImagePlotMPL(PlotMPL):
             transform = self.axes.transData
         else:
             transform = self._transform
+
         if hasattr(self.axes, "set_extent"):
-            # CartoPy hangs if we do not set_extent before imshow if we are
-            # displaying a small subset of the globe.  What I believe happens is
-            # that the transform for the points on the outside results in
-            # infinities, and then the scipy.spatial cKDTree hangs trying to
-            # identify nearest points.
-            #
-            # Also, set_extent is defined by cartopy, so not all axes will have
-            # it as a method.
-            #
-            # A potential downside is that other images may change, but I believe
-            # the result of imshow is to set_extent *regardless*.  This just
-            # changes the order in which it happens.
-            #
-            # NOTE: This is currently commented out because it breaks in some
-            # instances.  It is left as a historical note because we will
-            # eventually need some form of it.
-            # self.axes.set_extent(extent)
+            # some projections have trouble when passing extents at or near the
+            # limits. So we only set_extent when the plot is a subset of the
+            # globe, within the tolerance of the transform.
 
-            # possibly related issue (operation order dependency)
-            # https://github.com/SciTools/cartopy/issues/1468
+            # add validation to make sure transform IS a cartopy crs? pretty sure
+            # it should always be if we end up here....
 
-            # in cartopy 0.19 (or 0.20), some intented behaviour changes produced an
-            # incompatibility here where default values for extent would lead to a crash.
-            # A solution is to let the transform object set the image extents internally
-            # see https://github.com/SciTools/cartopy/issues/1955
-            extent = None
+            # note that `set_extent` here is setting the extent of the axes.
+            # still need to pass the extent arg to imshow below in order to
+            # ensure that it is properly scaled. also note that set_extent
+            # expects values in the coordinates of the transform: it will
+            # calculate the coordinates in the projection.
+            global_extent = transform.x_limits + transform.y_limits
+            thresh = transform.threshold
+            if all([extent[ie] < (global_extent[ie] - thresh) for ie in range(4)]):
+                self.axes.set_extent(extent, crs=transform)
+            else:
+                self.axes.set_global()
 
         self.image = self.axes.imshow(
             data.to_ndarray(),

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -292,7 +292,7 @@ class ImagePlotMPL(PlotMPL):
             # calculate the coordinates in the projection.
             global_extent = transform.x_limits + transform.y_limits
             thresh = transform.threshold
-            if all([extent[ie] < (global_extent[ie] - thresh) for ie in range(4)]):
+            if all(extent[ie] < (global_extent[ie] - thresh) for ie in range(4)):
                 self.axes.set_extent(extent, crs=transform)
             else:
                 self.axes.set_global()

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -1,3 +1,4 @@
+import sys
 import warnings
 from io import BytesIO
 
@@ -349,12 +350,12 @@ class ImagePlotMPL(PlotMPL):
         # if the axes are cartopy GeoAxes, this checks that the axes extent
         # is properly set.
 
-        if not "cartopy" in sys.modules:
+        if "cartopy" not in sys.modules:
             # cartopy isn't already loaded, nothing to do here
             return
-    
+
         from cartopy.mpl.geoaxes import GeoAxes
- 
+
         if isinstance(self.axes, GeoAxes):
             # some projections have trouble when passing extents at or near the
             # limits. So we only set_extent when the plot is a subset of the


### PR DESCRIPTION
This changes how the `extent` for GeoAxes is handled -- this version calls `set_extent` only if the data is not global and always passes the `extent` kwarg to imshow. Seemed to work well locally, but we'll see how CI does...

~~I may broaden the scope of this PR to include changing the default projection to set the `central_longitude` kwarg from the plot arguments when available, but if that proves to be too complex I'll just keep this PR to the `extent` modification.~~ EDIT: Will look into this for a follow up PR. 