### PR TITLE
MNT: Remove useless variables in Cython code

### DIFF
--- a/yt/frontends/artio/_artio_caller.pyx
+++ b/yt/frontends/artio/_artio_caller.pyx
@@ -1207,7 +1207,7 @@ cdef read_sfc_particles(artio_fileset artio_handle,
         check_artio_status(status)
         for ispec in range(num_species) :
             if accessed_species[ispec] == 0: continue
-            status = artio_particle_read_species_begin(handle, ispec);
+            status = artio_particle_read_species_begin(handle, ispec)
             check_artio_status(status)
             vp = &vpoints[ispec]
 

--- a/yt/frontends/artio/_artio_caller.pyx
+++ b/yt/frontends/artio/_artio_caller.pyx
@@ -1395,6 +1395,8 @@ cdef class ARTIORootMeshContainer:
     @cython.cdivision(True)
     def ires(self, SelectorObject selector, np.int64_t num_cells = -1,
                 int domain_id = -1):
+        # Note: self.mask has a side effect of setting self._last_mask_sum
+        self.mask(selector)
         num_cells = self._last_mask_sum
         cdef np.ndarray[np.int64_t, ndim=1] res
         res = np.zeros(num_cells, dtype="int64")

--- a/yt/frontends/gamer/cfields.pyx
+++ b/yt/frontends/gamer/cfields.pyx
@@ -69,8 +69,8 @@ cdef class SRHDFields:
             np.float64_t mz,
             np.float64_t kT,
         ):
-        cdef np.float64_t u2, c2, vx, vy, vz
-        cdef np.float64_t htilde, fac;
+        cdef np.float64_t u2
+        cdef np.float64_t fac
 
         fac = (1.0 / (rho * (self.h(kT, self._gamma) + 1.0))) ** 2
         u2 = (mx * mx + my * my + mz * mz) * fac
@@ -97,7 +97,6 @@ cdef class SRHDFields:
 
         out = np.empty_like(dens)
         cdef np.float64_t[:] outp = out.ravel()
-        cdef np.float64_t lf
         cdef int i
 
         for i in range(outp.shape[0]):
@@ -125,7 +124,6 @@ cdef class SRHDFields:
         cdef np.float64_t[:] kT = temp.ravel()
         out = np.empty_like(kT)
         cdef np.float64_t[:] outp = out.ravel()
-        cdef np.float64_t hp, cs2;
 
         cdef int i
         for i in range(outp.shape[0]):
@@ -142,7 +140,6 @@ cdef class SRHDFields:
 
         out = np.empty_like(dens)
         cdef np.float64_t[:] outp = out.ravel()
-        cdef np.float64_t[:] ui
         cdef int i
 
         for i in range(outp.shape[0]):
@@ -215,15 +212,10 @@ cdef class SRHDFields:
     @cython.wraparound(False)
     @cython.cdivision(True)
     def specific_thermal_energy(self, dens, momx, momy, momz, temp):
-        cdef np.float64_t[:] rho = dens.ravel()
-        cdef np.float64_t[:] mx = momx.ravel()
-        cdef np.float64_t[:] my = momy.ravel()
-        cdef np.float64_t[:] mz = momz.ravel()
         cdef np.float64_t[:] kT = temp.ravel()
 
         out = np.empty_like(dens)
         cdef np.float64_t[:] outp = out.ravel()
-        cdef np.float64_t lf, p, ht
         cdef int i
 
         for i in range(outp.shape[0]):
@@ -269,7 +261,7 @@ cdef class SRHDFields:
 
         out = np.empty_like(dens)
         cdef np.float64_t[:] outp = out.ravel()
-        cdef np.float64_t lf, u2, hp, cs
+        cdef np.float64_t cs
         cdef int i
 
         for i in range(outp.shape[0]):

--- a/yt/frontends/gamer/cfields.pyx
+++ b/yt/frontends/gamer/cfields.pyx
@@ -26,14 +26,14 @@ cdef np.float64_t gamma_eos4(np.float64_t kT, np.float64_t g):
     return c_p / c_v
 
 cdef np.float64_t cs_eos4(np.float64_t kT, np.float64_t c, np.float64_t g):
-    cdef np.float64_t hp, cs2;
+    cdef np.float64_t hp, cs2
     hp = h_eos4(kT, 0.0) + 1.0
     cs2 = kT / (3.0 * hp)
     cs2 *= (5.0 * hp - 8.0 * kT) / (hp - kT)
     return c * math.sqrt(cs2)
 
 cdef np.float64_t cs_eos(np.float64_t kT, np.float64_t c, np.float64_t g):
-    cdef np.float64_t hp, cs2;
+    cdef np.float64_t hp, cs2
     hp = h_eos(kT, g) + 1.0
     cs2 = g / hp * kT
     return c * math.sqrt(cs2)

