### PR TITLE
PERF: add explicit noexcept qualifiers to fp_utils functions

### DIFF
--- a/yt/utilities/lib/fp_utils.pxd
+++ b/yt/utilities/lib/fp_utils.pxd
@@ -10,45 +10,45 @@ cimport cython
 cimport numpy as np
 
 
-cdef inline np.int64_t imax(np.int64_t i0, np.int64_t i1) nogil:
+cdef inline np.int64_t imax(np.int64_t i0, np.int64_t i1) noexcept nogil:
     if i0 > i1: return i0
     return i1
 
-cdef inline np.float64_t fmax(np.float64_t f0, np.float64_t f1) nogil:
+cdef inline np.float64_t fmax(np.float64_t f0, np.float64_t f1) noexcept nogil:
     if f0 > f1: return f0
     return f1
 
-cdef inline np.int64_t imin(np.int64_t i0, np.int64_t i1) nogil:
+cdef inline np.int64_t imin(np.int64_t i0, np.int64_t i1) noexcept nogil:
     if i0 < i1: return i0
     return i1
 
-cdef inline np.float64_t fmin(np.float64_t f0, np.float64_t f1) nogil:
+cdef inline np.float64_t fmin(np.float64_t f0, np.float64_t f1) noexcept nogil:
     if f0 < f1: return f0
     return f1
 
-cdef inline np.float64_t fabs(np.float64_t f0) nogil:
+cdef inline np.float64_t fabs(np.float64_t f0) noexcept nogil:
     if f0 < 0.0: return -f0
     return f0
 
-cdef inline np.int64_t iclip(np.int64_t i, np.int64_t a, np.int64_t b) nogil:
+cdef inline np.int64_t iclip(np.int64_t i, np.int64_t a, np.int64_t b) noexcept nogil:
     if i < a: return a
     if i > b: return b
     return i
 
-cdef inline np.int64_t i64clip(np.int64_t i, np.int64_t a, np.int64_t b) nogil:
+cdef inline np.int64_t i64clip(np.int64_t i, np.int64_t a, np.int64_t b) noexcept nogil:
     if i < a: return a
     if i > b: return b
     return i
 
 cdef inline np.float64_t fclip(np.float64_t f,
-                      np.float64_t a, np.float64_t b) nogil:
+                      np.float64_t a, np.float64_t b) noexcept nogil:
     return fmin(fmax(f, a), b)
 
-cdef inline np.int64_t i64max(np.int64_t i0, np.int64_t i1) nogil:
+cdef inline np.int64_t i64max(np.int64_t i0, np.int64_t i1) noexcept nogil:
     if i0 > i1: return i0
     return i1
 
-cdef inline np.int64_t i64min(np.int64_t i0, np.int64_t i1) nogil:
+cdef inline np.int64_t i64min(np.int64_t i0, np.int64_t i1) noexcept nogil:
     if i0 < i1: return i0
     return i1
 


### PR DESCRIPTION
## PR Summary

Partially addresses the performance regression with Cython 3.0 discussed in #4355 (in particular, for the scope of this PR, see https://github.com/yt-project/yt/issues/4355#issuecomment-1485895507)

`noexcept` is a new qualifier in Cython 3 (backported as a noop in Cython 0.29.33 for ease of transition), which allows to disable error propagation (which is the default behaviour in Cython 0.29).
