### PR TITLE
Re-adding scipy optimize to on-demand imports

### DIFF
--- a/yt/utilities/on_demand_imports.py
+++ b/yt/utilities/on_demand_imports.py
@@ -252,6 +252,12 @@ class scipy_imports(OnDemand):
 
         return ndimage
 
+    @safe_import
+    def optimize(self):
+        from scipy import optimize
+
+        return optimize
+
 
 _scipy = scipy_imports()
 

--- a/yt/utilities/on_demand_imports.py
+++ b/yt/utilities/on_demand_imports.py
@@ -252,6 +252,9 @@ class scipy_imports(OnDemand):
 
         return ndimage
 
+    # Optimize is not presently used by yt, but appears here to enable
+    # required functionality in yt extension, trident
+
     @safe_import
     def optimize(self):
         from scipy import optimize


### PR DESCRIPTION
Recently, when the on-demand imports were being cleaned up in [#c501b8c](https://github.com/yt-project/yt/commit/c501b8cc746b4504a9cdcb6d48b85138d6bda390), scipy.optimize was removed as an alias.  It turns out that this broke Trident, so I'd like to add it back in.