### PR TITLE
BUG: fix issues with `requires_ds` + pytest

### DIFF
--- a/yt/frontends/cf_radial/data_structures.py
+++ b/yt/frontends/cf_radial/data_structures.py
@@ -294,6 +294,9 @@ class CFRadialDataset(Dataset):
         # This accepts a filename or a set of arguments and returns True or
         # False depending on if the file is of the type requested.
 
+        if not xr.__is_available__:
+            return False
+
         warn_netcdf(filename)
         is_cfrad = False
         try:

--- a/yt/frontends/cf_radial/tests/test_outputs.py
+++ b/yt/frontends/cf_radial/tests/test_outputs.py
@@ -39,14 +39,14 @@ _fields_units = {
 }
 
 
-@requires_file(cf)
 @requires_module("xarray")
+@requires_file(cf)
 def test_units_override():
     units_override_check(cf)
 
 
-@requires_file(cf)
 @requires_module("xarray")
+@requires_file(cf)
 def test_cf_radial_gridded():
     ds = data_dir_load(cf)
     assert isinstance(ds, CFRadialDataset)
@@ -89,8 +89,8 @@ def check_domain(ds):
     assert_equal(ds.domain_right_edge, domain_right_array)
 
 
-@requires_file(cf_nongridded)
 @requires_module("xarray")
+@requires_file(cf_nongridded)
 def test_auto_gridding():
     # loads up a radial dataset, which triggers the gridding.
 
@@ -123,8 +123,8 @@ def test_auto_gridding():
     shutil.rmtree(tempdir)
 
 
-@requires_file(cf_nongridded)
 @requires_module("xarray")
+@requires_file(cf_nongridded)
 def test_grid_parameters():
     # checks that the gridding parameters are used and that conflicts in parameters
     # are resolved as expected.
@@ -172,8 +172,8 @@ def test_grid_parameters():
     shutil.rmtree(tempdir)
 
 
-@requires_ds(cf)
 @requires_module("xarray")
+@requires_ds(cf)
 def test_cfradial_grid_field_values():
     ds = data_dir_load(cf)
     fields_to_check = [("cf_radial", field) for field in _fields_cfradial]

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -540,7 +540,11 @@ class FITSDataset(Dataset):
 
     @classmethod
     def _is_valid(cls, filename, *args, **kwargs):
-        fileh = check_fits_valid(filename)
+        try:
+            fileh = check_fits_valid(filename)
+        except Exception:
+            return False
+
         if fileh is None:
             return False
         else:
@@ -638,7 +642,11 @@ class YTFITSDataset(FITSDataset):
 
     @classmethod
     def _is_valid(cls, filename, *args, **kwargs):
-        fileh = check_fits_valid(filename)
+        try:
+            fileh = check_fits_valid(filename)
+        except Exception:
+            return False
+
         if fileh is None:
             return False
         else:
@@ -711,7 +719,10 @@ class SkyDataFITSDataset(FITSDataset):
 
     @classmethod
     def _is_valid(cls, filename, *args, **kwargs):
-        return check_sky_coords(filename, ndim=2)
+        try:
+            return check_sky_coords(filename, ndim=2)
+        except Exception:
+            return False
 
 
 class SpectralCubeFITSHierarchy(FITSHierarchy):
@@ -821,7 +832,10 @@ class SpectralCubeFITSDataset(SkyDataFITSDataset):
 
     @classmethod
     def _is_valid(cls, filename, *args, **kwargs):
-        return check_sky_coords(filename, ndim=3)
+        try:
+            return check_sky_coords(filename, ndim=3)
+        except Exception:
+            return False
 
 
 class EventsFITSHierarchy(FITSHierarchy):
@@ -920,7 +934,10 @@ class EventsFITSDataset(SkyDataFITSDataset):
 
     @classmethod
     def _is_valid(cls, filename, *args, **kwargs):
-        fileh = check_fits_valid(filename)
+        try:
+            fileh = check_fits_valid(filename)
+        except Exception:
+            return False
         if fileh is not None:
             try:
                 valid = fileh[1].name == "EVENTS"

--- a/yt/frontends/fits/tests/test_outputs.py
+++ b/yt/frontends/fits/tests/test_outputs.py
@@ -1,4 +1,9 @@
-from yt.testing import assert_equal, requires_file, units_override_check
+from yt.testing import (
+    assert_equal,
+    requires_file,
+    requires_module,
+    units_override_check,
+)
 from yt.utilities.answer_testing.framework import (
     data_dir_load,
     requires_ds,
@@ -31,6 +36,7 @@ _fields_vels = (("fits", "velocity_x"), ("fits", "velocity_y"), ("fits", "veloci
 vf = "UnigridData/velocity_field_20.fits"
 
 
+@requires_module("astropy")
 @requires_ds(vf)
 def test_velocity_field():
     ds = data_dir_load(vf, cls=FITSDataset)

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -34,7 +34,13 @@ from yt.testing import (
     assert_rel_equal,
     skipif,
 )
-from yt.utilities.exceptions import YTCloudError, YTNoAnswerNameSpecified, YTNoOldAnswer
+from yt.utilities.exceptions import (
+    YTAmbiguousDataType,
+    YTCloudError,
+    YTNoAnswerNameSpecified,
+    YTNoOldAnswer,
+    YTUnidentifiedDataType,
+)
 from yt.utilities.logger import disable_stream_logging
 from yt.visualization import (
     image_writer as image_writer,
@@ -313,6 +319,9 @@ def can_run_ds(ds_fn, file_check=False):
                 result_storage["tainted"] = True
             raise
         return False
+    except (YTUnidentifiedDataType, YTAmbiguousDataType):
+        return False
+
     return result_storage is not None
 
 


### PR DESCRIPTION
## PR Summary

fixes #4126

The third commit isn't strictly necessary but it's an improvement; running the following module with pytest
```python
# t.py
from yt.testing import requires_module
from yt.utilities.answer_testing.framework import requires_ds

@requires_module("xarray")
@requires_ds("CfRadialGrid/grid1.nc")
def test_1():
    pass

@requires_ds("CfRadialGrid/grid1.nc")
@requires_module("xarray")
def test_2():
    pass
```

gives

```
t.py::test_1 SKIPPED (Missing required module xarray)
t.py::test_2 SKIPPED (cannot load dataset)
```

The reason why we can't load the dataset *being* that `xarray` isn't available, the first option is clearer.