### PR TITLE
RFC: upgrade Cython 'language level' to Python 3

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -381,7 +381,7 @@ def create_build_ext(lib_exts, cythonize_aliases):
             self.distribution.ext_modules[:] = cythonize(
                 lib_exts,
                 aliases=cythonize_aliases,
-                compiler_directives={"language_level": 2},
+                compiler_directives={"language_level": 3},
                 nthreads=get_cpu_count(),
             )
             _build_ext.finalize_options(self)
@@ -430,7 +430,7 @@ def create_build_ext(lib_exts, cythonize_aliases):
             cythonize(
                 lib_exts,
                 aliases=cythonize_aliases,
-                compiler_directives={"language_level": 2},
+                compiler_directives={"language_level": 3},
                 nthreads=get_cpu_count(),
             )
             _sdist.run(self)

--- a/yt/geometry/_selection_routines/selector_object.pxi
+++ b/yt/geometry/_selection_routines/selector_object.pxi
@@ -1,3 +1,6 @@
+from .oct_visitors cimport CountTotalCells, CountTotalOcts
+
+
 cdef class SelectorObject:
 
     def __cinit__(self, dobj, *args):
@@ -61,14 +64,14 @@ cdef class SelectorObject:
         return gridi.astype("bool")
 
     def count_octs(self, OctreeContainer octree, int domain_id = -1):
-        cdef oct_visitors.CountTotalOcts visitor
-        visitor = oct_visitors.CountTotalOcts(octree, domain_id)
+        cdef CountTotalOcts visitor
+        visitor = CountTotalOcts(octree, domain_id)
         octree.visit_all_octs(self, visitor)
         return visitor.index
 
     def count_oct_cells(self, OctreeContainer octree, int domain_id = -1):
-        cdef oct_visitors.CountTotalCells visitor
-        visitor = oct_visitors.CountTotalCells(octree, domain_id)
+        cdef CountTotalCells visitor
+        visitor = CountTotalCells(octree, domain_id)
         octree.visit_all_octs(self, visitor)
         return visitor.index
 

--- a/yt/geometry/fake_octree.pyx
+++ b/yt/geometry/fake_octree.pyx
@@ -11,11 +11,12 @@ Make a fake octree, deposit particle at every leaf
 
 cimport numpy as np
 from libc.stdlib cimport RAND_MAX, rand
-from oct_visitors cimport cind
+
+from .oct_visitors cimport cind
 
 import numpy as np
 
-from oct_container cimport Oct, SparseOctreeContainer
+from .oct_container cimport Oct, SparseOctreeContainer
 
 
 # Create a balanced octree by a random walk that recursively

--- a/yt/geometry/grid_container.pxd
+++ b/yt/geometry/grid_container.pxd
@@ -9,19 +9,20 @@ Matching points on the grid to specific grids
 import numpy as np
 
 cimport cython
-cimport grid_visitors
 cimport numpy as np
