### PR TITLE
TYP: add static typing to Dataset._get_field_info_helper

### DIFF
--- a/doc/helper_scripts/show_fields.py
+++ b/doc/helper_scripts/show_fields.py
@@ -37,7 +37,7 @@ def _strip_ftype(field):
 
 
 np.random.seed(int(0x4D3D3D3))
-units = [base_ds._get_field_info(*f).units for f in fields]
+units = [base_ds._get_field_info(f).units for f in fields]
 fields = [_strip_ftype(f) for f in fields]
 ds = fake_random_ds(16, fields=fields, units=units, particles=1)
 ds.parameters["HydroMethod"] = "streaming"

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -2,12 +2,12 @@ import abc
 import weakref
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import List, Tuple
+from typing import TYPE_CHECKING, List, Tuple
 
 import numpy as np
 
 from yt._maintenance.deprecation import issue_deprecation_warning
-from yt._typing import AnyFieldKey
+from yt._typing import AnyFieldKey, FieldKey, FieldName
 from yt.config import ytcfg
 from yt.data_objects.field_data import YTFieldData
 from yt.data_objects.profiles import create_profile
@@ -28,6 +28,9 @@ from yt.utilities.exceptions import (
 from yt.utilities.object_registries import data_object_registry
 from yt.utilities.on_demand_imports import _firefly as firefly
 from yt.utilities.parameter_file_storage import ParameterFileStore
+
+if TYPE_CHECKING:
+    from yt.data_objects.static_output import Dataset
 
 
 def sanitize_weight_field(ds, field, weight):
@@ -84,6 +87,8 @@ class YTDataContainer(abc.ABC):
         # Dataset._add_object_class but it can also be passed as a parameter to the
         # constructor, in which case it will override the default.
         # This code ensures it is never not set.
+
+        self.ds: "Dataset"
         if ds is not None:
             self.ds = ds
         else:
@@ -161,7 +166,7 @@ class YTDataContainer(abc.ABC):
         except AttributeError:
             return self.ds.arr(arr, units=units)
 
-    def _first_matching_field(self, field):
+    def _first_matching_field(self, field: FieldName) -> FieldKey:
         for ftype, fname in self.ds.derived_field_list:
             if fname == field:
                 return (ftype, fname)

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -271,11 +271,7 @@ class YTDataContainer(abc.ABC):
         try:
             rv = self.field_data[f]
         except KeyError:
-            if isinstance(f, tuple):
-                fi = self.ds._get_field_info(f)
-            elif isinstance(f, bytes):
-                # TODO(4229): see if this branch could be dropped
-                fi = self.ds._get_field_info(("unknown", f))
+            fi = self.ds._get_field_info(f)
             rv = self.ds.arr(self.field_data[key], fi.units)
         return rv
 

--- a/yt/data_objects/index_subobjects/grid_patch.py
+++ b/yt/data_objects/index_subobjects/grid_patch.py
@@ -78,7 +78,7 @@ class AMRGridPatch(YTSelectionContainer):
             fields = self._determine_fields(key)
         except YTFieldTypeNotFound:
             return tr
-        finfo = self.ds._get_field_info(*fields[0])
+        finfo = self.ds._get_field_info(fields[0])
         if not finfo.sampling_type == "particle":
             num_nodes = 2 ** sum(finfo.nodal_flag)
             new_shape = list(self.ActiveDimensions)

--- a/yt/data_objects/index_subobjects/octree_subset.py
+++ b/yt/data_objects/index_subobjects/octree_subset.py
@@ -64,7 +64,7 @@ class OctreeSubset(YTSelectionContainer):
             fields = self._determine_fields(key)
         except YTFieldTypeNotFound:
             return tr
-        finfo = self.ds._get_field_info(*fields[0])
+        finfo = self.ds._get_field_info(fields[0])
         if not finfo.sampling_type == "particle":
             # We may need to reshape the field, if it is being queried from
             # field_data.  If it's already cached, it just passes through.

--- a/yt/data_objects/region_expression.py
+++ b/yt/data_objects/region_expression.py
@@ -27,9 +27,11 @@ class RegionExpression:
         # that result in a rectangular prism or a slice.
         try:
             return self.all_data[item]
-        except (TypeError, YTFieldNotParseable, YTFieldNotFound):
-            # TODO(4229): see if there's any reason left to catch YTFieldNotParseable here
-            # TODO(4229): Do NOT catch TypeError (may hide subtle bugs like internally broken function call)
+        except (YTFieldNotParseable, YTFieldNotFound):
+            # any error raised by self.ds._get_field_info
+            # signals a type error (not a field), however we don't want to
+            # catch plain TypeErrors as this may create subtle bugs very hard
+            # to decipher, like broken internal function calls.
             pass
 
         if isinstance(item, slice):

--- a/yt/data_objects/region_expression.py
+++ b/yt/data_objects/region_expression.py
@@ -3,7 +3,11 @@ from functools import cached_property
 
 from yt.funcs import obj_length
 from yt.units.yt_array import YTQuantity
-from yt.utilities.exceptions import YTDimensionalityError, YTFieldNotParseable
+from yt.utilities.exceptions import (
+    YTDimensionalityError,
+    YTFieldNotFound,
+    YTFieldNotParseable,
+)
 from yt.visualization.line_plot import LineBuffer
 
 from .data_containers import _get_ipython_key_completion
@@ -23,7 +27,9 @@ class RegionExpression:
         # that result in a rectangular prism or a slice.
         try:
             return self.all_data[item]
-        except (TypeError, YTFieldNotParseable):
+        except (TypeError, YTFieldNotParseable, YTFieldNotFound):
+            # TODO(4229): see if there's any reason left to catch YTFieldNotParseable here
+            # TODO(4229): Do NOT catch TypeError (may hide subtle bugs like internally broken function call)
             pass
 
         if isinstance(item, slice):

--- a/yt/data_objects/selection_objects/data_selection_objects.py
+++ b/yt/data_objects/selection_objects/data_selection_objects.py
@@ -107,7 +107,7 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface, abc.ABC):
             if inspected >= len(fields_to_get):
                 break
             inspected += 1
