### PR TITLE
Two new features for writing FITS images

### DIFF
--- a/doc/source/visualizing/FITSImageData.ipynb
+++ b/doc/source/visualizing/FITSImageData.ipynb
@@ -109,15 +109,38 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
-    "## Making FITS images from Particle Projections"
-   ],
+    "If you want the center coordinates of the image in either a slice or a projection to be (0,0) instead of the domain coordinates, set `origin=\"image\"`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prj_fits_img = yt.FITSProjection(\n",
+    "    ds,\n",
+    "    \"z\",\n",
+    "    (\"gas\", \"temperature\"),\n",
+    "    weight_field=(\"gas\", \"density\"),\n",
+    "    width=(500.0, \"kpc\"),\n",
+    "    origin=\"image\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "## Making FITS images from Particle Projections"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -579,7 +602,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "By default, a tangent RA/Dec projection is used, but one could also use another projection using the `ctype` keyword. We can now look at the header and see it has the appropriate WCS:"
+    "By default, a tangent RA/Dec projection is used, but one could also use another projection using the `ctype` keyword. We can now look at the header and see it has the appropriate WCS now. The old `\"yt\"` WCS has been added to a second WCS in the header, where the parameters have an `\"A\"` appended to them:"
    ]
   },
   {
@@ -595,7 +618,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "and now the `WCSNAME` has been set to `\"celestial\"`. If you don't want to override the default WCS but to add another one, then you can make the call to `create_sky_wcs` and set `replace_old_wcs=False`:"
+    "and now the `WCSNAME` has been set to `\"celestial\"`. If you want the original WCS to remain in the original place, then you can make the call to `create_sky_wcs` and set `replace_old_wcs=False`, which will put the new, celestial WCS in the second one:"
    ]
   },
   {
@@ -612,26 +635,12 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We now can see that there are two WCSes in the header, with the celestial WCS keywords having the \"A\" designation:"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "prj_fits3[\"temperature\"].header"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Any further WCSes that are added will have \"B\", \"C\", etc."
    ]
   },
   {

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -85,8 +85,9 @@ class FITSImageData:
             is not already provided by *data*.
         img_ctr : array_like or YTArray
             The center coordinates of the image. If a list or NumPy array,
-            it is assumed to be in *units*. Only used if this information
-            is not already provided by *data*.
+            it is assumed to be in *units*. This will overwrite any center
+            coordinates potentially provided by *data*. Default in other cases
+            is [0.0]*(number of dimensions).
         wcs : `~astropy.wcs.WCS` instance, optional
             Supply an AstroPy WCS instance. Will override automatic WCS
             creation from FixedResolutionBuffers and YTCoveringGrids.
@@ -159,8 +160,6 @@ class FITSImageData:
                 width = YTQuantity(width[0], width[1])
             else:
                 width = ds.quan(width[0], width[1])
-        if img_ctr is None:
-            img_ctr = np.zeros(3)
 
         exclude_fields = [
             "x",
@@ -314,22 +313,30 @@ class FITSImageData:
                 dy = (img_data.bounds[3] - img_data.bounds[2]).to_value(wcs_unit)
                 dx /= self.shape[0]
                 dy /= self.shape[1]
-                xctr = 0.5 * (img_data.bounds[1] + img_data.bounds[0]).to_value(
-                    wcs_unit
-                )
-                yctr = 0.5 * (img_data.bounds[3] + img_data.bounds[2]).to_value(
-                    wcs_unit
-                )
+                if img_ctr is not None:
+                    xctr, yctr = img_ctr
+                else:
+                    xctr = 0.5 * (img_data.bounds[1] + img_data.bounds[0]).to_value(
+                        wcs_unit
+                    )
+                    yctr = 0.5 * (img_data.bounds[3] + img_data.bounds[2]).to_value(
+                        wcs_unit
+                    )
                 center = [xctr, yctr]
                 cdelt = [dx, dy]
             elif isinstance(img_data, YTCoveringGrid):
                 cdelt = img_data.dds.to_value(wcs_unit)
-                center = 0.5 * (img_data.left_edge + img_data.right_edge).to_value(
-                    wcs_unit
-                )
+                if img_ctr is not None:
+                    center = img_ctr
+                else:
+                    center = 0.5 * (img_data.left_edge + img_data.right_edge).to_value(
+                        wcs_unit
+                    )
             else:
                 # If img_data is just an array we use the width and img_ctr
                 # parameters to determine the cell widths
+                if img_ctr is None:
+                    img_ctr = np.zeros(3)
                 if not is_sequence(width):
                     width = [width] * self.dimensionality
                 if isinstance(width[0], YTQuantity):
@@ -855,7 +862,8 @@ def sanitize_fits_unit(unit):
 axis_wcs = [[1, 2], [2, 0], [0, 1]]
 
 
-def construct_image(ds, axis, data_source, center, image_res, width, length_unit):
+def construct_image(ds, axis, data_source, center, image_res, width, length_unit,
+                    origin="domain"):
     if width is None:
         width = ds.domain_width[axis_wcs[axis]]
         unit = ds.get_smallest_appropriate_unit(width[0])
@@ -885,10 +893,13 @@ def construct_image(ds, axis, data_source, center, image_res, width, length_unit
     cunit = [length_unit] * 2
     ctype = ["LINEAR"] * 2
     cdelt = [dx.in_units(length_unit), dy.in_units(length_unit)]
-    if is_sequence(axis):
-        crval = center.in_units(length_unit)
-    else:
-        crval = [center[idx].in_units(length_unit) for idx in axis_wcs[axis]]
+    if origin == "domain":
+        if is_sequence(axis):
+            crval = center.in_units(length_unit)
+        else:
+            crval = [center[idx].in_units(length_unit) for idx in axis_wcs[axis]]
+    elif origin == "image":
+        crval = np.zeros(2)
     if hasattr(data_source, "to_frb"):
         if is_sequence(axis):
             frb = data_source.to_frb(width[0], (nx, ny), height=width[1])
@@ -1005,6 +1016,7 @@ class FITSSlice(FITSImageData):
         center="c",
         width=None,
         length_unit=None,
+        origin="domain",
         **kwargs,
     ):
         fields = list(iter_fields(fields))
@@ -1012,7 +1024,7 @@ class FITSSlice(FITSImageData):
         center, dcenter = ds.coordinates.sanitize_center(center, axis)
         slc = ds.slice(axis, center[axis], **kwargs)
         w, frb, lunit = construct_image(
-            ds, axis, slc, dcenter, image_res, width, length_unit
+            ds, axis, slc, dcenter, image_res, width, length_unit, origin=origin,
         )
         super().__init__(frb, fields=fields, length_unit=lunit, wcs=w)
 
@@ -1083,6 +1095,7 @@ class FITSProjection(FITSImageData):
         width=None,
         weight_field=None,
         length_unit=None,
+        origin="domain",
         *,
         moment=1,
         **kwargs,
@@ -1094,7 +1107,7 @@ class FITSProjection(FITSImageData):
             fields[0], axis, weight_field=weight_field, moment=moment, **kwargs
         )
         w, frb, lunit = construct_image(
-            ds, axis, prj, dcenter, image_res, width, length_unit
+            ds, axis, prj, dcenter, image_res, width, length_unit, origin=origin,
         )
         super().__init__(frb, fields=fields, length_unit=lunit, wcs=w)
 
@@ -1184,6 +1197,7 @@ class FITSParticleProjection(FITSImageData):
         density=False,
         field_parameters=None,
         data_source=None,
+        origin="domain",
     ):
         fields = list(iter_fields(fields))
         axis = fix_axis(axis, ds)
