### PR TITLE
BLD: fix compilation errors with Cython 3.0.0b1 (pow return type)

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -84,7 +84,7 @@ jobs:
     - name: Install build time dependencies
       shell: bash
       run: |
-        python -m pip install "Cython>=0.29.21,<3.0"
+        python -m pip install "Cython>=0.29.33,<3.0"
         python -m pip install oldest-supported-numpy
         python -m pip install --upgrade wheel
         python -m pip install --upgrade setuptools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
   # Cython 3.0 is the next version after 0.29, and a major change,
   # we forbid it until we can properly test against it
   # https://github.com/yt-project/yt/issues/4355
-  "Cython>=0.29.21,<3.0",
+  "Cython>=0.29.33,<3.0",
   "oldest-supported-numpy",
 ]
 

--- a/yt/frontends/ramses/io_utils.pyx
+++ b/yt/frontends/ramses/io_utils.pyx
@@ -14,6 +14,7 @@ ctypedef np.int32_t INT32_t
 ctypedef np.int64_t INT64_t
 ctypedef np.float64_t DOUBLE_t
 
+@cython.cpow(True)
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
@@ -82,6 +83,7 @@ def read_amr(FortranFile f, dict headers,
 
     return max_level
 
+@cython.cpow(True)
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
@@ -132,6 +134,7 @@ cpdef read_offset(FortranFile f, INT64_t min_level, INT64_t domain_id, INT64_t n
 
     return offset, level_count
 
+@cython.cpow(True)
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)

--- a/yt/utilities/lib/basic_octree.pyx
+++ b/yt/utilities/lib/basic_octree.pyx
@@ -38,7 +38,7 @@ cdef struct OctreeNode:
     np.float64_t *val
     np.float64_t weight_val
     np.int64_t pos[3]
-    int level
+    np.uint64_t level
     int nvals
     int max_level # The maximum level under this node with mass.
     OctreeNode *children[2][2][2]
@@ -129,7 +129,7 @@ cdef class Octree:
 
     def __cinit__(self, np.ndarray[np.int64_t, ndim=1] top_grid_dims,
                   int nvals, int incremental = False):
-        cdef int i, j, k
+        cdef np.uint64_t i, j, k
         self.incremental = incremental
         cdef np.int64_t pos[3]
         cdef np.float64_t *vals = <np.float64_t *> alloca(
@@ -499,7 +499,8 @@ cdef class Octree:
 
     cdef int node_ID(self, OctreeNode *node):
         # Returns an unique ID for this node based on its position and level.
-        cdef int ID, i, offset, root
+        cdef int ID, offset, root
+        cdef np.uint64_t i
         cdef np.int64_t this_grid_dims[3]
         offset = 0
         root = 1

--- a/yt/utilities/lib/geometry_utils.pyx
+++ b/yt/utilities/lib/geometry_utils.pyx
@@ -85,6 +85,7 @@ cdef np.int64_t tsb(np.int64_t x, np.int64_t width):
         i += 1
     return i
 
+@cython.cpow(True)
 @cython.cdivision(True)
 @cython.boundscheck(False)
 @cython.wraparound(False)
@@ -92,6 +93,7 @@ cdef np.int64_t bitrange(np.int64_t x, np.int64_t width,
                          np.int64_t start, np.int64_t end):
     return x >> (width-end) & ((2**(end-start))-1)
 
+@cython.cpow(True)
 @cython.cdivision(True)
 @cython.boundscheck(False)
 @cython.wraparound(False)
@@ -100,6 +102,7 @@ cdef np.int64_t rrot(np.int64_t x, np.int64_t i, np.int64_t width):
     x = (x>>i) | (x<<width-i)
     return x&(2**width-1)
 
+@cython.cpow(True)
 @cython.cdivision(True)
 @cython.boundscheck(False)
 @cython.wraparound(False)
@@ -122,6 +125,7 @@ cdef np.int64_t entry(np.int64_t x):
     if x == 0: return 0
     return graycode(2*((x-1)/2))
 
+@cython.cpow(True)
 @cython.cdivision(True)
 @cython.boundscheck(False)
 @cython.wraparound(False)
@@ -1186,7 +1190,8 @@ def knn_morton(np.ndarray[np.float64_t, ndim=2] P0, int k, np.uint64_t i0,
     cdef np.ndarray[np.uint64_t, ndim=1] sort_fwd = np.arange(N,dtype=np.uint64)
     cdef np.ndarray[np.uint64_t, ndim=1] sort_rev = np.arange(N,dtype=np.uint64)
     cdef np.ndarray[np.uint64_t, ndim=1] Ai
-    cdef np.int64_t idxmin, idxmax, u, l, I
+    cdef np.int64_t idxmin, idxmax, u, l
+    cdef np.uint64_t I
     # Sort if necessary
     if issorted:
         P = P0


### PR DESCRIPTION
## PR Summary

Fix most of the remaining compilation errors with Cython 3.0.0b1

Address the current top blocking problem in #4355
For context see https://github.com/cython/cython/issues/5299
