### PR TITLE
RFC: handle a deprecation warning from Cython (The keyword 'nogil' should appear at the end of the function signature line.)

### DIFF
--- a/yt/geometry/particle_deposit.pxd
+++ b/yt/geometry/particle_deposit.pxd
@@ -144,4 +144,4 @@ cdef class ParticleDepositOperation:
     cdef int process(self, int dim[3], int ipart, np.float64_t left_edge[3],
                      np.float64_t dds[3], np.int64_t offset,
                      np.float64_t ppos[3], np.float64_t[:] fields,
-                     np.int64_t domain_ind) nogil except -1
+                     np.int64_t domain_ind) except -1 nogil

--- a/yt/geometry/particle_deposit.pyx
+++ b/yt/geometry/particle_deposit.pyx
@@ -157,7 +157,7 @@ cdef class ParticleDepositOperation:
     cdef int process(self, int dim[3], int ipart, np.float64_t left_edge[3],
                      np.float64_t dds[3], np.int64_t offset,
                      np.float64_t ppos[3], np.float64_t[:] fields,
-                     np.int64_t domain_ind) nogil except -1:
+                     np.int64_t domain_ind) except -1 nogil:
         with gil:
             raise NotImplementedError
 
@@ -177,7 +177,7 @@ cdef class CountParticles(ParticleDepositOperation):
                      np.float64_t ppos[3], # this particle's position
                      np.float64_t[:] fields,
                      np.int64_t domain_ind
-                     ) nogil except -1:
+                     ) except -1 nogil:
         # here we do our thing; this is the kernel
         cdef int ii[3]
         cdef int i
@@ -215,7 +215,7 @@ cdef class SimpleSmooth(ParticleDepositOperation):
                      np.float64_t ppos[3],
                      np.float64_t[:] fields,
                      np.int64_t domain_ind
-                     ) nogil except -1:
+                     ) except -1 nogil:
         cdef int ii[3]
         cdef int ib0[3]
         cdef int ib1[3]
@@ -276,7 +276,7 @@ cdef class SumParticleField(ParticleDepositOperation):
                      np.float64_t ppos[3],
                      np.float64_t[:] fields,
                      np.int64_t domain_ind
-                     ) nogil except -1:
+                     ) except -1 nogil:
         cdef int ii[3]
         cdef int i
         for i in range(3):
@@ -319,7 +319,7 @@ cdef class StdParticleField(ParticleDepositOperation):
                      np.float64_t ppos[3],
                      np.float64_t[:] fields,
                      np.int64_t domain_ind
-                     ) nogil except -1:
+                     ) except -1 nogil:
         cdef int ii[3]
         cdef int i
         cdef float k, mk, qk
@@ -370,7 +370,7 @@ cdef class CICDeposit(ParticleDepositOperation):
                      np.float64_t ppos[3], # this particle's position
                      np.float64_t[:] fields,
                      np.int64_t domain_ind
-                     ) nogil except -1:
+                     ) except -1 nogil:
 
         cdef int i, j, k
         cdef int ind[3]
@@ -421,7 +421,7 @@ cdef class WeightedMeanParticleField(ParticleDepositOperation):
                      np.float64_t ppos[3],
                      np.float64_t[:] fields,
                      np.int64_t domain_ind
-                     ) nogil except -1:
+                     ) except -1 nogil:
         cdef int ii[3]
         cdef int i
         for i in range(3):
@@ -456,7 +456,7 @@ cdef class MeshIdentifier(ParticleDepositOperation):
                       np.float64_t ppos[3],
                       np.float64_t[:] fields,
                       np.int64_t domain_ind
-                      ) nogil except -1:
+                      ) except -1 nogil:
         fields[0] = domain_ind
         return 0
 
@@ -482,7 +482,7 @@ cdef class CellIdentifier(ParticleDepositOperation):
                       np.float64_t ppos[3],
                       np.float64_t[:] fields,
                       np.int64_t domain_ind
-                      ) nogil except -1:
+                      ) except -1 nogil:
         cdef int i, icell
         self.indexes[ipart] = offset
 
@@ -520,7 +520,7 @@ cdef class NNParticleField(ParticleDepositOperation):
                      np.float64_t ppos[3],
                      np.float64_t[:] fields,
                      np.int64_t domain_ind
