### PR TITLE
ENH: Store the Enzo-E version number in parameters attribute of EnzoEDataset

### DIFF
--- a/yt/frontends/enzo_e/data_structures.py
+++ b/yt/frontends/enzo_e/data_structures.py
@@ -399,10 +399,10 @@ class EnzoEDataset(Dataset):
         fh = h5py.File(os.path.join(self.directory, fn0), "r")
         self.domain_left_edge = fh.attrs["lower"]
         self.domain_right_edge = fh.attrs["upper"]
-        if 'version' in fh.attrs:
-            version = fh.attrs.get('version').tobytes().decode('ascii')
+        if "version" in fh.attrs:
+            version = fh.attrs.get("version").tobytes().decode("ascii")
         else:
-            version = None # earliest recorded version is '0.9.0'
+            version = None  # earliest recorded version is '0.9.0'
         self.parameters["version"] = version
 
         # all blocks are the same size

--- a/yt/frontends/enzo_e/data_structures.py
+++ b/yt/frontends/enzo_e/data_structures.py
@@ -399,6 +399,11 @@ class EnzoEDataset(Dataset):
         fh = h5py.File(os.path.join(self.directory, fn0), "r")
         self.domain_left_edge = fh.attrs["lower"]
         self.domain_right_edge = fh.attrs["upper"]
+        if 'version' in fh.attrs:
+            version = fh.attrs.get('version').tobytes().decode('ascii')
+        else:
+            version = None # earliest recorded version is '0.9.0'
+        self.parameters["version_string"] = version
 
         # all blocks are the same size
         ablock = fh[list(fh.keys())[0]]

--- a/yt/frontends/enzo_e/data_structures.py
+++ b/yt/frontends/enzo_e/data_structures.py
@@ -403,7 +403,7 @@ class EnzoEDataset(Dataset):
             version = fh.attrs.get('version').tobytes().decode('ascii')
         else:
             version = None # earliest recorded version is '0.9.0'
-        self.parameters["version_string"] = version
+        self.parameters["version"] = version
 
         # all blocks are the same size
         ablock = fh[list(fh.keys())[0]]

--- a/yt/frontends/enzo_e/io.py
+++ b/yt/frontends/enzo_e/io.py
@@ -20,7 +20,7 @@ class EnzoEIOHandler(BaseIOHandler):
         )
 
         # Determine if particle masses are actually masses or densities.
-        if self.ds.parameters['version'] is not None:
+        if self.ds.parameters["version"] is not None:
             # they're masses for enzo-e versions that record a version string
             mass_flag = True
         else:
@@ -31,7 +31,7 @@ class EnzoEIOHandler(BaseIOHandler):
             )
         # the historic approach for initializing the value of "mass_is_mass"
         # was unsound (and could yield a random value). Thus we should only
-        # check for the parameter's existence and not its value 
+        # check for the parameter's existence and not its value
         self._particle_mass_is_mass = mass_flag is not None
 
     def _read_field_names(self, grid):

--- a/yt/frontends/enzo_e/io.py
+++ b/yt/frontends/enzo_e/io.py
@@ -20,7 +20,7 @@ class EnzoEIOHandler(BaseIOHandler):
         )
 
         # Determine if particle masses are actually masses or densities.
-        if self.ds.parameters['version_string'] is not None:
+        if self.ds.parameters['version'] is not None:
             # they're masses for enzo-e versions that record a version string
             mass_flag = True
         else:

--- a/yt/frontends/enzo_e/io.py
+++ b/yt/frontends/enzo_e/io.py
@@ -29,6 +29,9 @@ class EnzoEIOHandler(BaseIOHandler):
             mass_flag = nested_dict_get(
                 self.ds.parameters, ("Particle", "mass_is_mass"), default=None
             )
+        # the historic approach for initializing the value of "mass_is_mass"
+        # was unsound (and could yield a random value). Thus we should only
+        # check for the parameter's existence and not its value 
         self._particle_mass_is_mass = mass_flag is not None
 
     def _read_field_names(self, grid):

--- a/yt/frontends/enzo_e/io.py
+++ b/yt/frontends/enzo_e/io.py
@@ -19,11 +19,16 @@ class EnzoEIOHandler(BaseIOHandler):
             slice(self.ds.ghost_zones, -self.ds.ghost_zones),
         )
 
-        # Determine if particle masses are actually densities by the
-        # existence of the "mass_is_mass" particles parameter.
-        mass_flag = nested_dict_get(
-            self.ds.parameters, ("Particle", "mass_is_mass"), default=None
-        )
+        # Determine if particle masses are actually masses or densities.
+        if self.ds.parameters['version_string'] is not None:
+            # they're masses for enzo-e versions that record a version string
+            mass_flag = True
+        else:
+            # in earlier versions: query the existence of the "mass_is_mass"
+            # particle parameter
+            mass_flag = nested_dict_get(
+                self.ds.parameters, ("Particle", "mass_is_mass"), default=None
+            )
         self._particle_mass_is_mass = mass_flag is not None
 
     def _read_field_names(self, grid):


### PR DESCRIPTION
More recent versions of `Enzo-E` record the version number in the outputs. This PR now stores that in the `parameters` attribute of `EnzoEDataset` instances (the value is associated with 'version_string').

The primary reason that `Enzo-E` now saves this version number is to make it easier to interpret the data, when the interpretation changes in newer versions.

At present, the version string only affects one thing: the distinction between particle masses and densities.
- Several months back `Enzo-E` started to save particle masses such that they should be interpreted as masses (previously they were usually treated as densities).
- At the time, to differentiate the interpretation of this data from outputs written by older code versions, we started to have `Enzo-E` append a parameter called `"mass_is_mass"` to the output copy of the parameter file (PR #3914 started querying of this parameter).
- Unfortunately, that approach introduced problems on certain platforms. Thus, we decided to record the version number as an attribute of output hdf5 files that could be used to make this distinction going forward (this will hopefully make any future changes in interpretations easier to handle as well)

Let me know if you need me to add any new tests for this PR.