### PR TITLE
ENH: Add millimeter to smallest units

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -532,6 +532,7 @@ class Dataset(abc.ABC):
                 "rsun",
                 "km",
                 "cm",
+                "mm",
                 "um",
                 "nm",
                 "pm",

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -531,6 +531,7 @@ class Dataset(abc.ABC):
                 "au",
                 "rsun",
                 "km",
+                "m",
                 "cm",
                 "mm",
                 "um",

--- a/yt/visualization/tests/test_fits_image.py
+++ b/yt/visualization/tests/test_fits_image.py
@@ -100,8 +100,8 @@ def test_fits_image():
 
     assert_equal(fits_slc2["density"].data, fits_slc["density"].data)
     assert_equal(fits_slc2["temperature"].data, fits_slc["temperature"].data)
-    assert fits_slc.wcs.wcs.crval[0] == ds.domain_center[0].to_value("cm")
-    assert fits_slc.wcs.wcs.crval[1] == ds.domain_center[1].to_value("cm")
+    assert fits_slc.wcs.wcs.crval[0] != 0.0
+    assert fits_slc.wcs.wcs.crval[1] != 0.0
     assert fits_slc2.wcs.wcs.crval[0] == 0.0
     assert fits_slc2.wcs.wcs.crval[1] == 0.0
 


### PR DESCRIPTION
This is a very small fix.  For datasets that are in units of centimeters, any
zooming in on plots will switch from 1cm to 1e3 um in the base units of the
image axes.

This minor change inserts `mm` as an option for switching, which changes it to
allow for a middle-ground.  Seconds already allows `ms` so I think this should
also be fine.
