### PR TITLE
BUG: avoid a deprecation warning from numpy

### DIFF
--- a/yt/visualization/_handlers.py
+++ b/yt/visualization/_handlers.py
@@ -285,12 +285,16 @@ class NormHandler:
         dvmin = dvmax = None
 
         finite_values_mask = np.isfinite(data)
-        if self.vmin not in (None, "min"):
+        if self.vmin is not None and not (
+            isinstance(self.vmin, str) and self.vmin == "min"
+        ):
             dvmin = self.to_float(self.vmin)
         elif np.any(finite_values_mask):
             dvmin = self.to_float(np.nanmin(data[finite_values_mask]))
 
-        if self.vmax not in (None, "max"):
+        if self.vmax is not None and not (
+            isinstance(self.vmax, str) and self.vmax == "max"
+        ):
             dvmax = self.to_float(self.vmax)
         elif np.any(finite_values_mask):
             dvmax = self.to_float(np.nanmax(data[finite_values_mask]))


### PR DESCRIPTION
## PR Summary
Fix #4241 for good
In insight, the logic here could be simplified a lot by using clearer sentinel values instead of special casing `None` AND some strings, but I'll keep the patch minimal so it's easier to review and backport
