### PR TITLE
BLD: do not require pyparsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ dependencies = [
     "numpy>=1.17.5",
     "packaging>=20.9",
     "pillow>=6.2.1", # transitive dependency via MPL (>=3.3)
-    "pyparsing>=2.0.3", # transitive dependency via packaging and MPL
     "tomli-w>=0.4.0",
     "tqdm>=3.4.0",
     "unyt>=2.9.2,<3.0", # see https://github.com/yt-project/yt/issues/4162
@@ -209,7 +208,6 @@ minimal = [
     "numpy==1.17.5",
     "packaging==20.9",
     "pillow==6.2.1",
-    "pyparsing==2.0.3",
     "tomli-w==0.4.0",
     "tqdm==3.4.0",
     "unyt==2.9.2",

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1201,11 +1201,11 @@ class PWViewerMPL(PlotWindow):
                     colorbar_label += r"$\ \ \left(" + units + r"\right)$"
 
             parser = MathTextParser("Agg")
-            from pyparsing import ParseFatalException
 
             try:
                 parser.parse(colorbar_label)
-            except ParseFatalException as err:
+            except Exception as err:
+                # unspecified exceptions might be raised from matplotlib via its own dependencies
                 raise YTCannotParseUnitDisplayName(f, colorbar_label, str(err)) from err
 
             self.plots[f].cb.set_label(colorbar_label)


### PR DESCRIPTION
## PR Summary

The only reason why `pyparsing` is currently declared as a dependency is that `matplotlib.mathtext.MathTextParser` (which we actually use) may raise exceptions from within `pyparsing`, but this behaviour isn't actually specified by the API we actually depend on. From yt's standpoint, it's an implementation detail in matplotlib.
In retrospect it seems cleaner to just catch any exceptions, since all we do is reraise as a controlled exception type anyway.
This allows us to remove `pyparsing` as a dependency.
