### PR TITLE
UX: add information about missing optional dependencies as warnings and error messages in yt.load

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -161,6 +161,7 @@ def requires_index(attr_name):
 
 
 class Dataset(abc.ABC):
+    _load_requirements: list[str] = []
     default_fluid_type = "gas"
     default_field = ("gas", "density")
     fluid_types: tuple[FieldType, ...] = ("gas", "deposit", "index")
@@ -377,10 +378,17 @@ class Dataset(abc.ABC):
             raise TypeError("force_periodicity expected a boolean.")
         self._force_periodicity = val
 
+    @classmethod
+    def _missing_load_requirements(cls) -> list[str]:
+        # return a list of optional dependencies that are
+        # needed for the present class to function, but currently missing.
+        # returning an empty list means that all requirements are met
+        return [name for name in cls._load_requirements if not find_spec(name)]
+
     # abstract methods require implementation in subclasses
     @classmethod
     @abc.abstractmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
         # A heuristic test to determine if the data format can be interpreted
         # with the present frontend
         return False

--- a/yt/frontends/_skeleton/data_structures.py
+++ b/yt/frontends/_skeleton/data_structures.py
@@ -76,6 +76,9 @@ class SkeletonDataset(Dataset):
     _index_class = SkeletonHierarchy
     _field_info_class = SkeletonFieldInfo
 
