### PR TITLE
RFC: change DerivedField.units attr type (str -> unyt.Unit)

### DIFF
--- a/yt/data_objects/selection_objects/data_selection_objects.py
+++ b/yt/data_objects/selection_objects/data_selection_objects.py
@@ -273,7 +273,7 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface, abc.ABC):
                         # dimensionless YTArray and verify that field is
                         # supposed to be unitless
                         fd = self.ds.arr(fd, "")
-                        if fi.units != Unit():
+                        if Unit(fi.units) != Unit():
                             raise YTFieldUnitError(fi, fd.units) from None
                     except UnitConversionError as e:
                         raise YTFieldUnitError(fi, fd.units) from e

--- a/yt/data_objects/selection_objects/data_selection_objects.py
+++ b/yt/data_objects/selection_objects/data_selection_objects.py
@@ -272,7 +272,8 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface, abc.ABC):
                         # dimensionless YTArray and verify that field is
                         # supposed to be unitless
                         fd = self.ds.arr(fd, "")
-                        if Unit(fi.units) != Unit():
+                        fiu = Unit(fi.units, registry=self.ds.unit_registry)
+                        if not fiu.is_dimensionless:
                             raise YTFieldUnitError(fi, fd.units) from None
                     except UnitConversionError as e:
                         raise YTFieldUnitError(fi, fd.units) from e

--- a/yt/data_objects/selection_objects/data_selection_objects.py
+++ b/yt/data_objects/selection_objects/data_selection_objects.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 
 import numpy as np
 from more_itertools import always_iterable
+from unyt import Unit
 from unyt.exceptions import UnitConversionError, UnitParseError
 
 import yt.geometry
@@ -272,7 +273,7 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface, abc.ABC):
                         # dimensionless YTArray and verify that field is
                         # supposed to be unitless
                         fd = self.ds.arr(fd, "")
-                        if fi.units != "":
+                        if fi.units != Unit():
                             raise YTFieldUnitError(fi, fd.units) from None
                     except UnitConversionError as e:
                         raise YTFieldUnitError(fi, fd.units) from e

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -237,6 +237,7 @@ class FieldInfoContainer(dict):
                 units = node.get("units", "")
                 aliases = node.get("aliases", [])
                 display_name = node.get("display_name", None)
+                args = units, aliases, display_name
 
             # We allow field_units to override this.  First we check if the
             # field *name* is in there, then the field *tuple*.

--- a/yt/fields/tests/test_fields.py
+++ b/yt/fields/tests/test_fields.py
@@ -1,4 +1,5 @@
 import numpy as np
+from unyt.exceptions import UnitParseError
 
 from yt import load
 from yt.frontends.stream.fields import StreamFieldInfo
@@ -16,11 +17,7 @@ from yt.testing import (
 )
 from yt.units.yt_array import YTArray, YTQuantity, array_like_field
 from yt.utilities.cosmology import Cosmology
-from yt.utilities.exceptions import (
-    YTDimensionalityError,
-    YTFieldUnitError,
-    YTFieldUnitParseError,
-)
+from yt.utilities.exceptions import YTDimensionalityError, YTFieldUnitError
 
 
 def get_params(ds):
@@ -324,7 +321,9 @@ def test_add_field_unit_semantics():
         sampling_type="cell",
         units="m/s",
     )
-    ds.add_field(
+    assert_raises(
+        UnitParseError,
+        ds.add_field,
         ("gas", "density_alias_unparseable_units"),
         sampling_type="cell",
         function=density_alias,
@@ -338,9 +337,6 @@ def test_add_field_unit_semantics():
         dimensions="temperature",
     )
     assert_raises(YTFieldUnitError, get_data, ds, ("gas", "density_alias_wrong_units"))
-    assert_raises(
-        YTFieldUnitParseError, get_data, ds, ("gas", "density_alias_unparseable_units")
-    )
     assert_raises(
         YTDimensionalityError, get_data, ds, ("gas", "density_alias_auto_wrong_dims")
     )

--- a/yt/fields/tests/test_magnetic_fields.py
+++ b/yt/fields/tests/test_magnetic_fields.py
@@ -43,19 +43,19 @@ def test_magnetic_fields():
     dd3 = ds3.all_data()
     dd4 = ds4.all_data()
 
-    assert ds0.fields.gas.magnetic_field_strength.units == "G"
-    assert ds1.fields.gas.magnetic_field_strength.units == "G"
-    assert ds1.fields.gas.magnetic_field_poloidal.units == "G"
-    assert ds1.fields.gas.magnetic_field_toroidal.units == "G"
-    assert ds2.fields.gas.magnetic_field_strength.units == "T"
-    assert ds2.fields.gas.magnetic_field_poloidal.units == "T"
-    assert ds2.fields.gas.magnetic_field_toroidal.units == "T"
-    assert ds3.fields.gas.magnetic_field_strength.units == "code_magnetic"
-    assert ds3.fields.gas.magnetic_field_poloidal.units == "code_magnetic"
-    assert ds3.fields.gas.magnetic_field_toroidal.units == "code_magnetic"
-    assert ds4.fields.gas.magnetic_field_strength.units == "code_magnetic"
-    assert ds4.fields.gas.magnetic_field_poloidal.units == "code_magnetic"
-    assert ds4.fields.gas.magnetic_field_toroidal.units == "code_magnetic"
+    assert str(ds0.fields.gas.magnetic_field_strength.units) == "G"
+    assert str(ds1.fields.gas.magnetic_field_strength.units) == "G"
+    assert str(ds1.fields.gas.magnetic_field_poloidal.units) == "G"
+    assert str(ds1.fields.gas.magnetic_field_toroidal.units) == "G"
+    assert str(ds2.fields.gas.magnetic_field_strength.units) == "T"
+    assert str(ds2.fields.gas.magnetic_field_poloidal.units) == "T"
+    assert str(ds2.fields.gas.magnetic_field_toroidal.units) == "T"
+    assert str(ds3.fields.gas.magnetic_field_strength.units) == "code_magnetic"
+    assert str(ds3.fields.gas.magnetic_field_poloidal.units) == "code_magnetic"
+    assert str(ds3.fields.gas.magnetic_field_toroidal.units) == "code_magnetic"
+    assert str(ds4.fields.gas.magnetic_field_strength.units) == "code_magnetic"
+    assert str(ds4.fields.gas.magnetic_field_poloidal.units) == "code_magnetic"
+    assert str(ds4.fields.gas.magnetic_field_toroidal.units) == "code_magnetic"
 
     emag0 = (
         dd0[("gas", "magnetic_field_x")] ** 2


### PR DESCRIPTION
## PR Summary

Rationale: it's easier to convert a Unit objet to string than vice versa.

Expected gain: overall simplifications.

If I find a reason why this change isn't feasible along the way, at least I'll have learned why, and I may even find some simplifications that can still be done.