### PR TITLE
`GAMER` frontend modification for incorporating lookback time in cosmological simulation

### DIFF
--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -336,7 +336,7 @@ class GAMERDataset(Dataset):
             # default to 0.7 for old data format
             self.hubble_constant = parameters.get("Hubble0", 0.7)
 
-            # use cosmology age computed by the given cosmological parameters as current time when COMOVING is on; cosmology age computed by subtracting lookback time at self.current_redshift, from the lookback time at z = 1e6, i.e. very early universe
+            # use the cosmological age computed by the given cosmological parameters as the current time when COMOVING is on; cosmological age is computed by subtracting the lookback time at self.current_redshift from that at z = 1e6 (i.e., very early universe)
             cosmo = Cosmology(
                 hubble_constant=self.hubble_constant,
                 omega_matter=self.omega_matter,

--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -7,8 +7,8 @@ from yt.data_objects.index_subobjects.grid_patch import AMRGridPatch
 from yt.data_objects.static_output import Dataset
 from yt.funcs import mylog, setdefaultattr
 from yt.geometry.grid_geometry_handler import GridIndex
-from yt.utilities.file_handler import HDF5FileHandler
 from yt.utilities.cosmology import Cosmology
+from yt.utilities.file_handler import HDF5FileHandler
 
 from .definitions import geometry_parameters
 from .fields import GAMERFieldInfo

--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -336,7 +336,7 @@ class GAMERDataset(Dataset):
             # default to 0.7 for old data format
             self.hubble_constant = parameters.get("Hubble0", 0.7)
 
-            # use cosmology age computed by the given cosmological parameters as current time when COMOVING is on; cosmolgy age computed by subtracting lookback time at self.current_redshift, with lookback time at z = 1e6, i.e. very early universe
+            # use cosmology age computed by the given cosmological parameters as current time when COMOVING is on; cosmology age computed by subtracting lookback time at self.current_redshift, with lookback time at z = 1e6, i.e. very early universe
             cosmo = Cosmology(
                 hubble_constant=self.hubble_constant,
                 omega_matter=self.omega_matter,

--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -335,7 +335,7 @@ class GAMERDataset(Dataset):
             self.omega_lambda = 1.0 - self.omega_matter
             # default to 0.7 for old data format
             self.hubble_constant = parameters.get("Hubble0", 0.7)
-            
+
             # use cosmological lookback time as current time when COMOVING is on
             cosmo = Cosmology(
                 hubble_constant=self.hubble_constant,

--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -329,12 +329,14 @@ class GAMERDataset(Dataset):
         # cosmological parameters
         if parameters["Comoving"]:
             self.cosmological_simulation = 1
+            # here parameters["Time"][0] is the scale factor a at certain redshift
             self.current_redshift = 1.0 / parameters["Time"][0] - 1.0
             self.omega_matter = parameters["OmegaM0"]
             self.omega_lambda = 1.0 - self.omega_matter
             # default to 0.7 for old data format
             self.hubble_constant = parameters.get("Hubble0", 0.7)
             
+            # use cosmological lookback time as current time when COMOVING is on
             cosmo = Cosmology(
                 hubble_constant=self.hubble_constant,
                 omega_matter=self.omega_matter,
@@ -347,6 +349,8 @@ class GAMERDataset(Dataset):
             self.omega_matter = 0.0
             self.omega_lambda = 0.0
             self.hubble_constant = 0.0
+
+            # use parameters["Time"][0] as current time when COMOVIG is off
             self.current_time = parameters["Time"][0]
 
         # make aliases to some frequently used variables

--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -336,7 +336,7 @@ class GAMERDataset(Dataset):
             # default to 0.7 for old data format
             self.hubble_constant = parameters.get("Hubble0", 0.7)
 
-            # use cosmological lookback time as current time when COMOVING is on
+            # use cosmology age computed by the given cosmological parameters as current time when COMOVING is on; cosmolgy age computed by subtracting lookback time at self.current_redshift, with lookback time at z = 1e6, i.e. very early universe
             cosmo = Cosmology(
                 hubble_constant=self.hubble_constant,
                 omega_matter=self.omega_matter,

--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -336,7 +336,7 @@ class GAMERDataset(Dataset):
             # default to 0.7 for old data format
             self.hubble_constant = parameters.get("Hubble0", 0.7)
 
-            # use cosmology age computed by the given cosmological parameters as current time when COMOVING is on; cosmology age computed by subtracting lookback time at self.current_redshift, with lookback time at z = 1e6, i.e. very early universe
+            # use cosmology age computed by the given cosmological parameters as current time when COMOVING is on; cosmology age computed by subtracting lookback time at self.current_redshift, from the lookback time at z = 1e6, i.e. very early universe
             cosmo = Cosmology(
                 hubble_constant=self.hubble_constant,
                 omega_matter=self.omega_matter,

--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -342,7 +342,7 @@ class GAMERDataset(Dataset):
                 omega_matter=self.omega_matter,
                 omega_lambda=self.omega_lambda,
             )
-            self.current_time    = cosmo.lookback_time(self.current_redshift, 1e6)
+            self.current_time = cosmo.lookback_time(self.current_redshift, 1e6)
         else:
             self.cosmological_simulation = 0
             self.current_redshift = 0.0
@@ -350,7 +350,7 @@ class GAMERDataset(Dataset):
             self.omega_lambda = 0.0
             self.hubble_constant = 0.0
 
-            # use parameters["Time"][0] as current time when COMOVIG is off
+            # use parameters["Time"][0] as current time when COMOVING is off
             self.current_time = parameters["Time"][0]
 
         # make aliases to some frequently used variables


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

Hi, this is a `GAMER` frontend modification for the `current_time` definition for `GAMER` cosmology simulation, thank you!
## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->
* Modify definition for `current_time` in `GAMER` cosmology simulation (`COMOVING` is on)
   * Before modification, `current_time` **equals to scale factor `a`**, resulting in **problematic value when annotating timestamp**.
   * After modification, `current_time` **equals to cosmological age at given redshift**. 
* Definition for `current_time` is intact for `COMOVING` is off
* Add explanation for code lines

<!--If it fixes an open issue, please link to the issue here.-->

<!--
## PR Checklist
-->

<!-- Note that some of these check boxes may not apply to all pull requests -->
<!--
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
-->

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->