-                     ) nogil except -1:
+                     ) except -1 nogil:
         # This one is a bit slow.  Every grid cell is going to be iterated
         # over, and we're going to deposit particles in it.
         cdef int i, j, k

--- a/yt/utilities/lib/bounded_priority_queue.pxd
+++ b/yt/utilities/lib/bounded_priority_queue.pxd
@@ -22,13 +22,13 @@ cdef class BoundedPriorityQueue:
     cdef np.intp_t size
     cdef np.intp_t max_elements
 
-    cdef int max_heapify(self, np.intp_t index) nogil except -1
-    cdef int propagate_up(self, np.intp_t index) nogil except -1
-    cdef int add(self, np.float64_t val) nogil except -1
-    cdef int add_pid(self, np.float64_t val, np.int64_t pid) nogil except -1
-    cdef int heap_append(self, np.float64_t val, np.int64_t ind) nogil except -1
-    cdef np.float64_t extract_max(self) nogil except -1
-    cdef int validate_heap(self) nogil except -1
+    cdef int max_heapify(self, np.intp_t index) except -1 nogil
+    cdef int propagate_up(self, np.intp_t index) except -1 nogil
+    cdef int add(self, np.float64_t val) except -1 nogil
+    cdef int add_pid(self, np.float64_t val, np.int64_t pid) except -1 nogil
+    cdef int heap_append(self, np.float64_t val, np.int64_t ind) except -1 nogil
+    cdef np.float64_t extract_max(self) except -1 nogil
+    cdef int validate_heap(self) except -1 nogil
 
 cdef class NeighborList:
     cdef public np.float64_t[:] data
@@ -39,5 +39,5 @@ cdef class NeighborList:
     cdef np.intp_t _max_size
 
     cdef int _update_memview(self) except -1
-    cdef int _extend(self) nogil except -1
-    cdef int add_pid(self, np.float64_t val, np.int64_t ind) nogil except -1
+    cdef int _extend(self) except -1 nogil
+    cdef int add_pid(self, np.float64_t val, np.int64_t ind) except -1 nogil

--- a/yt/utilities/lib/bounded_priority_queue.pyx
+++ b/yt/utilities/lib/bounded_priority_queue.pyx
@@ -35,7 +35,7 @@ cdef class BoundedPriorityQueue:
     @cython.wraparound(False)
     @cython.cdivision(True)
     @cython.initializedcheck(False)
-    cdef int max_heapify(self, np.intp_t index) nogil except -1:
+    cdef int max_heapify(self, np.intp_t index) except -1 nogil:
         cdef np.intp_t left = 2 * index + 1
         cdef np.intp_t right = 2 * index + 2
         cdef np.intp_t largest = index
@@ -60,7 +60,7 @@ cdef class BoundedPriorityQueue:
     @cython.wraparound(False)
     @cython.cdivision(True)
     @cython.initializedcheck(False)
