### PR TITLE
Fix pixel size calculation for density option in particle projection plots and FITS images

### DIFF
--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -771,8 +771,8 @@ class ParticleImageBuffer(FixedResolutionBuffer):
         # requested
         info = self._get_info(item)
         if density:
-            dpx = (self.bounds[1] - self.bounds[0]) / self.buff_size[0]
-            dpy = (self.bounds[3] - self.bounds[2]) / self.buff_size[1]
+            dpx = (bounds[1] - bounds[0]) / self.buff_size[0]
+            dpy = (bounds[3] - bounds[2]) / self.buff_size[1]
             norm = self.ds.quan(dpx * dpy, "code_length**2").in_base()
             buff /= norm.v
             units = data.units / norm.units

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -771,9 +771,9 @@ class ParticleImageBuffer(FixedResolutionBuffer):
         # requested
         info = self._get_info(item)
         if density:
-            width = self.data_source.width
-            norm = width[self.xax] * width[self.yax] / np.prod(self.buff_size)
-            norm = norm.in_base()
+            dpx = (self.bounds[1] - self.bounds[0]) / self.buff_size[0]
+            dpy = (self.bounds[3] - self.bounds[2]) / self.buff_size[1]
+            norm = self.ds.quan(dpx*dpy, "code_length**2").in_base()
             buff /= norm.v
             units = data.units / norm.units
             info["label"] = "%s $\\rm{Density}$" % info["label"]

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -773,7 +773,7 @@ class ParticleImageBuffer(FixedResolutionBuffer):
         if density:
             dpx = (self.bounds[1] - self.bounds[0]) / self.buff_size[0]
             dpy = (self.bounds[3] - self.bounds[2]) / self.buff_size[1]
-            norm = self.ds.quan(dpx*dpy, "code_length**2").in_base()
+            norm = self.ds.quan(dpx * dpy, "code_length**2").in_base()
             buff /= norm.v
             units = data.units / norm.units
             info["label"] = "%s $\\rm{Density}$" % info["label"]


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

`ParticleProjectionPlot` and `FITSParticleProjection` have a `density` option that divides the projected map by the area of the pixel of the fixed resolution buffer to compute a projected particle density. The computation of the pixel area was being handled incorrectly--it was using the width of the underlying `data_source` for the projection instead of the `bounds` of the FRB to compute the pixel sizes. This PR fixes that. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
