### PR TITLE
BUG: Off-axis projections of filtered gas particles are not scaled correctly

### DIFF
--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -228,12 +228,10 @@ def off_axis_projection(
                 )
 
             # Assure that the path length unit is in the default length units
-            # for the dataset by scaling the units of the smoothing length
-            path_length_unit = data_source.ds._get_field_info(
-                (ptype, "smoothing_length")
-            ).units
+            # for the dataset by scaling the units of the smoothing length,
+            # which in the above calculation is set to be code_length
             path_length_unit = Unit(
-                path_length_unit, registry=data_source.ds.unit_registry
+                "code_length", registry=data_source.ds.unit_registry
             )
             default_path_length_unit = data_source.ds.unit_system["length"]
             buf *= data_source.ds.quan(1, path_length_unit).in_units(


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

I discovered that off-axis projections of filtered gas particles have incorrect scaling. This can be seen clearly in the following notebook:

https://gist.github.com/f97283ce13c4850e31f4b0715f31202f

where the colorbar ranges for the on-axis and off-axis projection should be the same (same axis, different methods), but they are not. The difference arises because the off-axis projection code for SPH particles scales by the units of the `smoothing_length` field to compute the path length, and this is done incorrectly for filtered particles. The reason for this is because the projection calculation is done in code units, and for non-filtered gas particles the path length scaling is done in the units of the `smoothing_length`, which is always `code_length`. However, for filtered gas particles, the smoothing length is in default units of cm (or whatever the unit system happens to be).

The solution is to simply assume that the unit for the path length scaling will always be `code_length`, since the calculation above it of the projection is explicitly carried out in code units. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
