### PR TITLE
basic datetime functionality for stream frontend, annotate_timestamp

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -567,6 +567,9 @@ class Dataset(abc.ABC):
             np.seterr(**oldsettings)
         return self._instantiated_index
 
+    def _format_display_time(self, time):
+        return time
+
     @parallel_root_only
     def print_key_parameters(self):
         for a in [
@@ -580,6 +583,8 @@ class Dataset(abc.ABC):
                 mylog.error("Missing %s in parameter file definition!", a)
                 continue
             v = getattr(self, a)
+            if a == "current_time":
+                v = self._format_display_time(v)
             mylog.info("Parameters: %-25s = %s", a, v)
         if hasattr(self, "cosmological_simulation") and self.cosmological_simulation:
             for a in [

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -339,6 +339,7 @@ class StreamDataset(Dataset):
         default_species_fields=None,
     ):
         self.fluid_types += ("stream",)
+        self._display_datetime = False
         self.geometry = geometry
         self.stream_handler = stream_handler
         self._find_particle_types()
@@ -362,6 +363,11 @@ class StreamDataset(Dataset):
     def unique_identifier(self) -> str:
         return str(self.parameters["CurrentTimeIdentifier"])
 
+    def _format_display_time(self, time):
+        if self._display_datetime:
+            return np.datetime64(int(time.in_units("ns")), "ns")
+        return time
+
     def _parse_parameter_file(self):
         self.parameters["CurrentTimeIdentifier"] = time.time()
         self.domain_left_edge = self.stream_handler.domain_left_edge.copy()
@@ -370,7 +376,16 @@ class StreamDataset(Dataset):
         self.dimensionality = self.stream_handler.dimensionality
         self._periodicity = self.stream_handler.periodicity
         self.domain_dimensions = self.stream_handler.domain_dimensions
-        self.current_time = self.stream_handler.simulation_time
+
+        if isinstance(self.stream_handler.simulation_time, np.datetime64):
+            # always cast to ns before float so the float representation is
+            # properly padded. the result here will always be nanoseconds from
+            # 1970-01-01.
+            dtime = self.stream_handler.simulation_time.astype("datetime64[ns]")
+            self.current_time = self.quan(float(dtime), "ns")
+            self._display_datetime = True
+        else:
+            self.current_time = self.stream_handler.simulation_time
         self.gamma = 5.0 / 3.0
         self.parameters["EOSType"] = -1
         self.parameters["CosmologyHubbleConstantNow"] = 1.0

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -2737,15 +2737,19 @@ class TimestampCallback(PlotCallback):
         be used solo or in conjunction with the time parameter.
 
     time_format : string, optional
-        This specifies the format of the time output assuming "time" is the
+        This specifies the format of the time output. It can either be a format
+        string or the string 'datetime'. If a format string, then "time" is the
         number of time and "unit" is units of the time (e.g. 's', 'Myr', etc.)
         The time can be specified to arbitrary precision according to printf
         formatting codes (defaults to .1f -- a float with 1 digits after
         decimal).  Example: "Age = {time:.2f} {units}".
+        If time_format=='datetime' then the current time will be converted to
+        a date format for display.
 
     time_unit : string, optional
         time_unit must be a valid yt time unit (e.g. 's', 'min', 'hr', 'yr',
-        'Myr', etc.)
+        'Myr', etc.) OR if time_format=='datetime' then it can be one of the
+        datetime format options ('Y', 'M', 'D', 'h',  etc.)
 
     redshift_format : string, optional
         This specifies the format of the redshift output.  The redshift can
@@ -2844,6 +2848,8 @@ class TimestampCallback(PlotCallback):
             inset_box_args = def_inset_box_args
         self.inset_box_args = inset_box_args
 
+        self._enforce_datetime_constraints()
+
         # if inset box is not desired, set inset_box_args to {}
         if not draw_inset_box:
             self.inset_box_args = None
@@ -2882,35 +2888,7 @@ class TimestampCallback(PlotCallback):
 
         # If we're annotating the time, put it in the correct format
         if self.time:
-            # If no time_units are set, then identify a best fit time unit
-            if self.time_unit is None:
-                if plot.ds._uses_code_time_unit:
-                    # if the unit system is in code units
-                    # we should not convert to seconds for the plot.
-                    self.time_unit = plot.ds.unit_system.base_units[dimensions.time]
-                else:
-                    # in the case of non- code units then we
-                    self.time_unit = plot.ds.get_smallest_appropriate_unit(
-                        plot.ds.current_time, quantity="time"
-                    )
-            t = plot.ds.current_time.in_units(self.time_unit)
-            if self.time_offset is not None:
-                if isinstance(self.time_offset, tuple):
-                    toffset = plot.ds.quan(self.time_offset[0], self.time_offset[1])
-                elif isinstance(self.time_offset, Number):
-                    toffset = plot.ds.quan(self.time_offset, self.time_unit)
-                elif not isinstance(self.time_offset, YTQuantity):
-                    raise RuntimeError(
-                        "'time_offset' must be a float, tuple, or YTQuantity!"
-                    )
-                t -= toffset.in_units(self.time_unit)
-            try:
-                # here the time unit will be in brackets on the annotation.
-                un = self.time_unit.latex_representation()
-                time_unit = r"$\ \ (" + un + r")$"
-            except AttributeError:
-                time_unit = str(self.time_unit).replace("_", " ")
-            self.text += self.time_format.format(time=float(t), units=time_unit)
+            self.text += self._get_time_text(plot)
 
         # If time and redshift both shown, do one on top of the other
         if self.time and self.redshift:
