### PR TITLE
enable zooming into spherical center

### DIFF
--- a/yt/geometry/coordinates/spherical_coordinates.py
+++ b/yt/geometry/coordinates/spherical_coordinates.py
@@ -343,6 +343,11 @@ class SphericalCoordinateHandler(CoordinateHandler):
 
     def sanitize_center(self, center, axis):
         center, display_center = super().sanitize_center(center, axis)
+        display_center = [
+            0.0 * display_center[0],
+            0.0 * display_center[1],
+            0.0 * display_center[2],
+        ]
         name = self.axis_name[axis]
         if name == "r":
             xxmin, xxmax, yymin, yymax = self._aitoff_bounds
@@ -355,10 +360,9 @@ class SphericalCoordinateHandler(CoordinateHandler):
             yc = (yymin + yymax) / 2
             display_center = (xc, 0 * xc, yc)
         elif name == "phi":
-            Rmin, Rmax, zmin, zmax = self._poloidal_bounds
-            xc = (Rmin + Rmax) / 2
-            yc = (zmin + zmax) / 2
-            display_center = (xc, yc)
+            # use existing center value
+            for idx in (self.axis_id["r"], self.axis_id["theta"]):
+                display_center[idx] = center[idx]
         return center, display_center
 
     def sanitize_width(self, axis, width, depth):


### PR DESCRIPTION
Before this change, the plot center along `theta` axis of a spherical dataset is fixed at `(r_min + r_max) / 2`, and ignores the parameter `center` input from `PlotWindow`. In this case, zooming into the spherical center at `r = 0` is impossible.

This change is similar to the treatment under cylindrical geometries: whenever viewed from the axisymmetric axis (`theta` in cylindrical and `phi` in spherical), we always use existing center values to enable zooming into the axisymmetric center:

https://github.com/yt-project/yt/blob/7e90926ba3b687b520b29aca5a2145075e5c7664/yt/geometry/coordinates/cylindrical_coordinates.py#L212-L224