### PR TITLE
TYP: use FieldKey type aliases instead of Tuple[str, str]

### DIFF
--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -6,13 +6,13 @@ import zipfile
 from functools import partial, wraps
 from re import finditer
 from tempfile import NamedTemporaryFile, TemporaryFile
-from typing import Tuple
 
 import numpy as np
 from more_itertools import always_iterable
 from tqdm import tqdm
 
 from yt._maintenance.deprecation import issue_deprecation_warning
+from yt._typing import FieldKey
 from yt.config import ytcfg
 from yt.data_objects.field_data import YTFieldData
 from yt.data_objects.selection_objects.data_selection_objects import (
@@ -247,7 +247,7 @@ class YTProj(YTSelectionContainer2D):
         sfields = []
         if self.moment == 2:
 
-            def _sq_field(field, data, fname: Tuple[str, str]):
+            def _sq_field(field, data, fname: FieldKey):
                 return data[fname] ** 2
 
             for fname in fields:

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -2,11 +2,12 @@ import abc
 import weakref
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import List, Tuple, Union
+from typing import List, Tuple
 
 import numpy as np
 
 from yt._maintenance.deprecation import issue_deprecation_warning
+from yt._typing import AnyFieldKey
 from yt.config import ytcfg
 from yt.data_objects.field_data import YTFieldData
 from yt.data_objects.profiles import create_profile
@@ -66,7 +67,7 @@ class YTDataContainer(abc.ABC):
     _num_ghost_zones = 0
     _con_args: Tuple[str, ...] = ()
     _skip_add = False
-    _container_fields: Tuple[Union[str, Tuple[str, str]], ...] = ()
+    _container_fields: Tuple[AnyFieldKey, ...] = ()
     _tds_attrs: Tuple[str, ...] = ()
     _tds_fields: Tuple[str, ...] = ()
     _field_cache = None

--- a/yt/data_objects/index_subobjects/grid_patch.py
+++ b/yt/data_objects/index_subobjects/grid_patch.py
@@ -1,9 +1,10 @@
 import weakref
-from typing import List, Tuple
+from typing import List
 
 import numpy as np
 
 import yt.geometry.particle_deposit as particle_deposit
+from yt._typing import FieldKey
 from yt.config import ytcfg
 from yt.data_objects.selection_objects.data_selection_objects import (
     YTSelectionContainer,
@@ -269,7 +270,7 @@ class AMRGridPatch(YTSelectionContainer):
 
     def get_vertex_centered_data(
         self,
-        fields: List[Tuple[str, str]],
+        fields: List[FieldKey],
         smoothed: bool = True,
         no_ghost: bool = False,
     ):

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -20,7 +20,7 @@ from unyt import Unit
 from unyt.exceptions import UnitConversionError, UnitParseError
 
 from yt._maintenance.deprecation import issue_deprecation_warning
-from yt._typing import AnyFieldKey, FieldType, ParticleType
+from yt._typing import AnyFieldKey, FieldKey, FieldType, ParticleType
 from yt.config import ytcfg
 from yt.data_objects.particle_filters import ParticleFilter, filter_registry
 from yt.data_objects.region_expression import RegionExpression
@@ -165,7 +165,7 @@ class Dataset(abc.ABC):
     _particle_type_counts = None
     _proj_type = "quad_proj"
     _ionization_label_format = "roman_numeral"
-    _determined_fields: Optional[Dict[str, List[Tuple[str, str]]]] = None
+    _determined_fields: Optional[Dict[str, List[FieldKey]]] = None
     fields_detected = False
 
     # these are set in self._parse_parameter_file()
@@ -871,7 +871,7 @@ class Dataset(abc.ABC):
             # https://github.com/yt-project/yt/issues/3381
             return field_info
 
-        def _are_ambiguous(candidates: List[Tuple[str, str]]) -> bool:
+        def _are_ambiguous(candidates: List[FieldKey]) -> bool:
             if len(candidates) < 2:
                 return False
 
@@ -931,7 +931,7 @@ class Dataset(abc.ABC):
             except AttributeError:
                 ftype, fname = "unknown", ftype
 
-        candidates: List[Tuple[str, str]] = []
+        candidates: List[FieldKey] = []
 
         # storing this condition before altering it
         guessing_type = ftype == "unknown"

--- a/yt/fields/derived_field.py
+++ b/yt/fields/derived_field.py
@@ -1,12 +1,13 @@
 import contextlib
 import inspect
 import re
-from typing import Optional, Tuple, Union
+from typing import Optional, Union
 
 from more_itertools import always_iterable
 
 import yt.units.dimensions as ytdims
 from yt._maintenance.deprecation import issue_deprecation_warning
+from yt._typing import FieldKey
 from yt.funcs import iter_fields, validate_field_key
 from yt.units.unit_object import Unit  # type: ignore
 from yt.utilities.exceptions import YTFieldNotFound
@@ -109,7 +110,7 @@ class DerivedField:
 
     def __init__(
         self,
-        name: Tuple[str, str],
+        name: FieldKey,
         sampling_type,
         function,
         units: Optional[Union[str, bytes, Unit]] = None,
@@ -334,7 +335,7 @@ class DerivedField:
         return self._shared_aliases_list is other._shared_aliases_list
 
     @property
-    def alias_name(self) -> Optional[Tuple[str, str]]:
+    def alias_name(self) -> Optional[FieldKey]:
         if self.is_alias:
             return self._shared_aliases_list[0].name
         return None

--- a/yt/fields/domain_context.py
+++ b/yt/fields/domain_context.py
@@ -1,6 +1,8 @@
 import abc
 from typing import Tuple
 
+from yt._typing import FieldKey
+
 domain_context_registry = {}
 
 
@@ -10,8 +12,8 @@ class DomainContext(abc.ABC):
             type.__init__(cls, name, b, d)
             domain_context_registry[name] = cls
 
-    _known_fluid_fields: Tuple[Tuple[str, str], ...]
-    _known_particle_fields: Tuple[Tuple[str, str], ...]
+    _known_fluid_fields: Tuple[FieldKey, ...]
+    _known_particle_fields: Tuple[FieldKey, ...]
 
     def __init__(self, ds):
         self.ds = ds

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -6,7 +6,7 @@ from typing import Optional, Tuple
 import numpy as np
 from unyt.exceptions import UnitConversionError
 
-from yt._typing import KnownFieldsT
+from yt._typing import FieldKey, KnownFieldsT
 from yt.config import ytcfg
 from yt.fields.field_exceptions import NeedsConfiguration
 from yt.funcs import mylog, obj_length, only_on_root
@@ -43,7 +43,7 @@ class FieldInfoContainer(UserDict):
     fallback = None
     known_other_fields: KnownFieldsT = ()
     known_particle_fields: KnownFieldsT = ()
-    extra_union_fields: Tuple[Tuple[str, str], ...] = ()
+    extra_union_fields: Tuple[FieldKey, ...] = ()
 
     def __init__(self, ds, field_list, slice_info=None):
         super().__init__()
@@ -305,7 +305,7 @@ class FieldInfoContainer(UserDict):
 
     def add_field(
         self,
-        name: Tuple[str, str],
+        name: FieldKey,
         function: Callable,
         sampling_type: str,
         *,
@@ -406,8 +406,8 @@ class FieldInfoContainer(UserDict):
 
     def alias(
         self,
-        alias_name: Tuple[str, str],
-        original_name: Tuple[str, str],
+        alias_name: FieldKey,
+        original_name: FieldKey,
         units: Optional[str] = None,
         deprecate: Optional[Tuple[str, Optional[str]]] = None,
     ):
@@ -416,9 +416,9 @@ class FieldInfoContainer(UserDict):
 
         Parameters
         ----------
-        alias_name : Tuple[str, str]
+        alias_name : tuple[str, str]
             The new field name.
-        original_name : Tuple[str, str]
+        original_name : tuple[str, str]
             The field to be aliased.
         units : str
            A plain text string encoding the unit.  Powers must be in

--- a/yt/frontends/ramses/particle_handlers.py
+++ b/yt/frontends/ramses/particle_handlers.py
@@ -2,6 +2,7 @@ import abc
 import os
 from typing import List, Optional, Set, Tuple, Type
 
+from yt._typing import FieldKey
 from yt.config import ytcfg
 from yt.funcs import mylog
 from yt.utilities.cython_fortran_utils import FortranFile
@@ -39,7 +40,7 @@ class ParticleFileHandler(abc.ABC, HandlerMixin):
 
     attrs: Tuple[Tuple[str, int, str], ...]  # The attributes of the header
     known_fields: Optional[
-        List[Tuple[str, str]]
+        List[FieldKey]
     ] = None  # A list of tuple containing the field name and its type
     config_field: Optional[str] = None  # Name of the config section (if any)
 

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -1,8 +1,10 @@
 # We don't need to import 'exceptions'
 import os.path
-from typing import List, Tuple
+from typing import List
 
 from unyt.exceptions import UnitOperationError
+
+from yt._typing import FieldKey
 
 
 class YTException(Exception):
@@ -79,7 +81,7 @@ class YTFieldNotFound(YTException):
         self.field = field
         self.ds = ds
 
-    def _get_suggestions(self) -> List[Tuple[str, str]]:
+    def _get_suggestions(self) -> List[FieldKey]:
         from yt.funcs import levenshtein_distance
 
         field = self.field

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -2,11 +2,11 @@ import re
 import sys
 from functools import partial
 from numbers import Number as numeric_type
-from typing import Tuple
 
 import numpy as np
 from more_itertools import first, mark_ends
 
+from yt._typing import FieldKey
 from yt.data_objects.construction_data_containers import YTCoveringGrid
 from yt.data_objects.image_array import ImageArray
 from yt.fields.derived_field import DerivedField
@@ -1464,7 +1464,7 @@ class FITSOffAxisProjection(FITSImageData):
 
             if moment == 2:
 
-                def _sq_field(field, data, item: Tuple[str, str]):
+                def _sq_field(field, data, item: FieldKey):
                     return data[item] ** 2
 
                 fd = ds._get_field_info(*item)

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -1,10 +1,11 @@
 import weakref
 from functools import partial
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 import numpy as np
 
 from yt._maintenance.deprecation import issue_deprecation_warning
+from yt._typing import FieldKey
 from yt.data_objects.image_array import ImageArray
 from yt.frontends.ytdata.utilities import save_as_dataset
 from yt.funcs import get_output_filename, iter_fields, mylog
@@ -623,7 +624,7 @@ class OffAxisProjectionFixedResolutionBuffer(FixedResolutionBuffer):
         )
         if self.data_source.moment == 2:
 
-            def _sq_field(field, data, item: Tuple[str, str]):
+            def _sq_field(field, data, item: FieldKey):
                 return data[item] ** 2
 
             fd = self.ds._get_field_info(*item)

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -14,7 +14,7 @@ from matplotlib.font_manager import FontProperties
 from unyt.dimensions import length
 
 from yt._maintenance.deprecation import issue_deprecation_warning
-from yt._typing import Quantity
+from yt._typing import FieldKey, Quantity
 from yt.config import ytcfg
 from yt.data_objects.time_series import DatasetSeries
 from yt.funcs import ensure_dir, is_sequence, iter_fields
@@ -138,7 +138,7 @@ class PlotContainer(abc.ABC):
         self._font_color = None
         self._xlabel = None
         self._ylabel = None
-        self._minorticks: Dict[Tuple[str, str], bool] = {}
+        self._minorticks: Dict[FieldKey, bool] = {}
 
     @accepts_all_fields
     @invalidate_plot

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -10,6 +10,7 @@ import matplotlib
 import numpy as np
 
 from yt._maintenance.deprecation import issue_deprecation_warning
+from yt._typing import AnyFieldKey
 from yt.data_objects.data_containers import YTDataContainer
 from yt.data_objects.level_sets.clump_handling import Clump
 from yt.data_objects.selection_objects.cut_region import YTCutRegion
@@ -842,7 +843,7 @@ class ContourCallback(PlotCallback):
 
     def __init__(
         self,
-        field: Union[Tuple[str, str], str],
+        field: AnyFieldKey,
         levels: int = 5,
         *,
         factor: Union[Tuple[int, int], int] = 4,

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -8,6 +8,7 @@ import matplotlib
 import numpy as np
 from more_itertools.more import always_iterable, unzip
 
+from yt._typing import FieldKey
 from yt.data_objects.profiles import create_profile, sanitize_field_tuple_keys
 from yt.data_objects.static_output import Dataset
 from yt.frontends.ytdata.data_structures import YTProfileDataset
@@ -288,7 +289,7 @@ class ProfilePlot(BaseLinePlot):
         # Mypy is hardly convinced that we have a `profiles` attribute
         # at this stage, so we're lasily going to deactivate it locally
         unique = set(self.plots.values())
-        iters: Iterable[Tuple[Union[int, Tuple[str, str]], PlotMPL]]
+        iters: Iterable[Tuple[Union[int, FieldKey], PlotMPL]]
         if len(unique) < len(self.plots):
             iters = enumerate(sorted(unique))
         else:


### PR DESCRIPTION
## PR Summary
A noop followup to the introduction of type hint shortcuts in #4227
