### PR TITLE
TST: migrate OSX CI from osxfuse to macfuse

### DIFF
--- a/tests/ci_install.sh
+++ b/tests/ci_install.sh
@@ -15,7 +15,7 @@ linux|Linux)
 osx|macOS)
     sudo mkdir -p /usr/local/man
     sudo chown -R "${USER}:admin" /usr/local/man
-    HOMEBREW_NO_AUTO_UPDATE=1 brew install hdf5 geos open-mpi netcdf ccache osxfuse
+    HOMEBREW_NO_AUTO_UPDATE=1 brew install hdf5 geos open-mpi netcdf ccache macfuse
     ;;
 esac
 


### PR DESCRIPTION
## PR Summary
CI on MacOS is currently unstable (see for instance https://github.com/yt-project/yt/actions/runs/3315111034)

Here's the relevant snippet (I think) from the logs
```
++ brew install hdf5 geos open-mpi netcdf ccache osxfuse
13
==> Caveats
14
`osxfuse` has been succeeded by `macfuse` as of version 4.0.0.

...

Error: Failure while executing; `/usr/bin/sudo -E -- /usr/bin/env LOGNAME=runner USER=runner USERNAME=runner /usr/sbin/installer -pkg /usr/local/Caskroom/osxfuse/3.11.2/Extras/FUSE\ for\ macOS\ 3.11.2.pkg -target /` exited with 1. Here's the output:
38
installer: Error - The FUSE for macOS installation package is not compatible with this version of macOS.
```


Hopefully this patch fixes it