### PR TITLE
TST: bump image tests for matplotlib 3.6

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -88,7 +88,7 @@ full =
     libconf>=1.0.1
     miniballcpp>=0.2.1
     mpi4py>=3.0.3
-    netCDF4>=1.5.3
+    netCDF4!=1.6.1 # see https://github.com/Unidata/netcdf4-python/issues/1192,>=1.5.3
     pandas>=1.1.2
     pooch>=0.7.0
     pyaml>=17.10.0

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -100,7 +100,7 @@ answer_tests:
     - yt/frontends/owls/tests/test_outputs.py:test_snapshot_033
     - yt/frontends/owls/tests/test_outputs.py:test_OWLS_particlefilter
 
-  local_pw_046:  # PR 3849
+  local_pw_047:  #  PR 4132
     - yt/visualization/tests/test_plotwindow.py:test_attributes
     - yt/visualization/tests/test_particle_plot.py:test_particle_projection_answers
     - yt/visualization/tests/test_particle_plot.py:test_particle_projection_filter
@@ -176,10 +176,10 @@ answer_tests:
   local_axialpix_009: # PR 3818
     - yt/geometry/coordinates/tests/test_axial_pixelization.py:test_axial_pixelization
 
-  local_cylindrical_background_015:  # PR 3818, 3986
+  local_cylindrical_background_016:  # PR 4132
     - yt/geometry/coordinates/tests/test_cylindrical_coordinates.py:test_noise_plots
 
-  local_spherical_background_009:  # PR 3818, 3986
+  local_spherical_background_010:  # PR 4132
     - yt/geometry/coordinates/tests/test_spherical_coordinates.py:test_noise_plots
 
   #local_particle_trajectory_001:
@@ -188,7 +188,7 @@ answer_tests:
   local_nc4_cm1_002: # PR  2176, 2998
     - yt/frontends/nc4_cm1/tests/test_outputs.py:test_cm1_mesh_fields
 
-  local_norm_api_008: # PR 3849
+  local_norm_api_009: # PR 4132
     - yt/visualization/tests/test_norm_api_lineplot.py:test_lineplot_set_axis_properties
     - yt/visualization/tests/test_norm_api_profileplot.py:test_profileplot_set_axis_properties
     - yt/visualization/tests/test_norm_api_custom_norm.py:test_sliceplot_custom_norm


### PR DESCRIPTION
## PR Summary

Following the release of matplotlib 3.6, I'll use this PR to generate updates for the answer store submodule. I participated in the discussions leading to that release and I'm confident that it shouldn't have unwanted effects on yt plots, but it _does_ have desirable effects, so an update is still warranted.

Currently based on #4131
