### PR TITLE
MNT: re-add lost comments from setup.cfg

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,15 +44,15 @@ requires-python = ">=3.8"
 dependencies = [
     "cmyt>=1.1.2",
     "ipywidgets>=8.0.0",
-    "matplotlib!=3.4.2,>=3.2",
+    "matplotlib!=3.4.2,>=3.2", # keep in sync with tests/windows_conda_requirements.txt
     "more-itertools>=8.4",
     "numpy>=1.17.5",
     "packaging>=20.9",
-    "pillow>=6.2.1",
-    "pyparsing>=2.0.3",
+    "pillow>=6.2.1", # transitive dependency via MPL (>=3.3)
+    "pyparsing>=2.0.3", # transitive dependency via packaging and MPL
     "tomli-w>=0.4.0",
     "tqdm>=3.4.0",
-    "unyt>=2.9.2,<3.0",
+    "unyt>=2.9.2,<3.0", # see https://github.com/yt-project/yt/issues/4162
     "tomli>=1.2.3;python_version < '3.11'",
 ]
 
@@ -76,7 +76,7 @@ answer-testing = "yt.utilities.answer_testing.framework:AnswerTesting"
 [project.optional-dependencies]
 # some generic, reusable constraints on optional-deps
 HDF5 = ["h5py>=3.1.0,<4.0.0"]
-netCDF4 = ["netCDF4!=1.6.1,>=1.5.3"]
+netCDF4 = ["netCDF4!=1.6.1,>=1.5.3"]  # see https://github.com/Unidata/netcdf4-python/issues/1192
 Fortran = ["f90nml>=1.1"]
 
 # frontend-specific requirements
@@ -138,7 +138,7 @@ full = [
     "pykdtree>=1.3.1",
     "pyx>=0.15",
     "scipy>=1.5.0",
-    "glue-core!=1.2.4;python_version >= '3.10'",
+    "glue-core!=1.2.4;python_version >= '3.10'",  # see https://github.com/glue-viz/glue/issues/2263
     "ratarmount~=0.8.1;platform_system!='Windows' and platform_system!='Darwin'",
     "yt[adaptahop]",
     "yt[ahf]",
@@ -184,17 +184,16 @@ full = [
 doc = [
     "alabaster",
     "bottle",
-    "jinja2<3.1.0",
+    "jinja2<3.1.0", # see https://github.com/readthedocs/readthedocs.org/issues/9037
     "jupyter-client<7.0",
     "nbconvert==5.6.1",
     "pyx>=0.15",
     "runnotebook",
-    "scipy<=1.7.1",
+    "scipy<=1.7.1", # see https://github.com/yt-project/yt/issues/3966 and https://github.com/scipy/scipy/issues/16602
     "sphinx==3.1.2",
     "sphinx-bootstrap-theme",
     "sphinx-rtd-theme",
 ]
-
 mapserver = [
     "bottle",
 ]
@@ -218,7 +217,7 @@ test = [
     "nose-timer~=1.0.0",
     "pyaml>=17.10.0",
     "pytest>=6.1",
-    "sympy!=1.10,!=1.9",
+    "sympy!=1.10,!=1.9", # see https://github.com/sympy/sympy/issues/22241
 ]
 typecheck = [
     "mypy==0.991",


### PR DESCRIPTION
## PR Summary
In #4271 I forgot to manually migrate comments contained in `setup.cfg`. This fixes that.
