### PR TITLE
EXP: don't call _setup_plots() method inside invalidate_figure decorator

### DIFF
--- a/yt/visualization/_commons.py
+++ b/yt/visualization/_commons.py
@@ -144,7 +144,6 @@ def invalidate_figure(f):
             self.plots[field].figure = None
             self.plots[field].axes = None
             self.plots[field].cax = None
-        # self._setup_plots()
         return retv
 
     return newfunc

--- a/yt/visualization/_commons.py
+++ b/yt/visualization/_commons.py
@@ -144,7 +144,7 @@ def invalidate_figure(f):
             self.plots[field].figure = None
             self.plots[field].axes = None
             self.plots[field].cax = None
-        self._setup_plots()
+        # self._setup_plots()
         return retv
 
     return newfunc

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -608,6 +608,7 @@ class PlotWindow(ImagePlotContainer, abc.ABC):
         axname = self.ds.coordinates.axis_name[self.data_source.axis]
         transform = self.ds.coordinates.data_transform[axname]
         self._transform = get_mpl_transform(transform)
+        self._setup_plots()
         return self
 
     @invalidate_data


### PR DESCRIPTION
## PR Summary

This feels out of place. Assuming there's a "good" reason for this function call (maybe _not_ calling it will break something), it should at least bear a comment.
Let's run all tests without it and see what it gets us.