@@ -2938,6 +2916,75 @@ class TimestampCallback(PlotCallback):
             inset_box_args=self.inset_box_args,
         )
         return tcb(plot)
+
+    def _enforce_datetime_constraints(self):
+        # catches conflicting arguments at initialization
+        if self.time_format == "datetime":
+            if self.time_offset is not None:
+                # note: could implement this with time deltas, but not a clear
+                # need to do so.
+                raise NotImplementedError(
+                    "time_offset is not available to use with 'datetime' time_format"
+                )
+            valid_datetime_formats = [
+                "Y",
+                "M",
+                "D",
+                "W",
+                "s",
+                "h",
+                "m",
+                "s",
+                "ms",
+                "us",
+                "ns",
+            ]
+            if self.time_unit is None:
+                self.time_unit = "ns"
+            elif self.time_unit not in valid_datetime_formats:
+                raise ValueError(
+                    f"time_format='datetime' but time_unit ({self.time_unit}) is not a valid format."
+                )
+
+    def _get_time_text(self, plot):
+
+        if self.time_format == "datetime":
+            # there will be some potential rounding error here do to the required
+            # cast to int.
+            dtime = np.datetime64(int(plot.ds.current_time.in_units("ns")), "ns")
+            dtime = dtime.astype(f"datetime64[{self.time_unit}]")
+            return str(dtime)
+
+        # If no time_units are set, then identify a best fit time unit
+        if self.time_unit is None:
+            if plot.ds._uses_code_time_unit:
+                # if the unit system is in code units
+                # we should not convert to seconds for the plot.
+                self.time_unit = plot.ds.unit_system.base_units[dimensions.time]
+            else:
+                # in the case of non-code units then we
+                self.time_unit = plot.ds.get_smallest_appropriate_unit(
+                    plot.ds.current_time, quantity="time"
+                )
+
+        t = plot.ds.current_time.in_units(self.time_unit)
+        if self.time_offset is not None:
+            if isinstance(self.time_offset, tuple):
+                toffset = plot.ds.quan(self.time_offset[0], self.time_offset[1])
+            elif isinstance(self.time_offset, Number):
+                toffset = plot.ds.quan(self.time_offset, self.time_unit)
+            elif not isinstance(self.time_offset, YTQuantity):
+                raise RuntimeError(
+                    "'time_offset' must be a float, tuple, or YTQuantity!"
+                )
+            t -= toffset.in_units(self.time_unit)
+        try:
+            # here the time unit will be in brackets on the annotation.
+            un = self.time_unit.latex_representation()
+            time_unit = r"$\ \ (" + un + r")$"
+        except AttributeError:
+            time_unit = str(self.time_unit).replace("_", " ")
+        return self.time_format.format(time=float(t), units=time_unit)
 
 
 class ScaleCallback(PlotCallback):


### PR DESCRIPTION
This PR adds some very basic (but I think still useful) datetime functionality that let's you:

* set the `sim_time` parameter in the stream frontend with a `np.datetime64` value (which gets cast to float when setting `ds.current_time`)
* display the `current_time` as a datetime if that's what it was originally set as 
* format the time as a datetime for the `annotate_timestamp` plot callback (this one is not restricted to stream frontends)

Given the potential complexity of adding actual datetime handling internally (which I think would require some unyt work as well), this PR simply adds an ingestion step on dataset initialization to convert any datetime to a float and then adds some simple formatting when displaying the `ds.current_time`. I added it just to the stream frontend because that seemed the most likely use-case (though there may be a benefit to the nc4_cm1 and cf_radial frontends, so I'd be open to adding some of this logic at the base dataset level instead). 

No new tests yet cause I wanted to get a sense for whether or not this is a good idea before putting more time into it.... 

Functionality demo:

```python
import yt
import numpy as np
shape=(7,8,9)

sim_time = np.datetime64('2021-09-09')
data = np.ones(shape)
data[:,5:, :] = 10
ds = yt.load_uniform_grid({'density': data}, shape, sim_time=sim_time)
```
The parameters info will display as:
```
yt : [INFO     ] 2022-10-14 17:06:57,416 Parameters: current_time              = 2021-09-09T00:00:00.000000000
```
And when plotting:
```python
for tunit in [None, "D"]:
    slc = yt.SlicePlot(ds, 'x', ('stream', 'density'))
    slc.annotate_timestamp(time_format='datetime',time_unit=tunit)
    slc.save(f"{tunit}.png")
```
![None](https://user-images.githubusercontent.com/22038879/195952323-1e87fea7-88e1-4a4c-b0d3-eb9ec24029ca.png)
![D](https://user-images.githubusercontent.com/22038879/195952328-3f304600-c2ec-4520-b1a0-51a6dd35f914.png)
