### PR TITLE
Avoiding issue for CHOLLA LightRay datasets

### DIFF
--- a/yt/frontends/cholla/data_structures.py
+++ b/yt/frontends/cholla/data_structures.py
@@ -157,6 +157,10 @@ class ChollaDataset(Dataset):
         except AttributeError:
             return False
         else:
-            return "bounds" in attrs and "domain" in attrs
+            # Avoiding issue where CHOLLA LightRay datasets get selected
+            if attrs["data_type"] == "yt_light_ray":
+                return False
+            else:
+                return "bounds" in attrs and "domain" in attrs
         finally:
             fileh.close()

--- a/yt/frontends/cholla/data_structures.py
+++ b/yt/frontends/cholla/data_structures.py
@@ -160,7 +160,7 @@ class ChollaDataset(Dataset):
             return (
                 "bounds" in attrs
                 and "domain" in attrs
-                and attrs.get("data_type", None) != "yt_light_ray"
+                and attrs.get("data_type") != "yt_light_ray"
             )
         finally:
             fileh.close()

--- a/yt/frontends/cholla/data_structures.py
+++ b/yt/frontends/cholla/data_structures.py
@@ -157,10 +157,10 @@ class ChollaDataset(Dataset):
         except AttributeError:
             return False
         else:
-            # Avoiding issue where CHOLLA LightRay datasets get selected
-            if attrs["data_type"] == "yt_light_ray":
-                return False
-            else:
-                return "bounds" in attrs and "domain" in attrs
+            return (
+                "bounds" in attrs
+                and "domain" in attrs
+                and attrs.get("data_type", None) != "yt_light_ray"
+            )
         finally:
             fileh.close()


### PR DESCRIPTION
The CHOLLA frontend identifies its dataset based on the presence of a couple of HDF5 attributes.  When a yt `LightRay` dataset is created from any frontend, it inherits all of the attributes from that frontend.  So when someone tries to load a `LightRay` dataset created from a CHOLLA frontend, yt gets confused as it thinks it's both a CHOLLA frontend as well as a `LightRay `dataset and it barfs.  This removes that degeneracy by specifically looking for the `LightRay` attribute in the HDF5 file and not counting it as a CHOLLA dataset when it finds it.  Bug reported by @evaneschneider .
