### PR TITLE
TYP: fix mypy warnings about unchecked hints

### DIFF
--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -2,7 +2,7 @@ import abc
 import weakref
 from collections import defaultdict
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, List, Tuple
+from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import numpy as np
 
@@ -76,7 +76,7 @@ class YTDataContainer(abc.ABC):
     _index = None
     _key_fields: List[str]
 
-    def __init__(self, ds, field_parameters):
+    def __init__(self, ds: Optional["Dataset"], field_parameters) -> None:
         """
         Typically this is never called directly, but only due to inheritance.
         It associates a :class:`~yt.data_objects.static_output.Dataset` with the class,

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -28,7 +28,7 @@ from typing import (
 import numpy as np
 from more_itertools import unzip
 from sympy import Symbol
-from unyt import Unit, unyt_quantity
+from unyt import Unit, UnitSystem, unyt_quantity
 from unyt.exceptions import UnitConversionError, UnitParseError
 
 from yt._maintenance.deprecation import issue_deprecation_warning
@@ -1263,7 +1263,7 @@ class Dataset(abc.ABC):
 
         self._unit_system_name: str = unit_system
 
-        self.unit_system = us
+        self.unit_system: UnitSystem = us
         self.unit_registry.unit_system = self.unit_system
 
     @property


### PR DESCRIPTION
## PR Summary

fix current warning from mypy:
```
yt/data_objects/data_containers.py: note: In member "__init__" of class "YTDataContainer":
8
yt/data_objects/data_containers.py:91: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
```

It'd be useful to turn these notes into proper errors to avoid leaking them constantly, I'll look into it.
