### PR TITLE
TST: add missing @requires_module("h5py") decorators

### DIFF
--- a/yt/data_objects/level_sets/tests/test_clump_finding.py
+++ b/yt/data_objects/level_sets/tests/test_clump_finding.py
@@ -8,7 +8,7 @@ from yt.data_objects.level_sets.api import Clump, add_clump_info, find_clumps
 from yt.data_objects.level_sets.clump_info_items import clump_info_registry
 from yt.fields.derived_field import ValidateParameter
 from yt.loaders import load, load_uniform_grid
-from yt.testing import assert_array_equal, assert_equal, requires_file
+from yt.testing import assert_array_equal, assert_equal, requires_file, requires_module
 from yt.utilities.answer_testing.framework import data_dir_load
 
 
@@ -89,6 +89,7 @@ def test_clump_finding():
 i30 = "IsolatedGalaxy/galaxy0030/galaxy0030"
 
 
+@requires_module("h5py")
 @requires_file(i30)
 def test_clump_tree_save():
     tmpdir = tempfile.mkdtemp()
@@ -152,6 +153,7 @@ def test_clump_tree_save():
 i30 = "IsolatedGalaxy/galaxy0030/galaxy0030"
 
 
+@requires_module("h5py")
 @requires_file(i30)
 def test_clump_field_parameters():
     """

--- a/yt/data_objects/tests/test_covering_grid.py
+++ b/yt/data_objects/tests/test_covering_grid.py
@@ -24,6 +24,7 @@ def setup():
     ytcfg["yt", "internals", "within_testing"] = True
 
 
+@requires_module("h5py")
 @requires_file(cyl_2d)
 @requires_file(cyl_3d)
 def test_covering_grid():
@@ -91,6 +92,7 @@ def test_covering_grid():
         sp.quantities.total_mass()
 
 
+@requires_module("h5py")
 @requires_file(cyl_2d)
 @requires_file(cyl_3d)
 def test_covering_grid_data_source():

--- a/yt/data_objects/tests/test_dataset_access.py
+++ b/yt/data_objects/tests/test_dataset_access.py
@@ -8,6 +8,7 @@ from yt.testing import (
     fake_particle_ds,
     fake_random_ds,
     requires_file,
+    requires_module,
 )
 from yt.utilities.answer_testing.framework import data_dir_load
 from yt.utilities.exceptions import YTDimensionalityError
@@ -182,6 +183,7 @@ def test_particle_counts():
 g30 = "IsolatedGalaxy/galaxy0030/galaxy0030"
 
 
+@requires_module("h5py")
 @requires_file(g30)
 def test_checksum():
     assert fake_random_ds(16).checksum == "notafile"

--- a/yt/data_objects/tests/test_extract_regions.py
+++ b/yt/data_objects/tests/test_extract_regions.py
@@ -7,6 +7,7 @@ from yt.testing import (
     fake_amr_ds,
     fake_random_ds,
     requires_file,
+    requires_module,
 )
 
 
@@ -85,6 +86,7 @@ def test_region_and_particles():
 ISOGAL = "IsolatedGalaxy/galaxy0030/galaxy0030"
 
 
+@requires_module("h5py")
 @requires_file(ISOGAL)
 def test_region_chunked_read():
     # see #2104
@@ -95,6 +97,7 @@ def test_region_chunked_read():
     dense_sp.quantities.angular_momentum_vector()
 
 
+@requires_module("h5py")
 @requires_file(ISOGAL)
 def test_chained_cut_region():
     # see Issue #2233

--- a/yt/data_objects/tests/test_pickling.py
+++ b/yt/data_objects/tests/test_pickling.py
@@ -1,12 +1,13 @@
 import pickle
 
-from yt.testing import assert_equal, requires_file
+from yt.testing import assert_equal, requires_file, requires_module
 from yt.utilities.answer_testing.framework import data_dir_load
 
 tipsy_ds = "TipsyGalaxy/galaxy.00300"
 enzo_ds = "enzo_tiny_cosmology/DD0000/DD0000"
 
 
+@requires_module("h5py")
 @requires_file(enzo_ds)
 def test_grid_pickles():
     ds = data_dir_load(enzo_ds)

--- a/yt/data_objects/tests/test_rays.py
+++ b/yt/data_objects/tests/test_rays.py
@@ -1,7 +1,13 @@
 import numpy as np
 
 from yt import load
-from yt.testing import assert_equal, assert_rel_equal, fake_random_ds, requires_file
+from yt.testing import (
+    assert_equal,
+    assert_rel_equal,
+    fake_random_ds,
+    requires_file,
+    requires_module,
+)
 from yt.units._numpy_wrapper_functions import uconcatenate
 
 
@@ -58,6 +64,7 @@ def test_ray():
             assert_rel_equal(my_ray["dts"].sum(), unitary, 14)
 
 
+@requires_module("h5py")
 @requires_file("GadgetDiskGalaxy/snapshot_200.hdf5")
 def test_ray_particle():
     ds = load("GadgetDiskGalaxy/snapshot_200.hdf5")

--- a/yt/fields/tests/test_field_name_container.py
+++ b/yt/fields/tests/test_field_name_container.py
@@ -1,5 +1,5 @@
 from yt import load
-from yt.testing import fake_amr_ds, fake_hexahedral_ds, requires_file
+from yt.testing import fake_amr_ds, fake_hexahedral_ds, requires_file, requires_module
 
 
 def do_field_type(ft):
@@ -19,6 +19,7 @@ def do_field_type(ft):
 enzotiny = "enzo_tiny_cosmology/DD0046/DD0046"
 
 
+@requires_module("h5py")
 @requires_file(enzotiny)
 def test_field_name_container():
     ds = load(enzotiny)

--- a/yt/fields/tests/test_fields.py
+++ b/yt/fields/tests/test_fields.py
@@ -13,6 +13,7 @@ from yt.testing import (
     fake_particle_ds,
     fake_random_ds,
     requires_file,
+    requires_module,
 )
 from yt.units.yt_array import YTArray, YTQuantity, array_like_field
 from yt.utilities.cosmology import Cosmology
@@ -412,6 +413,7 @@ def test_array_like_field():
 ISOGAL = "IsolatedGalaxy/galaxy0030/galaxy0030"
 
 
+@requires_module("h5py")
 @requires_file(ISOGAL)
 def test_array_like_field_output_units():
     ds = load(ISOGAL)
@@ -495,6 +497,7 @@ def test_field_inference():
     assert_equal(ds._last_freq, (None, None))
 
 
+@requires_module("h5py")
 @requires_file(ISOGAL)
 def test_deposit_amr():
     ds = load(ISOGAL)

--- a/yt/fields/tests/test_particle_fields.py
+++ b/yt/fields/tests/test_particle_fields.py
@@ -1,9 +1,10 @@
-from yt.testing import assert_allclose_units, requires_file
+from yt.testing import assert_allclose_units, requires_file, requires_module
 from yt.utilities.answer_testing.framework import data_dir_load
 
 g30 = "IsolatedGalaxy/galaxy0030/galaxy0030"
 
 
+@requires_module("h5py")
 @requires_file(g30)
 def test_relative_particle_fields():
     ds = data_dir_load(g30)

--- a/yt/fields/tests/test_vector_fields.py
+++ b/yt/fields/tests/test_vector_fields.py
@@ -1,6 +1,11 @@
 import numpy as np
 
-from yt.testing import assert_allclose_units, fake_random_ds, requires_file
+from yt.testing import (
+    assert_allclose_units,
+    fake_random_ds,
+    requires_file,
+    requires_module,
+)
 from yt.units import cm, s  # type: ignore
 from yt.utilities.answer_testing.framework import data_dir_load
 from yt.visualization.volume_rendering.off_axis_projection import off_axis_projection
@@ -149,6 +154,7 @@ def test_vector_component_conversions_fake():
 g30 = "IsolatedGalaxy/galaxy0030/galaxy0030"
 
 
+@requires_module("h5py")
 @requires_file(g30)
 def test_vector_component_conversions_real():
     ds = data_dir_load(g30)

--- a/yt/frontends/arepo/tests/test_outputs.py
+++ b/yt/frontends/arepo/tests/test_outputs.py
@@ -3,7 +3,12 @@ import tempfile
 from collections import OrderedDict
 
 from yt.frontends.arepo.api import ArepoHDF5Dataset
-from yt.testing import ParticleSelectionComparison, assert_allclose_units, requires_file
+from yt.testing import (
+    ParticleSelectionComparison,
+    assert_allclose_units,
+    requires_file,
+    requires_module,
+)
 from yt.utilities.answer_testing.framework import data_dir_load, requires_ds, sph_answer
 
 bullet_h5 = "ArepoBullet/snapshot_150.hdf5"
@@ -12,6 +17,7 @@ _tng59_bbox = [[40669.34, 56669.34], [45984.04, 61984.04], [54114.9, 70114.9]]
 cr_h5 = "ArepoCosmicRays/snapshot_039.hdf5"
 
 
+@requires_module("h5py")
 @requires_file(bullet_h5)
 def test_arepo_hdf5_selection():
     ds = data_dir_load(bullet_h5)
@@ -30,6 +36,7 @@ bullet_fields = OrderedDict(
 )
 
 
+@requires_module("h5py")
 @requires_ds(bullet_h5)
 def test_arepo_bullet():
     ds = data_dir_load(bullet_h5)
@@ -54,6 +61,7 @@ tng59_fields = OrderedDict(
 )
 
 
+@requires_module("h5py")
 @requires_ds(tng59_h5)
 def test_arepo_tng59():
     ds = data_dir_load(tng59_h5, kwargs={"bounding_box": _tng59_bbox})
@@ -62,6 +70,7 @@ def test_arepo_tng59():
         yield test
 
 
+@requires_module("h5py")
 @requires_ds(tng59_h5)
 def test_arepo_tng59_periodicity():
     ds1 = data_dir_load(tng59_h5)
@@ -70,6 +79,7 @@ def test_arepo_tng59_periodicity():
     assert ds2.periodicity == (False, False, False)
 
 
+@requires_module("h5py")
 @requires_ds(tng59_h5)
 def test_index_override():
     # This tests that we can supply an index_filename, and that when we do, it
@@ -84,6 +94,7 @@ def test_index_override():
     assert len(open(tmpname).read()) == 0
 
 
+@requires_module("h5py")
 @requires_file(tng59_h5)
 def test_nh_density():
     ds = data_dir_load(tng59_h5, kwargs={"bounding_box": _tng59_bbox})
@@ -93,6 +104,7 @@ def test_nh_density():
     )
 
 
+@requires_module("h5py")
 @requires_file(tng59_h5)
 def test_arepo_tng59_selection():
     ds = data_dir_load(tng59_h5, kwargs={"bounding_box": _tng59_bbox})
@@ -109,6 +121,7 @@ cr_fields = OrderedDict(
 )
 
 
+@requires_module("h5py")
 @requires_ds(cr_h5)
 def test_arepo_cr():
     ds = data_dir_load(cr_h5)

--- a/yt/frontends/chimera/tests/test_outputs.py
+++ b/yt/frontends/chimera/tests/test_outputs.py
@@ -10,6 +10,7 @@ from yt.testing import (
     assert_array_equal,
     assert_equal,
     requires_file,
+    requires_module,
 )
 from yt.utilities.answer_testing.framework import (
     GenericArrayTest,
@@ -20,6 +21,7 @@ from yt.utilities.answer_testing.framework import (
 Two_D = "F37_80/chimera_00001_grid_1_01.h5"
 
 
+@requires_module("h5py")
 @requires_ds(Two_D)
 def test_2D():
     ds = data_dir_load(Two_D)
@@ -106,6 +108,7 @@ def test_2D():
 Three_D = "C15-3D-3deg/chimera_002715000_grid_1_01.h5"
 
 
+@requires_module("h5py")
 @requires_ds(Three_D)
 def test_3D():
     ds = data_dir_load(Three_D)

--- a/yt/frontends/cholla/tests/test_outputs.py
+++ b/yt/frontends/cholla/tests/test_outputs.py
@@ -1,6 +1,6 @@
 import yt
 from yt.frontends.cholla.api import ChollaDataset
-from yt.testing import assert_equal, requires_file
+from yt.testing import assert_equal, requires_file, requires_module
 from yt.utilities.answer_testing.framework import (
     data_dir_load,
     requires_ds,
@@ -15,11 +15,13 @@ _fields = (
 ChollaSimple = "ChollaSimple/0.h5"
 
 
+@requires_module("h5py")
 @requires_file(ChollaSimple)
 def test_ChollaDataset():
     assert isinstance(data_dir_load(ChollaSimple), ChollaDataset)
 
 
+@requires_module("h5py")
 @requires_file(ChollaSimple)
 def test_ChollaSimple_fields():
 
@@ -45,6 +47,7 @@ def test_ChollaSimple_fields():
         ad["cholla", field]
 
 
+@requires_module("h5py")
 @requires_file(ChollaSimple)
 def test_ChollaSimple_derived_fields():
 
@@ -75,6 +78,7 @@ _fields_chollasimple = (
 )
 
 
+@requires_module("h5py")
 @requires_ds(ChollaSimple)
 def test_cholla_data():
     ds = data_dir_load(ChollaSimple)

--- a/yt/frontends/chombo/tests/test_outputs.py
+++ b/yt/frontends/chombo/tests/test_outputs.py
@@ -1,5 +1,10 @@
 from yt.frontends.chombo.api import ChomboDataset, Orion2Dataset, PlutoDataset
-from yt.testing import assert_equal, requires_file, units_override_check
+from yt.testing import (
+    assert_equal,
+    requires_file,
+    requires_module,
+    units_override_check,
+)
 from yt.utilities.answer_testing.framework import (
     data_dir_load,
     requires_ds,
@@ -27,6 +32,7 @@ def test_gc():
 tb = "TurbBoxLowRes/data.0005.3d.hdf5"
 
 
+@requires_module("h5py")
 @requires_ds(tb)
 def test_tb():
     ds = data_dir_load(tb)
@@ -39,6 +45,7 @@ def test_tb():
 iso = "IsothermalSphere/data.0000.3d.hdf5"
 
 
+@requires_module("h5py")
 @requires_ds(iso)
 def test_iso():
     ds = data_dir_load(iso)
@@ -52,6 +59,7 @@ _zp_fields = (("chombo", "rhs"), ("chombo", "phi"))
 zp = "ZeldovichPancake/plt32.2d.hdf5"
 
 
+@requires_module("h5py")
 @requires_ds(zp)
 def test_zp():
     ds = data_dir_load(zp)
@@ -64,6 +72,7 @@ def test_zp():
 kho = "KelvinHelmholtz/data.0004.hdf5"
 
 
+@requires_module("h5py")
 @requires_ds(kho)
 def test_kho():
     ds = data_dir_load(kho)
@@ -73,31 +82,37 @@ def test_kho():
         yield test
 
 
+@requires_module("h5py")
 @requires_file(zp)
 def test_ChomboDataset():
     assert isinstance(data_dir_load(zp), ChomboDataset)
 
 
+@requires_module("h5py")
 @requires_file(gc)
 def test_Orion2Dataset():
     assert isinstance(data_dir_load(gc), Orion2Dataset)
 
 
+@requires_module("h5py")
 @requires_file(kho)
 def test_PlutoDataset():
     assert isinstance(data_dir_load(kho), PlutoDataset)
 
 
+@requires_module("h5py")
 @requires_file(zp)
 def test_units_override_zp():
     units_override_check(zp)
 
 
+@requires_module("h5py")
 @requires_file(gc)
 def test_units_override_gc():
     units_override_check(gc)
 
 
+@requires_module("h5py")
 @requires_file(kho)
 def test_units_override_kho():
     units_override_check(kho)

--- a/yt/frontends/eagle/tests/test_outputs.py
+++ b/yt/frontends/eagle/tests/test_outputs.py
@@ -1,10 +1,11 @@
 from yt.frontends.eagle.api import EagleDataset
-from yt.testing import ParticleSelectionComparison, requires_file
+from yt.testing import ParticleSelectionComparison, requires_file, requires_module
 from yt.utilities.answer_testing.framework import data_dir_load
 
 s28 = "snapshot_028_z000p000/snap_028_z000p000.0.hdf5"
 
 
+@requires_module("h5py")
 @requires_file(s28)
 def test_EagleDataset():
     ds = data_dir_load(s28)
@@ -16,6 +17,7 @@ def test_EagleDataset():
 s399 = "snipshot_399_z000p000/snip_399_z000p000.0.hdf5"
 
 
+@requires_module("h5py")
 @requires_file(s399)
 def test_Snipshot():
     ds = data_dir_load(s399)

--- a/yt/frontends/enzo/tests/test_outputs.py
+++ b/yt/frontends/enzo/tests/test_outputs.py
@@ -8,6 +8,7 @@ from yt.testing import (
     assert_array_equal,
     assert_equal,
     requires_file,
+    requires_module,
     units_override_check,
 )
 from yt.utilities.answer_testing.framework import (
@@ -105,6 +106,7 @@ def check_color_conservation(ds):
 m7 = "DD0010/moving7_0010"
 
 
+@requires_module("h5py")
 @requires_ds(m7)
 def test_moving7():
     ds = data_dir_load(m7)
@@ -114,6 +116,7 @@ def test_moving7():
         yield test
 
 
+@requires_module("h5py")
 @requires_ds(g30, big_data=True)
 def test_galaxy0030():
     ds = data_dir_load(g30)
@@ -125,6 +128,7 @@ def test_galaxy0030():
     assert_equal(ds.particle_type_counts, {"io": 1124453})
 
 
+@requires_module("h5py")
 @requires_ds(toro1d)
 def test_toro1d():
     ds = data_dir_load(toro1d)
@@ -134,6 +138,7 @@ def test_toro1d():
         yield test
 
 
+@requires_module("h5py")
 @requires_ds(kh2d)
 def test_kh2d():
     ds = data_dir_load(kh2d)
@@ -143,6 +148,7 @@ def test_kh2d():
         yield test
 
 
+@requires_module("h5py")
 @requires_ds(ecp, big_data=True)
 def test_ecp():
     ds = data_dir_load(ecp)
@@ -150,11 +156,13 @@ def test_ecp():
     yield check_color_conservation(ds)
 
 
+@requires_module("h5py")
 @requires_file(enzotiny)
 def test_units_override():
     units_override_check(enzotiny)
 
 
+@requires_module("h5py")
 @requires_ds(ecp, big_data=True)
 def test_nuclei_density_fields():
     ds = data_dir_load(ecp)
@@ -173,11 +181,13 @@ def test_nuclei_density_fields():
     )
 
 
+@requires_module("h5py")
 @requires_file(enzotiny)
 def test_EnzoDataset():
     assert isinstance(data_dir_load(enzotiny), EnzoDataset)
 
 
+@requires_module("h5py")
 @requires_file(two_sphere_test)
 @requires_file(active_particle_cosmology)
 def test_active_particle_datasets():
@@ -222,6 +232,7 @@ def test_active_particle_datasets():
     )
 
 
+@requires_module("h5py")
 @requires_file(mhdctot)
 def test_face_centered_mhdct_fields():
     ds = data_dir_load(mhdctot)
@@ -240,6 +251,7 @@ def test_face_centered_mhdct_fields():
     assert (ad[("enzo", "BzF")].sum(axis=-1) / 2 == ad[("enzo", "Bz")]).all()
 
 
+@requires_module("h5py")
 @requires_file(dnz)
 def test_deeply_nested_zoom():
     ds = data_dir_load(dnz)
@@ -264,6 +276,7 @@ def test_deeply_nested_zoom():
     assert_equal(max(g[("gas", "density")].max() for g in ds.index.grids), v)
 
 
+@requires_module("h5py")
 @requires_file(kh2d)
 def test_2d_grid_shape():
     # see issue #1601
@@ -274,6 +287,7 @@ def test_2d_grid_shape():
     assert g[("gas", "density")].shape == (128, 100, 1)
 
 
+@requires_module("h5py")
 @requires_file(p3mini)
 def test_nonzero_omega_radiation():
     """

