### PR TITLE
DEPR: deprecate yt.define_units

### DIFF
--- a/yt/__init__.py
+++ b/yt/__init__.py
@@ -8,6 +8,8 @@ yt is a toolkit for analyzing and visualizing volumetric data.
 
 """
 from ._version import __version__, version_info  # isort: skip
+from unyt import define_unit
+
 import yt.units as units
 import yt.utilities.physical_constants as physical_constants
 from yt.data_objects.api import (
@@ -68,7 +70,6 @@ from yt.units import (
     uunion1d,
     uvstack,
 )
-from yt.units.unit_object import define_unit  # type: ignore
 from yt.utilities.logger import set_log_level, ytLogger as mylog
 
 frontends = _frontend_container()

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -10,6 +10,7 @@ from tempfile import NamedTemporaryFile, TemporaryFile
 import numpy as np
 from more_itertools import always_iterable
 from tqdm import tqdm
+from unyt import Unit
 
 from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.config import ytcfg
@@ -25,7 +26,6 @@ from yt.funcs import get_memory_usage, is_sequence, iter_fields, mylog, only_on_
 from yt.geometry import particle_deposit as particle_deposit
 from yt.geometry.coordinates.cartesian_coordinates import all_data
 from yt.loaders import load_uniform_grid
-from yt.units.unit_object import Unit  # type: ignore
 from yt.units.yt_array import YTArray, uconcatenate  # type: ignore
 from yt.utilities.exceptions import (
     YTNoAPIKey,

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -1,11 +1,11 @@
 import numpy as np
 from more_itertools import collapse
+from unyt import Unit
 
 from yt.data_objects.field_data import YTFieldData
 from yt.fields.derived_field import DerivedField
 from yt.frontends.ytdata.utilities import save_as_dataset
 from yt.funcs import get_output_filename, is_sequence, iter_fields, mylog
-from yt.units.unit_object import Unit  # type: ignore
 from yt.units.yt_array import YTQuantity, array_like_field
 from yt.utilities.exceptions import (
     YTIllDefinedBounds,

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -15,6 +15,7 @@ from typing import DefaultDict, Dict, List, Optional, Set, Tuple, Type, Union
 
 import numpy as np
 from more_itertools import unzip
+from unyt import Unit, define_unit
 from unyt.exceptions import UnitConversionError, UnitParseError
 
 from yt._maintenance.deprecation import issue_deprecation_warning
@@ -39,7 +40,6 @@ from yt.geometry.coordinates.api import (
 from yt.geometry.geometry_handler import Index
 from yt.units import UnitContainer, _wrap_display_ytarray, dimensions
 from yt.units.dimensions import current_mks  # type: ignore
-from yt.units.unit_object import Unit, define_unit  # type: ignore
 from yt.units.unit_registry import UnitRegistry  # type: ignore
 from yt.units.unit_systems import (  # type: ignore
     create_code_unit_system,

--- a/yt/data_objects/tests/test_cutting_plane.py
+++ b/yt/data_objects/tests/test_cutting_plane.py
@@ -1,8 +1,9 @@
 import os
 import tempfile
 
+from unyt import Unit
+
 from yt.testing import assert_equal, fake_random_ds
-from yt.units.unit_object import Unit
 
 
 def setup():

--- a/yt/data_objects/tests/test_projection.py
+++ b/yt/data_objects/tests/test_projection.py
@@ -3,9 +3,9 @@ import tempfile
 from unittest import mock
 
 import numpy as np
+from unyt import Unit
 
 from yt.testing import assert_equal, assert_rel_equal, fake_amr_ds, fake_random_ds
-from yt.units.unit_object import Unit
 
 LENGTH_UNIT = 2.0
 

--- a/yt/data_objects/tests/test_slice.py
+++ b/yt/data_objects/tests/test_slice.py
@@ -3,9 +3,9 @@ import tempfile
 from unittest import mock
 
 import numpy as np
+from unyt import Unit
 
 from yt.testing import assert_equal, fake_random_ds
-from yt.units.unit_object import Unit
 
 
 def setup():

--- a/yt/fields/derived_field.py
+++ b/yt/fields/derived_field.py
@@ -4,11 +4,11 @@ import re
 from typing import Optional, Tuple, Union
 
 from more_itertools import always_iterable
+from unyt import Unit
 
 import yt.units.dimensions as ytdims
 from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.funcs import iter_fields, validate_field_key
-from yt.units.unit_object import Unit  # type: ignore
 from yt.utilities.exceptions import YTFieldNotFound
 from yt.utilities.logger import ytLogger as mylog
 

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -3,6 +3,7 @@ from numbers import Number as numeric_type
 from typing import Optional, Tuple
 
 import numpy as np
+from unyt import Unit
 from unyt.exceptions import UnitConversionError
 
 from yt._typing import KnownFieldsT
@@ -11,7 +12,6 @@ from yt.fields.field_exceptions import NeedsConfiguration
 from yt.funcs import mylog, obj_length, only_on_root
 from yt.geometry.geometry_handler import is_curvilinear
 from yt.units.dimensions import dimensionless  # type: ignore
-from yt.units.unit_object import Unit  # type: ignore
 from yt.utilities.exceptions import (
     YTCoordinateNotImplemented,
     YTDomainOverflow,

--- a/yt/fields/fluid_fields.py
+++ b/yt/fields/fluid_fields.py
@@ -1,7 +1,7 @@
 import numpy as np
+from unyt import Unit
 
 from yt.units.dimensions import current_mks  # type: ignore
-from yt.units.unit_object import Unit  # type: ignore
 from yt.utilities.chemical_formulas import compute_mu
 from yt.utilities.lib.misc_utilities import obtain_relative_velocity_vector
 

--- a/yt/fields/vector_operations.py
+++ b/yt/fields/vector_operations.py
@@ -152,7 +152,7 @@ def create_squared_field(
 
 
 def create_vector_fields(registry, basename, field_units, ftype="gas", slice_info=None):
-    from yt.units.unit_object import Unit
+    from unyt import Unit
 
     # slice_info would be the left, the right, and the factor.
     # For example, with the old Enzo-ZEUS fields, this would be:

--- a/yt/frontends/chombo/fields.py
+++ b/yt/frontends/chombo/fields.py
@@ -1,4 +1,5 @@
 import numpy as np
+from unyt import Unit
 
 from yt._typing import KnownFieldsT
 from yt.fields.field_info_container import (
@@ -7,7 +8,6 @@ from yt.fields.field_info_container import (
     particle_vector_functions,
     standard_particle_fields,
 )
-from yt.units.unit_object import Unit  # type: ignore
 from yt.utilities.exceptions import YTFieldNotFound
 
 rho_units = "code_mass / code_length**3"

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -10,6 +10,7 @@ from typing import Type
 import numpy as np
 import numpy.core.defchararray as np_char
 from more_itertools import always_iterable
+from unyt.exceptions import UnitParseError
 
 from yt.config import ytcfg
 from yt.data_objects.index_subobjects.grid_patch import AMRGridPatch
@@ -23,7 +24,6 @@ from yt.units.unit_lookup_table import (  # type: ignore
     default_unit_symbol_lut,
     unit_prefixes,
 )
-from yt.units.unit_object import UnitParseError  # type: ignore
 from yt.units.yt_array import YTQuantity
 from yt.utilities.decompose import decompose_array, get_psize
 from yt.utilities.file_handler import FITSFileHandler

--- a/yt/frontends/gdf/data_structures.py
+++ b/yt/frontends/gdf/data_structures.py
@@ -3,13 +3,13 @@ import sys
 import weakref
 
 import numpy as np
+from unyt import Unit
 
 from yt.data_objects.index_subobjects.grid_patch import AMRGridPatch
 from yt.data_objects.static_output import Dataset
 from yt.funcs import just_one, setdefaultattr
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.units.dimensions import dimensionless as sympy_one  # type: ignore
-from yt.units.unit_object import Unit  # type: ignore
 from yt.units.unit_systems import unit_system_registry  # type: ignore
 from yt.utilities.exceptions import YTGDFUnknownGeometry
 from yt.utilities.lib.misc_utilities import get_box_grids_level

--- a/yt/units/__init__.py
+++ b/yt/units/__init__.py
@@ -13,7 +13,7 @@ from unyt.array import (
     uunion1d,
     uvstack,
 )
-from unyt.unit_object import Unit, define_unit  # NOQA: F401
+from unyt.unit_object import Unit # NOQA: F401
 from unyt.unit_registry import UnitRegistry  # NOQA: Ffg401
 from unyt.unit_systems import UnitSystem  # NOQA: F401
 
@@ -22,6 +22,7 @@ from yt.units.physical_constants import _ConstantContainer
 from yt.units.unit_symbols import *
 from yt.units.unit_symbols import _SymbolContainer
 from yt.utilities.exceptions import YTArrayTooLargeToDisplay
+from yt.units.unit_object import define_unit
 
 YTArray = unyt_array
 

--- a/yt/units/unit_object.py
+++ b/yt/units/unit_object.py
@@ -1,1 +1,27 @@
-from unyt.unit_object import *
+# re-export all of unyt.unit_object's public interface, except for `define_unit`
+from unyt.unit_object import sympy_one, Unit, em_conversions, em_conversion_dims, NULL_UNIT
+
+
+def define_unit(
+    symbol, value, tex_repr=None, offset=None, prefixable=False, registry=None
+):
+    from unyt import define_unit as unyt_define_unit
+    from yt._maintenance.deprecation import issue_deprecation_warning
+
+    issue_deprecation_warning(
+        "yt.units.unit_object.define_unit is deprecated. "
+        "It is an alias for unyt.define_unit and does not actually make "
+        "new units available to yt datasets. "
+        "Use unyt.define_unit directly if it fits your needs. "
+        "Otherwise, if you wish to add units to yt datasets, use the ds.define_unit "
+        "method instead.",
+        since="4.1"
+    )
+    unyt_define_unit(
+        symbol,
+        value,
+        tex_repr=tex_repr,
+        offset=offset,
+        prefixable=prefixable,
+        registry=registry,
+    )

--- a/yt/utilities/cosmology.py
+++ b/yt/utilities/cosmology.py
@@ -1,9 +1,9 @@
 import functools
 
 import numpy as np
+from unyt import Unit
 
 from yt.units import dimensions
-from yt.units.unit_object import Unit  # type: ignore
 from yt.units.unit_registry import UnitRegistry  # type: ignore
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.physical_constants import (

--- a/yt/visualization/eps_writer.py
+++ b/yt/visualization/eps_writer.py
@@ -3,9 +3,9 @@ import os
 import numpy as np
 import pyx
 from matplotlib import pyplot as plt
+from unyt import Unit
 
 from yt.config import ytcfg
-from yt.units.unit_object import Unit  # type: ignore
 from yt.units.yt_array import YTQuantity
 from yt.utilities.logger import ytLogger as mylog
 

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -4,6 +4,7 @@ from numbers import Number as numeric_type
 
 import numpy as np
 from more_itertools import first, mark_ends
+from unyt import Unit
 
 from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.data_objects.construction_data_containers import YTCoveringGrid
@@ -11,7 +12,6 @@ from yt.data_objects.image_array import ImageArray
 from yt.fields.derived_field import DerivedField
 from yt.funcs import fix_axis, is_sequence, iter_fields, mylog
 from yt.units import dimensions
-from yt.units.unit_object import Unit  # type: ignore
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.on_demand_imports import _astropy
 from yt.utilities.parallel_tools.parallel_analysis_interface import parallel_root_only

--- a/yt/visualization/line_plot.py
+++ b/yt/visualization/line_plot.py
@@ -3,9 +3,9 @@ from typing import Optional
 
 import numpy as np
 from matplotlib.colors import LogNorm, Normalize, SymLogNorm
+from unyt import Unit
 
 from yt.funcs import is_sequence, mylog
-from yt.units.unit_object import Unit  # type: ignore
 from yt.units.yt_array import YTArray
 from yt.visualization.plot_container import (
     BaseLinePlot,

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional, Tuple, Type, Union
 import matplotlib
 from matplotlib.colors import LogNorm, Normalize, SymLogNorm
 from matplotlib.font_manager import FontProperties
+from unyt import Unit
 from unyt.dimensions import length
 
 from yt._maintenance.deprecation import issue_deprecation_warning
@@ -18,7 +19,6 @@ from yt._typing import Quantity
 from yt.config import ytcfg
 from yt.data_objects.time_series import DatasetSeries
 from yt.funcs import ensure_dir, is_sequence, iter_fields
-from yt.units.unit_object import Unit  # type: ignore
 from yt.utilities.definitions import formatted_length_unit_names
 from yt.utilities.exceptions import YTConfigurationError, YTNotInsideNotebook
 from yt.visualization._commons import get_default_from_config

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -7,13 +7,13 @@ import matplotlib
 import numpy as np
 from matplotlib.colors import Normalize
 from more_itertools import always_iterable
+from unyt import Unit
 from unyt.exceptions import UnitConversionError
 
 from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.data_objects.image_array import ImageArray
 from yt.frontends.ytdata.data_structures import YTSpatialPlotDataset
 from yt.funcs import fix_axis, fix_unitary, is_sequence, iter_fields, mylog, obj_length
-from yt.units.unit_object import Unit  # type: ignore
 from yt.units.unit_registry import UnitParseError  # type: ignore
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.exceptions import (

--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -1,8 +1,8 @@
 import numpy as np
+from unyt import Unit
 
 from yt.data_objects.api import ImageArray
 from yt.funcs import is_sequence, mylog
-from yt.units.unit_object import Unit  # type: ignore
 from yt.utilities.lib.partitioned_grid import PartitionedGrid
 from yt.utilities.lib.pixelization_routines import (
     normalization_2d_utility,


### PR DESCRIPTION
## PR Summary
Since its actual behaviour doesn't meet expectations (#3876), and it appears unfeasible to make this function relevant (#4060), I propose we simply deprecate it.
