### PR TITLE
BUG: Fix example in docs and missing displacement for unstructured mesh

### DIFF
--- a/yt/frontends/exodus_ii/data_structures.py
+++ b/yt/frontends/exodus_ii/data_structures.py
@@ -121,7 +121,7 @@ class ExodusIIDataset(Dataset):
         >>> ds = yt.load(
         ...     "MOOSE_sample_data/mps_out.e",
         ...     step=10,
-        ...     displacements={"connect2": (1.0, [0.0, 0.0, 0.0])},
+        ...     displacements={"connect2": (5.0, [0.0, 0.0, 0.0])},
         ... )
 
         This will load the Dataset at index 10, scaling the displacements for
@@ -319,11 +319,9 @@ class ExodusIIDataset(Dataset):
 
     def _apply_displacement(self, coords, mesh_id):
         mesh_name = "connect%d" % (mesh_id + 1)
+        new_coords = coords.copy()
         if mesh_name not in self.displacements:
-            new_coords = coords.copy()
             return new_coords
-
-        new_coords = np.zeros_like(coords)
         fac = self.displacements[mesh_name][0]
         offset = self.displacements[mesh_name][1]
 


### PR DESCRIPTION
This makes two changes.  One is to fix an incorrect docstring.  The other is to
address an issue where if displacement fields do not exist, supplying
displacement values will result in the coordinates being set uniformly to zero.

This behavior can be seen to break with:

```python
ds = yt.load_sample("SecondOrderTets", step=-1,
    displacements = {'connect1': (1.0, [0.0,0.0,0.0])})
s = yt.SlicePlot(ds, "y", ("all", "ux"))
```

The error message is confusing because it shows up as being an issue with the
selector.  This defaults to the behavior expected if the nodes are not named,
which should be the behavior for if displacement fields aren't found.
