### PR TITLE
TST: speedup test_callbacks (⏰ wait for #4122)

### DIFF
--- a/yt/visualization/tests/test_callbacks.py
+++ b/yt/visualization/tests/test_callbacks.py
@@ -710,7 +710,8 @@ def test_contour_callback():
         text_args={"fmt": "%1.1f"},
     )
     slc.render()
-    check_axis_manipulation(slc)
+    # deactivated because it makes the test case 7 times as long (10s to 70s)
+    # check_axis_manipulation(slc)
 
     ds = fake_amr_ds(
         fields=("density", "temperature"),

--- a/yt/visualization/tests/test_callbacks.py
+++ b/yt/visualization/tests/test_callbacks.py
@@ -1,7 +1,4 @@
-import contextlib
 import inspect
-import shutil
-import tempfile
 
 from numpy.testing import assert_array_equal, assert_raises
 
@@ -9,7 +6,6 @@ import yt.units as u
 from yt.config import ytcfg
 from yt.loaders import load
 from yt.testing import (
-    assert_fname,
     fake_amr_ds,
     fake_hexahedral_ds,
     fake_random_ds,
@@ -22,7 +18,7 @@ from yt.utilities.answer_testing.framework import (
     requires_ds,
 )
 from yt.utilities.exceptions import YTDataTypeUnsupported, YTPlotCallbackError
-from yt.visualization.api import OffAxisSlicePlot, ProjectionPlot, SlicePlot
+from yt.visualization.api import ProjectionPlot, SlicePlot
 from yt.visualization.plot_container import accepts_all_fields
 
 # These are a very simple set of tests that verify that each callback is or is
@@ -65,19 +61,12 @@ cyl_2d = "WDMerger_hdf5_chk_1000/WDMerger_hdf5_chk_1000.hdf5"
 cyl_3d = "MHD_Cyl3d_hdf5_plt_cnt_0100/MHD_Cyl3d_hdf5_plt_cnt_0100.hdf5"
 
 
-@contextlib.contextmanager
-def _cleanup_fname():
-    tmpdir = tempfile.mkdtemp()
-    yield tmpdir
-    shutil.rmtree(tmpdir)
-
-
 def test_method_signature():
     ds = fake_amr_ds(
         fields=[("gas", "density"), ("gas", "velocity_x"), ("gas", "velocity_y")],
         units=["g/cm**3", "m/s", "m/s"],
     )
-    p = SlicePlot(ds, "z", ("gas", "density"))
+    p = SlicePlot(ds, "z", ("gas", "density"), buff_size=(40, 40))
     sig = inspect.signature(p.annotate_velocity)
     # checking the first few arguments rather than the whole signature
     # we just want to validate that method wrapping works
@@ -94,12 +83,12 @@ def test_init_signature_error_callback():
         fields=[("gas", "density"), ("gas", "velocity_x"), ("gas", "velocity_y")],
         units=["g/cm**3", "m/s", "m/s"],
     )
-    p = SlicePlot(ds, "z", ("gas", "density"))
+    p = SlicePlot(ds, "z", ("gas", "density"), buff_size=(40, 40))
     # annotate_velocity accepts only one positional argument
     assert_raises(TypeError, p.annotate_velocity, 1, 2, 3)
 
 
-def check_axis_manipulation(plot_obj, prefix):
+def check_axis_manipulation(plot_obj):
     # convenience function for testing functionality of axis manipulation
     # callbacks. Can use in any of the other test functions.
 
@@ -107,7 +96,7 @@ def check_axis_manipulation(plot_obj, prefix):
     for cb in ("swap_axes", "flip_horizontal", "flip_vertical"):
         callback_handle = getattr(plot_obj, cb)
         callback_handle()  # toggles on for axis operation
-        assert_fname(plot_obj.save(prefix)[0])
+        plot_obj.render()
         callback_handle()  # toggle off
 
     # test all at once
@@ -115,375 +104,358 @@ def check_axis_manipulation(plot_obj, prefix):
         callback_handle = getattr(plot_obj, cb)
         callback_handle()
 
-    assert_fname(plot_obj.save(prefix)[0])
+    plot_obj.render()
 
 
 def test_timestamp_callback():
-    with _cleanup_fname() as prefix:
-        ax = "z"
-        vector = [1.0, 1.0, 1.0]
-        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
-        p = ProjectionPlot(ds, ax, ("gas", "density"))
-        p.annotate_timestamp()
-        assert_fname(p.save(prefix)[0])
-        p = SlicePlot(ds, ax, ("gas", "density"))
-        p.annotate_timestamp()
-        assert_fname(p.save(prefix)[0])
-        p = OffAxisSlicePlot(ds, vector, ("gas", "density"))
-        p.annotate_timestamp()
-        assert_fname(p.save(prefix)[0])
-        # Now we'll check a few additional minor things
-        p = SlicePlot(ds, "x", ("gas", "density"))
-        p.annotate_timestamp(corner="lower_right", redshift=True, draw_inset_box=True)
-        p.save(prefix)
+    ax = "z"
+    vector = [1.0, 1.0, 1.0]
+    ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
+    p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+    p.annotate_timestamp()
+    p.render()
+    p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+    p.annotate_timestamp()
+    p.render()
+    p = SlicePlot(ds, vector, ("gas", "density"), buff_size=(40, 40))
+    p.annotate_timestamp()
+    p.render()
+    # Now we'll check a few additional minor things
+    p = SlicePlot(ds, "x", ("gas", "density"), buff_size=(40, 40))
+    p.annotate_timestamp(corner="lower_right", redshift=True, draw_inset_box=True)
+    p.render()
 
-    with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
-        p = ProjectionPlot(ds, "r", ("gas", "density"))
-        assert_raises(YTDataTypeUnsupported, p.annotate_timestamp, coord_system="data")
-        p.annotate_timestamp(coord_system="axis")
-        assert_fname(p.save(prefix)[0])
+
+def test_timestamp_callback_spherical():
+    ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
+    p = SlicePlot(ds, "r", ("gas", "density"), buff_size=(40, 40))
+    assert_raises(YTDataTypeUnsupported, p.annotate_timestamp, coord_system="data")
+    p.annotate_timestamp(coord_system="axis")
+    p.render()
 
 
 def test_timestamp_callback_code_units():
     # see https://github.com/yt-project/yt/issues/3869
-    with _cleanup_fname() as prefix:
-        ds = fake_random_ds(2, unit_system="code")
-        p = SlicePlot(ds, "z", ("gas", "density"))
-        p.annotate_timestamp()
-        assert_fname(p.save(prefix)[0])
+    ds = fake_random_ds(2, unit_system="code")
+    p = SlicePlot(ds, "z", ("gas", "density"), buff_size=(40, 40))
+    p.annotate_timestamp()
+    p.render()
 
 
 def test_scale_callback():
-    with _cleanup_fname() as prefix:
-        ax = "z"
-        vector = [1.0, 1.0, 1.0]
-        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
-        p = ProjectionPlot(ds, ax, ("gas", "density"))
-        p.annotate_scale()
-        assert_fname(p.save(prefix)[0])
-        p = ProjectionPlot(ds, ax, ("gas", "density"), width=(0.5, 1.0))
-        p.annotate_scale()
-        assert_fname(p.save(prefix)[0])
-        p = ProjectionPlot(ds, ax, ("gas", "density"), width=(1.0, 1.5))
-        p.annotate_scale()
-        assert_fname(p.save(prefix)[0])
-        p = SlicePlot(ds, ax, ("gas", "density"))
-        p.annotate_scale()
-        assert_fname(p.save(prefix)[0])
-        p = OffAxisSlicePlot(ds, vector, ("gas", "density"))
-        p.annotate_scale()
-        assert_fname(p.save(prefix)[0])
-        # Now we'll check a few additional minor things
-        p = SlicePlot(ds, "x", ("gas", "density"))
-        p.annotate_scale(corner="upper_right", coeff=10.0, unit="kpc")
-        assert_fname(p.save(prefix)[0])
-        p = SlicePlot(ds, "x", ("gas", "density"))
-        p.annotate_scale(text_args={"size": 24})
-        assert_fname(p.save(prefix)[0])
-        p = SlicePlot(ds, "x", ("gas", "density"))
-        p.annotate_scale(text_args={"font": 24})
-        assert_raises(YTPlotCallbackError)
+    ax = "z"
+    vector = [1.0, 1.0, 1.0]
+    ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
+    p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+    p.annotate_scale()
+    p.render()
+    p = SlicePlot(ds, ax, ("gas", "density"), width=(0.5, 1.0), buff_size=(40, 40))
+    p.annotate_scale()
+    p.render()
+    p = SlicePlot(ds, ax, ("gas", "density"), width=(1.0, 1.5), buff_size=(40, 40))
+    p.annotate_scale()
+    p.render()
+    p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+    p.annotate_scale()
+    p.render()
+    p = SlicePlot(ds, vector, ("gas", "density"), buff_size=(40, 40))
+    p.annotate_scale()
+    p.render()
+    # Now we'll check a few additional minor things
+    p = SlicePlot(ds, "x", ("gas", "density"), buff_size=(40, 40))
+    p.annotate_scale(corner="upper_right", coeff=10.0, unit="kpc")
+    p.render()
+    p = SlicePlot(ds, "x", ("gas", "density"), buff_size=(40, 40))
+    p.annotate_scale(text_args={"size": 24})
+    p.render()
+    p = SlicePlot(ds, "x", ("gas", "density"), buff_size=(40, 40))
+    p.annotate_scale(text_args={"font": 24})
+    assert_raises(YTPlotCallbackError)
 
-    with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
-        p = ProjectionPlot(ds, "r", ("gas", "density"))
-        assert_raises(YTDataTypeUnsupported, p.annotate_scale)
-        assert_raises(YTDataTypeUnsupported, p.annotate_scale, coord_system="axis")
+
+def test_scale_callback_spherical():
+    ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
+    p = SlicePlot(ds, "r", ("gas", "density"), buff_size=(40, 40))
+    assert_raises(YTDataTypeUnsupported, p.annotate_scale)
+    assert_raises(YTDataTypeUnsupported, p.annotate_scale, coord_system="axis")
 
 
 def test_line_callback():
-    with _cleanup_fname() as prefix:
-        ax = "z"
-        vector = [1.0, 1.0, 1.0]
-        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
-        p = ProjectionPlot(ds, ax, ("gas", "density"))
-        p.annotate_line([0.1, 0.1, 0.1], [0.5, 0.5, 0.5])
-        assert_fname(p.save(prefix)[0])
-        p = SlicePlot(ds, ax, ("gas", "density"))
-        p.annotate_line([0.1, 0.1, 0.1], [0.5, 0.5, 0.5])
-        assert_fname(p.save(prefix)[0])
-        p = OffAxisSlicePlot(ds, vector, ("gas", "density"))
-        p.annotate_line([0.1, 0.1, 0.1], [0.5, 0.5, 0.5])
-        assert_fname(p.save(prefix)[0])
-        # Now we'll check a few additional minor things
-        p = SlicePlot(ds, "x", ("gas", "density"))
-        p.annotate_line([0.1, 0.1], [0.5, 0.5], coord_system="axis", color="red")
-        p.save(prefix)
-        check_axis_manipulation(p, prefix)
+    ax = "z"
+    vector = [1.0, 1.0, 1.0]
+    ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
+    p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+    p.annotate_line([0.1, 0.1, 0.1], [0.5, 0.5, 0.5])
+    p.render()
+    p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+    p.annotate_line([0.1, 0.1, 0.1], [0.5, 0.5, 0.5])
+    p.render()
+    p = SlicePlot(ds, vector, ("gas", "density"), buff_size=(40, 40))
+    p.annotate_line([0.1, 0.1, 0.1], [0.5, 0.5, 0.5])
+    p.render()
+    # Now we'll check a few additional minor things
+    p = SlicePlot(ds, "x", ("gas", "density"), buff_size=(40, 40))
+    p.annotate_line([0.1, 0.1], [0.5, 0.5], coord_system="axis", color="red")
+    p.render()
+    check_axis_manipulation(p)
 
-    with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
-        p = ProjectionPlot(ds, "r", ("gas", "density"))
-        assert_raises(
-            YTDataTypeUnsupported, p.annotate_line, [0.1, 0.1, 0.1], [0.5, 0.5, 0.5]
-        )
-        p.annotate_line([0.1, 0.1], [0.5, 0.5], coord_system="axis")
-        assert_fname(p.save(prefix)[0])
+    ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
+    p = SlicePlot(ds, "r", ("gas", "density"), buff_size=(40, 40))
+    assert_raises(
+        YTDataTypeUnsupported, p.annotate_line, [0.1, 0.1, 0.1], [0.5, 0.5, 0.5]
+    )
+    p.annotate_line([0.1, 0.1], [0.5, 0.5], coord_system="axis")
+    p.render()
 
 
 def test_ray_callback():
-    with _cleanup_fname() as prefix:
-        ax = "z"
-        vector = [1.0, 1.0, 1.0]
-        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
-        ray = ds.ray((0.1, 0.2, 0.3), (0.6, 0.8, 0.5))
-        oray = ds.ortho_ray(0, (0.3, 0.4))
-        p = ProjectionPlot(ds, ax, ("gas", "density"))
-        p.annotate_ray(oray)
-        p.annotate_ray(ray)
-        assert_fname(p.save(prefix)[0])
-        p = SlicePlot(ds, ax, ("gas", "density"))
-        p.annotate_ray(oray)
-        p.annotate_ray(ray)
-        assert_fname(p.save(prefix)[0])
-        p = OffAxisSlicePlot(ds, vector, ("gas", "density"))
-        p.annotate_ray(oray)
-        p.annotate_ray(ray)
-        assert_fname(p.save(prefix)[0])
-        # Now we'll check a few additional minor things
-        p = SlicePlot(ds, "x", ("gas", "density"))
-        p.annotate_ray(oray)
-        p.annotate_ray(ray, color="red")
-        p.save(prefix)
-        check_axis_manipulation(p, prefix)
+    ax = "z"
+    vector = [1.0, 1.0, 1.0]
+    ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
+    ray = ds.ray((0.1, 0.2, 0.3), (0.6, 0.8, 0.5))
+    oray = ds.ortho_ray(0, (0.3, 0.4))
+    p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+    p.annotate_ray(oray)
+    p.annotate_ray(ray)
+    p.render()
+    p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+    p.annotate_ray(oray)
+    p.annotate_ray(ray)
+    p.render()
+    p = SlicePlot(ds, vector, ("gas", "density"), buff_size=(40, 40))
+    p.annotate_ray(oray)
+    p.annotate_ray(ray)
+    p.render()
+    # Now we'll check a few additional minor things
+    p = SlicePlot(ds, "x", ("gas", "density"), buff_size=(40, 40))
+    p.annotate_ray(oray)
+    p.annotate_ray(ray, color="red")
+    p.render()
+    check_axis_manipulation(p)
 
-    with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
-        ray = ds.ray((0.1, 0.2, 0.3), (0.6, 0.8, 0.5))
-        oray = ds.ortho_ray(0, (0.3, 0.4))
-        p = ProjectionPlot(ds, "r", ("gas", "density"))
-        assert_raises(YTDataTypeUnsupported, p.annotate_ray, oray)
-        assert_raises(YTDataTypeUnsupported, p.annotate_ray, ray)
+    ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
+    ray = ds.ray((0.1, 0.2, 0.3), (0.6, 0.8, 0.5))
+    oray = ds.ortho_ray(0, (0.3, 0.4))
+    p = SlicePlot(ds, "r", ("gas", "density"), buff_size=(40, 40))
+    assert_raises(YTDataTypeUnsupported, p.annotate_ray, oray)
+    assert_raises(YTDataTypeUnsupported, p.annotate_ray, ray)
 
 
 def test_arrow_callback():
-    with _cleanup_fname() as prefix:
-        ax = "z"
-        vector = [1.0, 1.0, 1.0]
-        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
-        p = ProjectionPlot(ds, ax, ("gas", "density"))
-        p.annotate_arrow([0.5, 0.5, 0.5])
-        assert_fname(p.save(prefix)[0])
-        p = SlicePlot(ds, ax, ("gas", "density"))
-        p.annotate_arrow([0.5, 0.5, 0.5])
-        assert_fname(p.save(prefix)[0])
-        p = OffAxisSlicePlot(ds, vector, ("gas", "density"))
-        p.annotate_arrow([0.5, 0.5, 0.5])
-        assert_fname(p.save(prefix)[0])
-        # Now we'll check a few additional minor things
-        p = SlicePlot(ds, "x", ("gas", "density"))
-        p.annotate_arrow([0.5, 0.5], coord_system="axis", length=0.05)
-        p.annotate_arrow(
-            [[0.5, 0.6], [0.5, 0.6], [0.5, 0.6]], coord_system="data", length=0.05
-        )
-        p.annotate_arrow(
-            [[0.5, 0.6, 0.8], [0.5, 0.6, 0.8], [0.5, 0.6, 0.8]],
-            coord_system="data",
-            length=0.05,
-        )
-        p.annotate_arrow(
-            [[0.5, 0.6, 0.8], [0.5, 0.6, 0.8]], coord_system="axis", length=0.05
-        )
-        p.annotate_arrow(
-            [[0.5, 0.6, 0.8], [0.5, 0.6, 0.8]], coord_system="figure", length=0.05
-        )
-        p.annotate_arrow(
-            [[0.5, 0.6, 0.8], [0.5, 0.6, 0.8]], coord_system="plot", length=0.05
-        )
-        p.save(prefix)
-        check_axis_manipulation(p, prefix)
+    ax = "z"
+    vector = [1.0, 1.0, 1.0]
+    ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
+    p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+    p.annotate_arrow([0.5, 0.5, 0.5])
+    p.render()
+    p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+    p.annotate_arrow([0.5, 0.5, 0.5])
+    p.render()
+    p = SlicePlot(ds, vector, ("gas", "density"), buff_size=(40, 40))
+    p.annotate_arrow([0.5, 0.5, 0.5])
+    p.render()
+    # Now we'll check a few additional minor things
+    p = SlicePlot(ds, "x", ("gas", "density"), buff_size=(40, 40))
+    p.annotate_arrow([0.5, 0.5], coord_system="axis", length=0.05)
+    p.annotate_arrow(
+        [[0.5, 0.6], [0.5, 0.6], [0.5, 0.6]], coord_system="data", length=0.05
+    )
+    p.annotate_arrow(
+        [[0.5, 0.6, 0.8], [0.5, 0.6, 0.8], [0.5, 0.6, 0.8]],
+        coord_system="data",
+        length=0.05,
+    )
+    p.annotate_arrow(
+        [[0.5, 0.6, 0.8], [0.5, 0.6, 0.8]], coord_system="axis", length=0.05
+    )
+    p.annotate_arrow(
+        [[0.5, 0.6, 0.8], [0.5, 0.6, 0.8]], coord_system="figure", length=0.05
+    )
+    p.annotate_arrow(
+        [[0.5, 0.6, 0.8], [0.5, 0.6, 0.8]], coord_system="plot", length=0.05
+    )
+    p.render()
+    check_axis_manipulation(p)
 
-    with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
-        p = ProjectionPlot(ds, "r", ("gas", "density"))
-        assert_raises(YTDataTypeUnsupported, p.annotate_arrow, [0.5, 0.5, 0.5])
-        p.annotate_arrow([0.5, 0.5], coord_system="axis")
-        assert_fname(p.save(prefix)[0])
+    ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
+    p = SlicePlot(ds, "r", ("gas", "density"), buff_size=(40, 40))
+    assert_raises(YTDataTypeUnsupported, p.annotate_arrow, [0.5, 0.5, 0.5])
+    p.annotate_arrow([0.5, 0.5], coord_system="axis")
+    p.render()
 
 
 def test_marker_callback():
-    with _cleanup_fname() as prefix:
-        ax = "z"
-        vector = [1.0, 1.0, 1.0]
-        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
-        p = ProjectionPlot(ds, ax, ("gas", "density"))
-        p.annotate_marker([0.5, 0.5, 0.5])
-        assert_fname(p.save(prefix)[0])
-        p = SlicePlot(ds, ax, ("gas", "density"))
-        p.annotate_marker([0.5, 0.5, 0.5])
-        assert_fname(p.save(prefix)[0])
-        p = OffAxisSlicePlot(ds, vector, ("gas", "density"))
-        p.annotate_marker([0.5, 0.5, 0.5])
-        assert_fname(p.save(prefix)[0])
-        # Now we'll check a few additional minor things
-        p = SlicePlot(ds, "x", ("gas", "density"))
-        coord = ds.arr([0.75, 0.75, 0.75], "unitary")
-        coord.convert_to_units("kpc")
-        p.annotate_marker(coord, coord_system="data")
-        p.annotate_marker([0.5, 0.5], coord_system="axis", marker="*")
-        p.annotate_marker([[0.5, 0.6], [0.5, 0.6], [0.5, 0.6]], coord_system="data")
-        p.annotate_marker(
-            [[0.5, 0.6, 0.8], [0.5, 0.6, 0.8], [0.5, 0.6, 0.8]], coord_system="data"
-        )
-        p.annotate_marker([[0.5, 0.6, 0.8], [0.5, 0.6, 0.8]], coord_system="axis")
-        p.annotate_marker([[0.5, 0.6, 0.8], [0.5, 0.6, 0.8]], coord_system="figure")
-        p.annotate_marker([[0.5, 0.6, 0.8], [0.5, 0.6, 0.8]], coord_system="plot")
-        p.save(prefix)
-        check_axis_manipulation(p, prefix)
+    ax = "z"
+    vector = [1.0, 1.0, 1.0]
+    ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
+    p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+    p.annotate_marker([0.5, 0.5, 0.5])
+    p.render()
+    p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+    p.annotate_marker([0.5, 0.5, 0.5])
+    p.render()
+    p = SlicePlot(ds, vector, ("gas", "density"), buff_size=(40, 40))
+    p.annotate_marker([0.5, 0.5, 0.5])
+    p.render()
+    # Now we'll check a few additional minor things
+    p = SlicePlot(ds, "x", ("gas", "density"), buff_size=(40, 40))
+    coord = ds.arr([0.75, 0.75, 0.75], "unitary")
+    coord.convert_to_units("kpc")
+    p.annotate_marker(coord, coord_system="data")
+    p.annotate_marker([0.5, 0.5], coord_system="axis", marker="*")
+    p.annotate_marker([[0.5, 0.6], [0.5, 0.6], [0.5, 0.6]], coord_system="data")
+    p.annotate_marker(
+        [[0.5, 0.6, 0.8], [0.5, 0.6, 0.8], [0.5, 0.6, 0.8]], coord_system="data"
+    )
+    p.annotate_marker([[0.5, 0.6, 0.8], [0.5, 0.6, 0.8]], coord_system="axis")
+    p.annotate_marker([[0.5, 0.6, 0.8], [0.5, 0.6, 0.8]], coord_system="figure")
+    p.annotate_marker([[0.5, 0.6, 0.8], [0.5, 0.6, 0.8]], coord_system="plot")
+    p.render()
+    check_axis_manipulation(p)
 
-    with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
-        p = ProjectionPlot(ds, "r", ("gas", "density"))
-        assert_raises(YTDataTypeUnsupported, p.annotate_marker, [0.5, 0.5, 0.5])
-        p.annotate_marker([0.5, 0.5], coord_system="axis")
-        assert_fname(p.save(prefix)[0])
+    ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
+    p = SlicePlot(ds, "r", ("gas", "density"), buff_size=(40, 40))
+    assert_raises(YTDataTypeUnsupported, p.annotate_marker, [0.5, 0.5, 0.5])
+    p.annotate_marker([0.5, 0.5], coord_system="axis")
+    p.render()
 
 
 def test_particles_callback():
-    with _cleanup_fname() as prefix:
-        ax = "z"
-        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), particles=1)
-        p = ProjectionPlot(ds, ax, ("gas", "density"))
-        p.annotate_particles((10, "Mpc"))
-        assert_fname(p.save(prefix)[0])
-        p = SlicePlot(ds, ax, ("gas", "density"))
-        p.annotate_particles((10, "Mpc"))
-        assert_fname(p.save(prefix)[0])
-        # Now we'll check a few additional minor things
-        p = SlicePlot(ds, "x", ("gas", "density"))
-        ad = ds.all_data()
-        p.annotate_particles(
-            (10, "Mpc"),
-            p_size=1.0,
-            col="k",
-            marker="o",
-            stride=1,
-            ptype="all",
-            alpha=1.0,
-            data_source=ad,
-        )
-        p.save(prefix)
-        check_axis_manipulation(p, prefix)
+    ax = "z"
+    ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), particles=1)
+    p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+    p.annotate_particles((10, "Mpc"))
+    p.render()
+    p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+    p.annotate_particles((10, "Mpc"))
+    p.render()
+    # Now we'll check a few additional minor things
+    p = SlicePlot(ds, "x", ("gas", "density"), buff_size=(40, 40))
+    ad = ds.all_data()
+    p.annotate_particles(
+        (10, "Mpc"),
+        p_size=1.0,
+        col="k",
+        marker="o",
+        stride=1,
+        ptype="all",
+        alpha=1.0,
+        data_source=ad,
+    )
+    p.render()
+    check_axis_manipulation(p)
 
