### PR TITLE
TST: don't fail GHA tests fast

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -19,6 +19,8 @@ jobs:
   build:
     name: "${{ matrix.tests-type }} tests: py${{ matrix.python-version }} on ${{ matrix.os }} (${{ matrix.test-runner }})"
     strategy:
+      # run all tests even if e.g. image tests fail early
+      fail-fast: false
       matrix:
         os: [
           macos-latest,


### PR DESCRIPTION
## PR Summary
`fail-fast` defaults to true. This leads to situations where failing answer tests (typically much faster to run than unit tests) leads to cancelation of all other jobs.
When image answer tests are translated to pytest-mpl, this behaviour will be an inconvenience when adding new tests (pytest-mpl "fails" when no previous result exists), preventing unit tests to run.

This behaviour is also annoying these days as the answer tests job is flaky, and we regularly need to manually relaunch CI hoping for better results.
