### PR TITLE
DOC: fix multiple warnings in docs build

### DIFF
--- a/doc/source/developing/testing.rst
+++ b/doc/source/developing/testing.rst
@@ -171,8 +171,7 @@ In order to run the answer tests locally:
 
 * Add folders of the required data to this directory. Other yt data, such as ``IsolatedGalaxy``, can be downloaded to this directory as well.
 
-* Tell yt where it can find the data. This is done by setting the config parameter ``test_data_dir`` to the path of the
-directory with the test data downloaded from https://yt-project.org/data/. For example,
+* Tell yt where it can find the data. This is done by setting the config parameter ``test_data_dir`` to the path of the directory with the test data downloaded from https://yt-project.org/data/. For example,
 
 .. code-block:: bash
 

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -59,7 +59,7 @@ The functionality requires the package `ratarmount <https://github.com/mxmlnkn/r
 Under the hood, yt will mount the archive as a (read-only) filesystem. Note that this requires the
 entire archive to be read once to compute the location of each file in the archive; subsequent accesses
 will be much faster.
-All archive formats supported by `ratarmount <https://github.com/mxmlnkn/ratarmount>`_ should be loadable, provided
+All archive formats supported by `ratarmount <https://github.com/mxmlnkn/ratarmount>`__ should be loadable, provided
 the dependencies are installed; this includes ``tar``, ``tar.gz`` and tar.bz2`` formats.
 
 .. _loading-amrvac-data:

--- a/doc/source/reference/changelog.rst
+++ b/doc/source/reference/changelog.rst
@@ -561,7 +561,7 @@ Separate from our list of minor enhancements and bugfixes, we've grouped PRs
 related to infrastructure and testing in the next three sub-sub-sub sections.
 
 Testing and Infrastructure
-""""""""""""""""""""""""""
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 - infrastructure to change our testing from nose to pytest, see
   `PR 2401 <https://github.com/yt-project/yt/pull/2401>`__.
 - Adding test_requirements and test_minimum requirements files to have
@@ -580,7 +580,7 @@ Testing and Infrastructure
 - disable OSNI projection answer test to remove cartopy errors `PR 2350 <https://github.com/yt-project/yt/pull/2350>`__.
 
 CI related support
-""""""""""""""""""
+~~~~~~~~~~~~~~~~~~
 
 - disable coverage on OSX to speed up travis testing and avoid
   timeouts `PR 2076 <https://github.com/yt-project/yt/pull/2076>`__.
@@ -604,7 +604,7 @@ CI related support
 - update CI recipes to fix recent failures  `PR 2489 <https://github.com/yt-project/yt/pull/2489>`__.
 
 Other Infrastructure
-""""""""""""""""""""
+~~~~~~~~~~~~~~~~~~~~
 
 - Added a welcomebot to our github page for new contributors, see
   `PR 2181 <https://github.com/yt-project/yt/pull/2181>`__.

--- a/doc/source/visualizing/callbacks.rst
+++ b/doc/source/visualizing/callbacks.rst
@@ -38,7 +38,7 @@ For a brief demonstration of a few of these callbacks in action together,
 see the cookbook recipe: :ref:`annotations-recipe`.
 
 Also note that new ``annotate_`` methods can be defined without modifying yt's
-source code, see :ref:`extend-anotations`.
+source code, see :ref:`extend-annotations`.
 
 
 Coordinate Systems in Callbacks

--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -977,7 +977,7 @@ method to set a custom colormap range.
 
 Units can be left out, in which case they implicitly match the current display
 units of the colorbar (controlled with the ``set_unit`` method, see
-:ref:`_set-image-units`).
+:ref:`set-image-units`).
 
 It is not required to specify both ``zmin`` and ``zmax``. Left unset, they will
 default to the extreme values in the current view. This default behavior can be

--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -934,7 +934,7 @@ Use any of the colormaps listed in the :ref:`colormaps` section.
    slc.save()
 
 Colorbar Normalization / Scaling
-::::::::::::::::::::::::::::::::
+""""""""""""""""""""""""""""""""
 
 For a general introduction to the topic of colorbar scaling, see
 `<https://matplotlib.org/stable/tutorials/colors/colormapnorms.html>`_. Here we


### PR DESCRIPTION
## PR Summary
This adresses #3369
Currently we're at 37 warnings, 23 of which are similar errors with docstrings in `yt.utilities.lib.cykdtree.kdtree`.
Here I want to focus on fixing everything else.
