### PR TITLE
MNT: cleanup a pair of useless comments

### DIFF
--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -341,14 +341,12 @@ class AMRVACDataset(Dataset):
         if amrvac_geom is not None:
             self.geometry = self._parse_geometry(amrvac_geom)
         elif self.parameters["datfile_version"] > 4:
-            # py38: walrus here
             mylog.error(
                 "No 'geometry' flag found in datfile with version %d >4.",
                 self.parameters["datfile_version"],
             )
 
         if self._geometry_override is not None:
-            # py38: walrus here
             try:
                 new_geometry = self._parse_geometry(self._geometry_override)
                 if new_geometry == self.geometry:


### PR DESCRIPTION
## PR Summary
I wrote these comments 3 years ago when Python 3.8 was brand new and I couldn't wait to use it.
Now that we _can_ (3.8 is the oldest version we support), I actually disagree with my past self that using the walrus operator *in those instances* is desirable as it hurts readability and doesn't add value.
