### PR TITLE
BLD: fix broken constraint on netcdf4 requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -88,7 +88,7 @@ full =
     libconf>=1.0.1
     miniballcpp>=0.2.1
     mpi4py>=3.0.3
-    netCDF4!=1.6.1 # see https://github.com/Unidata/netcdf4-python/issues/1192,>=1.5.3
+    netCDF4!=1.6.1,>=1.5.3 # see https://github.com/Unidata/netcdf4-python/issues/1192
     pandas>=1.1.2
     pooch>=0.7.0
     pyaml>=17.10.0


### PR DESCRIPTION
## PR Summary

Follow up to #4131 in which I accidentally commented out an existing lower limit for netcdf4.