-            fi = self.ds._get_field_info(*field)
+            fi = self.ds._get_field_info(field)
             fd = self.ds.field_dependencies.get(
                 field, None
             ) or self.ds.field_dependencies.get(field[1], None)
@@ -165,7 +165,7 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface, abc.ABC):
         for field in self._determine_fields(fields):
             if field in self.field_data:
                 continue
-            finfo = self.ds._get_field_info(*field)
+            finfo = self.ds._get_field_info(field)
             try:
                 finfo.check_available(self)
             except NeedsGridType:
@@ -184,7 +184,7 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface, abc.ABC):
         fluids, particles = [], []
         finfos = {}
         for ftype, fname in fields_to_get:
-            finfo = self.ds._get_field_info(ftype, fname)
+            finfo = self.ds._get_field_info((ftype, fname))
             finfos[ftype, fname] = finfo
             if finfo.sampling_type == "particle":
                 particles.append((ftype, fname))
@@ -228,7 +228,7 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface, abc.ABC):
                 index += 1
                 if field in self.field_data:
                     continue
-                fi = self.ds._get_field_info(*field)
+                fi = self.ds._get_field_info(field)
                 try:
                     fd = self._generate_field(field)
                     if hasattr(fd, "units"):

--- a/yt/data_objects/selection_objects/data_selection_objects.py
+++ b/yt/data_objects/selection_objects/data_selection_objects.py
@@ -183,13 +183,13 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface, abc.ABC):
         # We now split up into readers for the types of fields
         fluids, particles = [], []
         finfos = {}
-        for ftype, fname in fields_to_get:
-            finfo = self.ds._get_field_info((ftype, fname))
-            finfos[ftype, fname] = finfo
+        for field_key in fields_to_get:
+            finfo = self.ds._get_field_info(field_key)
+            finfos[field_key] = finfo
             if finfo.sampling_type == "particle":
-                particles.append((ftype, fname))
-            elif (ftype, fname) not in fluids:
-                fluids.append((ftype, fname))
+                particles.append(field_key)
+            elif field_key not in fluids:
+                fluids.append(field_key)
         # The _read method will figure out which fields it needs to get from
         # disk, and return a dict of those fields along with the fields that
         # need to be generated.

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -754,7 +754,7 @@ class Dataset(abc.ABC):
             units = set()
             for s in union:
                 # First we check our existing fields for units
