### PR TITLE
ENH: automatically load external frontends in load()

### DIFF
--- a/doc/source/developing/extensions.rst
+++ b/doc/source/developing/extensions.rst
@@ -40,7 +40,10 @@ Frontend as an extension
 
 Starting with version 4.2 of yt, any externally installed package that exports
 :class:`~yt.data_objects.static_output.Dataset` subclass as an entrypoint in
-``yt.frontends`` namespace in ``setup.py``:
+``yt.frontends`` namespace in ``setup.py`` or ``pyproject.toml`` will be
+automatically loaded and immediately available in :func:`~yt.loaders.load`.
+
+To add an entrypoint in an external project's ``setup.py``:
 
 .. code-block:: python
 
@@ -62,8 +65,6 @@ or ``pyproject.toml``:
    myFrontend = "my_frontend.api:MyFrontendDataset"
    myOtherFrontend = "my_frontend.api:MyOtherFrontendDataset"
 
-will be automatically loaded and immediately available in
-:func:`~yt.loaders.load`.
 
 Extension Template
 ------------------

--- a/doc/source/developing/extensions.rst
+++ b/doc/source/developing/extensions.rst
@@ -35,6 +35,36 @@ In subsequent versions, we plan to include in yt a catalog of known extensions
 and where to find them; this will put discoverability directly into the code
 base.
 
+Frontend as an extension
+------------------------
+
+Starting with version 4.2 of yt, any externally installed package that exports
+:class:`~yt.data_objects.static_output.Dataset` subclass as an entrypoint in
+``yt.frontends`` namespace in ``setup.py``:
+
+.. code-block:: python
+
+   setup(
+       # ...,
+       entry_points={
+           "yt.frontends": [
+               "myFrontend = my_frontend.api.MyFrontendDataset",
+               "myOtherFrontend = my_frontend.api.MyOtherFrontendDataset",
+           ]
+       }
+   )
+
+or ``pyproject.toml``:
+
+.. code-block:: toml
+
+   [project.entry-points."yt.frontends"]
+   myFrontend = "my_frontend.api:MyFrontendDataset"
+   myOtherFrontend = "my_frontend.api:MyOtherFrontendDataset"
+
+will be automatically loaded and immediately available in
+:func:`~yt.loaders.load`.
+
 Extension Template
 ------------------
 

--- a/nose_unit.cfg
+++ b/nose_unit.cfg
@@ -6,5 +6,5 @@ nologcapture=1
 verbosity=2
 where=yt
 with-timer=1
-ignore-files=(test_load_errors.py|test_load_sample.py|test_commons.py|test_ambiguous_fields.py|test_field_access_pytest.py|test_save.py|test_line_annotation_unit.py|test_eps_writer.py|test_registration.py|test_invalid_origin.py|test_outputs_pytest\.py|test_normal_plot_api\.py|test_load_archive\.py|test_stream_particles\.py|test_file_sanitizer\.py|test_version\.py|\test_on_demand_imports\.py|test_set_zlim\.py|test_add_field\.py|test_glue\.py|test_geometries\.py|test_firefly\.py|test_callable_grids\.py|test_external_frontend\.py)
+ignore-files=(test_load_errors.py|test_load_sample.py|test_commons.py|test_ambiguous_fields.py|test_field_access_pytest.py|test_save.py|test_line_annotation_unit.py|test_eps_writer.py|test_registration.py|test_invalid_origin.py|test_outputs_pytest\.py|test_normal_plot_api\.py|test_load_archive\.py|test_stream_particles\.py|test_file_sanitizer\.py|test_version\.py|\test_on_demand_imports\.py|test_set_zlim\.py|test_add_field\.py|test_glue\.py|test_geometries\.py|test_firefly\.py|test_callable_grids\.py|test_external_frontends\.py)
 exclude-test=yt.frontends.gdf.tests.test_outputs.TestGDF

--- a/nose_unit.cfg
+++ b/nose_unit.cfg
@@ -6,5 +6,5 @@ nologcapture=1
 verbosity=2
 where=yt
 with-timer=1
-ignore-files=(test_load_errors.py|test_load_sample.py|test_commons.py|test_ambiguous_fields.py|test_field_access_pytest.py|test_save.py|test_line_annotation_unit.py|test_eps_writer.py|test_registration.py|test_invalid_origin.py|test_outputs_pytest\.py|test_normal_plot_api\.py|test_load_archive\.py|test_stream_particles\.py|test_file_sanitizer\.py|test_version\.py|\test_on_demand_imports\.py|test_set_zlim\.py|test_add_field\.py|test_glue\.py|test_geometries\.py|test_firefly\.py|test_callable_grids\.py)
+ignore-files=(test_load_errors.py|test_load_sample.py|test_commons.py|test_ambiguous_fields.py|test_field_access_pytest.py|test_save.py|test_line_annotation_unit.py|test_eps_writer.py|test_registration.py|test_invalid_origin.py|test_outputs_pytest\.py|test_normal_plot_api\.py|test_load_archive\.py|test_stream_particles\.py|test_file_sanitizer\.py|test_version\.py|\test_on_demand_imports\.py|test_set_zlim\.py|test_add_field\.py|test_glue\.py|test_geometries\.py|test_firefly\.py|test_callable_grids\.py|test_external_frontend\.py)
 exclude-test=yt.frontends.gdf.tests.test_outputs.TestGDF

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -230,6 +230,7 @@ other_tests:
      - "--ignore-file=test_geometries\\.py"
      - "--ignore-file=test_firefly\\.py"
      - "--ignore-file=test_callable_grids\\.py"
