### PR TITLE
Minor updates to answer tests infra

### DIFF
--- a/yt/utilities/answer_testing/answer_tests.py
+++ b/yt/utilities/answer_testing/answer_tests.py
@@ -87,10 +87,13 @@ def field_values(ds, field, obj_type=None, particle_type=False):
     # If needed build an instance of the dataset type
     obj = create_obj(ds, obj_type)
     determined_field = obj._determine_fields(field)[0]
+    fd = ds.field_info[determined_field]
     # Get the proper weight field depending on if we're looking at
     # particles or not
     if particle_type:
         weight_field = (determined_field[0], "particle_ones")
+    elif fd.is_sph_field:
+        weight_field = (determined_field[0], "ones")
     else:
         weight_field = ("index", "ones")
     # Get the average, min, and max

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -358,7 +358,7 @@ class FixedResolutionBuffer:
             fields = list(self.data.keys())
         output = h5py.File(filename, mode="a")
         for field in fields:
-            output.create_dataset(field, data=self[field])
+            output.create_dataset("_".join(field), data=self[field])
         output.close()
 
     def to_fits_data(self, fields=None, other_keys=None, length_unit=None, **kwargs):


### PR DESCRIPTION
## PR Summary

While working on pytest port I realized I have some local changes that should be pushed to yt repo first.

1. https://github.com/yt-project/yt/commit/3ed51d58491426c9dcfd4860050ff08c0788fa85 is fairly easy, it's just makes pytest do the same thing as nose. Otherwise some tests were broken on pytest side.
2. https://github.com/yt-project/yt/commit/8b35efb1666ab4836e8dcd270eb74dfb8c675a30 is clearly not tested by nose right now...
    ```
    >>> import h5py as h5
    >>> h5.File("/tmp/foo.h5", "w").create_dataset(("gas", "density"))
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/home/xarth/codes/xarthisius/yt/venv/lib/python3.8/site-packages/h5py/_hl/group.py", line 156, in 
    create_dataset
        name = self._e(name)
      File "/home/xarth/codes/xarthisius/yt/venv/lib/python3.8/site-packages/h5py/_hl/base.py", line 200, in _e
        name = name.encode('ascii')
    AttributeError: 'tuple' object has no attribute 'encode'
    ```


