### PR TITLE
BUG: make a MPL failure non-fatal for set_norm with old version of MPL

### DIFF
--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -333,7 +333,7 @@ class ImagePlotMPL(PlotMPL, ABC):
                         "Failed to format colorbar ticks. "
                         "This is expected when using the set_norm method "
                         "with some matplotlib classes (e.g. TwoSlopeNorm) "
-                        "with versions older than 3.5\n"
+                        "with matplotlib versions older than 3.5\n"
                         "Please try upgrading matplotlib to a more recent version. "
                         "If the problem persists, please file a report to "
                         "https://github.com/yt-project/yt/issues/new"

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -325,7 +325,21 @@ class ImagePlotMPL(PlotMPL, ABC):
         fmt_kwargs = dict(style="scientific", scilimits=(-2, 3), useMathText=True)
         self.image.axes.ticklabel_format(**fmt_kwargs)
         if type(norm) not in (LogNorm, SymLogNorm):
-            self.cb.ax.ticklabel_format(**fmt_kwargs)
+            try:
+                self.cb.ax.ticklabel_format(**fmt_kwargs)
+            except AttributeError as exc:
+                if MPL_VERSION < Version("3.5.0"):
+                    warnings.warn(
+                        "Failed to format colorbar ticks. "
+                        "This is expected when using the set_norm method "
+                        "with some matplotlib classes (e.g. TwoSlopeNorm) "
+                        "with versions older than 3.5\n"
+                        "Please try upgrading matplotlib to a more recent version. "
+                        "If the problem persists, please file a report to "
+                        "https://github.com/yt-project/yt/issues/new"
+                    )
+                else:
+                    raise exc
         if self.colorbar_handler.draw_minorticks:
             if isinstance(norm, SymLogNorm):
                 if MPL_VERSION < Version("3.5.0b"):


### PR DESCRIPTION
## PR Summary

This example script doesn't work with matplotlib <= 3.5 and crashes with an `AttributeError`
```python
import yt
from yt.testing import fake_random_ds
from matplotlib.colors import TwoSlopeNorm

ds = fake_random_ds(16)
field = ("gas", "density")
p = SlicePlot(ds, "z", field)
p.set_norm(field, norm=TwoSlopeNorm(vcenter=0, vmin=-0.5, vmax=1))
```
However this error is not critical so this patch makes it non-fatal, with a clear warning message.
This is extracted from #4122 to enable backporting.
Backporting the tests that come with it in #4122 would be much more complicated, so I hope it's okay to backport just the patch.
