### PR TITLE
MNT: cleanup unused import statements in Cython files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -81,3 +81,9 @@ repos:
         flake8-bugbear==22.7.1,
         flake8-logging-format==0.7.4,
       ]
+
+- repo: https://github.com/MarcoGorelli/cython-lint
+  rev: v0.2.1
+  hooks:
+  - id: cython-lint
+    args: [--no-pycodestyle]

--- a/doc/source/analyzing/_static/axes_calculator.pyx
+++ b/doc/source/analyzing/_static/axes_calculator.pyx
@@ -1,8 +1,5 @@
 import numpy as np
-
-cimport cython
 cimport numpy as np
-from libc.stdlib cimport free, malloc
 
 
 cdef extern from "axes.h":

--- a/yt/frontends/artio/_artio_caller.pyx
+++ b/yt/frontends/artio/_artio_caller.pyx
@@ -14,14 +14,9 @@ from libc.string cimport memcpy
 from yt.geometry.oct_container cimport OctObjectPool, SparseOctreeContainer
 from yt.geometry.oct_visitors cimport Oct
 from yt.geometry.particle_deposit cimport ParticleDepositOperation
-from yt.geometry.selection_routines cimport (
-    AlwaysSelector,
-    OctreeSubsetSelector,
-    SelectorObject,
-)
+from yt.geometry.selection_routines cimport AlwaysSelector, SelectorObject
 from yt.utilities.lib.fp_utils cimport imax
 
-import data_structures
 
 from yt.utilities.lib.misc_utilities import OnceIndirect
 

--- a/yt/geometry/fake_octree.pyx
+++ b/yt/geometry/fake_octree.pyx
@@ -10,12 +10,11 @@ Make a fake octree, deposit particle at every leaf
 
 
 cimport numpy as np
-from libc.stdlib cimport RAND_MAX, free, malloc, rand
+from libc.stdlib cimport RAND_MAX, rand
 from oct_visitors cimport cind
 
 import numpy as np
 
-cimport cython
 from oct_container cimport Oct, SparseOctreeContainer
 
 

--- a/yt/geometry/grid_visitors.pyx
+++ b/yt/geometry/grid_visitors.pyx
@@ -13,7 +13,7 @@ cimport cython
 cimport numpy as np
 from libc.stdlib cimport free, malloc
 
-from yt.utilities.lib.bitarray cimport ba_get_value, ba_set_value
+from yt.utilities.lib.bitarray cimport ba_set_value
 from yt.utilities.lib.fp_utils cimport iclip
 
 

--- a/yt/geometry/oct_container.pyx
+++ b/yt/geometry/oct_container.pyx
@@ -15,7 +15,7 @@ cimport numpy as np
 
 import numpy as np
 
