### PR TITLE
pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,12 +52,12 @@ repos:
       name: isort (cython)
       types: [cython]
 -   repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
     - id: flake8
       additional_dependencies: [
         flake8-bugbear==22.7.1,
-        flake8-logging-format==0.6.0,
+        flake8-logging-format==0.7.4,
         flake8-2020==1.6.1,
       ]
 -   repo: https://github.com/asottile/blacken-docs
@@ -79,5 +79,5 @@ repos:
       args: [--extend-ignore=E402]
       additional_dependencies: [
         flake8-bugbear==22.7.1,
-        flake8-logging-format==0.6.0,
+        flake8-logging-format==0.7.4,
       ]


### PR DESCRIPTION
Updates:
- [github.com/PyCQA/flake8: 4.01 → 5.0.4](https://github.com/PyCQA/flake8/compare/5.0.2...5.0.4)
- [github.com/globality-corp/flake8-logging-format: 0.6.0 → 0.7.4](https://github.com/globality-corp/flake8-logging-format/pull/47)

See https://github.com/yt-project/yt/pull/4045.