### PR TITLE
TST: bump Python from 3.7 to 3.9 in answer testing

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -50,7 +50,7 @@ jobs:
             # answer tests use 'yield', so they require nose
             # they are also attached to a specific, occasionally updated, Python version
             # but it does *not* have to match the current minimal supported version
-            python-version: '3.7'
+            python-version: '3.9'
             dependencies: full
             tests-type: answer
             test-runner: nose


### PR DESCRIPTION
## PR Summary

It's time to fix #3932, as matplotlib is starting the release process for version 3.6 [without wheels for Python 3.7](https://pypi.org/project/matplotlib/3.6.0rc1/#files), which means our reference answers will soon be out of sync with their latest release.

This will require a supporting PR to the answer store submodule to create reference answers for Python 3.9
Edit: here https://github.com/yt-project/answer-store/pull/32