-from libc.math cimport ceil, floor
+from libc.math cimport floor
 from selection_routines cimport AlwaysSelector, SelectorObject
 
 from yt.geometry.oct_visitors cimport (

--- a/yt/geometry/oct_visitors.pyx
+++ b/yt/geometry/oct_visitors.pyx
@@ -14,9 +14,9 @@ cimport numpy as np
 
 import numpy as np
 
-from libc.stdlib cimport free, malloc
+from libc.stdlib cimport malloc
 
-from yt.geometry.oct_container cimport OctInfo, OctreeContainer
+from yt.geometry.oct_container cimport OctreeContainer
 from yt.utilities.lib.fp_utils cimport *
 from yt.utilities.lib.geometry_utils cimport encode_morton_64bit
 

--- a/yt/geometry/particle_deposit.pyx
+++ b/yt/geometry/particle_deposit.pyx
@@ -14,9 +14,7 @@ cimport numpy as np
 import numpy as np
 
 cimport cython
-from cython.view cimport memoryview as cymemview
 from libc.math cimport sqrt
-from libc.stdlib cimport free, malloc
 from oct_container cimport Oct, OctInfo, OctreeContainer
 
 from yt.utilities.lib.fp_utils cimport *

--- a/yt/geometry/particle_oct_container.pyx
+++ b/yt/geometry/particle_oct_container.pyx
@@ -11,9 +11,8 @@ Oct container tuned for Particles
 """
 
 
-from libc.math cimport ceil, floor, fmod, log2
-from libc.stdlib cimport free, malloc, qsort
-from libc.string cimport memset
+from libc.math cimport ceil, log2
+from libc.stdlib cimport free, malloc
 from libcpp.map cimport map as cmap
 from libcpp.vector cimport vector
 
@@ -21,7 +20,6 @@ from yt.utilities.lib.ewah_bool_array cimport (
     bool_array,
     ewah_bool_array,
     ewah_bool_iterator,
-    ewah_map,
     ewah_word_type,
 )
 
@@ -36,20 +34,17 @@ from cython.operator cimport dereference, preincrement
 from oct_container cimport (
     ORDER_MAX,
     Oct,
-    OctAllocationContainer,
-    OctInfo,
     OctKey,
     OctreeContainer,
     SparseOctreeContainer,
 )
-from oct_visitors cimport OctVisitor, cind
+from oct_visitors cimport cind
 from selection_routines cimport AlwaysSelector, SelectorObject
 
 from yt.utilities.lib.fp_utils cimport *
 from yt.utilities.lib.geometry_utils cimport (
     bounded_morton,
     bounded_morton_dds,
-    bounded_morton_relative_dds,
     bounded_morton_split_dds,
     bounded_morton_split_relative_dds,
     decode_morton_64bit,
@@ -58,13 +53,10 @@ from yt.utilities.lib.geometry_utils cimport (
     morton_neighbors_refined,
 )
 
-from collections import defaultdict
-
 from yt.funcs import get_pbar
 
-from particle_deposit cimport gind
-
 #from yt.utilities.lib.ewah_bool_wrap cimport \
+
 from ..utilities.lib.ewah_bool_wrap cimport BoolArrayCollection
 
 import os
@@ -81,7 +73,6 @@ _bitmask_version = np.uint64(5)
 from ..utilities.lib.ewah_bool_wrap cimport (
     BoolArrayCollectionUncompressed as BoolArrayColl,
     FileBitmasks,
-    SparseUnorderedBitmaskSet as SparseUnorderedBitmask,
     SparseUnorderedRefinedBitmaskSet as SparseUnorderedRefinedBitmask,
 )
 

--- a/yt/geometry/particle_smooth.pyx
+++ b/yt/geometry/particle_smooth.pyx
@@ -15,9 +15,8 @@ import numpy as np
 
 cimport cython
 from cpython.exc cimport PyErr_CheckSignals
-from libc.math cimport cos, fabs, sin, sqrt
+from libc.math cimport cos, sin, sqrt
 from libc.stdlib cimport free, malloc, realloc
-from libc.string cimport memmove
 from oct_container cimport Oct, OctInfo, OctreeContainer
 
 

--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -18,17 +18,10 @@ from cython cimport floating
 from libc.math cimport sqrt
 from libc.stdlib cimport free, malloc
 
-from yt.utilities.lib.bitarray cimport ba_get_value, ba_set_value
+from yt.utilities.lib.bitarray cimport ba_get_value
 from yt.utilities.lib.fnv_hash cimport c_fnv_hash as fnv_hash
-from yt.utilities.lib.fp_utils cimport fclip, fmax, fmin, iclip, imax, imin
-from yt.utilities.lib.geometry_utils cimport (
-    bounded_morton_dds,
-    decode_morton_64bit,
-    encode_morton_64bit,
-    morton_neighbors_coarse,
-    morton_neighbors_refined,
-)
-from yt.utilities.lib.grid_traversal cimport sampler_function, walk_volume
+from yt.utilities.lib.fp_utils cimport fclip, fmax, fmin, iclip
+from yt.utilities.lib.grid_traversal cimport walk_volume
 from yt.utilities.lib.volume_container cimport VolumeContainer
 
 from .oct_container cimport Oct, OctreeContainer

--- a/yt/utilities/cython_fortran_utils.pyx
+++ b/yt/utilities/cython_fortran_utils.pyx
@@ -1,12 +1,8 @@
 # distutils: libraries = STD_LIBS
 cimport numpy as np
-
-import cython
 import numpy as np
 
 from libc.stdio cimport *
-
-import struct
 
 
 cdef INT32_SIZE = sizeof(np.int32_t)

--- a/yt/utilities/lib/_octree_raytracing.pyx
+++ b/yt/utilities/lib/_octree_raytracing.pyx
@@ -6,20 +6,9 @@ It relies on the seminal paper by  J. Revelles,, C.Ureña and M.Lastra.
 
 
 cimport numpy as np
-
 import numpy as np
 
 cimport cython
-from libcpp.vector cimport vector
-
-from cython.parallel import parallel, prange
-
-from libc.stdlib cimport free, malloc
-
-from .grid_traversal cimport sampler_function
-from .image_samplers cimport ImageAccumulator, ImageSampler
-from .partitioned_grid cimport PartitionedGrid
-from .volume_container cimport VolumeContainer
 
 DEF Nch = 4
 

--- a/yt/utilities/lib/basic_octree.pyx
+++ b/yt/utilities/lib/basic_octree.pyx
@@ -16,12 +16,11 @@ cimport cython
 # Double up here for def'd functions
 cimport numpy as np
 cimport numpy as cnp
-from libc.stdlib cimport abs, free, malloc
+from libc.stdlib cimport free, malloc
 
-from yt.utilities.lib.fp_utils cimport fclip, fmax, fmin, iclip, imax, imin
+from yt.utilities.lib.fp_utils cimport imax
 
 import sys
-import time
 
 
 cdef extern from "platform_dep.h":

--- a/yt/utilities/lib/bitarray.pyx
+++ b/yt/utilities/lib/bitarray.pyx
@@ -11,7 +11,6 @@ import numpy as np
 
 cimport cython
 cimport numpy as np
-from libc.stdlib cimport free, malloc
 
 
 cdef class bitarray:

--- a/yt/utilities/lib/bounding_volume_hierarchy.pyx
+++ b/yt/utilities/lib/bounding_volume_hierarchy.pyx
@@ -38,7 +38,6 @@ from yt.utilities.lib.primitives cimport (
     triangle_bbox,
     triangle_centroid,
 )
-from yt.utilities.lib.vec3_ops cimport L2_norm
 
 from .image_samplers cimport ImageSampler
 

--- a/yt/utilities/lib/contour_finding.pyx
+++ b/yt/utilities/lib/contour_finding.pyx
@@ -18,7 +18,6 @@ from libc.stdlib cimport free, malloc, realloc
 
 from yt.geometry.oct_container cimport OctInfo, OctreeContainer
 from yt.geometry.oct_visitors cimport Oct
-from yt.utilities.lib.fp_utils cimport imax
 
 from .amr_kdtools cimport Node
 from .partitioned_grid cimport PartitionedGrid

--- a/yt/utilities/lib/cykdtree/kdtree.pyx
+++ b/yt/utilities/lib/cykdtree/kdtree.pyx
@@ -4,13 +4,12 @@
 # distutils: depends = yt/utilities/lib/cykdtree/c_kdtree.hpp, yt/utilities/lib/cykdtree/c_utils.hpp
 # distutils: language = c++
 # distutils: extra_compile_args = CPP03_FLAG
-import cython
 import numpy as np
 
 cimport numpy as np
 from cpython cimport bool as pybool
 from cython.operator cimport dereference
-from libc.stdint cimport int32_t, int64_t, uint32_t, uint64_t
+from libc.stdint cimport uint32_t, uint64_t
 from libc.stdlib cimport free, malloc
 from libcpp cimport bool as cbool
 

--- a/yt/utilities/lib/cykdtree/utils.pyx
+++ b/yt/utilities/lib/cykdtree/utils.pyx
@@ -5,14 +5,9 @@
 # distutils: extra_compile_args = CPP03_FLAG
 import numpy as np
 
-cimport cython
 cimport numpy as np
-from libc.stdint cimport int32_t, int64_t, uint32_t, uint64_t
+from libc.stdint cimport int64_t, uint32_t, uint64_t
 from libcpp cimport bool as cbool
-from libcpp.pair cimport pair
-from libcpp.vector cimport vector
-
-import copy
 
 
 def py_max_pts(np.ndarray[np.float64_t, ndim=2] pos):

--- a/yt/utilities/lib/embree_mesh/mesh_construction.pyx
+++ b/yt/utilities/lib/embree_mesh/mesh_construction.pyx
@@ -15,13 +15,9 @@ Note - this file is only used for the Embree-accelerated ray-tracer.
 
 import numpy as np
 
-cimport cython
 cimport numpy as np
-cimport pyembree.rtcore as rtc
 cimport pyembree.rtcore_geometry as rtcg
 cimport pyembree.rtcore_geometry_user as rtcgu
-cimport pyembree.rtcore_ray as rtcr
-from libc.math cimport fmax, sqrt
 from libc.stdlib cimport free, malloc
 from mesh_intersection cimport (
     patchBoundsFunc,
@@ -31,7 +27,7 @@ from mesh_intersection cimport (
 )
 from mesh_samplers cimport sample_hex, sample_tetra, sample_wedge
 from mesh_traversal cimport YTEmbreeScene
-from pyembree.rtcore cimport Triangle, Vec3f, Vertex
+from pyembree.rtcore cimport Triangle, Vertex
 
 from yt.utilities.exceptions import YTElementTypeNotRecognized
 

--- a/yt/utilities/lib/embree_mesh/mesh_intersection.pyx
+++ b/yt/utilities/lib/embree_mesh/mesh_intersection.pyx
@@ -12,26 +12,15 @@ Note - this file is only used for the Embree-accelerated ray-tracer.
 
 
 cimport cython
-cimport numpy as np
-cimport pyembree.rtcore as rtc
 cimport pyembree.rtcore_geometry as rtcg
 cimport pyembree.rtcore_ray as rtcr
-from libc.math cimport fabs, fmax, fmin, sqrt
-from pyembree.rtcore cimport Vec3f
+from libc.math cimport fabs, fmax, fmin
 
-from yt.utilities.lib.bounding_volume_hierarchy cimport BBox
 from yt.utilities.lib.primitives cimport (
     RayHitData,
     compute_patch_hit,
     compute_tet_patch_hit,
-    patchSurfaceDerivU,
-    patchSurfaceDerivV,
-    patchSurfaceFunc,
-    tet_patchSurfaceDerivU,
-    tet_patchSurfaceDerivV,
-    tet_patchSurfaceFunc,
 )
-from yt.utilities.lib.vec3_ops cimport cross, distance, dot, subtract
 
 from .mesh_samplers cimport sample_hex20, sample_tet10
 

--- a/yt/utilities/lib/embree_mesh/mesh_samplers.pyx
+++ b/yt/utilities/lib/embree_mesh/mesh_samplers.pyx
@@ -12,11 +12,8 @@ Note - this file is only used for the Embree-accelerated ray-tracer.
 
 
 cimport cython
-cimport numpy as np
-cimport pyembree.rtcore as rtc
 cimport pyembree.rtcore_ray as rtcr
-from libc.math cimport fabs, fmax
-from pyembree.rtcore cimport Triangle, Vec3f, Vertex
+from pyembree.rtcore cimport Triangle
 
 from yt.utilities.lib.element_mappings cimport (
     ElementSampler,

--- a/yt/utilities/lib/embree_mesh/mesh_traversal.pyx
+++ b/yt/utilities/lib/embree_mesh/mesh_traversal.pyx
@@ -23,12 +23,6 @@ from libc.stdlib cimport free, malloc
 
 from yt.utilities.lib.image_samplers cimport ImageSampler
 
-from cython.parallel import parallel, prange, threadid
-
-from yt.visualization.image_writer import apply_colormap
-
-from yt.utilities.lib.bounding_volume_hierarchy cimport BVH, Ray
-
 rtc.rtcInit(NULL)
 rtc.rtcSetErrorFunction(error_printer)
 

--- a/yt/utilities/lib/ewah_bool_wrap.pyx
+++ b/yt/utilities/lib/ewah_bool_wrap.pyx
@@ -12,7 +12,7 @@ Wrapper for EWAH Bool Array: https://github.com/lemire/EWAHBoolArray
 import struct
 
 from cython.operator cimport dereference, preincrement
-from libc.stdlib cimport free, malloc, qsort
+from libc.stdlib cimport free, malloc
 from libcpp.algorithm cimport sort
 from libcpp.map cimport map as cmap
 

--- a/yt/utilities/lib/fortran_reader.pyx
+++ b/yt/utilities/lib/fortran_reader.pyx
@@ -11,7 +11,6 @@ Simple readers for fortran unformatted data, specifically for the Tiger code.
 import numpy as np
 
 cimport cython
-cimport libc.stdlib as stdlib
 cimport numpy as np
 from libc.stdio cimport FILE, fclose, fopen
 

--- a/yt/utilities/lib/geometry_utils.pyx
+++ b/yt/utilities/lib/geometry_utils.pyx
@@ -18,7 +18,7 @@ from cython cimport floating
 from libc.math cimport copysign, fabs, log2
 from libc.stdlib cimport free, malloc
 
-from yt.utilities.lib.fp_utils cimport fclip, i64clip
+from yt.utilities.lib.fp_utils cimport i64clip
 
 from yt.utilities.exceptions import YTDomainOverflow
 

--- a/yt/utilities/lib/grid_traversal.pyx
+++ b/yt/utilities/lib/grid_traversal.pyx
@@ -17,25 +17,9 @@ import numpy as np
 cimport cython
 cimport numpy as np
 from fixed_interpolator cimport *
-from libc.math cimport (
-    M_PI,
-    acos,
-    asin,
-    atan,
-    atan2,
-    cos,
-    exp,
-    fabs,
-    floor,
-    log2,
-    sin,
-    sqrt,
-)
+from libc.math cimport atan2, cos, fabs, floor, sin, sqrt
 
-#cimport healpix_interface
-from libc.stdlib cimport abs, calloc, free, malloc
-
-from yt.utilities.lib.fp_utils cimport fclip, fmax, fmin, i64clip, iclip, imax, imin
+from yt.utilities.lib.fp_utils cimport fmin
 
 DEF Nch = 4
 

--- a/yt/utilities/lib/image_samplers.pyx
+++ b/yt/utilities/lib/image_samplers.pyx
@@ -27,14 +27,7 @@ from libc.stdlib cimport free, malloc
 
 from yt.utilities.lib.fp_utils cimport fclip, i64clip, imin
 
-from .fixed_interpolator cimport (
-    eval_gradient,
-    fast_interpolate,
-    offset_fill,
-    offset_interpolate,
-    trilinear_interpolate,
-    vertex_interp,
-)
+from .fixed_interpolator cimport eval_gradient, offset_interpolate
 from .grid_traversal cimport sampler_function, walk_volume
 
 from yt.funcs import mylog
@@ -47,10 +40,9 @@ cdef extern from "platform_dep.h":
 
 DEF Nch = 4
 
-from cython.parallel import parallel, prange, threadid
+from cython.parallel import parallel, prange
 
 from cpython.exc cimport PyErr_CheckSignals
-from vec3_ops cimport L2_norm, dot, fma, subtract
 
 
 cdef struct VolumeRenderAccumulator:

--- a/yt/utilities/lib/image_utilities.pyx
+++ b/yt/utilities/lib/image_utilities.pyx
@@ -7,7 +7,6 @@ Utilities for images
 
 import numpy as np
 
-cimport cython
 cimport numpy as np
 
 from yt.utilities.lib.fp_utils cimport iclip

--- a/yt/utilities/lib/interpolators.pyx
+++ b/yt/utilities/lib/interpolators.pyx
@@ -13,7 +13,7 @@ import numpy as np
 cimport cython
 cimport numpy as np
 
-from yt.utilities.lib.fp_utils cimport fclip, fmax, fmin, iclip, imax, imin
+from yt.utilities.lib.fp_utils cimport iclip
 
 
 @cython.cdivision(True)

--- a/yt/utilities/lib/marching_cubes.pyx
+++ b/yt/utilities/lib/marching_cubes.pyx
@@ -22,9 +22,7 @@ from fixed_interpolator cimport (
     vertex_interp,
 )
 from libc.math cimport sqrt
-from libc.stdlib cimport abs, free, malloc
-
-from yt.utilities.lib.fp_utils cimport fclip, fmax, fmin, iclip, imax, imin
+from libc.stdlib cimport free, malloc
 
 from yt.units.yt_array import YTArray
 

--- a/yt/utilities/lib/mesh_utilities.pyx
+++ b/yt/utilities/lib/mesh_utilities.pyx
@@ -12,11 +12,8 @@ import numpy as np
 
 cimport cython
 cimport numpy as np
-from libc.stdlib cimport abs, free, malloc
 
-from yt.utilities.lib.fp_utils cimport fclip, fmax, fmin, i64clip, iclip, imax, imin
-
-from yt.units.yt_array import YTArray
+from yt.utilities.lib.fp_utils cimport fmax, fmin
 
 
 cdef extern from "platform_dep.h":

--- a/yt/utilities/lib/misc_utilities.pyx
+++ b/yt/utilities/lib/misc_utilities.pyx
@@ -16,16 +16,15 @@ from yt.funcs import get_pbar
 from yt.units.yt_array import YTArray
 
 cimport cython
-cimport libc.math as math
 cimport numpy as np
 from cpython cimport buffer
-from cython.view cimport array as cvarray, memoryview
+from cython.view cimport memoryview
 from libc.math cimport abs, sqrt
 from libc.stdlib cimport free, malloc
 from libc.string cimport strcmp
 
 from yt.geometry.selection_routines cimport _ensure_code
-from yt.utilities.lib.fp_utils cimport fmax, fmin, i64max, i64min
+from yt.utilities.lib.fp_utils cimport fmax, fmin
 
 
 cdef extern from "platform_dep.h":

--- a/yt/utilities/lib/particle_kdtree_tools.pyx
+++ b/yt/utilities/lib/particle_kdtree_tools.pyx
@@ -13,7 +13,6 @@ cimport cython
 cimport numpy as np
 from cpython.exc cimport PyErr_CheckSignals
 from libc.math cimport sqrt
-from libcpp.vector cimport vector
 
 from yt.utilities.lib.cykdtree.kdtree cimport KDTree, Node, PyKDTree, uint32_t, uint64_t
 

--- a/yt/utilities/lib/particle_mesh_operations.pyx
+++ b/yt/utilities/lib/particle_mesh_operations.pyx
@@ -13,7 +13,7 @@ cimport numpy as np
 
 import numpy as np
 
-from yt.utilities.lib.fp_utils cimport fclip, fmax, fmin, iclip, imax, imin
+from yt.utilities.lib.fp_utils cimport fclip
 
 
 @cython.boundscheck(False)

--- a/yt/utilities/lib/partitioned_grid.pyx
+++ b/yt/utilities/lib/partitioned_grid.pyx
@@ -16,7 +16,7 @@ import numpy as np
 
 cimport cython
 cimport numpy as np
-from libc.stdlib cimport abs, calloc, free, malloc
+from libc.stdlib cimport free, malloc
 
 from .fixed_interpolator cimport offset_interpolate
 

--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -56,7 +56,7 @@ from yt.utilities.lib.element_mappings cimport (
 from yt.funcs import get_pbar
 
 from yt.utilities.lib.bounded_priority_queue cimport BoundedPriorityQueue
-from yt.utilities.lib.cykdtree.kdtree cimport KDTree, Node, PyKDTree, uint32_t, uint64_t
+from yt.utilities.lib.cykdtree.kdtree cimport KDTree, PyKDTree
 from yt.utilities.lib.particle_kdtree_tools cimport (
     axes_range,
     find_neighbors,

--- a/yt/utilities/lib/quad_tree.pyx
+++ b/yt/utilities/lib/quad_tree.pyx
@@ -13,8 +13,7 @@ import numpy as np
 
 cimport cython
 cimport numpy as np
-from cython.operator cimport dereference as deref, preincrement as inc
-from libc.stdlib cimport abs, free, malloc
+from libc.stdlib cimport free, malloc
 
 from yt.utilities.lib.fp_utils cimport fmax, fmin
 

--- a/yt/utilities/voropp.pyx
+++ b/yt/utilities/voropp.pyx
@@ -7,8 +7,7 @@ Wrapping code for voro++
 
 
 cimport libcpp
-from cython.operator cimport dereference as deref, preincrement as inc
-from libc.stdlib cimport abs, calloc, free, labs, malloc
+from cython.operator cimport dereference as deref
 
 import numpy as np
 


### PR DESCRIPTION
## PR Summary
This is a first pass at #4193, focused on cleaning all unused imports detected by cython-lint
