### PR TITLE
Compute gradients for datasets with non-periodic boundaries

### DIFF
--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -35,7 +35,10 @@ from yt.utilities.exceptions import (
 )
 from yt.utilities.grid_data_format.writer import write_to_gdf
 from yt.utilities.lib.cyoctree import CyOctree
-from yt.utilities.lib.interpolators import ghost_zone_interpolate
+from yt.utilities.lib.interpolators import (
+    ghost_zone_interpolate, 
+    fix_nonperiodic
+)
 from yt.utilities.lib.marching_cubes import march_cubes_grid, march_cubes_grid_flux
 from yt.utilities.lib.misc_utilities import fill_region, fill_region_float
 from yt.utilities.lib.pixelization_routines import (
@@ -1513,6 +1516,9 @@ class YTSmoothedCoveringGrid(YTCoveringGrid):
 
     def _update_level_state(self, level_state):
         ls = level_state
+        if any(self.fix_nonperiodic):
+            for field in level_state.fields:
+                fix_nonperiodic(field, self.lo_offset, self.hi_offset)
         if ls.current_level >= self.level:
             return
         rf = float(self.ds.relative_refinement(ls.current_level, ls.current_level + 1))

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -1053,6 +1053,9 @@ class YTCoveringGrid(YTSelectionContainer3D):
         if self.comm.size > 1:
             for i in range(len(fields)):
                 output_fields[i] = self.comm.mpi_allreduce(output_fields[i], op="sum")
+        # if any(ls.fix_nonperiodic):
+        #     for i in range(len(fields)):
+        #         fix_nonperiodic(output_fields[i], self.fix_lo, self.fix_hi)
         for name, v in zip(fields, output_fields):
             fi = self.ds._get_field_info(*name)
             self[name] = self.ds.arr(v, fi.units)

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -170,6 +170,7 @@ class Dataset(abc.ABC):
     domain_offset = np.zeros(3, dtype="int64")
     _periodicity = MutableAttribute()
     _force_periodicity = False
+    _set_periodicity = None
 
     # these are set in self._set_derived_attrs()
     domain_width = MutableAttribute(True)
@@ -323,6 +324,8 @@ class Dataset(abc.ABC):
     def periodicity(self):
         if self._force_periodicity:
             return (True, True, True)
+        if self._set_periodicity is not None:
+            return self._set_periodicity
         return self._periodicity
 
     def force_periodicity(self, val=True):
@@ -335,6 +338,18 @@ class Dataset(abc.ABC):
         if not isinstance(val, bool):
             raise TypeError("force_periodicity expected a boolean.")
         self._force_periodicity = val
+
+    def set_periodicity(self, val):
+        """
+        Set box periodicity to user defined periodicity.
+        """
+        if isinstance(val, bool):
+            val = (val, val, val)
+        if not isinstance(val, tuple):
+            raise TypeError("set_periodicity must be a boolean or tuple of booleans.")
+        if len(val) != 3 or not all([isinstance(v, bool) for v in val]):
+            raise TypeError("user supplied periodicities must be a tuple of 3 booleans.")
+        self._set_periodicity = val
 
     # abstract methods require implementation in subclasses
     @classmethod


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

This PR is an attempt to allow the user to visualize the gradient field of an entire domain even if the boundaries are non-periodic without any errors or setting the dataset to be periodic. This will close #4083 . The reason for this PR is described in #4083 .

The basic idea for the fix is to _always_ assume periodicity, then replace the incorrect cells with extrapolation.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] Add functionality for gradient fields
- [ ] Add functionality for covering grids (i.e., extrapolate data)
- [ ] Ensure checks and warnings are in place
- [ ] Document new features with docstrings and narrative docs
- [ ] Add tests to ensure function work properly

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
