### PR TITLE
Make sure positions are in code_length in get_radius function.

### DIFF
--- a/yt/fields/field_functions.py
+++ b/yt/fields/field_functions.py
@@ -19,7 +19,7 @@ def get_radius(data, field_prefix, ftype):
         rdw = radius2.v
     for i, ax in enumerate("xyz"):
         np.subtract(
-            data[ftype, f"{field_prefix}{ax}"].d,
+            data[ftype, f"{field_prefix}{ax}"].to("code_length").d,
             center[i].d,
             r,
         )

--- a/yt/fields/field_functions.py
+++ b/yt/fields/field_functions.py
@@ -18,8 +18,11 @@ def get_radius(data, field_prefix, ftype):
     if any(data.ds.periodicity):
         rdw = radius2.v
     for i, ax in enumerate("xyz"):
+        pos = data[ftype, f"{field_prefix}{ax}"]
+        if str(pos.units) != "code_length":
+            pos.convert_to_units("code_length")
         np.subtract(
-            data[ftype, f"{field_prefix}{ax}"].to("code_length").d,
+            pos.d,
             center[i].d,
             r,
         )

--- a/yt/fields/field_functions.py
+++ b/yt/fields/field_functions.py
@@ -20,7 +20,7 @@ def get_radius(data, field_prefix, ftype):
     for i, ax in enumerate("xyz"):
         pos = data[ftype, f"{field_prefix}{ax}"]
         if str(pos.units) != "code_length":
-            pos.convert_to_units("code_length")
+            pos = pos.to("code_length")
         np.subtract(
             pos.d,
             center[i].d,


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

PR #4079 changed results for particle_radius calculation within a yt frontend embedded in ytree. After some digging, I discovered that positions for that frontend are returned in "unitary" units which, for that data, are not the same as "code_length". Unless we have a specification requiring positions to be returned in "code_length" for all frontends, this change is probably necessary. This may be quietly failing for other frontends.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