-                funits = self._get_field_info(s, field).units
+                funits = self._get_field_info((s, field)).units
                 # Then we override with field_units settings.
                 funits = self.field_units.get((s, field), funits)
                 units.add(funits)

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -887,9 +887,9 @@ class Dataset(abc.ABC):
 
             all_equivalent_particle_fields: bool
             if (
-                self.particle_types is None
-                or self.particle_unions is None
-                or self.particle_types_raw is None
+                not self.particle_types
+                or not self.particle_unions
+                or not self.particle_types_raw
             ):
                 all_equivalent_particle_fields = False
             elif all(ft in self.particle_types for ft in ftypes):

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -53,6 +53,7 @@ from yt.utilities.configure import YTConfig, configuration_callbacks
 from yt.utilities.cosmology import Cosmology
 from yt.utilities.exceptions import (
     YTFieldNotFound,
+    YTFieldNotParseable,
     YTGeometryNotSupported,
     YTIllDefinedParticleFilter,
     YTObjectNotImplemented,
@@ -925,9 +926,6 @@ class Dataset(abc.ABC):
         field: Union[Tuple[str, str], str, DerivedField],
         /,
     ):
-        # note: the present method is only allowed to raise
-        # TypeError or YTFieldNotFound exceptions.
-        # YTRegion.__getattr__'s implementation relies on this behaviour
         self.index
 
         if isinstance(field, str):
@@ -937,7 +935,7 @@ class Dataset(abc.ABC):
         elif isinstance(field, DerivedField):
             ftype, fname = field.name
         else:
-            raise TypeError(f"internal field parsing error. Got {field=}")
+            raise YTFieldNotParseable(field)
 
         candidates: List[FieldKey] = []
 

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -20,7 +20,7 @@ from unyt import Unit
 from unyt.exceptions import UnitConversionError, UnitParseError
 
 from yt._maintenance.deprecation import issue_deprecation_warning
-from yt._typing import AnyFieldKey, FieldKey, FieldType, ParticleType
+from yt._typing import AnyFieldKey, FieldKey, FieldType, ImplicitFieldKey, ParticleType
 from yt.config import ytcfg
 from yt.data_objects.particle_filters import ParticleFilter, filter_registry
 from yt.data_objects.region_expression import RegionExpression
@@ -147,9 +147,7 @@ class Dataset(abc.ABC):
     default_fluid_type = "gas"
     default_field = ("gas", "density")
     fluid_types: Tuple[FieldType, ...] = ("gas", "deposit", "index")
-    particle_types: Tuple[ParticleType, ...] = (
-        "io",
-    )  # By default we have an 'all'
+    particle_types: Tuple[ParticleType, ...] = ("io",)  # By default we have an 'all'
     particle_types_raw: Optional[Tuple[ParticleType, ...]] = ("io",)
     geometry = "cartesian"
     coordinates = None
@@ -862,7 +860,7 @@ class Dataset(abc.ABC):
 
     def _get_field_info(
         self,
-        field: Union[Tuple[str, str], str, DerivedField],
+        field: Union[FieldKey, ImplicitFieldKey, DerivedField],
         /,
     ) -> DerivedField:
         field_info, candidates = self._get_field_info_helper(field)
@@ -923,9 +921,9 @@ class Dataset(abc.ABC):
 
     def _get_field_info_helper(
         self,
-        field: Union[Tuple[str, str], str, DerivedField],
+        field: Union[FieldKey, ImplicitFieldKey, DerivedField],
         /,
-    ) -> Tuple[DerivedField, List[Tuple[str, str]]]:
+    ) -> Tuple[DerivedField, List[FieldKey]]:
         self.index
 
         ftype: str

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -952,15 +952,12 @@ class Dataset(abc.ABC):
             ftype = self._last_freq[0] if isinstance(self._last_freq, tuple) else ftype
             candidates = [(ft, fn) for ft, fn in self.field_info.keys() if fn == fname]
 
-        field: Tuple[str, str] = (ftype, fname)
+        ft: Tuple[str, str] = (ftype, fname)
 
-        if (
-            field == self._last_freq
-            and field not in self.field_info.field_aliases.values()
-        ):
+        if ft == self._last_freq and ft not in self.field_info.field_aliases.values():
             return self._last_finfo, candidates
-        if field in self.field_info:
-            self._last_freq = field
+        if ft in self.field_info:
+            self._last_freq = ft
             self._last_finfo = self.field_info[(ftype, fname)]
             return self._last_finfo, candidates
 
@@ -975,15 +972,15 @@ class Dataset(abc.ABC):
                 and len(self._last_freq) >= 1
                 and self._last_freq[0] not in self.particle_types
             ):