--- a/yt/frontends/enzo_e/tests/test_outputs.py
+++ b/yt/frontends/enzo_e/tests/test_outputs.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from yt.frontends.enzo_e.api import EnzoEDataset
 from yt.frontends.enzo_e.fields import NODAL_FLAGS
-from yt.testing import assert_array_equal, assert_equal, requires_file
+from yt.testing import assert_array_equal, assert_equal, requires_file, requires_module
 from yt.utilities.answer_testing.framework import (
     FieldValuesTest,
     PixelizedProjectionValuesTest,
@@ -33,11 +33,13 @@ ep_cosmo = "ENZOP_DD0140/ENZOP_DD0140.block_list"
 orszag_tang = "ENZOE_orszag-tang_0.5/ENZOE_orszag-tang_0.5.block_list"
 
 
+@requires_module("h5py")
 @requires_file(hello_world)
 def test_EnzoEDataset():
     assert isinstance(data_dir_load(hello_world), EnzoEDataset)
 
 
+@requires_module("h5py")
 @requires_ds(hello_world)
 def test_hello_world():
     ds = data_dir_load(hello_world)
@@ -57,6 +59,7 @@ def test_hello_world():
         assert_equal(s1, s2)
 
 
+@requires_module("h5py")
 @requires_ds(ep_cosmo)
 def test_particle_fields():
     ds = data_dir_load(ep_cosmo)
@@ -71,6 +74,7 @@ def test_particle_fields():
         assert_equal(s1, s2)
 
 
+@requires_module("h5py")
 @requires_file(hello_world)
 def test_hierarchy():
     ds = data_dir_load(hello_world)
@@ -89,6 +93,7 @@ def test_hierarchy():
     fh.close()
 
 
+@requires_module("h5py")
 @requires_file(ep_cosmo)
 def test_critical_density():
     ds = data_dir_load(ep_cosmo)
@@ -107,6 +112,7 @@ def test_critical_density():
     assert np.abs(c1 - c2) / max(c1, c2) < 1e-3
 
 
+@requires_module("h5py")
 @requires_file(orszag_tang)
 def test_face_centered_bfields():
     # this is based on the enzo frontend test, test_face_centered_mhdct_fields

--- a/yt/frontends/flash/tests/test_outputs.py
+++ b/yt/frontends/flash/tests/test_outputs.py
@@ -10,6 +10,7 @@ from yt.testing import (
     assert_equal,
     disable_dataset_cache,
     requires_file,
+    requires_module,
     units_override_check,
 )
 from yt.utilities.answer_testing.framework import (
@@ -38,6 +39,7 @@ _fields_2d = (("gas", "temperature"), ("gas", "density"))
 wt = "WindTunnel/windtunnel_4lev_hdf5_plt_cnt_0030"
 
 
+@requires_module("h5py")
 @requires_ds(wt)
 def test_wind_tunnel():
     ds = data_dir_load(wt)
@@ -47,17 +49,20 @@ def test_wind_tunnel():
         yield test
 
 
+@requires_module("h5py")
 @requires_file(wt)
 def test_FLASHDataset():
     assert isinstance(data_dir_load(wt), FLASHDataset)
 
 
+@requires_module("h5py")
 @requires_file(sloshing)
 def test_units_override():
     units_override_check(sloshing)
 
 
 @disable_dataset_cache
+@requires_module("h5py")
 @requires_file(sloshing)
 def test_magnetic_units():
     ds1 = load(sloshing)
@@ -74,6 +79,7 @@ def test_magnetic_units():
     assert str(mag_unit2.units) == "code_magnetic"
 
 
+@requires_module("h5py")
 @requires_file(sloshing)
 def test_mu():
     ds = data_dir_load(sloshing)
@@ -96,11 +102,13 @@ fid_1to3_b1_fields = OrderedDict(
 )
 
 
+@requires_module("h5py")
 @requires_file(fid_1to3_b1)
 def test_FLASHParticleDataset():
     assert isinstance(data_dir_load(fid_1to3_b1), FLASHParticleDataset)
 
 
+@requires_module("h5py")
 @requires_file(fid_1to3_b1)
 def test_FLASHParticleDataset_selection():
     ds = data_dir_load(fid_1to3_b1)
@@ -111,6 +119,7 @@ def test_FLASHParticleDataset_selection():
 dens_turb_mag = "DensTurbMag/DensTurbMag_hdf5_plt_cnt_0015"
 
 
+@requires_module("h5py")
 @requires_file(dens_turb_mag)
 def test_FLASH25_dataset():
     ds = data_dir_load(dens_turb_mag)
@@ -123,6 +132,7 @@ def test_FLASH25_dataset():
     dd[("gas", "density")]
 
 
+@requires_module("h5py")
 @requires_ds(fid_1to3_b1, big_data=True)
 def test_fid_1to3_b1():
     ds = data_dir_load(fid_1to3_b1)
@@ -136,6 +146,7 @@ def test_fid_1to3_b1():
 loc_bub_dust = "LocBub_dust/LocBub_dust_hdf5_plt_cnt_0220"
 
 
+@requires_module("h5py")
 @requires_file(loc_bub_dust)
 def test_blockless_particles():
     ds = data_dir_load(loc_bub_dust)

--- a/yt/frontends/gadget/tests/test_outputs.py
+++ b/yt/frontends/gadget/tests/test_outputs.py
@@ -7,7 +7,7 @@ from itertools import product
 import yt
 from yt.frontends.gadget.api import GadgetDataset, GadgetHDF5Dataset
 from yt.frontends.gadget.testing import fake_gadget_binary
-from yt.testing import ParticleSelectionComparison, requires_file
+from yt.testing import ParticleSelectionComparison, requires_file, requires_module
 from yt.utilities.answer_testing.framework import data_dir_load, requires_ds, sph_answer
 
 isothermal_h5 = "IsothermalCollapse/snap_505.hdf5"
@@ -55,6 +55,7 @@ def test_gadget_binary():
     shutil.rmtree(tmpdir)
 
 
+@requires_module("h5py")
 @requires_file(isothermal_h5)
 def test_gadget_hdf5():
     assert isinstance(

--- a/yt/frontends/gadget_fof/tests/test_outputs.py
+++ b/yt/frontends/gadget_fof/tests/test_outputs.py
@@ -6,6 +6,7 @@ from yt.testing import (
     assert_array_equal,
     assert_equal,
     requires_file,
+    requires_module,
 )
 from yt.utilities.answer_testing.framework import (
     FieldValuesTest,
@@ -29,18 +30,21 @@ g5 = "gadget_fof_halos/groups_005/fof_subhalo_tab_005.0.hdf5"
 g42 = "gadget_fof_halos/groups_042/fof_subhalo_tab_042.0.hdf5"
 
 
+@requires_module("h5py")
 @requires_ds(g5)
 def test_fields_g5():
     for field in _fields:
         yield FieldValuesTest(g5, field, particle_type=True)
 
 
+@requires_module("h5py")
 @requires_ds(g42)
 def test_fields_g42():
     for field in _fields:
         yield FieldValuesTest(g42, field, particle_type=True)
 
 
+@requires_module("h5py")
 @requires_file(g42)
 def test_GadgetFOFDataset():
     assert isinstance(data_dir_load(g42), GadgetFOFDataset)
@@ -50,6 +54,7 @@ def test_GadgetFOFDataset():
 g298 = "gadget_halos/data/groups_298/fof_subhalo_tab_298.0.hdf5"
 
 
+@requires_module("h5py")
 @requires_file(g298)
 def test_particle_selection():
     ds = data_dir_load(g298)
@@ -57,6 +62,7 @@ def test_particle_selection():
     psc.run_defaults()
 
 
+@requires_module("h5py")
 @requires_file(g298)
 def test_subhalos():
     ds = data_dir_load(g298)
@@ -75,6 +81,7 @@ def test_subhalos():
     assert_equal(total_sub, total_int)
 
 
+@requires_module("h5py")
 @requires_file(g298)
 def test_halo_masses():
     ds = data_dir_load(g298)
@@ -97,6 +104,7 @@ g56 = "gadget_halos/data/groups_056/fof_subhalo_tab_056.0.hdf5"
 
 # This dataset has halos in one file and ids in another,
 # which can confuse the field detection.
+@requires_module("h5py")
 @requires_file(g56)
 def test_unbalanced_dataset():
     ds = data_dir_load(g56)
@@ -111,6 +119,7 @@ g76 = "gadget_halos/data/groups_076/fof_subhalo_tab_076.0.hdf5"
 
 # This dataset has one halo with particles distributed over 3 files
 # with the 2nd file being empty.
+@requires_module("h5py")
 @requires_file(g76)
 def test_3file_halo():
     ds = data_dir_load(g76)

--- a/yt/frontends/gdf/tests/test_outputs.py
+++ b/yt/frontends/gdf/tests/test_outputs.py
@@ -1,7 +1,7 @@
 import pytest
 
 from yt.frontends.gdf.api import GDFDataset
-from yt.testing import requires_file, units_override_check
+from yt.testing import requires_file, requires_module, units_override_check
 from yt.utilities.answer_testing.answer_tests import small_patch_amr
 
 # Test data
@@ -23,6 +23,7 @@ class TestGDF:
     def test_GDFDataset(self, ds):
         assert isinstance(ds, GDFDataset)
 
+    @requires_module("h5py")
     @requires_file(sedov)
     def test_units_override(self):
         units_override_check(sedov)

--- a/yt/frontends/gdf/tests/test_outputs_nose.py
+++ b/yt/frontends/gdf/tests/test_outputs_nose.py
@@ -1,5 +1,10 @@
 from yt.frontends.gdf.api import GDFDataset
-from yt.testing import assert_equal, requires_file, units_override_check
+from yt.testing import (
+    assert_equal,
+    requires_file,
+    requires_module,
+    units_override_check,
+)
 from yt.utilities.answer_testing.framework import (
     data_dir_load,
     requires_ds,
@@ -20,11 +25,13 @@ def test_sedov_tunnel():
         yield test
 
 
+@requires_module("h5py")
 @requires_file(sedov)
 def test_GDFDataset():
     assert isinstance(data_dir_load(sedov), GDFDataset)
 
 
+@requires_module("h5py")
 @requires_file(sedov)
 def test_units_override():
     units_override_check(sedov)

--- a/yt/frontends/gizmo/tests/test_outputs.py
+++ b/yt/frontends/gizmo/tests/test_outputs.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 import yt
 from yt.frontends.gizmo.api import GizmoDataset
 from yt.frontends.gizmo.fields import metal_elements
-from yt.testing import requires_file
+from yt.testing import requires_file, requires_module
 from yt.utilities.answer_testing.framework import requires_ds, sph_answer
 
 # This maps from field names to weight field names to use for projections
@@ -22,6 +22,7 @@ gmhd = "gizmo_mhd_mwdisk/gizmo_mhd_mwdisk.hdf5"
 gmhd_bbox = [[-400, 400]] * 3
 
 
+@requires_module("h5py")
 @requires_ds(g64, big_data=True)
 def test_gizmo_64():
     ds = yt.load(g64)
@@ -31,6 +32,7 @@ def test_gizmo_64():
         yield test
 
 
+@requires_module("h5py")
 @requires_file(gmhd)
 def test_gizmo_mhd():
     """
@@ -53,6 +55,7 @@ def test_gizmo_mhd():
         assert f.shape == (409013,)
 
 
+@requires_module("h5py")
 @requires_file(gmhd)
 def test_gas_particle_fields():
     """
@@ -87,6 +90,7 @@ def test_gas_particle_fields():
         assert (ptype, field) in ds.derived_field_list
 
 
+@requires_module("h5py")
 @requires_file(gmhd)
 def test_star_particle_fields():
     """

--- a/yt/frontends/moab/tests/test_c5.py
+++ b/yt/frontends/moab/tests/test_c5.py
@@ -5,6 +5,7 @@ from yt.testing import (
     assert_almost_equal,
     assert_equal,
     requires_file,
+    requires_module,
     units_override_check,
 )
 from yt.utilities.answer_testing.framework import (
@@ -18,6 +19,7 @@ _fields = (("moab", "flux"),)
 c5 = "c5/c5.h5m"
 
 
+@requires_module("h5py")
 @requires_ds(c5)
 def test_cantor_5():
     np.random.seed(0x4D3D3D3)
@@ -51,6 +53,7 @@ def test_cantor_5():
             yield FieldValuesTest(c5, field, dobj_name)
 
 
+@requires_module("h5py")
 @requires_file(c5)
 def test_MoabHex8Dataset():
     assert isinstance(data_dir_load(c5), MoabHex8Dataset)

--- a/yt/frontends/open_pmd/tests/test_outputs.py
+++ b/yt/frontends/open_pmd/tests/test_outputs.py
@@ -9,6 +9,7 @@ from yt.testing import (
     assert_array_equal,
     assert_equal,
     requires_file,
+    requires_module,
 )
 from yt.utilities.answer_testing.framework import data_dir_load
 
@@ -34,6 +35,7 @@ particle_fields = [
 ]
 
 
+@requires_module("h5py")
 @requires_file(threeD)
 def test_3d_out():
     ds = data_dir_load(threeD)
@@ -56,6 +58,7 @@ def test_3d_out():
     assert_almost_equal(ds.domain_right_edge - ds.domain_left_edge, domain_width)
 
 
+@requires_module("h5py")
 @requires_file(twoD)
 def test_2d_out():
     ds = data_dir_load(twoD)
@@ -89,6 +92,7 @@ def test_2d_out():
     assert_almost_equal(ds.domain_right_edge - ds.domain_left_edge, domain_width)
 
 
+@requires_module("h5py")
 @requires_file(noFields)
 def test_no_fields_out():
     ds = data_dir_load(noFields)
@@ -111,6 +115,7 @@ def test_no_fields_out():
     assert_almost_equal(ds.domain_right_edge - ds.domain_left_edge, domain_width)
 
 
+@requires_module("h5py")
 @requires_file(noParticles)
 def test_no_particles_out():
     ds = data_dir_load(noParticles)
@@ -136,6 +141,7 @@ def test_no_particles_out():
     assert_almost_equal(ds.domain_right_edge - ds.domain_left_edge, domain_width)
 
 
+@requires_module("h5py")
 @requires_file(groupBased)
 def test_groupBased_out():
     dss = load(groupBased)

--- a/yt/frontends/owls/tests/test_outputs.py
+++ b/yt/frontends/owls/tests/test_outputs.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 
 from yt.data_objects.particle_filters import add_particle_filter
 from yt.frontends.owls.api import OWLSDataset
-from yt.testing import ParticleSelectionComparison, requires_file
+from yt.testing import ParticleSelectionComparison, requires_file, requires_module
 from yt.utilities.answer_testing.framework import data_dir_load, requires_ds, sph_answer
 
 os33 = "snapshot_033/snap_033.0.hdf5"
@@ -19,6 +19,7 @@ _fields = OrderedDict(
 )
 
 
+@requires_module("h5py")
 @requires_ds(os33, big_data=True)
 def test_snapshot_033():
     ds = data_dir_load(os33)
@@ -29,11 +30,13 @@ def test_snapshot_033():
         yield test
 
 
+@requires_module("h5py")
 @requires_file(os33)
 def test_OWLSDataset():
     assert isinstance(data_dir_load(os33), OWLSDataset)
 
 
+@requires_module("h5py")
 @requires_ds(os33)
 def test_OWLS_particlefilter():
     ds = data_dir_load(os33)

--- a/yt/frontends/owls_subfind/tests/test_outputs.py
+++ b/yt/frontends/owls_subfind/tests/test_outputs.py
@@ -1,6 +1,6 @@
 import os.path
 
-from yt.testing import assert_equal
+from yt.testing import assert_equal, requires_module
 from yt.utilities.answer_testing.framework import (
     FieldValuesTest,
     data_dir_load,
@@ -21,6 +21,7 @@ g1 = "owls_fof_halos/groups_001/group_001.0.hdf5"
 g8 = "owls_fof_halos/groups_008/group_008.0.hdf5"
 
 
+@requires_module("h5py")
 @requires_ds(g8)
 def test_fields_g8():
     ds = data_dir_load(g8)
@@ -29,6 +30,7 @@ def test_fields_g8():
         yield FieldValuesTest(g8, field, particle_type=True)
 
 
+@requires_module("h5py")
 @requires_ds(g1)
 def test_fields_g1():
     ds = data_dir_load(g1)

--- a/yt/frontends/swift/tests/test_outputs.py
+++ b/yt/frontends/swift/tests/test_outputs.py
@@ -2,7 +2,12 @@ import numpy as np
 
 from yt import load
 from yt.frontends.swift.api import SwiftDataset
-from yt.testing import ParticleSelectionComparison, assert_almost_equal, requires_file
+from yt.testing import (
+    ParticleSelectionComparison,
+    assert_almost_equal,
+    requires_file,
+    requires_module,
+)
 from yt.utilities.on_demand_imports import _h5py as h5py
 
 keplerian_ring = "KeplerianRing/keplerian_ring_0020.hdf5"
@@ -10,6 +15,7 @@ EAGLE_6 = "EAGLE_6/eagle_0005.hdf5"
 
 # Combined the tests for loading a file and ensuring the units have been
 # implemented correctly to save time on re-loading a dataset
+@requires_module("h5py")
 @requires_file(keplerian_ring)
 def test_non_cosmo_dataset():
     ds = load(keplerian_ring)
@@ -49,6 +55,7 @@ def test_non_cosmo_dataset():
     assert_almost_equal(yt_density.d, raw_density)
 
 
+@requires_module("h5py")
 @requires_file(keplerian_ring)
 def test_non_cosmo_dataset_selection():
     ds = load(keplerian_ring)
@@ -56,6 +63,7 @@ def test_non_cosmo_dataset_selection():
     psc.run_defaults()
 
 
+@requires_module("h5py")
 @requires_file(EAGLE_6)
 def test_cosmo_dataset():
     ds = load(EAGLE_6)
@@ -100,6 +108,7 @@ def test_cosmo_dataset():
     assert_almost_equal(yt_density.d, raw_density)
 
 
+@requires_module("h5py")
 @requires_file(EAGLE_6)
 def test_cosmo_dataset_selection():
     ds = load(EAGLE_6)

--- a/yt/frontends/ytdata/tests/test_old_outputs.py
+++ b/yt/frontends/ytdata/tests/test_old_outputs.py
@@ -23,7 +23,13 @@ from yt.frontends.ytdata.tests.test_outputs import (
     YTDataFieldTest,
     compare_unit_attributes,
 )
-from yt.testing import assert_allclose_units, assert_array_equal, requires_file, skip
+from yt.testing import (
+    assert_allclose_units,
+    assert_array_equal,
+    requires_file,
+    requires_module,
+    skip,
+)
 from yt.units.yt_array import YTArray
 from yt.utilities.answer_testing.framework import data_dir_load, requires_ds
 from yt.visualization.profile_plotter import PhasePlot, ProfilePlot
@@ -33,6 +39,7 @@ ytdata_dir = "ytdata_test"
 
 
 @skip(reason="See https://github.com/yt-project/yt/issues/3909")
+@requires_module("h5py")
 @requires_ds(enzotiny)
 @requires_file(os.path.join(ytdata_dir, "DD0046_sphere.h5"))
 @requires_file(os.path.join(ytdata_dir, "DD0046_cut_region.h5"))
@@ -55,6 +62,7 @@ def test_old_datacontainer_data():
 
 
 @skip(reason="See https://github.com/yt-project/yt/issues/3909")
+@requires_module("h5py")
 @requires_ds(enzotiny)
 @requires_file(os.path.join(ytdata_dir, "DD0046_covering_grid.h5"))
 @requires_file(os.path.join(ytdata_dir, "DD0046_arbitrary_grid.h5"))
@@ -92,6 +100,7 @@ def test_old_grid_datacontainer_data():
 
 
 @skip(reason="See https://github.com/yt-project/yt/issues/3909")
+@requires_module("h5py")
 @requires_ds(enzotiny)
 @requires_file(os.path.join(ytdata_dir, "DD0046_proj.h5"))
 def test_old_spatial_data():
@@ -105,6 +114,7 @@ def test_old_spatial_data():
 
 
 @skip(reason="See https://github.com/yt-project/yt/issues/3909")
+@requires_module("h5py")
 @requires_ds(enzotiny)
 @requires_file(os.path.join(ytdata_dir, "DD0046_Profile1D.h5"))
 @requires_file(os.path.join(ytdata_dir, "DD0046_Profile2D.h5"))
@@ -168,6 +178,7 @@ def test_old_profile_data():
 
 
 @skip(reason="See https://github.com/yt-project/yt/issues/3909")
+@requires_module("h5py")
 @requires_ds(enzotiny)
 @requires_file(os.path.join(ytdata_dir, "test_data.h5"))
 @requires_file(os.path.join(ytdata_dir, "random_data.h5"))

--- a/yt/utilities/tests/test_cosmology.py
+++ b/yt/utilities/tests/test_cosmology.py
@@ -255,6 +255,7 @@ def test_cosmology_calculator_answers():
 enzotiny = "enzo_tiny_cosmology/DD0020/DD0020"
 
 
+@requires_module("h5py")
 @requires_file(enzotiny)
 def test_dataset_cosmology_calculator():
     """

--- a/yt/utilities/tests/test_minimal_representation.py
+++ b/yt/utilities/tests/test_minimal_representation.py
@@ -2,7 +2,7 @@ import os.path
 
 import yt
 from yt.config import ytcfg
-from yt.testing import assert_equal, assert_raises, requires_file
+from yt.testing import assert_equal, assert_raises, requires_file, requires_module
 
 G30 = "IsolatedGalaxy/galaxy0030/galaxy0030"
 
@@ -15,6 +15,7 @@ def teardown():
     ytcfg["yt", "serialize"] = False
 
 
+@requires_module("h5py")
 @requires_file(G30)
 def test_store():
     ds = yt.load(G30)

--- a/yt/visualization/tests/test_callbacks.py
+++ b/yt/visualization/tests/test_callbacks.py
@@ -15,6 +15,7 @@ from yt.testing import (
     fake_random_ds,
     fake_tetrahedral_ds,
     requires_file,
+    requires_module,
 )
 from yt.utilities.answer_testing.framework import (
     PlotWindowAttributeTest,
@@ -437,6 +438,7 @@ def test_text_callback():
         assert_fname(p.save(prefix)[0])
 
 
+@requires_module("h5py")
 @requires_file(cyl_2d)
 @requires_file(cyl_3d)
 def test_velocity_callback():
@@ -504,6 +506,7 @@ def test_velocity_callback_spherical():
         assert_raises(NotImplementedError, p.save, prefix)
 
 
+@requires_module("h5py")
 @requires_file(cyl_2d)
 @requires_file(cyl_3d)
 def test_magnetic_callback():
@@ -594,6 +597,7 @@ def test_magnetic_callback():
         assert_raises(NotImplementedError, p.save, prefix)
 
 
+@requires_module("h5py")
 @requires_file(cyl_2d)
 @requires_file(cyl_3d)
 def test_quiver_callback():
@@ -682,6 +686,7 @@ def test_quiver_callback_spherical():
         assert_fname(p.save(prefix)[0])
 
 
+@requires_module("h5py")
 @requires_file(cyl_2d)
 def test_contour_callback():
     with _cleanup_fname() as prefix:
@@ -764,6 +769,7 @@ def test_contour_callback():
         )
 
 
+@requires_module("h5py")
 @requires_file(cyl_2d)
 def test_grids_callback():
     with _cleanup_fname() as prefix:
@@ -819,6 +825,7 @@ def test_grids_callback():
         assert_raises(YTDataTypeUnsupported, p.annotate_grids, **kwargs)
 
 
+@requires_module("h5py")
 @requires_file(cyl_2d)
 def test_cell_edges_callback():
     with _cleanup_fname() as prefix:
@@ -870,6 +877,7 @@ def test_mesh_lines_callback():
         check_axis_manipulation(sl, prefix)  # only test the final field
 
 
+@requires_module("h5py")
 @requires_file(cyl_2d)
 @requires_file(cyl_3d)
 def test_streamline_callback():
@@ -965,6 +973,7 @@ def test_streamline_callback():
         )
 
 
+@requires_module("h5py")
 @requires_file(cyl_2d)
 @requires_file(cyl_3d)
 def test_line_integral_convolution_callback():


### PR DESCRIPTION
## PR Summary
facilitate running tests with tests files installed but not h5py
