### PR TITLE
BLD: forbid netcdf4 1.6.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -88,7 +88,7 @@ full =
     libconf>=1.0.1
     miniballcpp>=0.2.1
     mpi4py>=3.0.3
-    netCDF4>=1.5.3
+    netCDF4!=1.6.1 # see https://github.com/Unidata/netcdf4-python/issues/1192,>=1.5.3
     pandas>=1.1.2
     pooch>=0.7.0
     pyaml>=17.10.0


### PR DESCRIPTION
## PR Summary
Tentative fix for #4128
Even if this works (not sure yet), we might not want to merge this, depending on how reactive NETCDF4 is.
I'm opening mostly to _check_ my assumption that this is the source of instability.
