### PR TITLE
ENH: delay expensive imports

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -109,6 +109,12 @@ def pytest_configure(config):
     ):
         config.addinivalue_line("filterwarnings", value)
 
+    if MPL_VERSION < Version("3.5.0"):
+        config.addinivalue_line(
+            "filterwarnings",
+            r"ignore:distutils Version classes are deprecated:DeprecationWarning",
+        )
+
     if MPL_VERSION < Version("3.5.2") and PILLOW_VERSION >= Version("9.1"):
         # see https://github.com/matplotlib/matplotlib/pull/22766
         config.addinivalue_line(

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -10,7 +10,6 @@ from typing import Tuple
 
 import numpy as np
 from more_itertools import always_iterable
-from tqdm import tqdm
 
 from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.config import ytcfg
@@ -952,6 +951,8 @@ class YTCoveringGrid(YTSelectionContainer3D):
             self[p] = self._data_source[p]
 
     def _fill_sph_particles(self, fields):
+        from tqdm import tqdm
+
         # checks that we have the field and gets information
         fields = [f for f in fields if f not in self.field_data]
         if len(fields) == 0:
@@ -2948,6 +2949,8 @@ class YTOctree(YTSelectionContainer3D):
         self[fields] = self.ds.arr(buff[~self[("index", "refined")]], units)
 
     def _scatter_smooth(self, fields, units, normalize):
+        from tqdm import tqdm
+
         buff = np.zeros(self.tree.num_nodes, dtype="float64")
 
         if normalize:

--- a/yt/frontends/tipsy/io.py
+++ b/yt/frontends/tipsy/io.py
@@ -3,7 +3,6 @@ import os
 import struct
 
 import numpy as np
-from numpy.lib.recfunctions import append_fields
 
 from yt.frontends.sph.io import IOHandlerSPH
 from yt.frontends.tipsy.definitions import npart_mapping
@@ -152,6 +151,7 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
         return self._read_smoothing_length(data_file, shape[0])
 
     def _read_particle_data_file(self, data_file, ptf, selector=None):
+        from numpy.lib.recfunctions import append_fields
 
         return_data = {}
 

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -1,18 +1,15 @@
 import argparse
 import base64
-import getpass
 import json
 import os
 import pprint
 import sys
 import textwrap
 import urllib
-import urllib.request
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 from more_itertools import always_iterable
-from tqdm import tqdm
 
 from yt.config import ytcfg
 from yt.funcs import (
@@ -144,6 +141,8 @@ class FileStreamer:
         self.f = f
 
     def __iter__(self):
+        from tqdm import tqdm
+
         with tqdm(
             total=self.final_size, desc="Uploading file", unit="B", unit_scale=True
         ) as pbar:
@@ -629,22 +628,6 @@ _common_options = dict(
         help="Make projections with halo profiler.",
     ),
 )
-
-# This code snippet is modified from Georg Brandl
-def bb_apicall(endpoint, data, use_pass=True):
-    uri = f"https://api.bitbucket.org/1.0/{endpoint}/"
-    # since bitbucket doesn't return the required WWW-Authenticate header when
-    # making a request without Authorization, we cannot use the standard urllib2
-    # auth handlers; we have to add the requisite header from the start
-    if data is not None:
-        data = urllib.parse.urlencode(data)
-    req = urllib.request.Request(uri, data)
-    if use_pass:
-        username = input("Bitbucket Username? ")
-        password = getpass.getpass()
-        upw = f"{username}:{password}"
-        req.add_header("Authorization", f"Basic {base64.b64encode(upw).strip()}")
-    return urllib.request.urlopen(req).read()
 
 
 class YTInstInfoCmd(YTCommand):

--- a/yt/utilities/rpdb.py
+++ b/yt/utilities/rpdb.py
@@ -1,5 +1,4 @@
 import cmd
-import pdb
 import signal
 import sys
 import traceback
@@ -59,6 +58,8 @@ def rpdb_excepthook(exc_type, exc, tb):
 
 class pdb_handler:
     def __init__(self, tb):
+        import pdb
+
         self.cin = StringIO()
         sys.stdin = self.cin
         self.cout = StringIO()

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -2,13 +2,11 @@ import sys
 import warnings
 from abc import ABC
 from io import BytesIO
-from typing import Optional, Tuple, Union
+from typing import TYPE_CHECKING, Optional, Tuple, Union
 
 import matplotlib
 import numpy as np
-from matplotlib.axis import Axis
 from matplotlib.colors import LogNorm, Normalize, SymLogNorm
-from matplotlib.figure import Figure
 from matplotlib.ticker import LogFormatterMathtext
 from packaging.version import Version
 
@@ -22,6 +20,10 @@ from ._commons import (
     get_symlog_minorticks,
     validate_image_name,
 )
+
+if TYPE_CHECKING:
+    from matplotlib.axis import Axis
+    from matplotlib.figure import Figure
 
 BACKEND_SPECS = {
     "GTK": ["backend_gtk", "FigureCanvasGTK", "FigureManagerGTK"],
@@ -91,8 +93,8 @@ class PlotMPL:
         axrect,
         *,
         norm_handler: NormHandler,
-        figure: Optional[Figure] = None,
-        axes: Optional[Axis] = None,
+        figure: Optional["Figure"] = None,
+        axes: Optional["Axis"] = None,
     ):
         """Initialize PlotMPL class"""
         import matplotlib.figure
@@ -224,9 +226,9 @@ class ImagePlotMPL(PlotMPL, ABC):
         *,
         norm_handler: NormHandler,
         colorbar_handler: ColorbarHandler,
-        figure: Optional[Figure] = None,
-        axes: Optional[Axis] = None,
-        cax: Optional[Axis] = None,
+        figure: Optional["Figure"] = None,
+        axes: Optional["Axis"] = None,
+        cax: Optional["Axis"] = None,
     ):
         """Initialize ImagePlotMPL class object"""
         self.colorbar_handler = colorbar_handler


### PR DESCRIPTION
## PR Summary
Reduces yt's startup time by ~30% (from 1.57s to 1.07s on my machine, averaged over 100 runs)

Measured with this simple script
```python
from time import monotonic_ns

tstart = monotonic_ns()
import yt
tstop = monotonic_ns()
print(f"{(tstop-tstart)/1e9:.3f}")                                                                      
```
![diff](https://user-images.githubusercontent.com/14075922/209435861-8710dee0-e844-489c-aa12-ba6563dbfd92.png)
