### PR TITLE
TST: test against cartopy 0.21

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -149,26 +149,6 @@ def pytest_configure(config):
             ),
         )
 
-    if find_spec("cartopy") is not None:
-        # This can be removed when cartopy 0.21 is released
-        # see https://github.com/SciTools/cartopy/pull/1957
-        config.addinivalue_line(
-            "filterwarnings",
-            (
-                r"ignore:The default value for the \*approx\* keyword argument to "
-                r"\w+ will change from True to False after 0\.18\.:UserWarning"
-            ),
-        )
-        # this one could be resolved by upgrading PROJ on Jenkins,
-        # but there's isn't much else that can be done about it.
-        config.addinivalue_line(
-            "filterwarnings",
-            (
-                "ignore:The Stereographic projection in Proj older than 5.0.0 incorrectly "
-                "transforms points when central_latitude=0. Use this projection with caution.:UserWarning"
-            ),
-        )
-
 
 def pytest_collection_modifyitems(config, items):
     r"""

--- a/tests/ci_install.sh
+++ b/tests/ci_install.sh
@@ -6,9 +6,6 @@ linux|Linux)
     sudo apt-get -qqy install \
       libhdf5-serial-dev \
       libnetcdf-dev \
-      libproj-dev \
-      proj-data \
-      proj-bin \
       libgeos-dev \
       libopenmpi-dev \
       libfuse2
@@ -16,7 +13,7 @@ linux|Linux)
 osx|macOS)
     sudo mkdir -p /usr/local/man
     sudo chown -R "${USER}:admin" /usr/local/man
-    HOMEBREW_NO_AUTO_UPDATE=1 brew install hdf5 proj geos open-mpi netcdf ccache osxfuse
+    HOMEBREW_NO_AUTO_UPDATE=1 brew install hdf5 geos open-mpi netcdf ccache osxfuse
     ;;
 esac
 

--- a/tests/windows_conda_requirements.txt
+++ b/tests/windows_conda_requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.19.4
 cython>=0.29.21,<3.0
-cartopy>=0.20.1
+cartopy>=0.21.0
 h5py~=3.1.0
 matplotlib!=3.4.2,>=3.1  # keep in sync with setup.cfg
 scipy~=1.5.0


### PR DESCRIPTION
## PR Summary
Cartopy 0.21 was released a few hours ago. This patch is mostly a pretext to run CI with the newest version and see if we find any new incompatibilities.

[The release notes](https://github.com/SciTools/cartopy/releases/tag/v0.21.0) also hint that PROJ headers are not a dependency anymore, which may allow for a couple other simplifications in our infrastructure, so I may iterate a couple commits here before I open to reviews.