### PR TITLE
ENH: Improved Enzo-E frontend's determination of fluid properties

### DIFF
--- a/yt/frontends/enzo_e/data_structures.py
+++ b/yt/frontends/enzo_e/data_structures.py
@@ -15,6 +15,7 @@ from yt.frontends.enzo_e.misc import (
     get_root_blocks,
     is_parent,
     nested_dict_get,
+    get_listed_subparam
 )
 from yt.funcs import get_pbar, setdefaultattr
 from yt.geometry.grid_geometry_handler import GridIndex
@@ -464,18 +465,15 @@ class EnzoEDataset(Dataset):
             self.gamma = nested_dict_get(self.parameters, ("Field", "gamma"))
 
             uses_de = False
-            method_list = nested_dict_get(
-                self.parameters,
-                ("Method", "list"),
-                default = []
-            )
             for method in ("ppm", "mhd_vlct"):
-                if method in method_list:
-                    uses_de = nested_dict_get(
-                        self.parameters,
-                        ("Method", method, "dual_energy"),
-                        default = False
-                    )
+                subparams = get_listed_subparam(
+                    self.parameters,
+                    "Method",
+                    method,
+                    default = None
+                )
+                if subparams is not None:
+                    uses_de = subparams.get("dual_energy", False)
         self.parameters['uses_dual_energy'] = uses_de
 
     def _set_code_unit_attributes(self):

--- a/yt/frontends/enzo_e/data_structures.py
+++ b/yt/frontends/enzo_e/data_structures.py
@@ -365,10 +365,6 @@ class EnzoEDataset(Dataset):
                 default = []
             )
             if "cosmology" in physics_list:
