### PR TITLE
ENH: avoid subclassing builtin dict

### DIFF
--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -1,3 +1,4 @@
+from collections import UserDict
 from collections.abc import Callable
 from numbers import Number as numeric_type
 from typing import Optional, Tuple
@@ -30,7 +31,7 @@ from .particle_fields import (
 )
 
 
-class FieldInfoContainer(dict):
+class FieldInfoContainer(UserDict):
     """
     This is a generic field container.  It contains a list of potential derived
     fields, all of which know how to act on a data object and return a value.
@@ -45,6 +46,7 @@ class FieldInfoContainer(dict):
     extra_union_fields: Tuple[Tuple[str, str], ...] = ()
 
     def __init__(self, ds, field_list, slice_info=None):
+        super().__init__()
         self._show_field_errors = []
         self.ds = ds
         # Now we start setting things up.
@@ -544,19 +546,19 @@ class FieldInfoContainer(dict):
         return obj
 
     def __contains__(self, key):
-        if dict.__contains__(self, key):
+        if super().__contains__(key):
             return True
         if self.fallback is None:
             return False
         return key in self.fallback
 
     def __iter__(self):
-        yield from dict.__iter__(self)
+        yield from super().__iter__()
         if self.fallback is not None:
             yield from self.fallback
 
     def keys(self):
-        keys = dict.keys(self)
+        keys = super().keys()
         if self.fallback:
             keys += list(self.fallback.keys())
         return keys

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -3,6 +3,7 @@ import sys
 import time
 import uuid
 import weakref
+from collections import UserDict
 from itertools import chain, product, repeat
 from numbers import Number as numeric_type
 from typing import Type
@@ -441,7 +442,7 @@ class StreamDataset(Dataset):
         self.particle_types_raw = self.particle_types
 
 
-class StreamDictFieldHandler(dict):
+class StreamDictFieldHandler(UserDict):
     _additional_fields = ()
 
     @property

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -17,6 +17,7 @@ import time
 import traceback
 import urllib.parse
 import urllib.request
+from collections import UserDict
 from functools import lru_cache, wraps
 from numbers import Number as numeric_type
 from typing import Any, Callable, Type
@@ -1266,7 +1267,7 @@ def dictWithFactory(factory: Callable[[Any], Any]) -> Type:
         since="4.1",
     )
 
-    class DictWithFactory(dict):
+    class DictWithFactory(UserDict):
         def __init__(self, *args, **kwargs):
             self.factory = factory
             super().__init__(*args, **kwargs)

--- a/yt/utilities/operator_registry.py
+++ b/yt/utilities/operator_registry.py
@@ -1,7 +1,8 @@
 import copy
+from collections import UserDict
 
 
-class OperatorRegistry(dict):
+class OperatorRegistry(UserDict):
     def find(self, op, *args, **kwargs):
         if isinstance(op, str):
             # Lookup, assuming string or hashable object

--- a/yt/utilities/sdf.py
+++ b/yt/utilities/sdf.py
@@ -1,4 +1,5 @@
 import os
+from collections import UserDict
 from io import StringIO
 
 import numpy as np
@@ -256,7 +257,7 @@ class HTTPDataStruct(DataStruct):
             self.data[k] = RedirectArray(self.handle, k)
 
 
-class SDFRead(dict):
+class SDFRead(UserDict):
 
     _eof = "SDF-EO"
     _data_struct = DataStruct
@@ -297,6 +298,7 @@ class SDFRead(dict):
         >>> print(sdf["x"])
 
         """
+        super().__init__()
         self.filename = filename
         if header is None:
             header = filename


### PR DESCRIPTION
## PR Summary

### problem
Subclassing builtin types like `dict` is error prone because overriden methods are mostly ignored.
This can lead to very subtle bugs where custom classes don't behave as one would expect

```python
class DoubleDict(dict):
    def __setitem__(self, key, value):
        return super().__setitem__(key, [value] * 2)

d = DoubleDict(a=1)
d["b"] = 2
print(d)
```

outputs
```
{'a': 1, 'b': [2, 2]}
```
We see that the user-defined `__setitem__` method is correctly used when setting a new value, but is ignored at initialization.


### solution
subclass `collections.UserDict` instead, which is intended to avoid these subtle issues