+     - "--ignore-file=test_external_frontend\\.py"
      - "--exclude-test=yt.frontends.gdf.tests.test_outputs.TestGDF"
      - "--exclude-test=yt.frontends.adaptahop.tests.test_outputs"
      - "--exclude-test=yt.frontends.stream.tests.test_stream_particles.test_stream_non_cartesian_particles"

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -230,7 +230,7 @@ other_tests:
      - "--ignore-file=test_geometries\\.py"
      - "--ignore-file=test_firefly\\.py"
      - "--ignore-file=test_callable_grids\\.py"
-     - "--ignore-file=test_external_frontend\\.py"
+     - "--ignore-file=test_external_frontends\\.py"
      - "--exclude-test=yt.frontends.gdf.tests.test_outputs.TestGDF"
      - "--exclude-test=yt.frontends.adaptahop.tests.test_outputs"
      - "--exclude-test=yt.frontends.stream.tests.test_stream_particles.test_stream_non_cartesian_particles"

--- a/yt/frontends/sdf/data_structures.py
+++ b/yt/frontends/sdf/data_structures.py
@@ -183,8 +183,11 @@ class SDFDataset(ParticleDataset):
             # Grab a whole 4k page.
             line = next(hreq.iter_content(4096))
         elif os.path.isfile(sdf_header):
-            with open(sdf_header, encoding="ISO-8859-1") as f:
-                line = f.read(10).strip()
+            try:
+                with open(sdf_header, encoding="ISO-8859-1") as f:
+                    line = f.read(10).strip()
+            except PermissionError:
+                return False
         else:
             return False
         return line.startswith("# SDF")

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -9,6 +9,7 @@ import tarfile
 import time
 import types
 import warnings
+from importlib.metadata import entry_points
 from multiprocessing import Pipe, Process
 from multiprocessing.connection import Connection
 from pathlib import Path
@@ -96,6 +97,15 @@ def load(
     # either in the current dir or yt.config.ytcfg['data_dir_directory']
     if not fn.startswith("http"):
         fn = str(lookup_on_disk_data(fn))
+
+    if sys.version_info >= (3, 10):
+        external_frontends = entry_points(group="yt.frontends")
+    else:
+        external_frontends = entry_points().get("yt.frontends", [])
+
+    # Ensure that external frontends are loaded
+    for entrypoint in external_frontends:
+        entrypoint.load()
 
     candidates = []
     for cls in output_type_registry.values():

--- a/yt/tests/test_external_frontends.py
+++ b/yt/tests/test_external_frontends.py
@@ -19,6 +19,7 @@ class MockEntryPoint:
 
             def _parse_parameter_file(self):
                 self.current_time = 1.0
+                self.cosmological_simulation = 0
 
             def _set_code_unit_attributes(self):
                 self.length_unit = self.quan(1.0, "code_length")

--- a/yt/tests/test_external_frontends.py
+++ b/yt/tests/test_external_frontends.py
@@ -1,0 +1,47 @@
+import sys
+import tempfile
+from unittest import mock
+
+from yt.data_objects.static_output import Dataset
+from yt.geometry.grid_geometry_handler import GridIndex
+from yt.loaders import load
+from yt.utilities.object_registries import output_type_registry
+
+
+class MockEntryPoint:
+    @classmethod
+    def load(cls):
+        class MockHierarchy(GridIndex):
+            grid = None
+
+        class ExtDataset(Dataset):
+            _index_class = MockHierarchy
+
+            def _parse_parameter_file(self):
+                self.current_time = 1.0
+
+            def _set_code_unit_attributes(self):
+                self.length_unit = self.quan(1.0, "code_length")
+                self.mass_unit = self.quan(1.0, "code_mass")
+                self.time_unit = self.quan(1.0, "code_time")
+
+            @classmethod
+            def _is_valid(cls, filename, *args, **kwargs):
+                prefix = tempfile.gettempdir()
+                return filename.startswith(prefix) and filename.endswith("mock")
+
+
+def test_external_frontend():
+    assert "ExtDataset" not in output_type_registry
+
+    with tempfile.NamedTemporaryFile(suffix="mock") as test_file:
+        with mock.patch("yt.loaders.entry_points") as ep:
+            if sys.version_info >= (3, 10):
+                ep.return_value = [MockEntryPoint]
+            else:
+                ep.return_value = {"yt.frontends": [MockEntryPoint]}
+            ds = load(test_file.name)
+            assert "ExtDataset" in str(ds.__class__)
+
+    assert "ExtDataset" in output_type_registry
+    output_type_registry.pop("ExtDataset")


### PR DESCRIPTION
## PR Summary

This PR modifies the behavior of `yt.load` to auto-include subclasses of `Dataset` from external, installed packages. External packages must define an entry point in `yt.frontends` linked to the Dataset subclass (see docs for an example).

## PR Checklist

- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.