### PR TITLE
For Boxlib frontend, allow reading of 1D particle data

### DIFF
--- a/yt/frontends/boxlib/io.py
+++ b/yt/frontends/boxlib/io.py
@@ -146,6 +146,8 @@ class IOHandlerBoxlib(BaseIOHandler):
                             f, pheader.real_type, pheader.num_real * npart
                         )
 
+                        # Allow reading particles in 1, 2, and 3 dimensions,
+                        # setting the appropriate default for unused dimensions.
                         pos = []
                         for idim in [1,2,3]:
                             if g.ds.dimensionality >= idim:

--- a/yt/frontends/boxlib/io.py
+++ b/yt/frontends/boxlib/io.py
@@ -149,11 +149,18 @@ class IOHandlerBoxlib(BaseIOHandler):
                         # Allow reading particles in 1, 2, and 3 dimensions,
                         # setting the appropriate default for unused dimensions.
                         pos = []
-                        for idim in [1,2,3]:
+                        for idim in [1, 2, 3]:
                             if g.ds.dimensionality >= idim:
-                                pos.append(np.asarray(rdata[idim-1 :: pheader.num_real], dtype=np.float64))
+                                pos.append(
+                                    np.asarray(
+                                        rdata[idim - 1 :: pheader.num_real],
+                                        dtype=np.float64,
+                                    )
+                                )
                             else:
-                                center = 0.5 * (g.LeftEdge[idim-1] + g.RightEdge[idim-1])
+                                center = 0.5 * (
+                                    g.LeftEdge[idim - 1] + g.RightEdge[idim - 1]
+                                )
                                 pos.append(np.full_like(pos[0], center))
                         x, y, z = pos
 

--- a/yt/frontends/boxlib/io.py
+++ b/yt/frontends/boxlib/io.py
@@ -145,15 +145,15 @@ class IOHandlerBoxlib(BaseIOHandler):
                         rdata = np.fromfile(
                             f, pheader.real_type, pheader.num_real * npart
                         )
-                        x = np.asarray(rdata[0 :: pheader.num_real], dtype=np.float64)
-                        y = np.asarray(rdata[1 :: pheader.num_real], dtype=np.float64)
-                        if g.ds.dimensionality == 2:
-                            z = np.ones_like(y)
-                            z *= 0.5 * (g.LeftEdge[2] + g.RightEdge[2])
-                        else:
-                            z = np.asarray(
-                                rdata[2 :: pheader.num_real], dtype=np.float64
-                            )
+
+                        pos = []
+                        for idim in [1,2,3]:
+                            if g.ds.dimensionality >= idim:
+                                pos.append(np.asarray(rdata[idim-1 :: pheader.num_real], dtype=np.float64))
+                            else:
+                                center = 0.5 * (g.LeftEdge[idim-1] + g.RightEdge[idim-1])
+                                pos.append(np.full_like(pos[0], center))
+                        x, y, z = pos
 
                         if selector is None:
                             # This only ever happens if the call is made from

--- a/yt/frontends/boxlib/io.py
+++ b/yt/frontends/boxlib/io.py
@@ -161,9 +161,7 @@ class IOHandlerBoxlib(BaseIOHandler):
                                 center = 0.5 * (
                                     g.LeftEdge[idim - 1] + g.RightEdge[idim - 1]
                                 )
-                                pos.append(
-                                    np.full(npart, center, dtype=np.float64)
-                                )
+                                pos.append(np.full(npart, center, dtype=np.float64))
                         x, y, z = pos
 
                         if selector is None:

--- a/yt/frontends/boxlib/io.py
+++ b/yt/frontends/boxlib/io.py
@@ -161,7 +161,9 @@ class IOHandlerBoxlib(BaseIOHandler):
                                 center = 0.5 * (
                                     g.LeftEdge[idim - 1] + g.RightEdge[idim - 1]
                                 )
-                                pos.append(np.full_like(pos[0], center))
+                                pos.append(
+                                    np.full(npart, center, dtype=np.float64)
+                                )
                         x, y, z = pos
 
                         if selector is None:


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

Currently, yt cannot read in 1D particle data using the Boxlib frontend. The target code, WarpX, allows 1D simulations so this capability is needed. The issue traces down to the code in `boxlib/io.py` where the particle data arrays are read in. The code explicitly handles 2D and 3D data, but not 1D (which falls back to the 3D case). This puts erroneous data in the y and z positions and when the selector is used to chose only particles within the domain, the erroneous data is out of the bounds and so all of the particles are rejected.

The fix is to include a test for 1D data. The bit of code was rewritten to use a loop over dimensionality to avoid messy if checks of the dimensionality.

## PR Checklist

No changes are needed in the documentation. The updated code is commented.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
