### PR TITLE
TYP: typing improvements using latest mypy (0.991)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -117,11 +117,11 @@ test =
     pytest>=6.1
     sympy!=1.10,!=1.9 # see https://github.com/sympy/sympy/issues/22241
 typecheck =
-    mypy==0.971
-    types-PyYAML==5.4.10
-    types-chardet==4.0.0
-    types-requests==2.25.9
-    types-setuptools==57.4.0
+    mypy==0.991
+    types-PyYAML==6.0.12.2
+    types-chardet==5.0.4
+    types-requests==2.28.11.5
+    types-setuptools==65.6.0.1
 
 [flake8]
 max-line-length = 88

--- a/yt/_typing.py
+++ b/yt/_typing.py
@@ -6,6 +6,7 @@ from numpy import ndarray
 FieldDescT = Tuple[str, Tuple[str, List[str], Optional[str]]]
 KnownFieldsT = Tuple[FieldDescT, ...]
 
+ParticleType = str
 FieldType = str
 FieldName = str
 FieldKey = Tuple[FieldType, FieldName]

--- a/yt/_typing.py
+++ b/yt/_typing.py
@@ -6,6 +6,12 @@ from numpy import ndarray
 FieldDescT = Tuple[str, Tuple[str, List[str], Optional[str]]]
 KnownFieldsT = Tuple[FieldDescT, ...]
 
