### PR TITLE
ENH: Allow to store multiple bitmap indices in the ewah-sidecar

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ keywords = [
 requires-python = ">=3.8"
 dependencies = [
     "cmyt>=1.1.2",
-    "h5py>=3.1.0",
     "ipywidgets>=8.0.0",
     "matplotlib!=3.4.2,>=3.2", # keep in sync with tests/windows_conda_requirements.txt
     "more-itertools>=8.4",
@@ -76,6 +75,7 @@ answer-testing = "yt.utilities.answer_testing.framework:AnswerTesting"
 
 [project.optional-dependencies]
 # some generic, reusable constraints on optional-deps
+HDF5 = ["h5py>=3.1.0,<4.0.0"]
 netCDF4 = ["netCDF4!=1.6.1,>=1.5.3"]  # see https://github.com/Unidata/netcdf4-python/issues/1192
 Fortran = ["f90nml>=1.1"]
 
@@ -89,40 +89,40 @@ adaptahop = []
 ahf = []
 amrvac = ["yt[Fortran]"]
 art = []
-arepo = []
+arepo = ["yt[HDF5]"]
 artio = []
 athena = []
 athena-pp = []
 boxlib = []
 cf-radial = ["xarray>=0.16.1", "arm-pyart!=1.12.5,>=1.11.4"]
-chimera = []
-chombo = []
-cholla = []
-eagle = []
-enzo-e = ["libconf>=1.0.1"]
-enzo = ["libconf>=1.0.1"]
+chimera = ["yt[HDF5]"]
+chombo = ["yt[HDF5]"]
+cholla = ["yt[HDF5]"]
+eagle = ["yt[HDF5]"]
+enzo-e = ["yt[HDF5]", "libconf>=1.0.1"]
+enzo = ["yt[HDF5]", "libconf>=1.0.1"]
 exodus-ii = ["yt[netCDF4]"]
 fits = ["astropy>=4.0.1", "regions>=0.7"]
-flash = []
-gadget = []
-gadget-fof = []
-gamer = []
-gdf = []
-gizmo = []
-halo-catalog = []
+flash = ["yt[HDF5]"]
+gadget = ["yt[HDF5]"]
+gadget-fof = ["yt[HDF5]"]
+gamer = ["yt[HDF5]"]
+gdf = ["yt[HDF5]"]
+gizmo = ["yt[HDF5]"]
+halo-catalog = ["yt[HDF5]"]
 http-stream = ["requests>=2.20.0"]
-moab = []
+moab = ["yt[HDF5]"]
 nc4-cm1 = ["yt[netCDF4]"]
-open-pmd = []
-owls = []
-owls-subfind = []
+open-pmd = ["yt[HDF5]"]
+owls = ["yt[HDF5]"]
+owls-subfind = ["yt[HDF5]"]
 ramses = ["yt[Fortran]"]
 rockstar = []
 sdf = ["requests>=2.20.0"]
 stream = []
-swift = []
+swift = ["yt[HDF5]"]
 tipsy = []
-ytdata = []
+ytdata = ["yt[HDF5]"]
 
 # "full" should contain all optional dependencies intended for users (not devs)
 # in particular it should enable support for all frontends
@@ -199,7 +199,6 @@ mapserver = [
 ]
 minimal = [
     "cmyt==1.1.2",
-    "h5py==3.1.0",
     "ipywidgets==8.0.0",
     "matplotlib==3.2",
     "more-itertools==8.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ keywords = [
 requires-python = ">=3.8"
 dependencies = [
     "cmyt>=1.1.2",
+    "h5py>=3.1.0",
     "ipywidgets>=8.0.0",
     "matplotlib!=3.4.2,>=3.2", # keep in sync with tests/windows_conda_requirements.txt
     "more-itertools>=8.4",
@@ -75,7 +76,6 @@ answer-testing = "yt.utilities.answer_testing.framework:AnswerTesting"
 
 [project.optional-dependencies]
 # some generic, reusable constraints on optional-deps
-HDF5 = ["h5py>=3.1.0,<4.0.0"]
 netCDF4 = ["netCDF4!=1.6.1,>=1.5.3"]  # see https://github.com/Unidata/netcdf4-python/issues/1192
 Fortran = ["f90nml>=1.1"]
 
@@ -89,40 +89,40 @@ adaptahop = []
 ahf = []
 amrvac = ["yt[Fortran]"]
 art = []
-arepo = ["yt[HDF5]"]
+arepo = []
 artio = []
 athena = []
 athena-pp = []
 boxlib = []
 cf-radial = ["xarray>=0.16.1", "arm-pyart!=1.12.5,>=1.11.4"]
-chimera = ["yt[HDF5]"]
-chombo = ["yt[HDF5]"]
-cholla = ["yt[HDF5]"]
-eagle = ["yt[HDF5]"]
-enzo-e = ["yt[HDF5]", "libconf>=1.0.1"]
-enzo = ["yt[HDF5]", "libconf>=1.0.1"]
+chimera = []
+chombo = []
+cholla = []
+eagle = []
+enzo-e = ["libconf>=1.0.1"]
+enzo = ["libconf>=1.0.1"]
 exodus-ii = ["yt[netCDF4]"]
 fits = ["astropy>=4.0.1", "regions>=0.7"]
-flash = ["yt[HDF5]"]
-gadget = ["yt[HDF5]"]
-gadget-fof = ["yt[HDF5]"]
-gamer = ["yt[HDF5]"]
-gdf = ["yt[HDF5]"]
-gizmo = ["yt[HDF5]"]
-halo-catalog = ["yt[HDF5]"]
+flash = []
+gadget = []
+gadget-fof = []
+gamer = []
+gdf = []
+gizmo = []
+halo-catalog = []
 http-stream = ["requests>=2.20.0"]
-moab = ["yt[HDF5]"]
+moab = []
 nc4-cm1 = ["yt[netCDF4]"]
-open-pmd = ["yt[HDF5]"]
-owls = ["yt[HDF5]"]
-owls-subfind = ["yt[HDF5]"]
+open-pmd = []
+owls = []
+owls-subfind = []
 ramses = ["yt[Fortran]"]
 rockstar = []
 sdf = ["requests>=2.20.0"]
 stream = []
-swift = ["yt[HDF5]"]
+swift = []
 tipsy = []
-ytdata = ["yt[HDF5]"]
+ytdata = []
 
 # "full" should contain all optional dependencies intended for users (not devs)
 # in particular it should enable support for all frontends
@@ -199,6 +199,7 @@ mapserver = [
 ]
 minimal = [
     "cmyt==1.1.2",
+    "h5py==3.1.0",
     "ipywidgets==8.0.0",
     "matplotlib==3.2",
     "more-itertools==8.4",

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -18,7 +18,6 @@ answer_tests:
   local_arepo_010:  # PR 3386
     - yt/frontends/arepo/tests/test_outputs.py:test_arepo_bullet
     - yt/frontends/arepo/tests/test_outputs.py:test_arepo_tng59
-    - yt/frontends/arepo/tests/test_outputs.py:test_index_override
     - yt/frontends/arepo/tests/test_outputs.py:test_arepo_cr
 
   local_artio_004:

--- a/yt/frontends/arepo/tests/test_outputs.py
+++ b/yt/frontends/arepo/tests/test_outputs.py
@@ -1,5 +1,3 @@
-import os
-import tempfile
 from collections import OrderedDict
 
 from yt.frontends.arepo.api import ArepoHDF5Dataset
@@ -77,21 +75,6 @@ def test_arepo_tng59_periodicity():
     assert ds1.periodicity == (True, True, True)
     ds2 = data_dir_load(tng59_h5, kwargs={"bounding_box": _tng59_bbox})
     assert ds2.periodicity == (False, False, False)
-
-
-@requires_module("h5py")
-@requires_ds(tng59_h5)
-def test_index_override():
-    # This tests that we can supply an index_filename, and that when we do, it
-    # doesn't get written if our bounding_box is overwritten.
-    tmpfd, tmpname = tempfile.mkstemp(suffix=".index6_4.ewah")
-    os.close(tmpfd)
-    ds = data_dir_load(
-        tng59_h5, kwargs={"index_filename": tmpname, "bounding_box": _tng59_bbox}
-    )
-    assert isinstance(ds, ArepoHDF5Dataset)
-    ds.index
-    assert len(open(tmpname).read()) == 0
 
 
 @requires_module("h5py")

--- a/yt/frontends/gadget/tests/test_outputs.py
+++ b/yt/frontends/gadget/tests/test_outputs.py
@@ -31,6 +31,7 @@ iso_fields = OrderedDict(
 iso_kwargs = dict(bounding_box=[[-3, 3], [-3, 3], [-3, 3]])
 
 
+@requires_module("h5py")
 def test_gadget_binary():
     header_specs = ["default", "default+pad32", ["default", "pad32"]]
     curdir = os.getcwd()

--- a/yt/geometry/particle_oct_container.pyx
+++ b/yt/geometry/particle_oct_container.pyx
@@ -7,7 +7,6 @@ Oct container tuned for Particles
 
 
 
-
 """
 
 
@@ -23,7 +22,6 @@ from yt.utilities.lib.ewah_bool_array cimport (
     ewah_word_type,
 )
 
-import h5py
 import numpy as np
 
 cimport cython
@@ -1003,6 +1001,7 @@ cdef class ParticleBitmap:
         return self.bitmasks._iseq(solf.get_bitmasks())
 
     def save_bitmasks(self, fname):
+        import h5py
         cdef bytes serial_BAC
         cdef np.uint64_t ifile
         with h5py.File(fname, mode="a") as fp:
@@ -1035,6 +1034,7 @@ cdef class ParticleBitmap:
         self.bitmasks._reset()
 
     def load_bitmasks(self, fname):
+        import h5py
         cdef bint read_flag = 1
         cdef bint irflag
         cdef np.uint64_t ver

--- a/yt/geometry/particle_oct_container.pyx
+++ b/yt/geometry/particle_oct_container.pyx
@@ -1023,7 +1023,7 @@ cdef class ParticleBitmap:
 
             for ifile in range(self.nfiles):
                 serial_BAC = self.bitmasks._dumps(ifile)
-                grp.create_dataset(f"nfile_{ifile}", data=np.void(serial_BAC))
+                grp.create_dataset(f"nfile_{ifile:05}", data=np.void(serial_BAC))
             serial_BAC = self.collisions._dumps()
             grp.create_dataset("collisions", data=np.void(serial_BAC))
 
@@ -1061,7 +1061,7 @@ cdef class ParticleBitmap:
             pb = get_pbar("Loading particle index", self.nfiles)
             for ifile in range(self.nfiles):
                 pb.update(ifile+1)
-                irflag = self.bitmasks._loads(ifile, grp[f"nfile_{ifile}"][...].tobytes())
+                irflag = self.bitmasks._loads(ifile, grp[f"nfile_{ifile:05}"][...].tobytes())
                 if irflag == 0:
                     read_flag = 0
             pb.finish()

--- a/yt/geometry/tests/test_particle_octree.py
+++ b/yt/geometry/tests/test_particle_octree.py
@@ -6,7 +6,7 @@ import yt.units.dimensions as dimensions
 from yt.geometry.oct_container import _ORDER_MAX
 from yt.geometry.particle_oct_container import ParticleBitmap, ParticleOctreeContainer
 from yt.geometry.selection_routines import RegionSelector
-from yt.testing import assert_array_equal, assert_equal, assert_true
+from yt.testing import assert_array_equal, assert_equal, assert_true, requires_module
 from yt.units.unit_registry import UnitRegistry
 from yt.units.yt_array import YTArray
 from yt.utilities.lib.geometry_utils import (
@@ -276,6 +276,7 @@ def test_bitmap_collisions():
     assert_equal(nr, 2 ** (3 * (order1 + order2)), "%d collisions" % nr)
 
 
+@requires_module("h5py")
 def test_bitmap_save_load():
     # Test init for slabs of points in x
     left_edge = np.array([0.0, 0.0, 0.0])


### PR DESCRIPTION
## PR Summary

My attempt at fixing https://github.com/yt-project/yt/issues/3327. The main "upgrade" is that we can now store indices of the same order for different domain sizes, which we currently don't allow. Each cached index is identified by: `left_edge`, `right_edge`, hash of data file, `periodicity`, `index_order1`, `index_order2` and `nfiles`.
Drowback is that `h5py` is a strict requirement now.

## PR Checklist

- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

