### PR TITLE
TYP: upgrade mypy (0.991 -> 1.0.0)

### DIFF
--- a/.github/workflows/type-checking.yaml
+++ b/.github/workflows/type-checking.yaml
@@ -9,6 +9,7 @@ on:
       - yt/**/*.py
       - setup.cfg
       - .github/workflows/type-checking.yaml
+  workflow_dispatch:
 
 jobs:
   build:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,7 +222,7 @@ test = [
     "sympy!=1.10,!=1.9", # see https://github.com/sympy/sympy/issues/22241
 ]
 typecheck = [
-    "mypy==0.991",
+    "mypy==1.0.0",
     "types-PyYAML==6.0.12.2",
     "types-chardet==5.0.4",
     "types-requests==2.28.11.5",


### PR DESCRIPTION
## PR Summary

This is a noop PR to celebrate mypy going out of beta.
The 1.0.0 release is advertised as 40% faster than 0.991 (which I was able to verify in the case of yt), so even without using new features it still brings *something* to the table.
A feature I've been waiting for also has landed in this version ([Support for `Self` type](https://github.com/python/mypy/pull/14041)), though I'd prefer leveraging it in a following PR.

I'm also adding a `workflow_dispatch` trigger to the type-checking workflow, which was useful for me to test the upgrade on my fork.