### PR TITLE
RFC: uniformize cython.floating usage

### DIFF
--- a/yt/geometry/_selection_routines/selector_object.pxi
+++ b/yt/geometry/_selection_routines/selector_object.pxi
@@ -567,9 +567,9 @@ cdef class SelectorObject:
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    def count_points(self, np.ndarray[floating, ndim=1] x,
-                           np.ndarray[floating, ndim=1] y,
-                           np.ndarray[floating, ndim=1] z,
+    def count_points(self, np.ndarray[cython.floating, ndim=1] x,
+                           np.ndarray[cython.floating, ndim=1] y,
+                           np.ndarray[cython.floating, ndim=1] z,
                            radii):
         cdef int count = 0
         cdef int i
@@ -602,9 +602,9 @@ cdef class SelectorObject:
     @cython.wraparound(False)
     @cython.cdivision(True)
     def select_points(self,
-                      np.ndarray[floating, ndim=1] x,
-                      np.ndarray[floating, ndim=1] y,
-                      np.ndarray[floating, ndim=1] z,
+                      np.ndarray[cython.floating, ndim=1] x,
+                      np.ndarray[cython.floating, ndim=1] y,
+                      np.ndarray[cython.floating, ndim=1] z,
                       radii):
         cdef int count = 0
         cdef int i

--- a/yt/geometry/particle_oct_container.pyx
+++ b/yt/geometry/particle_oct_container.pyx
@@ -27,7 +27,6 @@ import numpy as np
 cimport cython
 cimport numpy as np
 from cpython.exc cimport PyErr_CheckSignals
-from cython cimport floating
 from cython.operator cimport dereference, preincrement
 
 from yt.geometry cimport oct_visitors
@@ -537,8 +536,8 @@ cdef class ParticleBitmap:
     @cython.wraparound(False)
     @cython.cdivision(True)
     def _coarse_index_data_file(self,
-                                np.ndarray[floating, ndim=2] pos,
-                                np.ndarray[floating, ndim=1] hsml,
+                                np.ndarray[cython.floating, ndim=2] pos,
+                                np.ndarray[cython.floating, ndim=1] hsml,
                                 np.uint64_t file_id):
         return self.__coarse_index_data_file(pos, hsml, file_id)
 
@@ -546,8 +545,8 @@ cdef class ParticleBitmap:
     @cython.wraparound(False)
     @cython.cdivision(True)
     cdef void __coarse_index_data_file(self,
-                                       np.ndarray[floating, ndim=2] pos,
-                                       np.ndarray[floating, ndim=1] hsml,
+                                       np.ndarray[cython.floating, ndim=2] pos,
+                                       np.ndarray[cython.floating, ndim=1] hsml,
                                        np.uint64_t file_id) except *:
         # Initialize
         cdef np.int64_t i, p
@@ -667,8 +666,8 @@ cdef class ParticleBitmap:
     @cython.initializedcheck(False)
     def _refined_index_data_file(self,
                                  BoolArrayCollection in_collection,
-                                 np.ndarray[floating, ndim=2] pos,
-                                 np.ndarray[floating, ndim=1] hsml,
+                                 np.ndarray[cython.floating, ndim=2] pos,
+                                 np.ndarray[cython.floating, ndim=1] hsml,
                                  np.ndarray[np.uint8_t, ndim=1] mask,
                                  np.ndarray[np.uint64_t, ndim=1] sub_mi1,
                                  np.ndarray[np.uint64_t, ndim=1] sub_mi2,
@@ -690,8 +689,8 @@ cdef class ParticleBitmap:
     cdef BoolArrayCollection __refined_index_data_file(
         self,
         BoolArrayCollection in_collection,
-        np.ndarray[floating, ndim=2] pos,
-        np.ndarray[floating, ndim=1] hsml,
+        np.ndarray[cython.floating, ndim=2] pos,
+        np.ndarray[cython.floating, ndim=1] hsml,
         np.ndarray[np.uint8_t, ndim=1] mask,
         np.uint64_t count_threshold, np.uint8_t mask_threshold
     ):

--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -13,7 +13,6 @@ import numpy as np
 
 cimport cython
 cimport numpy as np
-from cython cimport floating
 from libc.math cimport sqrt
 from libc.stdlib cimport free, malloc
 
@@ -92,7 +91,7 @@ def convert_mask_to_indices(np.ndarray[np.uint8_t, ndim=3, cast=True] mask,
 cdef _mask_fill(np.ndarray[np.float64_t, ndim=1] out,
                 np.int64_t offset,
                 np.ndarray[np.uint8_t, ndim=3, cast=True] mask,
-                np.ndarray[floating, ndim=3] vals):
+                np.ndarray[cython.floating, ndim=3] vals):
     cdef np.int64_t count = 0
     cdef int i, j, k
     for i in range(mask.shape[0]):

--- a/yt/utilities/lib/contour_finding.pyx
+++ b/yt/utilities/lib/contour_finding.pyx
@@ -13,7 +13,6 @@ import numpy as np
 
 cimport cython
 cimport numpy as np
-from cython cimport floating
 from libc.stdlib cimport free, malloc, realloc
 
 from yt.geometry.oct_container cimport OctInfo, OctreeContainer
@@ -516,7 +515,7 @@ cdef class ParticleContourTree(ContourTree):
     @cython.wraparound(False)
     def identify_contours(self, OctreeContainer octree,
                                 np.ndarray[np.int64_t, ndim=1] dom_ind,
-                                np.ndarray[floating, ndim=2] positions,
+                                np.ndarray[cython.floating, ndim=2] positions,
                                 np.ndarray[np.int64_t, ndim=1] particle_ids,
                                 int domain_id, int domain_offset):
         cdef np.ndarray[np.int64_t, ndim=1] pdoms, pcount, pind, doff
@@ -554,7 +553,7 @@ cdef class ParticleContourTree(ContourTree):
             pdoms[i] = offset
         pind = np.argsort(pdoms)
         cdef np.int64_t *ipind = <np.int64_t*> pind.data
-        cdef floating *fpos = <floating*> positions.data
+        cdef cython.floating *fpos = <cython.floating*> positions.data
         # pind is now the pointer into the position and particle_ids array.
         for i in range(positions.shape[0]):
             offset = pdoms[pind[i]]
@@ -636,7 +635,7 @@ cdef class ParticleContourTree(ContourTree):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     cdef void link_particles(self, ContourID **container,
-                                   floating *positions,
+                                   cython.floating *positions,
                                    np.int64_t *pind,
                                    np.int64_t pcount,
                                    np.int64_t noffset,

--- a/yt/utilities/lib/geometry_utils.pyx
+++ b/yt/utilities/lib/geometry_utils.pyx
@@ -14,7 +14,6 @@ import numpy as np
 
 cimport cython
 cimport numpy as np
-from cython cimport floating
 from libc.math cimport copysign, fabs, log2
 from libc.stdlib cimport free, malloc
 
@@ -734,7 +733,7 @@ def morton_qsort_swap(np.ndarray[np.uint64_t, ndim=1] ind,
     ind[a] = ind[b]
     ind[b] = t
 
-def morton_qsort_partition(np.ndarray[floating, ndim=2] pos,
+def morton_qsort_partition(np.ndarray[cython.floating, ndim=2] pos,
                            np.int64_t l, np.int64_t h,
                            np.ndarray[np.uint64_t, ndim=1] ind,
                            use_loop = False):
@@ -800,7 +799,7 @@ def morton_qsort_partition(np.ndarray[floating, ndim=2] pos,
 @cython.cdivision(True)
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def morton_qsort_recursive(np.ndarray[floating, ndim=2] pos,
+def morton_qsort_recursive(np.ndarray[cython.floating, ndim=2] pos,
                            np.int64_t l, np.int64_t h,
                            np.ndarray[np.uint64_t, ndim=1] ind,
                            use_loop = False):
@@ -814,7 +813,7 @@ def morton_qsort_recursive(np.ndarray[floating, ndim=2] pos,
 @cython.cdivision(True)
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def morton_qsort_iterative(np.ndarray[floating, ndim=2] pos,
+def morton_qsort_iterative(np.ndarray[cython.floating, ndim=2] pos,
                            np.int64_t l, np.int64_t h,
                            np.ndarray[np.uint64_t, ndim=1] ind,
                            use_loop = False):
@@ -852,7 +851,7 @@ def morton_qsort_iterative(np.ndarray[floating, ndim=2] pos,
 @cython.cdivision(True)
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def morton_qsort(np.ndarray[floating, ndim=2] pos,
+def morton_qsort(np.ndarray[cython.floating, ndim=2] pos,
                  np.int64_t l, np.int64_t h,
                  np.ndarray[np.uint64_t, ndim=1] ind,
                  recursive = False,
@@ -866,7 +865,7 @@ def morton_qsort(np.ndarray[floating, ndim=2] pos,
 @cython.cdivision(True)
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def get_morton_argsort1(np.ndarray[floating, ndim=2] pos,
+def get_morton_argsort1(np.ndarray[cython.floating, ndim=2] pos,
                         np.int64_t start, np.int64_t end,
                         np.ndarray[np.uint64_t, ndim=1] ind):
     # Return if only one position selected
@@ -883,7 +882,7 @@ def get_morton_argsort1(np.ndarray[floating, ndim=2] pos,
         get_morton_argsort1(pos,start,top-1,ind)
     return
 
-def compare_morton(np.ndarray[floating, ndim=1] p0, np.ndarray[floating, ndim=1] q0):
+def compare_morton(np.ndarray[cython.floating, ndim=1] p0, np.ndarray[cython.floating, ndim=1] q0):
     cdef np.float64_t p[3]
     cdef np.float64_t q[3]
     # cdef np.int64_t iep,ieq,imp,imq
@@ -899,9 +898,9 @@ def compare_morton(np.ndarray[floating, ndim=1] p0, np.ndarray[floating, ndim=1]
 @cython.cdivision(True)
 @cython.boundscheck(False)
 @cython.wraparound(False)
-cdef np.int64_t position_to_morton(np.ndarray[floating, ndim=1] pos_x,
-                        np.ndarray[floating, ndim=1] pos_y,
-                        np.ndarray[floating, ndim=1] pos_z,
+cdef np.int64_t position_to_morton(np.ndarray[cython.floating, ndim=1] pos_x,
+                        np.ndarray[cython.floating, ndim=1] pos_y,
+                        np.ndarray[cython.floating, ndim=1] pos_z,
                         np.float64_t dds[3], np.float64_t DLE[3],
                         np.float64_t DRE[3],
                         np.ndarray[np.uint64_t, ndim=1] ind,

--- a/yt/utilities/lib/primitives.pxd
+++ b/yt/utilities/lib/primitives.pxd
@@ -1,5 +1,4 @@
 cimport cython
-from cython cimport floating
 
 import numpy as np
 

--- a/yt/utilities/lib/primitives.pyx
+++ b/yt/utilities/lib/primitives.pyx
@@ -16,7 +16,6 @@ cimport cython
 
 import numpy as np
 
-from cython cimport floating
 cimport numpy as np
 from libc.math cimport fabs
 

--- a/yt/utilities/lib/vec3_ops.pxd
+++ b/yt/utilities/lib/vec3_ops.pxd
@@ -1,5 +1,4 @@
 cimport cython
-from cython cimport floating
 from libc.math cimport sqrt
 
 


### PR DESCRIPTION
Follow up to #4357 in response to https://github.com/cython/cython/issues/5288#issuecomment-1453161940
this one is a pure refactor (not a fix, and backward compatible) that just adopts the dominant import style for `cython.floating`