### PR TITLE
BUG: Fix typo in vector operations and enable plot modifications for spherical geometry

### DIFF
--- a/yt/fields/vector_operations.py
+++ b/yt/fields/vector_operations.py
@@ -529,7 +529,7 @@ def create_vector_fields(
                         * np.cos(data[(ftype, "phi")])
                         + data[(ftype, f"{basename}_theta")]
                         * np.cos(data[(ftype, "theta")])
-                        * np.cos([(ftype, "phi")])
+                        * np.cos(data[(ftype, "phi")])
                         - data[(ftype, f"{basename}_phi")]
                         * np.sin(data[(ftype, "phi")])
                     )
@@ -546,7 +546,7 @@ def create_vector_fields(
                         * np.sin(data[(ftype, "phi")])
                         + data[(ftype, f"{basename}_theta")]
                         * np.cos(data[(ftype, "theta")])
-                        * np.sin([(ftype, "phi")])
+                        * np.sin(data[(ftype, "phi")])
                         + data[(ftype, f"{basename}_phi")]
                         * np.cos(data[(ftype, "phi")])
                     )

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -1213,7 +1213,13 @@ class StreamlineCallback(PlotCallback):
     """
 
     _type_name = "streamlines"
-    _supported_geometries = ("cartesian", "spectral_cube", "polar", "cylindrical", "spherical")
+    _supported_geometries = (
+        "cartesian",
+        "spectral_cube",
+        "polar",
+        "cylindrical",
+        "spherical",
+    )
     _incompatible_plot_types = ("OffAxisProjection", "Particle")
 
     def __init__(
@@ -3052,7 +3058,13 @@ class LineIntegralConvolutionCallback(PlotCallback):
     """
 
     _type_name = "line_integral_convolution"
-    _supported_geometries = ("cartesian", "spectral_cube", "polar", "cylindrical", "spherical")
+    _supported_geometries = (
+        "cartesian",
+        "spectral_cube",
+        "polar",
+        "cylindrical",
+        "spherical",
+    )
     _incompatible_plot_types = ("LineIntegralConvolutionCallback",)
 
     def __init__(

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -495,7 +495,7 @@ class VelocityCallback(PlotCallback):
 
             if geometry is Geometry.POLAR or geometry is Geometry.CYLINDRICAL:
                 if axis_names[plot.data.axis] == "z":
-                    # polar_z and cyl_z is aligned with carteian_z
+                    # polar_z and cyl_z is aligned with cartesian_z
                     # should convert r-theta plane to x-y plane
                     xv = (ftype, "velocity_cartesian_x")
                     yv = (ftype, "velocity_cartesian_y")
@@ -628,7 +628,7 @@ class MagFieldCallback(PlotCallback):
 
             if geometry is Geometry.POLAR or geometry is Geometry.CYLINDRICAL:
                 if axis_names[plot.data.axis] == "z":
-                    # polar_z and cyl_z is aligned with carteian_z
+                    # polar_z and cyl_z is aligned with cartesian_z
                     # should convert r-theta plane to x-y plane
                     xv = (ftype, "magnetic_field_cartesian_x")
                     yv = (ftype, "magnetic_field_cartesian_y")
@@ -1213,7 +1213,7 @@ class StreamlineCallback(PlotCallback):
     """
 
     _type_name = "streamlines"
-    _supported_geometries = ("cartesian", "spectral_cube", "polar", "cylindrical")
+    _supported_geometries = ("cartesian", "spectral_cube", "polar", "cylindrical", "spherical")
     _incompatible_plot_types = ("OffAxisProjection", "Particle")
 
     def __init__(
@@ -3052,7 +3052,7 @@ class LineIntegralConvolutionCallback(PlotCallback):
     """
 
     _type_name = "line_integral_convolution"
-    _supported_geometries = ("cartesian", "spectral_cube", "polar", "cylindrical")
+    _supported_geometries = ("cartesian", "spectral_cube", "polar", "cylindrical", "spherical")
     _incompatible_plot_types = ("LineIntegralConvolutionCallback",)
 
     def __init__(

--- a/yt/visualization/tests/test_callbacks.py
+++ b/yt/visualization/tests/test_callbacks.py
@@ -959,13 +959,16 @@ def test_streamline_callback():
             units=("g/cm**3", "cm/s", "cm/s", "cm/s"),
             geometry="spherical",
         )
-        p = SlicePlot(ds, "r", ("gas", "density"))
-        assert_raises(
-            YTDataTypeUnsupported,
-            p.annotate_streamlines,
-            ("gas", "velocity_theta"),
-            ("gas", "velocity_phi"),
+        slc = SlicePlot(ds, "phi", ("gas", "velocity_magnitude"))
+        slc.annotate_streamlines(
+            ("gas", "velocity_cylindrical_radius"), ("gas", "velocity_cylindrical_z")
         )
+        assert_fname(slc.save(prefix)[0])
+        slc = SlicePlot(ds, "theta", ("gas", "velocity_magnitude"))
+        slc.annotate_streamlines(
+            ("gas", "velocity_conic_x"), ("gas", "velocity_conic_y")
+        )
+        assert_fname(slc.save(prefix)[0])
 
 
 @requires_module("h5py")
@@ -1041,13 +1044,17 @@ def test_line_integral_convolution_callback():
             units=("g/cm**3", "cm/s", "cm/s", "cm/s"),
             geometry="spherical",
         )
-        p = SlicePlot(ds, "r", ("gas", "density"))
-        assert_raises(
-            YTDataTypeUnsupported,
-            p.annotate_line_integral_convolution,
-            ("gas", "velocity_theta"),
-            ("gas", "velocity_phi"),
+        slc = SlicePlot(ds, "phi", ("gas", "velocity_magnitude"))
+        slc.annotate_line_integral_convolution(
+            ("gas", "velocity_cylindrical_radius"), ("gas", "velocity_cylindrical_z")
         )
+        assert_fname(slc.save(prefix)[0])
+        slc = SlicePlot(ds, "theta", ("gas", "velocity_magnitude"))
+        slc.annotate_line_integral_convolution(
+            ("gas", "velocity_conic_x"), ("gas", "velocity_conic_y")
+        )
+        assert_fname(slc.save(prefix)[0])
+        check_axis_manipulation(slc, prefix)
 
 
 def test_accepts_all_fields_decorator():


### PR DESCRIPTION
- Fixed typos in vector operations in spherical geometry
- Enable `Streamline` and `LineIntegralConvolution` callbacks for spherical geometry
- Callback tests added

Some further thoughts -- when using `Quiver`, `Streamline` and `LineIntegralConvolution` callbacks for curvilinear geometries, we assume users know what vector fields to plot (`_cartesian_x`, `_conic_x`, `_cylindrical_radius` etc.), while this is obscure and hidden in the source code. Maybe improvement could be made in future to generate a warning message when users try to use `inappropriate` vector fields in those callbacks.