### PR TITLE
BUG: Fix index order if loading from EWAH file

### DIFF
--- a/yt/geometry/particle_geometry_handler.py
+++ b/yt/geometry/particle_geometry_handler.py
@@ -173,6 +173,9 @@ class ParticleIndex(Index):
         try:
             if dont_load:
                 raise OSError
+            # We must make sure the index order is correct, here and
+            # in the particle bitmap
+            self.ds.index_order = self.regions.correct_index_order(fname)
             rflag = self.regions.load_bitmasks(fname)
             rflag = self.regions.check_bitmasks()
             self._initialize_frontend_specific()

--- a/yt/geometry/particle_oct_container.pyx
+++ b/yt/geometry/particle_oct_container.pyx
@@ -1033,6 +1033,21 @@ cdef class ParticleBitmap:
     def reset_bitmasks(self):
         self.bitmasks._reset()
 
+    def correct_index_order(self, fname):
+        import h5py
+        # Verify that file is correct version
+        if not os.path.isfile(fname):
+            raise OSError
+        with h5py.File(fname, mode="r") as fp:
+            try:
+                grp = fp[str(self.hash_value)]
+            except KeyError:
+                raise OSError(f"Index not found in the {fname}")
+            index_order = grp.attrs["index_order1"], grp.attrs["index_order2"]
+        self.index_order1 = index_order[0]
+        self.index_order2 = index_order[1]
+        return index_order
+
     def load_bitmasks(self, fname):
         import h5py
         cdef bint read_flag = 1


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

PR #4307 allowed for the possibility of storing multiple particle indices in the EWAH sidecar file. It stores also the `index_order` in the file, _after_ there is the possibility of the second value in the tuple being updated. 

When this file is reloaded, the updated `index_order` is not taken into account, and the bitmasks that are loaded from the file, which are consistent with the `index_order` in the file, are not the ones consistent with the `index_order` yt thinks it is using (because the update in yt only occurs if the indices are being generated from scratch).

This PR fixes the issue by ensuring that we load the correct `index_order` from the file, and tell the `ParticleBitmap` and the `Dataset`'s `index' accordingly. 

Closes issue #4371. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
