### PR TITLE
STY: upgrade flake8-bugbear and fix newly detected errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
     hooks:
     - id: flake8
       additional_dependencies: [
-        flake8-bugbear==22.7.1,
+        flake8-bugbear==22.12.6,
         flake8-logging-format==0.7.4,
         flake8-2020==1.6.1,
       ]
@@ -78,7 +78,7 @@ repos:
     - id: nbqa-flake8
       args: [--extend-ignore=E402]
       additional_dependencies: [
-        flake8-bugbear==22.7.1,
+        flake8-bugbear==22.12.6,
         flake8-logging-format==0.7.4,
       ]
 

--- a/doc/helper_scripts/run_recipes.py
+++ b/doc/helper_scripts/run_recipes.py
@@ -46,11 +46,11 @@ def run_recipe(payload):
         prep_dirs()
         try:
             subprocess.check_call(["python", recipe])
-        except Exception:
+        except Exception as exc:
             trace = "".join(traceback.format_exception(*sys.exc_info()))
             trace += f" in module: {module_name}\n"
             trace += f" recipe: {recipe}\n"
-            raise Exception(trace)
+            raise Exception(trace) from exc
         open(f"{CWD}/_temp/{module_name}.done", "wb").close()
         for pattern in FPATTERNS:
             for fname in glob.glob(pattern):

--- a/setup.cfg
+++ b/setup.cfg
@@ -145,4 +145,6 @@ ignore =
     E741,
     W503,
 enable-extensions = G  # flake8-logging-format (extension is disabled by default)
+extend-select =
+    B902,
 jobs = 8

--- a/setup.cfg
+++ b/setup.cfg
@@ -147,4 +147,5 @@ ignore =
 enable-extensions = G  # flake8-logging-format (extension is disabled by default)
 extend-select =
     B902,
+    B904,
 jobs = 8

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -49,7 +49,7 @@ def call_unix_command(command):
         raise RuntimeError(
             "Command '%s' failed with return code '%s' and error:\n\n%s"
             % (command, er.returncode, er.output.decode("utf-8"))
-        )
+        ) from er
     finally:
         if len(output.splitlines()) > 25:
             print("truncated output:")

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -456,7 +456,7 @@ class Dataset(abc.ABC):
         """
         return [], True
 
-    def close(self):
+    def close(self):  # noqa: B027
         pass
 
     def __getitem__(self, key):
@@ -1966,7 +1966,7 @@ def _reconstruct_ds(*args, **kwargs):
 
 
 @functools.total_ordering
-class ParticleFile(abc.ABC):
+class ParticleFile:
     filename: str
     file_id: int
 
@@ -1989,13 +1989,13 @@ class ParticleFile(abc.ABC):
             self.start = 0
         self.end = max(self.total_particles.values()) + self.start
 
-    def select(self, selector):
+    def select(self, selector):  # noqa: B027
         pass
 
-    def count(self, selector):
+    def count(self, selector):  # noqa: B027
         pass
 
-    def _calculate_offsets(self, fields, pcounts):
+    def _calculate_offsets(self, fields, pcounts):  # noqa: B027
         pass
 
     def __lt__(self, other):

--- a/yt/data_objects/time_series.py
+++ b/yt/data_objects/time_series.py
@@ -3,6 +3,7 @@ import glob
 import inspect
 import os
 import weakref
+from abc import ABC, abstractmethod
 from functools import wraps
 from typing import Optional, Type
 
@@ -478,7 +479,7 @@ class DatasetSeriesObject:
         return cls(*self._args, **self._kwargs)
 
 
-class SimulationTimeSeries(DatasetSeries):
+class SimulationTimeSeries(DatasetSeries, ABC):
     def __init__(self, parameter_filename, find_outputs=False):
         """
         Base class for generating simulation time series types.
@@ -506,19 +507,23 @@ class SimulationTimeSeries(DatasetSeries):
 
         self.print_key_parameters()
 
-    def _set_parameter_defaults(self):
+    def _set_parameter_defaults(self):  # noqa: B027
         pass
 
+    @abstractmethod
     def _parse_parameter_file(self):
         pass
 
+    @abstractmethod
     def _set_units(self):
         pass
 
+    @abstractmethod
     def _calculate_simulation_bounds(self):
         pass
 
-    def _get_all_outputs(**kwargs):
+    @abstractmethod
+    def _get_all_outputs(self, *, find_outputs=False):
         pass
 
     def __repr__(self):

