### PR TITLE
MNT: diminish pre-commit.ci autoupdate frequency (weekly -> monthly)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ yt/extern\
 
 ci:
     autofix_prs: false
+    autoupdate_schedule: monthly
 
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
## PR Summary

After two years of weekly updates, I think the time is ripe to slow down a little.