### PR TITLE
MNT: cleanup an unused and hidden class attribute

### DIFF
--- a/yt/data_objects/index_subobjects/grid_patch.py
+++ b/yt/data_objects/index_subobjects/grid_patch.py
@@ -26,7 +26,6 @@ class AMRGridPatch(YTSelectionContainer):
     _num_ghost_zones = 0
     _grids = None
     _id_offset = 1
-    _cache_mask = True
 
     _type_name = "grid"
     _skip_add = True
@@ -398,12 +397,11 @@ class AMRGridPatch(YTSelectionContainer):
         yield self, mask
 
     def _get_selector_mask(self, selector):
-        if self._cache_mask and hash(selector) == self._last_selector_id:
+        if hash(selector) == self._last_selector_id:
             mask = self._last_mask
         else:
             mask = selector.fill_mask(self)
-            if self._cache_mask:
-                self._last_mask = mask
+            self._last_mask = mask
             self._last_selector_id = hash(selector)
             if mask is None:
                 self._last_count = 0


### PR DESCRIPTION
## PR Summary
This boolean attribute is not user exposed and _never_ set to any other than `True`.
It probably had value as a debugging switch but it's not doing anything now and it's also very simple to reimplement if the need arises in a debugging session, so I suggest we just remove it.