### PR TITLE
RAMSES: catch assertion errors with ill-written namelist files

### DIFF
--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -1028,7 +1028,9 @@ class RAMSESDataset(Dataset):
                     nml = f90nml.read(f)
             except ImportError as e:
                 nml = f"An error occurred when reading the namelist: {str(e)}"
-            except (ValueError, StopIteration) as err:
+            except (ValueError, StopIteration, AssertionError) as err:
+                # Note: f90nml may raise a StopIteration, a ValueError or an AssertionError if
+                # the namelist is not valid.
                 mylog.warning(
                     "Could not parse `namelist.txt` file as it was malformed:",
                     exc_info=err,


### PR DESCRIPTION
## PR Summary

RAMSES stores along with its output the namelist containing the parameters of the simulation. Unfortunately, with old version of RAMSES, this file may be in binary format (this was a bug that has now been fixed). This then may lead to `f90nml`, the package we rely on to parse the namelist, to raise an `AssertionError`.

This PR catches it.

See also: https://github.com/marshallward/f90nml/issues/147