### PR TITLE
BLD: upgrade CIBW

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build wheels for CPython
-        uses: pypa/cibuildwheel@v2.9.0
+        uses: pypa/cibuildwheel@v2.10.2
         with:
           output-dir: dist
         env:


### PR DESCRIPTION
## PR Summary
upgrading cibuildwheel so that CPython 3.11 wheels are built with version 3.11.0rc2 instead of 3.11.0rc1
see release notes
https://github.com/pypa/cibuildwheel#v2100

