### PR TITLE
TYP: add missing type hints

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -233,7 +233,17 @@ class Dataset(abc.ABC):
         filename: str,
         dataset_type: Optional[str] = None,
         units_override: Optional[Dict[str, str]] = None,
-        unit_system: Literal["cgs", "mks", "code"] = "cgs",
+        # valid unit_system values include all keys from unyt.unit_systems.unit_systems_registry + "code"
+        unit_system: Literal[
+            "cgs",
+            "mks",
+            "imperial",
+            "galactic",
+            "solar",
+            "geometrized",
+            "planck",
+            "code",
+        ] = "cgs",
         default_species_fields: Optional[
             "Any"
         ] = None,  # Any used as a placeholder here
@@ -1215,7 +1225,20 @@ class Dataset(abc.ABC):
     def relative_refinement(self, l0, l1):
         return self.refine_by ** (l1 - l0)
 
-    def _assign_unit_system(self, unit_system: Literal["cgs", "mks", "code"]) -> None:
+    def _assign_unit_system(
+        self,
+        # valid unit_system values include all keys from unyt.unit_systems.unit_systems_registry + "code"
+        unit_system: Literal[
+            "cgs",
+            "mks",
+            "imperial",
+            "galactic",
+            "solar",
+            "geometrized",
+            "planck",
+            "code",
+        ],
+    ) -> None:
         # we need to determine if the requested unit system
         # is mks-like: i.e., it has a current with the same
         # dimensions as amperes.

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -1309,7 +1309,7 @@ class YTUploadFileCmd(YTCommand):
 
 
 class YTConfigLocalConfigHandler:
-    def load_config(self, args):
+    def load_config(self, args) -> None:
         import os
 
         from yt.config import YTConfig
@@ -1324,12 +1324,12 @@ class YTConfigLocalConfigHandler:
         local_arg_exists = hasattr(args, "local")
         global_arg_exists = hasattr(args, "global")
 
+        config_file: Optional[str] = None
         if getattr(args, "local", False):
             config_file = local_config_file
         elif getattr(args, "global", False):
             config_file = global_config_file
         else:
-            config_file: Optional[str] = None
             if local_exists and global_exists:
                 s = (
                     "Yt detected a local and a global configuration file, refusing "

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -3,7 +3,7 @@ import re
 import warnings
 from abc import ABC, abstractmethod
 from functools import update_wrapper
-from numbers import Integral, Number, Real
+from numbers import Integral, Number
 from typing import Any, Dict, Optional, Tuple, Type, Union
 
 import matplotlib
@@ -879,7 +879,7 @@ class ContourCallback(PlotCallback):
         self.text_args = text_args
         self.data_source = data_source
 
-    def __call__(self, plot):
+    def __call__(self, plot) -> None:
         from matplotlib.tri import LinearTriInterpolator, Triangulation
 
         # These need to be in code_length
@@ -917,7 +917,7 @@ class ContourCallback(PlotCallback):
                 XShifted = data["px"].copy()
                 YShifted = data["py"].copy()
                 dom_x, dom_y = plot._period
-                for shift in np.mgrid[-1:1:3j]:
+                for shift in np.mgrid[-1:1:3j]:  # type: ignore [misc]
                     xlim = (data["px"] + shift * dom_x >= x0) & (
                         data["px"] + shift * dom_x <= x1
                     )
@@ -955,7 +955,7 @@ class ContourCallback(PlotCallback):
         if take_log:
             zi = np.log10(zi)
 
-        clim: Union[Tuple[Real, Real], None]
+        clim: Optional[Tuple[float, float]]
         if take_log and self.clim is not None:
             clim = np.log10(self.clim[0]), np.log10(self.clim[1])
         else:

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -181,7 +181,7 @@ class PlotWindow(ImagePlotContainer, abc.ABC):
         setup=False,
         *,
         geometry="cartesian",
-    ):
+    ) -> None:
 
         # axis manipulation operations are callback-only:
         self._swap_axes_input = False
@@ -191,7 +191,7 @@ class PlotWindow(ImagePlotContainer, abc.ABC):
         self.center = None
         self._periodic = periodic
         self.oblique = oblique
-        self._equivalencies = defaultdict(lambda: (None, {}))
+        self._equivalencies = defaultdict(lambda: (None, {}))  # type: ignore [var-annotated]
         self.buff_size = buff_size
         self.antialias = antialias
         self._axes_unit_names = None
@@ -204,6 +204,7 @@ class PlotWindow(ImagePlotContainer, abc.ABC):
         fields = list(iter_fields(fields))
         self.override_fields = list(set(fields).intersection(set(skip)))
         self.fields = [f for f in fields if f not in skip]
+        self._frb: Optional[FixedResolutionBuffer] = None
         super().__init__(data_source, window_size, fontsize)
 
         self._set_window(bounds)  # this automatically updates the data and plot
@@ -273,8 +274,6 @@ class PlotWindow(ImagePlotContainer, abc.ABC):
         for ds in self.ts.piter(*args, **kwargs):
             self._switch_ds(ds)
             yield self
-
-    _frb: Optional[FixedResolutionBuffer] = None
 
     @property
     def frb(self):
@@ -856,7 +855,6 @@ class PWViewerMPL(PlotWindow):
         if self._plot_type is None:
             self._plot_type = kwargs.pop("plot_type")
         self._splat_color = kwargs.pop("splat_color", None)
-        self._frb: Optional[FixedResolutionBuffer] = None
         PlotWindow.__init__(self, *args, **kwargs)
 
         # import type here to avoid import cycles

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -274,7 +274,7 @@ class PlotWindow(ImagePlotContainer, abc.ABC):
             self._switch_ds(ds)
             yield self
 
-    _frb = None
+    _frb: Optional[FixedResolutionBuffer] = None
 
     @property
     def frb(self):
@@ -850,7 +850,7 @@ class PWViewerMPL(PlotWindow):
     _frb_generator: Optional[Type[FixedResolutionBuffer]] = None
     _plot_type: Optional[str] = None
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         if self._frb_generator is None:
             self._frb_generator = kwargs.pop("frb_generator")
         if self._plot_type is None:


### PR DESCRIPTION
## PR Summary

Complements #4229 in fixing the remaining warnings from mypy (`[annotation-unchecked]`)

```
yt/data_objects/static_output.py: note: In member "_assign_unit_system" of class "Dataset":
yt/data_objects/static_output.py:1254: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
... 
```
