### PR TITLE
TST: resolve compatibility with pytest 7.2

### DIFF
--- a/nose_unit.cfg
+++ b/nose_unit.cfg
@@ -6,5 +6,5 @@ nologcapture=1
 verbosity=2
 where=yt
 with-timer=1
-ignore-files=(test_load_errors.py|test_load_sample.py|test_commons.py|test_ambiguous_fields.py|test_field_access_pytest.py|test_save.py|test_line_annotation_unit.py|test_eps_writer.py|test_registration.py|test_invalid_origin.py|test_outputs_pytest\.py|test_normal_plot_api\.py|test_load_archive\.py|test_stream_particles\.py|test_file_sanitizer\.py|test_version\.py|\test_on_demand_imports\.py|test_set_zlim\.py|test_add_field\.py)
+ignore-files=(test_load_errors.py|test_load_sample.py|test_commons.py|test_ambiguous_fields.py|test_field_access_pytest.py|test_save.py|test_line_annotation_unit.py|test_eps_writer.py|test_registration.py|test_invalid_origin.py|test_outputs_pytest\.py|test_normal_plot_api\.py|test_load_archive\.py|test_stream_particles\.py|test_file_sanitizer\.py|test_version\.py|\test_on_demand_imports\.py|test_set_zlim\.py|test_add_field\.py|test_glue\.py)
 exclude-test=yt.frontends.gdf.tests.test_outputs.TestGDF

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,8 @@ addopts = '''
     --ignore='yt/frontends/owls_subfind/tests/test_outputs.py'
     --ignore='yt/frontends/ramses/tests/test_outputs.py'
     --ignore='yt/frontends/cholla/tests/test_outputs.py'
+    --ignore='yt/utilities/lib/cykdtree/tests/test_kdtree.py'
+    --ignore='yt/utilities/lib/cykdtree/tests/test_utils.py'
 '''
 
 

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -226,6 +226,7 @@ other_tests:
      - "--ignore-files=test_version\\.py"
      - "--ignore-files=test_set_zlim\\.py"
      - "--ignore-file=test_add_field\\.py"
+     - "--ignore-file=test_glue\\.py"
      - "--exclude-test=yt.frontends.gdf.tests.test_outputs.TestGDF"
      - "--exclude-test=yt.frontends.adaptahop.tests.test_outputs"
      - "--exclude-test=yt.frontends.stream.tests.test_stream_particles.test_stream_non_cartesian_particles"

--- a/yt/data_objects/tests/test_glue.py
+++ b/yt/data_objects/tests/test_glue.py
@@ -1,15 +1,19 @@
-import nose
+import pytest
 
 from yt.config import ytcfg
-from yt.testing import fake_random_ds, requires_module
+from yt.testing import fake_random_ds, requires_module_pytest as requires_module
 
 
-def setup_func():
+@pytest.fixture
+def within_testing():
+    old_value = ytcfg["yt", "internals", "within_testing"]
     ytcfg["yt", "internals", "within_testing"] = True
+    yield
+    ytcfg["yt", "internals", "within_testing"] = old_value
 
 
-@requires_module("glue")
-@nose.with_setup(setup_func)
+@pytest.mark.usefixtures("within_testing")
+@requires_module("glue", "astropy")
 def test_glue_data_object():
     ds = fake_random_ds(16)
     ad = ds.all_data()

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -925,15 +925,9 @@ def requires_module_pytest(*module_names):
 
     So that it can be later renamed to `requires_module`.
     """
-    from yt.utilities import on_demand_imports as odi
 
     def deco(func):
-        missing = [
-            name
-            for name in module_names
-            if not getattr(odi, f"_{name}").__is_available__
-            for name in module_names
-        ]
+        missing = [name for name in module_names if find_spec(name) is None]
 
         # note that order between these two decorators matters
         @pytest.mark.skipif(


### PR DESCRIPTION
## PR Summary
Quick fix for #4188
- TST: configure pytest to ignore test modules using deprecated nose support
- TST: migrate a test from nose to pytest API
