### PR TITLE
cell_widths validation for load_uniform_grid

### DIFF
--- a/nose_unit.cfg
+++ b/nose_unit.cfg
@@ -6,5 +6,5 @@ nologcapture=1
 verbosity=2
 where=yt
 with-timer=1
-ignore-files=(test_load_errors.py|test_load_sample.py|test_commons.py|test_ambiguous_fields.py|test_field_access_pytest.py|test_save.py|test_line_annotation_unit.py|test_eps_writer.py|test_registration.py|test_invalid_origin.py|test_outputs_pytest\.py|test_normal_plot_api\.py|test_load_archive\.py|test_stream_particles\.py|test_file_sanitizer\.py|test_version\.py|\test_on_demand_imports\.py|test_set_zlim\.py|test_add_field\.py|test_glue\.py|test_geometries\.py|test_firefly\.py|test_callable_grids\.py|test_external_frontends\.py)
+ignore-files=(test_load_errors.py|test_load_sample.py|test_commons.py|test_ambiguous_fields.py|test_field_access_pytest.py|test_save.py|test_line_annotation_unit.py|test_eps_writer.py|test_registration.py|test_invalid_origin.py|test_outputs_pytest\.py|test_normal_plot_api\.py|test_load_archive\.py|test_stream_particles\.py|test_file_sanitizer\.py|test_version\.py|\test_on_demand_imports\.py|test_set_zlim\.py|test_add_field\.py|test_glue\.py|test_geometries\.py|test_firefly\.py|test_callable_grids\.py|test_external_frontends\.py|test_stream_stretched\.py)
 exclude-test=yt.frontends.gdf.tests.test_outputs.TestGDF

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -230,6 +230,7 @@ other_tests:
      - "--ignore-file=test_firefly\\.py"
      - "--ignore-file=test_callable_grids\\.py"
      - "--ignore-file=test_external_frontends\\.py"
+     - "--ingore-file=test_stream_stretched\\.py"
      - "--exclude-test=yt.frontends.gdf.tests.test_outputs.TestGDF"
      - "--exclude-test=yt.frontends.adaptahop.tests.test_outputs"
      - "--exclude-test=yt.frontends.stream.tests.test_stream_particles.test_stream_non_cartesian_particles"

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -230,7 +230,7 @@ other_tests:
      - "--ignore-file=test_firefly\\.py"
      - "--ignore-file=test_callable_grids\\.py"
      - "--ignore-file=test_external_frontends\\.py"
-     - "--ingore-file=test_stream_stretched\\.py"
+     - "--ignore-file=test_stream_stretched\\.py"
      - "--exclude-test=yt.frontends.gdf.tests.test_outputs.TestGDF"
      - "--exclude-test=yt.frontends.adaptahop.tests.test_outputs"
      - "--exclude-test=yt.frontends.stream.tests.test_stream_particles.test_stream_non_cartesian_particles"

--- a/yt/_typing.py
+++ b/yt/_typing.py
@@ -12,6 +12,7 @@ FieldName = str
 FieldKey = Tuple[FieldType, FieldName]
 ImplicitFieldKey = FieldName
 AnyFieldKey = Union[FieldKey, ImplicitFieldKey]
