### PR TITLE
BLD: add missing noexcept qualifier (Cython 3 compat)

### DIFF
--- a/yt/geometry/oct_container.pyx
+++ b/yt/geometry/oct_container.pyx
@@ -928,7 +928,7 @@ cdef class OctreeContainer:
         self.visit_all_octs(selector, visitor)
         assert ((visitor.global_index+1)*visitor.nzones == visitor.index)
 
-cdef int root_node_compare(const void *a, const void *b) nogil:
+cdef int root_node_compare(const void *a, const void *b) noexcept nogil:
     cdef OctKey *ao
     cdef OctKey *bo
     ao = <OctKey *>a


### PR DESCRIPTION
## PR Summary

This resolves the last compilation error on Cython 3.0.0b1 currently listed in #4355
While this is sufficient to enable compilation on my personal dev machine, compilation still fails on GHA, so I won't enable continuous testing yet, and will tackle *these* issues next.
