### PR TITLE
add some missing test for stream grids with callables

### DIFF
--- a/nose_unit.cfg
+++ b/nose_unit.cfg
@@ -6,5 +6,5 @@ nologcapture=1
 verbosity=2
 where=yt
 with-timer=1
-ignore-files=(test_load_errors.py|test_load_sample.py|test_commons.py|test_ambiguous_fields.py|test_field_access_pytest.py|test_save.py|test_line_annotation_unit.py|test_eps_writer.py|test_registration.py|test_invalid_origin.py|test_outputs_pytest\.py|test_normal_plot_api\.py|test_load_archive\.py|test_stream_particles\.py|test_file_sanitizer\.py|test_version\.py|\test_on_demand_imports\.py|test_set_zlim\.py|test_add_field\.py|test_glue\.py|test_geometries\.py)
+ignore-files=(test_load_errors.py|test_load_sample.py|test_commons.py|test_ambiguous_fields.py|test_field_access_pytest.py|test_save.py|test_line_annotation_unit.py|test_eps_writer.py|test_registration.py|test_invalid_origin.py|test_outputs_pytest\.py|test_normal_plot_api\.py|test_load_archive\.py|test_stream_particles\.py|test_file_sanitizer\.py|test_version\.py|\test_on_demand_imports\.py|test_set_zlim\.py|test_add_field\.py|test_glue\.py|test_geometries\.py|test_callable_grids\.py)
 exclude-test=yt.frontends.gdf.tests.test_outputs.TestGDF

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -228,6 +228,7 @@ other_tests:
      - "--ignore-file=test_add_field\\.py"
      - "--ignore-file=test_glue\\.py"
      - "--ignore-file=test_geometries\\.py"
+     - "--ignore-file=test_callable_grids\\.py"
      - "--exclude-test=yt.frontends.gdf.tests.test_outputs.TestGDF"
      - "--exclude-test=yt.frontends.adaptahop.tests.test_outputs"
      - "--exclude-test=yt.frontends.stream.tests.test_stream_particles.test_stream_non_cartesian_particles"

--- a/yt/frontends/stream/tests/test_callable_grids.py
+++ b/yt/frontends/stream/tests/test_callable_grids.py
@@ -1,6 +1,7 @@
 import numpy as np
+import pytest
 
-from yt import load_amr_grids, load_hdf5_file
+from yt import load_amr_grids, load_hdf5_file, load_uniform_grid
 from yt.testing import (
     _amr_grid_index,
     assert_almost_equal,
@@ -100,3 +101,19 @@ def test_load_callable():
     assert_equal(ds.r[:].sum("cell_volume"), ds.domain_width.prod())
     assert_almost_equal(ds.r[:].max("density").d, 2660218.62833899)
     assert_almost_equal(ds.r[:].min("density").d, -2660218.62833899)
+
+
+def test_load_uniform_grid_callable():
+    data = {"density": _grid_data_function}
+    ds = load_uniform_grid(
+        data, [32, 32, 32], bbox=np.array([[0.0, 1.0], [0.0, 1.0], [0.0, 1.0]])
+    )
+    assert_equal(ds.r[:].sum("cell_volume"), ds.domain_width.prod())
+
+    with pytest.raises(RuntimeError, match="Callable functions can not be specified"):
+        _ = load_uniform_grid(
+            data,
+            [32, 32, 32],
+            bbox=np.array([[0.0, 1.0], [0.0, 1.0], [0.0, 1.0]]),
+            nprocs=16,
+        )

--- a/yt/frontends/stream/tests/test_callable_grids.py
+++ b/yt/frontends/stream/tests/test_callable_grids.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+import unyt
 
 from yt import load_amr_grids, load_hdf5_file, load_uniform_grid
 from yt.testing import (
@@ -104,11 +105,18 @@ def test_load_callable():
 
 
 def test_load_uniform_grid_callable():
-    data = {"density": _grid_data_function}
+    data = {"density": _grid_data_function, "my_temp": (_grid_data_function, "K")}
     ds = load_uniform_grid(
         data, [32, 32, 32], bbox=np.array([[0.0, 1.0], [0.0, 1.0], [0.0, 1.0]])
     )
     assert_equal(ds.r[:].sum("cell_volume"), ds.domain_width.prod())
+    # note: the following min/max values differ from test_load_callable because
+    # the grid here is coarser and the min/max values of the function are not
+    # well-sampled.
+    assert_almost_equal(ds.r[:].max("density").d, 1559160.37194738)
+    assert_almost_equal(ds.r[:].min("density").d, -1559160.37194738)
+
+    assert ds.r[:].min("my_temp").units == unyt.K
 
     with pytest.raises(RuntimeError, match="Callable functions can not be specified"):
         _ = load_uniform_grid(


### PR DESCRIPTION
This PR adds a test for calling `load_uniform_grid` with data specified via a function. It also moves the whole `test_callable_grids.py` suite to pytest-only. 