### PR TITLE
DEPR: deprecate calling yt.load with first argument passed as keyword

### DIFF
--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -18,6 +18,7 @@ from urllib.parse import urlsplit
 import numpy as np
 from more_itertools import always_iterable
 
+from yt._maintenance.deprecation import future_positional_only
 from yt.data_objects.static_output import Dataset
 from yt.funcs import levenshtein_distance
 from yt.sample_data.api import lookup_on_disk_data
@@ -41,6 +42,7 @@ from yt.utilities.on_demand_imports import _pooch as pooch, _ratarmount as ratar
 # --- Loaders for known data formats ---
 
 
+@future_positional_only({0: "fn"}, since="4.2.0")
 def load(
     fn: Union[str, "os.PathLike[str]"], *args, hint: Optional[str] = None, **kwargs
 ):

--- a/yt/tests/test_load_errors.py
+++ b/yt/tests/test_load_errors.py
@@ -1,5 +1,6 @@
 import pytest
 
+from yt._maintenance.deprecation import VisibleDeprecationWarning
 from yt.data_objects.static_output import Dataset
 from yt.geometry.grid_geometry_handler import GridIndex
 from yt.loaders import load, load_simulation
@@ -158,3 +159,42 @@ def test_load_ambiguous_data_with_hint(hint, expected_type, tmp_path):
 
     ds = ts[1]
     assert type(ds).__name__ == expected_type
+
+
+@pytest.fixture()
+def catchall_dataset_class():
+    # define a Dataset class matching any input,
+    # just so that we don't have to require an actual
+    # dataset for some tests
+    class MockHierarchy(GridIndex):
+        pass
+
+    class MockDataset(Dataset):
+        _index_class = MockHierarchy
+
+        def _parse_parameter_file(self, *args, **kwargs):
+            self.current_time = -1.0
+            self.cosmological_simulation = 0
+
+        def _set_code_unit_attributes(self, *args, **kwargs):
+            self.length_unit = self.quan(1, "m")
+            self.mass_unit = self.quan(1, "kg")
+            self.time_unit = self.quan(1, "s")
+
+        @classmethod
+        def _is_valid(cls, *args, **kwargs):
+            return True
+
+    yield
+
+    # teardown to avoid possible breakage in following tests
+    output_type_registry.pop("MockDataset")
+
+
+@pytest.mark.usefixtures("catchall_dataset_class")
+def test_depr_load_keyword(tmp_path):
+    with pytest.raises(
+        VisibleDeprecationWarning,
+        match=r"Using the 'fn' argument as keyword \(on position 0\) is deprecated\.",
+    ):
+        load(fn=tmp_path)


### PR DESCRIPTION
## PR Summary
This is a proposed solution to close #2879:
IMO, the name of the first argument to yt.load is bound to be meaningless.
It's current name `fn` is short for "filename", but we support loading from directories and in some cases, urls !
I think that making it a positional-only argument lifts out the weigh of carying a meaningless name forever.
Now, the difficult part is in continuously evolving the API to avoid sudden breaking changes, which is why 99% of this patch consists in adding a custom decorator to do just that, so existing code that might rely on loading data as `yt.load(fn=..., ...)` will not immediately break but will still emit some warnings, and we can keep backward compatibility for a while.


TODO:
- [x] add a test for the warning part