### PR TITLE
ENH: public API `render` methods to `PlotContainer` and `FixedResolutionBuffer`

### DIFF
--- a/doc/source/visualizing/geographic_projections_and_transforms.rst
+++ b/doc/source/visualizing/geographic_projections_and_transforms.rst
@@ -107,12 +107,12 @@ available with matplotlib should be available for customization. Here a
 .. code-block:: python
 
     p.set_mpl_projection("Robinson")
-    p._setup_plots()
+    p.render()
     p.plots["AIRDENS"].axes.set_global()
     p.plots["AIRDENS"].axes.coastlines()
     p.show()
 
-``p._setup_plots()`` is required here to access the plot axes. When a new
+``p.render()`` is required here to access the plot axes. When a new
 projection is called the plot axes are reset and are not available unless set
 up again.
 

--- a/yt/utilities/answer_testing/answer_tests.py
+++ b/yt/utilities/answer_testing/answer_tests.py
@@ -109,9 +109,9 @@ def pixelized_projection_values(ds, axis, field, weight_field=None, dobj_type=No
         obj = None
     proj = ds.proj(field, axis, weight_field=weight_field, data_source=obj)
     frb = proj.to_frb((1.0, "unitary"), 256)
-    frb[field]
+    frb.render(field)
     if weight_field is not None:
-        frb[weight_field]
+        frb.render(weight_field)
     d = frb.data
     for f in proj.field_data:
         # Sometimes f will be a tuple.

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -635,13 +635,10 @@ class PixelizedProjectionValuesTest(AnswerTestingTest):
             obj = create_obj(self.ds, self.obj_type)
         else:
             obj = None
-        proj = self.ds.proj(
-            self.field, self.axis, weight_field=self.weight_field, data_source=obj
-        )
-        frb = proj.to_frb((1.0, "unitary"), 256)
-        frb[self.field]
+        proj, frb = self._get_frb(obj)
+        frb.render(self.field)
         if self.weight_field is not None:
-            frb[self.weight_field]
+            frb.render(self.weight_field)
         d = frb.data
         for f in proj.field_data:
             # Sometimes f will be a tuple.

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -194,6 +194,11 @@ class FixedResolutionBuffer:
         self._data_valid = True
         return self.data[item]
 
+    def render(self, item):
+        # deleguate to __getitem__ for historical reasons
+        # this method exists for clarity of intention
+        return self[item]
+
     def _apply_filters(self, buffer: np.ndarray) -> np.ndarray:
         for f in self._filters:
             buffer = f(buffer)
@@ -208,7 +213,7 @@ class FixedResolutionBuffer:
         fields += getattr(self.data_source, "field_data", {}).keys()
         for f in fields:
             if f not in exclude and f[0] not in self.data_source.ds.particle_types:
-                self[f]
+                self.render(f)
 
     def _get_info(self, item):
         info = {}
@@ -815,4 +820,4 @@ class ParticleImageBuffer(FixedResolutionBuffer):
         fields += getattr(self.data_source, "field_data", {}).keys()
         for f in fields:
             if f not in exclude:
-                self[f]
+                self.render(f)

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -323,6 +323,21 @@ class PlotContainer(abc.ABC):
         # Left blank to be overridden in subclasses
         pass
 
+    def render(self) -> None:
+        r"""Render plots.
+        This operation is expensive and usually doesn't need to be requested explicitly.
+        In most cases, yt handles rendering automatically and delays it as much as possible
+        to avoid redundant calls on each plot modification (e.g. via `annotate_*` methods).
+
+        However, valid use cases of this method include:
+        - fine control of render (and clear) operations when yt plots are combined with plot
+          customizations other than plot callbacks (`annotate_*`)
+        - testing
+        """
+        # this is a pure alias to the historic `_setup_plots` method
+        # which preserves backward compatibility for extension code
+        self._setup_plots()
+
     def _initialize_dataset(self, ts):
         if not isinstance(ts, DatasetSeries):
             if not is_sequence(ts):

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -332,7 +332,7 @@ class PlotWindow(ImagePlotContainer, abc.ABC):
         if old_fields is not None:
             # Restore the old fields
             for key, units in zip(old_fields, old_units):
-                self._frb[key]
+                self._frb.render(key)
                 equiv = self._equivalencies[key]
                 if equiv[0] is None:
                     self._frb[key].convert_to_units(units)
@@ -341,7 +341,7 @@ class PlotWindow(ImagePlotContainer, abc.ABC):
 
         # Restore the override fields
         for key in self.override_fields:
-            self._frb[key]
+            self._frb.render(key)
 
     @property
     def _has_swapped_axes(self):

--- a/yt/visualization/tests/test_filters.py
+++ b/yt/visualization/tests/test_filters.py
@@ -16,7 +16,7 @@ def test_white_noise_filter():
     frb = p.to_frb((1, "unitary"), 64)
     frb.apply_white_noise()
     frb.apply_white_noise(1e-3)
-    frb[("gas", "density")]
+    frb.render(("gas", "density"))
 
 
 @requires_module("scipy")
@@ -25,7 +25,7 @@ def test_gauss_beam_filter():
     p = ds.proj(("gas", "density"), "z")
     frb = p.to_frb((1, "unitary"), 64)
     frb.apply_gauss_beam(sigma=1.0)
-    frb[("gas", "density")]
+    frb.render(("gas", "density"))
 
 
 @requires_module("scipy")


### PR DESCRIPTION
## PR Summary
A simple addition to the public interface would be useful in #4118 to avoid using private methods directly.
Content:
- ENH: add a PlotContainer.render method (public interface for _setup_plots)
- DOC: avoid using private `_setup_plots` method in user docs

For backward compatibility, I avoided simply renaming `_setup_plots`.
Hopefully the intented usage is clear from the docstring and the docs update.

I'm not completely certain that my use of the `@validate_plot` is warranted or justified, and I would particularly appreciate feedback specifically on this.