--- a/yt/frontends/ramses/io_utils.pyx
+++ b/yt/frontends/ramses/io_utils.pyx
@@ -93,7 +93,6 @@ cpdef read_offset(FortranFile f, INT64_t min_level, INT64_t domain_id, INT64_t n
     cdef INT64_t ilevel, icpu
     cdef INT32_t file_ilevel, file_ncache
 
-    numbl = headers['numbl']
     ndim = headers['ndim']
     nboundary = headers['nboundary']
     nlevelmax = headers['nlevelmax']
@@ -157,7 +156,7 @@ def fill_hydro(FortranFile f,
 
     twotondim = 2**ndim
     nfields = len(all_fields)
-    ncpu = offsets.shape[0]
+
     nlevels = offsets.shape[1]
     ncpu_selected = len(cpu_enumerator)
 

--- a/yt/geometry/oct_container.pyx
+++ b/yt/geometry/oct_container.pyx
@@ -51,13 +51,12 @@ cdef class OctreeContainer:
         # This will just initialize the root mesh octs
         self.nz = num_zones
         self.partial_coverage = partial_coverage
-        cdef int i, j, k, p
+        cdef int i
         for i in range(3):
             self.nn[i] = oct_domain_dimensions[i]
         self.num_domains = 0
         self.level_offset = 0
         self.domains = OctObjectPool()
-        p = 0
         self.nocts = 0 # Increment when initialized
         for i in range(3):
             self.DLE[i] = domain_left_edge[i] #0
@@ -89,7 +88,7 @@ cdef class OctreeContainer:
         cdef SelectorObject selector = AlwaysSelector(None)
         cdef oct_visitors.LoadOctree visitor
         visitor = oct_visitors.LoadOctree(obj, -1)
-        cdef int i, j, k, n
+        cdef int i, j, k
         visitor.global_index = -1
         visitor.level = 0
         visitor.nz = visitor.nzones = 1
@@ -153,7 +152,7 @@ cdef class OctreeContainer:
     cdef void visit_all_octs(self, SelectorObject selector,
                         OctVisitor visitor, int vc = -1,
                         np.int64_t *indices = NULL):
-        cdef int i, j, k, n
+        cdef int i, j, k
         if vc == -1:
             vc = self.partial_coverage
         visitor.global_index = -1
@@ -264,7 +263,7 @@ cdef class OctreeContainer:
         cdef np.ndarray[np.int64_t, ndim=1] oct_id
         oct_id = np.ones(positions.shape[0], dtype="int64") * -1
         recorded = np.zeros(self.nocts, dtype="uint8")
-        cdef np.int64_t i, j, k
+        cdef np.int64_t i, j
         for i in range(positions.shape[0]):
             for j in range(3):
                 pos[j] = positions[i,j]
@@ -661,7 +660,6 @@ cdef class OctreeContainer:
     def file_index_octs(self, SelectorObject selector, int domain_id,
                         num_cells = -1):
         # We create oct arrays of the correct size
-        cdef np.int64_t i
         cdef np.ndarray[np.uint8_t, ndim=1] levels
         cdef np.ndarray[np.uint8_t, ndim=1] cell_inds
         cdef np.ndarray[np.int64_t, ndim=1] file_inds
@@ -893,7 +891,6 @@ cdef class OctreeContainer:
         +---+---+---+---+
 
         """
-        cdef np.int64_t i
         cdef int num_octs
         if num_cells < 0:
             num_octs = selector.count_octs(self, domain_id)
@@ -1012,8 +1009,8 @@ cdef class SparseOctreeContainer(OctreeContainer):
                         OctVisitor visitor,
                         int vc = -1,
                         np.int64_t *indices = NULL):
-        cdef int i, j, k, n
-        cdef np.int64_t key, ukey
+        cdef int i, j
+        cdef np.int64_t key
         visitor.global_index = -1
         visitor.level = 0
         if vc == -1:
@@ -1175,7 +1172,6 @@ cdef class OctObjectPool(ObjectPool):
 
     cdef void setup_objs(self, void *obj, np.uint64_t n, np.uint64_t offset,
                          np.int64_t con_id):
-        cdef np.uint64_t i
         cdef Oct* octs = <Oct *> obj
         for n in range(n):
             octs[n].file_ind = octs[n].domain = - 1
@@ -1184,7 +1180,7 @@ cdef class OctObjectPool(ObjectPool):
 
     cdef void teardown_objs(self, void *obj, np.uint64_t n, np.uint64_t offset,
                            np.int64_t con_id):
-        cdef np.uint64_t i, j
+        cdef np.uint64_t i
         cdef Oct *my_octs = <Oct *> obj
         for i in range(n):
             if my_octs[i].children != NULL:

--- a/yt/geometry/oct_visitors.pyx
+++ b/yt/geometry/oct_visitors.pyx
@@ -278,8 +278,6 @@ cdef class StoreOctree(OctVisitor):
     @cython.boundscheck(False)
     @cython.initializedcheck(False)
     cdef void visit(self, Oct* o, np.uint8_t selected):
-        cdef np.uint8_t res, ii
-        ii = cind(self.ind[0], self.ind[1], self.ind[2])
         if o.children == NULL:
             # Not refined.
             res = 0

--- a/yt/geometry/particle_deposit.pyx
+++ b/yt/geometry/particle_deposit.pyx
@@ -64,11 +64,9 @@ cdef class ParticleDepositOperation:
         cdef np.float64_t[:] field_vals = np.empty(nf, dtype="float64")
         cdef int dims[3]
         dims[0] = dims[1] = dims[2] = octree.nz
-        cdef int nz = dims[0] * dims[1] * dims[2]
         cdef OctInfo oi
         cdef np.int64_t offset, moff
         cdef Oct *oct
-        cdef np.int64_t numpart = positions.shape[0]
         cdef np.int8_t use_lvlmax
         moff = octree.get_domain_offset(domain_id + domain_offset)
         if lvlmax is None:
@@ -324,7 +322,7 @@ cdef class StdParticleField(ParticleDepositOperation):
                      np.int64_t domain_ind
                      ) nogil except -1:
         cdef int ii[3]
-        cdef int i, cell_index
+        cdef int i
         cdef float k, mk, qk
         for i in range(3):
             ii[i] = <int>((ppos[i] - left_edge[i])/dds[i])
@@ -376,13 +374,9 @@ cdef class CICDeposit(ParticleDepositOperation):
                      ) nogil except -1:
 
         cdef int i, j, k
-        cdef np.uint64_t ii
         cdef int ind[3]
         cdef np.float64_t rpos[3]
         cdef np.float64_t rdds[3][2]
-        cdef np.float64_t fact, edge0, edge1, edge2
-        cdef np.float64_t le0, le1, le2
-        cdef np.float64_t dx, dy, dz, dx2, dy2, dz2
 
         # Compute the position of the central cell
         for i in range(3):
@@ -531,7 +525,6 @@ cdef class NNParticleField(ParticleDepositOperation):
         # This one is a bit slow.  Every grid cell is going to be iterated
         # over, and we're going to deposit particles in it.
         cdef int i, j, k
-        cdef int ii[3]
         cdef np.float64_t r2
         cdef np.float64_t gpos[3]
         gpos[0] = left_edge[0] + 0.5 * dds[0]

--- a/yt/geometry/particle_oct_container.pyx
+++ b/yt/geometry/particle_oct_container.pyx
@@ -403,7 +403,7 @@ cdef class ParticleOctreeContainer(OctreeContainer):
             if o != NULL:
                 _mask_children(oct_mask, o)
                 coct += 1
-            cmi += 1;
+            cmi += 1
             preincrement(iter_set[0])
         # Get domain ind
         cdef np.ndarray[np.int64_t, ndim=1] ind

--- a/yt/geometry/particle_smooth.pyx
+++ b/yt/geometry/particle_smooth.pyx
@@ -34,7 +34,6 @@ cdef void cart_coord_setup(np.float64_t ipos[3], np.float64_t opos[3]):
 cdef class ParticleSmoothOperation:
     def __init__(self, nvals, nfields, max_neighbors, kernel_name):
         # This is the set of cells, in grids, blocks or octs, we are handling.
-        cdef int i
         self.nvals = nvals
         self.nfields = nfields
         self.maxn = max_neighbors
@@ -88,22 +87,17 @@ cdef class ParticleSmoothOperation:
         if particle_octree is None:
             particle_octree = mesh_octree
             pdom_ind = mdom_ind
-        cdef int nf, i, j, n
+        cdef int nf, i, j
         cdef int dims[3]
-        cdef np.float64_t[:] *field_check
         cdef np.float64_t **field_pointers
-        cdef np.float64_t *field_vals
         cdef np.float64_t pos[3]
-        cdef np.float64_t dds[3]
-        cdef np.float64_t **octree_field_pointers
         cdef int nsize = 0
         cdef np.int64_t *nind = NULL
-        cdef OctInfo moi, poi
+        cdef OctInfo moi
         cdef Oct *oct
-        cdef np.int64_t numpart, offset, local_ind, poff
+        cdef np.int64_t offset, poff
         cdef np.int64_t moff_p, moff_m
         cdef np.int64_t[:] pind, doff, pdoms, pcount
-        cdef np.int64_t[:,:] doff_m
         cdef np.ndarray[np.float64_t, ndim=1] tarr
         cdef np.ndarray[np.float64_t, ndim=4] iarr
         cdef np.float64_t[:,:] cart_positions
@@ -129,14 +123,12 @@ cdef class ParticleSmoothOperation:
             raise NotImplementedError
         dims[0] = dims[1] = dims[2] = mesh_octree.nz
         cdef int nz = dims[0] * dims[1] * dims[2]
-        numpart = positions.shape[0]
         # pcount is the number of particles per oct.
         pcount = np.zeros_like(pdom_ind)
         oct_left_edges = np.zeros((pdom_ind.shape[0], 3), dtype='float64')
         oct_dds = np.zeros_like(oct_left_edges)
         # doff is the offset to a given oct in the sorted particles.
         doff = np.zeros_like(pdom_ind) - 1
-        doff_m = np.zeros((mdom_ind.shape[0], 2), dtype="int64")
         moff_p = particle_octree.get_domain_offset(domain_id + domain_offset)
         moff_m = mesh_octree.get_domain_offset(domain_id + domain_offset)
         # pdoms points particles at their octs.  So the value in this array, for
@@ -242,20 +234,14 @@ cdef class ParticleSmoothOperation:
         # attributes (*not* mesh attributes) can be created that rely on the
         # values of nearby particles.  For instance, a smoothing kernel, or a
         # nearest-neighbor field.
-        cdef int nf, i, j, k, n
-        cdef int dims[3]
+        cdef int nf, i, j, k
         cdef np.float64_t **field_pointers
-        cdef np.float64_t *field_vals
-        cdef np.float64_t dds[3]
         cdef np.float64_t pos[3]
-        cdef np.float64_t **octree_field_pointers
         cdef int nsize = 0
         cdef np.int64_t *nind = NULL
-        cdef OctInfo moi, poi
         cdef Oct *oct
-        cdef Oct **neighbors = NULL
-        cdef np.int64_t nneighbors, numpart, offset, local_ind
-        cdef np.int64_t moff_p, moff_m, pind0, poff
+        cdef np.int64_t offset
+        cdef np.int64_t moff_p, pind0, poff
         cdef np.int64_t[:] pind, doff, pdoms, pcount
         cdef np.ndarray[np.float64_t, ndim=1] tarr
         cdef np.ndarray[np.float64_t, ndim=2] cart_positions
@@ -277,7 +263,6 @@ cdef class ParticleSmoothOperation:
             periodicity = (False, False, False)
         else:
             raise NotImplementedError
-        numpart = positions.shape[0]
         pcount = np.zeros_like(pdom_ind)
         doff = np.zeros_like(pdom_ind) - 1
         moff_p = particle_octree.get_domain_offset(domain_id + domain_offset)
@@ -324,8 +309,6 @@ cdef class ParticleSmoothOperation:
         #raise RuntimeError
         # Now doff is full of offsets to the first entry in the pind that
         # refers to that oct's particles.
-        cdef int maxnei = 0
-        cdef int nproc = 0
         # This should be thread-private if we ever go to OpenMP
         cdef DistanceQueue dist_queue = DistanceQueue(self.maxn)
         dist_queue._setup(self.DW, self.periodicity)
@@ -450,7 +433,7 @@ cdef class ParticleSmoothOperation:
         cdef np.float64_t pos[3]
         cdef np.float64_t ex[2]
         cdef np.float64_t DR[2]
-        cdef np.float64_t cp, r2_trunc, r2, dist
+        cdef np.float64_t r2_trunc, r2, dist
         dq.neighbor_reset()
         for ni in range(nneighbors):
             if nind[ni] == -1: continue
@@ -560,7 +543,7 @@ cdef class ParticleSmoothOperation:
         # Note that we assume that fields[0] == smoothing length in the native
         # units supplied.  We can now iterate over every cell in the block and
         # every particle to find the nearest.  We will use a priority heap.
-        cdef int i, j, k, ntot, nntot, m
+        cdef int i, j, k
         cdef int dim[3]
         cdef Oct *oct = NULL
         cdef np.int64_t nneighbors = 0
@@ -615,9 +598,8 @@ cdef class VolumeWeightedSmooth(ParticleSmoothOperation):
         # We have our i, j, k for our cell, as well as the cell position.
         # We also have a list of neighboring particles with particle numbers.
         cdef int n, fi
-        cdef np.float64_t weight, r2, val, hsml, dens, mass, coeff, max_r
+        cdef np.float64_t weight, r2, val, hsml, dens, mass, max_r
         cdef np.float64_t max_hsml, ihsml, ihsml3, kern
-        coeff = 0.0
         cdef np.int64_t pn
         # We get back our mass
         # rho_i = sum(j = 1 .. n) m_j * W_ij

--- a/yt/utilities/lib/_octree_raytracing.pyx
+++ b/yt/utilities/lib/_octree_raytracing.pyx
@@ -1,5 +1,5 @@
 # distutils: language = c++
-# distutils: extra_compile_args = CPP14_FLAG
+# distutils: extra_compile_args = CPP14_FLAG OMP_ARGS
 """This is a wrapper around the C++ class to efficiently cast rays into an octree.
 It relies on the seminal paper by  J. Revelles,, C.Ureña and M.Lastra.
 """

--- a/yt/utilities/lib/allocation_container.pyx
+++ b/yt/utilities/lib/allocation_container.pyx
@@ -50,8 +50,6 @@ cdef class ObjectPool:
     cdef void allocate_objs(self, int n_objs, np.int64_t con_id = -1) except *:
         cdef AllocationContainer *n_cont
         cdef AllocationContainer *prev
-        cdef int n, i, j, k
-        cdef char *obj # char so we can do pointer math
         self.containers = <AllocationContainer*> realloc(
               self.containers,
               sizeof(AllocationContainer) * (self.n_con + 1))
@@ -68,7 +66,6 @@ cdef class ObjectPool:
         n_cont.n = n_objs
         n_cont.n_assigned = 0
         n_cont.con_id = con_id
-        obj = <char*> n_cont.my_objs
         self.setup_objs(n_cont.my_objs, n_objs, n_cont.offset, n_cont.con_id)
 
     cdef void setup_objs(self, void *obj, np.uint64_t count,

--- a/yt/utilities/lib/autogenerated_element_samplers.pyx
+++ b/yt/utilities/lib/autogenerated_element_samplers.pyx
@@ -15,9 +15,9 @@ cdef void Q1Function3D(double* fx,
                        double* x,
                        double* vertices,
                        double* phys_x) nogil:
-	fx[0] = 0.125*(1 - x[0])*(1 - x[1])*(1 - x[2])*vertices[0] + 0.125*(1 - x[0])*(1 - x[1])*(1 + x[2])*vertices[12] + 0.125*(1 - x[0])*(1 + x[1])*(1 - x[2])*vertices[9] + 0.125*(1 - x[0])*(1 + x[1])*(1 + x[2])*vertices[21] + 0.125*(1 + x[0])*(1 - x[1])*(1 - x[2])*vertices[3] + 0.125*(1 + x[0])*(1 - x[1])*(1 + x[2])*vertices[15] + 0.125*(1 + x[0])*(1 + x[1])*(1 - x[2])*vertices[6] + 0.125*(1 + x[0])*(1 + x[1])*(1 + x[2])*vertices[18] - phys_x[0];
-	fx[1] = 0.125*(1 - x[0])*(1 - x[1])*(1 - x[2])*vertices[1] + 0.125*(1 - x[0])*(1 - x[1])*(1 + x[2])*vertices[13] + 0.125*(1 - x[0])*(1 + x[1])*(1 - x[2])*vertices[10] + 0.125*(1 - x[0])*(1 + x[1])*(1 + x[2])*vertices[22] + 0.125*(1 + x[0])*(1 - x[1])*(1 - x[2])*vertices[4] + 0.125*(1 + x[0])*(1 - x[1])*(1 + x[2])*vertices[16] + 0.125*(1 + x[0])*(1 + x[1])*(1 - x[2])*vertices[7] + 0.125*(1 + x[0])*(1 + x[1])*(1 + x[2])*vertices[19] - phys_x[1];
-	fx[2] = 0.125*(1 - x[0])*(1 - x[1])*(1 - x[2])*vertices[2] + 0.125*(1 - x[0])*(1 - x[1])*(1 + x[2])*vertices[14] + 0.125*(1 - x[0])*(1 + x[1])*(1 - x[2])*vertices[11] + 0.125*(1 - x[0])*(1 + x[1])*(1 + x[2])*vertices[23] + 0.125*(1 + x[0])*(1 - x[1])*(1 - x[2])*vertices[5] + 0.125*(1 + x[0])*(1 - x[1])*(1 + x[2])*vertices[17] + 0.125*(1 + x[0])*(1 + x[1])*(1 - x[2])*vertices[8] + 0.125*(1 + x[0])*(1 + x[1])*(1 + x[2])*vertices[20] - phys_x[2];
+	fx[0] = 0.125*(1 - x[0])*(1 - x[1])*(1 - x[2])*vertices[0] + 0.125*(1 - x[0])*(1 - x[1])*(1 + x[2])*vertices[12] + 0.125*(1 - x[0])*(1 + x[1])*(1 - x[2])*vertices[9] + 0.125*(1 - x[0])*(1 + x[1])*(1 + x[2])*vertices[21] + 0.125*(1 + x[0])*(1 - x[1])*(1 - x[2])*vertices[3] + 0.125*(1 + x[0])*(1 - x[1])*(1 + x[2])*vertices[15] + 0.125*(1 + x[0])*(1 + x[1])*(1 - x[2])*vertices[6] + 0.125*(1 + x[0])*(1 + x[1])*(1 + x[2])*vertices[18] - phys_x[0]
+	fx[1] = 0.125*(1 - x[0])*(1 - x[1])*(1 - x[2])*vertices[1] + 0.125*(1 - x[0])*(1 - x[1])*(1 + x[2])*vertices[13] + 0.125*(1 - x[0])*(1 + x[1])*(1 - x[2])*vertices[10] + 0.125*(1 - x[0])*(1 + x[1])*(1 + x[2])*vertices[22] + 0.125*(1 + x[0])*(1 - x[1])*(1 - x[2])*vertices[4] + 0.125*(1 + x[0])*(1 - x[1])*(1 + x[2])*vertices[16] + 0.125*(1 + x[0])*(1 + x[1])*(1 - x[2])*vertices[7] + 0.125*(1 + x[0])*(1 + x[1])*(1 + x[2])*vertices[19] - phys_x[1]
+	fx[2] = 0.125*(1 - x[0])*(1 - x[1])*(1 - x[2])*vertices[2] + 0.125*(1 - x[0])*(1 - x[1])*(1 + x[2])*vertices[14] + 0.125*(1 - x[0])*(1 + x[1])*(1 - x[2])*vertices[11] + 0.125*(1 - x[0])*(1 + x[1])*(1 + x[2])*vertices[23] + 0.125*(1 + x[0])*(1 - x[1])*(1 - x[2])*vertices[5] + 0.125*(1 + x[0])*(1 - x[1])*(1 + x[2])*vertices[17] + 0.125*(1 + x[0])*(1 + x[1])*(1 - x[2])*vertices[8] + 0.125*(1 + x[0])*(1 + x[1])*(1 + x[2])*vertices[20] - phys_x[2]
 
 
 @cython.boundscheck(False)
@@ -29,15 +29,15 @@ cdef void Q1Jacobian3D(double* rcol,
                        double* x,
                        double* vertices,
                        double* phys_x) nogil:
-	rcol[0] = -0.125*(1 - x[1])*(1 - x[2])*vertices[0] + 0.125*(1 - x[1])*(1 - x[2])*vertices[3] - 0.125*(1 - x[1])*(1 + x[2])*vertices[12] + 0.125*(1 - x[1])*(1 + x[2])*vertices[15] + 0.125*(1 + x[1])*(1 - x[2])*vertices[6] - 0.125*(1 + x[1])*(1 - x[2])*vertices[9] + 0.125*(1 + x[1])*(1 + x[2])*vertices[18] - 0.125*(1 + x[1])*(1 + x[2])*vertices[21];
-	scol[0] = -0.125*(1 - x[0])*(1 - x[2])*vertices[0] + 0.125*(1 - x[0])*(1 - x[2])*vertices[9] - 0.125*(1 - x[0])*(1 + x[2])*vertices[12] + 0.125*(1 - x[0])*(1 + x[2])*vertices[21] - 0.125*(1 + x[0])*(1 - x[2])*vertices[3] + 0.125*(1 + x[0])*(1 - x[2])*vertices[6] - 0.125*(1 + x[0])*(1 + x[2])*vertices[15] + 0.125*(1 + x[0])*(1 + x[2])*vertices[18];
-	tcol[0] = -0.125*(1 - x[0])*(1 - x[1])*vertices[0] + 0.125*(1 - x[0])*(1 - x[1])*vertices[12] - 0.125*(1 - x[0])*(1 + x[1])*vertices[9] + 0.125*(1 - x[0])*(1 + x[1])*vertices[21] - 0.125*(1 + x[0])*(1 - x[1])*vertices[3] + 0.125*(1 + x[0])*(1 - x[1])*vertices[15] - 0.125*(1 + x[0])*(1 + x[1])*vertices[6] + 0.125*(1 + x[0])*(1 + x[1])*vertices[18];
-	rcol[1] = -0.125*(1 - x[1])*(1 - x[2])*vertices[1] + 0.125*(1 - x[1])*(1 - x[2])*vertices[4] - 0.125*(1 - x[1])*(1 + x[2])*vertices[13] + 0.125*(1 - x[1])*(1 + x[2])*vertices[16] + 0.125*(1 + x[1])*(1 - x[2])*vertices[7] - 0.125*(1 + x[1])*(1 - x[2])*vertices[10] + 0.125*(1 + x[1])*(1 + x[2])*vertices[19] - 0.125*(1 + x[1])*(1 + x[2])*vertices[22];
-	scol[1] = -0.125*(1 - x[0])*(1 - x[2])*vertices[1] + 0.125*(1 - x[0])*(1 - x[2])*vertices[10] - 0.125*(1 - x[0])*(1 + x[2])*vertices[13] + 0.125*(1 - x[0])*(1 + x[2])*vertices[22] - 0.125*(1 + x[0])*(1 - x[2])*vertices[4] + 0.125*(1 + x[0])*(1 - x[2])*vertices[7] - 0.125*(1 + x[0])*(1 + x[2])*vertices[16] + 0.125*(1 + x[0])*(1 + x[2])*vertices[19];
-	tcol[1] = -0.125*(1 - x[0])*(1 - x[1])*vertices[1] + 0.125*(1 - x[0])*(1 - x[1])*vertices[13] - 0.125*(1 - x[0])*(1 + x[1])*vertices[10] + 0.125*(1 - x[0])*(1 + x[1])*vertices[22] - 0.125*(1 + x[0])*(1 - x[1])*vertices[4] + 0.125*(1 + x[0])*(1 - x[1])*vertices[16] - 0.125*(1 + x[0])*(1 + x[1])*vertices[7] + 0.125*(1 + x[0])*(1 + x[1])*vertices[19];
-	rcol[2] = -0.125*(1 - x[1])*(1 - x[2])*vertices[2] + 0.125*(1 - x[1])*(1 - x[2])*vertices[5] - 0.125*(1 - x[1])*(1 + x[2])*vertices[14] + 0.125*(1 - x[1])*(1 + x[2])*vertices[17] + 0.125*(1 + x[1])*(1 - x[2])*vertices[8] - 0.125*(1 + x[1])*(1 - x[2])*vertices[11] + 0.125*(1 + x[1])*(1 + x[2])*vertices[20] - 0.125*(1 + x[1])*(1 + x[2])*vertices[23];
-	scol[2] = -0.125*(1 - x[0])*(1 - x[2])*vertices[2] + 0.125*(1 - x[0])*(1 - x[2])*vertices[11] - 0.125*(1 - x[0])*(1 + x[2])*vertices[14] + 0.125*(1 - x[0])*(1 + x[2])*vertices[23] - 0.125*(1 + x[0])*(1 - x[2])*vertices[5] + 0.125*(1 + x[0])*(1 - x[2])*vertices[8] - 0.125*(1 + x[0])*(1 + x[2])*vertices[17] + 0.125*(1 + x[0])*(1 + x[2])*vertices[20];
-	tcol[2] = -0.125*(1 - x[0])*(1 - x[1])*vertices[2] + 0.125*(1 - x[0])*(1 - x[1])*vertices[14] - 0.125*(1 - x[0])*(1 + x[1])*vertices[11] + 0.125*(1 - x[0])*(1 + x[1])*vertices[23] - 0.125*(1 + x[0])*(1 - x[1])*vertices[5] + 0.125*(1 + x[0])*(1 - x[1])*vertices[17] - 0.125*(1 + x[0])*(1 + x[1])*vertices[8] + 0.125*(1 + x[0])*(1 + x[1])*vertices[20];
+	rcol[0] = -0.125*(1 - x[1])*(1 - x[2])*vertices[0] + 0.125*(1 - x[1])*(1 - x[2])*vertices[3] - 0.125*(1 - x[1])*(1 + x[2])*vertices[12] + 0.125*(1 - x[1])*(1 + x[2])*vertices[15] + 0.125*(1 + x[1])*(1 - x[2])*vertices[6] - 0.125*(1 + x[1])*(1 - x[2])*vertices[9] + 0.125*(1 + x[1])*(1 + x[2])*vertices[18] - 0.125*(1 + x[1])*(1 + x[2])*vertices[21]
+	scol[0] = -0.125*(1 - x[0])*(1 - x[2])*vertices[0] + 0.125*(1 - x[0])*(1 - x[2])*vertices[9] - 0.125*(1 - x[0])*(1 + x[2])*vertices[12] + 0.125*(1 - x[0])*(1 + x[2])*vertices[21] - 0.125*(1 + x[0])*(1 - x[2])*vertices[3] + 0.125*(1 + x[0])*(1 - x[2])*vertices[6] - 0.125*(1 + x[0])*(1 + x[2])*vertices[15] + 0.125*(1 + x[0])*(1 + x[2])*vertices[18]
+	tcol[0] = -0.125*(1 - x[0])*(1 - x[1])*vertices[0] + 0.125*(1 - x[0])*(1 - x[1])*vertices[12] - 0.125*(1 - x[0])*(1 + x[1])*vertices[9] + 0.125*(1 - x[0])*(1 + x[1])*vertices[21] - 0.125*(1 + x[0])*(1 - x[1])*vertices[3] + 0.125*(1 + x[0])*(1 - x[1])*vertices[15] - 0.125*(1 + x[0])*(1 + x[1])*vertices[6] + 0.125*(1 + x[0])*(1 + x[1])*vertices[18]
+	rcol[1] = -0.125*(1 - x[1])*(1 - x[2])*vertices[1] + 0.125*(1 - x[1])*(1 - x[2])*vertices[4] - 0.125*(1 - x[1])*(1 + x[2])*vertices[13] + 0.125*(1 - x[1])*(1 + x[2])*vertices[16] + 0.125*(1 + x[1])*(1 - x[2])*vertices[7] - 0.125*(1 + x[1])*(1 - x[2])*vertices[10] + 0.125*(1 + x[1])*(1 + x[2])*vertices[19] - 0.125*(1 + x[1])*(1 + x[2])*vertices[22]
+	scol[1] = -0.125*(1 - x[0])*(1 - x[2])*vertices[1] + 0.125*(1 - x[0])*(1 - x[2])*vertices[10] - 0.125*(1 - x[0])*(1 + x[2])*vertices[13] + 0.125*(1 - x[0])*(1 + x[2])*vertices[22] - 0.125*(1 + x[0])*(1 - x[2])*vertices[4] + 0.125*(1 + x[0])*(1 - x[2])*vertices[7] - 0.125*(1 + x[0])*(1 + x[2])*vertices[16] + 0.125*(1 + x[0])*(1 + x[2])*vertices[19]
+	tcol[1] = -0.125*(1 - x[0])*(1 - x[1])*vertices[1] + 0.125*(1 - x[0])*(1 - x[1])*vertices[13] - 0.125*(1 - x[0])*(1 + x[1])*vertices[10] + 0.125*(1 - x[0])*(1 + x[1])*vertices[22] - 0.125*(1 + x[0])*(1 - x[1])*vertices[4] + 0.125*(1 + x[0])*(1 - x[1])*vertices[16] - 0.125*(1 + x[0])*(1 + x[1])*vertices[7] + 0.125*(1 + x[0])*(1 + x[1])*vertices[19]
+	rcol[2] = -0.125*(1 - x[1])*(1 - x[2])*vertices[2] + 0.125*(1 - x[1])*(1 - x[2])*vertices[5] - 0.125*(1 - x[1])*(1 + x[2])*vertices[14] + 0.125*(1 - x[1])*(1 + x[2])*vertices[17] + 0.125*(1 + x[1])*(1 - x[2])*vertices[8] - 0.125*(1 + x[1])*(1 - x[2])*vertices[11] + 0.125*(1 + x[1])*(1 + x[2])*vertices[20] - 0.125*(1 + x[1])*(1 + x[2])*vertices[23]
+	scol[2] = -0.125*(1 - x[0])*(1 - x[2])*vertices[2] + 0.125*(1 - x[0])*(1 - x[2])*vertices[11] - 0.125*(1 - x[0])*(1 + x[2])*vertices[14] + 0.125*(1 - x[0])*(1 + x[2])*vertices[23] - 0.125*(1 + x[0])*(1 - x[2])*vertices[5] + 0.125*(1 + x[0])*(1 - x[2])*vertices[8] - 0.125*(1 + x[0])*(1 + x[2])*vertices[17] + 0.125*(1 + x[0])*(1 + x[2])*vertices[20]
+	tcol[2] = -0.125*(1 - x[0])*(1 - x[1])*vertices[2] + 0.125*(1 - x[0])*(1 - x[1])*vertices[14] - 0.125*(1 - x[0])*(1 + x[1])*vertices[11] + 0.125*(1 - x[0])*(1 + x[1])*vertices[23] - 0.125*(1 + x[0])*(1 - x[1])*vertices[5] + 0.125*(1 + x[0])*(1 - x[1])*vertices[17] - 0.125*(1 + x[0])*(1 + x[1])*vertices[8] + 0.125*(1 + x[0])*(1 + x[1])*vertices[20]
 
 
 @cython.boundscheck(False)
@@ -47,8 +47,8 @@ cdef void Q1Function2D(double* fx,
                        double* x,
                        double* vertices,
                        double* phys_x) nogil:
-	fx[0] = 0.25*(1 - x[0])*(1 - x[1])*vertices[0] + 0.25*(1 - x[0])*(1 + x[1])*vertices[6] + 0.25*(1 + x[0])*(1 - x[1])*vertices[2] + 0.25*(1 + x[0])*(1 + x[1])*vertices[4] - phys_x[0];
-	fx[1] = 0.25*(1 - x[0])*(1 - x[1])*vertices[1] + 0.25*(1 - x[0])*(1 + x[1])*vertices[7] + 0.25*(1 + x[0])*(1 - x[1])*vertices[3] + 0.25*(1 + x[0])*(1 + x[1])*vertices[5] - phys_x[1];
+	fx[0] = 0.25*(1 - x[0])*(1 - x[1])*vertices[0] + 0.25*(1 - x[0])*(1 + x[1])*vertices[6] + 0.25*(1 + x[0])*(1 - x[1])*vertices[2] + 0.25*(1 + x[0])*(1 + x[1])*vertices[4] - phys_x[0]
+	fx[1] = 0.25*(1 - x[0])*(1 - x[1])*vertices[1] + 0.25*(1 - x[0])*(1 + x[1])*vertices[7] + 0.25*(1 + x[0])*(1 - x[1])*vertices[3] + 0.25*(1 + x[0])*(1 + x[1])*vertices[5] - phys_x[1]
 
 
 @cython.boundscheck(False)
@@ -59,10 +59,10 @@ cdef void Q1Jacobian2D(double* rcol,
                        double* x,
                        double* vertices,
                        double* phys_x) nogil:
-	rcol[0] = -0.25*(1 - x[1])*vertices[0] + 0.25*(1 - x[1])*vertices[2] + 0.25*(1 + x[1])*vertices[4] - 0.25*(1 + x[1])*vertices[6];
-	scol[0] = -0.25*(1 - x[0])*vertices[0] + 0.25*(1 - x[0])*vertices[6] - 0.25*(1 + x[0])*vertices[2] + 0.25*(1 + x[0])*vertices[4];
-	rcol[1] = -0.25*(1 - x[1])*vertices[1] + 0.25*(1 - x[1])*vertices[3] + 0.25*(1 + x[1])*vertices[5] - 0.25*(1 + x[1])*vertices[7];
-	scol[1] = -0.25*(1 - x[0])*vertices[1] + 0.25*(1 - x[0])*vertices[7] - 0.25*(1 + x[0])*vertices[3] + 0.25*(1 + x[0])*vertices[5];
+	rcol[0] = -0.25*(1 - x[1])*vertices[0] + 0.25*(1 - x[1])*vertices[2] + 0.25*(1 + x[1])*vertices[4] - 0.25*(1 + x[1])*vertices[6]
+	scol[0] = -0.25*(1 - x[0])*vertices[0] + 0.25*(1 - x[0])*vertices[6] - 0.25*(1 + x[0])*vertices[2] + 0.25*(1 + x[0])*vertices[4]
+	rcol[1] = -0.25*(1 - x[1])*vertices[1] + 0.25*(1 - x[1])*vertices[3] + 0.25*(1 + x[1])*vertices[5] - 0.25*(1 + x[1])*vertices[7]
+	scol[1] = -0.25*(1 - x[0])*vertices[1] + 0.25*(1 - x[0])*vertices[7] - 0.25*(1 + x[0])*vertices[3] + 0.25*(1 + x[0])*vertices[5]
 
 
 @cython.boundscheck(False)
@@ -72,8 +72,8 @@ cdef void Q2Function2D(double* fx,
                        double* x,
                        double* vertices,
                        double* phys_x) nogil:
-	fx[0] = (1 + x[0])*(-1 + x[0])*(1 + x[1])*(-1 + x[1])*vertices[16] - 0.5*(1 + x[0])*(-1 + x[0])*x[1]*(-1 + x[1])*vertices[8] - 0.5*(1 + x[0])*(-1 + x[0])*x[1]*(1 + x[1])*vertices[12] - phys_x[0] - 0.5*x[0]*(-1 + x[0])*(1 + x[1])*(-1 + x[1])*vertices[14] + 0.25*x[0]*(-1 + x[0])*x[1]*(-1 + x[1])*vertices[0] + 0.25*x[0]*(-1 + x[0])*x[1]*(1 + x[1])*vertices[6] - 0.5*x[0]*(1 + x[0])*(1 + x[1])*(-1 + x[1])*vertices[10] + 0.25*x[0]*(1 + x[0])*x[1]*(-1 + x[1])*vertices[2] + 0.25*x[0]*(1 + x[0])*x[1]*(1 + x[1])*vertices[4];
-	fx[1] = (1 + x[0])*(-1 + x[0])*(1 + x[1])*(-1 + x[1])*vertices[17] - 0.5*(1 + x[0])*(-1 + x[0])*x[1]*(-1 + x[1])*vertices[9] - 0.5*(1 + x[0])*(-1 + x[0])*x[1]*(1 + x[1])*vertices[13] - phys_x[1] - 0.5*x[0]*(-1 + x[0])*(1 + x[1])*(-1 + x[1])*vertices[15] + 0.25*x[0]*(-1 + x[0])*x[1]*(-1 + x[1])*vertices[1] + 0.25*x[0]*(-1 + x[0])*x[1]*(1 + x[1])*vertices[7] - 0.5*x[0]*(1 + x[0])*(1 + x[1])*(-1 + x[1])*vertices[11] + 0.25*x[0]*(1 + x[0])*x[1]*(-1 + x[1])*vertices[3] + 0.25*x[0]*(1 + x[0])*x[1]*(1 + x[1])*vertices[5];
+	fx[0] = (1 + x[0])*(-1 + x[0])*(1 + x[1])*(-1 + x[1])*vertices[16] - 0.5*(1 + x[0])*(-1 + x[0])*x[1]*(-1 + x[1])*vertices[8] - 0.5*(1 + x[0])*(-1 + x[0])*x[1]*(1 + x[1])*vertices[12] - phys_x[0] - 0.5*x[0]*(-1 + x[0])*(1 + x[1])*(-1 + x[1])*vertices[14] + 0.25*x[0]*(-1 + x[0])*x[1]*(-1 + x[1])*vertices[0] + 0.25*x[0]*(-1 + x[0])*x[1]*(1 + x[1])*vertices[6] - 0.5*x[0]*(1 + x[0])*(1 + x[1])*(-1 + x[1])*vertices[10] + 0.25*x[0]*(1 + x[0])*x[1]*(-1 + x[1])*vertices[2] + 0.25*x[0]*(1 + x[0])*x[1]*(1 + x[1])*vertices[4]
+	fx[1] = (1 + x[0])*(-1 + x[0])*(1 + x[1])*(-1 + x[1])*vertices[17] - 0.5*(1 + x[0])*(-1 + x[0])*x[1]*(-1 + x[1])*vertices[9] - 0.5*(1 + x[0])*(-1 + x[0])*x[1]*(1 + x[1])*vertices[13] - phys_x[1] - 0.5*x[0]*(-1 + x[0])*(1 + x[1])*(-1 + x[1])*vertices[15] + 0.25*x[0]*(-1 + x[0])*x[1]*(-1 + x[1])*vertices[1] + 0.25*x[0]*(-1 + x[0])*x[1]*(1 + x[1])*vertices[7] - 0.5*x[0]*(1 + x[0])*(1 + x[1])*(-1 + x[1])*vertices[11] + 0.25*x[0]*(1 + x[0])*x[1]*(-1 + x[1])*vertices[3] + 0.25*x[0]*(1 + x[0])*x[1]*(1 + x[1])*vertices[5]
 
 
 @cython.boundscheck(False)
@@ -84,10 +84,10 @@ cdef void Q2Jacobian2D(double* rcol,
                        double* x,
                        double* vertices,
                        double* phys_x) nogil:
-	rcol[0] = -0.5*(-1 + x[0])*(1 + x[1])*(-1 + x[1])*vertices[14] + (-1 + x[0])*(1 + x[1])*(-1 + x[1])*vertices[16] + 0.25*(-1 + x[0])*x[1]*(-1 + x[1])*vertices[0] - 0.5*(-1 + x[0])*x[1]*(-1 + x[1])*vertices[8] + 0.25*(-1 + x[0])*x[1]*(1 + x[1])*vertices[6] - 0.5*(-1 + x[0])*x[1]*(1 + x[1])*vertices[12] - 0.5*(1 + x[0])*(1 + x[1])*(-1 + x[1])*vertices[10] + (1 + x[0])*(1 + x[1])*(-1 + x[1])*vertices[16] + 0.25*(1 + x[0])*x[1]*(-1 + x[1])*vertices[2] - 0.5*(1 + x[0])*x[1]*(-1 + x[1])*vertices[8] + 0.25*(1 + x[0])*x[1]*(1 + x[1])*vertices[4] - 0.5*(1 + x[0])*x[1]*(1 + x[1])*vertices[12] - 0.5*x[0]*(1 + x[1])*(-1 + x[1])*vertices[10] - 0.5*x[0]*(1 + x[1])*(-1 + x[1])*vertices[14] + 0.25*x[0]*x[1]*(-1 + x[1])*vertices[0] + 0.25*x[0]*x[1]*(-1 + x[1])*vertices[2] + 0.25*x[0]*x[1]*(1 + x[1])*vertices[4] + 0.25*x[0]*x[1]*(1 + x[1])*vertices[6];
-	scol[0] = -0.5*(-1 + x[1])*(1 + x[0])*(-1 + x[0])*vertices[8] + (-1 + x[1])*(1 + x[0])*(-1 + x[0])*vertices[16] + 0.25*(-1 + x[1])*x[0]*(-1 + x[0])*vertices[0] - 0.5*(-1 + x[1])*x[0]*(-1 + x[0])*vertices[14] + 0.25*(-1 + x[1])*x[0]*(1 + x[0])*vertices[2] - 0.5*(-1 + x[1])*x[0]*(1 + x[0])*vertices[10] - 0.5*(1 + x[1])*(1 + x[0])*(-1 + x[0])*vertices[12] + (1 + x[1])*(1 + x[0])*(-1 + x[0])*vertices[16] + 0.25*(1 + x[1])*x[0]*(-1 + x[0])*vertices[6] - 0.5*(1 + x[1])*x[0]*(-1 + x[0])*vertices[14] + 0.25*(1 + x[1])*x[0]*(1 + x[0])*vertices[4] - 0.5*(1 + x[1])*x[0]*(1 + x[0])*vertices[10] - 0.5*x[1]*(1 + x[0])*(-1 + x[0])*vertices[8] - 0.5*x[1]*(1 + x[0])*(-1 + x[0])*vertices[12] + 0.25*x[1]*x[0]*(-1 + x[0])*vertices[0] + 0.25*x[1]*x[0]*(-1 + x[0])*vertices[6] + 0.25*x[1]*x[0]*(1 + x[0])*vertices[2] + 0.25*x[1]*x[0]*(1 + x[0])*vertices[4];
-	rcol[1] = -0.5*(-1 + x[0])*(1 + x[1])*(-1 + x[1])*vertices[15] + (-1 + x[0])*(1 + x[1])*(-1 + x[1])*vertices[17] + 0.25*(-1 + x[0])*x[1]*(-1 + x[1])*vertices[1] - 0.5*(-1 + x[0])*x[1]*(-1 + x[1])*vertices[9] + 0.25*(-1 + x[0])*x[1]*(1 + x[1])*vertices[7] - 0.5*(-1 + x[0])*x[1]*(1 + x[1])*vertices[13] - 0.5*(1 + x[0])*(1 + x[1])*(-1 + x[1])*vertices[11] + (1 + x[0])*(1 + x[1])*(-1 + x[1])*vertices[17] + 0.25*(1 + x[0])*x[1]*(-1 + x[1])*vertices[3] - 0.5*(1 + x[0])*x[1]*(-1 + x[1])*vertices[9] + 0.25*(1 + x[0])*x[1]*(1 + x[1])*vertices[5] - 0.5*(1 + x[0])*x[1]*(1 + x[1])*vertices[13] - 0.5*x[0]*(1 + x[1])*(-1 + x[1])*vertices[11] - 0.5*x[0]*(1 + x[1])*(-1 + x[1])*vertices[15] + 0.25*x[0]*x[1]*(-1 + x[1])*vertices[1] + 0.25*x[0]*x[1]*(-1 + x[1])*vertices[3] + 0.25*x[0]*x[1]*(1 + x[1])*vertices[5] + 0.25*x[0]*x[1]*(1 + x[1])*vertices[7];
-	scol[1] = -0.5*(-1 + x[1])*(1 + x[0])*(-1 + x[0])*vertices[9] + (-1 + x[1])*(1 + x[0])*(-1 + x[0])*vertices[17] + 0.25*(-1 + x[1])*x[0]*(-1 + x[0])*vertices[1] - 0.5*(-1 + x[1])*x[0]*(-1 + x[0])*vertices[15] + 0.25*(-1 + x[1])*x[0]*(1 + x[0])*vertices[3] - 0.5*(-1 + x[1])*x[0]*(1 + x[0])*vertices[11] - 0.5*(1 + x[1])*(1 + x[0])*(-1 + x[0])*vertices[13] + (1 + x[1])*(1 + x[0])*(-1 + x[0])*vertices[17] + 0.25*(1 + x[1])*x[0]*(-1 + x[0])*vertices[7] - 0.5*(1 + x[1])*x[0]*(-1 + x[0])*vertices[15] + 0.25*(1 + x[1])*x[0]*(1 + x[0])*vertices[5] - 0.5*(1 + x[1])*x[0]*(1 + x[0])*vertices[11] - 0.5*x[1]*(1 + x[0])*(-1 + x[0])*vertices[9] - 0.5*x[1]*(1 + x[0])*(-1 + x[0])*vertices[13] + 0.25*x[1]*x[0]*(-1 + x[0])*vertices[1] + 0.25*x[1]*x[0]*(-1 + x[0])*vertices[7] + 0.25*x[1]*x[0]*(1 + x[0])*vertices[3] + 0.25*x[1]*x[0]*(1 + x[0])*vertices[5];
+	rcol[0] = -0.5*(-1 + x[0])*(1 + x[1])*(-1 + x[1])*vertices[14] + (-1 + x[0])*(1 + x[1])*(-1 + x[1])*vertices[16] + 0.25*(-1 + x[0])*x[1]*(-1 + x[1])*vertices[0] - 0.5*(-1 + x[0])*x[1]*(-1 + x[1])*vertices[8] + 0.25*(-1 + x[0])*x[1]*(1 + x[1])*vertices[6] - 0.5*(-1 + x[0])*x[1]*(1 + x[1])*vertices[12] - 0.5*(1 + x[0])*(1 + x[1])*(-1 + x[1])*vertices[10] + (1 + x[0])*(1 + x[1])*(-1 + x[1])*vertices[16] + 0.25*(1 + x[0])*x[1]*(-1 + x[1])*vertices[2] - 0.5*(1 + x[0])*x[1]*(-1 + x[1])*vertices[8] + 0.25*(1 + x[0])*x[1]*(1 + x[1])*vertices[4] - 0.5*(1 + x[0])*x[1]*(1 + x[1])*vertices[12] - 0.5*x[0]*(1 + x[1])*(-1 + x[1])*vertices[10] - 0.5*x[0]*(1 + x[1])*(-1 + x[1])*vertices[14] + 0.25*x[0]*x[1]*(-1 + x[1])*vertices[0] + 0.25*x[0]*x[1]*(-1 + x[1])*vertices[2] + 0.25*x[0]*x[1]*(1 + x[1])*vertices[4] + 0.25*x[0]*x[1]*(1 + x[1])*vertices[6]
+	scol[0] = -0.5*(-1 + x[1])*(1 + x[0])*(-1 + x[0])*vertices[8] + (-1 + x[1])*(1 + x[0])*(-1 + x[0])*vertices[16] + 0.25*(-1 + x[1])*x[0]*(-1 + x[0])*vertices[0] - 0.5*(-1 + x[1])*x[0]*(-1 + x[0])*vertices[14] + 0.25*(-1 + x[1])*x[0]*(1 + x[0])*vertices[2] - 0.5*(-1 + x[1])*x[0]*(1 + x[0])*vertices[10] - 0.5*(1 + x[1])*(1 + x[0])*(-1 + x[0])*vertices[12] + (1 + x[1])*(1 + x[0])*(-1 + x[0])*vertices[16] + 0.25*(1 + x[1])*x[0]*(-1 + x[0])*vertices[6] - 0.5*(1 + x[1])*x[0]*(-1 + x[0])*vertices[14] + 0.25*(1 + x[1])*x[0]*(1 + x[0])*vertices[4] - 0.5*(1 + x[1])*x[0]*(1 + x[0])*vertices[10] - 0.5*x[1]*(1 + x[0])*(-1 + x[0])*vertices[8] - 0.5*x[1]*(1 + x[0])*(-1 + x[0])*vertices[12] + 0.25*x[1]*x[0]*(-1 + x[0])*vertices[0] + 0.25*x[1]*x[0]*(-1 + x[0])*vertices[6] + 0.25*x[1]*x[0]*(1 + x[0])*vertices[2] + 0.25*x[1]*x[0]*(1 + x[0])*vertices[4]
+	rcol[1] = -0.5*(-1 + x[0])*(1 + x[1])*(-1 + x[1])*vertices[15] + (-1 + x[0])*(1 + x[1])*(-1 + x[1])*vertices[17] + 0.25*(-1 + x[0])*x[1]*(-1 + x[1])*vertices[1] - 0.5*(-1 + x[0])*x[1]*(-1 + x[1])*vertices[9] + 0.25*(-1 + x[0])*x[1]*(1 + x[1])*vertices[7] - 0.5*(-1 + x[0])*x[1]*(1 + x[1])*vertices[13] - 0.5*(1 + x[0])*(1 + x[1])*(-1 + x[1])*vertices[11] + (1 + x[0])*(1 + x[1])*(-1 + x[1])*vertices[17] + 0.25*(1 + x[0])*x[1]*(-1 + x[1])*vertices[3] - 0.5*(1 + x[0])*x[1]*(-1 + x[1])*vertices[9] + 0.25*(1 + x[0])*x[1]*(1 + x[1])*vertices[5] - 0.5*(1 + x[0])*x[1]*(1 + x[1])*vertices[13] - 0.5*x[0]*(1 + x[1])*(-1 + x[1])*vertices[11] - 0.5*x[0]*(1 + x[1])*(-1 + x[1])*vertices[15] + 0.25*x[0]*x[1]*(-1 + x[1])*vertices[1] + 0.25*x[0]*x[1]*(-1 + x[1])*vertices[3] + 0.25*x[0]*x[1]*(1 + x[1])*vertices[5] + 0.25*x[0]*x[1]*(1 + x[1])*vertices[7]
+	scol[1] = -0.5*(-1 + x[1])*(1 + x[0])*(-1 + x[0])*vertices[9] + (-1 + x[1])*(1 + x[0])*(-1 + x[0])*vertices[17] + 0.25*(-1 + x[1])*x[0]*(-1 + x[0])*vertices[1] - 0.5*(-1 + x[1])*x[0]*(-1 + x[0])*vertices[15] + 0.25*(-1 + x[1])*x[0]*(1 + x[0])*vertices[3] - 0.5*(-1 + x[1])*x[0]*(1 + x[0])*vertices[11] - 0.5*(1 + x[1])*(1 + x[0])*(-1 + x[0])*vertices[13] + (1 + x[1])*(1 + x[0])*(-1 + x[0])*vertices[17] + 0.25*(1 + x[1])*x[0]*(-1 + x[0])*vertices[7] - 0.5*(1 + x[1])*x[0]*(-1 + x[0])*vertices[15] + 0.25*(1 + x[1])*x[0]*(1 + x[0])*vertices[5] - 0.5*(1 + x[1])*x[0]*(1 + x[0])*vertices[11] - 0.5*x[1]*(1 + x[0])*(-1 + x[0])*vertices[9] - 0.5*x[1]*(1 + x[0])*(-1 + x[0])*vertices[13] + 0.25*x[1]*x[0]*(-1 + x[0])*vertices[1] + 0.25*x[1]*x[0]*(-1 + x[0])*vertices[7] + 0.25*x[1]*x[0]*(1 + x[0])*vertices[3] + 0.25*x[1]*x[0]*(1 + x[0])*vertices[5]
 
 
 @cython.boundscheck(False)
@@ -97,9 +97,9 @@ cdef void Tet2Function3D(double* fx,
                        double* x,
                        double* vertices,
                        double* phys_x) nogil:
-	fx[0] = (-x[0] + 2*pow(x[0], 2))*vertices[3] + (-x[1] + 2*pow(x[1], 2))*vertices[6] + (-x[2] + 2*pow(x[2], 2))*vertices[9] + (4*x[0] - 4*x[0]*x[1] - 4*x[0]*x[2] - 4*pow(x[0], 2))*vertices[12] + (4*x[1] - 4*x[1]*x[0] - 4*x[1]*x[2] - 4*pow(x[1], 2))*vertices[18] + (4*x[2] - 4*x[2]*x[0] - 4*x[2]*x[1] - 4*pow(x[2], 2))*vertices[21] + (1 - 3*x[0] + 4*x[0]*x[1] + 4*x[0]*x[2] + 2*pow(x[0], 2) - 3*x[1] + 4*x[1]*x[2] + 2*pow(x[1], 2) - 3*x[2] + 2*pow(x[2], 2))*vertices[0] - phys_x[0] + 4*x[0]*x[1]*vertices[15] + 4*x[0]*x[2]*vertices[24] + 4*x[1]*x[2]*vertices[27];
-	fx[1] = (-x[0] + 2*pow(x[0], 2))*vertices[4] + (-x[1] + 2*pow(x[1], 2))*vertices[7] + (-x[2] + 2*pow(x[2], 2))*vertices[10] + (4*x[0] - 4*x[0]*x[1] - 4*x[0]*x[2] - 4*pow(x[0], 2))*vertices[13] + (4*x[1] - 4*x[1]*x[0] - 4*x[1]*x[2] - 4*pow(x[1], 2))*vertices[19] + (4*x[2] - 4*x[2]*x[0] - 4*x[2]*x[1] - 4*pow(x[2], 2))*vertices[22] + (1 - 3*x[0] + 4*x[0]*x[1] + 4*x[0]*x[2] + 2*pow(x[0], 2) - 3*x[1] + 4*x[1]*x[2] + 2*pow(x[1], 2) - 3*x[2] + 2*pow(x[2], 2))*vertices[1] - phys_x[1] + 4*x[0]*x[1]*vertices[16] + 4*x[0]*x[2]*vertices[25] + 4*x[1]*x[2]*vertices[28];
-	fx[2] = (-x[0] + 2*pow(x[0], 2))*vertices[5] + (-x[1] + 2*pow(x[1], 2))*vertices[8] + (-x[2] + 2*pow(x[2], 2))*vertices[11] + (4*x[0] - 4*x[0]*x[1] - 4*x[0]*x[2] - 4*pow(x[0], 2))*vertices[14] + (4*x[1] - 4*x[1]*x[0] - 4*x[1]*x[2] - 4*pow(x[1], 2))*vertices[20] + (4*x[2] - 4*x[2]*x[0] - 4*x[2]*x[1] - 4*pow(x[2], 2))*vertices[23] + (1 - 3*x[0] + 4*x[0]*x[1] + 4*x[0]*x[2] + 2*pow(x[0], 2) - 3*x[1] + 4*x[1]*x[2] + 2*pow(x[1], 2) - 3*x[2] + 2*pow(x[2], 2))*vertices[2] - phys_x[2] + 4*x[0]*x[1]*vertices[17] + 4*x[0]*x[2]*vertices[26] + 4*x[1]*x[2]*vertices[29];
+	fx[0] = (-x[0] + 2*pow(x[0], 2))*vertices[3] + (-x[1] + 2*pow(x[1], 2))*vertices[6] + (-x[2] + 2*pow(x[2], 2))*vertices[9] + (4*x[0] - 4*x[0]*x[1] - 4*x[0]*x[2] - 4*pow(x[0], 2))*vertices[12] + (4*x[1] - 4*x[1]*x[0] - 4*x[1]*x[2] - 4*pow(x[1], 2))*vertices[18] + (4*x[2] - 4*x[2]*x[0] - 4*x[2]*x[1] - 4*pow(x[2], 2))*vertices[21] + (1 - 3*x[0] + 4*x[0]*x[1] + 4*x[0]*x[2] + 2*pow(x[0], 2) - 3*x[1] + 4*x[1]*x[2] + 2*pow(x[1], 2) - 3*x[2] + 2*pow(x[2], 2))*vertices[0] - phys_x[0] + 4*x[0]*x[1]*vertices[15] + 4*x[0]*x[2]*vertices[24] + 4*x[1]*x[2]*vertices[27]
+	fx[1] = (-x[0] + 2*pow(x[0], 2))*vertices[4] + (-x[1] + 2*pow(x[1], 2))*vertices[7] + (-x[2] + 2*pow(x[2], 2))*vertices[10] + (4*x[0] - 4*x[0]*x[1] - 4*x[0]*x[2] - 4*pow(x[0], 2))*vertices[13] + (4*x[1] - 4*x[1]*x[0] - 4*x[1]*x[2] - 4*pow(x[1], 2))*vertices[19] + (4*x[2] - 4*x[2]*x[0] - 4*x[2]*x[1] - 4*pow(x[2], 2))*vertices[22] + (1 - 3*x[0] + 4*x[0]*x[1] + 4*x[0]*x[2] + 2*pow(x[0], 2) - 3*x[1] + 4*x[1]*x[2] + 2*pow(x[1], 2) - 3*x[2] + 2*pow(x[2], 2))*vertices[1] - phys_x[1] + 4*x[0]*x[1]*vertices[16] + 4*x[0]*x[2]*vertices[25] + 4*x[1]*x[2]*vertices[28]
+	fx[2] = (-x[0] + 2*pow(x[0], 2))*vertices[5] + (-x[1] + 2*pow(x[1], 2))*vertices[8] + (-x[2] + 2*pow(x[2], 2))*vertices[11] + (4*x[0] - 4*x[0]*x[1] - 4*x[0]*x[2] - 4*pow(x[0], 2))*vertices[14] + (4*x[1] - 4*x[1]*x[0] - 4*x[1]*x[2] - 4*pow(x[1], 2))*vertices[20] + (4*x[2] - 4*x[2]*x[0] - 4*x[2]*x[1] - 4*pow(x[2], 2))*vertices[23] + (1 - 3*x[0] + 4*x[0]*x[1] + 4*x[0]*x[2] + 2*pow(x[0], 2) - 3*x[1] + 4*x[1]*x[2] + 2*pow(x[1], 2) - 3*x[2] + 2*pow(x[2], 2))*vertices[2] - phys_x[2] + 4*x[0]*x[1]*vertices[17] + 4*x[0]*x[2]*vertices[26] + 4*x[1]*x[2]*vertices[29]
 
 
 @cython.boundscheck(False)
@@ -111,15 +111,15 @@ cdef void Tet2Jacobian3D(double* rcol,
                        double* x,
                        double* vertices,
                        double* phys_x) nogil:
-	rcol[0] = (-1 + 4*x[0])*vertices[3] + (-3 + 4*x[0] + 4*x[1] + 4*x[2])*vertices[0] + (4 - 8*x[0] - 4*x[1] - 4*x[2])*vertices[12] + 4*x[1]*vertices[15] - 4*x[1]*vertices[18] - 4*x[2]*vertices[21] + 4*x[2]*vertices[24];
-	scol[0] = (-1 + 4*x[1])*vertices[6] + (-3 + 4*x[0] + 4*x[1] + 4*x[2])*vertices[0] + (4 - 4*x[0] - 8*x[1] - 4*x[2])*vertices[18] - 4*x[0]*vertices[12] + 4*x[0]*vertices[15] - 4*x[2]*vertices[21] + 4*x[2]*vertices[27];
-	tcol[0] = (-1 + 4*x[2])*vertices[9] + (-3 + 4*x[0] + 4*x[1] + 4*x[2])*vertices[0] + (4 - 4*x[0] - 4*x[1] - 8*x[2])*vertices[21] - 4*x[0]*vertices[12] + 4*x[0]*vertices[24] - 4*x[1]*vertices[18] + 4*x[1]*vertices[27];
-	rcol[1] = (-1 + 4*x[0])*vertices[4] + (-3 + 4*x[0] + 4*x[1] + 4*x[2])*vertices[1] + (4 - 8*x[0] - 4*x[1] - 4*x[2])*vertices[13] + 4*x[1]*vertices[16] - 4*x[1]*vertices[19] - 4*x[2]*vertices[22] + 4*x[2]*vertices[25];
-	scol[1] = (-1 + 4*x[1])*vertices[7] + (-3 + 4*x[0] + 4*x[1] + 4*x[2])*vertices[1] + (4 - 4*x[0] - 8*x[1] - 4*x[2])*vertices[19] - 4*x[0]*vertices[13] + 4*x[0]*vertices[16] - 4*x[2]*vertices[22] + 4*x[2]*vertices[28];
-	tcol[1] = (-1 + 4*x[2])*vertices[10] + (-3 + 4*x[0] + 4*x[1] + 4*x[2])*vertices[1] + (4 - 4*x[0] - 4*x[1] - 8*x[2])*vertices[22] - 4*x[0]*vertices[13] + 4*x[0]*vertices[25] - 4*x[1]*vertices[19] + 4*x[1]*vertices[28];
-	rcol[2] = (-1 + 4*x[0])*vertices[5] + (-3 + 4*x[0] + 4*x[1] + 4*x[2])*vertices[2] + (4 - 8*x[0] - 4*x[1] - 4*x[2])*vertices[14] + 4*x[1]*vertices[17] - 4*x[1]*vertices[20] - 4*x[2]*vertices[23] + 4*x[2]*vertices[26];
-	scol[2] = (-1 + 4*x[1])*vertices[8] + (-3 + 4*x[0] + 4*x[1] + 4*x[2])*vertices[2] + (4 - 4*x[0] - 8*x[1] - 4*x[2])*vertices[20] - 4*x[0]*vertices[14] + 4*x[0]*vertices[17] - 4*x[2]*vertices[23] + 4*x[2]*vertices[29];
-	tcol[2] = (-1 + 4*x[2])*vertices[11] + (-3 + 4*x[0] + 4*x[1] + 4*x[2])*vertices[2] + (4 - 4*x[0] - 4*x[1] - 8*x[2])*vertices[23] - 4*x[0]*vertices[14] + 4*x[0]*vertices[26] - 4*x[1]*vertices[20] + 4*x[1]*vertices[29];
+	rcol[0] = (-1 + 4*x[0])*vertices[3] + (-3 + 4*x[0] + 4*x[1] + 4*x[2])*vertices[0] + (4 - 8*x[0] - 4*x[1] - 4*x[2])*vertices[12] + 4*x[1]*vertices[15] - 4*x[1]*vertices[18] - 4*x[2]*vertices[21] + 4*x[2]*vertices[24]
+	scol[0] = (-1 + 4*x[1])*vertices[6] + (-3 + 4*x[0] + 4*x[1] + 4*x[2])*vertices[0] + (4 - 4*x[0] - 8*x[1] - 4*x[2])*vertices[18] - 4*x[0]*vertices[12] + 4*x[0]*vertices[15] - 4*x[2]*vertices[21] + 4*x[2]*vertices[27]
+	tcol[0] = (-1 + 4*x[2])*vertices[9] + (-3 + 4*x[0] + 4*x[1] + 4*x[2])*vertices[0] + (4 - 4*x[0] - 4*x[1] - 8*x[2])*vertices[21] - 4*x[0]*vertices[12] + 4*x[0]*vertices[24] - 4*x[1]*vertices[18] + 4*x[1]*vertices[27]
+	rcol[1] = (-1 + 4*x[0])*vertices[4] + (-3 + 4*x[0] + 4*x[1] + 4*x[2])*vertices[1] + (4 - 8*x[0] - 4*x[1] - 4*x[2])*vertices[13] + 4*x[1]*vertices[16] - 4*x[1]*vertices[19] - 4*x[2]*vertices[22] + 4*x[2]*vertices[25]
+	scol[1] = (-1 + 4*x[1])*vertices[7] + (-3 + 4*x[0] + 4*x[1] + 4*x[2])*vertices[1] + (4 - 4*x[0] - 8*x[1] - 4*x[2])*vertices[19] - 4*x[0]*vertices[13] + 4*x[0]*vertices[16] - 4*x[2]*vertices[22] + 4*x[2]*vertices[28]
+	tcol[1] = (-1 + 4*x[2])*vertices[10] + (-3 + 4*x[0] + 4*x[1] + 4*x[2])*vertices[1] + (4 - 4*x[0] - 4*x[1] - 8*x[2])*vertices[22] - 4*x[0]*vertices[13] + 4*x[0]*vertices[25] - 4*x[1]*vertices[19] + 4*x[1]*vertices[28]
+	rcol[2] = (-1 + 4*x[0])*vertices[5] + (-3 + 4*x[0] + 4*x[1] + 4*x[2])*vertices[2] + (4 - 8*x[0] - 4*x[1] - 4*x[2])*vertices[14] + 4*x[1]*vertices[17] - 4*x[1]*vertices[20] - 4*x[2]*vertices[23] + 4*x[2]*vertices[26]
+	scol[2] = (-1 + 4*x[1])*vertices[8] + (-3 + 4*x[0] + 4*x[1] + 4*x[2])*vertices[2] + (4 - 4*x[0] - 8*x[1] - 4*x[2])*vertices[20] - 4*x[0]*vertices[14] + 4*x[0]*vertices[17] - 4*x[2]*vertices[23] + 4*x[2]*vertices[29]
+	tcol[2] = (-1 + 4*x[2])*vertices[11] + (-3 + 4*x[0] + 4*x[1] + 4*x[2])*vertices[2] + (4 - 4*x[0] - 4*x[1] - 8*x[2])*vertices[23] - 4*x[0]*vertices[14] + 4*x[0]*vertices[26] - 4*x[1]*vertices[20] + 4*x[1]*vertices[29]
 
 
 @cython.boundscheck(False)
@@ -129,8 +129,8 @@ cdef void T2Function2D(double* fx,
                        double* x,
                        double* vertices,
                        double* phys_x) nogil:
-	fx[0] = (-x[0] + 2*pow(x[0], 2))*vertices[2] + (-x[1] + 2*pow(x[1], 2))*vertices[4] + (-4*x[0]*x[1] + 4*x[1] - 4*pow(x[1], 2))*vertices[10] + (4*x[0] - 4*x[0]*x[1] - 4*pow(x[0], 2))*vertices[6] + (1 - 3*x[0] + 4*x[0]*x[1] + 2*pow(x[0], 2) - 3*x[1] + 2*pow(x[1], 2))*vertices[0] - phys_x[0] + 4*x[0]*x[1]*vertices[8];
-	fx[1] = (-x[0] + 2*pow(x[0], 2))*vertices[3] + (-x[1] + 2*pow(x[1], 2))*vertices[5] + (-4*x[0]*x[1] + 4*x[1] - 4*pow(x[1], 2))*vertices[11] + (4*x[0] - 4*x[0]*x[1] - 4*pow(x[0], 2))*vertices[7] + (1 - 3*x[0] + 4*x[0]*x[1] + 2*pow(x[0], 2) - 3*x[1] + 2*pow(x[1], 2))*vertices[1] - phys_x[1] + 4*x[0]*x[1]*vertices[9];
+	fx[0] = (-x[0] + 2*pow(x[0], 2))*vertices[2] + (-x[1] + 2*pow(x[1], 2))*vertices[4] + (-4*x[0]*x[1] + 4*x[1] - 4*pow(x[1], 2))*vertices[10] + (4*x[0] - 4*x[0]*x[1] - 4*pow(x[0], 2))*vertices[6] + (1 - 3*x[0] + 4*x[0]*x[1] + 2*pow(x[0], 2) - 3*x[1] + 2*pow(x[1], 2))*vertices[0] - phys_x[0] + 4*x[0]*x[1]*vertices[8]
+	fx[1] = (-x[0] + 2*pow(x[0], 2))*vertices[3] + (-x[1] + 2*pow(x[1], 2))*vertices[5] + (-4*x[0]*x[1] + 4*x[1] - 4*pow(x[1], 2))*vertices[11] + (4*x[0] - 4*x[0]*x[1] - 4*pow(x[0], 2))*vertices[7] + (1 - 3*x[0] + 4*x[0]*x[1] + 2*pow(x[0], 2) - 3*x[1] + 2*pow(x[1], 2))*vertices[1] - phys_x[1] + 4*x[0]*x[1]*vertices[9]
 
 
 @cython.boundscheck(False)
@@ -141,10 +141,10 @@ cdef void T2Jacobian2D(double* rcol,
                        double* x,
                        double* vertices,
                        double* phys_x) nogil:
-	rcol[0] = (-1 + 4*x[0])*vertices[2] + (-3 + 4*x[0] + 4*x[1])*vertices[0] + (4 - 8*x[0] - 4*x[1])*vertices[6] + 4*x[1]*vertices[8] - 4*x[1]*vertices[10];
-	scol[0] = (-1 + 4*x[1])*vertices[4] + (-3 + 4*x[0] + 4*x[1])*vertices[0] + (4 - 4*x[0] - 8*x[1])*vertices[10] - 4*x[0]*vertices[6] + 4*x[0]*vertices[8];
-	rcol[1] = (-1 + 4*x[0])*vertices[3] + (-3 + 4*x[0] + 4*x[1])*vertices[1] + (4 - 8*x[0] - 4*x[1])*vertices[7] + 4*x[1]*vertices[9] - 4*x[1]*vertices[11];
-	scol[1] = (-1 + 4*x[1])*vertices[5] + (-3 + 4*x[0] + 4*x[1])*vertices[1] + (4 - 4*x[0] - 8*x[1])*vertices[11] - 4*x[0]*vertices[7] + 4*x[0]*vertices[9];
+	rcol[0] = (-1 + 4*x[0])*vertices[2] + (-3 + 4*x[0] + 4*x[1])*vertices[0] + (4 - 8*x[0] - 4*x[1])*vertices[6] + 4*x[1]*vertices[8] - 4*x[1]*vertices[10]
+	scol[0] = (-1 + 4*x[1])*vertices[4] + (-3 + 4*x[0] + 4*x[1])*vertices[0] + (4 - 4*x[0] - 8*x[1])*vertices[10] - 4*x[0]*vertices[6] + 4*x[0]*vertices[8]
+	rcol[1] = (-1 + 4*x[0])*vertices[3] + (-3 + 4*x[0] + 4*x[1])*vertices[1] + (4 - 8*x[0] - 4*x[1])*vertices[7] + 4*x[1]*vertices[9] - 4*x[1]*vertices[11]
+	scol[1] = (-1 + 4*x[1])*vertices[5] + (-3 + 4*x[0] + 4*x[1])*vertices[1] + (4 - 4*x[0] - 8*x[1])*vertices[11] - 4*x[0]*vertices[7] + 4*x[0]*vertices[9]
 
 
 @cython.boundscheck(False)
@@ -154,9 +154,9 @@ cdef void W1Function3D(double* fx,
                        double* x,
                        double* vertices,
                        double* phys_x) nogil:
-	fx[0] = 0.5*(1 - x[0] - x[1])*(1 - x[2])*vertices[0] + 0.5*(1 - x[0] - x[1])*(1 + x[2])*vertices[9] - phys_x[0] + 0.5*x[0]*(1 - x[2])*vertices[3] + 0.5*x[0]*(1 + x[2])*vertices[12] + 0.5*x[1]*(1 - x[2])*vertices[6] + 0.5*x[1]*(1 + x[2])*vertices[15];
-	fx[1] = 0.5*(1 - x[0] - x[1])*(1 - x[2])*vertices[1] + 0.5*(1 - x[0] - x[1])*(1 + x[2])*vertices[10] - phys_x[1] + 0.5*x[0]*(1 - x[2])*vertices[4] + 0.5*x[0]*(1 + x[2])*vertices[13] + 0.5*x[1]*(1 - x[2])*vertices[7] + 0.5*x[1]*(1 + x[2])*vertices[16];
-	fx[2] = 0.5*(1 - x[0] - x[1])*(1 - x[2])*vertices[2] + 0.5*(1 - x[0] - x[1])*(1 + x[2])*vertices[11] - phys_x[2] + 0.5*x[0]*(1 - x[2])*vertices[5] + 0.5*x[0]*(1 + x[2])*vertices[14] + 0.5*x[1]*(1 - x[2])*vertices[8] + 0.5*x[1]*(1 + x[2])*vertices[17];
+	fx[0] = 0.5*(1 - x[0] - x[1])*(1 - x[2])*vertices[0] + 0.5*(1 - x[0] - x[1])*(1 + x[2])*vertices[9] - phys_x[0] + 0.5*x[0]*(1 - x[2])*vertices[3] + 0.5*x[0]*(1 + x[2])*vertices[12] + 0.5*x[1]*(1 - x[2])*vertices[6] + 0.5*x[1]*(1 + x[2])*vertices[15]
+	fx[1] = 0.5*(1 - x[0] - x[1])*(1 - x[2])*vertices[1] + 0.5*(1 - x[0] - x[1])*(1 + x[2])*vertices[10] - phys_x[1] + 0.5*x[0]*(1 - x[2])*vertices[4] + 0.5*x[0]*(1 + x[2])*vertices[13] + 0.5*x[1]*(1 - x[2])*vertices[7] + 0.5*x[1]*(1 + x[2])*vertices[16]
+	fx[2] = 0.5*(1 - x[0] - x[1])*(1 - x[2])*vertices[2] + 0.5*(1 - x[0] - x[1])*(1 + x[2])*vertices[11] - phys_x[2] + 0.5*x[0]*(1 - x[2])*vertices[5] + 0.5*x[0]*(1 + x[2])*vertices[14] + 0.5*x[1]*(1 - x[2])*vertices[8] + 0.5*x[1]*(1 + x[2])*vertices[17]
 
 
 @cython.boundscheck(False)
@@ -168,12 +168,12 @@ cdef void W1Jacobian3D(double* rcol,
                        double* x,
                        double* vertices,
                        double* phys_x) nogil:
-	rcol[0] = -0.5*(1 - x[2])*vertices[0] + 0.5*(1 - x[2])*vertices[3] - 0.5*(1 + x[2])*vertices[9] + 0.5*(1 + x[2])*vertices[12];
-	scol[0] = -0.5*(1 - x[2])*vertices[0] + 0.5*(1 - x[2])*vertices[6] - 0.5*(1 + x[2])*vertices[9] + 0.5*(1 + x[2])*vertices[15];
-	tcol[0] = -0.5*(1 - x[0] - x[1])*vertices[0] + 0.5*(1 - x[0] - x[1])*vertices[9] - 0.5*x[0]*vertices[3] + 0.5*x[0]*vertices[12] - 0.5*x[1]*vertices[6] + 0.5*x[1]*vertices[15];
-	rcol[1] = -0.5*(1 - x[2])*vertices[1] + 0.5*(1 - x[2])*vertices[4] - 0.5*(1 + x[2])*vertices[10] + 0.5*(1 + x[2])*vertices[13];
-	scol[1] = -0.5*(1 - x[2])*vertices[1] + 0.5*(1 - x[2])*vertices[7] - 0.5*(1 + x[2])*vertices[10] + 0.5*(1 + x[2])*vertices[16];
-	tcol[1] = -0.5*(1 - x[0] - x[1])*vertices[1] + 0.5*(1 - x[0] - x[1])*vertices[10] - 0.5*x[0]*vertices[4] + 0.5*x[0]*vertices[13] - 0.5*x[1]*vertices[7] + 0.5*x[1]*vertices[16];
-	rcol[2] = -0.5*(1 - x[2])*vertices[2] + 0.5*(1 - x[2])*vertices[5] - 0.5*(1 + x[2])*vertices[11] + 0.5*(1 + x[2])*vertices[14];
-	scol[2] = -0.5*(1 - x[2])*vertices[2] + 0.5*(1 - x[2])*vertices[8] - 0.5*(1 + x[2])*vertices[11] + 0.5*(1 + x[2])*vertices[17];
-	tcol[2] = -0.5*(1 - x[0] - x[1])*vertices[2] + 0.5*(1 - x[0] - x[1])*vertices[11] - 0.5*x[0]*vertices[5] + 0.5*x[0]*vertices[14] - 0.5*x[1]*vertices[8] + 0.5*x[1]*vertices[17];
+	rcol[0] = -0.5*(1 - x[2])*vertices[0] + 0.5*(1 - x[2])*vertices[3] - 0.5*(1 + x[2])*vertices[9] + 0.5*(1 + x[2])*vertices[12]
+	scol[0] = -0.5*(1 - x[2])*vertices[0] + 0.5*(1 - x[2])*vertices[6] - 0.5*(1 + x[2])*vertices[9] + 0.5*(1 + x[2])*vertices[15]
+	tcol[0] = -0.5*(1 - x[0] - x[1])*vertices[0] + 0.5*(1 - x[0] - x[1])*vertices[9] - 0.5*x[0]*vertices[3] + 0.5*x[0]*vertices[12] - 0.5*x[1]*vertices[6] + 0.5*x[1]*vertices[15]
+	rcol[1] = -0.5*(1 - x[2])*vertices[1] + 0.5*(1 - x[2])*vertices[4] - 0.5*(1 + x[2])*vertices[10] + 0.5*(1 + x[2])*vertices[13]
+	scol[1] = -0.5*(1 - x[2])*vertices[1] + 0.5*(1 - x[2])*vertices[7] - 0.5*(1 + x[2])*vertices[10] + 0.5*(1 + x[2])*vertices[16]
+	tcol[1] = -0.5*(1 - x[0] - x[1])*vertices[1] + 0.5*(1 - x[0] - x[1])*vertices[10] - 0.5*x[0]*vertices[4] + 0.5*x[0]*vertices[13] - 0.5*x[1]*vertices[7] + 0.5*x[1]*vertices[16]
+	rcol[2] = -0.5*(1 - x[2])*vertices[2] + 0.5*(1 - x[2])*vertices[5] - 0.5*(1 + x[2])*vertices[11] + 0.5*(1 + x[2])*vertices[14]
+	scol[2] = -0.5*(1 - x[2])*vertices[2] + 0.5*(1 - x[2])*vertices[8] - 0.5*(1 + x[2])*vertices[11] + 0.5*(1 + x[2])*vertices[17]
+	tcol[2] = -0.5*(1 - x[0] - x[1])*vertices[2] + 0.5*(1 - x[0] - x[1])*vertices[11] - 0.5*x[0]*vertices[5] + 0.5*x[0]*vertices[14] - 0.5*x[1]*vertices[8] + 0.5*x[1]*vertices[17]

--- a/yt/utilities/lib/bounding_volume_hierarchy.pyx
+++ b/yt/utilities/lib/bounding_volume_hierarchy.pyx
@@ -346,10 +346,10 @@ cdef class BVH:
             return
 
         # check for leaf
-        cdef np.int64_t i, hit
+        cdef np.int64_t i
         if (node.end - node.begin) <= LEAF_SIZE:
             for i in range(node.begin, node.end):
-                hit = self.get_intersect(self.primitives, self.prim_ids[i], ray)
+                self.get_intersect(self.primitives, self.prim_ids[i], ray)
             return
 
         # if not leaf, intersect with left and right children

--- a/yt/utilities/lib/cykdtree/kdtree.pyx
+++ b/yt/utilities/lib/cykdtree/kdtree.pyx
@@ -243,7 +243,7 @@ cdef class PyKDTree:
         if data_version is None:
             data_version = 0
         self.data_version = data_version
-        cdef uint32_t k,i,j
+        cdef uint32_t i
         self.npts = <uint64_t>pts.shape[0]
         self.ndim = <uint32_t>pts.shape[1]
         assert(left_edge.size == self.ndim)
@@ -323,7 +323,6 @@ cdef class PyKDTree:
         self.leaves = [None for _ in xrange(self.num_leaves)]
         cdef Node* leafnode
         cdef PyNode leafnode_py
-        cdef object leaf_neighbors = None
         for k in xrange(self.num_leaves):
             leafnode = self._tree.leaves[k]
             leafnode_py = PyNode()

--- a/yt/utilities/lib/cykdtree/kdtree.pyx
+++ b/yt/utilities/lib/cykdtree/kdtree.pyx
@@ -251,7 +251,7 @@ cdef class PyKDTree:
         self.leafsize = leafsize
         self._left_edge = <double *>malloc(self.ndim*sizeof(double))
         self._right_edge = <double *>malloc(self.ndim*sizeof(double))
-        self._periodic = <cbool *>malloc(self.ndim*sizeof(cbool));
+        self._periodic = <cbool *>malloc(self.ndim*sizeof(cbool))
         for i in range(self.ndim):
             self._left_edge[i] = left_edge[i]
             self._right_edge[i] = right_edge[i]
@@ -367,7 +367,7 @@ cdef class PyKDTree:
 
     cdef np.ndarray[np.uint32_t, ndim=1] _get_neighbor_ids(self, np.ndarray[double, ndim=1] pos):
         cdef np.uint32_t i
-        cdef vector[uint32_t] vout = self._tree.get_neighbor_ids(&pos[0]);
+        cdef vector[uint32_t] vout = self._tree.get_neighbor_ids(&pos[0])
         cdef np.ndarray[np.uint32_t, ndim=1] out = np.empty(vout.size(), 'uint32')
         for i in xrange(vout.size()):
             out[i] = vout[i]
@@ -394,7 +394,7 @@ cdef class PyKDTree:
 
     cdef np.ndarray[np.uint32_t, ndim=1] _get_neighbor_ids_3(self, np.float64_t pos[3]):
         cdef np.uint32_t i
-        cdef vector[uint32_t] vout = self._tree.get_neighbor_ids(&pos[0]);
+        cdef vector[uint32_t] vout = self._tree.get_neighbor_ids(&pos[0])
         cdef np.ndarray[np.uint32_t, ndim=1] out = np.empty(vout.size(), 'uint32')
         for i in xrange(vout.size()):
             out[i] = vout[i]

--- a/yt/utilities/lib/cyoctree.pyx
+++ b/yt/utilities/lib/cyoctree.pyx
@@ -595,7 +595,7 @@ cdef class CyOctree:
         """
 
         cdef Octree * tree = self.c_octree
-        cdef double q_ij, diff_x, diff_y, diff_z, diff, sx, sy, sz, size
+        cdef double q_ij, diff_x, diff_y, diff_z, diff, sx, sy, sz
         cdef int i
         cdef long int child_node
 
@@ -676,7 +676,7 @@ cdef class CyOctree:
         """
         self.kernel = get_kernel_func(kernel_name)
 
-        cdef int i, j
+        cdef int i
         cdef double prefactor, prefactor_norm
         for i in range(posx.shape[0]):
             prefactor = pmass[i] / pdens[i] / hsml[i]**3

--- a/yt/utilities/lib/distance_queue.pyx
+++ b/yt/utilities/lib/distance_queue.pyx
@@ -66,7 +66,6 @@ cdef class PriorityQueue:
     is because our typical use case is to store radii.
     """
     def __cinit__(self, int maxn):
-        cdef int i
         self.maxn = maxn
         self.curn = 0
         self.items = <ItemList *> malloc(

--- a/yt/utilities/lib/element_mappings.pyx
+++ b/yt/utilities/lib/element_mappings.pyx
@@ -750,11 +750,10 @@ cdef class W1Sampler3D(NonlinearSolveSampler3D):
     @cython.wraparound(False)
     @cython.cdivision(True)
     cdef int check_mesh_lines(self, double* mapped_coord) nogil:
-        cdef double r, s, t
+        cdef double r, s
         cdef double thresh = 5.0e-2
         r = mapped_coord[0]
         s = mapped_coord[1]
-        t = mapped_coord[2]
 
         cdef int near_edge_r, near_edge_s, near_edge_t
         near_edge_r = (r < thresh) or (fabs(r + s - 1.0) < thresh)
@@ -932,7 +931,6 @@ cdef class Q2Sampler2D(NonlinearSolveSampler2D):
     @cython.wraparound(False)
     @cython.cdivision(True)
     cdef double sample_at_unit_point(self, double* coord, double* vals) nogil:
-        cdef double F, rm, rp, sm, sp
         cdef double[9] phi
         cdef double rv = 0
 

--- a/yt/utilities/lib/embree_mesh/mesh_construction.pyx
+++ b/yt/utilities/lib/embree_mesh/mesh_construction.pyx
@@ -271,7 +271,7 @@ cdef class QuadraticElementMesh:
                                   np.ndarray field_data):
         cdef int i, j, k, ind, idim
         cdef int ne = indices_in.shape[0]
-        cdef int npatch = self.ppe*ne;
+        cdef int npatch = self.ppe*ne
 
         cdef unsigned int mesh = rtcgu.rtcNewUserGeometry(scene.scene_i, npatch)
         cdef np.ndarray[np.float64_t, ndim=2] element_vertices
@@ -314,7 +314,7 @@ cdef class QuadraticElementMesh:
                                   np.ndarray field_data):
         cdef int i, j, k, ind, idim
         cdef int ne = indices_in.shape[0]
-        cdef int npatch = self.ppe*ne;
+        cdef int npatch = self.ppe*ne
 
         cdef unsigned int mesh = rtcgu.rtcNewUserGeometry(scene.scene_i, npatch)
         cdef np.ndarray[np.float64_t, ndim=2] element_vertices

--- a/yt/utilities/lib/embree_mesh/mesh_construction.pyx
+++ b/yt/utilities/lib/embree_mesh/mesh_construction.pyx
@@ -249,7 +249,6 @@ cdef class QuadraticElementMesh:
                  np.ndarray vertices,
                  np.ndarray indices,
                  np.ndarray field_data):