-    cdef int propagate_up(self, np.intp_t index) nogil except -1:
+    cdef int propagate_up(self, np.intp_t index) except -1 nogil:
         while index != 0 and self.heap_ptr[(index - 1) // 2] < self.heap_ptr[index]:
             self.heap_ptr[index], self.heap_ptr[(index - 1) // 2] = self.heap_ptr[(index - 1) // 2], self.heap_ptr[index]
             if self.use_pids:
@@ -73,7 +73,7 @@ cdef class BoundedPriorityQueue:
     @cython.wraparound(False)
     @cython.cdivision(True)
     @cython.initializedcheck(False)
-    cdef int add(self, np.float64_t val) nogil except -1:
+    cdef int add(self, np.float64_t val) except -1 nogil:
         # if not at max size append, if at max size, only append if smaller than
         # the maximum value
         if self.size == self.max_elements:
@@ -88,7 +88,7 @@ cdef class BoundedPriorityQueue:
     @cython.wraparound(False)
     @cython.cdivision(True)
     @cython.initializedcheck(False)
-    cdef int add_pid(self, np.float64_t val, np.int64_t ind) nogil except -1:
+    cdef int add_pid(self, np.float64_t val, np.int64_t ind) except -1 nogil:
         if self.size == self.max_elements:
             if val < self.heap_ptr[0]:
                 self.extract_max()
@@ -101,7 +101,7 @@ cdef class BoundedPriorityQueue:
     @cython.wraparound(False)
     @cython.cdivision(True)
     @cython.initializedcheck(False)
-    cdef int heap_append(self, np.float64_t val, np.int64_t ind) nogil except -1:
+    cdef int heap_append(self, np.float64_t val, np.int64_t ind) except -1 nogil:
         self.heap_ptr[self.size] = val
         if self.use_pids:
             self.pids_ptr[self.size] = ind
@@ -113,7 +113,7 @@ cdef class BoundedPriorityQueue:
     @cython.wraparound(False)
     @cython.cdivision(True)
     @cython.initializedcheck(False)
-    cdef np.float64_t extract_max(self) nogil except -1:
+    cdef np.float64_t extract_max(self) except -1 nogil:
         cdef np.float64_t maximum = self.heap_ptr[0]
         cdef np.float64_t val
         cdef np.int64_t ind
@@ -133,7 +133,7 @@ cdef class BoundedPriorityQueue:
             self.max_heapify(0)
         return maximum
 
-    cdef int validate_heap(self) nogil except -1:
+    cdef int validate_heap(self) except -1 nogil:
         # this function loops through every element in the heap, if any children
         # are greater than their parents then we return zero, which is an error
         # as the heap condition is not satisfied
@@ -174,7 +174,7 @@ cdef class NeighborList:
     @cython.wraparound(False)
     @cython.cdivision(True)
     @cython.initializedcheck(False)
-    cdef int _extend(self) nogil except -1:
+    cdef int _extend(self) except -1 nogil:
         if self.size == self._max_size:
             self._max_size *= 2
             with gil:
@@ -193,7 +193,7 @@ cdef class NeighborList:
     @cython.wraparound(False)
     @cython.cdivision(True)
     @cython.initializedcheck(False)
-    cdef int add_pid(self, np.float64_t val, np.int64_t ind) nogil except -1:
+    cdef int add_pid(self, np.float64_t val, np.int64_t ind) except -1 nogil:
         self._extend()
         self.data_ptr[self.size] = val
         self.pids_ptr[self.size] = ind

--- a/yt/utilities/lib/image_samplers.pxd
+++ b/yt/utilities/lib/image_samplers.pxd
@@ -23,7 +23,7 @@ DEF Nch = 4
 cdef struct VolumeRenderAccumulator
 
 ctypedef int calculate_extent_function(ImageSampler image,
-            VolumeContainer *vc, np.int64_t rv[4]) nogil except -1
+            VolumeContainer *vc, np.int64_t rv[4]) except -1 nogil
 
 ctypedef void generate_vector_info_function(ImageSampler im,
             np.int64_t vi, np.int64_t vj,

--- a/yt/utilities/lib/lenses.pyx
+++ b/yt/utilities/lib/lenses.pyx
@@ -20,7 +20,7 @@ from .image_samplers cimport ImageSampler
 @cython.wraparound(False)
 @cython.cdivision(True)
 cdef int calculate_extent_plane_parallel(ImageSampler image,
-            VolumeContainer *vc, np.int64_t rv[4]) nogil except -1:
+            VolumeContainer *vc, np.int64_t rv[4]) except -1 nogil:
     # We do this for all eight corners
     cdef np.float64_t temp
     cdef np.float64_t *edges[2]
@@ -58,7 +58,7 @@ cdef int calculate_extent_plane_parallel(ImageSampler image,
 @cython.wraparound(False)
 @cython.cdivision(True)
 cdef int calculate_extent_perspective(ImageSampler image,
-            VolumeContainer *vc, np.int64_t rv[4]) nogil except -1:
+            VolumeContainer *vc, np.int64_t rv[4]) except -1 nogil:
 
     cdef np.float64_t cam_pos[3]
     cdef np.float64_t cam_width[3]
@@ -167,7 +167,7 @@ cdef int calculate_extent_perspective(ImageSampler image,
 @cython.wraparound(False)
 @cython.cdivision(True)
 cdef int calculate_extent_null(ImageSampler image,
-            VolumeContainer *vc, np.int64_t rv[4]) nogil except -1:
+            VolumeContainer *vc, np.int64_t rv[4]) except -1 nogil:
     rv[0] = 0
     rv[1] = image.nv[0]
     rv[2] = 0

--- a/yt/utilities/lib/particle_kdtree_tools.pxd
+++ b/yt/utilities/lib/particle_kdtree_tools.pxd
@@ -14,4 +14,4 @@ cdef int set_axes_range(axes_range *axes, int skipaxis)
 
 cdef int find_neighbors(np.float64_t * pos, np.float64_t[:, ::1] tree_positions,
                         BoundedPriorityQueue queue, KDTree * c_tree,
-                        uint64_t skipidx, axes_range * axes) nogil except -1
+                        uint64_t skipidx, axes_range * axes) except -1 nogil

