### PR TITLE
CI: silence `set-output` warning

### DIFF
--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -35,7 +35,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Set up Python (newest testable version)
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         # the '-dev' suffix allows to use alphas and betas if no final release is available yet
         # this version should be upgraded as often as possible, typically once a year when numpy

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -67,7 +67,7 @@ jobs:
 
     steps:
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Checkout repo (bare)

--- a/.github/workflows/type-checking.yaml
+++ b/.github/workflows/type-checking.yaml
@@ -28,7 +28,7 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         # run with oldest support python version
         # so that we always get compatible versions of

--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -71,7 +71,7 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: '3.10'
     - name: install check-manifest


### PR DESCRIPTION
See

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Updating `setup-python` to v4 should fix that