@@ -1207,7 +1221,7 @@ class FITSParticleProjection(FITSImageData):
             density=density,
         )
         w, frb, lunit = construct_image(
-            ds, axis, ps, dcenter, image_res, width, length_unit
+            ds, axis, ps, dcenter, image_res, width, length_unit, origin=origin
         )
         super().__init__(frb, fields=fields, length_unit=lunit, wcs=w)
 

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -862,8 +862,9 @@ def sanitize_fits_unit(unit):
 axis_wcs = [[1, 2], [2, 0], [0, 1]]
 
 
-def construct_image(ds, axis, data_source, center, image_res, width, length_unit,
-                    origin="domain"):
+def construct_image(
+    ds, axis, data_source, center, image_res, width, length_unit, origin="domain"
+):
     if width is None:
         width = ds.domain_width[axis_wcs[axis]]
         unit = ds.get_smallest_appropriate_unit(width[0])
@@ -1005,6 +1006,11 @@ class FITSSlice(FITSImageData):
     length_unit : string, optional
         the length units that the coordinates are written in. The default
         is to use the default length unit of the dataset.
+    origin : string
+        The origin of the coordinate system in the file. If "domain", then the
+        center coordinates will be the same as the center of the image as
+        defined by the *center* keyword argument. If "image", then the center
+        coordinates will be set to (0,0). Default: "domain"
     """
 
     def __init__(
@@ -1016,6 +1022,7 @@ class FITSSlice(FITSImageData):
         center="c",
         width=None,
         length_unit=None,
+        *,
         origin="domain",
         **kwargs,
     ):
@@ -1024,7 +1031,14 @@ class FITSSlice(FITSImageData):
         center, dcenter = ds.coordinates.sanitize_center(center, axis)
         slc = ds.slice(axis, center[axis], **kwargs)
         w, frb, lunit = construct_image(
-            ds, axis, slc, dcenter, image_res, width, length_unit, origin=origin,
+            ds,
+            axis,
+            slc,
+            dcenter,
+            image_res,
+            width,
+            length_unit,
+            origin=origin,
         )
         super().__init__(frb, fields=fields, length_unit=lunit, wcs=w)
 
@@ -1079,6 +1093,11 @@ class FITSProjection(FITSImageData):
     length_unit : string, optional
         the length units that the coordinates are written in. The default
         is to use the default length unit of the dataset.
+    origin : string
+        The origin of the coordinate system in the file. If "domain", then the
+        center coordinates will be the same as the center of the image as
+        defined by the *center* keyword argument. If "image", then the center
+        coordinates will be set to (0,0). Default: "domain"
     moment : integer, optional
         for a weighted projection, moment = 1 (the default) corresponds to a
         weighted average. moment = 2 corresponds to a weighted standard
@@ -1095,8 +1114,8 @@ class FITSProjection(FITSImageData):
         width=None,
         weight_field=None,
         length_unit=None,
-        origin="domain",
         *,
+        origin="domain",
         moment=1,
         **kwargs,
     ):
@@ -1107,7 +1126,14 @@ class FITSProjection(FITSImageData):
             fields[0], axis, weight_field=weight_field, moment=moment, **kwargs
         )
         w, frb, lunit = construct_image(
-            ds, axis, prj, dcenter, image_res, width, length_unit, origin=origin,
+            ds,
+            axis,
+            prj,
+            dcenter,
+            image_res,
+            width,
+            length_unit,
+            origin=origin,
         )
         super().__init__(frb, fields=fields, length_unit=lunit, wcs=w)
 
@@ -1180,6 +1206,11 @@ class FITSParticleProjection(FITSImageData):
     data_source : yt.data_objects.data_containers.YTSelectionContainer, optional
         If specified, this will be the data source used for selecting regions
         to project.
+    origin : string
+        The origin of the coordinate system in the file. If "domain", then the
+        center coordinates will be the same as the center of the image as
+        defined by the *center* keyword argument. If "image", then the center
+        coordinates will be set to (0,0). Default: "domain"
     """
 
     def __init__(
@@ -1197,6 +1228,7 @@ class FITSParticleProjection(FITSImageData):
         density=False,
         field_parameters=None,
         data_source=None,
+        *,
         origin="domain",
     ):
         fields = list(iter_fields(fields))

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -789,9 +789,9 @@ class FITSImageData:
         wcsname : string, optional
             The name of the WCS to be stored in the FITS header.
         replace_old_wcs : boolean, optional
