### PR TITLE
BLD: fix missing specs from minimal requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -104,9 +104,11 @@ minimal =
     matplotlib==3.2
     more-itertools==8.4
     numpy==1.17.5
+    packaging==20.9
     pillow==6.2.1
     pyparsing==2.0.3
     tomli-w==0.4.0
+    tqdm==3.4.0
     unyt==2.9.2
     tomli==1.2.3;python_version < '3.11'
 test =


### PR DESCRIPTION
## PR Summary

Just spotted these two out-of-sync requirements from install_requires.
