### PR TITLE
ENH: Optimized radius calculation. 

### DIFF
--- a/yt/fields/field_functions.py
+++ b/yt/fields/field_functions.py
@@ -9,7 +9,7 @@ from yt.utilities.lib.misc_utilities import obtain_position_vector
 def get_radius(data, field_prefix, ftype):
     center = data.get_field_parameter("center").to("code_length")
     DW = (data.ds.domain_right_edge - data.ds.domain_left_edge).to("code_length")
-    # This is in cm so it can be the destination for our r later.
+    # This is in code_length so it can be the destination for our r later.
     radius2 = data.ds.arr(
         np.zeros(data[ftype, field_prefix + "x"].shape, dtype="float64"), "code_length")
     
@@ -17,8 +17,6 @@ def get_radius(data, field_prefix, ftype):
     if any(data.ds.periodicity):
         rdw = radius2.v
     for i, ax in enumerate("xyz"):
-        # This will coerce the units, so we don't need to worry that we copied
-        # it from a cm**2 array.
         np.subtract(
             data[ftype, f"{field_prefix}{ax}"].d,
             center[i].d,

--- a/yt/fields/field_functions.py
+++ b/yt/fields/field_functions.py
@@ -11,8 +11,9 @@ def get_radius(data, field_prefix, ftype):
     DW = (data.ds.domain_right_edge - data.ds.domain_left_edge).to("code_length")
     # This is in code_length so it can be the destination for our r later.
     radius2 = data.ds.arr(
-        np.zeros(data[ftype, field_prefix + "x"].shape, dtype="float64"), "code_length")
-    
+        np.zeros(data[ftype, field_prefix + "x"].shape, dtype="float64"), "code_length"
+    )
+
     r = radius2.v
     if any(data.ds.periodicity):
         rdw = radius2.v

--- a/yt/fields/field_functions.py
+++ b/yt/fields/field_functions.py
@@ -7,37 +7,35 @@ from yt.utilities.lib.misc_utilities import obtain_position_vector
 
 
 def get_radius(data, field_prefix, ftype):
-    unit_system = data.ds.unit_system
-    center = data.get_field_parameter("center").in_base(unit_system.name)
-    DW = (data.ds.domain_right_edge - data.ds.domain_left_edge).in_base(
-        unit_system.name
-    )
-    # This is in cm**2 so it can be the destination for our r later.
+    center = data.get_field_parameter("center").to("code_length")
+    DW = (data.ds.domain_right_edge - data.ds.domain_left_edge).to("code_length")
+    # This is in cm so it can be the destination for our r later.
     radius2 = data.ds.arr(
-        np.zeros(data[ftype, field_prefix + "x"].shape, dtype="float64"), "cm**2"
-    )
-    r = radius2.copy()
+        np.zeros(data[ftype, field_prefix + "x"].shape, dtype="float64"), "code_length")
+    
+    r = radius2.v
     if any(data.ds.periodicity):
-        rdw = radius2.copy()
+        rdw = radius2.v
     for i, ax in enumerate("xyz"):
         # This will coerce the units, so we don't need to worry that we copied
         # it from a cm**2 array.
         np.subtract(
-            data[ftype, f"{field_prefix}{ax}"].in_base(unit_system.name),
-            center[i],
+            data[ftype, f"{field_prefix}{ax}"].d,
+            center[i].d,
             r,
         )
         if data.ds.periodicity[i]:
             np.abs(r, r)
-            np.subtract(r, DW[i], rdw)
+            np.subtract(r, DW.d[i], rdw)
             np.abs(rdw, rdw)
             np.minimum(r, rdw, r)
         np.multiply(r, r, r)
-        np.add(radius2, r, radius2)
+        np.add(radius2.d, r, radius2.d)
         if data.ds.dimensionality < i + 1:
             break
-    # Now it's cm.
-    np.sqrt(radius2, radius2)
+    # Using the views into the array is not changing units and as such keeps
+    # from having to do symbolic manipulations
+    np.sqrt(radius2.d, radius2.d)
     # Alias it, just for clarity.
     radius = radius2
     return radius

--- a/yt/fields/field_functions.py
+++ b/yt/fields/field_functions.py
@@ -14,7 +14,7 @@ def get_radius(data, field_prefix, ftype):
         np.zeros(data[ftype, field_prefix + "x"].shape, dtype="float64"), "code_length"
     )
 
-    r = radius2.v
+    r = np.empty_like(radius2, subok=False)
     if any(data.ds.periodicity):
         rdw = radius2.v
     for i, ax in enumerate("xyz"):


### PR DESCRIPTION
## PR Summary

Changes one of the routines that calculated spherical radius. 
`get_radius` in `fields/field_functions.py`
It runs approximately twice as fast as the original routine it replaces. 
Performance benefits come from minimizing allocations and triggering unit conversions. 

The script I used for testing is here: 
```python
import yt

for i in range(10):
    ds = yt.frontends.enzo.EnzoDataset(fn)
    ds._periodicity = (False, False, False) # Checking periodicity is slow in yt
    readit = ds.all_data()  # already defines xyz

    r = readit[("index", "radius")]

yt.SlicePlot(ds, "z", ("index", "radius")).save()

```
where `fn` can be obtained in a separate script as
```python
import yt
fn = yt.load_sample("HiresIsolatedGalaxy").filename
```
