### PR TITLE
ENH: migrate from pkg_resources to importlib.resources on Python 3.9+

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -1,5 +1,6 @@
 import contextlib
 import glob
+import importlib.resources
 import logging
 import os
 import platform
@@ -13,8 +14,6 @@ from distutils.ccompiler import CCompiler, new_compiler
 from distutils.sysconfig import customize_compiler
 from subprocess import PIPE, Popen
 from sys import platform as _platform
-
-from pkg_resources import resource_filename
 from setuptools.command.build_ext import build_ext as _build_ext
 from setuptools.command.sdist import sdist as _sdist
 from setuptools.errors import CompileError, LinkError
@@ -204,8 +203,16 @@ def check_CPP14_flags(possible_compile_flags):
 def check_for_pyembree(std_libs):
     embree_libs = []
     embree_aliases = {}
+
+    if sys.version_info >= (3, 9):
+        _path_finder = importlib.resources.files
+    else:
+        from pkg_resources import resource_filename
+        from functools import partial
+        _path_finder = partial(resource_filename, resource_name="rtcore.pxd")
+
     try:
-        _ = resource_filename("pyembree", "rtcore.pxd")
+        _path_finder("pyembree")
     except ImportError:
         return embree_libs, embree_aliases
 

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -4,6 +4,7 @@ import contextlib
 import copy
 import errno
 import glob
+import importlib.resources
 import inspect
 import itertools
 import os
@@ -547,10 +548,13 @@ def get_git_version(path):
 
 
 def get_yt_version():
-    import pkg_resources
+    if sys.version_info >= (3, 9):
+        path = os.path.dirname(importlib.resources.files("yt"))
+    else:
+        from pkg_resources import get_provider
 
-    yt_provider = pkg_resources.get_provider("yt")
-    path = os.path.dirname(yt_provider.module_path)
+        path = os.path.dirname(get_provider("yt").module_path)
+
     version = get_git_version(path)
     if version is None:
         return version

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -1,5 +1,6 @@
 import argparse
 import base64
+import importlib.resources
 import json
 import os
 import pprint
@@ -655,10 +656,13 @@ class YTInstInfoCmd(YTCommand):
         """
 
     def __call__(self, opts):
-        import pkg_resources
+        if sys.version_info >= (3, 9):
+            path = os.path.dirname(importlib.resources.files("yt"))
+        else:
+            from pkg_resources import get_provider
 
-        yt_provider = pkg_resources.get_provider("yt")
-        path = os.path.dirname(yt_provider.module_path)
+            path = os.path.dirname(get_provider("yt").module_path)
+
         vstring = _print_installation_information(path)
         if vstring is not None:
             print("This installation CAN be automatically updated.")
@@ -1180,10 +1184,12 @@ class YTUpdateCmd(YTCommand):
         """
 
     def __call__(self, opts):
-        import pkg_resources
+        if sys.version_info >= (3, 9):
+            path = os.path.dirname(importlib.resources.files("yt"))
+        else:
+            from pkg_resources import get_provider
 
-        yt_provider = pkg_resources.get_provider("yt")
-        path = os.path.dirname(yt_provider.module_path)
+            path = os.path.dirname(get_provider("yt").module_path)
         vstring = _print_installation_information(path)
         if vstring is not None:
             print()


### PR DESCRIPTION
## PR Summary

fix #4287
Turns out it was super easy, barely an inconvenience.
