### PR TITLE
TST: bump CI from Python 3.10 to 3.11

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -27,7 +27,7 @@ jobs:
           windows-latest,
           ubuntu-latest,
         ]
-        python-version: ['3.10']
+        python-version: ['3.11']
         dependencies: [full]
         tests-type: [unit]
         test-runner: [pytest]
@@ -53,15 +53,6 @@ jobs:
             dependencies: full
             tests-type: answer
             test-runner: nose
-          - os: ubuntu-latest
-            # bare environment with latest CPython
-            # (no special requirements, no optional dependencies)
-            # this job is meant to be removed when wheels are available
-            # for all (or most) optional dependencies and we can bump 3.10 -> 3.11
-            python-version: '3.11-dev'
-            dependencies: ""
-            tests-type: unit
-            test-runner: pytest
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
## PR Summary
Now that h5py 3.8 was released with Python 3.11 wheels, we can bump the bulk of CI to that version.

Note that this currently adds a few minutes of overhead as compared with Python 3.10 because a couple of our optional (some, indirect) dependencies still need to be built from source, but I'll give a hand upstream to remedy that on the medium term.