### PR TITLE
ENH: stop using deprecated np.int

### DIFF
--- a/yt/frontends/athena/data_structures.py
+++ b/yt/frontends/athena/data_structures.py
@@ -332,9 +332,9 @@ class AthenaHierarchy(GridIndex):
         ).astype("int")
 
         if self.dataset.dimensionality <= 2:
-            self.dataset.domain_dimensions[2] = np.int(1)
+            self.dataset.domain_dimensions[2] = 1
         if self.dataset.dimensionality == 1:
-            self.dataset.domain_dimensions[1] = np.int(1)
+            self.dataset.domain_dimensions[1] = 1
 
         dle = self.dataset.domain_left_edge
         dre = self.dataset.domain_right_edge

--- a/yt/frontends/athena_pp/data_structures.py
+++ b/yt/frontends/athena_pp/data_structures.py
@@ -75,7 +75,7 @@ class AthenaPPLogarithmicIndex(UnstructuredIndex):
         nb = np.array([nbx, nby, nbz], dtype="int64")
         self.mesh_factors = np.ones(3, dtype="int64") * ((nb > 1).astype("int") + 1)
 
-        block_grid = -np.ones((nbx, nby, nbz, nlevel), dtype=np.int)
+        block_grid = -np.ones((nbx, nby, nbz, nlevel), dtype="int64")
         block_grid[log_loc[:, 0], log_loc[:, 1], log_loc[:, 2], levels[:]] = np.arange(
             num_blocks
         )


### PR DESCRIPTION
## PR Summary
Found these while working on pytest-mpl tests
```
DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information
```