### PR TITLE
TST: fixup logger configuration in CI

### DIFF
--- a/tests/ci_install.sh
+++ b/tests/ci_install.sh
@@ -20,7 +20,7 @@ osx|macOS)
 esac
 
 # Disable excessive output
-echo "[yt]\nlog_level = 50" > yt.toml
+echo "[yt]\nlog_level = 50\n" > yt.toml
 cat yt.toml
 
 # Sets default backend to Agg

--- a/tests/ci_install.sh
+++ b/tests/ci_install.sh
@@ -19,10 +19,6 @@ osx|macOS)
     ;;
 esac
 
-# Disable excessive output
-echo "[yt]\nlog_level = 50\n" > yt.toml
-cat yt.toml
-
 # Sets default backend to Agg
 cp tests/matplotlibrc .
 
@@ -55,5 +51,9 @@ else
    # test with no special requirements
    python -m pip install -e ".[test]"
 fi
+
+# Disable excessive output
+yt config set --local yt log_level 50
+cat yt.toml
 
 set +x

--- a/yt/tests/test_load_sample.py
+++ b/yt/tests/test_load_sample.py
@@ -39,7 +39,7 @@ def capturable_logger(caplog):
     ytLogger.propagate = propagate
 
 
-@requires_module_pytest("pandas", "pooch")
+@requires_module_pytest("pandas", "pooch", "f90nml")
 @pytest.mark.usefixtures("capturable_logger")
 @pytest.mark.parametrize(
     "fn, archive, exact_loc, class_",

--- a/yt/tests/test_load_sample.py
+++ b/yt/tests/test_load_sample.py
@@ -33,7 +33,7 @@ def capturable_logger(caplog):
     propagate = ytLogger.propagate
     ytLogger.propagate = True
 
-    with caplog.at_level(logging.INFO):
+    with caplog.at_level(logging.INFO, "yt"):
         yield
 
     ytLogger.propagate = propagate


### PR DESCRIPTION
## PR Summary

fix yt configuration file used in CI

The solution is given by a warning
```
/home/runner/work/yt/yt/yt/utilities/configure.py:96: UserWarning: Could not load configuration file /home/runner/work/yt/yt/yt.toml (invalid TOML: Expected newline or end of document after a statement (at line 1, column 5))
```
fix my own mistake from #4311 