--- a/yt/exthook.py
+++ b/yt/exthook.py
@@ -79,7 +79,7 @@ class ExtensionImporter:
                 # we swallow it and try the next choice.  The skipped frame
                 # is the one from __import__ above which we don't care about
                 if self.is_important_traceback(realname, tb):
-                    raise exc_value.with_traceback(tb.tb_next)
+                    raise exc_value.with_traceback(tb.tb_next)  # noqa: B904
                 continue
             module = sys.modules[fullname] = sys.modules[realname]
             if "." not in modname:

--- a/yt/fields/field_detector.py
+++ b/yt/fields/field_detector.py
@@ -67,7 +67,7 @@ class FieldDetector(defaultdict):
 
         class fake_index:
             class fake_io:
-                def _read_data_set(io_self, data, field):
+                def _read_data_set(io_self, data, field):  # noqa: B902
                     return self._read_data(field)
 
                 _read_exception = RuntimeError

--- a/yt/frontends/adaptahop/definitions.py
+++ b/yt/frontends/adaptahop/definitions.py
@@ -4,7 +4,6 @@ Data structures for AdaptaHOP
 
 
 """
-import abc
 from typing import Tuple, Union
 
 from yt.funcs import mylog
@@ -28,7 +27,8 @@ def HEADER_ATTRIBUTES(*, double: bool, longint: bool) -> ATTR_T:
 ADAPTAHOP_TEMPLATES = {}
 
 
-class AdaptaHOPDefTemplate(abc.ABC):
+class AdaptaHOPDefTemplate:
+    # this is a mixin class
     def __init_subclass__(cls, *args, **kwargs):
         super().__init_subclass__(*args, **kwargs)
         mylog.debug("Registering AdaptaHOP template class %s", cls.__name__)

--- a/yt/frontends/chimera/data_structures.py
+++ b/yt/frontends/chimera/data_structures.py
@@ -267,7 +267,7 @@ class ChimeraDataset(Dataset):
         self.cosmological_simulation = 0  # Chimera is not a cosmological simulation
 
     @classmethod
-    def _is_valid(self, *args, **kwargs):
+    def _is_valid(cls, *args, **kwargs):
         # This accepts a filename or a set of arguments and returns True or
         # False depending on if the file is of the type requested.
         try:

--- a/yt/frontends/enzo/simulation_handling.py
+++ b/yt/frontends/enzo/simulation_handling.py
@@ -495,7 +495,7 @@ class EnzoSimulation(SimulationTimeSeries):
             self.all_time_outputs.append(output)
             index += 1
 
-    def _get_all_outputs(self, find_outputs=False):
+    def _get_all_outputs(self, *, find_outputs=False):
         """
         Get all potential datasets and combine into a time-sorted list.
         """

--- a/yt/frontends/gadget/simulation_handling.py
+++ b/yt/frontends/gadget/simulation_handling.py
@@ -408,7 +408,7 @@ class GadgetSimulation(SimulationTimeSeries):
         filename = f"{self.parameters['SnapshotFileBase']}_{count}{suffix}"
         return os.path.join(self.data_dir, filename)
 
-    def _get_all_outputs(self, find_outputs=False):
+    def _get_all_outputs(self, *, find_outputs=False):
         """
         Get all potential datasets and combine into a time-sorted list.
         """

--- a/yt/frontends/halo_catalog/data_structures.py
+++ b/yt/frontends/halo_catalog/data_structures.py
@@ -383,7 +383,7 @@ class YTHaloDataset(HaloDataset):
         pass
 
     @classmethod
-    def _is_valid(self, *args, **kwargs):
+    def _is_valid(cls, *args, **kwargs):
         # We don't ever want this to be loaded by yt.load.
         return False
 

--- a/yt/frontends/stream/definitions.py
+++ b/yt/frontends/stream/definitions.py
@@ -159,20 +159,19 @@ def process_data(data, grid_dims=None, allow_callables=True):
 
         # val is a tuple of (data, units)
         elif isinstance(val, tuple) and len(val) == 2:
-            try:
-                valid_data = isinstance(val[0], np.ndarray)
-                if allow_callables:
-                    valid_data = valid_data or callable(val[0])
-                assert isinstance(field, (str, tuple)), "Field name is not a string!"
-                assert (
-                    valid_data
-                ), "Field data is not an ndarray or callable (with nproc == 1)!"
-                assert isinstance(val[1], str), "Unit specification is not a string!"
-                field_units[field] = val[1]
-                new_data[field] = val[0]
-            except AssertionError as e:
-                raise RuntimeError("The data dict appears to be invalid.\n" + str(e))
-
+            valid_data = isinstance(val[0], np.ndarray)
+            if allow_callables:
+                valid_data = valid_data or callable(val[0])
+            if not isinstance(field, (str, tuple)):
+                raise TypeError("Field name is not a string!")
+            if not valid_data:
+                raise TypeError(
+                    "Field data is not an ndarray or callable (with nproc == 1)!"
+                )
+            if not isinstance(val[1], str):
+                raise TypeError("Unit specification is not a string!")
+            field_units[field] = val[1]
+            new_data[field] = val[0]
         # val is a list of data to be turned into an array
         elif is_sequence(val):
             field_units[field] = ""

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -1588,8 +1588,8 @@ def load_archive(
 
     try:
         tarfile.open(fn)
-    except tarfile.ReadError:
-        raise YTUnidentifiedDataType(fn, *args, **kwargs)
+    except tarfile.ReadError as exc:
+        raise YTUnidentifiedDataType(fn, *args, **kwargs) from exc
 
     # Note: the temporary directory will be created by ratarmount
     tempdir = fn + ".mount"

--- a/yt/tests/test_testing.py
+++ b/yt/tests/test_testing.py
@@ -33,4 +33,4 @@ def test_requires_active_backend():
     except SkipTest:
         raise AssertionError(
             "@requires_backend appears to be broken (skip was not expected)"
-        )
+        ) from None

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -216,8 +216,8 @@ class AnswerTestCloudStorage(AnswerTestStorage):
         url = _url_path.format(self.reference_name, ds_name)
         try:
             resp = urllib.request.urlopen(url)
-        except urllib.error.HTTPError:
-            raise YTNoOldAnswer(url)
+        except urllib.error.HTTPError as exc:
+            raise YTNoOldAnswer(url) from exc
         else:
             for _ in range(3):
                 try:

--- a/yt/utilities/minimal_representation.py
+++ b/yt/utilities/minimal_representation.py
@@ -131,7 +131,7 @@ class MinimalRepresentation(metaclass=abc.ABCMeta):
                     else:
                         g.create_dataset(fname, data=fdata, compression="lzf")
 
-    def restore(self, storage, ds):
+    def restore(self, storage, ds):  # noqa: B027
         pass
 
     def upload(self):

--- a/yt/utilities/parameter_file_storage.py
+++ b/yt/utilities/parameter_file_storage.py
@@ -75,8 +75,8 @@ class ParameterFileStore:
         try:
             if not os.path.isdir(dbdir):
                 os.mkdir(dbdir)
-        except OSError:
-            raise NoParameterShelf()
+        except OSError as exc:
+            raise NoParameterShelf from exc
         open(dbn, "ab")  # make sure it exists, allow to close
         # Now we read in all our records and return them
         # these will be broadcast

--- a/yt/utilities/sdf.py
+++ b/yt/utilities/sdf.py
@@ -14,7 +14,7 @@ def get_thingking_deps():
     except ImportError:
         raise ImportError(
             "This functionality requires the thingking package to be installed"
-        )
+        ) from None
     return HTTPArray, PageCacheURL
 
 

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -2536,14 +2536,16 @@ class TimestampCallback(PlotCallback):
         if self.time and self.redshift:
             self.text += "\n"
 
+        if self.redshift and not hasattr(plot.data.ds, "current_redshift"):
+            warnings.warn(
+                f"dataset {plot.data.ds} does not have current_redshift attribute. "
+                "Set redshift=False to silence this warning."
+            )
+            self.redshift = False
+
         # If we're annotating the redshift, put it in the correct format
         if self.redshift:
-            try:
-                z = plot.data.ds.current_redshift
-            except AttributeError:
-                raise AttributeError(
-                    "Dataset does not have current_redshift. Set redshift=False."
-                )
+            z = plot.data.ds.current_redshift
             # Replace instances of -0.0* with 0.0* to avoid
             # negative null redshifts (e.g., "-0.00").
             self.text += self.redshift_format.format(redshift=float(z))

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1367,9 +1367,10 @@ class PWViewerMPL(PlotWindow):
         return fig
 
 
-class NormalPlot(abc.ABC):
+class NormalPlot:
     """This is the abstraction for SlicePlot and ProjectionPlot, where
     we define the common sanitizing mechanism for user input (normal direction).
+    It is implemented as a mixin class.
     """
 
     @staticmethod


### PR DESCRIPTION
## PR Summary
Opening as a draft because it's not obvious that adding `@abstractmethod` decorators here and there will not crash tests


TODO:
- [x] survive CI (use noqa comments when making empty methods abstract breaks things)
- [x] extend checks to B902 + fix
- [x] extend checks to B904 + fix 