### PR TITLE
TST: accelerate type-checking workflow

### DIFF
--- a/.github/workflows/type-checking.yaml
+++ b/.github/workflows/type-checking.yaml
@@ -25,8 +25,6 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - name: Set up Python
       uses: actions/setup-python@v4


### PR DESCRIPTION
Citing [the documentation for `actions/checkout`](https://github.com/actions/checkout)

> Only a single commit is fetched by default, for the ref/SHA that triggered the workflow. Set fetch-depth: 0 to fetch all history for all branches and tags.

I think that I may have read this backwards or something when I explicitly added this option (or maybe I was just copy-pasting code from somewhere) ... anyway it's not needed and it wastes about 20s, let's clean it up.