### PR TITLE
MAESTROeX uses namespaces for paramters

### DIFF
--- a/yt/frontends/boxlib/fields.py
+++ b/yt/frontends/boxlib/fields.py
@@ -448,8 +448,10 @@ class MaestroFieldInfo(FieldInfoContainer):
         # pick the correct temperature field
         tfromp = False
         if "use_tfromp" in self.ds.parameters:
+            # original MAESTRO (F90) code
             tfromp = self.ds.parameters["use_tfromp"]
         elif "maestro.use_tfromp" in self.ds.parameters:
+            # new MAESTROeX (C++) code
             tfromp = self.ds.parameters["maestro.use_tfromp"]
 
         if tfromp:

--- a/yt/frontends/boxlib/fields.py
+++ b/yt/frontends/boxlib/fields.py
@@ -446,7 +446,13 @@ class MaestroFieldInfo(FieldInfoContainer):
     def setup_fluid_fields(self):
         unit_system = self.ds.unit_system
         # pick the correct temperature field
-        if self.ds.parameters["use_tfromp"]:
+        tfromp = False
+        if "use_tfromp" in self.ds.parameters:
+            tfromp = self.ds.parameters["use_tfromp"]
+        elif "maestro.use_tfromp" in self.ds.parameters:
+            tfromp = self.ds.parameters["maestro.use_tfromp"]
+
+        if tfromp:
             self.alias(
                 ("gas", "temperature"),
                 ("boxlib", "tfromp"),


### PR DESCRIPTION
this fixes the detection of how temperature is defined

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
