### PR TITLE
ENH: add support for installing yt with cherry-picked, frontend specific optional dependencies with pip

### DIFF
--- a/doc/source/installing.rst
+++ b/doc/source/installing.rst
@@ -85,7 +85,7 @@ Additional requirements (pip only)
 
 yt knows about several data file formats. In many cases (e.g. HDF5), additional
 dependencies are needed to enable parsing, that are not installed with yt by default.
-In order to install every requirements for a specific format alongside yt,
+In order to install all required packages for a specific format alongside yt,
 one can specify them as, for instance
 
 .. code-block:: bash

--- a/doc/source/installing.rst
+++ b/doc/source/installing.rst
@@ -65,7 +65,7 @@ will work best for you depends on your precise situation:
 Installing a stable release
 +++++++++++++++++++++++++++
 
-The latest stable release can be obtained from Pypi with pip
+The latest stable release can be obtained from PyPI with pip
 
 .. code-block:: bash
 
@@ -78,6 +78,23 @@ Or using the Anaconda/Miniconda Python distributions
 .. code-block:: bash
 
   $ conda install --channel conda-forge yt
+
+
+Additional requirements (pip only)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+yt knows about several data file formats. In many cases (e.g. HDF5), additional
+dependencies are needed to enable parsing, that are not installed with yt by default.
+In order to install every requirements for a specific format alongside yt,
+one can specify them as, for instance
+
+.. code-block:: bash
+
+  $ python -m pip install --upgrade pip
+  $ python -m pip install --user "yt[ramses]"
+
+Extra requirements can be combined, separated by commas (say ``yt[ramses,enzo_e]``).
+Note that all format names are normalized to lower case.
 
 
 .. _install-from-source:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,114 @@ Tracker = "https://github.com/yt-project/yt/issues"
 answer-testing = "yt.utilities.answer_testing.framework:AnswerTesting"
 
 [project.optional-dependencies]
