### PR TITLE
Preliminary support for tensor fields

### DIFF
--- a/yt/fields/astro_fields.py
+++ b/yt/fields/astro_fields.py
@@ -145,7 +145,7 @@ def setup_astro_fields(registry, ftype="gas", slice_info=None):
 
         return _four_velocity
 
-    for u in "xyz":
+    for u in registry.ds.coordinates.axis_order:
         registry.add_field(
             ("gas", f"four_velocity_{u}"),
             sampling_type="local",

--- a/yt/fields/stress_energy.py
+++ b/yt/fields/stress_energy.py
@@ -1,0 +1,35 @@
+from functools import partial
+
+ax = "txyz"
+
+
+def metric(mu: int, nu: int):
+    if (mu, nu) == (0, 0):
+        return -1
+    elif mu == nu:
+        return 1
+    else:
+        return 0
+
+
+def setup_stress_energy_ideal(registry, ftype="gas"):
+
+    pc = registry.ds.units.physical_constants
+    invc2 = 1.0 / (pc.clight * pc.clight)
+
+    def _T(field, data, mu: int, nu: int):
+        Umu = data[ftype, f"four_velocity_{ax[mu]}"]
+        Unu = data[ftype, f"four_velocity_{ax[nu]}"]
+        p = data[ftype, "pressure"]
+        e = data[ftype, "thermal_energy_density"]
+        rho = data[ftype, "density"]
+        return (rho + (e + p) * invc2) * Umu * Unu + metric(mu, nu) * p
+
+    for mu in range(5):
+        for nu in range(5):
+            registry.add_field(
+                (ftype, f"T^{mu}{nu}"),
+                sampling_type="local",
+                function=partial(_T, mu=mu, nu=nu),
+                units=registry.ds.unit_system["pressure"],
+            )

--- a/yt/fields/tensor_fields.py
+++ b/yt/fields/tensor_fields.py
@@ -1,6 +1,5 @@
 from functools import partial
 
-ax = "txyz"
 
 # This is the metric for Minkowski spacetime in SR
 def metric(mu: int, nu: int):
@@ -14,6 +13,8 @@ def metric(mu: int, nu: int):
 
 
 def setup_stress_energy_ideal(registry, ftype="gas"):
+
+    ax = "t" + "".join(registry.ds.coordinates.axis_order)
 
     pc = registry.ds.units.physical_constants
     inv_c2 = 1.0 / (pc.clight * pc.clight)

--- a/yt/fields/tensor_fields.py
+++ b/yt/fields/tensor_fields.py
@@ -2,8 +2,9 @@ from functools import partial
 
 ax = "txyz"
 
-
+# This is the metric for Minkowski spacetime in SR
 def metric(mu: int, nu: int):
+    # This assumes the -+++ signature
     if (mu, nu) == (0, 0):
         return -1
     elif mu == nu:
@@ -28,7 +29,7 @@ def setup_stress_energy_ideal(registry, ftype="gas"):
     for mu in range(5):
         for nu in range(5):
             registry.add_field(
-                (ftype, f"T^{mu}{nu}"),
+                (ftype, f"T{mu}{nu}"),
                 sampling_type="local",
                 function=partial(_T, mu=mu, nu=nu),
                 units=registry.ds.unit_system["pressure"],

--- a/yt/fields/tensor_fields.py
+++ b/yt/fields/tensor_fields.py
@@ -15,7 +15,7 @@ def metric(mu: int, nu: int):
 def setup_stress_energy_ideal(registry, ftype="gas"):
 
     pc = registry.ds.units.physical_constants
-    invc2 = 1.0 / (pc.clight * pc.clight)
+    inv_c2 = 1.0 / (pc.clight * pc.clight)
 
     def _T(field, data, mu: int, nu: int):
         Umu = data[ftype, f"four_velocity_{ax[mu]}"]
@@ -23,7 +23,7 @@ def setup_stress_energy_ideal(registry, ftype="gas"):
         p = data[ftype, "pressure"]
         e = data[ftype, "thermal_energy_density"]
         rho = data[ftype, "density"]
-        return (rho + (e + p) * invc2) * Umu * Unu + metric(mu, nu) * p
+        return (rho + (e + p) * inv_c2) * Umu * Unu + metric(mu, nu) * p
 
     for mu in range(5):
         for nu in range(5):

--- a/yt/fields/tensor_fields.py
+++ b/yt/fields/tensor_fields.py
@@ -14,8 +14,7 @@ def metric(mu: int, nu: int):
 
 def setup_stress_energy_ideal(registry, ftype="gas"):
 
-    ax = "t" + "".join(registry.ds.coordinates.axis_order)
-
+    ax = ("t",) + registry.ds.coordinates.axis_order
     pc = registry.ds.units.physical_constants
     inv_c2 = 1.0 / (pc.clight * pc.clight)
 

--- a/yt/frontends/gamer/fields.py
+++ b/yt/frontends/gamer/fields.py
@@ -1,5 +1,6 @@
 from yt._typing import KnownFieldsT
 from yt.fields.field_info_container import FieldInfoContainer
+from yt.fields.stress_energy import setup_stress_energy_ideal
 
 from .cfields import SRHDFields
 
@@ -240,6 +241,9 @@ class GAMERFieldInfo(FieldInfoContainer):
                 function=_mach_number,
                 units="",
             )
+
+            setup_stress_energy_ideal(self)
+
         else:
 
             # density

--- a/yt/frontends/gamer/fields.py
+++ b/yt/frontends/gamer/fields.py
@@ -244,7 +244,7 @@ class GAMERFieldInfo(FieldInfoContainer):
 
             setup_stress_energy_ideal(self)
 
-        else:
+        else:  # not RHD
 
             # density
             self.alias(
@@ -310,6 +310,16 @@ class GAMERFieldInfo(FieldInfoContainer):
             sampling_type="cell",
             function=_specific_thermal_energy,
             units=unit_system["specific_energy"],
+        )
+
+        def _thermal_energy_density(field, data):
+            return data["gas", "density"] * data["gas", "specific_thermal_energy"]
+
+        self.add_field(
+            ("gas", "thermal_energy_density"),
+            sampling_type="cell",
+            function=_thermal_energy_density,
+            units=unit_system["pressure"],
         )
 
         self.add_field(

--- a/yt/frontends/gamer/fields.py
+++ b/yt/frontends/gamer/fields.py
@@ -1,6 +1,6 @@
 from yt._typing import KnownFieldsT
 from yt.fields.field_info_container import FieldInfoContainer
-from yt.fields.stress_energy import setup_stress_energy_ideal
+from yt.fields.tensor_fields import setup_stress_energy_ideal
 
 from .cfields import SRHDFields
 

--- a/yt/frontends/gamer/tests/test_outputs.py
+++ b/yt/frontends/gamer/tests/test_outputs.py
@@ -1,5 +1,10 @@
 from yt.frontends.gamer.api import GAMERDataset
-from yt.testing import assert_equal, requires_file, units_override_check
+from yt.testing import (
+    assert_array_almost_equal,
+    assert_equal,
+    requires_file,
+    units_override_check,
+)
 from yt.utilities.answer_testing.framework import (
     data_dir_load,
     requires_ds,
@@ -97,3 +102,32 @@ def test_jiw():
     for test in small_patch_amr(ds, _fields_jiw):
         test_jiw.__name__ = test.description
         yield test
+
+
+@requires_ds(jiw, big_data=True)
+def test_stress_energy():
+    axes = "txyz"
+    ds = data_dir_load(jiw)
+    center = ds.arr([3.0, 10.0, 10.0], "kpc")
+    sp = ds.sphere(center, (1.0, "kpc"))
+    c2 = ds.units.clight**2
+    inv_c2 = 1.0 / c2
+    rho = sp["gas", "density"]
+    p = sp["gas", "pressure"]
+    e = sp["gas", "thermal_energy_density"]
+    gamma = sp["gas", "lorentz_factor"]
+    h = rho + (e + p) * inv_c2
+    T00 = gamma * gamma * c2 * h - p
+    assert_array_almost_equal(sp["T^00"], T00)
+    for mu in range(4):
+        for nu in range(4):
+            # matrix is symmetric so only do the upper-right part
+            if nu > mu:
+                Umu = sp[f"four_velocity_{axes[mu]}"]
+                Unu = sp[f"four_velocity_{axes[nu]}"]
+                Tmunu = h * Umu * Unu
+                if mu != nu:
+                    assert_array_almost_equal(sp[f"T^{mu}{nu}"], sp[f"T^{nu}{mu}"])
+                else:
+                    Tmunu += p
+                assert_array_almost_equal(sp[f"T^{mu}{nu}"], Tmunu)

--- a/yt/frontends/gamer/tests/test_outputs.py
+++ b/yt/frontends/gamer/tests/test_outputs.py
@@ -118,7 +118,7 @@ def test_stress_energy():
     gamma = sp["gas", "lorentz_factor"]
     h = rho + (e + p) * inv_c2
     T00 = gamma * gamma * c2 * h - p
-    assert_array_almost_equal(sp["T^00"], T00)
+    assert_array_almost_equal(sp["T00"], T00)
     for mu in range(4):
         for nu in range(4):
             # matrix is symmetric so only do the upper-right part
@@ -127,7 +127,7 @@ def test_stress_energy():
                 Unu = sp[f"four_velocity_{axes[nu]}"]
                 Tmunu = h * Umu * Unu
                 if mu != nu:
-                    assert_array_almost_equal(sp[f"T^{mu}{nu}"], sp[f"T^{nu}{mu}"])
+                    assert_array_almost_equal(sp[f"T{mu}{nu}"], sp[f"T{nu}{mu}"])
                 else:
                     Tmunu += p
-                assert_array_almost_equal(sp[f"T^{mu}{nu}"], Tmunu)
+                assert_array_almost_equal(sp[f"T{mu}{nu}"], Tmunu)

--- a/yt/frontends/gamer/tests/test_outputs.py
+++ b/yt/frontends/gamer/tests/test_outputs.py
@@ -115,14 +115,11 @@ def test_stress_energy():
     rho = sp["gas", "density"]
     p = sp["gas", "pressure"]
     e = sp["gas", "thermal_energy_density"]
-    gamma = sp["gas", "lorentz_factor"]
     h = rho + (e + p) * inv_c2
-    T00 = gamma * gamma * c2 * h - p
-    assert_array_almost_equal(sp["T00"], T00)
     for mu in range(4):
         for nu in range(4):
             # matrix is symmetric so only do the upper-right part
-            if nu > mu:
+            if nu >= mu:
                 Umu = sp[f"four_velocity_{axes[mu]}"]
                 Unu = sp[f"four_velocity_{axes[nu]}"]
                 Tmunu = h * Umu * Unu


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

yt has support for vector fields--but of course in some domains tensor fields are also useful. This is especially true in applications involving special relativity. 

This PR takes a first stab at adding tensor fields to yt by adding the [stress-energy tensor for a perfect fluid](https://en.wikipedia.org/wiki/Perfect_fluid), which is used by GAMER (implemented here) and Athena++ (to be implemented later). 

So for example, accessing the "T^00" component of a tensor field works like this: `dd["T00"]`, and the "T^10" would work like this: `dd["T10"]`, and so on. Have to think about how to handle raising/lowering indices (if at all) and if one wants to support other coordinates than just cartesian (harder, but doable I guess).

I expect there may be some conversation about the field naming convention. Docs forthcoming.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
