### PR TITLE
DOC: fix typos

### DIFF
--- a/yt/_maintenance/backports.py
+++ b/yt/_maintenance/backports.py
@@ -1,5 +1,5 @@
 # A namespace to store simple backports from most recent Python versions
-# Backports should be contained in (if/else) blocks, cheking on the runtime
+# Backports should be contained in (if/else) blocks, checking on the runtime
 # Python version, e.g.
 #
 # if sys.version_info < (3, 8):

--- a/yt/_maintenance/deprecation.py
+++ b/yt/_maintenance/deprecation.py
@@ -66,7 +66,7 @@ def future_positional_only(positions2names: Dict[int, str], /, **depr_kwargs):
                 issue_deprecation_warning(
                     f"Using the {name!r} argument as keyword (on position {no}) "
                     "is deprecated. "
-                    "Pass the argument as positional to supress this warning, "
+                    "Pass the argument as positional to suppress this warning, "
                     f"i.e., use {func.__name__}({value!r}, ...)",
                     **depr_kwargs,
                 )

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -105,7 +105,7 @@ _cached_datasets: MutableMapping[
 ] = weakref.WeakValueDictionary()
 
 # we set this global to None as a place holder
-# its actual instanciation is delayed until after yt.__init__
+# its actual instantiation is delayed until after yt.__init__
 # is completed because we need yt.config.ytcfg to be instantiated first
 
 _ds_store: Optional[ParameterFileStore] = None
@@ -234,7 +234,7 @@ class Dataset(abc.ABC):
         super().__init_subclass__(*args, **kwargs)
         if cls.__name__ in output_type_registry:
             warnings.warn(
-                f"Overwritting {cls.__name__}, which was previously registered. "
+                f"Overwriting {cls.__name__}, which was previously registered. "
                 "This is expected if you're importing a yt extension with a "
                 "frontend that was already migrated to the main code base."
             )
@@ -798,7 +798,7 @@ class Dataset(abc.ABC):
         # end compatibility layer
         if not isinstance(self.geometry, Geometry):
             raise TypeError(
-                "Excpected dataset.geometry attribute to be of "
+                "Expected dataset.geometry attribute to be of "
                 "type yt.geometry.geometry_enum.Geometry\n"
                 f"Got {self.geometry=} with type {type(self.geometry)}"
             )

--- a/yt/data_objects/tests/test_registration.py
+++ b/yt/data_objects/tests/test_registration.py
@@ -10,7 +10,7 @@ def test_reregistration_warning():
         with pytest.warns(
             UserWarning,
             match=(
-                "Overwritting EnzoDataset, which was previously registered. "
+                "Overwriting EnzoDataset, which was previously registered. "
                 "This is expected if you're importing a yt extension with a "
                 "frontend that was already migrated to the main code base."
             ),

--- a/yt/fields/local_fields.py
+++ b/yt/fields/local_fields.py
@@ -7,7 +7,7 @@ from yt.utilities.logger import ytLogger as mylog
 from .field_info_container import FieldInfoContainer
 from .field_plugin_registry import register_field_plugin
 
-# workaround mypy not being confortable around decorator preserving signatures
+# workaround mypy not being comfortable around decorator preserving signatures
 # adapted from
 # https://github.com/python/mypy/issues/1551#issuecomment-253978622
 TFun = TypeVar("TFun", bound=Callable[..., Any])

--- a/yt/frontends/artio/artio_headers/LICENSE
+++ b/yt/frontends/artio/artio_headers/LICENSE
@@ -1,5 +1,5 @@
 ARTIO is licensed under the GNU Lesser General Public License (LGPL) version 3,
-which is an extension of the GNU Gneral Public License (GPL).  The text of both
+which is an extension of the GNU General Public License (GPL).  The text of both
 licenses are included here.
 
 ===============================================================================

--- a/yt/frontends/cf_radial/data_structures.py
+++ b/yt/frontends/cf_radial/data_structures.py
@@ -109,7 +109,7 @@ class CFRadialDataset(Dataset):
             storage_filename will be over-written if it exists. Default is False.
         grid_shape : Optional[Tuple[int, int, int]]
             when gridding to cartesian, grid_shape is the number of cells in the
-            z, y, x coordinatess. If not provided, yt attempts to calculate a
+            z, y, x coordinates. If not provided, yt attempts to calculate a
             reasonable shape based on the resolution of the original cfradial grid
         grid_limit_x : Optional[Tuple[float, float]]
             The x range of the cartesian-gridded data in the form (xmin, xmax) with

--- a/yt/frontends/chimera/data_structures.py
+++ b/yt/frontends/chimera/data_structures.py
@@ -105,8 +105,8 @@ class ChimeraUNSIndex(UnstructuredIndex):
                     )
                 coords.shape = (nxd * nyd * nzd, 3)
                 # Connectivity is an array of rows, each of which corresponds to a grid cell.
