### PR TITLE
BUG: fix the error when loading a non-cosmological `Gizmo` dataset

### DIFF
--- a/yt/frontends/gizmo/fields.py
+++ b/yt/frontends/gizmo/fields.py
@@ -49,6 +49,8 @@ class GizmoFieldInfo(GadgetFieldInfo):
         if ("PartType0", "Metallicity_00") in self.field_list:
             self.nuclei_names = metal_elements
             self.species_names = ["H_p0", "H_p1"] + metal_elements
+        else:
+            self.nuclei_names = []
 
     def setup_particle_fields(self, ptype):
         FieldInfoContainer.setup_particle_fields(self, ptype)


### PR DESCRIPTION
Fix the error `'GizmoFieldInfo' object has no attribute 'nuclei_names'` complained by Line 122
https://github.com/yt-project/yt/blob/bd6357eea0121c4071a6580bedcf543122824d35/yt/frontends/gizmo/fields.py#L122-L124
when loading a non-cosmological `Gizmo` dataset.