### PR TITLE
[bugfix] H nuclei are being double-counted in the Arepo frontend

### DIFF
--- a/yt/frontends/arepo/fields.py
+++ b/yt/frontends/arepo/fields.py
@@ -127,8 +127,6 @@ class ArepoFieldInfo(GadgetFieldInfo):
                     field = f"{species}{suf}"
                     self.alias(("gas", field), (ptype, field))
 
-            self.alias(("gas", "H_nuclei_density"), ("gas", "H_number_density"))
-
         if (ptype, "ElectronAbundance") in self.field_list:
 
             # If we have ElectronAbundance but not NeutralHydrogenAbundance, assume the

--- a/yt/frontends/arepo/fields.py
+++ b/yt/frontends/arepo/fields.py
@@ -87,10 +87,7 @@ class ArepoFieldInfo(GadgetFieldInfo):
 
         if (ptype, "GFM_Metals_00") in self.field_list:
             self.nuclei_names = metal_elements
-            self.species_names = ["H"]
-            if (ptype, "NeutralHydrogenAbundance") in self.field_list:
-                self.species_names += ["H_p0", "H_p1"]
-            self.species_names += metal_elements
+            self.species_names = ["H"] + metal_elements
 
         if (ptype, "MagneticField") in self.field_list:
             setup_magnetic_field_aliases(self, ptype, "MagneticField")

--- a/yt/frontends/arepo/tests/test_outputs.py
+++ b/yt/frontends/arepo/tests/test_outputs.py
@@ -3,7 +3,7 @@ import tempfile
 from collections import OrderedDict
 
 from yt.frontends.arepo.api import ArepoHDF5Dataset
-from yt.testing import ParticleSelectionComparison, requires_file
+from yt.testing import ParticleSelectionComparison, assert_allclose_units, requires_file
 from yt.utilities.answer_testing.framework import data_dir_load, requires_ds, sph_answer
 
 bullet_h5 = "ArepoBullet/snapshot_150.hdf5"
@@ -82,6 +82,15 @@ def test_index_override():
     assert isinstance(ds, ArepoHDF5Dataset)
     ds.index
     assert len(open(tmpname).read()) == 0
+
+
+@requires_file(tng59_h5)
+def test_nh_density():
+    ds = data_dir_load(tng59_h5, kwargs={"bounding_box": _tng59_bbox})
+    ad = ds.all_data()
+    assert_allclose_units(
+        ad["gas", "H_number_density"], (ad["gas", "H_nuclei_density"])
+    )
 
 
 @requires_file(tng59_h5)


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

yt computes "nuclei density" fields by summing up ion number density fields for the same nuclei with different ionization states. The Arepo frontend currently has `"H"`, `"H_p0"`, and `"H_p1"` all added to the `species_names` attribute in `ArepoFieldInfo`, which is then used to compute the set up the species fields and compute the fields for specific abundances. 

The `"H_p0"` and `"H_p1"` do not belong in this list for two reasons:

1. Their respective associated fields are handled later on in the method `ArepoFieldInfo.setup_gas_particle_fields`, and do not need to be handled by `setup_species_fields`.
2. Putting them in `species_names` results in the number of hydrogen nuclei being double-counted

This PR removes those ionization species from the `species_names` attribute and also removes an alias between `H_nuclei_density` and `H_number_density` which was supposed to work (and maybe did at one point) but is no longer working. It is also unnecessary with the above fix. 
 
<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