-        cdef int i, j
 
         # 20-point hexes
         if indices.shape[1] == 20:
@@ -272,7 +271,6 @@ cdef class QuadraticElementMesh:
                                   np.ndarray field_data):
         cdef int i, j, k, ind, idim
         cdef int ne = indices_in.shape[0]
-        cdef int nv = vertices_in.shape[0]
         cdef int npatch = self.ppe*ne;
 
         cdef unsigned int mesh = rtcgu.rtcNewUserGeometry(scene.scene_i, npatch)
@@ -316,7 +314,6 @@ cdef class QuadraticElementMesh:
                                   np.ndarray field_data):
         cdef int i, j, k, ind, idim
         cdef int ne = indices_in.shape[0]
-        cdef int nv = vertices_in.shape[0]
         cdef int npatch = self.ppe*ne;
 
         cdef unsigned int mesh = rtcgu.rtcNewUserGeometry(scene.scene_i, npatch)

--- a/yt/utilities/lib/embree_mesh/mesh_samplers.pyx
+++ b/yt/utilities/lib/embree_mesh/mesh_samplers.pyx
@@ -175,7 +175,7 @@ cdef void sample_wedge(void* userPtr,
 @cython.cdivision(True)
 cdef void sample_hex20(void* userPtr,
                        rtcr.RTCRay& ray) nogil:
-    cdef int ray_id, elem_id, i
+    cdef int ray_id, i
     cdef double val
     cdef double[3] position
     cdef float[3] pos
@@ -191,7 +191,6 @@ cdef void sample_hex20(void* userPtr,
     # embree, in which the primitives are patches. Here,
     # we convert this to the element id by dividing by the
     # number of patches per element.
-    elem_id = ray_id / 6
 
     # fills "position" with the physical position of the hit
     patchSurfaceFunc(data[ray_id].v, ray.u, ray.v, pos)
@@ -258,7 +257,7 @@ cdef void sample_tetra(void* userPtr,
 @cython.cdivision(True)
 cdef void sample_tet10(void* userPtr,
                        rtcr.RTCRay& ray) nogil:
-    cdef int ray_id, elem_id, i
+    cdef int ray_id, i
     cdef double val
     cdef double[3] position
     cdef float[3] pos
@@ -274,7 +273,6 @@ cdef void sample_tet10(void* userPtr,
     # embree, in which the primitives are patches. Here,
     # we convert this to the element id by dividing by the
     # number of patches per element.
-    elem_id = ray_id / 4
 
     # fills "position" with the physical position of the hit
     tet_patchSurfaceFunc(data[ray_id].v, ray.u, ray.v, pos)

--- a/yt/utilities/lib/fixed_interpolator.cpp
+++ b/yt/utilities/lib/fixed_interpolator.cpp
@@ -33,7 +33,6 @@ npy_float64 fast_interpolate(int ds[3], int ci[3], npy_float64 dp[3],
 
 npy_float64 offset_interpolate(int ds[3], npy_float64 dp[3], npy_float64 *data)
 {
-    int i;
     npy_float64 dv, vz[4];
 
     dv = 1.0 - dp[2];

--- a/yt/utilities/lib/fnv_hash.pyx
+++ b/yt/utilities/lib/fnv_hash.pyx
@@ -19,7 +19,6 @@ cdef np.int64_t c_fnv_hash(unsigned char[:] octets) nogil:
     # https://bitbucket.org/yt_analysis/yt/issues/1052/field-access-tests-fail-under-python3
     # FNV hash cf. http://www.isthe.com/chongo/tech/comp/fnv/index.html
     cdef np.int64_t hash_val = 2166136261
-    cdef unsigned char octet
     cdef int i
     for i in range(octets.shape[0]):
         hash_val = hash_val ^ octets[i]

--- a/yt/utilities/lib/fortran_reader.pyx
+++ b/yt/utilities/lib/fortran_reader.pyx
@@ -61,11 +61,11 @@ def count_art_octs(char *fn, long offset,
     cdef FILE *f = fopen(fn, "rb")
     fseek(f, offset, SEEK_SET)
     for _ in range(min_level + 1, max_level + 1):
-        fread(dummy_records, sizeof(int), 2, f);
+        fread(dummy_records, sizeof(int), 2, f)
         fread(&nLevel, sizeof(int), 1, f); FIX_LONG(nLevel)
         print(level_info)
         level_info.append(nLevel)
-        fread(dummy_records, sizeof(int), 2, f);
+        fread(dummy_records, sizeof(int), 2, f)
         fread(&next_record, sizeof(int), 1, f); FIX_LONG(next_record)
         print("Record size is:", next_record)
         # Offset for one record header we just read
@@ -138,7 +138,7 @@ def read_art_tree(char *fn, long offset,
             #oct_parents[iOct] = readin - 1
             fread(&readin, sizeof(int), 1, f); FIX_LONG(readin)
             oct_levels[iOct] = readin
-            fread(&iOct, sizeof(int), 1, f); FIX_LONG(iOct);
+            fread(&iOct, sizeof(int), 1, f); FIX_LONG(iOct)
             iOct -= 1
             assert next_record > 0
             fseek(f, next_record, SEEK_SET)
@@ -150,7 +150,7 @@ def read_art_tree(char *fn, long offset,
         #skip over the hydro variables
         #find the length of one child section
         #print('measuring child record ',)
-        fread(&next_record, sizeof(int), 1, f);
+        fread(&next_record, sizeof(int), 1, f)
         #print(next_record,)
         FIX_LONG(next_record)
         #print(next_record)
@@ -193,7 +193,7 @@ def read_art_root_vars(char *fn, long root_grid_offset,
     fseek(f, cell_record_size * my_offset, SEEK_CUR)
     #(((C)*GridDimension[1]+(B))*GridDimension[0]+A)
     for j in range(nhydro_vars):
-        fread(&temp, sizeof(float), 1, f);
+        fread(&temp, sizeof(float), 1, f)
         if j in fields:
             FIX_FLOAT(temp)
             var[l]=temp

--- a/yt/utilities/lib/geometry_utils.pyx
+++ b/yt/utilities/lib/geometry_utils.pyx
@@ -906,7 +906,6 @@ cdef np.int64_t position_to_morton(np.ndarray[floating, ndim=1] pos_x,
                         np.float64_t DRE[3],
                         np.ndarray[np.uint64_t, ndim=1] ind,
                         int filter):
-    cdef np.uint64_t mi
     cdef np.uint64_t ii[3]
     cdef np.float64_t p[3]
     cdef np.int64_t i, j, use
@@ -1114,7 +1113,6 @@ def csearch_morton(np.ndarray[np.float64_t, ndim=2] P, int k, np.uint64_t i,
         ValueError: If l<i<h. l and h must be on the same side of i.
 
     """
-    cdef int j
     cdef np.uint64_t m
     # Make sure that h and l are both larger/smaller than i
     if (l < i) and (h > i):

--- a/yt/utilities/lib/line_integral_convolution.pyx
+++ b/yt/utilities/lib/line_integral_convolution.pyx
@@ -63,7 +63,6 @@ def line_integral_convolution_2d(
 
     w = vectors.shape[0]
     h = vectors.shape[1]
-    t = vectors.shape[2]
 
     kernellen = kernel.shape[0]
     result = np.zeros((w,h),dtype=np.double)

--- a/yt/utilities/lib/misc_utilities.pyx
+++ b/yt/utilities/lib/misc_utilities.pyx
@@ -354,7 +354,6 @@ def zpoints(np.ndarray[np.float64_t, ndim=3] image,
 
     cdef int nx = image.shape[0]
     cdef int ny = image.shape[1]
-    cdef int nl = xs.shape[0]
     cdef np.float64_t[:] alpha
     cdef np.float64_t talpha
     cdef int i, j, c
@@ -974,7 +973,7 @@ def gravitational_binding_energy(
         np.float64_t kinetic,
         int num_threads = 0):
 
-    cdef int q_outer, q_inner, n_q, i
+    cdef int q_outer, q_inner, n_q
     cdef np.float64_t mass_o, x_o, y_o, z_o
     cdef np.float64_t mass_i, x_i, y_i, z_i
     cdef np.float64_t total_potential = 0.

--- a/yt/utilities/lib/origami_tags.c
+++ b/yt/utilities/lib/origami_tags.c
@@ -14,17 +14,16 @@ int compute_tags(int ng, double boxsize, double **r, int np,
                  unsigned char *m) {
   /* Note that the particles must be fed in according to the order specified in
    * the README file */
-  double predict, xmin,xmax,ymin,ymax,zmin,zmax;
+  double xmin,xmax,ymin,ymax,zmin,zmax;
 
   double negb2, b2;
-  int ng2,ng4, h, i,i2, x,y,z,nhalo,nhalo0,nhalo1,nhalo2,nhaloany;
+  int ng4, h, i,i2, x,y,z,nhalo,nhalo0,nhalo1,nhalo2,nhaloany;
   unsigned char *m0,*m1,*m2, mn,m0n,m1n,m2n; /*Morphology tag */
 
   double dx,d1,d2;
 
   b2 = boxsize/2.;
   negb2 = -boxsize/2.;
-  ng2=ng/2;
   ng4=ng/4;
 
   /* Boxsize should be the range in r, yielding a range 0-1 */

--- a/yt/utilities/lib/particle_kdtree_tools.pyx
+++ b/yt/utilities/lib/particle_kdtree_tools.pyx
@@ -80,7 +80,6 @@ def generate_smoothing_length(np.float64_t[:, ::1] tree_positions,
     cdef np.float64_t * pos
     cdef np.float64_t[:] smoothing_length = np.empty(n_particles)
     cdef BoundedPriorityQueue queue = BoundedPriorityQueue(n_neighbors)
-    cdef np.int64_t skipaxis = -1
 
     # We are using all spatial dimensions
     cdef axes_range axes
@@ -231,7 +230,6 @@ cdef inline int cull_node(Node* node,
     cdef int k
     cdef np.float64_t v
     cdef np.float64_t tpos, ndist = 0
-    cdef uint32_t leafid
 
     if node.leafid == skipleaf:
         return True
@@ -334,7 +332,6 @@ cdef inline int cull_node_ball(Node* node,
     cdef int k
     cdef np.float64_t v
     cdef np.float64_t tpos, ndist = 0
-    cdef uint32_t leafid
 
     if node.leafid == skipleaf:
         return True
@@ -364,7 +361,7 @@ cdef inline int process_node_points_ball(Node* node,
                                          axes_range * axes,
                                          ) nogil except -1:
     """Add points from the leaf node within the ball to the neighbor list."""
-    cdef uint64_t i, k, n
+    cdef uint64_t i, k
     cdef np.float64_t tpos, sq_dist
     for i in range(node.left_idx, node.left_idx + node.children):
         if i == skipidx:

--- a/yt/utilities/lib/particle_mesh_operations.pyx
+++ b/yt/utilities/lib/particle_mesh_operations.pyx
@@ -151,8 +151,6 @@ def NGPDeposit_2(np.float64_t[:] posx,
 
     cdef int i, j, i1, j1, n
     cdef np.float64_t xpos, ypos
-    cdef np.float64_t edge0, edge1
-    cdef np.float64_t le0, le1
     cdef np.float64_t[2] x_endpoints
     cdef np.float64_t[2] y_endpoints
 

--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -282,7 +282,7 @@ def pixelize_cartesian_nodal(np.float64_t[:,:] buff,
     cdef np.float64_t x_min, x_max, y_min, y_max
     cdef np.float64_t period_x = 0.0, period_y = 0.0
     cdef np.float64_t width, height, px_dx, px_dy, ipx_dx, ipx_dy
-    cdef np.float64_t ld_x, ld_y, cx, cy, cz
+    cdef np.float64_t cx, cy, cz
     cdef int i, j, p, xi, yi
     cdef int lc, lr, rc, rr
     cdef np.float64_t lypx, rypx, lxpx, rxpx, overlap1, overlap2
@@ -807,7 +807,7 @@ cdef int check_face_dot(int nvertices,
         nf = HEX_NF
     else:
         return -1
-    cdef int i, j, n, vi1a, vi1b, vi2a, vi2b
+    cdef int n, vi1a, vi1b, vi2a, vi2b
 
     for n in range(nf):
         vi1a = faces[n][0][0]
@@ -1076,13 +1076,12 @@ def pixelize_sph_kernel_projection(
     cdef np.float64_t q_ij2, posx_diff, posy_diff, ih_j2
     cdef np.float64_t x, y, dx, dy, idx, idy, h_j2, px, py
     cdef np.float64_t period_x = 0, period_y = 0
-    cdef int index, i, j, ii, jj
+    cdef int i, j, ii, jj
     cdef np.float64_t[:] _weight_field
     cdef int * xiter
     cdef int * yiter
     cdef np.float64_t * xiterv
     cdef np.float64_t * yiterv
-    cdef np.float64_t * local_buf
 
     if weight_field is not None:
         _weight_field = weight_field
@@ -1403,13 +1402,12 @@ def pixelize_sph_kernel_slice(
     cdef np.int64_t xi, yi, x0, x1, y0, y1, xxi, yyi
     cdef np.float64_t q_ij, posx_diff, posy_diff, ih_j
     cdef np.float64_t x, y, dx, dy, idx, idy, h_j2, h_j, px, py
-    cdef int index, i, j, ii, jj
+    cdef int i, j, ii, jj
     cdef np.float64_t period_x = 0, period_y = 0
     cdef int * xiter
     cdef int * yiter
     cdef np.float64_t * xiterv
     cdef np.float64_t * yiterv
-    cdef np.float64_t * local_buf
 
     if period is not None:
         period_x = period[0]
@@ -1541,7 +1539,7 @@ def pixelize_sph_kernel_arbitrary_grid(np.float64_t[:, :, :] buff,
     cdef np.int64_t xi, yi, zi, x0, x1, y0, y1, z0, z1
     cdef np.float64_t q_ij, posx_diff, posy_diff, posz_diff, px, py, pz
     cdef np.float64_t x, y, z, dx, dy, dz, idx, idy, idz, h_j3, h_j2, h_j, ih_j
-    cdef int index, i, j, k, ii, jj, kk
+    cdef int j, ii, jj, kk
     cdef np.float64_t period_x = 0, period_y = 0, period_z = 0
 
     cdef int xiter[2]

--- a/yt/utilities/voropp.pyx
+++ b/yt/utilities/voropp.pyx
@@ -63,7 +63,6 @@ cdef class VoronoiVolume:
     @cython.wraparound(False)
     def get_volumes(self):
         cdef np.ndarray vol = np.zeros(self.npart, 'double')
-        cdef double *vdouble = <double *> vol.data
         #self.my_con.store_cell_volumes(vdouble)
         cdef c_loop_all *vl = new c_loop_all(deref(self.my_con))
         cdef voronoicell c


### PR DESCRIPTION
## PR Summary

This removes all unused variables in Cython files as flagged by https://github.com/MarcoGorelli/cython-lint (see #4193).

Additional nits:
- removed a few useless variables. The few catches were found by compiling with `CC="gcc -Werror=unused" CXX="g++ -Werror=unused" python setup.py develop`. Note that the project does not compile with the above-mentioned flags due to some function being defined deep in Numpy and not used by yt.
- brought back support for parallel raycasting for octrees. The issue was that the `.hpp` file was not compiled with the `-fopenmp` flag on, so that the OMP pragma was just ignored.