+    # names of additional modules that may be required to load data from disk
+    _load_requirements: list[str] = []
+
     def __init__(
         self,
         filename,
@@ -160,7 +163,7 @@ class SkeletonDataset(Dataset):
         self.cosmological_simulation = 0
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
         # This accepts a filename or a set of arguments and returns True or
         # False depending on if the file is of the type requested.
         #

--- a/yt/frontends/adaptahop/data_structures.py
+++ b/yt/frontends/adaptahop/data_structures.py
@@ -171,7 +171,7 @@ class AdaptaHOPDataset(Dataset):
         self.parameters.update(params)
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
         fname = os.path.split(filename)[1]
         if not fname.startswith("tree_bricks") or not re.match(
             r"^tree_bricks\d{3}$", fname

--- a/yt/frontends/ahf/data_structures.py
+++ b/yt/frontends/ahf/data_structures.py
@@ -118,13 +118,11 @@ class AHFHalosDataset(Dataset):
         self.current_time = cosmo.lookback_time(param["z"], 1e6).in_units("s")
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
         if not filename.endswith(".parameter"):
             return False
         with open(filename) as f:
-            if f.readlines()[11].startswith("AHF"):
-                return True
-        return False
+            return f.readlines()[11].startswith("AHF")
 
     # Helper methods
 

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -264,7 +264,7 @@ class AMRVACDataset(Dataset):
         self.refine_by = 2
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
         """At load time, check whether data is recognized as AMRVAC formatted."""
         validation = False
         if filename.endswith(".dat"):

--- a/yt/frontends/arepo/data_structures.py
+++ b/yt/frontends/arepo/data_structures.py
@@ -8,6 +8,7 @@ from .fields import ArepoFieldInfo
 
 
 class ArepoHDF5Dataset(GadgetHDF5Dataset):
+    _load_requirements = ["h5py"]
     _field_info_class = ArepoFieldInfo
 
     def __init__(
@@ -44,7 +45,10 @@ class ArepoHDF5Dataset(GadgetHDF5Dataset):
         self.gamma_cr = self.parameters.get("GammaCR", 4.0 / 3.0)
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
+        if cls._missing_load_requirements():
+            return False
+
         need_groups = ["Header", "Config"]
         veto_groups = ["FOF", "Group", "Subhalo"]
         valid = True

--- a/yt/frontends/art/data_structures.py
+++ b/yt/frontends/art/data_structures.py
@@ -372,7 +372,7 @@ class ARTDataset(Dataset):
             self.add_particle_union(pu)
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
         """
         Defined for the NMSU file naming scheme.
         This could differ for other formats.
@@ -665,7 +665,7 @@ class DarkMatterARTDataset(ARTDataset):
         pass
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
         """
         Defined for the NMSU file naming scheme.
         This could differ for other formats.

--- a/yt/frontends/artio/data_structures.py
+++ b/yt/frontends/artio/data_structures.py
@@ -516,7 +516,7 @@ class ARTIODataset(Dataset):
             self.add_particle_union(pu)
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
         # a valid artio header file starts with a prefix and ends with .art
         name, _, ext = filename.rpartition(".")
         if ext != "art":

--- a/yt/frontends/athena/data_structures.py
+++ b/yt/frontends/athena/data_structures.py
@@ -630,7 +630,7 @@ class AthenaDataset(Dataset):
         )
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
         if not filename.endswith(".vtk"):
             return False
 

--- a/yt/frontends/athena_pp/data_structures.py
+++ b/yt/frontends/athena_pp/data_structures.py
@@ -254,13 +254,8 @@ class AthenaPPDataset(Dataset):
         )
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
-        try:
-            if filename.endswith(".athdf"):
-                return True
-        except Exception:
-            pass
-        return False
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
+        return filename.endswith(".athdf")
 
     @property
     def _skip_cache(self):

--- a/yt/frontends/chimera/data_structures.py
+++ b/yt/frontends/chimera/data_structures.py
@@ -195,6 +195,7 @@ class ChimeraUNSIndex(UnstructuredIndex):
 
 
 class ChimeraDataset(Dataset):
+    _load_requirements = ["h5py"]
     _index_class = ChimeraUNSIndex  # ChimeraHierarchy
     _field_info_class = ChimeraFieldInfo
 
@@ -267,17 +268,20 @@ class ChimeraDataset(Dataset):
         self.cosmological_simulation = 0  # Chimera is not a cosmological simulation
 
     @classmethod
-    def _is_valid(cls, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
         # This accepts a filename or a set of arguments and returns True or
         # False depending on if the file is of the type requested.
+        if cls._missing_load_requirements():
+            return False
+
         try:
-            fileh = HDF5FileHandler(args[0])
+            fileh = HDF5FileHandler(filename)
             if (
                 "fluid" in fileh
                 and "agr_c" in fileh["fluid"].keys()
                 and "grav_x_c" in fileh["fluid"].keys()
             ):
                 return True  # Numpy bless
-        except (OSError, ImportError):
+        except OSError:
             pass
         return False

--- a/yt/frontends/cholla/data_structures.py
+++ b/yt/frontends/cholla/data_structures.py
@@ -62,6 +62,7 @@ class ChollaHierarchy(GridIndex):
 
 
 class ChollaDataset(Dataset):
+    _load_requirements = ["h5py"]
     _index_class = ChollaHierarchy
     _field_info_class = ChollaFieldInfo
 
@@ -144,12 +145,15 @@ class ChollaDataset(Dataset):
         self.geometry = Geometry.CARTESIAN
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
         # This accepts a filename or a set of arguments and returns True or
         # False depending on if the file is of the type requested.
+        if cls._missing_load_requirements():
+            return False
+
         try:
             fileh = h5py.File(filename, mode="r")
-        except (ImportError, OSError):
+        except OSError:
             return False
 
         try:

--- a/yt/frontends/chombo/data_structures.py
+++ b/yt/frontends/chombo/data_structures.py
@@ -10,7 +10,7 @@ from yt.fields.field_info_container import FieldInfoContainer
 from yt.funcs import mylog, setdefaultattr
 from yt.geometry.api import Geometry
 from yt.geometry.grid_geometry_handler import GridIndex
-from yt.utilities.file_handler import HDF5FileHandler, warn_h5py
+from yt.utilities.file_handler import HDF5FileHandler, valid_hdf5_signature
 from yt.utilities.lib.misc_utilities import get_box_grids_level
 from yt.utilities.on_demand_imports import _h5py as h5py
 from yt.utilities.parallel_tools.parallel_analysis_interface import parallel_root_only
@@ -234,6 +234,7 @@ class ChomboHierarchy(GridIndex):
 
 
 class ChomboDataset(Dataset):
+    _load_requirements = ["h5py"]
     _index_class = ChomboHierarchy
     _field_info_class: type[FieldInfoContainer] = ChomboFieldInfo
 
@@ -358,7 +359,10 @@ class ChomboDataset(Dataset):
         return R_index - L_index
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
+        if cls._missing_load_requirements():
+            return False
+
         if not is_chombo_hdf5(filename):
             return False
 
@@ -552,7 +556,10 @@ class PlutoDataset(ChomboDataset):
         self._determine_current_time()
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
+        if cls._missing_load_requirements():
+            return False
+
         if not is_chombo_hdf5(filename):
             return False
 
@@ -632,6 +639,7 @@ class Orion2Hierarchy(ChomboHierarchy):
 
 
 class Orion2Dataset(ChomboDataset):
+    _load_requirements = ["h5py"]
     _index_class = Orion2Hierarchy
     _field_info_class = Orion2FieldInfo
 
@@ -709,7 +717,10 @@ class Orion2Dataset(ChomboDataset):
                 self.gamma = np.float64(vals)
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
+        if cls._missing_load_requirements():
+            return False
+
         if not is_chombo_hdf5(filename):
             return False
 
@@ -747,6 +758,7 @@ class ChomboPICHierarchy(ChomboHierarchy):
 
 
 class ChomboPICDataset(ChomboDataset):
+    _load_requirements = ["h5py"]
     _index_class = ChomboPICHierarchy
     _field_info_class = ChomboPICFieldInfo3D
 
@@ -774,8 +786,12 @@ class ChomboPICDataset(ChomboDataset):
             self._field_info_class = ChomboPICFieldInfo2D
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
-        warn_h5py(filename)
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
+        if not valid_hdf5_signature(filename):
+            return False
+
+        if cls._missing_load_requirements():
+            return False
 
         if not is_chombo_hdf5(filename):
             return False

--- a/yt/frontends/eagle/data_structures.py
+++ b/yt/frontends/eagle/data_structures.py
@@ -10,6 +10,7 @@ from .fields import EagleNetworkFieldInfo
 
 
 class EagleDataset(GadgetHDF5Dataset):
+    _load_requirements = ["h5py"]
     _particle_mass_name = "Mass"
     _field_info_class: type[FieldInfoContainer] = OWLSFieldInfo
     _time_readin_ = "Time"
@@ -36,7 +37,10 @@ class EagleDataset(GadgetHDF5Dataset):
         self._set_owls_eagle_units()
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
+        if cls._missing_load_requirements():
+            return False
+
         need_groups = [
             "Config",
             "Constants",
@@ -68,12 +72,16 @@ class EagleDataset(GadgetHDF5Dataset):
 
 
 class EagleNetworkDataset(EagleDataset):
+    _load_requirements = ["h5py"]
     _particle_mass_name = "Mass"
     _field_info_class = EagleNetworkFieldInfo
     _time_readin = "Time"
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
+        if cls._missing_load_requirements():
+            return False
+
         try:
             fileh = h5py.File(filename, mode="r")
             if (

--- a/yt/frontends/enzo/data_structures.py
+++ b/yt/frontends/enzo/data_structures.py
@@ -664,6 +664,7 @@ class EnzoDataset(Dataset):
     Enzo-specific output, set at a fixed time.
     """
 
+    _load_requirements = ["h5py", "libconf"]
     _index_class = EnzoHierarchy
     _field_info_class = EnzoFieldInfo
 
@@ -980,10 +981,10 @@ class EnzoDataset(Dataset):
         setdefaultattr(self, "magnetic_unit", self.quan(magnetic_unit, "gauss"))
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
-        if str(filename).endswith(".hierarchy"):
-            return True
-        return os.path.exists(f"{filename}.hierarchy")
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
+        return filename.endswith(".hierarchy") or os.path.exists(
+            f"{filename}.hierarchy"
+        )
 
     @classmethod
     def _guess_candidates(cls, base, directories, files):
@@ -1061,7 +1062,7 @@ class EnzoDatasetInMemory(EnzoDataset):
         return enzo
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
         return False
 
 

--- a/yt/frontends/enzo_e/data_structures.py
+++ b/yt/frontends/enzo_e/data_structures.py
@@ -284,6 +284,7 @@ class EnzoEDataset(Dataset):
     Enzo-E-specific output, set at a fixed time.
     """
 
+    _load_requirements = ["h5py", "libconf"]
     refine_by = 2
     _index_class = EnzoEHierarchy
     _field_info_class = EnzoEFieldInfo
@@ -497,10 +498,14 @@ class EnzoEDataset(Dataset):
         return self.basename[: -len(self._suffix)]
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
         ddir = os.path.dirname(filename)
         if not filename.endswith(cls._suffix):
             return False
+
+        if cls._missing_load_requirements():
+            return False
+
         try:
             with open(filename) as f:
                 block, block_file = f.readline().strip().split()

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -314,6 +314,7 @@ def check_sky_coords(filename, ndim):
 
 
 class FITSDataset(Dataset):
+    _load_requirements = ["astropy"]
     _index_class = FITSHierarchy
     _field_info_class: type[FieldInfoContainer] = FITSFieldInfo
     _dataset_type = "fits"
@@ -539,7 +540,10 @@ class FITSDataset(Dataset):
         self.lon_name = "X"
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
+        if cls._missing_load_requirements():
+            return False
+
         try:
             fileh = check_fits_valid(filename)
         except Exception:
@@ -577,6 +581,7 @@ def find_axes(axis_names, prefixes):
 
 
 class YTFITSDataset(FITSDataset):
+    _load_requirements = ["astropy"]
     _field_info_class = YTFITSFieldInfo
 
     def _parse_parameter_file(self):
@@ -641,7 +646,10 @@ class YTFITSDataset(FITSDataset):
         self.domain_right_edge = domain_right_edge
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
+        if cls._missing_load_requirements():
+            return False
+
         try:
             fileh = check_fits_valid(filename)
         except Exception:
@@ -659,6 +667,7 @@ class YTFITSDataset(FITSDataset):
 
 
 class SkyDataFITSDataset(FITSDataset):
+    _load_requirements = ["astropy"]
     _field_info_class = WCSFITSFieldInfo
 
     def _determine_wcs(self):
@@ -718,7 +727,10 @@ class SkyDataFITSDataset(FITSDataset):
             self.unit_registry.add("beam", beam_size, dimensions=dimensions.solid_angle)
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
+        if cls._missing_load_requirements():
+            return False
+
         try:
             return check_sky_coords(filename, ndim=2)
         except Exception:
@@ -745,6 +757,7 @@ class SpectralCubeFITSHierarchy(FITSHierarchy):
 
 
 class SpectralCubeFITSDataset(SkyDataFITSDataset):
+    _load_requirements = ["astropy"]
     _index_class = SpectralCubeFITSHierarchy
 
     def __init__(
@@ -831,7 +844,10 @@ class SpectralCubeFITSDataset(SkyDataFITSDataset):
         return self.arr((pv.v - self._p0) * self._dz + self._z0, self.spec_unit)
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
+        if cls._missing_load_requirements():
+            return False
+
         try:
             return check_sky_coords(filename, ndim=3)
         except Exception:
@@ -864,6 +880,7 @@ class EventsFITSHierarchy(FITSHierarchy):
 
 
 class EventsFITSDataset(SkyDataFITSDataset):
+    _load_requirements = ["astropy"]
     _index_class = EventsFITSHierarchy
 
     def __init__(
@@ -933,7 +950,10 @@ class EventsFITSDataset(SkyDataFITSDataset):
         self.wcs_2d = self.wcs
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
+        if cls._missing_load_requirements():
+            return False
+
         try:
             fileh = check_fits_valid(filename)
         except Exception:

--- a/yt/frontends/gadget/data_structures.py
+++ b/yt/frontends/gadget/data_structures.py
@@ -531,11 +531,8 @@ class GadgetDataset(SPHDataset):
         self.magnetic_unit = self.quan(*magnetic_unit)
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
-        if "header_spec" in kwargs:
-            header_spec = kwargs["header_spec"]
-        else:
-            header_spec = "default"
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
+        header_spec = kwargs.get("header_spec", "default")
         # Check to see if passed filename is a directory. If so, use it to get
         # the .0 snapshot file. Make sure there's only one such file, otherwise
         # there's an ambiguity about which file the user wants. Ignore ewah files
@@ -562,6 +559,7 @@ class GadgetHDF5File(ParticleFile):
 
 
 class GadgetHDF5Dataset(GadgetDataset):
+    _load_requirements = ["h5py"]
     _file_class = GadgetHDF5File
     _index_class = SPHParticleIndex
     _field_info_class: type[FieldInfoContainer] = GadgetFieldInfo
@@ -691,7 +689,10 @@ class GadgetHDF5Dataset(GadgetDataset):
         self.specific_energy_unit = self.quan(specific_energy_unit_cgs, "(cm/s)**2")
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
+        if cls._missing_load_requirements():
+            return False
+
         need_groups = ["Header"]
         veto_groups = ["FOF", "Group", "Subhalo"]
         valid = True
@@ -709,7 +710,7 @@ class GadgetHDF5Dataset(GadgetDataset):
             fh = h5py.File(filename, mode="r")
             valid = fh["Header"].attrs["Code"].decode("utf-8") != "SWIFT"
             fh.close()
-        except (OSError, KeyError, ImportError):
+        except (OSError, KeyError):
             pass
 
         return valid

--- a/yt/frontends/gadget_fof/data_structures.py
+++ b/yt/frontends/gadget_fof/data_structures.py
@@ -137,6 +137,7 @@ class GadgetFOFHDF5File(HaloCatalogFile):
 
 
 class GadgetFOFDataset(ParticleDataset):
+    _load_requirements = ["h5py"]
     _index_class = GadgetFOFParticleIndex
     _file_class = GadgetFOFHDF5File
     _field_info_class = GadgetFOFFieldInfo
@@ -291,7 +292,10 @@ class GadgetFOFDataset(ParticleDataset):
         return self.basename.split(".", 1)[0]
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
+        if cls._missing_load_requirements():
+            return False
+
         need_groups = ["Group", "Header", "Subhalo"]
         veto_groups = ["FOF"]
         valid = True
@@ -430,7 +434,7 @@ class GadgetFOFHaloDataset(HaloDataset):
         super().__init__(ds, dataset_type)
 
     @classmethod
-    def _is_valid(cls, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
         # This class is not meant to be instantiated by yt.load()
         return False
 

--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -202,6 +202,7 @@ class GAMERHierarchy(GridIndex):
 
 
 class GAMERDataset(Dataset):
+    _load_requirements = ["h5py"]
     _index_class = GAMERHierarchy
     _field_info_class = GAMERFieldInfo
     _handle = None
@@ -372,7 +373,10 @@ class GAMERDataset(Dataset):
         self.geometry = Geometry(geometry_parameters[parameters.get("Coordinate", 1)])
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
+        if cls._missing_load_requirements():
+            return False
+
         try:
             # define a unique way to identify GAMER datasets
             f = HDF5FileHandler(filename)

--- a/yt/frontends/gdf/data_structures.py
+++ b/yt/frontends/gdf/data_structures.py
@@ -148,6 +148,7 @@ class GDFHierarchy(GridIndex):
 
 
 class GDFDataset(Dataset):
+    _load_requirements = ["h5py"]
     _index_class = GDFHierarchy
     _field_info_class = GDFFieldInfo
 
@@ -284,7 +285,10 @@ class GDFDataset(Dataset):
         del self._handle
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
+        if cls._missing_load_requirements():
+            return False
+
         try:
             fileh = h5py.File(filename, mode="r")
             if "gridded_data_format" in fileh:

--- a/yt/frontends/gizmo/data_structures.py
+++ b/yt/frontends/gizmo/data_structures.py
@@ -11,10 +11,14 @@ from .fields import GizmoFieldInfo
 
 
 class GizmoDataset(GadgetHDF5Dataset):
+    _load_requirements = ["h5py"]
     _field_info_class = GizmoFieldInfo
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
+        if cls._missing_load_requirements():
+            return False
+
         need_groups = ["Header"]
         veto_groups = ["Config", "Constants", "FOF", "Group", "Subhalo"]
         valid = True
@@ -55,7 +59,6 @@ class GizmoDataset(GadgetHDF5Dataset):
             fh.close()
         except Exception:
             valid = False
-            pass
         return valid
 
     def _set_code_unit_attributes(self):

--- a/yt/frontends/halo_catalog/data_structures.py
+++ b/yt/frontends/halo_catalog/data_structures.py
@@ -97,6 +97,7 @@ class YTHaloCatalogDataset(SavedDataset):
     in yt_astro_analysis.
     """
 
+    _load_requirements = ["h5py"]
     _index_class = ParticleIndex
     _file_class = YTHaloCatalogFile
     _field_info_class = YTHaloCatalogFieldInfo
@@ -162,9 +163,13 @@ class YTHaloCatalogDataset(SavedDataset):
         super()._parse_parameter_file()
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
         if not filename.endswith(".h5"):
             return False
+
+        if cls._missing_load_requirements():
+            return False
+
         with h5py.File(filename, mode="r") as f:
             if (
                 "data_type" in f.attrs
@@ -382,7 +387,7 @@ class YTHaloDataset(HaloDataset):
         pass
 
     @classmethod
-    def _is_valid(cls, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
         # We don't ever want this to be loaded by yt.load.
         return False
 

--- a/yt/frontends/http_stream/data_structures.py
+++ b/yt/frontends/http_stream/data_structures.py
@@ -15,6 +15,7 @@ class HTTPParticleFile(ParticleFile):
 
 
 class HTTPStreamDataset(ParticleDataset):
+    _load_requirements = ["requests"]
     _index_class = ParticleIndex
     _file_class = HTTPParticleFile
     _field_info_class = SPHFieldInfo
@@ -95,11 +96,11 @@ class HTTPStreamDataset(ParticleDataset):
         self.conversion_factors["density"] = density_unit
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
         if not filename.startswith("http://"):
             return False
-        try:
-            return requests.get(filename + "/yt_index.json").status_code == 200
-        except ImportError:
-            # requests is not installed
+
+        if cls._missing_load_requirements():
             return False
+
+        return requests.get(filename + "/yt_index.json").status_code == 200

--- a/yt/frontends/moab/data_structures.py
+++ b/yt/frontends/moab/data_structures.py
@@ -48,6 +48,7 @@ class MoabHex8Hierarchy(UnstructuredIndex):
 
 
 class MoabHex8Dataset(Dataset):
+    _load_requirements = ["h5py"]
     _index_class = MoabHex8Hierarchy
     _field_info_class = MoabFieldInfo
     periodicity = (False, False, False)
@@ -96,8 +97,8 @@ class MoabHex8Dataset(Dataset):
         self.cosmological_simulation = 0
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
-        return filename.endswith(".h5m")
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
+        return filename.endswith(".h5m") and not cls._missing_load_requirements()
 
     def __str__(self):
         return self.basename.rsplit(".", 1)[0]
@@ -204,7 +205,7 @@ class PyneMoabHex8Dataset(Dataset):
         self.cosmological_simulation = 0
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
         return False
 
     def __str__(self):

--- a/yt/frontends/open_pmd/data_structures.py
+++ b/yt/frontends/open_pmd/data_structures.py
@@ -14,7 +14,7 @@ from yt.frontends.open_pmd.fields import OpenPMDFieldInfo
 from yt.frontends.open_pmd.misc import get_component, is_const_component
 from yt.funcs import setdefaultattr
 from yt.geometry.grid_geometry_handler import GridIndex
-from yt.utilities.file_handler import HDF5FileHandler, warn_h5py
+from yt.utilities.file_handler import HDF5FileHandler, valid_hdf5_signature
 from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.on_demand_imports import _h5py as h5py
 
@@ -431,6 +431,7 @@ class OpenPMDDataset(Dataset):
     - particle and mesh positions are *absolute* with respect to the simulation origin.
     """
 
+    _load_requirements = ["h5py"]
     _index_class = OpenPMDHierarchy
     _field_info_class = OpenPMDFieldInfo
 
@@ -601,9 +602,14 @@ class OpenPMDDataset(Dataset):
         self.current_time = f[bp].attrs["time"] * f[bp].attrs["timeUnitSI"]
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
         """Checks whether the supplied file can be read by this frontend."""
-        warn_h5py(filename)
+        if not valid_hdf5_signature(filename):
+            return False
+
+        if cls._missing_load_requirements():
+            return False
+
         try:
             with h5py.File(filename, mode="r") as f:
                 attrs = list(f["/"].attrs.keys())
@@ -618,7 +624,7 @@ class OpenPMDDataset(Dataset):
                     return True
 
                 return False
-        except (OSError, ImportError):
+        except OSError:
             return False
 
 
@@ -656,6 +662,7 @@ class OpenPMDDatasetSeries(DatasetSeries):
 
 
 class OpenPMDGroupBasedDataset(Dataset):
+    _load_requirements = ["h5py"]
     _index_class = OpenPMDHierarchy
     _field_info_class = OpenPMDFieldInfo
 
@@ -665,8 +672,13 @@ class OpenPMDGroupBasedDataset(Dataset):
         return ret
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
-        warn_h5py(filename)
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
+        if not valid_hdf5_signature(filename):
+            return False
+
+        if cls._missing_load_requirements():
+            return False
+
         try:
             with h5py.File(filename, mode="r") as f:
                 attrs = list(f["/"].attrs.keys())
@@ -681,5 +693,5 @@ class OpenPMDGroupBasedDataset(Dataset):
                     return True
 
                 return False
-        except (OSError, ImportError):
+        except OSError:
             return False

--- a/yt/frontends/owls/data_structures.py
+++ b/yt/frontends/owls/data_structures.py
@@ -9,6 +9,7 @@ from .fields import OWLSFieldInfo
 
 
 class OWLSDataset(GadgetHDF5Dataset):
+    _load_requirements = ["h5py"]
     _particle_mass_name = "Mass"
     _field_info_class = OWLSFieldInfo
     _time_readin = "Time_GYR"
@@ -30,7 +31,10 @@ class OWLSDataset(GadgetHDF5Dataset):
         self._set_owls_eagle_units()
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
+        if cls._missing_load_requirements():
+            return False
+
         need_groups = ["Constants", "Header", "Parameters", "Units"]
         veto_groups = [
             "SUBFIND",
@@ -71,5 +75,4 @@ class OWLSDataset(GadgetHDF5Dataset):
             fileh.close()
         except Exception:
             valid = False
-            pass
         return valid

--- a/yt/frontends/owls_subfind/data_structures.py
+++ b/yt/frontends/owls_subfind/data_structures.py
@@ -79,6 +79,7 @@ class OWLSSubfindHDF5File(ParticleFile):
 
 
 class OWLSSubfindDataset(ParticleDataset):
+    _load_requirements = ["h5py"]
     _index_class = OWLSSubfindParticleIndex
     _file_class = OWLSSubfindHDF5File
     _field_info_class = OWLSSubfindFieldInfo
@@ -202,17 +203,16 @@ class OWLSSubfindDataset(ParticleDataset):
         setdefaultattr(self, "time_unit", self.quan(time_unit[0], time_unit[1]))
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
+        if cls._missing_load_requirements():
+            return False
+
         need_groups = ["Constants", "Header", "Parameters", "Units", "FOF"]
-        veto_groups = []
         valid = True
         try:
             fh = h5py.File(filename, mode="r")
-            valid = all(ng in fh["/"] for ng in need_groups) and not any(
-                vg in fh["/"] for vg in veto_groups
-            )
+            valid = all(ng in fh["/"] for ng in need_groups)
             fh.close()
         except Exception:
             valid = False
-            pass
         return valid

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -693,6 +693,7 @@ class RAMSESIndex(OctreeIndex):
 
 
 class RAMSESDataset(Dataset):
+    _load_requirements = ["f90nml"]
     _index_class = RAMSESIndex
     _field_info_class = RAMSESFieldInfo
     gamma = 1.4  # This will get replaced on hydro_fn open
@@ -1036,5 +1037,8 @@ class RAMSESDataset(Dataset):
             self.parameters["namelist"] = nml
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
+        if cls._missing_load_requirements():
+            return False
+
         return RAMSESFileSanitizer(filename).is_valid

--- a/yt/frontends/rockstar/data_structures.py
+++ b/yt/frontends/rockstar/data_structures.py
@@ -112,11 +112,13 @@ class RockstarDataset(ParticleDataset):
         setdefaultattr(self, "time_unit", self.length_unit / self.velocity_unit)
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
         if not filename.endswith(".bin"):
             return False
-        with open(filename, mode="rb") as f:
-            header = fpu.read_cattrs(f, header_dt)
-            if header["magic"] == 18077126535843729616:
-                return True
-        return False
+        try:
+            with open(filename, mode="rb") as f:
+                header = fpu.read_cattrs(f, header_dt)
+        except OSError:
+            return False
+        else:
+            return header["magic"] == 18077126535843729616

--- a/yt/frontends/sdf/data_structures.py
+++ b/yt/frontends/sdf/data_structures.py
@@ -24,6 +24,7 @@ class SDFFile(ParticleFile):
 
 
 class SDFDataset(ParticleDataset):
+    _load_requirements = ["requests"]
     _index_class = ParticleIndex
     _file_class = SDFFile
     _field_info_class = SDFFieldInfo
@@ -170,14 +171,14 @@ class SDFDataset(ParticleDataset):
         setdefaultattr(self, "mass_unit", self.quan(float(factor), unit))
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
+        if cls._missing_load_requirements():
+            return False
+
         sdf_header = kwargs.get("sdf_header", filename)
         if sdf_header.startswith("http"):
-            try:
-                hreq = requests.get(sdf_header, stream=True)
-            except ImportError:
-                # requests is not installed
-                return False
+            hreq = requests.get(sdf_header, stream=True)
+
             if hreq.status_code != 200:
                 return False
             # Grab a whole 4k page.

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -445,7 +445,7 @@ class StreamDataset(Dataset):
             )
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
         return False
 
     @property

--- a/yt/frontends/swift/data_structures.py
+++ b/yt/frontends/swift/data_structures.py
@@ -13,6 +13,7 @@ class SwiftParticleFile(ParticleFile):
 
 
 class SwiftDataset(SPHDataset):
+    _load_requirements = ["h5py"]
     _index_class = SPHParticleIndex
     _field_info_class = SPHFieldInfo
     _file_class = SwiftParticleFile
@@ -168,19 +169,22 @@ class SwiftDataset(SPHDataset):
         return
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
         """
         Checks to see if the file is a valid output from SWIFT.
         This requires the file to have the Code attribute set in the
         Header dataset to "SWIFT".
         """
+        if cls._missing_load_requirements():
+            return False
+
         valid = True
         # Attempt to open the file, if it's not a hdf5 then this will fail:
         try:
             handle = h5py.File(filename, mode="r")
             valid = handle["Header"].attrs["Code"].decode("utf-8") == "SWIFT"
             handle.close()
-        except (OSError, KeyError, ImportError):
+        except (OSError, KeyError):
             valid = False
 
         return valid

--- a/yt/frontends/tipsy/data_structures.py
+++ b/yt/frontends/tipsy/data_structures.py
@@ -331,5 +331,5 @@ class TipsyDataset(SPHDataset):
         return True, endianswap
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
         return TipsyDataset._validate_header(filename)[0]

--- a/yt/frontends/ytdata/data_structures.py
+++ b/yt/frontends/ytdata/data_structures.py
@@ -236,6 +236,7 @@ class YTDataHDF5File(ParticleFile):
 class YTDataContainerDataset(YTDataset):
     """Dataset for saved geometric data containers."""
 
+    _load_requirements = ["h5py"]
     _index_class = ParticleIndex
     _file_class = YTDataHDF5File
     _field_info_class: type[FieldInfoContainer] = YTDataContainerFieldInfo
@@ -299,9 +300,13 @@ class YTDataContainerDataset(YTDataset):
         return my_obj(*my_args)
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
         if not filename.endswith(".h5"):
             return False
+
+        if cls._missing_load_requirements():
+            return False
+
         with h5py.File(filename, mode="r") as f:
             data_type = parse_h5_attr(f, "data_type")
             cont_type = parse_h5_attr(f, "container_type")
@@ -317,6 +322,8 @@ class YTDataContainerDataset(YTDataset):
 
 class YTDataLightRayDataset(YTDataContainerDataset):
     """Dataset for saved LightRay objects."""
+
+    _load_requirements = ["h5py"]
 
     def _parse_parameter_file(self):
         super()._parse_parameter_file()
@@ -346,9 +353,13 @@ class YTDataLightRayDataset(YTDataContainerDataset):
                 self.light_ray_solution[i][field_name] = self.parameters[field][i]
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
         if not filename.endswith(".h5"):
             return False
+
+        if cls._missing_load_requirements():
+            return False
+
         with h5py.File(filename, mode="r") as f:
             data_type = parse_h5_attr(f, "data_type")
             if data_type in ["yt_light_ray"]:
@@ -359,6 +370,7 @@ class YTDataLightRayDataset(YTDataContainerDataset):
 class YTSpatialPlotDataset(YTDataContainerDataset):
     """Dataset for saved slices and projections."""
 
+    _load_requirements = ["h5py"]
     _field_info_class = YTGridFieldInfo
 
     def __init__(self, *args, **kwargs):
@@ -376,9 +388,13 @@ class YTSpatialPlotDataset(YTDataContainerDataset):
                 self.parameters["weight_field"] = tuple(self.parameters["weight_field"])
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
         if not filename.endswith(".h5"):
             return False
+
+        if cls._missing_load_requirements():
+            return False
+
         with h5py.File(filename, mode="r") as f:
             data_type = parse_h5_attr(f, "data_type")
             cont_type = parse_h5_attr(f, "container_type")
@@ -479,6 +495,7 @@ class YTGridHierarchy(YTDataHierarchy):
 class YTGridDataset(YTDataset):
     """Dataset for saved covering grids, arbitrary grids, and FRBs."""
 
+    _load_requirements = ["h5py"]
     _index_class: type[Index] = YTGridHierarchy
     _field_info_class = YTGridFieldInfo
     _dataset_type = "ytgridhdf5"
@@ -550,9 +567,13 @@ class YTGridDataset(YTDataset):
                 self.field_info.alias(("gas", field), ("grid", field))
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
         if not filename.endswith(".h5"):
             return False
+
+        if cls._missing_load_requirements():
+            return False
+
         with h5py.File(filename, mode="r") as f:
             data_type = parse_h5_attr(f, "data_type")
             cont_type = parse_h5_attr(f, "container_type")
@@ -711,6 +732,7 @@ class YTNonspatialHierarchy(YTDataHierarchy):
 class YTNonspatialDataset(YTGridDataset):
     """Dataset for general array data."""
 
+    _load_requirements = ["h5py"]
     _index_class = YTNonspatialHierarchy
     _field_info_class = YTGridFieldInfo
     _dataset_type = "ytnonspatialhdf5"
@@ -766,9 +788,13 @@ class YTNonspatialDataset(YTGridDataset):
         mylog.warning("Geometric data selection not available for this dataset type.")
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
         if not filename.endswith(".h5"):
             return False
+
+        if cls._missing_load_requirements():
+            return False
+
         with h5py.File(filename, mode="r") as f:
             data_type = parse_h5_attr(f, "data_type")
             if data_type == "yt_array_data":
@@ -779,6 +805,7 @@ class YTNonspatialDataset(YTGridDataset):
 class YTProfileDataset(YTNonspatialDataset):
     """Dataset for saved profile objects."""
 
+    _load_requirements = ["h5py"]
     fluid_types = ("data", "gas", "standard_deviation")
 
     def __init__(self, filename, unit_system="cgs"):
@@ -881,9 +908,13 @@ class YTProfileDataset(YTNonspatialDataset):
         super().print_key_parameters()
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
         if not filename.endswith(".h5"):
             return False
+
+        if cls._missing_load_requirements():
+            return False
+
         with h5py.File(filename, mode="r") as f:
             data_type = parse_h5_attr(f, "data_type")
             if data_type == "yt_profile":
@@ -929,6 +960,8 @@ class YTClumpContainer(TreeContainer):
 class YTClumpTreeDataset(YTNonspatialDataset):
     """Dataset for saved clump-finder data."""
 
+    _load_requirements = ["h5py"]
+
     def __init__(self, filename, unit_system="cgs"):
         super().__init__(filename, unit_system=unit_system)
         self._load_tree()
@@ -956,9 +989,13 @@ class YTClumpTreeDataset(YTNonspatialDataset):
         return [clump for clump in self.tree if clump.children is None]
 
     @classmethod
-    def _is_valid(cls, filename, *args, **kwargs):
+    def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
         if not filename.endswith(".h5"):
             return False
+
+        if cls._missing_load_requirements():
+            return False
+
         with h5py.File(filename, mode="r") as f:
             data_type = parse_h5_attr(f, "data_type")
             if data_type is None:

--- a/yt/tests/test_load_errors.py
+++ b/yt/tests/test_load_errors.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from yt.data_objects.static_output import Dataset
@@ -202,3 +204,98 @@ def test_depr_load_keyword(tmp_path):
         match=r"Using the 'fn' argument as keyword \(on position 0\) is deprecated\.",
     ):
         load(fn=tmp_path)
+
+
+@pytest.fixture()
+def invalid_dataset_class_with_missing_requirements():
+    # define a Dataset class matching any input,
+    # just so that we don't have to require an actual
+    # dataset for some tests
+    class MockHierarchy(GridIndex):
+        pass
+
+    class MockDataset(Dataset):
+        _load_requirements = ["mock_package_name"]
+        _index_class = MockHierarchy
+
+        def _parse_parameter_file(self, *args, **kwargs):
+            self.current_time = -1.0
+            self.cosmological_simulation = 0
+
+        def _set_code_unit_attributes(self, *args, **kwargs):
+            self.length_unit = self.quan(1, "m")
+            self.mass_unit = self.quan(1, "kg")
+            self.time_unit = self.quan(1, "s")
+
+        @classmethod
+        def _is_valid(cls, *args, **kwargs):
+            return False
+
+    yield
+
+    # teardown to avoid possible breakage in following tests
+    output_type_registry.pop("MockDataset")
+
+
+@pytest.mark.usefixtures("invalid_dataset_class_with_missing_requirements")
+def test_all_invalid_with_missing_requirements(tmp_path):
+    with pytest.raises(
+        YTUnidentifiedDataType,
+        match=re.compile(
+            re.escape(f"Could not determine input format from {tmp_path!r}\n")
+            + "The following types could not be thorougly checked against your data because "
+            "their requirements are missing. "
+            "You may want to inspect this list and check your installation:\n"
+            r".*"
+            r"- MockDataset \(requires: mock_package_name\)"
+            r".*"
+            "\n\n"
+            "Please make sure you are running a sufficiently recent version of yt.",
+            re.DOTALL,
+        ),
+    ):
+        load(tmp_path)
+
+
+@pytest.fixture()
+def valid_dataset_class_with_missing_requirements():
+    # define a Dataset class matching any input,
+    # just so that we don't have to require an actual
+    # dataset for some tests
+    class MockHierarchy(GridIndex):
+        pass
+
+    class MockDataset(Dataset):
+        _load_requirements = ["mock_package_name"]
+        _index_class = MockHierarchy
+
+        def _parse_parameter_file(self, *args, **kwargs):
+            self.current_time = -1.0
+            self.cosmological_simulation = 0
+
+        def _set_code_unit_attributes(self, *args, **kwargs):
+            self.length_unit = self.quan(1, "m")
+            self.mass_unit = self.quan(1, "kg")
+            self.time_unit = self.quan(1, "s")
+
+        @classmethod
+        def _is_valid(cls, *args, **kwargs):
+            return True
+
+    yield
+
+    # teardown to avoid possible breakage in following tests
+    output_type_registry.pop("MockDataset")
+
+
+@pytest.mark.usefixtures("valid_dataset_class_with_missing_requirements")
+def test_single_valid_with_missing_requirements(tmp_path):
+    with pytest.warns(
+        UserWarning,
+        match=(
+            "This dataset appears to be of type MockDataset, "
+            "but the following requirements are currently missing: mock_package_name\n"
+            "Please verify your installation."
+        ),
+    ):
+        load(tmp_path)

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -20,11 +20,29 @@ class YTUnidentifiedDataType(YTException):
         self.kwargs = kwargs
 
     def __str__(self):
+        from yt.utilities.hierarchy_inspection import (
+            get_classes_with_missing_requirements,
+        )
+
         msg = f"Could not determine input format from {self.filename!r}"
         if self.args:
             msg += ", " + (", ".join(f"{a!r}" for a in self.args))
         if self.kwargs:
             msg += ", " + (", ".join(f"{k}={v!r}" for k, v in self.kwargs.items()))
+
+        msg += "\n"
+
+        if len(unusable_classes := get_classes_with_missing_requirements()) > 0:
+            msg += (
+                "The following types could not be thorougly checked against your data because "
+                "their requirements are missing. "
+                "You may want to inspect this list and check your installation:"
+            )
+            for cls, missing in unusable_classes.items():
+                requirements_str = ", ".join(missing)
+                msg += f"\n- {cls.__name__} (requires: {requirements_str})"
+            msg += "\n\n"
+        msg += "Please make sure you are running a sufficiently recent version of yt."
         return msg
 
 

--- a/yt/utilities/file_handler.py
+++ b/yt/utilities/file_handler.py
@@ -1,9 +1,10 @@
 from contextlib import contextmanager
 
+from yt._maintenance.deprecation import issue_deprecation_warning
 from yt.utilities.on_demand_imports import NotAModule, _h5py as h5py
 
 
-def valid_hdf5_signature(fn):
+def valid_hdf5_signature(fn: str, /) -> bool:
     signature = b"\x89HDF\r\n\x1a\n"
     try:
         with open(fn, "rb") as f:
@@ -14,6 +15,9 @@ def valid_hdf5_signature(fn):
 
 
 def warn_h5py(fn):
+    issue_deprecation_warning(
+        "warn_h5py is not used within yt any more and is deprecated.", since="4.2.0"
+    )
     needs_h5py = valid_hdf5_signature(fn)
     if needs_h5py and isinstance(h5py.File, NotAModule):
         raise RuntimeError(
@@ -76,7 +80,23 @@ class FITSFileHandler(HDF5FileHandler):
         self.handle.close()
 
 
+def valid_netcdf_signature(fn: str, /) -> bool:
+    try:
+        with open(fn, "rb") as f:
+            header = f.read(4)
+    except Exception:
+        return False
+    else:
+        return header in (b"CDF\x01", b"CDF\x02") or (
+            fn.endswith((".nc", ".nc4")) and valid_hdf5_signature(fn)
+        )
+
+
 def valid_netcdf_classic_signature(filename):
+    issue_deprecation_warning(
+        "valid_netcdf_classic_signature is not used within yt any more and is deprecated.",
+        since="4.2.0",
+    )
     signature_v1 = b"CDF\x01"
     signature_v2 = b"CDF\x02"
     try:
@@ -89,6 +109,10 @@ def valid_netcdf_classic_signature(filename):
 
 def warn_netcdf(fn):
     # There are a few variants of the netCDF format.
+    issue_deprecation_warning(
+        "warn_netcdf is not used within yt any more and is deprecated.", since="4.2.0"
+    )
+
     classic = valid_netcdf_classic_signature(fn)
     # NetCDF-4 Classic files are HDF5 files constrained to the Classic
     # data model used by netCDF-3.

--- a/yt/utilities/file_handler.py
+++ b/yt/utilities/file_handler.py
@@ -16,7 +16,7 @@ def valid_hdf5_signature(fn: str, /) -> bool:
 
 def warn_h5py(fn):
     issue_deprecation_warning(
-        "warn_h5py is not used within yt any more and is deprecated.", since="4.2.0"
+        "warn_h5py is not used within yt any more and is deprecated.", since="4.3"
     )
     needs_h5py = valid_hdf5_signature(fn)
     if needs_h5py and isinstance(h5py.File, NotAModule):
@@ -95,7 +95,7 @@ def valid_netcdf_signature(fn: str, /) -> bool:
 def valid_netcdf_classic_signature(filename):
     issue_deprecation_warning(
         "valid_netcdf_classic_signature is not used within yt any more and is deprecated.",
-        since="4.2.0",
+        since="4.3",
     )
     signature_v1 = b"CDF\x01"
     signature_v2 = b"CDF\x02"
@@ -110,7 +110,7 @@ def valid_netcdf_classic_signature(filename):
 def warn_netcdf(fn):
     # There are a few variants of the netCDF format.
     issue_deprecation_warning(
-        "warn_netcdf is not used within yt any more and is deprecated.", since="4.2.0"
+        "warn_netcdf is not used within yt any more and is deprecated.", since="4.3"
     )
 
     classic = valid_netcdf_classic_signature(fn)

--- a/yt/utilities/hierarchy_inspection.py
+++ b/yt/utilities/hierarchy_inspection.py
@@ -1,10 +1,16 @@
 import inspect
 from collections import Counter
+from typing import TypeVar
 
 from more_itertools import flatten
 
+from yt.data_objects.static_output import Dataset
+from yt.utilities.object_registries import output_type_registry
 
-def find_lowest_subclasses(candidates: list[type]) -> list[type]:
+T = TypeVar("T")
+
+
+def find_lowest_subclasses(candidates: list[type[T]]) -> list[type[T]]:
     """
     This function takes a list of classes, and returns only the ones that are
     are not super classes of any others in the list. i.e. the ones that are at
@@ -24,3 +30,14 @@ def find_lowest_subclasses(candidates: list[type]) -> list[type]:
     """
     count = Counter(flatten(inspect.getmro(c) for c in candidates))
     return [x for x in candidates if count[x] == 1]
+
+
+def get_classes_with_missing_requirements() -> dict[type[Dataset], list[str]]:
+    # We need a function here rather than an global constant registry because:
+    # - computation should be delayed until needed so that the result is independent of import order
+    # - tests might (temporarily) mutate output_type_registry
+    return {
+        cls: missing
+        for cls in sorted(output_type_registry.values(), key=lambda c: c.__name__)
+        if (missing := cls._missing_load_requirements())
+    }


### PR DESCRIPTION
## PR Summary
Fix #4274
For now I've only tested this manually but it should be relatively straightforward to add tests.


TODO:
- [x] tests
- [x] clean up redundant checks and warnings (`warn_h5py` and the likes) from `_is_valid` methods
- [x] implement early returns in `_is_valid` methods when requirements are missing
- [x] rebase