-from grid_visitors cimport (
+from libc.stdlib cimport free, malloc
+
+from yt.geometry cimport grid_visitors
+from yt.geometry.grid_visitors cimport (
     GridTreeNode,
     GridTreeNodePadded,
     GridVisitorData,
     grid_visitor_function,
 )
-from libc.stdlib cimport free, malloc
-
-from yt.geometry.selection_routines cimport SelectorObject, _ensure_code
 from yt.utilities.lib.bitarray cimport bitarray
 from yt.utilities.lib.fp_utils cimport iclip
+
+from .selection_routines cimport SelectorObject, _ensure_code
 
 
 cdef class GridTree:

--- a/yt/geometry/oct_container.pxd
+++ b/yt/geometry/oct_container.pxd
@@ -9,11 +9,10 @@ Oct definitions file
 
 cimport cython
 cimport numpy as np
-cimport oct_visitors
-cimport selection_routines
 from libc.math cimport floor
 from libc.stdlib cimport bsearch, free, malloc, qsort, realloc
 
+from yt.geometry cimport oct_visitors, selection_routines
 from yt.utilities.lib.allocation_container cimport AllocationContainer, ObjectPool
 from yt.utilities.lib.fp_utils cimport *
 

--- a/yt/geometry/oct_container.pyx
+++ b/yt/geometry/oct_container.pyx
@@ -16,14 +16,14 @@ cimport numpy as np
 import numpy as np
 
 from libc.math cimport floor
-from selection_routines cimport AlwaysSelector, SelectorObject
 
-from yt.geometry.oct_visitors cimport (
+from .oct_visitors cimport (
     NeighbourCellIndexVisitor,
     NeighbourCellVisitor,
     OctPadded,
     StoreIndex,
 )
+from .selection_routines cimport AlwaysSelector, SelectorObject
 
 ORDER_MAX = 20
 _ORDER_MAX = ORDER_MAX

--- a/yt/geometry/oct_visitors.pxd
+++ b/yt/geometry/oct_visitors.pxd
@@ -143,7 +143,7 @@ cdef inline int cind(int i, int j, int k) nogil:
     # THIS ONLY WORKS FOR CHILDREN.  It is not general for zones.
     return (((i*2)+j)*2+k)
 
-from oct_container cimport OctreeContainer
+from .oct_container cimport OctreeContainer
 
 
 cdef class StoreIndex(OctVisitor):

--- a/yt/geometry/oct_visitors.pyx
+++ b/yt/geometry/oct_visitors.pyx
@@ -16,9 +16,10 @@ import numpy as np
 
 from libc.stdlib cimport malloc
 
-from yt.geometry.oct_container cimport OctreeContainer
 from yt.utilities.lib.fp_utils cimport *
 from yt.utilities.lib.geometry_utils cimport encode_morton_64bit
+
+from .oct_container cimport OctreeContainer
 
 # Now some visitor functions
 

--- a/yt/geometry/particle_deposit.pyx
+++ b/yt/geometry/particle_deposit.pyx
@@ -15,9 +15,10 @@ import numpy as np
 
 cimport cython
 from libc.math cimport sqrt
-from oct_container cimport Oct, OctInfo, OctreeContainer
 
 from yt.utilities.lib.fp_utils cimport *
+
+from .oct_container cimport Oct, OctInfo, OctreeContainer
 
 from yt.utilities.lib.misc_utilities import OnceIndirect
 

--- a/yt/geometry/particle_oct_container.pyx
+++ b/yt/geometry/particle_oct_container.pyx
@@ -27,20 +27,11 @@ import numpy as np
 
 cimport cython
 cimport numpy as np
-cimport oct_visitors
 from cpython.exc cimport PyErr_CheckSignals
 from cython cimport floating
 from cython.operator cimport dereference, preincrement
-from oct_container cimport (
-    ORDER_MAX,
-    Oct,
-    OctKey,
-    OctreeContainer,
-    SparseOctreeContainer,
-)
-from oct_visitors cimport cind
-from selection_routines cimport AlwaysSelector, SelectorObject
 
+from yt.geometry cimport oct_visitors
 from yt.utilities.lib.fp_utils cimport *
 from yt.utilities.lib.geometry_utils cimport (
     bounded_morton,
@@ -53,9 +44,17 @@ from yt.utilities.lib.geometry_utils cimport (
     morton_neighbors_refined,
 )
 
-from yt.funcs import get_pbar
+from .oct_container cimport (
+    ORDER_MAX,
+    Oct,
+    OctKey,
+    OctreeContainer,
+    SparseOctreeContainer,
+)
+from .oct_visitors cimport cind
+from .selection_routines cimport AlwaysSelector, SelectorObject
 
-#from yt.utilities.lib.ewah_bool_wrap cimport \
+from yt.funcs import get_pbar
 
 from ..utilities.lib.ewah_bool_wrap cimport BoolArrayCollection
 

--- a/yt/geometry/particle_smooth.pxd
+++ b/yt/geometry/particle_smooth.pxd
@@ -14,7 +14,6 @@ import numpy as np
 cimport cython
 from libc.math cimport sqrt
 from libc.stdlib cimport free, malloc, qsort
-from oct_container cimport Oct, OctreeContainer
 
 from yt.utilities.lib.distance_queue cimport (
     DistanceQueue,
@@ -24,6 +23,7 @@ from yt.utilities.lib.distance_queue cimport (
 )
 from yt.utilities.lib.fp_utils cimport *
 
+from .oct_container cimport Oct, OctreeContainer
 from .particle_deposit cimport get_kernel_func, gind, kernel_func
 
 

--- a/yt/geometry/particle_smooth.pyx
+++ b/yt/geometry/particle_smooth.pyx
@@ -17,7 +17,8 @@ cimport cython
 from cpython.exc cimport PyErr_CheckSignals
 from libc.math cimport cos, sin, sqrt
 from libc.stdlib cimport free, malloc, realloc
-from oct_container cimport Oct, OctInfo, OctreeContainer
+
+from .oct_container cimport Oct, OctInfo, OctreeContainer
 
 
 cdef void spherical_coord_setup(np.float64_t ipos[3], np.float64_t opos[3]):

--- a/yt/geometry/selection_routines.pxd
+++ b/yt/geometry/selection_routines.pxd
@@ -8,17 +8,18 @@ Geometry selection routine imports.
 
 
 cimport numpy as np
-from grid_visitors cimport (
+
+from yt.geometry.grid_visitors cimport (
     GridTreeNode,
     GridVisitorData,
     check_child_masked,
     grid_visitor_function,
 )
-from oct_container cimport OctreeContainer
-from oct_visitors cimport Oct, OctVisitor
-
 from yt.utilities.lib.fp_utils cimport _ensure_code
 from yt.utilities.lib.geometry_utils cimport decode_morton_64bit
+
+from .oct_container cimport OctreeContainer
+from .oct_visitors cimport Oct, OctVisitor
 
 
 cdef class SelectorObject:

--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -13,7 +13,6 @@ import numpy as np
 
 cimport cython
 cimport numpy as np
-cimport oct_visitors
 from cython cimport floating
 from libc.math cimport sqrt
 from libc.stdlib cimport free, malloc

--- a/yt/utilities/lib/cykdtree/kdtree.pyx
+++ b/yt/utilities/lib/cykdtree/kdtree.pyx
@@ -226,7 +226,7 @@ cdef class PyKDTree:
         # Set leafsize of number of leaves provided
         if nleaves > 0:
             nleaves = <int>(2**np.ceil(np.log2(<float>nleaves)))
-            leafsize = pts.shape[0]/nleaves + 1
+            leafsize = pts.shape[0]//nleaves + 1
         if (leafsize < 2):
             # This is here to prevent segfault. The cpp code needs modified to
             # support leafsize = 1

--- a/yt/utilities/lib/fortran_reader.pyx
+++ b/yt/utilities/lib/fortran_reader.pyx
@@ -72,7 +72,7 @@ def count_art_octs(char *fn, long offset,
         fseek(f, next_record, SEEK_CUR)
         # Now we skip the second section
         fread(&readin, sizeof(int), 1, f); FIX_LONG(readin)
-        nhydro_vars = next_record/4-2-3 #nhvar in daniel's code
+        nhydro_vars = next_record//4-2-3 #nhvar in daniel's code
         #record length is normally 2 pad bytes, 8 + 2 hvars (the 2 is nchem)
         # and then 3 vars, but we can find nhvars only here and not in other
         # file headers

--- a/yt/utilities/lib/grid_traversal.pyx
+++ b/yt/utilities/lib/grid_traversal.pyx
@@ -16,10 +16,11 @@ import numpy as np
 
 cimport cython
 cimport numpy as np
-from fixed_interpolator cimport *
 from libc.math cimport atan2, cos, fabs, floor, sin, sqrt
 
 from yt.utilities.lib.fp_utils cimport fmin
+
+from .fixed_interpolator cimport *
 
 DEF Nch = 4
 

--- a/yt/utilities/lib/grid_traversal.pyx
+++ b/yt/utilities/lib/grid_traversal.pyx
@@ -333,8 +333,8 @@ def arr_fisheye_vectors(int resolution, np.float64_t fov, int nimx=1, int
     cdef int i, j
     cdef np.float64_t r, phi, theta, px, py
     cdef np.float64_t fov_rad = fov * np.pi / 180.0
-    cdef int nx = resolution/nimx
-    cdef int ny = resolution/nimy
+    cdef int nx = resolution//nimx
+    cdef int ny = resolution//nimy
     vp = np.zeros((nx,ny, 3), dtype="float64")
     for i in range(nx):
         px = (2.0 * (nimi*nx + i)) / resolution - 1.0

--- a/yt/utilities/lib/image_samplers.pyx
+++ b/yt/utilities/lib/image_samplers.pyx
@@ -15,18 +15,18 @@ Image sampler definitions
 import numpy as np
 
 cimport cython
-cimport lenses
-from field_interpolation_tables cimport (
+from libc.math cimport sqrt
+from libc.stdlib cimport free, malloc
+
+from yt.utilities.lib cimport lenses
+from yt.utilities.lib.fp_utils cimport fclip, i64clip, imin
+
+from .field_interpolation_tables cimport (
     FieldInterpolationTable,
     FIT_eval_transfer,
     FIT_eval_transfer_with_light,
     FIT_initialize_table,
 )
-from libc.math cimport sqrt
-from libc.stdlib cimport free, malloc
-
-from yt.utilities.lib.fp_utils cimport fclip, i64clip, imin
-
 from .fixed_interpolator cimport eval_gradient, offset_interpolate
 from .grid_traversal cimport sampler_function, walk_volume
 

--- a/yt/utilities/lib/lenses.pxd
+++ b/yt/utilities/lib/lenses.pxd
@@ -25,7 +25,6 @@ from libc.math cimport (
     sin,
     sqrt,
 )
-from vec3_ops cimport L2_norm, dot, fma, subtract
 
 from yt.utilities.lib.fp_utils cimport fclip, fmax, fmin, i64clip, iclip, imax, imin
 
@@ -34,6 +33,7 @@ from .image_samplers cimport (
     calculate_extent_function,
     generate_vector_info_function,
 )
+from .vec3_ops cimport L2_norm, dot, fma, subtract
 from .volume_container cimport VolumeContainer
 
 

--- a/yt/utilities/lib/marching_cubes.pyx
+++ b/yt/utilities/lib/marching_cubes.pyx
@@ -15,14 +15,15 @@ cimport numpy as np
 
 import numpy as np
 
-from fixed_interpolator cimport (
+from libc.math cimport sqrt
+from libc.stdlib cimport free, malloc
+
+from .fixed_interpolator cimport (
     eval_gradient,
     offset_fill,
     offset_interpolate,
     vertex_interp,
 )
-from libc.math cimport sqrt
-from libc.stdlib cimport free, malloc
 
 from yt.units.yt_array import YTArray
 

--- a/yt/utilities/lib/mesh_triangulation.pyx
+++ b/yt/utilities/lib/mesh_triangulation.pyx
@@ -59,7 +59,7 @@ cdef np.uint64_t triangle_hash(np.int64_t tri[3]) nogil:
     cdef np.uint64_t h = 1
     for i in range(3):
         h *= (1779033703 + 2*tri[i])
-    return h / 2
+    return h // 2
 
 # should be enough, consider dynamic resizing in the future
 cdef np.int64_t TABLE_SIZE = 2**24

--- a/yt/utilities/lib/misc_utilities.pyx
+++ b/yt/utilities/lib/misc_utilities.pyx
@@ -831,7 +831,7 @@ def count_collisions(np.ndarray[np.uint8_t, ndim=2] masks):
     counts = np.zeros(masks.shape[1], dtype="uint32")
     collides = np.zeros(masks.shape[1], dtype="uint8")
     for i in range(masks.shape[1]):
-        print i
+        print(i)
         for j in range(masks.shape[1]):
             collides[j] = 0
         for k in range(masks.shape[0]):

--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -36,7 +36,6 @@ from yt.utilities.exceptions import YTElementTypeNotRecognized, YTPixelizeError
 from cpython.exc cimport PyErr_CheckSignals
 from cython.parallel cimport parallel, prange
 from libc.stdlib cimport free, malloc
-from vec3_ops cimport cross, dot, subtract
 
 from yt.geometry.particle_deposit cimport get_kernel_func, kernel_func
 from yt.utilities.lib.element_mappings cimport (
@@ -52,6 +51,8 @@ from yt.utilities.lib.element_mappings cimport (
     Tet2Sampler3D,
     W1Sampler3D,
 )
+
+from .vec3_ops cimport cross, dot, subtract
 
 from yt.funcs import get_pbar
 

--- a/yt/utilities/lib/primitives.pxd
+++ b/yt/utilities/lib/primitives.pxd
@@ -4,7 +4,8 @@ cimport cython.floating
 import numpy as np
 
 cimport numpy as np
-from vec3_ops cimport cross, dot, subtract
+
+from .vec3_ops cimport cross, dot, subtract
 
 
 cdef struct Ray:


### PR DESCRIPTION
## PR Summary

This should be a noop, and gets us more in line with Cython 3.0 upcoming standards. See https://cython.readthedocs.io/en/latest/src/userguide/migrating_to_cy30.html?highlight=language_level#python-3-syntax-semantics