### PR TITLE
BUG: Fix intersections between SPH particles and regions when the boundary is periodic

### DIFF
--- a/yt/data_objects/tests/test_sph_data_objects.py
+++ b/yt/data_objects/tests/test_sph_data_objects.py
@@ -82,6 +82,21 @@ def test_region():
                 assert_equal(reg["gas", "density"].shape[0], answer)
 
 
+def test_periodic_region():
+    ds = fake_sph_grid_ds(10.0)
+    coords = [0.7, 1.4, 2.8]
+
+    for x in coords:
+        for y in coords:
+            for z in coords:
+                center = np.array([x, y, z])
+                for n, w in zip((8, 27), (1.0, 2.0)):
+                    le = center - 0.5 * w
+                    re = center + 0.5 * w
+                    box = ds.box(le, re)
+                    assert box["io", "particle_ones"].size == n
+
+
 SPHERE_ANSWERS = {
     ((0, 0, 0), 4): 7,
     ((0, 0, 0), 3): 7,

--- a/yt/geometry/_selection_routines/region_selector.pxi
+++ b/yt/geometry/_selection_routines/region_selector.pxi
@@ -147,9 +147,10 @@ cdef class RegionSelector(SelectorObject):
         cdef np.float64_t dmin = 0
         cdef np.float64_t d = 0
         for i in range(3):
-            if self.right_edge_shift[i] <= pos[i] < self.left_edge[i]:
+            if (pos[i]+radius < self.left_edge[i] and \
+                pos[i]-radius >= self.right_edge_shift[i]):
                 d = self.periodic_difference(pos[i], self.left_edge[i], i)
-            elif pos[i] > self.right_edge[i]:
+            elif pos[i]-radius > self.right_edge[i]:
                 d = self.periodic_difference(pos[i], self.right_edge[i], i)
             dmin += d*d
         return int(dmin <= r2)

--- a/yt/geometry/_selection_routines/region_selector.pxi
+++ b/yt/geometry/_selection_routines/region_selector.pxi
@@ -145,15 +145,13 @@ cdef class RegionSelector(SelectorObject):
         cdef np.float64_t p
         cdef np.float64_t r2 = radius**2
         cdef np.float64_t dmin = 0
+        cdef np.float64_t d = 0
         for i in range(3):
-            if self.periodicity[i] and self.check_period[i]:
-                p = pos[i] + self.right_edge_shift[i]
-            else:
-                p = pos[i]
-            if p < self.left_edge[i]:
-                dmin += (p - self.left_edge[i])**2
+            if self.right_edge_shift[i] <= pos[i] < self.left_edge[i]:
+                d = self.periodic_difference(pos[i], self.left_edge[i], i)
             elif pos[i] > self.right_edge[i]:
-                dmin += (p - self.right_edge[i])**2
+                d = self.periodic_difference(pos[i], self.right_edge[i], i)
+            dmin += d*d
         return int(dmin <= r2)
 
     @cython.boundscheck(False)


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

This PR fixes the issue raised by #3916 and seen in other contexts where sometimes particles which properly belong to a rectangular region straddling a periodic boundary would get missed. 

I think something was not quite right in the overall logic, but I have to be honest I am not certain. What I do know for sure is that instead of checking the particle position itself for particles that lay outside the boundary of a region, we should be checking the "left_edge" and "right_edge" of the particle in question (defined by the +/- the radius away from the position), and then computing the radius of the particle to the edge. That was inspired by considering the region/cell intersection implementation: 

https://github.com/yt-project/yt/blob/6c0780f0e00a6ef6ed4f40510d4570d04f7cf59a/yt/geometry/_selection_routines/region_selector.pxi#L81-L92 

This PR implements that logic, and makes the code logic clearer. It also uses the already defined `periodic_difference` in the superclass to compute the distance between the particle position and the region edge. However, I noticed during this exercise that we have this same logic implemented in two different places (both of which are used):

Here: 

https://github.com/yt-project/yt/blob/6c0780f0e00a6ef6ed4f40510d4570d04f7cf59a/yt/geometry/_selection_routines/selector_object.pxi#L266-L278

and here:

https://github.com/yt-project/yt/blob/6c0780f0e00a6ef6ed4f40510d4570d04f7cf59a/yt/geometry/selection_routines.pxd#L81-L89

Should I presume the latter would be faster? 

Also, it's possible this change may break some answer tests.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