-            Whether or not to overwrite the default WCS of the
-            FITSImageData instance. If false, a second WCS will
-            be added to the header. Default: True.
+            If True, the original WCS will be overwritten but
+            first copied to a second WCS ("WCSAXESA"). If False, this
+            new WCS will be placed into the second WCS.
         """
         if ctype is None:
             ctype = ["RA---TAN", "DEC--TAN"]
@@ -831,6 +831,7 @@ class FITSImageData:
             new_wcs.wcs.cd = pc
         if replace_old_wcs:
             self.set_wcs(new_wcs, wcsname=wcsname)
+            self.set_wcs(old_wcs, wcsname="yt", suffix="a")
         else:
             self.set_wcs(new_wcs, wcsname=wcsname, suffix="a")
 

--- a/yt/visualization/tests/test_fits_image.py
+++ b/yt/visualization/tests/test_fits_image.py
@@ -89,6 +89,22 @@ def test_fits_image():
     assert_equal(fid2["density"].data, fits_slc["density"].data)
     assert_equal(fid2["temperature"].data, fits_slc["temperature"].data)
 
+    fits_slc2 = FITSSlice(
+        ds,
+        "z",
+        [("gas", "density"), ("gas", "temperature")],
+        image_res=128,
+        width=(0.5, "unitary"),
+        origin="image",
+    )
+
+    assert_equal(fits_slc2["density"].data, fits_slc["density"].data)
+    assert_equal(fits_slc2["temperature"].data, fits_slc["temperature"].data)
+    assert fits_slc.wcs.wcs.crval[0] == ds.domain_center[0].to_value("cm")
+    assert fits_slc.wcs.wcs.crval[1] == ds.domain_center[1].to_value("cm")
+    assert fits_slc2.wcs.wcs.crval[0] == 0.0
+    assert fits_slc2.wcs.wcs.crval[1] == 0.0
+
     dens_img = fid2.pop("density")
     temp_img = fid2.pop("temperature")
 
@@ -133,6 +149,10 @@ def test_fits_image():
     assert new_fid3.wcs.wcs.cunit[1] == "deg"
     assert new_fid3.wcs.wcs.ctype[0] == "RA---TAN"
     assert new_fid3.wcs.wcs.ctype[1] == "DEC--TAN"
+    assert new_fid3.wcsa.wcs.cunit[0] == "cm"
+    assert new_fid3.wcsa.wcs.cunit[1] == "cm"
+    assert new_fid3.wcsa.wcs.ctype[0] == "linear"
+    assert new_fid3.wcsa.wcs.ctype[1] == "linear"
 
     buf = off_axis_projection(
         ds, ds.domain_center, [0.1, 0.2, -0.9], 0.5, 128, ("gas", "density")


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

This PR adds two new features to FITS image writing. 

1. When adding a celestial coordinate system to a FITS image created from yt using the `create_sky_wcs` method, it overwrites the existing, linear coordinate coordinate system by default. This PR changes the behavior so that the old coordinate system is retained in the FITS header but is moved to the "second" slot for coordinate systems. 
2. Adding an `origin` keyword argument to `FITSSlice`, `FITSProjection`, and `FITSParticleProjection` that optionally allows the center coordinates to be set to (0,0) if `origin="image"`.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