-    with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
-        p = ProjectionPlot(ds, "r", ("gas", "density"))
-        assert_raises(YTDataTypeUnsupported, p.annotate_particles, (10, "Mpc"))
+    ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
+    p = SlicePlot(ds, "r", ("gas", "density"), buff_size=(40, 40))
+    assert_raises(YTDataTypeUnsupported, p.annotate_particles, (10, "Mpc"))
 
 
 def test_sphere_callback():
-    with _cleanup_fname() as prefix:
-        ax = "z"
-        vector = [1.0, 1.0, 1.0]
-        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
-        p = ProjectionPlot(ds, ax, ("gas", "density"))
-        p.annotate_sphere([0.5, 0.5, 0.5], 0.1)
-        assert_fname(p.save(prefix)[0])
-        p = SlicePlot(ds, ax, ("gas", "density"))
-        p.annotate_sphere([0.5, 0.5, 0.5], 0.1)
-        assert_fname(p.save(prefix)[0])
-        p = OffAxisSlicePlot(ds, vector, ("gas", "density"))
-        p.annotate_sphere([0.5, 0.5, 0.5], 0.1)
-        assert_fname(p.save(prefix)[0])
-        # Now we'll check a few additional minor things
-        p = SlicePlot(ds, "x", ("gas", "density"))
-        p.annotate_sphere([0.5, 0.5], 0.1, coord_system="axis", text="blah")
-        p.save(prefix)
+    ax = "z"
+    vector = [1.0, 1.0, 1.0]
+    ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
+    p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+    p.annotate_sphere([0.5, 0.5, 0.5], 0.1)
+    p.render()
+    p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+    p.annotate_sphere([0.5, 0.5, 0.5], 0.1)
+    p.render()
+    p = SlicePlot(ds, vector, ("gas", "density"), buff_size=(40, 40))
+    p.annotate_sphere([0.5, 0.5, 0.5], 0.1)
+    p.render()
+    # Now we'll check a few additional minor things
+    p = SlicePlot(ds, "x", ("gas", "density"), buff_size=(40, 40))
+    p.annotate_sphere([0.5, 0.5], 0.1, coord_system="axis", text="blah")
+    p.render()
 
