### PR TITLE
Adds `data_source` argument to covering grid

### DIFF
--- a/doc/source/examining/low_level_inspection.rst
+++ b/doc/source/examining/low_level_inspection.rst
@@ -229,6 +229,33 @@ to reduce edge effects, it is a nearly identical process:
    print(all_data_level_2_s["gas", "density"][128, 128, 128])
    1.763744852165591e-31
 
+
+Covering grids can also accept a ``data_source`` argument, in which case only
+the cells of the covering grid that are contained by the ``data_source`` will be
+filled. This can be useful to create regularized arrays of more complex
+geometries. For example, if we provide a sphere, we see that the covering grid
+shape is the same, but the number of cells with data is less
+
+.. code-block:: python
+
+   sp = ds.sphere(ds.domain_center, (0.25, "code_length"))
+   cg_sp = ds.covering_grid(
+       level=0, left_edge=[0, 0.0, 0.0], dims=ds.domain_dimensions, data_source=sp
+   )
+
+   print(cg_sp[("gas", "density")].shape)
+   (64, 64, 64)
+
+   print(cg_sp[("gas", "density")].size)
+   262144
+
+   print(cg_sp[("gas", "density")][cg_sp[("gas", "density")] != 0].size)
+   17256
+
+The ``data_source`` can be any :ref:`3D Data Container <region-reference>`. Also
+note that the ``data_source`` argument is only available for the ``covering_grid``
+at present (not the ``smoothed_covering_grid``).
+
 .. _examining-image-data-in-a-fixed-resolution-array:
 
 Examining Image Data in a Fixed Resolution Array

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -656,6 +656,8 @@ class YTCoveringGrid(YTSelectionContainer3D):
         num_ghost_zones=0,
         use_pbar=True,
         field_parameters=None,
+        *,
+        data_source=None,
     ):
         if field_parameters is None:
             center = None
@@ -683,6 +685,7 @@ class YTCoveringGrid(YTSelectionContainer3D):
             )
             + self.ds.domain_offset
         )
+        self._extra_data_source = data_source  # copy instead of reference???
         self._setup_data_source()
         self.get_data(fields)
 
@@ -816,6 +819,11 @@ class YTCoveringGrid(YTSelectionContainer3D):
 
     def _setup_data_source(self):
         self._data_source = self.ds.region(self.center, self.left_edge, self.right_edge)
+        if self._extra_data_source is not None:
+            # intersect the extra with the region
+            self._data_source = self.ds.intersection(
+                [self._extra_data_source, self._data_source]
+            )
         self._data_source.min_level = 0
         self._data_source.max_level = self.level
         # This triggers "special" behavior in the RegionSelector to ensure we

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -627,6 +627,9 @@ class YTCoveringGrid(YTSelectionContainer3D):
         A list of fields that you'd like pre-generated for your object
     num_ghost_zones : integer, optional
         The number of padding ghost zones used when accessing fields.
+    data_source :
+        An existing data_source to intersect with the covering grid. Grid points
+        outside the data_source will exist as empty values.
 
     Examples
     --------
@@ -685,7 +688,7 @@ class YTCoveringGrid(YTSelectionContainer3D):
             )
             + self.ds.domain_offset
         )
-        self._extra_data_source = data_source  # copy instead of reference???
+        self._base_data_source = data_source
         self._setup_data_source()
         self.get_data(fields)
 
@@ -819,10 +822,10 @@ class YTCoveringGrid(YTSelectionContainer3D):
 
     def _setup_data_source(self):
         self._data_source = self.ds.region(self.center, self.left_edge, self.right_edge)
-        if self._extra_data_source is not None:
+        if self._base_data_source is not None:
             # intersect the extra with the region
             self._data_source = self.ds.intersection(
-                [self._extra_data_source, self._data_source]
+                [self._base_data_source, self._data_source]
             )
         self._data_source.min_level = 0
         self._data_source.max_level = self.level

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -666,9 +666,7 @@ class YTCoveringGrid(YTSelectionContainer3D):
             center = None
         else:
             center = field_parameters.get("center", None)
-        super().__init__(
-            self, center, ds, field_parameters, data_source=data_source
-        )
+        super().__init__(center, ds, field_parameters, data_source=data_source)
 
         self.level = level
         self.left_edge = self._sanitize_edge(left_edge)
@@ -825,7 +823,10 @@ class YTCoveringGrid(YTSelectionContainer3D):
 
         reg = self.ds.region(self.center, self.left_edge, self.right_edge)
         if self._data_source is None:
-            # always True for YTArbitraryGrid (does not accept a data_source)
+            # note: https://github.com/yt-project/yt/pull/4063 implemented
+            # a data_source kwarg for YTCoveringGrid, but not YTArbitraryGrid
+            # so as of 4063, this will always be True for YTArbitraryGrid
+            # instances.
             self._data_source = reg
         else:
             self._data_source = self.ds.intersection([self._data_source, reg])

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -628,7 +628,7 @@ class YTCoveringGrid(YTSelectionContainer3D):
     num_ghost_zones : integer, optional
         The number of padding ghost zones used when accessing fields.
     data_source :
-        An existing data_source to intersect with the covering grid. Grid points
+        An existing data object to intersect with the covering grid. Grid points
         outside the data_source will exist as empty values.
 
     Examples
@@ -666,7 +666,7 @@ class YTCoveringGrid(YTSelectionContainer3D):
             center = None
         else:
             center = field_parameters.get("center", None)
