### PR TITLE
TST: enable colored logs for pytest colored in GHA CI

### DIFF
--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -61,4 +61,4 @@ jobs:
         python -m pip install -e .[test] --no-build-isolation
 
     - name: Run Tests
-      run: pytest -vvv
+      run: pytest -vvv --color=yes

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -93,7 +93,7 @@ jobs:
       if: matrix.test-runner == 'pytest'
       env:
         testsuite: ${{ matrix.tests-type }}
-      run: pytest
+      run: pytest --color=yes
     - name: Run Tests (nose)
       if: matrix.test-runner == 'nose'
       env:


### PR DESCRIPTION
## PR Summary

I recently realized that GitHub action supports colored logs, but pytest currently doesn't enable them by default.
I think this is an uncontroversial quality of life improvement for devs.