+DomainDimensions = Union[Tuple[int, ...], List[int], ndarray]
 
 ParticleCoordinateTuple = Tuple[
     str,  # particle type

--- a/yt/frontends/stream/misc.py
+++ b/yt/frontends/stream/misc.py
@@ -1,17 +1,21 @@
-from typing import Tuple, List
+from typing import List, Tuple
+
 import numpy as np
 
-def _validate_cell_widths(cell_widths: List[np.ndarray],
-                          domain_dimensions: Tuple[int, ...]) -> List[List[np.ndarray],]:
 
+def _validate_cell_widths(
+    cell_widths: List[np.ndarray], domain_dimensions: Tuple[int, ...]
+) -> List[List[np.ndarray],]:
     # check dimensionality
     ndims = len(domain_dimensions)
     nwids = len(cell_widths)
     if nwids != ndims:
-        raise ValueError(f"The number of elements in cell_widths ({nwids}) "
-                         f"must match the number of dimensions ({ndims}).")
+        raise ValueError(
+            f"The number of elements in cell_widths ({nwids}) "
+            f"must match the number of dimensions ({ndims})."
+        )
 
-    # check the cell width dtypes for each dimension, upcast to float64 if needed
+    # check the dtypes for each dimension, upcast to float64 if needed
     cast_dims = []
     for idim, cell_wid in enumerate(cell_widths):
         if cell_wid.dtype != np.float64:
@@ -22,5 +26,7 @@ def _validate_cell_widths(cell_widths: List[np.ndarray],
 
     # finally, need to return a list of the cell_widths for each grid object.
     # since there is only single grid, just wrap it in a list.
-    cell_widths =  [cell_widths,]
+    cell_widths = [
+        cell_widths,
+    ]
     return cell_widths

--- a/yt/frontends/stream/misc.py
+++ b/yt/frontends/stream/misc.py
@@ -17,7 +17,7 @@ def _validate_cell_widths(
         )
 
     # check the dtypes for each dimension, upcast to float64 if needed
-    for idim in len(cell_widths):
+    for idim in range(len(cell_widths)):
         cell_widths[idim] = cell_widths[idim].astype(np.float64, copy=False)
 
     # finally, need to return a list of the cell_widths for each grid object.

--- a/yt/frontends/stream/misc.py
+++ b/yt/frontends/stream/misc.py
@@ -8,28 +8,18 @@ from yt._typing import DomainDimensions
 def _validate_cell_widths(
     cell_widths: List[np.ndarray],
     domain_dimensions: DomainDimensions,
-) -> List[List[np.ndarray],]:
+) -> List[List[np.ndarray]]:
     # check dimensionality
-    ndims = len(domain_dimensions)
-    nwids = len(cell_widths)
-    if nwids != ndims:
+    if (nwids := len(cell_widths)) != (ndims := len(domain_dimensions)):
         raise ValueError(
             f"The number of elements in cell_widths ({nwids}) "
             f"must match the number of dimensions ({ndims})."
         )
 
     # check the dtypes for each dimension, upcast to float64 if needed
-    cast_dims = []
-    for idim, cell_wid in enumerate(cell_widths):
-        if cell_wid.dtype != np.float64:
-            cast_dims.append(idim)
-
-    for idim in cast_dims:
-        cell_widths[idim] = cell_widths[idim].astype(np.float64)
+    for idim in len(cell_widths):
+        cell_widths[idim] = cell_widths[idim].astype(np.float64, copy=False)
 
     # finally, need to return a list of the cell_widths for each grid object.
     # since there is only a single grid, just wrap it in a list.
-    cell_widths_out = [
-        cell_widths,
-    ]
-    return cell_widths_out
+    return [cell_widths]

--- a/yt/frontends/stream/misc.py
+++ b/yt/frontends/stream/misc.py
@@ -1,0 +1,26 @@
+from typing import Tuple, List
+import numpy as np
+
+def _validate_cell_widths(cell_widths: List[np.ndarray],
+                          domain_dimensions: Tuple[int, ...]) -> List[List[np.ndarray],]:
+
+    # check dimensionality
+    ndims = len(domain_dimensions)
+    nwids = len(cell_widths)
+    if nwids != ndims:
+        raise ValueError(f"The number of elements in cell_widths ({nwids}) "
+                         f"must match the number of dimensions ({ndims}).")
+
+    # check the cell width dtypes for each dimension, upcast to float64 if needed
+    cast_dims = []
+    for idim, cell_wid in enumerate(cell_widths):
+        if cell_wid.dtype != np.float64:
+            cast_dims.append(idim)
+
+    for idim in cast_dims:
+        cell_widths[idim] = cell_widths[idim].astype(np.float64)
+
+    # finally, need to return a list of the cell_widths for each grid object.
+    # since there is only single grid, just wrap it in a list.
+    cell_widths =  [cell_widths,]
+    return cell_widths

--- a/yt/frontends/stream/misc.py
+++ b/yt/frontends/stream/misc.py
@@ -1,15 +1,16 @@
 from typing import List
 
 import numpy as np
-from numpy.typing import ArrayLike
+
+from yt._typing import DomainDimensions
 
 
 def _validate_cell_widths(
     cell_widths: List[np.ndarray],
-    domain_dimensions: ArrayLike,
+    domain_dimensions: DomainDimensions,
 ) -> List[List[np.ndarray],]:
     # check dimensionality
-    ndims = len(np.asarray(domain_dimensions))  # cast to array for type checking
+    ndims = len(domain_dimensions)
     nwids = len(cell_widths)
     if nwids != ndims:
         raise ValueError(

--- a/yt/frontends/stream/misc.py
+++ b/yt/frontends/stream/misc.py
@@ -1,14 +1,15 @@
-from typing import List, Tuple
+from typing import List
 
 import numpy as np
+from numpy.typing import ArrayLike
 
 
 def _validate_cell_widths(
     cell_widths: List[np.ndarray],
-    domain_dimensions: Tuple[int, ...],
+    domain_dimensions: ArrayLike,
 ) -> List[List[np.ndarray],]:
     # check dimensionality
-    ndims = len(domain_dimensions)
+    ndims = len(np.asarray(domain_dimensions))  # cast to array for type checking
     nwids = len(cell_widths)
     if nwids != ndims:
         raise ValueError(
@@ -27,7 +28,7 @@ def _validate_cell_widths(
 
     # finally, need to return a list of the cell_widths for each grid object.
     # since there is only a single grid, just wrap it in a list.
-    cell_widths = [
+    cell_widths_out = [
         cell_widths,
     ]
-    return cell_widths
+    return cell_widths_out

--- a/yt/frontends/stream/misc.py
+++ b/yt/frontends/stream/misc.py
@@ -4,7 +4,8 @@ import numpy as np
 
 
 def _validate_cell_widths(
-    cell_widths: List[np.ndarray], domain_dimensions: Tuple[int, ...]
+    cell_widths: List[np.ndarray],
+    domain_dimensions: Tuple[int, ...],
 ) -> List[List[np.ndarray],]:
     # check dimensionality
     ndims = len(domain_dimensions)
@@ -25,7 +26,7 @@ def _validate_cell_widths(
         cell_widths[idim] = cell_widths[idim].astype(np.float64)
 
     # finally, need to return a list of the cell_widths for each grid object.
-    # since there is only single grid, just wrap it in a list.
+    # since there is only a single grid, just wrap it in a list.
     cell_widths = [
         cell_widths,
     ]

--- a/yt/frontends/stream/tests/test_stream_stretched.py
+++ b/yt/frontends/stream/tests/test_stream_stretched.py
@@ -57,7 +57,6 @@ def test_variable_dx():
 
 
 def test_cell_width_type():
-
     # checks that cell widths are properly upcast to float64 (this errors
     # if that is not the case).
 
@@ -80,11 +79,11 @@ def test_cell_width_type():
 
     _ = ds.slice(0, ds.domain_center[0])[("stream", "density")]
 
+
 def test_cell_width_dimensionality():
     np.random.seed(0x4D3D3D3)
     N = 16
     data = {"density": np.random.random((N, N, N))}
-
 
     cw = np.random.random(N)
     cw /= cw.sum()

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -261,6 +261,10 @@ def load_uniform_grid(
     axis_order: tuple of three strings, optional
         Force axis ordering, e.g. ("z", "y", "x") with cartesian geometry
         Otherwise use geometry-specific default ordering.
+    cell_widths: list, optional
+        If set, cell_widths is a list of arrays with an array for each dimension,
+        specificing the cell spacing in that dimension. Must be consistent with
+        the domain_dimensions.
     parameters: dictionary, optional
         Optional dictionary used to populate the dataset parameters, useful
         for storing dataset metadata.
@@ -287,6 +291,7 @@ def load_uniform_grid(
         process_data,
         set_particle_types,
     )
+    from yt.frontends.stream.misc import _validate_cell_widths
 
     geometry, axis_order = _sanitize_axis_order_args(geometry, axis_order)
     domain_dimensions = np.array(domain_dimensions)
@@ -346,8 +351,7 @@ def load_uniform_grid(
         grid_dimensions = domain_dimensions.reshape(nprocs, 3).astype("int32")
 
     if cell_widths is not None:
-        # make sure this is a list, or else leave it as an empty guard value
-        cell_widths = [cell_widths]
+        cell_widths = _validate_cell_widths(cell_widths, domain_dimensions)
 
     if length_unit is None:
         length_unit = "code_length"

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -351,6 +351,7 @@ def load_uniform_grid(
         grid_dimensions = domain_dimensions.reshape(nprocs, 3).astype("int32")
 
     if cell_widths is not None:
+        # cell_widths left as an empty guard value if None
         cell_widths = _validate_cell_widths(cell_widths, domain_dimensions)
 
     if length_unit is None:

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -264,7 +264,7 @@ def load_uniform_grid(
     cell_widths: list, optional
         If set, cell_widths is a list of arrays with an array for each dimension,
         specificing the cell spacing in that dimension. Must be consistent with
-        the domain_dimensions.
+        the domain_dimensions. nprocs must remain 1 to set cell_widths.
     parameters: dictionary, optional
         Optional dictionary used to populate the dataset parameters, useful
         for storing dataset metadata.
@@ -352,6 +352,8 @@ def load_uniform_grid(
 
     if cell_widths is not None:
         # cell_widths left as an empty guard value if None
+        if nprocs != 1:
+            raise NotImplementedError("nprocs must equal 1 if supplying cell_widths.")
         cell_widths = _validate_cell_widths(cell_widths, domain_dimensions)
 
     if length_unit is None:

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -353,6 +353,7 @@ def load_uniform_grid(
     if cell_widths is not None:
         # cell_widths left as an empty guard value if None
         if nprocs != 1:
+            # see https://github.com/yt-project/yt/issues/4330
             raise NotImplementedError("nprocs must equal 1 if supplying cell_widths.")
         cell_widths = _validate_cell_widths(cell_widths, domain_dimensions)
 


### PR DESCRIPTION
# Summary

This PR:
* adds some validation for the cell_widths argument to load_uniform_grid (including dtype checks)
* adds a missing docstring entry for cell_widths
* adds some tests (and makes test_stream_stretched.py pytest-only)

# Background: dtype bug

This started as a bug fix for when the cell_widths do not have a dtype of float64 and expanded a bit to better capture what cell_widths has to be. The bug can be replicated with:

```python
import yt
import numpy as np

N = 8
data = {"density": np.random.random((N, N, N))}

cell_widths = []
for i in range(3):
    widths = np.random.random(N)
    widths /= widths.sum()  # Normalize to span 0 .. 1.
    cell_widths.append(widths.astype(np.float32)) # <----------- note cell width dtype

ds = yt.load_uniform_grid(
    data,
    [N, N, N],
    bbox=np.array([[0.0, 1.0], [0.0, 1.0], [0.0, 1.0]]),
    cell_widths=cell_widths,
)

slc = ds.slice(0, ds.domain_center[0])[("stream", "density")]
```
I encountered this while loading some data from a netcdf file where the coordinate arrays happened to be in `float32`. The error that the above code raises is:

```
ValueError                                Traceback (most recent call last)
Input In [6], in <cell line: 21>()
     12     cell_widths.append(widths.astype(np.float32))
     14 ds = yt.load_uniform_grid(
     15     data,
     16     [N, N, N],
     17     bbox=np.array([[0.0, 1.0], [0.0, 1.0], [0.0, 1.0]]),
     18     cell_widths=cell_widths,
     19 )
---> 21 slc = ds.slice(0, ds.domain_center[0])[("stream", "density")]

File ~/src/yt_/yt_dev/yt/yt/data_objects/data_containers.py:269, in YTDataContainer.__getitem__(self, key)
    267         return self.field_data[f]
    268     else:
--> 269         self.get_data(f)
    270 # fi.units is the unit expression string. We depend on the registry
    271 # hanging off the dataset to define this unit object.
    272 # Note that this is less succinct so that we can account for the case
    273 # when there are, for example, no elements in the object.
    274 try:

File ~/src/yt_/yt_dev/yt/yt/data_objects/selection_objects/data_selection_objects.py:131, in YTSelectionContainer.get_data(self, fields)
    129 def get_data(self, fields=None):
    130     if self._current_chunk is None:
--> 131         self.index._identify_base_chunk(self)
    132     if fields is None:
    133         return

File ~/src/yt_/yt_dev/yt/yt/geometry/grid_geometry_handler.py:351, in GridIndex._identify_base_chunk(self, dobj)
    347 # These next two lines, when uncommented, turn "on" the fast index.
    348 # if dobj._type_name != "grid":
    349 #    fast_index = self._get_grid_tree()
    350 if getattr(dobj, "size", None) is None:
--> 351     dobj.size = self._count_selection(dobj, fast_index=fast_index)
    352 if getattr(dobj, "shape", None) is None:
    353     dobj.shape = (dobj.size,)

File ~/src/yt_/yt_dev/yt/yt/geometry/grid_geometry_handler.py:363, in GridIndex._count_selection(self, dobj, grids, fast_index)
    361 if grids is None:
    362     grids = dobj._chunk_info
--> 363 count = sum(g.count(dobj.selector) for g in grids)
    364 return count

File ~/src/yt_/yt_dev/yt/yt/geometry/grid_geometry_handler.py:363, in <genexpr>(.0)
    361 if grids is None:
    362     grids = dobj._chunk_info
--> 363 count = sum(g.count(dobj.selector) for g in grids)
    364 return count

File ~/src/yt_/yt_dev/yt/yt/data_objects/index_subobjects/grid_patch.py:418, in AMRGridPatch.count(self, selector)
    417 def count(self, selector):
--> 418     mask = self._get_selector_mask(selector)
    419     if mask is None:
    420         return 0

File ~/src/yt_/yt_dev/yt/yt/data_objects/index_subobjects/stretched_grid.py:23, in StretchedGrid._get_selector_mask(self, selector)
     21     mask = self._last_mask
     22 else:
---> 23     mask = selector.fill_mask(self)
     24     if self._cache_mask:
     25         self._last_mask = mask

File yt/geometry/_selection_routines/selector_object.pxi:440, in yt.geometry.selection_routines.SelectorObject.fill_mask()

ValueError: Buffer dtype mismatch, expected 'float64_t' but got 'float'
```

# The bug fix

The fix to the bug is to simply cast the cell_widths to float64 if they are not already. Casting to float64 seems in line with other yt behavior (alternatively I could have caught the case and raised a more meaningful error message than what you get now from deep in the selection routines).

# The rest of the PR

In fixing this bug, it seemed a good idea to better encapsulate the requirements for using the `cell_widths` argument with `load_uniform_grid` (we are actually missing a docstring entry for cell_widths as well). The summary of those requirements:

* nprocs must remain 1 (this is hopefully a temporary requirement, but as of now it is required as far as I can tell... you get indexing errors with nproc>1.)
* you must supply a cell_width array for each dimension (as opposed to a single array that is applied to each dimension)