-        YTSelectionContainer3D.__init__(
+        super().__init__(
             self, center, ds, field_parameters, data_source=data_source
         )
 

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -825,7 +825,7 @@ class YTCoveringGrid(YTSelectionContainer3D):
 
         reg = self.ds.region(self.center, self.left_edge, self.right_edge)
         if self._data_source is None:
-            # alwasy True for YTArbitraryGrid (does not accept a data_source)
+            # always True for YTArbitraryGrid (does not accept a data_source)
             self._data_source = reg
         else:
             self._data_source = self.ds.intersection([self._data_source, reg])

--- a/yt/data_objects/tests/test_covering_grid.py
+++ b/yt/data_objects/tests/test_covering_grid.py
@@ -82,17 +82,37 @@ def test_covering_grid():
                     ]
                     assert_equal(f, g[("gas", "density")])
 
-            # test the data_source kwarg (new with PR 4063)
+    # More tests for cylindrical geometry
+    for fn in [cyl_2d, cyl_3d]:
+        ds = load(fn)
+        ad = ds.all_data()
+        upper_ad = ad.cut_region(["obj[('index', 'z')] > 0"])
+        sp = ds.sphere((0, 0, 0), 0.5 * ds.domain_width[0], data_source=upper_ad)
+        sp.quantities.total_mass()
+
+
+@requires_file(cyl_2d)
+@requires_file(cyl_3d)
+def test_covering_grid_data_source():
+    # test the data_source kwarg (new with PR 4063)
+
+    for level in [0, 1, 2]:
+        for nprocs in [1, 2, 4, 8]:
+            ds = fake_random_ds(16, nprocs=nprocs)
+            dn = ds.refine_by**level
+            cg = ds.covering_grid(level, [0.0, 0.0, 0.0], dn * ds.domain_dimensions)
 
             # check that the regularized sphere is centered where it should be,
-            # to within the tolerance of the grid
-            center = (
-                ds.domain_center + np.min(ds.domain_width) * 0.15
-            )  # offset the sphere center a bit
+            # to within the tolerance of the grid. Use a center offsect from
+            # the domain center by a bit
+            center = ds.domain_center + np.min(ds.domain_width) * 0.15
             sp = ds.sphere(center, (0.1, "code_length"))
             dims = dn * ds.domain_dimensions
             cg_sp = ds.covering_grid(level, [0.0, 0.0, 0.0], dims, data_source=sp)
-            cg_mask = cg_sp["gas", "density"] != 0  # only values inside will be nonzero
+
+            # find the discrete center of the sphere by averaging the position
+            # along each dimension where values are non-zero
+            cg_mask = cg_sp["gas", "density"] != 0
             discrete_c = ds.arr(
                 [
                     np.mean(cg_sp[("index", dim)][cg_mask])
@@ -106,7 +126,7 @@ def test_covering_grid():
             )
             assert np.all(np.abs(discrete_c - center) <= grid_tol)
 
-            # a region covering the whole domain should look the same as no data_source
+            # check that a region covering the whole domain matches no data_source
             reg = ds.region(ds.domain_center, ds.domain_left_edge, ds.domain_right_edge)
             cg_reg = ds.covering_grid(level, [0.0, 0.0, 0.0], dims, data_source=reg)
             assert np.all(cg[("gas", "density")] == cg_reg[("gas", "density")])
@@ -121,14 +141,6 @@ def test_covering_grid():
             ].sum()
             actual_vol = np.prod(right_edge - ds.domain_left_edge)
             assert box_vol == actual_vol
-
-    # More tests for cylindrical geometry
-    for fn in [cyl_2d, cyl_3d]:
-        ds = load(fn)
-        ad = ds.all_data()
-        upper_ad = ad.cut_region(["obj[('index', 'z')] > 0"])
-        sp = ds.sphere((0, 0, 0), 0.5 * ds.domain_width[0], data_source=upper_ad)
-        sp.quantities.total_mass()
 
 
 @requires_module("xarray")

--- a/yt/data_objects/tests/test_covering_grid.py
+++ b/yt/data_objects/tests/test_covering_grid.py
@@ -310,3 +310,7 @@ def test_arbitrary_grid_edge():
         assert ag.left_edge.units.registry == ds.unit_registry
         assert ag.right_edge.units.registry == ds.unit_registry
         ag[("gas", "density")]
+
+
+# def test_covering_grid_data_source_intersection()
+#     placeholder for a great new test


### PR DESCRIPTION
This adds a `data_source` keyword (only) argument to the `YTCoveringGrid` and then intersects  that `data_source` with the region used for the covering grid in order to create a regularized sampling of, e.g., a sphere. 

Here's an example:

```python
import yt
import numpy as np
import matplotlib.pyplot as plt 

ds = yt.load_sample("IsolatedGalaxy")

cg = ds.covering_grid(2, left_edge=[0.0, 0.0, 0.0], dims=[128, 128, 128])
gridded_dens = cg[("gas", "density")]

sp = ds.sphere(ds.domain_center, 0.2)
cg_sp_intx = ds.covering_grid(2, left_edge=[0.0, 0.0, 0.0], dims=[128, 128, 128], data_source=sp)
gridded_dens_in_sphere = cg_sp_intx[("gas", "density")]

f, axs = plt.subplots(nrows=1, ncols=2)
axs[0].imshow(np.log10(gridded_dens[:,:,64]))
axs[1].imshow(np.log10(gridded_dens_in_sphere[:,:,64]))
```

![image](https://user-images.githubusercontent.com/22038879/183475195-cdda5fd1-8c0b-480d-af16-570c3a0429f0.png)

Pushing a  nominally working draft now... but when ready this would close #4052 