### PR TITLE
Correcting deceptive typo in error message.

### DIFF
--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -489,7 +489,7 @@ class ImagePlotMPL(PlotMPL, ABC):
             # last checked with Matplotlib 3.5
             warnings.warn(
                 f"Previously set background color {self.colorbar_handler.background_color} "
-                "has no effect. Pass `draw_axes=True` if you wish to preserve background color.",
+                "has no effect. Pass `draw_frame=True` if you wish to preserve background color.",
                 stacklevel=4,
             )
         self.axes.set_frame_on(draw_frame)

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -489,7 +489,7 @@ class ImagePlotMPL(PlotMPL, ABC):
             # last checked with Matplotlib 3.5
             warnings.warn(
                 f"Previously set background color {self.colorbar_handler.background_color} "
-                "has no effect. Pass `draw_axis=True` if you wish to preserve background color.",
+                "has no effect. Pass `draw_axes=True` if you wish to preserve background color.",
                 stacklevel=4,
             )
         self.axes.set_frame_on(draw_frame)


### PR DESCRIPTION
There is a warning that has a typo in it, which is misleading.  I searched the docs and the codebase but couldn't find any reference to `draw_axis` kwarg, until I stumbled upon `draw_axes` instead.  But even after having identified the correct kwarg, I still don't even know what function to pass this kwarg to.  `set_background_color()`? `save()`?