### PR TITLE
[BUGFIX] Memory leak: free C++ memory before deallocing Python object

### DIFF
--- a/yt/geometry/oct_container.pyx
+++ b/yt/geometry/oct_container.pyx
@@ -1073,6 +1073,11 @@ cdef class SparseOctreeContainer(OctreeContainer):
     def __dealloc__(self):
         # This gets called BEFORE the superclass deallocation.  But, both get
         # called.
+        cdef OctKey *ikey
+        for i in range(self.num_root):
+            ikey = &self.root_nodes[i]
+            tdelete(<void *>ikey, &self.tree_root, root_node_compare)
+
         if self.root_nodes != NULL: free(self.root_nodes)
 
 cdef class ARTOctreeContainer(OctreeContainer):


### PR DESCRIPTION
## PR Summary

This fixes a memory leak issue reported in https://mail.python.org/archives/list/yt-users@python.org/thread/H3WCK5PA2WNGEDBVHOCWV5YCPV2ZYIXY/.

The root cause of the issue is that, for octree datasets (RAMSES, ART), the base grid is stored using a tree-like structure that is allocated in C. Unfortunately, when associated Python gets deleted, we were not freeing the memory in the process.

This PR fixes this by explicitely removing all entries in the query tree updon deallocation of the Python object.

## Notes

For _very_ large datasets, the operation may be quite slow `O(N log(N))`, where `N` is the number of base grid elements. For a RAMSES dataset with `levelmin=8`, that would be `~3 × 8 × (2^8)^3` operations.
It should in principle be possible to deallocate everything in `3 × N` operations by beeing clever. Alternatively, a longer term solution would be to move away from the manually-implemented `tsearch` function and use e.g. a `C++`-backed regular hashmap.