-                # The 8 elements of each row are integers representing the cell verticies.
-                # These integers refrence the numerical index of the element of the
+                # The 8 elements of each row are integers representing the cell vertices.
+                # These integers reference the numerical index of the element of the
                 # "coords" array which corresponds to the spatial coordinate.
 
                 connectivity = np.zeros(

--- a/yt/frontends/enzo_e/data_structures.py
+++ b/yt/frontends/enzo_e/data_structures.py
@@ -433,7 +433,7 @@ class EnzoEDataset(Dataset):
         if fp_params is not None:
             # in newer versions of enzo-e, this data is specified in a
             # centralized parameter group called Physics:fluid_props
-            # -  for internal reasons related to backwards compatability,
+            # -  for internal reasons related to backwards compatibility,
             #    treatment of this physics-group is somewhat special (compared
             #    to the cosmology group). The parameters in this group are
             #    honored even if Physics:list does not include "fluid_props"

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -743,7 +743,7 @@ class RAMSESDataset(Dataset):
 
         file_handler = RAMSESFileSanitizer(filename)
 
-        # ensure validation happens even if the class is instanciated
+        # ensure validation happens even if the class is instantiated
         # directly rather than from yt.load
         file_handler.validate()
 

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -343,7 +343,7 @@ class StreamDataset(Dataset):
         from yt.data_objects.static_output import _cached_datasets
 
         if geometry == "spectral_cube":
-            # mimick FITSDataset specific interface to allow testing with
+            # mimic FITSDataset specific interface to allow testing with
             # fake, in memory data
             setdefaultattr(self, "lon_axis", 0)
             setdefaultattr(self, "lat_axis", 1)

--- a/yt/geometry/coordinates/spherical_coordinates.py
+++ b/yt/geometry/coordinates/spherical_coordinates.py
@@ -334,7 +334,7 @@ class SphericalCoordinateHandler(CoordinateHandler):
             xmin = min(xmin, ONE * aitoff_x(0, lonmin))
             xmax = max(xmax, ONE * aitoff_x(0, lonmax))
 
-        # the y direction is more straighforward because aitoff-projected parallels (y)
+        # the y direction is more straightforward because aitoff-projected parallels (y)
         # draw a convex shape, while aitoff-projected meridians (x) draw a concave shape
         ymin = ONE * min(y for x, y in aitoff_corner_coords)
         ymax = ONE * max(y for x, y in aitoff_corner_coords)

--- a/yt/geometry/coordinates/tests/test_sanitize_center.py
+++ b/yt/geometry/coordinates/tests/test_sanitize_center.py
@@ -84,7 +84,7 @@ def test_invalid_center_type_default_error(reusable_fake_dataset, user_input):
         (
             unyt_array([0.5] * 3, "kg"),
             UnitConversionError,
-            "...",  # don't match the exact error message since it's unyt's responsability
+            "...",  # don't match the exact error message since it's unyt's responsibility
         ),
         # only validate 3 elements unyt_arrays
         (

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -88,7 +88,7 @@ def load(
         If fn matches existing files or directories with undetermined format.
 
     yt.utilities.exceptions.YTAmbiguousDataType
-        If the data format matches more than one class of similar specilization levels.
+        If the data format matches more than one class of similar specialization levels.
     """
     fn = os.path.expanduser(fn)
 
@@ -1684,7 +1684,7 @@ def load_archive(
     proc = Process(target=_mount_helper, args=(fn, tempdir, ratarmount_kwa, child_conn))
     proc.start()
     if not parent_conn.recv():
-        raise MountError(f"An error occured while mounting {fn} in {tempdir}")
+        raise MountError(f"An error occurred while mounting {fn} in {tempdir}")
 
     # Note: the mounting needs to happen in another process which
     # needs be run in the foreground (otherwise it may

--- a/yt/units/_numpy_wrapper_functions.py
+++ b/yt/units/_numpy_wrapper_functions.py
@@ -1,6 +1,6 @@
 # This module is not part of the public namespace `yt.units`
 # It is home to wrapper functions that are directly copied from unyt 2.9.2
-# We vendor them as a transition step towards unyt 3.0 (in devlopment),
+# We vendor them as a transition step towards unyt 3.0 (in development),
 # where these wrapper functions are deprecated and are should be replaced with vanilla numpy API
 # FUTURE:
 # - require unyt>=3.0

--- a/yt/utilities/logger.py
+++ b/yt/utilities/logger.py
@@ -128,7 +128,7 @@ def disable_stream_logging():
 
 
 def _runtime_configuration(ytcfg: YTConfig) -> None:
-    # only run this at the end of yt.__init__, after yt.config.ytcfg was instanciated
+    # only run this at the end of yt.__init__, after yt.config.ytcfg was instantiated
 
     global _original_emitter, _yt_sh
 

--- a/yt/utilities/on_demand_imports.py
+++ b/yt/utilities/on_demand_imports.py
@@ -27,7 +27,7 @@ class NotAModule:
             exc.add_note(error_note)
             self.error = exc
         else:
-            # mimick Python 3.11 behaviour:
+            # mimic Python 3.11 behaviour:
             # preserve error message and traceback
             self.error = type(exc)(f"{exc!s}\n{error_note}").with_traceback(
                 exc.__traceback__
@@ -55,7 +55,7 @@ class OnDemand:
 
     def __new__(cls):
         if cls is OnDemand:
-            raise TypeError("The OnDemand base class cannot be instanciated.")
+            raise TypeError("The OnDemand base class cannot be instantiated.")
         else:
             return object.__new__(cls)
 

--- a/yt/utilities/tests/test_config.py
+++ b/yt/utilities/tests/test_config.py
@@ -52,7 +52,7 @@ class TestYTConfig(unittest.TestCase):
         os.environ["XDG_CONFIG_HOME"] = self.tmpdir
         os.mkdir(os.path.join(self.tmpdir, "yt"))
 
-        # run inside another temporary directory to avoid poluting the
+        # run inside another temporary directory to avoid polluting the
         # local space when we dump configuration to a local yt.toml file
         self.origin = os.getcwd()
         os.chdir(tempfile.mkdtemp())

--- a/yt/utilities/tests/test_on_demand_imports.py
+++ b/yt/utilities/tests/test_on_demand_imports.py
@@ -57,6 +57,6 @@ def test_class_invalidation():
 
 def test_base_class_instanciation():
     with pytest.raises(
-        TypeError, match="The OnDemand base class cannot be instanciated."
+        TypeError, match="The OnDemand base class cannot be instantiated."
     ):
         OnDemand()

--- a/yt/visualization/_handlers.py
+++ b/yt/visualization/_handlers.py
@@ -414,7 +414,7 @@ class ColorbarHandler:
     def draw_cbar(self, newval) -> None:
         if not isinstance(newval, bool):
             raise TypeError(
-                f"Excpected a boolean, got {newval} with type {type(newval)}"
+                f"Expected a boolean, got {newval} with type {type(newval)}"
             )
         self._draw_cbar = newval
 
@@ -426,7 +426,7 @@ class ColorbarHandler:
     def draw_minorticks(self, newval) -> None:
         if not isinstance(newval, bool):
             raise TypeError(
-                f"Excpected a boolean, got {newval} with type {type(newval)}"
+                f"Expected a boolean, got {newval} with type {type(newval)}"
             )
         self._draw_minorticks = newval
 

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -405,7 +405,7 @@ class ImagePlotMPL(PlotMPL, ABC):
         # - self._draw_axes: bool
         # - self.colorbar_handler: ColorbarHandler
 
-        # optional attribtues
+        # optional attributes
         # - self._unit_aspect: float
 
         # Ensure the figure size along the long axis is always equal to _figure_size

--- a/yt/visualization/color_maps.py
+++ b/yt/visualization/color_maps.py
@@ -104,10 +104,10 @@ for k, v in list(_cm.color_map_luts.items()):
 
 def get_colormap_lut(cmap_id: Union[Tuple[str, str], str]):
     # "lut" stands for "lookup table". This function provides a consistent and
-    # reusable accessor to a hidden (and by defaut, uninitialized) attribute
+    # reusable accessor to a hidden (and by default, uninitialized) attribute
     # (`_lut`) in registered colormaps, from matplotlib or palettable.
     # colormap "lookup tables" are RGBA arrays in matplotlib,
-    # and contain sufficient data to reconstruct the colormaps entierly.
+    # and contain sufficient data to reconstruct the colormaps entirely.
     # This exists mostly for historical reasons, hence the custom output format.
     # It isn't meant as part of yt's public api.
 

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -122,7 +122,7 @@ class FixedResolutionBuffer:
         # note that this import statement is actually crucial at runtime:
         # the filter methods for the present class are defined only when
         # fixed_resolution_filters is imported, so we need to guarantee
-        # that it happens no later than instanciation
+        # that it happens no later than instantiation
         from yt.visualization.fixed_resolution_filters import (
             FixedResolutionBufferFilter,
         )

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -868,7 +868,7 @@ class PWViewerMPL(PlotWindow):
         # note that this import statement is actually crucial at runtime:
         # the filter methods for the present class are defined only when
         # fixed_resolution_filters is imported, so we need to guarantee
-        # that it happens no later than instanciation
+        # that it happens no later than instantiation
         from yt.visualization.plot_modifications import PlotCallback
 
         self._callbacks: List[PlotCallback] = []
@@ -880,7 +880,7 @@ class PWViewerMPL(PlotWindow):
     @_data_valid.setter
     def _data_valid(self, value):
         if self._frb is None:
-            # we delegate the (in)validation responsability to the FRB
+            # we delegate the (in)validation responsibility to the FRB
             # if we don't have one yet, we can exit without doing anything
             return
         else:
@@ -1052,7 +1052,7 @@ class PWViewerMPL(PlotWindow):
 
             # extentx/y arrays inherit units from xlim and ylim attributes
             # and these attributes are always length even for angular and
-            # dimensionless axes so we need to stip out units for consistency
+            # dimensionless axes so we need to strip out units for consistency
             if unit_x == "dimensionless":
                 extentx = extentx / extentx.units
             else:
@@ -1448,13 +1448,13 @@ class SlicePlot(NormalPlot):
         simulation output to be plotted.
     normal : int, str, or 3-element sequence of floats
         This specifies the normal vector to the slice.
-        Valid int values are 0, 1 and 2. Coresponding str values depend on the
+        Valid int values are 0, 1 and 2. Corresponding str values depend on the
         geometry of the dataset and are generally given by `ds.coordinates.axis_order`.
         E.g. in cartesian they are 'x', 'y' and 'z'.
         An arbitrary normal vector may be specified as a 3-element sequence of floats.
 
         This returns a :class:`OffAxisSlicePlot` object or a
-        :class:`AxisAlignedSlicePlot` object, depending on wether the requested
+        :class:`AxisAlignedSlicePlot` object, depending on whether the requested
         normal directions corresponds to a natural axis of the dataset's geometry.
 
     fields : a (or a list of) 2-tuple of strings (ftype, fname)
@@ -1617,13 +1617,13 @@ class ProjectionPlot(NormalPlot):
         simulation output to be plotted.
     normal : int, str, or 3-element sequence of floats
         This specifies the normal vector to the slice.
-        Valid int values are 0, 1 and 2. Coresponding str values depend on the
+        Valid int values are 0, 1 and 2. Corresponding str values depend on the
         geometry of the dataset and are generally given by `ds.coordinates.axis_order`.
         E.g. in cartesian they are 'x', 'y' and 'z'.
         An arbitrary normal vector may be specified as a 3-element sequence of floats.
 
         This function will return a :class:`OffAxisProjectionPlot` object or a
-        :class:`AxisAlignedProjectionPlot` object, depending on wether the requested
+        :class:`AxisAlignedProjectionPlot` object, depending on whether the requested
         normal directions corresponds to a natural axis of the dataset's geometry.
 
     fields : a (or a list of) 2-tuple of strings (ftype, fname)

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -838,7 +838,7 @@ def test_nan_data():
 
 def test_sanitize_valid_normal_vector():
     # note: we don't test against non-cartesian geometries
-    # because the way normal "vectors" work isn't cleary
+    # because the way normal "vectors" work isn't clearly
     # specified and works more as an implementation detail
     # at the moment
     ds = fake_amr_ds(geometry="cartesian")

--- a/yt/visualization/tests/test_save.py
+++ b/yt/visualization/tests/test_save.py
@@ -85,7 +85,7 @@ def test_invalid_format_from_filename(simple_sliceplot, tmp_path):
     output_files = list(tmp_path.glob("*"))
     assert len(output_files) == 1
     # the output filename may contain a generated part
-    # it's not exactly clear if it's desirable or intented in this case
+    # it's not exactly clear if it's desirable or intended in this case
     # so we just check conditions that should hold in any case
     assert output_files[0].name.startswith("myfile.nope")
     assert output_files[0].name.endswith(".png")


### PR DESCRIPTION
Fix a bunch of typos detected (and mostly auto-fixed) with `codespell`