### PR TITLE
BLD: drop pkg_resources as a dependency on Python 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = [
   "setuptools>=61.2",
+  "importlib_resources>=1.3;python_version < '3.9'",
   # see https://github.com/numpy/numpy/pull/18389
   "wheel>=0.36.2",
 
@@ -53,6 +54,7 @@ dependencies = [
     "tomli-w>=0.4.0",
     "tqdm>=3.4.0",
     "unyt>=2.9.2,<3.0", # see https://github.com/yt-project/yt/issues/4162
+    "importlib_resources>=1.3;python_version < '3.9'",
     "tomli>=1.2.3;python_version < '3.11'",
     "typing-extensions>=4.1.0;python_version < '3.11'",
 ]
@@ -210,6 +212,7 @@ minimal = [
     "tomli-w==0.4.0",
     "tqdm==3.4.0",
     "unyt==2.9.2",
+    "importlib_resources==1.3;python_version < '3.9'",
     "tomli==1.2.3;python_version < '3.11'",
     "typing-extensions==4.1.0;python_version < '3.11'",
 ]
@@ -226,7 +229,7 @@ typecheck = [
     "types-PyYAML==6.0.12.2",
     "types-chardet==5.0.4",
     "types-requests==2.28.11.5",
-    "types-setuptools==65.6.0.1",
+    "importlib_resources==1.3;python_version < '3.9'",
     "typing-extensions==4.1.0;python_version < '3.11'",
 ]
 

--- a/setupext.py
+++ b/setupext.py
@@ -1,6 +1,5 @@
 import contextlib
 import glob
-import importlib.resources
 import logging
 import os
 import platform
@@ -17,6 +16,11 @@ from sys import platform as _platform
 from setuptools.command.build_ext import build_ext as _build_ext
 from setuptools.command.sdist import sdist as _sdist
 from setuptools.errors import CompileError, LinkError
+
+if sys.version_info >= (3, 9):
+    import importlib.resources as importlib_resources
+else:
+    import importlib_resources
 
 log = logging.getLogger("setupext")
 
@@ -204,15 +208,8 @@ def check_for_pyembree(std_libs):
     embree_libs = []
     embree_aliases = {}
 
-    if sys.version_info >= (3, 9):
-        _path_finder = importlib.resources.files
-    else:
-        from pkg_resources import resource_filename
-        from functools import partial
-        _path_finder = partial(resource_filename, resource_name="rtcore.pxd")
-
     try:
-        _path_finder("pyembree")
+        importlib_resources.files("pyembree")
     except ImportError:
         return embree_libs, embree_aliases
 

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -4,7 +4,6 @@ import contextlib
 import copy
 import errno
 import glob
-import importlib.resources
 import inspect
 import itertools
 import os
@@ -30,6 +29,11 @@ from yt.units import YTArray, YTQuantity
 from yt.utilities.exceptions import YTInvalidWidthError
 from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.on_demand_imports import _requests as requests
+
+if sys.version_info >= (3, 9):
+    import importlib.resources as importlib_resources
+else:
+    import importlib_resources
 
 # Some functions for handling sequences and other types
 
@@ -548,14 +552,7 @@ def get_git_version(path):
 
 
 def get_yt_version():
-    if sys.version_info >= (3, 9):
-        path = os.path.dirname(importlib.resources.files("yt"))
-    else:
-        from pkg_resources import get_provider
-
-        path = os.path.dirname(get_provider("yt").module_path)
-
-    version = get_git_version(path)
+    version = get_git_version(os.path.dirname(importlib_resources.files("yt")))
     if version is None:
         return version
     else:

--- a/yt/sample_data/api.py
+++ b/yt/sample_data/api.py
@@ -1,7 +1,6 @@
 """
 This is a collection of helper functions to yt.load_sample
 """
-import importlib.resources
 import json
 import re
 import sys
@@ -18,6 +17,11 @@ from yt.utilities.on_demand_imports import (
     _pooch as pooch,
     _requests as requests,
 )
+
+if sys.version_info >= (3, 9):
+    import importlib.resources as importlib_resources
+else:
+    import importlib_resources
 
 num_exp = re.compile(r"\d*(\.\d*)?")
 byte_unit_exp = re.compile(r"[KMGT]?B")
@@ -81,17 +85,11 @@ def _parse_byte_size(s: str):
 
 
 def _get_sample_data_registry():
-    if sys.version_info >= (3, 9):
-        return json.loads(
-            importlib.resources.files("yt")
-            .joinpath("sample_data_registry.json")
-            .read_bytes()
-        )
-    else:
-        from pkg_resources import resource_stream
-
-        with resource_stream("yt", "sample_data_registry.json") as fh:
-            return json.load(fh)
+    return json.loads(
+        importlib_resources.files("yt")
+        .joinpath("sample_data_registry.json")
+        .read_bytes()
+    )
 
 
 @lru_cache(maxsize=128)

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -1,6 +1,5 @@
 import argparse
 import base64
-import importlib.resources
 import json
 import os
 import pprint
@@ -26,6 +25,11 @@ from yt.loaders import load
 from yt.utilities.exceptions import YTFieldNotParseable, YTUnidentifiedDataType
 from yt.utilities.metadata import get_metadata
 from yt.visualization.plot_window import ProjectionPlot, SlicePlot
+
+if sys.version_info >= (3, 9):
+    import importlib.resources as importlib_resources
+else:
+    import importlib_resources
 
 # isort: off
 # This needs to be set before importing startup_tasks
@@ -656,13 +660,7 @@ class YTInstInfoCmd(YTCommand):
         """
 
     def __call__(self, opts):
-        if sys.version_info >= (3, 9):
-            path = os.path.dirname(importlib.resources.files("yt"))
-        else:
-            from pkg_resources import get_provider
-
-            path = os.path.dirname(get_provider("yt").module_path)
-
+        path = os.path.dirname(importlib_resources.files("yt"))
         vstring = _print_installation_information(path)
         if vstring is not None:
             print("This installation CAN be automatically updated.")
@@ -1184,12 +1182,7 @@ class YTUpdateCmd(YTCommand):
         """
 
     def __call__(self, opts):
-        if sys.version_info >= (3, 9):
-            path = os.path.dirname(importlib.resources.files("yt"))
-        else:
-            from pkg_resources import get_provider
-
-            path = os.path.dirname(get_provider("yt").module_path)
+        path = os.path.dirname(importlib_resources.files("yt"))
         vstring = _print_installation_information(path)
         if vstring is not None:
             print()


### PR DESCRIPTION
## PR Summary

Follow up to #4292

Rationale: see warning at the top of [this page](https://setuptools.pypa.io/en/latest/pkg_resources.html)