### PR TITLE
TST: add --fix-missing flag to apt-get calls in ci_install.sh

### DIFF
--- a/tests/ci_install.sh
+++ b/tests/ci_install.sh
@@ -5,7 +5,7 @@ set -x   # Show which command is being run
 case ${RUNNER_OS} in
 linux|Linux)
     sudo apt-get -q update
-    sudo apt-get -q install \
+    sudo apt-get -q --fix-missing install \
       libhdf5-serial-dev \
       libnetcdf-dev \
       libgeos-dev \

--- a/tests/ci_install.sh
+++ b/tests/ci_install.sh
@@ -4,8 +4,8 @@ set -x   # Show which command is being run
 # https://scitools.org.uk/cartopy/docs/latest/installing.html?highlight=install#building-from-source
 case ${RUNNER_OS} in
 linux|Linux)
-    sudo apt-get -qqy update
-    sudo apt-get -qqy install \
+    sudo apt-get -q update
+    sudo apt-get -q install \
       libhdf5-serial-dev \
       libnetcdf-dev \
       libgeos-dev \


### PR DESCRIPTION
## PR Summary
Supposedly fix #4299