-    with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
-        p = ProjectionPlot(ds, "r", ("gas", "density"))
-        assert_raises(
-            YTDataTypeUnsupported,
-            p.annotate_sphere,
-            [0.5, 0.5, 0.5],
-            0.1,
-        )
-        p.annotate_sphere([0.5, 0.5], 0.1, coord_system="axis", text="blah")
-        assert_fname(p.save(prefix)[0])
+    ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
+    p = SlicePlot(ds, "r", ("gas", "density"), buff_size=(40, 40))
+    assert_raises(
+        YTDataTypeUnsupported,
+        p.annotate_sphere,
+        [0.5, 0.5, 0.5],
+        0.1,
+    )
+    p.annotate_sphere([0.5, 0.5], 0.1, coord_system="axis", text="blah")
+    p.render()
 
 
 def test_text_callback():
-    with _cleanup_fname() as prefix:
-        ax = "z"
-        vector = [1.0, 1.0, 1.0]
-        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
-        p = ProjectionPlot(ds, ax, ("gas", "density"))
-        p.annotate_text([0.5, 0.5, 0.5], "dinosaurs!")
-        assert_fname(p.save(prefix)[0])
-        p = SlicePlot(ds, ax, ("gas", "density"))
-        p.annotate_text([0.5, 0.5, 0.5], "dinosaurs!")
-        assert_fname(p.save(prefix)[0])
-        p = OffAxisSlicePlot(ds, vector, ("gas", "density"))
-        p.annotate_text([0.5, 0.5, 0.5], "dinosaurs!")
-        assert_fname(p.save(prefix)[0])
-        # Now we'll check a few additional minor things
-        p = SlicePlot(ds, "x", ("gas", "density"))
-        p.annotate_text(
-            [0.5, 0.5], "dinosaurs!", coord_system="axis", text_args={"color": "red"}
-        )
-        p.save(prefix)
+    ax = "z"
+    vector = [1.0, 1.0, 1.0]
+    ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
+    p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+    p.annotate_text([0.5, 0.5, 0.5], "dinosaurs!")
+    p.render()
+    p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+    p.annotate_text([0.5, 0.5, 0.5], "dinosaurs!")
+    p.render()
+    p = SlicePlot(ds, vector, ("gas", "density"), buff_size=(40, 40))
+    p.annotate_text([0.5, 0.5, 0.5], "dinosaurs!")
+    p.render()
+    # Now we'll check a few additional minor things
+    p = SlicePlot(ds, "x", ("gas", "density"), buff_size=(40, 40))
+    p.annotate_text(
+        [0.5, 0.5], "dinosaurs!", coord_system="axis", text_args={"color": "red"}
+    )
+    p.render()
 