-                field = "all", field[1]
+                ft = "all", ft[1]
             elif (
                 not fi.sampling_type == "particle"
                 and isinstance(self._last_freq, tuple)
                 and len(self._last_freq) >= 1
                 and self._last_freq[0] not in self.fluid_types
             ):
-                field = self.default_fluid_type, field[1]
-            self._last_freq = field
+                ft = self.default_fluid_type, ft[1]
+            self._last_freq = ft
             return self._last_finfo, candidates
         except KeyError:
             pass
@@ -1001,6 +998,7 @@ class Dataset(abc.ABC):
                     self._last_freq = (ftype, fname)
                     self._last_finfo = self.field_info[(ftype, fname)]
                     return self._last_finfo, candidates
+        # TODO(4229): drop INPUT var (field var shouldn't be reused in this scope)
         raise YTFieldNotFound(field=INPUT, ds=self)
 
     def _setup_classes(self):

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -942,7 +942,7 @@ class Dataset(abc.ABC):
         # storing this condition before altering it
         guessing_type = ftype == "unknown"
         if guessing_type:
-            candidates = [(ft, fn) for ft, fn in self.field_info.keys() if fn == fname]
+            candidates = [(ft, fn) for ft, fn in self.field_info if fn == fname]
 
         ft: Tuple[str, str] = (ftype, fname)
         if ft in self.field_info:

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -936,7 +936,7 @@ class Dataset(abc.ABC):
 
         if isinstance(field, str):
             ftype, fname = "unknown", field
-        elif is_sequence(field) and len(field) == 2:
+        elif isinstance(field, tuple) and len(field) == 2:
             ftype, fname = field
         elif isinstance(field, DerivedField):
             ftype, fname = field.name

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -146,7 +146,7 @@ class Dataset(abc.ABC):
     default_fluid_type = "gas"
     default_field = ("gas", "density")
     fluid_types: Tuple[FieldType, ...] = ("gas", "deposit", "index")
