### PR TITLE
DOC: load unstructured mesh SlicePlot

### DIFF
--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -2144,7 +2144,7 @@ The in-memory dataset can then be visualized as usual, e.g.:
 
 .. code-block:: python
 
-    sl = yt.SlicePlot(ds, "z", "test")
+    sl = yt.SlicePlot(ds, "z", ("connect1", "test"))
     sl.annotate_mesh_lines()
 
 Note that load_unstructured_mesh can take either a single mesh or a list of meshes.


### PR DESCRIPTION
The SlicePlot call in the first load_unstructured_mesh generic example is missing a field type for the field argument.