-    with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
-        p = ProjectionPlot(ds, "r", ("gas", "density"))
-        assert_raises(
-            YTDataTypeUnsupported, p.annotate_text, [0.5, 0.5, 0.5], "dinosaurs!"
-        )
-        p.annotate_text(
-            [0.5, 0.5], "dinosaurs!", coord_system="axis", text_args={"color": "red"}
-        )
-        assert_fname(p.save(prefix)[0])
+    ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
+    p = SlicePlot(ds, "r", ("gas", "density"), buff_size=(40, 40))
+    assert_raises(YTDataTypeUnsupported, p.annotate_text, [0.5, 0.5, 0.5], "dinosaurs!")
+    p.annotate_text(
+        [0.5, 0.5], "dinosaurs!", coord_system="axis", text_args={"color": "red"}
+    )
+    p.render()
 
 
 @requires_file(cyl_2d)
 @requires_file(cyl_3d)
 def test_velocity_callback():
-    with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(
-            fields=("density", "velocity_x", "velocity_y", "velocity_z"),
-            units=("g/cm**3", "cm/s", "cm/s", "cm/s"),
+    ds = fake_amr_ds(
+        fields=("density", "velocity_x", "velocity_y", "velocity_z"),
+        units=("g/cm**3", "cm/s", "cm/s", "cm/s"),
+    )
+    for ax in "xyz":
+        p = ProjectionPlot(
+            ds,
+            ax,
+            ("gas", "density"),
+            weight_field=("gas", "density"),
+            buff_size=(40, 40),
         )
-        for ax in "xyz":
-            p = ProjectionPlot(
-                ds, ax, ("gas", "density"), weight_field=("gas", "density")
-            )
-            p.annotate_velocity()
-            assert_fname(p.save(prefix)[0])
-            p = SlicePlot(ds, ax, ("gas", "density"))
-            p.annotate_velocity()
-            assert_fname(p.save(prefix)[0])
-        # Test for OffAxis Slice
-        p = SlicePlot(ds, [1, 1, 0], ("gas", "density"), north_vector=[0, 0, 1])
-        p.annotate_velocity(factor=40, normalize=True)
-        assert_fname(p.save(prefix)[0])
-        # Now we'll check a few additional minor things
-        p = SlicePlot(ds, "x", ("gas", "density"))
-        p.annotate_velocity(factor=8, scale=0.5, scale_units="inches", normalize=True)
-        assert_fname(p.save(prefix)[0])
+        p.annotate_velocity()
+        p.render()
+        p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+        p.annotate_velocity()
+        p.render()
+    # Test for OffAxis Slice
+    p = SlicePlot(ds, [1, 1, 0], ("gas", "density"), north_vector=[0, 0, 1])
+    p.annotate_velocity(factor=40, normalize=True)
+    p.render()
+    # Now we'll check a few additional minor things
+    p = SlicePlot(ds, "x", ("gas", "density"), buff_size=(40, 40))
+    p.annotate_velocity(factor=8, scale=0.5, scale_units="inches", normalize=True)
+    p.render()
 
-    with _cleanup_fname() as prefix:
-        ds = fake_hexahedral_ds(fields=[f"velocity_{ax}" for ax in "xyz"])
-        sl = SlicePlot(ds, 1, ("connect1", "test"))
-        sl.annotate_velocity()
-        assert_fname(sl.save(prefix)[0])
+    ds = fake_hexahedral_ds(fields=[f"velocity_{ax}" for ax in "xyz"])
+    sl = SlicePlot(ds, 1, ("connect1", "test"), buff_size=(40, 40))
+    sl.annotate_velocity()
+    sl.save()
 
-    with _cleanup_fname() as prefix:
-        ds = load(cyl_2d)
-        slc = SlicePlot(ds, "theta", ("gas", "velocity_magnitude"))
+    ds = load(cyl_2d)
+    slc = SlicePlot(ds, "theta", ("gas", "velocity_magnitude"), buff_size=(40, 40))
+    slc.annotate_velocity()
+    slc.render()
+
+    ds = load(cyl_3d)
+    for ax in ["r", "z", "theta"]:
+        slc = SlicePlot(ds, ax, ("gas", "velocity_magnitude"), buff_size=(40, 40))
         slc.annotate_velocity()
-        assert_fname(slc.save(prefix)[0])
-
-    with _cleanup_fname() as prefix:
-        ds = load(cyl_3d)
-        for ax in ["r", "z", "theta"]:
-            slc = SlicePlot(ds, ax, ("gas", "velocity_magnitude"))
-            slc.annotate_velocity()
-            assert_fname(slc.save(prefix)[0])
-            slc = ProjectionPlot(ds, ax, ("gas", "velocity_magnitude"))
-            slc.annotate_velocity()
-            assert_fname(slc.save(prefix)[0])
+        slc.render()
+        slc = SlicePlot(ds, ax, ("gas", "velocity_magnitude"), buff_size=(40, 40))
+        slc.annotate_velocity()
+        slc.render()
 
 
 def test_velocity_callback_spherical():
@@ -493,161 +465,158 @@ def test_velocity_callback_spherical():
         geometry="spherical",
     )
 
-    with _cleanup_fname() as prefix:
-        p = ProjectionPlot(ds, "phi", ("stream", "density"))
-        p.annotate_velocity(factor=40, normalize=True)
-        assert_fname(p.save(prefix)[0])
+    p = SlicePlot(ds, "phi", ("stream", "density"), buff_size=(40, 40))
+    p.annotate_velocity(factor=40, normalize=True)
+    p.render()
 
-    with _cleanup_fname() as prefix:
-        p = ProjectionPlot(ds, "r", ("stream", "density"))
-        p.annotate_velocity(factor=40, normalize=True)
-        assert_raises(NotImplementedError, p.save, prefix)
+    p = SlicePlot(ds, "r", ("stream", "density"), buff_size=(40, 40))
+    p.annotate_velocity(factor=40, normalize=True)
+    assert_raises(NotImplementedError, p.save)
 
 
 @requires_file(cyl_2d)
 @requires_file(cyl_3d)
 def test_magnetic_callback():
