### PR TITLE
Update to grid_patch.py to avoid calling units

### DIFF
--- a/yt/data_objects/index_subobjects/grid_patch.py
+++ b/yt/data_objects/index_subobjects/grid_patch.py
@@ -338,8 +338,8 @@ class AMRGridPatch(YTSelectionContainer):
             return np.empty((0, 3), dtype="float64")
         coords = convert_mask_to_indices(mask, self._last_count).astype("float64")
         coords += 0.5
-        coords *= self.dds[None, :]
-        coords += self.LeftEdge[None, :]
+        coords *= self.dds.d[None, :]
+        coords += self.LeftEdge.d[None, :]
         return coords
 
     def select_fwidth(self, dobj):


### PR DESCRIPTION
This is to speed up calculations of the grid coordinates x, y, z which also benefits radius calculations and other geometric operations in derived fields.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