--- a/yt/utilities/lib/particle_kdtree_tools.pyx
+++ b/yt/utilities/lib/particle_kdtree_tools.pyx
@@ -180,7 +180,7 @@ def estimate_density(np.float64_t[:, ::1] tree_positions, np.float64_t[:] mass,
 @cython.wraparound(False)
 cdef int find_neighbors(np.float64_t * pos, np.float64_t[:, ::1] tree_positions,
                         BoundedPriorityQueue queue, KDTree * c_tree,
-                        uint64_t skipidx, axes_range * axes) nogil except -1:
+                        uint64_t skipidx, axes_range * axes) except -1 nogil:
     cdef Node* leafnode
 
     # Make an initial guess based on the closest node
@@ -202,7 +202,7 @@ cdef int find_knn(Node* node,
                   uint32_t skipleaf,
                   uint64_t skipidx,
                   axes_range * axes,
-                  ) nogil except -1:
+                  ) except -1 nogil:
     # if we aren't a leaf then we keep traversing until we find a leaf, else we
     # we actually begin to check the leaf
     if not node.is_leaf:
@@ -225,7 +225,7 @@ cdef inline int cull_node(Node* node,
                           BoundedPriorityQueue queue,
                           uint32_t skipleaf,
                           axes_range * axes,
-                          ) nogil except -1:
+                          ) except -1 nogil:
     cdef int k
     cdef np.float64_t v
     cdef np.float64_t tpos, ndist = 0
@@ -255,7 +255,7 @@ cdef inline int process_node_points(Node* node,
                                     np.float64_t* pos,
                                     int skipidx,
                                     axes_range * axes,
-                                    ) nogil except -1:
+                                    ) except -1 nogil:
     cdef uint64_t i, k
     cdef np.float64_t tpos, sq_dist
     for i in range(node.left_idx, node.left_idx + node.children):
@@ -280,7 +280,7 @@ cdef int find_neighbors_ball(np.float64_t * pos, np.float64_t r2,
                              np.float64_t[:, ::1] tree_positions,
                              NeighborList nblist, KDTree * c_tree,
                              uint64_t skipidx, axes_range * axes
-                             ) nogil except -1:
+                             ) except -1 nogil:
     """Find neighbors within a ball."""
     cdef Node* leafnode
 
@@ -304,7 +304,7 @@ cdef int find_ball(Node* node,
                    uint32_t skipleaf,
                    uint64_t skipidx,
                    axes_range * axes,
-                   ) nogil except -1:
+                   ) except -1 nogil:
     """Traverse the k-d tree to process leaf nodes."""
     if not node.is_leaf:
         if not cull_node_ball(node.less, pos, r2, skipleaf, axes):
@@ -326,7 +326,7 @@ cdef inline int cull_node_ball(Node* node,
                                np.float64_t r2,
                                uint32_t skipleaf,
                                axes_range * axes,
-                               ) nogil except -1:
+                               ) except -1 nogil:
     """Check if the node does not intersect with the ball at all."""
     cdef int k
     cdef np.float64_t v
@@ -358,7 +358,7 @@ cdef inline int process_node_points_ball(Node* node,
                                          np.float64_t r2,
                                          int skipidx,
                                          axes_range * axes,
-                                         ) nogil except -1:
+                                         ) except -1 nogil:
     """Add points from the leaf node within the ball to the neighbor list."""
     cdef uint64_t i, k
     cdef np.float64_t tpos, sq_dist


### PR DESCRIPTION
## PR Summary

Fix a deprecation warning from Cython 3.0.0b1
```
The keyword 'nogil' should appear at the end of the function signature line. Placing it before 'except' or 'noexcept' will be disallowed in a future version of Cython
```

reduce the compatibility gap with Cython 3.1
This is a noop on Cython 0.29.x