-                cosmo = nested_dict_get(
-                    self.parameters,
-                    ("Physics", "cosmology")
-                )
                 self.cosmological_simulation = 1
                 co_pars = [
                     "hubble_constant_now",

--- a/yt/frontends/enzo_e/data_structures.py
+++ b/yt/frontends/enzo_e/data_structures.py
@@ -356,8 +356,18 @@ class EnzoEDataset(Dataset):
             with open(lcfn) as lf:
                 self.parameters = libconf.load(lf)
 
-            cosmo = nested_dict_get(self.parameters, ("Physics", "cosmology"))
-            if cosmo is not None:
+            # Enzo-E ignores all cosmology parameters if "cosmology" is not in
+            # the Physics:list parameter
+            physics_list = nested_dict_get(
+                self.parameters,
+                ("Physics", "list"),
+                default = []
+            )
+            if "cosmology" in physics_list:
+                cosmo = nested_dict_get(
+                    self.parameters,
+                    ("Physics", "cosmology")
+                )
                 self.cosmological_simulation = 1
                 co_pars = [
                     "hubble_constant_now",
@@ -422,7 +432,51 @@ class EnzoEDataset(Dataset):
             self.current_redshift = co.z_from_t(self.current_time * self.time_unit)
 
         self._periodicity += (False,) * (3 - self.dimensionality)
-        self.gamma = nested_dict_get(self.parameters, ("Field", "gamma"))
+        self._parse_fluid_prop_params()
+
+    def _parse_fluid_prop_params(self):
+        """
+        Parse the fluid properties.
+        """
+
+        fp_params = nested_dict_get(
+            self.parameters,
+            ("Physics", "fluid_props"),
+            default = None
+        )
+
+        if fp_params is not None:
+            # in newer versions of enzo-e, this data is specified in a
+            # centralized parameter group called Physics:fluid_props
+            # -  for internal reasons related to backwards compatability,
+            #    treatment of this physics-group is somewhat special (compared
+            #    to the cosmology group). The parameters in this group are
+            #    honored even if Physics:list does not include "fluid_props"
+            self.gamma = nested_dict_get(fp_params, ("eos", "gamma"))
+            de_type = nested_dict_get(
+                fp_params,
+                ("dual_energy", "type"),
+                default = "disabled"
+            )
+            uses_de = de_type != "disabled"
+        else:
+            # in older versions, these parameters were more scattered
+            self.gamma = nested_dict_get(self.parameters, ("Field", "gamma"))
+
+            uses_de = False
+            method_list = nested_dict_get(
+                self.parameters,
+                ("Method", "list"),
+                default = []
+            )
+            for method in ("ppm", "mhd_vlct"):
+                if method in method_list:
+                    uses_de = nested_dict_get(
+                        self.parameters,
+                        ("Method", method, "dual_energy"),
+                        default = False
+                    )
+        self.parameters['uses_dual_energy'] = uses_de
 
     def _set_code_unit_attributes(self):
         if self.cosmological_simulation:

--- a/yt/frontends/enzo_e/data_structures.py
+++ b/yt/frontends/enzo_e/data_structures.py
@@ -11,11 +11,11 @@ from yt.frontends.enzo_e.fields import EnzoEFieldInfo
 from yt.frontends.enzo_e.misc import (
     get_block_info,
     get_child_index,
+    get_listed_subparam,
     get_root_block_id,
     get_root_blocks,
     is_parent,
     nested_dict_get,
-    get_listed_subparam
 )
 from yt.funcs import get_pbar, setdefaultattr
 from yt.geometry.grid_geometry_handler import GridIndex
@@ -360,9 +360,7 @@ class EnzoEDataset(Dataset):
             # Enzo-E ignores all cosmology parameters if "cosmology" is not in
             # the Physics:list parameter
             physics_list = nested_dict_get(
-                self.parameters,
-                ("Physics", "list"),
-                default = []
+                self.parameters, ("Physics", "list"), default=[]
             )
             if "cosmology" in physics_list:
                 self.cosmological_simulation = 1
@@ -437,9 +435,7 @@ class EnzoEDataset(Dataset):
         """
 
         fp_params = nested_dict_get(
-            self.parameters,
-            ("Physics", "fluid_props"),
-            default = None
+            self.parameters, ("Physics", "fluid_props"), default=None
         )
 
         if fp_params is not None:
@@ -451,9 +447,7 @@ class EnzoEDataset(Dataset):
             #    honored even if Physics:list does not include "fluid_props"
             self.gamma = nested_dict_get(fp_params, ("eos", "gamma"))
             de_type = nested_dict_get(
-                fp_params,
-                ("dual_energy", "type"),
-                default = "disabled"
+                fp_params, ("dual_energy", "type"), default="disabled"
             )
             uses_de = de_type != "disabled"
         else:
@@ -463,14 +457,11 @@ class EnzoEDataset(Dataset):
             uses_de = False
             for method in ("ppm", "mhd_vlct"):
                 subparams = get_listed_subparam(
-                    self.parameters,
-                    "Method",
-                    method,
-                    default = None
+                    self.parameters, "Method", method, default=None
                 )
                 if subparams is not None:
                     uses_de = subparams.get("dual_energy", False)
-        self.parameters['uses_dual_energy'] = uses_de
+        self.parameters["uses_dual_energy"] = uses_de
 
     def _set_code_unit_attributes(self):
         if self.cosmological_simulation:

--- a/yt/frontends/enzo_e/fields.py
+++ b/yt/frontends/enzo_e/fields.py
@@ -5,9 +5,9 @@ from yt.fields.field_info_container import FieldInfoContainer
 from yt.fields.magnetic_field import setup_magnetic_field_aliases
 from yt.fields.particle_fields import add_union_field
 from yt.frontends.enzo_e.misc import (
+    get_listed_subparam,
     get_particle_mass_correction,
     nested_dict_get,
-    get_listed_subparam
 )
 
 rho_units = "code_mass / code_length**3"
@@ -74,18 +74,13 @@ class EnzoEFieldInfo(FieldInfoContainer):
         # check if we have a field for internal energy
         has_ie_field = ("enzoe", "internal_energy") in self.field_list
         # check if we need to account for magnetic energy
-        vlct_params = get_listed_subparam(
-            self.ds.parameters,
-            "Method",
-            "mhd_vlct",
-            {}
-        )
-        has_magnetic = "no_bfield" != vlct_params.get("mhd_choice","no_bfield")
+        vlct_params = get_listed_subparam(self.ds.parameters, "Method", "mhd_vlct", {})
+        has_magnetic = "no_bfield" != vlct_params.get("mhd_choice", "no_bfield")
 
         # define the ("gas", "specific_thermal_energy") field
         # - this is already done for us if the simulation used the dual-energy
         #   formalism AND ("enzoe", "internal_energy") was saved to disk
-        if not (self.ds.parameters['uses_dual_energy'] and has_ie_field):
+        if not (self.ds.parameters["uses_dual_energy"] and has_ie_field):
 
             def _tot_minus_kin(field, data):
                 return (

--- a/yt/frontends/enzo_e/fields.py
+++ b/yt/frontends/enzo_e/fields.py
@@ -34,7 +34,7 @@ class EnzoEFieldInfo(FieldInfoContainer):
         ("density", (rho_units, ["density"], None)),
         ("density_total", (rho_units, ["total_density"], None)),
         ("total_energy", (energy_units, ["specific_total_energy"], None)),
-        ("internal_energy", (energy_units, ["specific_internal_energy"], None)),
+        ("internal_energy", (energy_units, ["specific_thermal_energy"], None)),
         ("bfield_x", (b_units, [], None)),
         ("bfield_y", (b_units, [], None)),
         ("bfield_z", (b_units, [], None)),
@@ -72,7 +72,7 @@ class EnzoEFieldInfo(FieldInfoContainer):
     def setup_energy_field(self):
         unit_system = self.ds.unit_system
         # check if we have a field for internal energy
-        has_ie_field = ("enzoe", "specific_internal_energy") in self.field_list
+        has_ie_field = ("enzoe", "internal_energy") in self.field_list
         # check if we need to account for magnetic energy
         vlct_params = get_listed_subparam(
             self.ds.parameters,
@@ -82,13 +82,10 @@ class EnzoEFieldInfo(FieldInfoContainer):
         )
         has_magnetic = "no_bfield" != vlct_params.get("mhd_choice","no_bfield")
 
-        # identify if the dual energy formalism is in use:
-        if self.ds.parameters['uses_dual_energy'] and has_ie_field:
-            self.alias(
-                ("gas", "specific_thermal_energy"),
-                ("enzoe", "specific_internal_energy"),
-            )
-        else:
+        # define the ("gas", "specific_thermal_energy") field
+        # - this is already done for us if the simulation used the dual-energy
+        #   formalism AND ("enzoe", "internal_energy") was saved to disk
+        if not (self.ds.parameters['uses_dual_energy'] and has_ie_field):
 
             def _tot_minus_kin(field, data):
                 return (

--- a/yt/frontends/enzo_e/fields.py
+++ b/yt/frontends/enzo_e/fields.py
@@ -65,23 +65,16 @@ class EnzoEFieldInfo(FieldInfoContainer):
         self.setup_energy_field()
         setup_magnetic_field_aliases(self, "enzoe", [f"bfield_{ax}" for ax in "xyz"])
 
-    def uses_dual_energy_formalism(self):
-        for name in ["ppm", "mhd_vlct"]:
-            param = nested_dict_get(self.ds.parameters, ("Method", name), None)
-            if (param is not None) and param.get("dual_energy", False):
-                return True
-        return False
-
     def setup_energy_field(self):
         unit_system = self.ds.unit_system
         # check if we need to include magnetic energy
         has_magnetic = "bfield_x" in self.ds.parameters["Field"]["list"]
 
         # identify if the dual energy formalism is in use:
-        if self.uses_dual_energy_formalism():
+        if self.ds.parameters['uses_dual_energy']:
             self.alias(
                 ("gas", "specific_thermal_energy"),
-                ("enzop", "specific_internal_energy"),
+                ("enzoe", "specific_internal_energy"),
             )
         else:
 

--- a/yt/frontends/enzo_e/fields.py
+++ b/yt/frontends/enzo_e/fields.py
@@ -67,11 +67,13 @@ class EnzoEFieldInfo(FieldInfoContainer):
 
     def setup_energy_field(self):
         unit_system = self.ds.unit_system
-        # check if we need to include magnetic energy
+        # check if we have a field for internal energy
+        has_ie_field = ("enzoe", "specific_internal_energy") in self.field_list
+        # check if we need to account for magnetic energy
         has_magnetic = "bfield_x" in self.ds.parameters["Field"]["list"]
 
         # identify if the dual energy formalism is in use:
-        if self.ds.parameters['uses_dual_energy']:
+        if self.ds.parameters['uses_dual_energy'] and has_ie_field:
             self.alias(
                 ("gas", "specific_thermal_energy"),
                 ("enzoe", "specific_internal_energy"),
@@ -83,9 +85,6 @@ class EnzoEFieldInfo(FieldInfoContainer):
                     data["enzoe", "total_energy"]
                     - 0.5 * data["gas", "velocity_magnitude"] ** 2.0
                 )
-
-            # check if we need to include magnetic energy
-            has_magnetic = "bfield_x" in self.ds.parameters["Field"]["list"]
 
             if not has_magnetic:
                 # thermal energy = total energy - kinetic energy

--- a/yt/frontends/enzo_e/fields.py
+++ b/yt/frontends/enzo_e/fields.py
@@ -4,7 +4,11 @@ from yt._typing import KnownFieldsT
 from yt.fields.field_info_container import FieldInfoContainer
 from yt.fields.magnetic_field import setup_magnetic_field_aliases
 from yt.fields.particle_fields import add_union_field
-from yt.frontends.enzo_e.misc import get_particle_mass_correction, nested_dict_get
+from yt.frontends.enzo_e.misc import (
+    get_particle_mass_correction,
+    nested_dict_get,
+    get_listed_subparam
+)
 
 rho_units = "code_mass / code_length**3"
 vel_units = "code_velocity"
@@ -70,7 +74,13 @@ class EnzoEFieldInfo(FieldInfoContainer):
         # check if we have a field for internal energy
         has_ie_field = ("enzoe", "specific_internal_energy") in self.field_list
         # check if we need to account for magnetic energy
-        has_magnetic = "bfield_x" in self.ds.parameters["Field"]["list"]
+        vlct_params = get_listed_subparam(
+            self.ds.parameters,
+            "Method",
+            "mhd_vlct",
+            {}
+        )
+        has_magnetic = "no_bfield" != vlct_params.get("mhd_choice","no_bfield")
 
         # identify if the dual energy formalism is in use:
         if self.ds.parameters['uses_dual_energy'] and has_ie_field:

--- a/yt/frontends/enzo_e/misc.py
+++ b/yt/frontends/enzo_e/misc.py
@@ -123,6 +123,18 @@ def nested_dict_get(pdict, keys, default=None):
     return val
 
 
+def get_listed_subparam(pdict, parent_param, subparam, default = None):
+    """
+    Returns nested_dict_get(pdict, (parent_param,subparam), default) if
+    subparam is an entry in nested_dict_get(pdict, (parent_param, 'list'), [])
+
+    This is a common idiom in Enzo-E's parameter parsing
+    """
+    if subparam in nested_dict_get(pdict, (parent_param, 'list'), []):
+        return nested_dict_get(pdict, (parent_param, subparam), default)
+    return default
+
+
 def get_particle_mass_correction(ds):
     """
     Normalize particle masses by the root grid cell volume.

--- a/yt/frontends/enzo_e/misc.py
+++ b/yt/frontends/enzo_e/misc.py
@@ -123,14 +123,14 @@ def nested_dict_get(pdict, keys, default=None):
     return val
 
 
-def get_listed_subparam(pdict, parent_param, subparam, default = None):
+def get_listed_subparam(pdict, parent_param, subparam, default=None):
     """
     Returns nested_dict_get(pdict, (parent_param,subparam), default) if
     subparam is an entry in nested_dict_get(pdict, (parent_param, 'list'), [])
 
     This is a common idiom in Enzo-E's parameter parsing
     """
-    if subparam in nested_dict_get(pdict, (parent_param, 'list'), []):
+    if subparam in nested_dict_get(pdict, (parent_param, "list"), []):
         return nested_dict_get(pdict, (parent_param, subparam), default)
     return default
 


### PR DESCRIPTION
## PR Summary

The primary purpose of this PR is to modify the way that the Enzo-E frontend determines generic fluid properties (namely the adiabatic index and whether the internal_energy field is an alias of the `('gas', 'specific_thermal_energy')` field). This is necessary to reflect a recent change in how this information is specified in Enzo-E's parameter files (this information is now a lot more centralized than it used to be).

This also introduces a handful of minor tweaks.
- I modified some logic to more correctly handle some parsing corner cases (to more accurately reflect the behavior of Enzo-E). This relates to determining cosmological parameters and the older approach for determining if the simulation used the dual-energy formalism.
- I modified the way that the frontend determines whether magnetic fields need to be considered if it has to manually derive the `('gas', 'specific_thermal_energy')` field. This new approach is more robust 
- Fixed a bug where we were accidentally aliasing `('enzoe', 'internal_energy')` as `('gas', 'specific_internal_energy')` instead of `('gas', 'specific_thermal_energy')`. In certain cases, this error prevented the automatic creation of fluid fields like `('gas', 'pressure')`.

As an aside, I wanted to highlight a helper function called `get_listed_subparam`, and I'm really on the fence about whether it's necessary. On the one hand it's short and we only call it in 2 locations, but on the other hand I think it significantly simplifies the logic (and the line-count) in the two places that we call it. Let me know if you want me to drop it (or rename it)...

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

I'm not really sure if I should be introducing any new tests. Doing that would probably require us to introduce a new test dataset. Please let me know if you have any suggestions.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
