### PR TITLE
BUG: Fix flux calculation on surface when there is no fluxing_field

### DIFF
--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -1739,7 +1739,10 @@ class YTSurface(YTSelectionContainer3D):
 
         vc_data = grid.get_vertex_centered_data(vc_fields)
         if fluxing_field is None:
-            ff = np.ones_like(vc_data[self.surface_field].d, dtype="float64")
+            ff = self.ds.arr(
+                np.ones_like(vc_data[self.surface_field].d, dtype="float64"),
+                "dimensionless",
+            )
         else:
             ff = vc_data[fluxing_field]
         surf_vals = vc_data[self.surface_field]

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -1695,9 +1695,8 @@ class YTSurface(YTSelectionContainer3D):
 
         Returns
         -------
-        flux : float
-            The summed flux.  Note that it is not currently scaled; this is
-            simply the code-unit area times the fields.
+        flux : YTQuantity
+            The summed flux.
 
         References
         ----------
@@ -1740,7 +1739,7 @@ class YTSurface(YTSelectionContainer3D):
 
         vc_data = grid.get_vertex_centered_data(vc_fields)
         if fluxing_field is None:
-            ff = np.ones_like(vc_data[self.surface_field], dtype="float64")
+            ff = np.ones_like(vc_data[self.surface_field].d, dtype="float64")
         else:
             ff = vc_data[fluxing_field]
         surf_vals = vc_data[self.surface_field]

--- a/yt/data_objects/tests/test_fluxes.py
+++ b/yt/data_objects/tests/test_fluxes.py
@@ -24,6 +24,11 @@ def test_flux_calculation():
     )
     assert_almost_equal(flux.value, 1.0, 12)
     assert_equal(str(flux.units), "cm**2")
+    flux2 = surf.calculate_flux(
+        ("index", "ones"), ("index", "zeros"), ("index", "zeros")
+    )
+    assert_almost_equal(flux2.value, 1.0, 12)
+    assert_equal(str(flux2.units), "cm**2")
 
 
 def test_sampling():


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

 
Nominally, when one creates a `YTSurface` object using `ds.surface`, and then uses `calculate_flux` on the object to calculate a flux through the surface, if no `fluxing_field` is provided it should default to `1.0 dimensionless`. I discovered by accident today that this isn't the case--mainly because `np.ones_like` now preserves units (see code below). This is the fix for that. The test has been improved to catch it. 
 
<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
