### PR TITLE
DEPR: do not try to predict removal dates in deprecation warnings by default

### DIFF
--- a/yt/_maintenance/deprecation.py
+++ b/yt/_maintenance/deprecation.py
@@ -44,11 +44,9 @@ def issue_deprecation_warning(
     ... )
     """
 
-    msg += f"\nDeprecated since yt {since}\nThis feature is planned for removal "
-    if removal is None:
-        msg += "two minor releases later (anticipated)"
-    else:
-        msg += f"in yt {removal}"
+    msg += f"\nDeprecated since yt {since}"
+    if removal is not None:
+        msg += f"\nThis feature is planned for removal in yt {removal}"
     warnings.warn(msg, VisibleDeprecationWarning, stacklevel=stacklevel)
 
 


### PR DESCRIPTION
## PR Summary

A hard-learned lesson from yt 4.1 was that making promises about when deprecated features would be removed can sometimes come back at us and make releases much more difficult to polish.
In most recent feature releases (4.0, 4.1, and soon 4.2), we made some eager cuts through stuff that was deprecated in the previous 7 or so years, but long term it's probably better to just _not_ try to anticipate too accurately when deprecated code is actually going to be removed, and we can probably just live with it as long as it doesn't impede further developments.