+# some generic, reusable constraints on optional-deps
+HDF5 = ["h5py>=3.1.0,<4.0.0"]
+netCDF4 = ["netCDF4!=1.6.1,>=1.5.3"]
+Fortran = ["f90nml>=1.1"]
+
+# frontend-specific requirements
+# all frontends should have a target, even if no additional requirements are needed
+# note that, because pip normalizes underscores to hyphens, we need to apply this transformation
+# in target names here so that recursive dependencies link correctly.
+# This does *not* prevent end-users to write, say `pip install yt[enzo_e]`.
+# We also normalize all target names to lower case for consistency.
+adaptahop = []
+ahf = []
+amrvac = ["yt[Fortran]"]
+art = []
+arepo = ["yt[HDF5]"]
+artio = []
+athena = []
+athena-pp = []
+boxlib = []
+cf-radial = ["xarray>=0.16.1", "arm-pyart!=1.12.5,>=1.11.4"]
+chimera = ["yt[HDF5]"]
+chombo = ["yt[HDF5]"]
+cholla = ["yt[HDF5]"]
+eagle = ["yt[HDF5]"]
+enzo-e = ["yt[HDF5]", "libconf>=1.0.1"]
+enzo = ["yt[HDF5]", "libconf>=1.0.1"]
+exodus-ii = ["yt[netCDF4]"]
+fits = ["astropy>=4.0.1", "regions>=0.7"]
+flash = ["yt[HDF5]"]
+gadget = ["yt[HDF5]"]
+gadget-fof = ["yt[HDF5]"]
+gamer = ["yt[HDF5]"]
+gdf = ["yt[HDF5]"]
+gizmo = ["yt[HDF5]"]
+halo-catalog = ["yt[HDF5]"]
+http-stream = ["requests>=2.20.0"]
+moab = ["yt[HDF5]"]
+nc4-cm1 = ["yt[netCDF4]"]
+open-pmd = ["yt[HDF5]"]
+owls = ["yt[HDF5]"]
+owls-subfind = ["yt[HDF5]"]
+ramses = ["yt[Fortran]"]
+rockstar = []
+sdf = ["requests>=2.20.0"]
+stream = []
+swift = ["yt[HDF5]"]
+tipsy = []
+ytdata = ["yt[HDF5]"]
+
+# "full" should contain all optional dependencies intended for users (not devs)
+# in particular it should enable support for all frontends
+full = [
+    "firefly>=3.2.0,<4.0.0",
+    "glueviz>=0.13.3",
+    "ipython>=2.0.0",
+    "miniballcpp>=0.2.1",
+    "mpi4py>=3.0.3",
+    "pandas>=1.1.2",
+    "pooch>=0.7.0",
+    "pyaml>=17.10.0",
+    "pykdtree>=1.3.1",
+    "pyqt5>=5.15.2",
+    "pyx>=0.15",
+    "scipy>=1.5.0",
+    "glue-core!=1.2.4;python_version >= '3.10'",
+    "ratarmount~=0.8.1;platform_system!='Windows' and platform_system!='Darwin'",
+    "yt[adaptahop]",
+    "yt[ahf]",
+    "yt[amrvac]",
+    "yt[art]",
+    "yt[arepo]",
+    "yt[artio]",
+    "yt[athena]",
+    "yt[athena_pp]",
+    "yt[boxlib]",
+    "yt[cf_radial]",
+    "yt[chimera]",
+    "yt[chombo]",
+    "yt[cholla]",
+    "yt[eagle]",
+    "yt[enzo_e]",
+    "yt[enzo]",
+    "yt[exodus_ii]",
+    "yt[fits]",
+    "yt[flash]",
+    "yt[gadget]",
+    "yt[gadget_fof]",
+    "yt[gamer]",
+    "yt[gdf]",
+    "yt[gizmo]",
+    "yt[halo_catalog]",
+    "yt[http_stream]",
+    "yt[moab]",
+    "yt[nc4_cm1]",
+    "yt[open_pmd]",
+    "yt[owls]",
+    "yt[owls_subfind]",
+    "yt[ramses]",
+    "yt[rockstar]",
+    "yt[sdf]",
+    "yt[stream]",
+    "yt[swift]",
+    "yt[tipsy]",
+    "yt[ytdata]",
+]
+
+# dev-only extra targets
 doc = [
     "alabaster",
     "bottle",
@@ -81,37 +189,13 @@ doc = [
     "jupyter-client<7.0",
     "nbconvert==5.6.1",
     "pyx>=0.15",
-    "regions>=0.7",
     "runnotebook",
     "scipy<=1.7.1",
     "sphinx==3.1.2",
     "sphinx-bootstrap-theme",
     "sphinx-rtd-theme",
 ]
-full = [
-    "arm-pyart!=1.12.5,>=1.11.4",
-    "astropy>=4.0.1,<6.0.0",
-    "f90nml>=1.1.2",
-    "firefly>=3.2.0,<4.0.0",
-    "glueviz>=0.13.3",
-    "h5py>=3.1.0,<4.0.0",
-    "ipython>=2.0.0",
-    "libconf>=1.0.1",
-    "miniballcpp>=0.2.1",
-    "mpi4py>=3.0.3",
-    "netCDF4!=1.6.1,>=1.5.3",
-    "pandas>=1.1.2",
-    "pooch>=0.7.0",
-    "pyaml>=17.10.0",
-    "pykdtree>=1.3.1",
-    "pyqt5>=5.15.2",
-    "pyx>=0.15",
-    "requests>=2.20.0",
-    "scipy>=1.5.0",
-    "xarray>=0.16.1",
-    "glue-core!=1.2.4;python_version >= '3.10'",
-    "ratarmount~=0.8.1;platform_system!='Windows' and platform_system!='Darwin'",
-]
+
 mapserver = [
     "bottle",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,6 @@ full = [
     "pooch>=0.7.0",
     "pyaml>=17.10.0",
     "pykdtree>=1.3.1",
-    "pyqt5>=5.15.2",
     "pyx>=0.15",
     "scipy>=1.5.0",
     "glue-core!=1.2.4;python_version >= '3.10'",


### PR DESCRIPTION
## PR Summary
Fix #4270
I still need to add documentation, but I'm opening as a draft to see how it goes with CI

## PR Checklist

- [x] New features are documented, with docstrings and narrative docs
- [N/A] Adds a test for any bugs fixed. Adds tests for new features.
