### PR TITLE
RFC: eliminate some unused deprecated Cython macros

### DIFF
--- a/yt/geometry/particle_oct_container.pyx
+++ b/yt/geometry/particle_oct_container.pyx
@@ -59,11 +59,6 @@ from ..utilities.lib.ewah_bool_wrap cimport BoolArrayCollection
 
 import os
 
-# If set to 1, ghost cells are added at the refined level regardless of if the
-# coarse cell containing it is refined in the selector.
-# If set to 0, ghost cells are only added at the refined level if the coarse
-# index for the ghost cell is refined in the selector.
-DEF RefinedExternalGhosts = 1
 
 _bitmask_version = np.uint64(5)
 
@@ -1682,16 +1677,22 @@ cdef class ParticleBitmapSelector:
             mi1_n = self.neighbor_list1[m]
             mi2_n = self.neighbor_list2[m]
             self.coarse_ghosts_bool[mi1_n] = 1
-            IF RefinedExternalGhosts == 1:
-                if mi1_n == mi1:
-                    self.refined_ghosts_bool[mi2_n] = 1
-                else:
-                    self.refined_ghosts_list._set(mi1_n, mi2_n)
-            ELSE:
-                if mi1_n == mi1:
-                    self.refined_ghosts_bool[mi2_n] = 1
-                elif self.is_refined(mi1_n) == 1:
-                    self.refined_ghosts_list._set(mi1_n, mi2_n)
+
+            # Ghost cells are added at the refined level regardless of if the
+            # coarse cell containing it is refined in the selector.
+            if mi1_n == mi1:
+                self.refined_ghosts_bool[mi2_n] = 1
+            else:
+                self.refined_ghosts_list._set(mi1_n, mi2_n)
+
+            # alternative implementation by Meagan Lang
+            # see ed95b1ac2f7105092b1116f9c76568ae27024751
+            # Ghost cells are only added at the refined level if the coarse
+            # index for the ghost cell is refined in the selector.
+            #if mi1_n == mi1:
+            #    self.refined_ghosts_bool[mi2_n] = 1
+            #elif self.is_refined(mi1_n) == 1:
+            #    self.refined_ghosts_list._set(mi1_n, mi2_n)
 
     @cython.boundscheck(False)
     @cython.wraparound(False)

--- a/yt/utilities/lib/_octree_raytracing.pyx
+++ b/yt/utilities/lib/_octree_raytracing.pyx
@@ -10,8 +10,6 @@ import numpy as np
 
 cimport cython
 
-DEF Nch = 4
-
 
 cdef class _OctreeRayTracing:
     def __init__(self, np.ndarray LE, np.ndarray RE, int depth):

--- a/yt/utilities/lib/amr_kdtools.pyx
+++ b/yt/utilities/lib/amr_kdtools.pyx
@@ -15,8 +15,6 @@ cimport numpy as np
 from cython.view cimport array as cvarray
 from libc.stdlib cimport free, malloc
 
-DEF Nch = 4
-
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)

--- a/yt/utilities/lib/grid_traversal.pyx
+++ b/yt/utilities/lib/grid_traversal.pyx
@@ -22,7 +22,6 @@ from yt.utilities.lib.fp_utils cimport fmin
 
 from .fixed_interpolator cimport *
 
-DEF Nch = 4
 
 @cython.boundscheck(False)
 @cython.wraparound(False)


### PR DESCRIPTION
## PR Summary

`IF` and `DEF` macros are deprecated in Cython 3. While it is not urgent to migrate to long term replacements, here I'm eliminating only occurences that are actually unused.
