### PR TITLE
BUG: fix missing entries in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,8 +7,9 @@ include yt/utilities/tests/cosmology_answers.yml
 include yt/utilities/mesh_types.yaml
 exclude scripts/pr_backport.py
 exclude yt/utilities/lib/cykdtree/c_kdtree.cpp
-prune tests
+exclude .flake8
 prune docker
+prune tests
 prune answer-store
 recursive-include yt *.py *.pyx *.pxi *.pxd *.h *.hpp README* *.txt LICENSE* *.cu
 recursive-include doc *.rst *.txt *.py *.ipynb *.png *.jpg *.css *.html


### PR DESCRIPTION
## PR Summary

As noted by @matthewturk, the `Check MANIFEST.in` step of the wheel s workflow has been broken since #4271
This fixes it.

To validate this patch, I ran the workflow on my fork, see https://github.com/neutrinoceros/yt/actions/runs/3802301284/jobs/6467650714