-    with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(
-            fields=(
-                "density",
-                "magnetic_field_x",
-                "magnetic_field_y",
-                "magnetic_field_z",
-            ),
-            units=(
-                "g/cm**3",
-                "G",
-                "G",
-                "G",
-            ),
+    ds = fake_amr_ds(
+        fields=(
+            "density",
+            "magnetic_field_x",
+            "magnetic_field_y",
+            "magnetic_field_z",
+        ),
+        units=(
+            "g/cm**3",
+            "G",
+            "G",
+            "G",
+        ),
+    )
+    for ax in "xyz":
+        p = ProjectionPlot(
+            ds,
+            ax,
+            ("gas", "density"),
+            weight_field=("gas", "density"),
+            buff_size=(40, 40),
         )
-        for ax in "xyz":
-            p = ProjectionPlot(
-                ds, ax, ("gas", "density"), weight_field=("gas", "density")
-            )
-            p.annotate_magnetic_field()
-            assert_fname(p.save(prefix)[0])
-            p = SlicePlot(ds, ax, ("gas", "density"))
-            p.annotate_magnetic_field()
-            assert_fname(p.save(prefix)[0])
-        # Test for OffAxis Slice
-        p = SlicePlot(ds, [1, 1, 0], ("gas", "density"), north_vector=[0, 0, 1])
-        p.annotate_magnetic_field(factor=40, normalize=True)
-        assert_fname(p.save(prefix)[0])
-        # Now we'll check a few additional minor things
-        p = SlicePlot(ds, "x", ("gas", "density"))
-        p.annotate_magnetic_field(
-            factor=8, scale=0.5, scale_units="inches", normalize=True
-        )
-        assert_fname(p.save(prefix)[0])
+        p.annotate_magnetic_field()
+        p.render()
+        p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+        p.annotate_magnetic_field()
+        p.render()
+    # Test for OffAxis Slice
+    p = SlicePlot(
+        ds,
+        [1, 1, 0],
+        ("gas", "density"),
+        north_vector=[0, 0, 1],
+        buff_size=(40, 40),
+    )
+    p.annotate_magnetic_field(factor=40, normalize=True)
+    p.render()
+    # Now we'll check a few additional minor things
+    p = SlicePlot(ds, "x", ("gas", "density"), buff_size=(40, 40))
+    p.annotate_magnetic_field(factor=8, scale=0.5, scale_units="inches", normalize=True)
+    p.render()
 
-    with _cleanup_fname() as prefix:
-        ds = load(cyl_2d)
-        slc = SlicePlot(ds, "theta", ("gas", "magnetic_field_strength"))
+    ds = load(cyl_2d)
+    slc = SlicePlot(ds, "theta", ("gas", "magnetic_field_strength"), buff_size=(40, 40))
+    slc.annotate_magnetic_field()
+    slc.render()
+
+    ds = load(cyl_3d)
+    for ax in ["r", "z", "theta"]:
+        slc = SlicePlot(ds, ax, ("gas", "magnetic_field_strength"), buff_size=(40, 40))
         slc.annotate_magnetic_field()
-        assert_fname(slc.save(prefix)[0])
+        slc.render()
+        slc = SlicePlot(ds, ax, ("gas", "magnetic_field_strength"), buff_size=(40, 40))
+        slc.annotate_magnetic_field()
+        slc.render()
+    check_axis_manipulation(slc)  # only test the last axis
 
-    with _cleanup_fname() as prefix:
-        ds = load(cyl_3d)
-        for ax in ["r", "z", "theta"]:
-            slc = SlicePlot(ds, ax, ("gas", "magnetic_field_strength"))
-            slc.annotate_magnetic_field()
-            assert_fname(slc.save(prefix)[0])
-            slc = ProjectionPlot(ds, ax, ("gas", "magnetic_field_strength"))
-            slc.annotate_magnetic_field()
-            assert_fname(slc.save(prefix)[0])
-        check_axis_manipulation(slc, prefix)  # only test the last axis
+    ds = fake_amr_ds(
+        fields=(
+            "density",
+            "magnetic_field_r",
+            "magnetic_field_theta",
+            "magnetic_field_phi",
+        ),
+        units=(
+            "g/cm**3",
+            "G",
+            "G",
+            "G",
+        ),
+        geometry="spherical",
+    )
+    p = SlicePlot(ds, "phi", ("gas", "density"), buff_size=(40, 40))
+    p.annotate_magnetic_field(factor=8, scale=0.5, scale_units="inches", normalize=True)
+    p.render()
 
-    with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(
-            fields=(
-                "density",
-                "magnetic_field_r",
-                "magnetic_field_theta",
-                "magnetic_field_phi",
-            ),
-            units=(
-                "g/cm**3",
-                "G",
-                "G",
-                "G",
-            ),
-            geometry="spherical",
-        )
-        p = ProjectionPlot(ds, "phi", ("gas", "density"))
-        p.annotate_magnetic_field(
-            factor=8, scale=0.5, scale_units="inches", normalize=True
-        )
-        assert_fname(p.save(prefix)[0])
+    p = SlicePlot(ds, "theta", ("gas", "density"), buff_size=(40, 40))
+    p.annotate_magnetic_field(factor=8, scale=0.5, scale_units="inches", normalize=True)
+    p.render()
 
-        p = ProjectionPlot(ds, "theta", ("gas", "density"))
-        p.annotate_magnetic_field(
-            factor=8, scale=0.5, scale_units="inches", normalize=True
-        )
-        assert_fname(p.save(prefix)[0])
-
-        p = ProjectionPlot(ds, "r", ("gas", "density"))
-        p.annotate_magnetic_field(
-            factor=8, scale=0.5, scale_units="inches", normalize=True
-        )
-        assert_raises(NotImplementedError, p.save, prefix)
+    p = SlicePlot(ds, "r", ("gas", "density"), buff_size=(40, 40))
+    p.annotate_magnetic_field(factor=8, scale=0.5, scale_units="inches", normalize=True)
+    assert_raises(NotImplementedError, p.save)
 
 
 @requires_file(cyl_2d)
 @requires_file(cyl_3d)
 def test_quiver_callback():
-    with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(
-            fields=("density", "velocity_x", "velocity_y", "velocity_z"),
-            units=("g/cm**3", "cm/s", "cm/s", "cm/s"),
+    ds = fake_amr_ds(
+        fields=("density", "velocity_x", "velocity_y", "velocity_z"),
+        units=("g/cm**3", "cm/s", "cm/s", "cm/s"),
+    )
+    for ax in "xyz":
+        p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+        p.annotate_quiver(("gas", "velocity_x"), ("gas", "velocity_y"))
+        p.render()
+        p = ProjectionPlot(
+            ds,
+            ax,
+            ("gas", "density"),
+            weight_field=("gas", "density"),
+            buff_size=(40, 40),
         )
-        for ax in "xyz":
-            p = ProjectionPlot(ds, ax, ("gas", "density"))
-            p.annotate_quiver(("gas", "velocity_x"), ("gas", "velocity_y"))
-            assert_fname(p.save(prefix)[0])
-            p = ProjectionPlot(
-                ds, ax, ("gas", "density"), weight_field=("gas", "density")
-            )
-            p.annotate_quiver(("gas", "velocity_x"), ("gas", "velocity_y"))
-            assert_fname(p.save(prefix)[0])
-            p = SlicePlot(ds, ax, ("gas", "density"))
-            p.annotate_quiver(("gas", "velocity_x"), ("gas", "velocity_y"))
-            assert_fname(p.save(prefix)[0])
-        # Now we'll check a few additional minor things
-        p = SlicePlot(ds, "x", ("gas", "density"))
-        p.annotate_quiver(
-            ("gas", "velocity_x"),
-            ("gas", "velocity_y"),
-            factor=8,
-            scale=0.5,
-            scale_units="inches",
-            normalize=True,
-            bv_x=0.5 * u.cm / u.s,
-            bv_y=0.5 * u.cm / u.s,
-        )
-        assert_fname(p.save(prefix)[0])
-        check_axis_manipulation(p, prefix)
+        p.annotate_quiver(("gas", "velocity_x"), ("gas", "velocity_y"))
+        p.render()
+        p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+        p.annotate_quiver(("gas", "velocity_x"), ("gas", "velocity_y"))
+        p.render()
+    # Now we'll check a few additional minor things
+    p = SlicePlot(ds, "x", ("gas", "density"), buff_size=(40, 40))
+    p.annotate_quiver(
+        ("gas", "velocity_x"),
+        ("gas", "velocity_y"),
+        factor=8,
+        scale=0.5,
+        scale_units="inches",
+        normalize=True,
+        bv_x=0.5 * u.cm / u.s,
+        bv_y=0.5 * u.cm / u.s,
+    )
+    p.render()
+    check_axis_manipulation(p)
 
-    with _cleanup_fname() as prefix:
-        ds = load(cyl_2d)
-        slc = SlicePlot(ds, "theta", ("gas", "density"))
-        slc.annotate_quiver(("gas", "velocity_r"), ("gas", "velocity_z"))
-        assert_fname(slc.save(prefix)[0])
+    ds = load(cyl_2d)
+    slc = SlicePlot(ds, "theta", ("gas", "density"), buff_size=(40, 40))
+    slc.annotate_quiver(("gas", "velocity_r"), ("gas", "velocity_z"))
+    slc.render()
 
-    with _cleanup_fname() as prefix:
-        ds = load(cyl_3d)
-        slc = SlicePlot(ds, "r", ("gas", "velocity_magnitude"))
-        slc.annotate_quiver(("gas", "velocity_theta"), ("gas", "velocity_z"))
-        assert_fname(slc.save(prefix)[0])
-        slc = SlicePlot(ds, "z", ("gas", "velocity_magnitude"))
-        slc.annotate_quiver(
-            ("gas", "velocity_cartesian_x"), ("gas", "velocity_cartesian_y")
-        )
-        assert_fname(slc.save(prefix)[0])
-        slc = SlicePlot(ds, "theta", ("gas", "velocity_magnitude"))
-        slc.annotate_quiver(("gas", "velocity_r"), ("gas", "velocity_z"))
-        assert_fname(slc.save(prefix)[0])
+    ds = load(cyl_3d)
+    slc = SlicePlot(ds, "r", ("gas", "velocity_magnitude"), buff_size=(40, 40))
+    slc.annotate_quiver(("gas", "velocity_theta"), ("gas", "velocity_z"))
+    slc.render()
+    slc = SlicePlot(ds, "z", ("gas", "velocity_magnitude"), buff_size=(40, 40))
+    slc.annotate_quiver(
+        ("gas", "velocity_cartesian_x"), ("gas", "velocity_cartesian_y")
+    )
+    slc.render()
+    slc = SlicePlot(ds, "theta", ("gas", "velocity_magnitude"), buff_size=(40, 40))
+    slc.annotate_quiver(("gas", "velocity_r"), ("gas", "velocity_z"))
+    slc.render()
 
 
 def test_quiver_callback_spherical():
@@ -657,393 +626,388 @@ def test_quiver_callback_spherical():
         geometry="spherical",
     )
 
-    with _cleanup_fname() as prefix:
-        p = ProjectionPlot(ds, "phi", ("gas", "density"))
-        p.annotate_quiver(
-            ("gas", "velocity_cylindrical_radius"),
-            ("gas", "velocity_cylindrical_z"),
-            factor=8,
-            scale=0.5,
-            scale_units="inches",
-            normalize=True,
-        )
-        assert_fname(p.save(prefix)[0])
+    p = SlicePlot(ds, "phi", ("gas", "density"), buff_size=(40, 40))
+    p.annotate_quiver(
+        ("gas", "velocity_cylindrical_radius"),
+        ("gas", "velocity_cylindrical_z"),
+        factor=8,
+        scale=0.5,
+        scale_units="inches",
+        normalize=True,
+    )
+    p.render()
 
-    with _cleanup_fname() as prefix:
-        p = ProjectionPlot(ds, "r", ("gas", "density"))
-        p.annotate_quiver(
-            ("gas", "velocity_theta"),
-            ("gas", "velocity_phi"),
-            factor=8,
-            scale=0.5,
-            scale_units="inches",
-            normalize=True,
-        )
-        assert_fname(p.save(prefix)[0])
+    p = SlicePlot(ds, "r", ("gas", "density"), buff_size=(40, 40))
+    p.annotate_quiver(
+        ("gas", "velocity_theta"),
+        ("gas", "velocity_phi"),
+        factor=8,
+        scale=0.5,
+        scale_units="inches",
+        normalize=True,
+    )
+    p.render()
 
 
 @requires_file(cyl_2d)
 def test_contour_callback():
-    with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density", "temperature"), units=("g/cm**3", "K"))
-        for ax in "xyz":
-            p = ProjectionPlot(ds, ax, ("gas", "density"))
-            p.annotate_contour(("gas", "temperature"))
-            assert_fname(p.save(prefix)[0])
-            p = ProjectionPlot(
-                ds, ax, ("gas", "density"), weight_field=("gas", "density")
-            )
-            p.annotate_contour(("gas", "temperature"))
-            assert_fname(p.save(prefix)[0])
-            p = SlicePlot(ds, ax, ("gas", "density"))
-            p.annotate_contour(("gas", "temperature"))  # BREAKS WITH ndarray
-            assert_fname(p.save(prefix)[0])
-        # Now we'll check a few additional minor things
-        p = SlicePlot(ds, "x", ("gas", "density"))
-        p.annotate_contour(
-            ("gas", "temperature"),
-            levels=10,
-            factor=8,
-            take_log=False,
-            clim=(0.4, 0.6),
-            plot_args={"linewidths": 2.0},
-            label=True,
-            text_args={"fontsize": "x-large"},
+    ds = fake_amr_ds(fields=("density", "temperature"), units=("g/cm**3", "K"))
+    for ax in "xyz":
+        p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+        p.annotate_contour(("gas", "temperature"))
+        p.render()
+        p = ProjectionPlot(
+            ds,
+            ax,
+            ("gas", "density"),
+            weight_field=("gas", "density"),
+            buff_size=(40, 40),
         )
-        p.save(prefix)
+        p.annotate_contour(("gas", "temperature"))
+        p.render()
+        p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+        p.annotate_contour(("gas", "temperature"))  # BREAKS WITH ndarray
+        p.render()
+    # Now we'll check a few additional minor things
+    p = SlicePlot(ds, "x", ("gas", "density"), buff_size=(40, 40))
+    p.annotate_contour(
+        ("gas", "temperature"),
+        levels=10,
+        factor=8,
+        take_log=False,
+        clim=(0.4, 0.6),
+        plot_args={"linewidths": 2.0},
+        label=True,
+        text_args={"fontsize": "x-large"},
+    )
+    p.render()
 
-        p = SlicePlot(ds, "x", ("gas", "density"))
-        s2 = ds.slice(0, 0.2)
-        p.annotate_contour(
-            ("gas", "temperature"),
-            levels=10,
-            factor=8,
-            take_log=False,
-            clim=(0.4, 0.6),
-            plot_args={"linewidths": 2.0},
-            label=True,
-            text_args={"fontsize": "x-large"},
-            data_source=s2,
-        )
-        p.save(prefix)
+    p = SlicePlot(ds, "x", ("gas", "density"), buff_size=(40, 40))
+    s2 = ds.slice(0, 0.2)
+    p.annotate_contour(
+        ("gas", "temperature"),
+        levels=10,
+        factor=8,
+        take_log=False,
+        clim=(0.4, 0.6),
+        plot_args={"linewidths": 2.0},
+        label=True,
+        text_args={"fontsize": "x-large"},
+        data_source=s2,
+    )
+    p.render()
 
-    with _cleanup_fname() as prefix:
-        ds = load(cyl_2d)
-        slc = SlicePlot(ds, "theta", ("gas", "plasma_beta"))
-        slc.annotate_contour(
-            ("gas", "plasma_beta"),
-            levels=2,
-            factor=7,
-            take_log=False,
-            clim=(1.0e-1, 1.0e1),
-            label=True,
-            plot_args={"colors": ("c", "w"), "linewidths": 1},
-            text_args={"fmt": "%1.1f"},
-        )
-        assert_fname(slc.save(prefix)[0])
-        check_axis_manipulation(slc, prefix)
+    ds = load(cyl_2d)
+    slc = SlicePlot(ds, "theta", ("gas", "plasma_beta"), buff_size=(40, 40))
+    slc.annotate_contour(
+        ("gas", "plasma_beta"),
+        levels=2,
+        factor=7,
+        take_log=False,
+        clim=(1.0e-1, 1.0e1),
+        label=True,
+        plot_args={"colors": ("c", "w"), "linewidths": 1},
+        text_args={"fmt": "%1.1f"},
+    )
+    slc.render()
+    check_axis_manipulation(slc)
 
-    with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(
-            fields=("density", "temperature"),
-            units=("g/cm**3", "K"),
-            geometry="spherical",
-        )
-        p = SlicePlot(ds, "r", ("gas", "density"))
-        kwargs = dict(
-            levels=10,
-            factor=8,
-            take_log=False,
-            clim=(0.4, 0.6),
-            plot_args={"linewidths": 2.0},
-            label=True,
-            text_args={"fontsize": "x-large"},
-        )
-        assert_raises(
-            YTDataTypeUnsupported, p.annotate_contour, ("gas", "temperature"), **kwargs
-        )
+    ds = fake_amr_ds(
+        fields=("density", "temperature"),
+        units=("g/cm**3", "K"),
+        geometry="spherical",
+    )
+    p = SlicePlot(ds, "r", ("gas", "density"), buff_size=(40, 40))
+    kwargs = dict(
+        levels=10,
+        factor=8,
+        take_log=False,
+        clim=(0.4, 0.6),
+        plot_args={"linewidths": 2.0},
+        label=True,
+        text_args={"fontsize": "x-large"},
+    )
+    assert_raises(
+        YTDataTypeUnsupported, p.annotate_contour, ("gas", "temperature"), **kwargs
+    )
 
 
 @requires_file(cyl_2d)
 def test_grids_callback():
-    with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
-        for ax in "xyz":
-            p = ProjectionPlot(ds, ax, ("gas", "density"))
-            p.annotate_grids()
-            assert_fname(p.save(prefix)[0])
-            p = ProjectionPlot(
-                ds, ax, ("gas", "density"), weight_field=("gas", "density")
-            )
-            p.annotate_grids()
-            assert_fname(p.save(prefix)[0])
-            p = SlicePlot(ds, ax, ("gas", "density"))
-            p.annotate_grids()
-            assert_fname(p.save(prefix)[0])
-        # Now we'll check a few additional minor things
-        p = SlicePlot(ds, "x", ("gas", "density"))
-        p.annotate_grids(
-            alpha=0.7,
-            min_pix=10,
-            min_pix_ids=30,
-            draw_ids=True,
-            id_loc="upper right",
-            periodic=False,
-            min_level=2,
-            max_level=3,
-            cmap="gist_stern",
+    ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
+    for ax in "xyz":
+        p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+        p.annotate_grids()
+        p.render()
+        p = ProjectionPlot(
+            ds,
+            ax,
+            ("gas", "density"),
+            weight_field=("gas", "density"),
+            buff_size=(40, 40),
         )
-        p.save(prefix)
+        p.annotate_grids()
+        p.render()
+        p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+        p.annotate_grids()
+        p.render()
+    # Now we'll check a few additional minor things
+    p = SlicePlot(ds, "x", ("gas", "density"), buff_size=(40, 40))
+    p.annotate_grids(
+        alpha=0.7,
+        min_pix=10,
+        min_pix_ids=30,
+        draw_ids=True,
+        id_loc="upper right",
+        periodic=False,
+        min_level=2,
+        max_level=3,
+        cmap="gist_stern",
+    )
+    p.render()
 
-    with _cleanup_fname() as prefix:
-        ds = load(cyl_2d)
-        slc = SlicePlot(ds, "theta", ("gas", "density"))
-        slc.annotate_grids()
-        assert_fname(slc.save(prefix)[0])
-        check_axis_manipulation(slc, prefix)
+    ds = load(cyl_2d)
+    slc = SlicePlot(ds, "theta", ("gas", "density"), buff_size=(40, 40))
+    slc.annotate_grids()
+    slc.render()
+    check_axis_manipulation(slc)
 
-    with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
-        p = SlicePlot(ds, "r", ("gas", "density"))
-        kwargs = dict(
-            alpha=0.7,
-            min_pix=10,
-            min_pix_ids=30,
-            draw_ids=True,
-            id_loc="upper right",
-            periodic=False,
-            min_level=2,
-            max_level=3,
-            cmap="gist_stern",
-        )
-        assert_raises(YTDataTypeUnsupported, p.annotate_grids, **kwargs)
+    ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
+    p = SlicePlot(ds, "r", ("gas", "density"), buff_size=(40, 40))
+    kwargs = dict(
+        alpha=0.7,
+        min_pix=10,
+        min_pix_ids=30,
+        draw_ids=True,
+        id_loc="upper right",
+        periodic=False,
+        min_level=2,
+        max_level=3,
+        cmap="gist_stern",
+    )
+    assert_raises(YTDataTypeUnsupported, p.annotate_grids, **kwargs)
 
 
 @requires_file(cyl_2d)
 def test_cell_edges_callback():
-    with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
-        for ax in "xyz":
-            p = ProjectionPlot(ds, ax, ("gas", "density"))
-            p.annotate_cell_edges()
-            assert_fname(p.save(prefix)[0])
-            p = ProjectionPlot(
-                ds, ax, ("gas", "density"), weight_field=("gas", "density")
-            )
-            p.annotate_cell_edges()
-            assert_fname(p.save(prefix)[0])
-            p = SlicePlot(ds, ax, ("gas", "density"))
-            p.annotate_cell_edges()
-            assert_fname(p.save(prefix)[0])
-        # Now we'll check a few additional minor things
-        p = SlicePlot(ds, "x", ("gas", "density"))
-        p.annotate_cell_edges(alpha=0.7, line_width=0.9, color=(0.0, 1.0, 1.0))
-        p.save(prefix)
-        check_axis_manipulation(p, prefix)
 
-    with _cleanup_fname() as prefix:
-        ds = load(cyl_2d)
-        slc = SlicePlot(ds, "theta", ("gas", "density"))
-        slc.annotate_cell_edges()
-        assert_fname(slc.save(prefix)[0])
+    ds = fake_amr_ds(fields=("density",), units=("g/cm**3",))
+    for ax in "xyz":
+        p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+        p.annotate_cell_edges()
+        p.render()
+        p = ProjectionPlot(
+            ds,
+            ax,
+            ("gas", "density"),
+            weight_field=("gas", "density"),
+            buff_size=(40, 40),
+        )
+        p.annotate_cell_edges()
+        p.render()
+        p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+        p.annotate_cell_edges()
+        p.render()
+    # Now we'll check a few additional minor things
+    p = SlicePlot(ds, "x", ("gas", "density"), buff_size=(40, 40))
+    p.annotate_cell_edges(alpha=0.7, line_width=0.9, color=(0.0, 1.0, 1.0))
+    p.render()
+    check_axis_manipulation(p)
 
-    with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
-        p = SlicePlot(ds, "r", ("gas", "density"))
-        assert_raises(YTDataTypeUnsupported, p.annotate_cell_edges)
+    ds = load(cyl_2d)
+    slc = SlicePlot(ds, "theta", ("gas", "density"), buff_size=(40, 40))
+    slc.annotate_cell_edges()
+    slc.render()
+
+    ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
+    p = SlicePlot(ds, "r", ("gas", "density"), buff_size=(40, 40))
+    assert_raises(YTDataTypeUnsupported, p.annotate_cell_edges)
 
 
 def test_mesh_lines_callback():
-    with _cleanup_fname() as prefix:
+    ds = fake_hexahedral_ds()
+    for field in ds.field_list:
+        sl = SlicePlot(ds, 1, field, buff_size=(40, 40))
+        sl.annotate_mesh_lines(color="black")
+        sl.save()
 
-        ds = fake_hexahedral_ds()
-        for field in ds.field_list:
-            sl = SlicePlot(ds, 1, field)
-            sl.annotate_mesh_lines(color="black")
-            assert_fname(sl.save(prefix)[0])
-
-        ds = fake_tetrahedral_ds()
-        for field in ds.field_list:
-            sl = SlicePlot(ds, 1, field)
-            sl.annotate_mesh_lines(color="black")
-            assert_fname(sl.save(prefix)[0])
-        check_axis_manipulation(sl, prefix)  # only test the final field
+    ds = fake_tetrahedral_ds()
+    for field in ds.field_list:
+        sl = SlicePlot(ds, 1, field, buff_size=(40, 40))
+        sl.annotate_mesh_lines(color="black")
+        sl.save()
+    check_axis_manipulation(sl)  # only test the final field
 
 
 @requires_file(cyl_2d)
 @requires_file(cyl_3d)
 def test_streamline_callback():
+    ds = fake_amr_ds(
+        fields=("density", "velocity_x", "velocity_y", "magvel"),
+        units=("g/cm**3", "cm/s", "cm/s", "cm/s"),
+    )
 
-    with _cleanup_fname() as prefix:
+    for ax in "xyz":
+        # Projection plot tests
+        p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+        p.annotate_streamlines(("gas", "velocity_x"), ("gas", "velocity_y"))
+        p.render()
 
-        ds = fake_amr_ds(
-            fields=("density", "velocity_x", "velocity_y", "magvel"),
-            units=("g/cm**3", "cm/s", "cm/s", "cm/s"),
+        p = ProjectionPlot(
+            ds,
+            ax,
+            ("gas", "density"),
+            weight_field=("gas", "density"),
+            buff_size=(40, 40),
         )
+        p.annotate_streamlines(("gas", "velocity_x"), ("gas", "velocity_y"))
+        p.render()
 
-        for ax in "xyz":
-            # Projection plot tests
-            p = ProjectionPlot(ds, ax, ("gas", "density"))
-            p.annotate_streamlines(("gas", "velocity_x"), ("gas", "velocity_y"))
-            assert_fname(p.save(prefix)[0])
+        # Slice plot test
+        p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+        p.annotate_streamlines(("gas", "velocity_x"), ("gas", "velocity_y"))
+        p.render()
 
-            p = ProjectionPlot(
-                ds, ax, ("gas", "density"), weight_field=("gas", "density")
-            )
-            p.annotate_streamlines(("gas", "velocity_x"), ("gas", "velocity_y"))
-            assert_fname(p.save(prefix)[0])
+        # Additional features
+        p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+        p.annotate_streamlines(
+            ("gas", "velocity_x"), ("gas", "velocity_y"), factor=8, density=4
+        )
+        p.render()
 
-            # Slice plot test
-            p = SlicePlot(ds, ax, ("gas", "density"))
-            p.annotate_streamlines(("gas", "velocity_x"), ("gas", "velocity_y"))
-            assert_fname(p.save(prefix)[0])
+        p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+        p.annotate_streamlines(
+            ("gas", "velocity_x"),
+            ("gas", "velocity_y"),
+            field_color=("stream", "magvel"),
+        )
+        p.render()
+        check_axis_manipulation(p)
 
-            # Additional features
-            p = SlicePlot(ds, ax, ("gas", "density"))
-            p.annotate_streamlines(
-                ("gas", "velocity_x"), ("gas", "velocity_y"), factor=32, density=4
-            )
-            assert_fname(p.save(prefix)[0])
-
-            p = SlicePlot(ds, ax, ("gas", "density"))
-            p.annotate_streamlines(
-                ("gas", "velocity_x"),
-                ("gas", "velocity_y"),
-                field_color=("stream", "magvel"),
-            )
-            assert_fname(p.save(prefix)[0])
-            check_axis_manipulation(p, prefix)
-
-            p = SlicePlot(ds, ax, ("gas", "density"))
-            p.annotate_streamlines(
-                ("gas", "velocity_x"),
-                ("gas", "velocity_y"),
-                field_color=("stream", "magvel"),
-                display_threshold=0.5,
-                cmap="viridis",
-                arrowstyle="->",
-            )
-            assert_fname(p.save(prefix)[0])
+        p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+        p.annotate_streamlines(
+            ("gas", "velocity_x"),
+            ("gas", "velocity_y"),
+            field_color=("stream", "magvel"),
+            display_threshold=0.5,
+            cmap="viridis",
+            arrowstyle="->",
+        )
+        p.render()
 
     # Axisymmetric dataset
+    ds = load(cyl_2d)
+    slc = SlicePlot(ds, "theta", ("gas", "velocity_magnitude"), buff_size=(40, 40))
+    slc.annotate_streamlines(("gas", "velocity_r"), ("gas", "velocity_z"))
+    slc.render()
 
-    with _cleanup_fname() as prefix:
-
-        ds = load(cyl_2d)
-        slc = SlicePlot(ds, "theta", ("gas", "velocity_magnitude"))
-        slc.annotate_streamlines(("gas", "velocity_r"), ("gas", "velocity_z"))
-        assert_fname(slc.save(prefix)[0])
-
-    with _cleanup_fname() as prefix:
-        ds = load(cyl_3d)
-        slc = SlicePlot(ds, "r", ("gas", "velocity_magnitude"))
-        slc.annotate_streamlines(("gas", "velocity_theta"), ("gas", "velocity_z"))
-        assert_fname(slc.save(prefix)[0])
-        slc = SlicePlot(ds, "z", ("gas", "velocity_magnitude"))
-        slc.annotate_streamlines(
-            ("gas", "velocity_cartesian_x"), ("gas", "velocity_cartesian_y")
-        )
-        assert_fname(slc.save(prefix)[0])
-        slc = SlicePlot(ds, "theta", ("gas", "velocity_magnitude"))
-        slc.annotate_streamlines(("gas", "velocity_r"), ("gas", "velocity_z"))
-        assert_fname(slc.save(prefix)[0])
+    ds = load(cyl_3d)
+    slc = SlicePlot(ds, "r", ("gas", "velocity_magnitude"), buff_size=(40, 40))
+    slc.annotate_streamlines(("gas", "velocity_theta"), ("gas", "velocity_z"))
+    slc.render()
+    slc = SlicePlot(ds, "z", ("gas", "velocity_magnitude"), buff_size=(40, 40))
+    slc.annotate_streamlines(
+        ("gas", "velocity_cartesian_x"), ("gas", "velocity_cartesian_y")
+    )
+    slc.render()
+    slc = SlicePlot(ds, "theta", ("gas", "velocity_magnitude"), buff_size=(40, 40))
+    slc.annotate_streamlines(("gas", "velocity_r"), ("gas", "velocity_z"))
+    slc.render()
 
     # Spherical dataset
-    with _cleanup_fname() as prefix:
-
-        ds = fake_amr_ds(
-            fields=("density", "velocity_r", "velocity_theta", "velocity_phi"),
-            units=("g/cm**3", "cm/s", "cm/s", "cm/s"),
-            geometry="spherical",
-        )
-        p = SlicePlot(ds, "r", ("gas", "density"))
-        assert_raises(
-            YTDataTypeUnsupported,
-            p.annotate_streamlines,
-            ("gas", "velocity_theta"),
-            ("gas", "velocity_phi"),
-        )
+    ds = fake_amr_ds(
+        fields=("density", "velocity_r", "velocity_theta", "velocity_phi"),
+        units=("g/cm**3", "cm/s", "cm/s", "cm/s"),
+        geometry="spherical",
+    )
+    p = SlicePlot(ds, "r", ("gas", "density"), buff_size=(40, 40))
+    assert_raises(
+        YTDataTypeUnsupported,
+        p.annotate_streamlines,
+        ("gas", "velocity_theta"),
+        ("gas", "velocity_phi"),
+    )
 
 
 @requires_file(cyl_2d)
 @requires_file(cyl_3d)
 def test_line_integral_convolution_callback():
-    with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(
-            fields=("density", "velocity_x", "velocity_y", "velocity_z"),
-            units=("g/cm**3", "cm/s", "cm/s", "cm/s"),
-        )
-        for ax in "xyz":
-            p = ProjectionPlot(ds, ax, ("gas", "density"))
-            p.annotate_line_integral_convolution(
-                ("gas", "velocity_x"), ("gas", "velocity_y")
-            )
-            assert_fname(p.save(prefix)[0])
-            p = ProjectionPlot(
-                ds, ax, ("gas", "density"), weight_field=("gas", "density")
-            )
-            p.annotate_line_integral_convolution(
-                ("gas", "velocity_x"), ("gas", "velocity_y")
-            )
-            assert_fname(p.save(prefix)[0])
-            p = SlicePlot(ds, ax, ("gas", "density"))
-            p.annotate_line_integral_convolution(
-                ("gas", "velocity_x"), ("gas", "velocity_y")
-            )
-            assert_fname(p.save(prefix)[0])
-        # Now we'll check a few additional minor things
-        p = SlicePlot(ds, "x", ("gas", "density"))
+    ds = fake_amr_ds(
+        fields=("density", "velocity_x", "velocity_y", "velocity_z"),
+        units=("g/cm**3", "cm/s", "cm/s", "cm/s"),
+    )
+    for ax in "xyz":
+        p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
         p.annotate_line_integral_convolution(
-            ("gas", "velocity_x"),
-            ("gas", "velocity_y"),
-            kernellen=100.0,
-            lim=(0.4, 0.7),
-            cmap=ytcfg.get("yt", "default_colormap"),
-            alpha=0.9,
-            const_alpha=True,
+            ("gas", "velocity_x"), ("gas", "velocity_y")
         )
-        p.save(prefix)
+        p.render()
+        p = ProjectionPlot(
+            ds,
+            ax,
+            ("gas", "density"),
+            weight_field=("gas", "density"),
+            buff_size=(40, 40),
+        )
+        p.annotate_line_integral_convolution(
+            ("gas", "velocity_x"), ("gas", "velocity_y")
+        )
+        p.render()
+        p = SlicePlot(ds, ax, ("gas", "density"), buff_size=(40, 40))
+        p.annotate_line_integral_convolution(
+            ("gas", "velocity_x"), ("gas", "velocity_y")
+        )
+        p.render()
+    # Now we'll check a few additional minor things
+    p = SlicePlot(ds, "x", ("gas", "density"), buff_size=(40, 40))
+    p.annotate_line_integral_convolution(
+        ("gas", "velocity_x"),
+        ("gas", "velocity_y"),
+        kernellen=100.0,
+        lim=(0.4, 0.7),
+        cmap=ytcfg.get("yt", "default_colormap"),
+        alpha=0.9,
+        const_alpha=True,
+    )
+    p.render()
 
-    with _cleanup_fname() as prefix:
-        ds = load(cyl_2d)
-        slc = SlicePlot(ds, "theta", ("gas", "magnetic_field_strength"))
-        slc.annotate_line_integral_convolution(
-            ("gas", "magnetic_field_r"), ("gas", "magnetic_field_z")
-        )
-        assert_fname(slc.save(prefix)[0])
+    ds = load(cyl_2d)
+    slc = SlicePlot(ds, "theta", ("gas", "magnetic_field_strength"), buff_size=(40, 40))
+    slc.annotate_line_integral_convolution(
+        ("gas", "magnetic_field_r"), ("gas", "magnetic_field_z")
+    )
+    slc.render()
 
-    with _cleanup_fname() as prefix:
-        ds = load(cyl_3d)
-        slc = SlicePlot(ds, "r", ("gas", "magnetic_field_strength"))
-        slc.annotate_line_integral_convolution(
-            ("gas", "magnetic_field_theta"), ("gas", "magnetic_field_z")
-        )
-        assert_fname(slc.save(prefix)[0])
-        slc = SlicePlot(ds, "z", ("gas", "magnetic_field_strength"))
-        slc.annotate_line_integral_convolution(
-            ("gas", "magnetic_field_cartesian_x"), ("gas", "magnetic_field_cartesian_y")
-        )
-        assert_fname(slc.save(prefix)[0])
-        slc = SlicePlot(ds, "theta", ("gas", "magnetic_field_strength"))
-        slc.annotate_line_integral_convolution(
-            ("gas", "magnetic_field_r"), ("gas", "magnetic_field_z")
-        )
-        assert_fname(slc.save(prefix)[0])
-        check_axis_manipulation(slc, prefix)
+    ds = load(cyl_3d)
+    slc = SlicePlot(ds, "r", ("gas", "magnetic_field_strength"), buff_size=(40, 40))
+    slc.annotate_line_integral_convolution(
+        ("gas", "magnetic_field_theta"), ("gas", "magnetic_field_z")
+    )
+    slc.render()
+    slc = SlicePlot(ds, "z", ("gas", "magnetic_field_strength"), buff_size=(40, 40))
+    slc.annotate_line_integral_convolution(
+        ("gas", "magnetic_field_cartesian_x"), ("gas", "magnetic_field_cartesian_y")
+    )
+    slc.render()
+    slc = SlicePlot(ds, "theta", ("gas", "magnetic_field_strength"), buff_size=(40, 40))
+    slc.annotate_line_integral_convolution(
+        ("gas", "magnetic_field_r"), ("gas", "magnetic_field_z")
+    )
+    slc.render()
+    check_axis_manipulation(slc)
 
-    with _cleanup_fname() as prefix:
-        ds = fake_amr_ds(
-            fields=("density", "velocity_r", "velocity_theta", "velocity_phi"),
-            units=("g/cm**3", "cm/s", "cm/s", "cm/s"),
-            geometry="spherical",
-        )
-        p = SlicePlot(ds, "r", ("gas", "density"))
-        assert_raises(
-            YTDataTypeUnsupported,
-            p.annotate_line_integral_convolution,
-            ("gas", "velocity_theta"),
-            ("gas", "velocity_phi"),
-        )
+    ds = fake_amr_ds(
+        fields=("density", "velocity_r", "velocity_theta", "velocity_phi"),
+        units=("g/cm**3", "cm/s", "cm/s", "cm/s"),
+        geometry="spherical",
+    )
+    p = SlicePlot(ds, "r", ("gas", "density"), buff_size=(40, 40))
+    assert_raises(
+        YTDataTypeUnsupported,
+        p.annotate_line_integral_convolution,
+        ("gas", "velocity_theta"),
+        ("gas", "velocity_phi"),
+    )
 
 
 def test_accepts_all_fields_decorator():
@@ -1055,7 +1019,7 @@ def test_accepts_all_fields_decorator():
     ]
     units = ["g/cm**3", "cm/s", "dyn/cm**2", "K"]
     ds = fake_random_ds(16, fields=fields, units=units)
-    plot = SlicePlot(ds, "z", fields=fields)
+    plot = SlicePlot(ds, "z", fields=fields, buff_size=(40, 40))
 
     # mocking a class method
     plot.fake_attr = {f: "not set" for f in fields}


### PR DESCRIPTION
## PR Summary
This test module takes about 10% of the total test time on Jenkins by my estimate (about 5min on my laptop, and usually the whole suite runs in ~45 on Jnkins), and there are a couple of ways we can save time:
- avoid saving image files that we don't even look at
- reduce buffer size
- prefer SlicePlot over ProjectionPlot
- avoid reloading the same dataset many many times
- avoid using real data, which would also greatly improve portability (currently running all these tests locally requires having the data on disk and h5Py installed)

I'll attempt to do that more or less systematically here.