### PR TITLE
BUG: avoid setting `basename` attribute in `EnzoDatasetInMemory._parse_parameter_file`

### DIFF
--- a/yt/frontends/enzo/data_structures.py
+++ b/yt/frontends/enzo/data_structures.py
@@ -1014,7 +1014,9 @@ class EnzoDatasetInMemory(EnzoDataset):
 
     def _parse_parameter_file(self):
         enzo = self._obtain_enzo()
-        self.basename = "cycle%08i" % (enzo.yt_parameter_file["NumberOfPythonCalls"])
+        self._input_filename = "cycle%08i" % (
+            enzo.yt_parameter_file["NumberOfPythonCalls"]
+        )
         self.parameters["CurrentTimeIdentifier"] = time.time()
         self.parameters.update(enzo.yt_parameter_file)
         self.conversion_factors.update(enzo.conversion_factors)


### PR DESCRIPTION
Changes `EnzoDatasetInMemory._parse_parameter_file` to avoid setting `self.basename` (which will error as of #3772). 