+FieldType = str
+FieldName = str
+FieldKey = Tuple[FieldType, FieldName]
+ImplicitFieldKey = FieldName
+AnyFieldKey = Union[FieldKey, ImplicitFieldKey]
+
 ParticleCoordinateTuple = Tuple[
     str,  # particle type
     Tuple[ndarray, ndarray, ndarray],  # xyz

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -271,6 +271,11 @@ class Dataset(abc.ABC):
         # the cache, we move that check to here from __new__.  This avoids
         # double-instantiation.
         # PR 3124: _set_derived_attrs() can change the hash, check store here
+        if _ds_store is None:
+            raise RuntimeError(
+                "Something went wrong during yt's initialization: "
+                "dataset cache isn't properly initialized"
+            )
         try:
             _ds_store.check_ds(self)
         except NoParameterShelf:

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -20,7 +20,7 @@ from unyt import Unit
 from unyt.exceptions import UnitConversionError, UnitParseError
 
 from yt._maintenance.deprecation import issue_deprecation_warning
-from yt._typing import AnyFieldKey
+from yt._typing import AnyFieldKey, FieldType, ParticleType
 from yt.config import ytcfg
 from yt.data_objects.particle_filters import ParticleFilter, filter_registry
 from yt.data_objects.region_expression import RegionExpression
@@ -145,14 +145,16 @@ class Dataset(abc.ABC):
 
     default_fluid_type = "gas"
     default_field = ("gas", "density")
-    fluid_types: Tuple[str, ...] = ("gas", "deposit", "index")
-    particle_types: Optional[Tuple[str, ...]] = ("io",)  # By default we have an 'all'
-    particle_types_raw: Optional[Tuple[str, ...]] = ("io",)
+    fluid_types: Tuple[FieldType, ...] = ("gas", "deposit", "index")
+    particle_types: Optional[Tuple[ParticleType, ...]] = (
+        "io",
+    )  # By default we have an 'all'
+    particle_types_raw: Optional[Tuple[ParticleType, ...]] = ("io",)
     geometry = "cartesian"
     coordinates = None
     storage_filename = None
-    particle_unions: Optional[Dict[str, ParticleUnion]] = None
-    known_filters: Optional[Dict[str, ParticleFilter]] = None
+    particle_unions: Optional[Dict[ParticleType, ParticleUnion]] = None
+    known_filters: Optional[Dict[ParticleType, ParticleFilter]] = None
     _index_class: Type[Index]
     field_units: Optional[Dict[AnyFieldKey, Unit]] = None
     derived_field_list = requires_index("derived_field_list")

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -78,7 +78,7 @@ _cached_datasets: MutableMapping[
 
 # we set this global to None as a place holder
 # its actual instanciation is delayed until after yt.__init__
-# is completed because we need yt.config.ytcfg to be instanciated first
+# is completed because we need yt.config.ytcfg to be instantiated first
 
 _ds_store: Optional[ParameterFileStore] = None
 
@@ -159,7 +159,7 @@ class Dataset(abc.ABC):
     field_units: Optional[Dict[AnyFieldKey, Unit]] = None
     derived_field_list = requires_index("derived_field_list")
     fields = requires_index("fields")
-    # _instanciated represents an instanciation time (since Epoch)
+    # _instantiated represents an instantiation time (since Epoch)
     # the default is a place holder sentinel, falsy value
     _instantiated: float = 0
     _particle_type_counts = None

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -1639,7 +1639,7 @@ def load_hdf5_file(
     fn: Union[str, "os.PathLike[str]"],
     root_node: Optional[str] = "/",
     fields: Optional[List[str]] = None,
-    bbox: np.ndarray = None,
+    bbox: Optional[np.ndarray] = None,
     nchunks: int = 0,
     dataset_arguments: Optional[dict] = None,
 ):

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -849,7 +849,7 @@ class ContourCallback(PlotCallback):
         clim: Optional[Tuple[float, float]] = None,
         label: bool = False,
         take_log: Optional[bool] = None,
-        data_source: YTDataContainer = None,
+        data_source: Optional[YTDataContainer] = None,
         plot_args: Optional[Dict[str, Any]] = None,
         text_args: Optional[Dict[str, Any]] = None,
         ncont: Optional[int] = None,  # deprecated

--- a/yt/visualization/volume_rendering/render_source.py
+++ b/yt/visualization/volume_rendering/render_source.py
@@ -327,7 +327,7 @@ class VolumeSource(RenderSource, abc.ABC):
         """The field to be rendered"""
         return self._field
 
-    @field.setter  # type: ignore
+    @field.setter
     @invalidate_volume
     def field(self, value):
         field = self.data_source._determine_fields(value)
@@ -353,7 +353,7 @@ class VolumeSource(RenderSource, abc.ABC):
         """Whether or not the field rendering is computed in log space"""
         return self._log_field
 
-    @log_field.setter  # type: ignore
+    @log_field.setter
     @invalidate_volume
     def log_field(self, value):
         self.transfer_function = None
@@ -366,7 +366,7 @@ class VolumeSource(RenderSource, abc.ABC):
         values at grid boundaries"""
         return self._use_ghost_zones
 
-    @use_ghost_zones.setter  # type: ignore
+    @use_ghost_zones.setter
     @invalidate_volume
     def use_ghost_zones(self, value):
         self._use_ghost_zones = value
@@ -379,7 +379,7 @@ class VolumeSource(RenderSource, abc.ABC):
         """
         return self._weight_field
 
-    @weight_field.setter  # type: ignore
+    @weight_field.setter
     @invalidate_volume
     def weight_field(self, value):
         self._weight_field = value


### PR DESCRIPTION
## PR Summary

- TYP: upgrade mypy (0.971 -> 0.991) and additional typecheck dependencies
- TYP: cleanup obsolete 'type: ignore' comments
- TYP: fix PEP 484 errors (implicit None) in function signatures

All newly detected errors are fixed here, but it's worth noting that `mypy yt` now produces a short list of warnings hinting at unannotated functions that have small bits of typing information in their bodies:
```
yt/data_objects/static_output.py: note: In member "__init__" of class "Dataset":
yt/data_objects/static_output.py:240: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
yt/data_objects/static_output.py: note: In member "_get_field_info_helper" of class "Dataset":
yt/data_objects/static_output.py:921: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
yt/data_objects/static_output.py: note: In member "_assign_unit_system" of class "Dataset":
yt/data_objects/static_output.py:1241: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
yt/visualization/plot_window.py: note: In member "__init__" of class "PWViewerMPL":
yt/visualization/plot_window.py:859: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
yt/visualization/plot_window.py:869: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
yt/visualization/plot_modifications.py: note: In member "__call__" of class "ContourCallback":
yt/visualization/plot_modifications.py:948: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
yt/visualization/plot_modifications.py:958: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
yt/visualization/plot_modifications.py:964: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
yt/utilities/command_line.py: note: In member "load_config" of class "YTConfigLocalConfigHandler":
yt/utilities/command_line.py:1332: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
Success: no issues found in 500 source files
```

I consider fixing those is out of scope for the present PR because I expect it to snowball into a much larger list of actual errors. It should be done at some point though.