-    particle_types: Optional[Tuple[ParticleType, ...]] = (
+    particle_types: Tuple[ParticleType, ...] = (
         "io",
     )  # By default we have an 'all'
     particle_types_raw: Optional[Tuple[ParticleType, ...]] = ("io",)

--- a/yt/data_objects/tests/test_cutting_plane.py
+++ b/yt/data_objects/tests/test_cutting_plane.py
@@ -40,7 +40,7 @@ def test_cutting_plane():
         for width in [(1.0, "unitary"), 1.0, ds.quan(0.5, "code_length")]:
             frb = cut.to_frb(width, 64)
             for cut_field in [("index", "ones"), ("gas", "density")]:
-                fi = ds._get_field_info("unknown", cut_field)
+                fi = ds._get_field_info(cut_field)
                 data = frb[cut_field]
                 assert_equal(data.info["data_source"], cut.__str__())
                 assert_equal(data.info["axis"], 4)

--- a/yt/data_objects/tests/test_data_containers.py
+++ b/yt/data_objects/tests/test_data_containers.py
@@ -56,7 +56,7 @@ class TestDataContainers(unittest.TestCase):
         # Delete a non-existent field
         with assert_raises(YTFieldNotFound) as ex:
             del proj["p_mass"]
-        desired = "Could not find field ('unknown', 'p_mass') in UniformGridData."
+        desired = "Could not find field 'p_mass' in UniformGridData."
         assert_equal(str(ex.exception), desired)
 
     def test_write_out(self):

--- a/yt/data_objects/tests/test_firefly.py
+++ b/yt/data_objects/tests/test_firefly.py
@@ -222,11 +222,6 @@ def test_field_tuple_specification(
             YTFieldNotFound,
         ),  # Test nonexistent field (dinos)
         (
-            ["pt2only_field"],
-            ["code_length"],
-            YTFieldNotFound,
-        ),  # Test unique field (match_any_particle_types=False)
-        (
             ["common_field"],
             ["code_length"],
             ValueError,
@@ -236,11 +231,6 @@ def test_field_tuple_specification(
             ["code_length"],
             YTFieldNotFound,
         ),  # Test nonexistent field tuple (pt1, pt2only_field)
-        (
-            ["pt2only_field", ("pt1", "common_field")],
-            ["code_length", "code_length"],
-            YTFieldNotFound,
-        ),  # Test mixed field spec (match_any_particle_types=False)
     ],
 )
 def test_field_invalid_specification(

--- a/yt/fields/field_detector.py
+++ b/yt/fields/field_detector.py
@@ -107,7 +107,7 @@ class FieldDetector(defaultdict):
             field = ("unknown", item)
         else:
             field = item
-        finfo = self.ds._get_field_info(*field)
+        finfo = self.ds._get_field_info(field)
         params, permute_params = finfo._get_needed_parameters(self)
         self.field_parameters.update(params)
         # For those cases where we are guessing the field type, we will
@@ -212,7 +212,7 @@ class FieldDetector(defaultdict):
 
     def _read_data(self, field_name):
         self.requested.append(field_name)
-        finfo = self.ds._get_field_info(*field_name)
+        finfo = self.ds._get_field_info(field_name)
         if finfo.sampling_type == "particle":
             self.requested.append(field_name)
             return np.ones(self.NumberOfParticles)

--- a/yt/fields/particle_fields.py
+++ b/yt/fields/particle_fields.py
@@ -67,7 +67,6 @@ def _field_concat(fname):
     def _AllFields(field, data):
         v = []
         for ptype in data.ds.particle_types:
-            data.ds._last_freq = (ptype, None)
             if ptype == "all" or ptype in data.ds.known_filters:
                 continue
             v.append(data[ptype, fname].copy())
@@ -81,7 +80,6 @@ def _field_concat_slice(fname, axi):
     def _AllFields(field, data):
         v = []
         for ptype in data.ds.particle_types:
-            data.ds._last_freq = (ptype, None)
             if ptype == "all" or ptype in data.ds.known_filters:
                 continue
             v.append(data[ptype, fname][:, axi])

--- a/yt/fields/tests/test_fields.py
+++ b/yt/fields/tests/test_fields.py
@@ -68,7 +68,7 @@ class TestFieldAccess:
         self.ds = ds
 
     def __call__(self):
-        field = self.ds._get_field_info(*self.field_name)
+        field = self.ds._get_field_info(self.field_name)
         skip_grids = False
         needs_spatial = False
         for v in field.validators:

--- a/yt/fields/tests/test_fields.py
+++ b/yt/fields/tests/test_fields.py
@@ -489,14 +489,6 @@ def test_morton_index():
     assert_array_equal(a1, a2)
 
 
-def test_field_inference():
-    ds = fake_random_ds(16)
-    ds.index
-    # If this is not true this means the result of field inference depends
-    # on the order we did field detection, which is random in Python3
-    assert_equal(ds._last_freq, (None, None))
-
-
 @requires_module("h5py")
 @requires_file(ISOGAL)
 def test_deposit_amr():

--- a/yt/fields/xray_emission_fields.py
+++ b/yt/fields/xray_emission_fields.py
@@ -216,7 +216,7 @@ def add_xray_emissivity_field(
     """
     if not isinstance(metallicity, float) and metallicity is not None:
         try:
-            metallicity = ds._get_field_info(*metallicity)
+            metallicity = ds._get_field_info(metallicity)
         except YTFieldNotFound as e:
             raise RuntimeError(
                 f"Your dataset does not have a {metallicity} field! "

--- a/yt/frontends/enzo_e/data_structures.py
+++ b/yt/frontends/enzo_e/data_structures.py
@@ -1,5 +1,6 @@
 import os
 from functools import cached_property
+from typing import Tuple
 
 import numpy as np
 
@@ -290,7 +291,7 @@ class EnzoEDataset(Dataset):
     _index_class = EnzoEHierarchy
     _field_info_class = EnzoEFieldInfo
     _suffix = ".block_list"
-    particle_types = None
+    particle_types: Tuple[str, ...] = ()
     particle_types_raw = None
 
     def __init__(

--- a/yt/frontends/stream/tests/test_stream_particles.py
+++ b/yt/frontends/stream/tests/test_stream_particles.py
@@ -56,35 +56,35 @@ def test_stream_particles():
 
     for ptype in ("all", "io"):
         assert (
-            ug1._get_field_info(ptype, "particle_position_x").sampling_type
+            ug1._get_field_info((ptype, "particle_position_x")).sampling_type
             == "particle"
         )
         assert (
-            ug1._get_field_info(ptype, "particle_position_y").sampling_type
+            ug1._get_field_info((ptype, "particle_position_y")).sampling_type
             == "particle"
         )
         assert (
-            ug1._get_field_info(ptype, "particle_position_z").sampling_type
+            ug1._get_field_info((ptype, "particle_position_z")).sampling_type
             == "particle"
         )
-        assert ug1._get_field_info(ptype, "particle_mass").sampling_type == "particle"
-    assert not ug1._get_field_info("gas", "density").sampling_type == "particle"
+        assert ug1._get_field_info((ptype, "particle_mass")).sampling_type == "particle"
+    assert not ug1._get_field_info(("gas", "density")).sampling_type == "particle"
 
     for ptype in ("all", "io"):
         assert (
-            ug2._get_field_info(ptype, "particle_position_x").sampling_type
+            ug2._get_field_info((ptype, "particle_position_x")).sampling_type
             == "particle"
         )
         assert (
-            ug2._get_field_info(ptype, "particle_position_y").sampling_type
+            ug2._get_field_info((ptype, "particle_position_y")).sampling_type
             == "particle"
         )
         assert (
-            ug2._get_field_info(ptype, "particle_position_z").sampling_type
+            ug2._get_field_info((ptype, "particle_position_z")).sampling_type
             == "particle"
         )
-        assert ug2._get_field_info(ptype, "particle_mass").sampling_type == "particle"
-    assert not ug2._get_field_info("gas", "density").sampling_type == "particle"
+        assert ug2._get_field_info((ptype, "particle_mass")).sampling_type == "particle"
+    assert not ug2._get_field_info(("gas", "density")).sampling_type == "particle"
 
     # Now perform similar checks, but with multiple particle types
 
@@ -138,31 +138,31 @@ def test_stream_particles():
 
     for ptype in ("dm", "star"):
         assert (
-            ug3._get_field_info(ptype, "particle_position_x").sampling_type
+            ug3._get_field_info((ptype, "particle_position_x")).sampling_type
             == "particle"
         )
         assert (
-            ug3._get_field_info(ptype, "particle_position_y").sampling_type
+            ug3._get_field_info((ptype, "particle_position_y")).sampling_type
             == "particle"
         )
         assert (
-            ug3._get_field_info(ptype, "particle_position_z").sampling_type
+            ug3._get_field_info((ptype, "particle_position_z")).sampling_type
             == "particle"
         )
-        assert ug3._get_field_info(ptype, "particle_mass").sampling_type == "particle"
+        assert ug3._get_field_info((ptype, "particle_mass")).sampling_type == "particle"
         assert (
-            ug4._get_field_info(ptype, "particle_position_x").sampling_type
-            == "particle"
-        )
-        assert (
-            ug4._get_field_info(ptype, "particle_position_y").sampling_type
+            ug4._get_field_info((ptype, "particle_position_x")).sampling_type
             == "particle"
         )
         assert (
-            ug4._get_field_info(ptype, "particle_position_z").sampling_type
+            ug4._get_field_info((ptype, "particle_position_y")).sampling_type
             == "particle"
         )
-        assert ug4._get_field_info(ptype, "particle_mass").sampling_type == "particle"
+        assert (
+            ug4._get_field_info((ptype, "particle_position_z")).sampling_type
+            == "particle"
+        )
+        assert ug4._get_field_info((ptype, "particle_mass")).sampling_type == "particle"
 
 
 def test_load_particles_types():

--- a/yt/frontends/ytdata/data_structures.py
+++ b/yt/frontends/ytdata/data_structures.py
@@ -407,7 +407,7 @@ class YTGrid(AMRGridPatch):
             fields = self._determine_fields(key)
         except YTFieldTypeNotFound:
             return tr
-        finfo = self.ds._get_field_info(*fields[0])
+        finfo = self.ds._get_field_info(fields[0])
         if not finfo.sampling_type == "particle":
             return tr.reshape(self.ActiveDimensions[: self.ds.dimensionality])
         return tr
@@ -578,7 +578,7 @@ class YTNonspatialGrid(AMRGridPatch):
             fields = self._determine_fields(key)
         except YTFieldTypeNotFound:
             return tr
-        self.ds._get_field_info(*fields[0])
+        self.ds._get_field_info(fields[0])
         return tr
 
     def get_data(self, fields=None):
@@ -610,7 +610,7 @@ class YTNonspatialGrid(AMRGridPatch):
         for field in self._determine_fields(fields):
             if field in self.field_data:
                 continue
-            finfo = self.ds._get_field_info(*field)
+            finfo = self.ds._get_field_info(field)
             try:
                 finfo.check_available(self)
             except NeedsGridType:
@@ -629,7 +629,7 @@ class YTNonspatialGrid(AMRGridPatch):
         fluids, particles = [], []
         finfos = {}
         for ftype, fname in fields_to_get:
-            finfo = self.ds._get_field_info(ftype, fname)
+            finfo = self.ds._get_field_info((ftype, fname))
             finfos[ftype, fname] = finfo
             if finfo.sampling_type == "particle":
                 particles.append((ftype, fname))

--- a/yt/frontends/ytdata/data_structures.py
+++ b/yt/frontends/ytdata/data_structures.py
@@ -628,13 +628,13 @@ class YTNonspatialGrid(AMRGridPatch):
         # We now split up into readers for the types of fields
         fluids, particles = [], []
         finfos = {}
-        for ftype, fname in fields_to_get:
-            finfo = self.ds._get_field_info((ftype, fname))
-            finfos[ftype, fname] = finfo
+        for field_key in fields_to_get:
+            finfo = self.ds._get_field_info(field_key)
+            finfos[field_key] = finfo
             if finfo.sampling_type == "particle":
-                particles.append((ftype, fname))
-            elif (ftype, fname) not in fluids:
-                fluids.append((ftype, fname))
+                particles.append(field_key)
+            elif field_key not in fluids:
+                fluids.append(field_key)
 
         # The _read method will figure out which fields it needs to get from
         # disk, and return a dict of those fields along with the fields that

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -1080,10 +1080,7 @@ def obj_length(v):
 
 def array_like_field(data, x, field):
     field = data._determine_fields(field)[0]
-    if isinstance(field, tuple):
-        finfo = data.ds._get_field_info(field[0], field[1])
-    else:
-        finfo = data.ds._get_field_info(field)
+    finfo = data.ds._get_field_info(field)
     if finfo.sampling_type == "particle":
         units = finfo.output_units
     else:

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -127,7 +127,7 @@ class YTFieldNotFound(YTException):
         ]
 
     def __str__(self):
-        msg = f"Could not find field {self.field} in {self.ds}."
+        msg = f"Could not find field {self.field!r} in {self.ds}."
         try:
             suggestions = self._get_suggestions()
         except AttributeError:

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -408,7 +408,7 @@ class YTFieldNotParseable(YTException):
         self.field = field
 
     def __str__(self):
-        return f"Cannot identify field {self.field}"
+        return f"Cannot identify field {self.field!r}"
 
 
 class YTDataSelectorNotImplemented(YTException):

--- a/yt/utilities/lib/octree_raytracing.py
+++ b/yt/utilities/lib/octree_raytracing.py
@@ -44,7 +44,7 @@ class OctreeRayTracing:
         data_source = self.data_source
         chunks = data_source.index._chunk(data_source, "spatial", ngz=1)
 
-        finfo = data_source.ds._get_field_info(*field)
+        finfo = data_source.ds._get_field_info(field)
         units = finfo.units
         rv = data_source.ds.arr(
             np.zeros((2, 2, 2, data_source.ires.size), dtype="float64"), units

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -1447,8 +1447,8 @@ class FITSOffAxisProjection(FITSImageData):
         fields = source._determine_fields(list(iter_fields(fields)))
         stddev_str = "_stddev" if moment == 2 else ""
         for item in fields:
-
-            key = (item[0], item[1] + stddev_str)
+            ftype, fname = item
+            key = (ftype, f"{fname}{stddev_str}")
 
             buf[key] = off_axis_projection(
                 source,
@@ -1467,9 +1467,8 @@ class FITSOffAxisProjection(FITSImageData):
                 def _sq_field(field, data, item: FieldKey):
                     return data[item] ** 2
 
-                fd = ds._get_field_info(*item)
-
-                field_sq = (item[0], f"tmp_{item[1]}_squared")
+                fd = ds._get_field_info(item)
+                field_sq = (ftype, f"tmp_{fname}_squared")
 
                 ds.add_field(
                     field_sq,

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -219,7 +219,7 @@ class FixedResolutionBuffer:
     def _get_info(self, item):
         info = {}
         ftype, fname = field = self.data_source._determine_fields(item)[0]
-        finfo = self.data_source.ds._get_field_info(*field)
+        finfo = self.data_source.ds._get_field_info(field)
         info["data_source"] = self.data_source.__str__()
         info["axis"] = self.data_source.axis
         info["field"] = str(item)
@@ -627,9 +627,10 @@ class OffAxisProjectionFixedResolutionBuffer(FixedResolutionBuffer):
             def _sq_field(field, data, item: FieldKey):
                 return data[item] ** 2
 
-            fd = self.ds._get_field_info(*item)
+            fd = self.ds._get_field_info(item)
+            ftype, fname = item
 
-            item_sq = (item[0], f"tmp_{item[1]}_squared")
+            item_sq = (ftype, f"tmp_{fname}_squared")
             self.ds.add_field(
                 item_sq,
                 partial(_sq_field, item=item),

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -1107,7 +1107,7 @@ class BaseLinePlot(PlotContainer, abc.ABC):
         axrect = self._get_axrect()
 
         pnh = NormHandler(self.data_source, display_units=self.data_source[field].units)
-        finfo = self.data_source.ds._get_field_info(*field)
+        finfo = self.data_source.ds._get_field_info(field)
         if not finfo.take_log:
             pnh.norm_type = Normalize
         plot = PlotMPL(self.figure_size, axrect, norm_handler=pnh)

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -951,7 +951,7 @@ class ContourCallback(PlotCallback):
             take_log = self.take_log
         else:
             field = data._determine_fields([self.field])[0]
-            take_log = plot.ds._get_field_info(*field).take_log
+            take_log = plot.ds._get_field_info(field).take_log
 
         if take_log:
             zi = np.log10(zi)

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -241,7 +241,7 @@ class PlotWindow(ImagePlotContainer, abc.ABC):
         self._setup_plots()
 
         for field in self.data_source._determine_fields(self.fields):
-            finfo = self.data_source.ds._get_field_info(*field)
+            finfo = self.data_source.ds._get_field_info(field)
             pnh = self.plots[field].norm_handler
             if finfo.take_log is False:
                 # take_log can be `None` so we explicitly compare against a boolean

--- a/yt/visualization/tests/test_geo_projections.py
+++ b/yt/visualization/tests/test_geo_projections.py
@@ -64,7 +64,7 @@ class TestGeoProjections(unittest.TestCase):
     def setUp(self):
         self.ds = fake_amr_ds(geometry="geographic")
         # switch off the log plot to avoid some unrelated matplotlib issues
-        f = self.ds._get_field_info("stream", "Density")
+        f = self.ds._get_field_info(("stream", "Density"))
         f.take_log = False
 
     @requires_module("cartopy")

--- a/yt/visualization/volume_rendering/old_camera.py
+++ b/yt/visualization/volume_rendering/old_camera.py
@@ -203,7 +203,7 @@ class Camera(ParallelAnalysisInterface):
         dd = self.ds.all_data()
         efields = dd._determine_fields(self.fields)
         if self.log_fields is None:
-            self.log_fields = [self.ds._get_field_info(*f).take_log for f in efields]
+            self.log_fields = [self.ds._get_field_info(f).take_log for f in efields]
         self.no_ghost = no_ghost
         self.use_light = use_light
         self.light_dir = None
@@ -1703,7 +1703,7 @@ class FisheyeCamera(Camera):
         fields = dd._determine_fields(fields)
         self.fields = fields
         if log_fields is None:
-            log_fields = [self.ds._get_field_info(*f).take_log for f in fields]
+            log_fields = [self.ds._get_field_info(f).take_log for f in fields]
         self.log_fields = log_fields
         self.sub_samples = sub_samples
         if volume is None:
@@ -2144,7 +2144,7 @@ class ProjectionCamera(Camera):
         ds = self.ds
         dd = ds.all_data()
         field = dd._determine_fields([self.field])[0]
-        finfo = ds._get_field_info(*field)
+        finfo = ds._get_field_info(field)
         dl = 1.0
         if self.method == "integrate":
             if self.weight is None:
@@ -2201,7 +2201,7 @@ class ProjectionCamera(Camera):
     def save_image(self, image, fn=None, clip_ratio=None):
         dd = self.ds.all_data()
         field = dd._determine_fields([self.field])[0]
-        finfo = self.ds._get_field_info(*field)
+        finfo = self.ds._get_field_info(field)
         if finfo.take_log:
             im = np.log10(image)
         else:


### PR DESCRIPTION
## PR Summary

While working on #4227 I stumbled again on this method, which turns out to be extremely delicate to correctly type.

Because this method is private, it doesn't *need* the amount of type flexibility it currently has: being strict on input type would make it much easier to maintain, and wouldn't take anything away from users.
I'll use this PR as an experimental playground to see how much of the codebase actually falls apart if I take away type flexibility and how much work is needed to fix it. I'm hoping the answer to both questions is "not that much".
