### PR TITLE
PERF: add explicit noexcept qualifiers to resolve perf regressions (Cython 3)

### DIFF
--- a/yt/frontends/artio/_artio_caller.pyx
+++ b/yt/frontends/artio/_artio_caller.pyx
@@ -1626,19 +1626,19 @@ cdef class SFCRangeSelector(SelectorObject):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) nogil:
+    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) noexcept nogil:
         return 1
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) nogil:
+    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) noexcept nogil:
         return self.select_point(pos)
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_point(self, np.float64_t pos[3]) nogil:
+    cdef int select_point(self, np.float64_t pos[3]) noexcept nogil:
         cdef np.int64_t sfc = self.mesh_container.pos_to_sfc(pos)
         if sfc > self.sfc_end: return 0
         cdef np.int64_t oc = self.range_handler.doct_count[
@@ -1650,7 +1650,7 @@ cdef class SFCRangeSelector(SelectorObject):
     @cython.wraparound(False)
     @cython.cdivision(True)
     cdef int select_bbox(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
+                               np.float64_t right_edge[3]) noexcept nogil:
         return self.base_selector.select_bbox(left_edge, right_edge)
 
     @cython.boundscheck(False)
@@ -1658,7 +1658,7 @@ cdef class SFCRangeSelector(SelectorObject):
     @cython.cdivision(True)
     cdef int select_grid(self, np.float64_t left_edge[3],
                          np.float64_t right_edge[3], np.int32_t level,
-                         Oct *o = NULL) nogil:
+                         Oct *o = NULL) noexcept nogil:
         # Because visitors now use select_grid, we should be explicitly
         # checking this.
         return self.base_selector.select_grid(left_edge, right_edge, level, o)

--- a/yt/geometry/_selection_routines/always_selector.pxi
+++ b/yt/geometry/_selection_routines/always_selector.pxi
@@ -17,26 +17,26 @@ cdef class AlwaysSelector(SelectorObject):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) nogil:
+    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) noexcept nogil:
         return 1
 
     cdef int select_grid(self, np.float64_t left_edge[3],
                          np.float64_t right_edge[3], np.int32_t level,
-                         Oct *o = NULL) nogil:
+                         Oct *o = NULL) noexcept nogil:
         return 1
 
-    cdef int select_point(self, np.float64_t pos[3]) nogil:
+    cdef int select_point(self, np.float64_t pos[3]) noexcept nogil:
         return 1
 
-    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) nogil:
+    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) noexcept nogil:
         return 1
 
     cdef int select_bbox(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
+                               np.float64_t right_edge[3]) noexcept nogil:
         return 1
 
     cdef int select_bbox_edge(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
+                               np.float64_t right_edge[3]) noexcept nogil:
         return 1
 
     def _hash_vals(self):

--- a/yt/geometry/_selection_routines/boolean_selectors.pxi
+++ b/yt/geometry/_selection_routines/boolean_selectors.pxi
@@ -15,7 +15,7 @@ cdef class BooleanSelector(SelectorObject):
 
 cdef class BooleanANDSelector(BooleanSelector):
     cdef int select_bbox(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
+                               np.float64_t right_edge[3]) noexcept nogil:
         cdef int rv1 = self.sel1.select_bbox(left_edge, right_edge)
         if rv1 == 0: return 0
         cdef int rv2 = self.sel2.select_bbox(left_edge, right_edge)
@@ -23,7 +23,7 @@ cdef class BooleanANDSelector(BooleanSelector):
         return 1
 
     cdef int select_bbox_edge(self, np.float64_t left_edge[3],
-                              np.float64_t right_edge[3]) nogil:
+                              np.float64_t right_edge[3]) noexcept nogil:
         cdef int rv1 = self.sel1.select_bbox_edge(left_edge, right_edge)
         if rv1 == 0: return 0
         cdef int rv2 = self.sel2.select_bbox_edge(left_edge, right_edge)
@@ -32,28 +32,28 @@ cdef class BooleanANDSelector(BooleanSelector):
 
     cdef int select_grid(self, np.float64_t left_edge[3],
                          np.float64_t right_edge[3], np.int32_t level,
-                         Oct *o = NULL) nogil:
+                         Oct *o = NULL) noexcept nogil:
         cdef int rv1 = self.sel1.select_grid(left_edge, right_edge, level, o)
         if rv1 == 0: return 0
         cdef int rv2 = self.sel2.select_grid(left_edge, right_edge, level, o)
         if rv2 == 0: return 0
         return 1
 
-    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) nogil:
+    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) noexcept nogil:
         cdef int rv1 = self.sel1.select_cell(pos, dds)
         if rv1 == 0: return 0
         cdef int rv2 = self.sel2.select_cell(pos, dds)
         if rv2 == 0: return 0
         return 1
 
-    cdef int select_point(self, np.float64_t pos[3]) nogil:
+    cdef int select_point(self, np.float64_t pos[3]) noexcept nogil:
         cdef int rv1 = self.sel1.select_point(pos)
         if rv1 == 0: return 0
         cdef int rv2 = self.sel2.select_point(pos)
         if rv2 == 0: return 0
         return 1
 
-    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) nogil:
+    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) noexcept nogil:
         cdef int rv1 = self.sel1.select_sphere(pos, radius)
         if rv1 == 0: return 0
         cdef int rv2 = self.sel2.select_sphere(pos, radius)
@@ -67,7 +67,7 @@ cdef class BooleanANDSelector(BooleanSelector):
 
 cdef class BooleanORSelector(BooleanSelector):
     cdef int select_bbox(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
+                               np.float64_t right_edge[3]) noexcept nogil:
         cdef int rv1 = self.sel1.select_bbox(left_edge, right_edge)
         if rv1 == 1: return 1
         cdef int rv2 = self.sel2.select_bbox(left_edge, right_edge)
@@ -75,7 +75,7 @@ cdef class BooleanORSelector(BooleanSelector):
         return 0
 
     cdef int select_bbox_edge(self, np.float64_t left_edge[3],
-                              np.float64_t right_edge[3]) nogil:
+                              np.float64_t right_edge[3]) noexcept nogil:
         cdef int rv1 = self.sel1.select_bbox_edge(left_edge, right_edge)
         if rv1 == 1: return 1
         cdef int rv2 = self.sel2.select_bbox_edge(left_edge, right_edge)
@@ -84,7 +84,7 @@ cdef class BooleanORSelector(BooleanSelector):
 
     cdef int select_grid(self, np.float64_t left_edge[3],
                          np.float64_t right_edge[3], np.int32_t level,
-                         Oct *o = NULL) nogil:
+                         Oct *o = NULL) noexcept nogil:
         cdef int rv1 = self.sel1.select_grid(left_edge, right_edge, level, o)
         if rv1 == 1: return 1
         cdef int rv2 = self.sel2.select_grid(left_edge, right_edge, level, o)
@@ -92,21 +92,21 @@ cdef class BooleanORSelector(BooleanSelector):
         if (rv1 == 2) or (rv2 == 2): return 2
         return 0
 
-    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) nogil:
+    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) noexcept nogil:
         cdef int rv1 = self.sel1.select_cell(pos, dds)
         if rv1 == 1: return 1
         cdef int rv2 = self.sel2.select_cell(pos, dds)
         if rv2 == 1: return 1
         return 0
 
-    cdef int select_point(self, np.float64_t pos[3]) nogil:
+    cdef int select_point(self, np.float64_t pos[3]) noexcept nogil:
         cdef int rv1 = self.sel1.select_point(pos)
         if rv1 == 1: return 1
         cdef int rv2 = self.sel2.select_point(pos)
         if rv2 == 1: return 1
         return 0
 
-    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) nogil:
+    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) noexcept nogil:
         cdef int rv1 = self.sel1.select_sphere(pos, radius)
         if rv1 == 1: return 1
         cdef int rv2 = self.sel2.select_sphere(pos, radius)
@@ -120,13 +120,13 @@ cdef class BooleanORSelector(BooleanSelector):
 
 cdef class BooleanNOTSelector(BooleanSelector):
     cdef int select_bbox(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
+                               np.float64_t right_edge[3]) noexcept nogil:
         # We always return True here, because we don't have a "fully included"
         # check anywhere else.
         return 1
 
     cdef int select_bbox_edge(self, np.float64_t left_edge[3],
-                              np.float64_t right_edge[3]) nogil:
+                              np.float64_t right_edge[3]) noexcept nogil:
         cdef int rv1 = self.sel1.select_bbox_edge(left_edge, right_edge)
         if rv1 == 0: return 1
         elif rv1 == 1: return 0
@@ -134,20 +134,20 @@ cdef class BooleanNOTSelector(BooleanSelector):
 
     cdef int select_grid(self, np.float64_t left_edge[3],
                          np.float64_t right_edge[3], np.int32_t level,
-                         Oct *o = NULL) nogil:
+                         Oct *o = NULL) noexcept nogil:
         return 1
 
-    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) nogil:
+    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) noexcept nogil:
         cdef int rv1 = self.sel1.select_cell(pos, dds)
         if rv1 == 0: return 1
         return 0
 
-    cdef int select_point(self, np.float64_t pos[3]) nogil:
+    cdef int select_point(self, np.float64_t pos[3]) noexcept nogil:
         cdef int rv1 = self.sel1.select_point(pos)
         if rv1 == 0: return 1
         return 0
 
-    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) nogil:
+    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) noexcept nogil:
         cdef int rv1 = self.sel1.select_sphere(pos, radius)
         if rv1 == 0: return 1
         return 0
@@ -159,13 +159,13 @@ cdef class BooleanNOTSelector(BooleanSelector):
 cdef class BooleanXORSelector(BooleanSelector):
 
     cdef int select_bbox(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
+                               np.float64_t right_edge[3]) noexcept nogil:
         # We always return True here, because we don't have a "fully included"
         # check anywhere else.
         return 1
 
     cdef int select_bbox_edge(self, np.float64_t left_edge[3],
-                              np.float64_t right_edge[3]) nogil:
+                              np.float64_t right_edge[3]) noexcept nogil:
         # Return 2 in cases where one or both selectors partially overlap since
         # part of the bounding box could satisfy the condition unless the
         # selectors are identical.
@@ -184,22 +184,22 @@ cdef class BooleanXORSelector(BooleanSelector):
 
     cdef int select_grid(self, np.float64_t left_edge[3],
                          np.float64_t right_edge[3], np.int32_t level,
-                         Oct *o = NULL) nogil:
+                         Oct *o = NULL) noexcept nogil:
         return 1
 
-    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) nogil:
+    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) noexcept nogil:
         cdef int rv1 = self.sel1.select_cell(pos, dds)
         cdef int rv2 = self.sel2.select_cell(pos, dds)
         if rv1 == rv2: return 0
         return 1
 
-    cdef int select_point(self, np.float64_t pos[3]) nogil:
+    cdef int select_point(self, np.float64_t pos[3]) noexcept nogil:
         cdef int rv1 = self.sel1.select_point(pos)
         cdef int rv2 = self.sel2.select_point(pos)
         if rv1 == rv2: return 0
         return 1
 
-    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) nogil:
+    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) noexcept nogil:
         cdef int rv1 = self.sel1.select_sphere(pos, radius)
         cdef int rv2 = self.sel2.select_sphere(pos, radius)
         if rv1 == rv2: return 0
@@ -213,13 +213,13 @@ cdef class BooleanXORSelector(BooleanSelector):
 cdef class BooleanNEGSelector(BooleanSelector):
 
     cdef int select_bbox(self, np.float64_t left_edge[3],
-                         np.float64_t right_edge[3]) nogil:
+                         np.float64_t right_edge[3]) noexcept nogil:
         # We always return True here, because we don't have a "fully included"
         # check anywhere else.
         return self.sel1.select_bbox(left_edge, right_edge)
 
     cdef int select_bbox_edge(self, np.float64_t left_edge[3],
-                              np.float64_t right_edge[3]) nogil:
+                              np.float64_t right_edge[3]) noexcept nogil:
         cdef int rv1 = self.sel1.select_bbox_edge(left_edge, right_edge)
         if rv1 == 0: return 0
         cdef int rv2 = self.sel2.select_bbox_edge(left_edge, right_edge)
@@ -234,24 +234,24 @@ cdef class BooleanNEGSelector(BooleanSelector):
 
     cdef int select_grid(self, np.float64_t left_edge[3],
                          np.float64_t right_edge[3], np.int32_t level,
-                         Oct *o = NULL) nogil:
+                         Oct *o = NULL) noexcept nogil:
         return self.sel1.select_grid(left_edge, right_edge, level, o)
 
-    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) nogil:
+    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) noexcept nogil:
         cdef int rv1 = self.sel1.select_cell(pos, dds)
         if rv1 == 0: return 0
         cdef int rv2 = self.sel2.select_cell(pos, dds)
         if rv2 == 1: return 0
         return 1
 
-    cdef int select_point(self, np.float64_t pos[3]) nogil:
+    cdef int select_point(self, np.float64_t pos[3]) noexcept nogil:
         cdef int rv1 = self.sel1.select_point(pos)
         if rv1 == 0: return 0
         cdef int rv2 = self.sel2.select_point(pos)
         if rv2 == 1: return 0
         return 1
 
-    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) nogil:
+    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) noexcept nogil:
         cdef int rv1 = self.sel1.select_sphere(pos, radius)
         if rv1 == 0: return 0
         cdef int rv2 = self.sel2.select_sphere(pos, radius)
@@ -278,7 +278,7 @@ cdef class ChainedBooleanANDSelector(ChainedBooleanSelector):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     cdef int select_bbox(self, np.float64_t left_edge[3],
-                         np.float64_t right_edge[3]) nogil:
+                         np.float64_t right_edge[3]) noexcept nogil:
         with gil:
             for i in range(self.n_obj):
                 if (<SelectorObject>self.selectors[i]).select_bbox(
@@ -290,7 +290,7 @@ cdef class ChainedBooleanANDSelector(ChainedBooleanSelector):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     cdef int select_bbox_edge(self, np.float64_t left_edge[3],
-                              np.float64_t right_edge[3]) nogil:
+                              np.float64_t right_edge[3]) noexcept nogil:
         cdef int selected = 1
         cdef int ret
         with gil:
@@ -308,7 +308,7 @@ cdef class ChainedBooleanANDSelector(ChainedBooleanSelector):
     @cython.wraparound(False)
     cdef int select_grid(self, np.float64_t left_edge[3],
                          np.float64_t right_edge[3], np.int32_t level,
-                         Oct *o = NULL) nogil:
+                         Oct *o = NULL) noexcept nogil:
         with gil:
             for i in range(self.n_obj):
                 if (<SelectorObject>self.selectors[i]).select_grid(
@@ -319,7 +319,7 @@ cdef class ChainedBooleanANDSelector(ChainedBooleanSelector):
     @cython.cdivision(True)
     @cython.boundscheck(False)
     @cython.wraparound(False)
-    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) nogil:
+    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) noexcept nogil:
         with gil:
             for i in range(self.n_obj):
                 if (<SelectorObject>self.selectors[i]).select_cell(
@@ -330,7 +330,7 @@ cdef class ChainedBooleanANDSelector(ChainedBooleanSelector):
     @cython.cdivision(True)
     @cython.boundscheck(False)
     @cython.wraparound(False)
-    cdef int select_point(self, np.float64_t pos[3]) nogil:
+    cdef int select_point(self, np.float64_t pos[3]) noexcept nogil:
         with gil:
             for i in range(self.n_obj):
                 if (<SelectorObject>self.selectors[i]).select_point(pos) == 0:
@@ -340,7 +340,7 @@ cdef class ChainedBooleanANDSelector(ChainedBooleanSelector):
     @cython.cdivision(True)
     @cython.boundscheck(False)
     @cython.wraparound(False)
-    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) nogil:
+    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) noexcept nogil:
         with gil:
             for i in range(self.n_obj):
                 if (<SelectorObject>self.selectors[i]).select_sphere(
@@ -361,7 +361,7 @@ cdef class ChainedBooleanORSelector(ChainedBooleanSelector):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     cdef int select_bbox(self, np.float64_t left_edge[3],
-                         np.float64_t right_edge[3]) nogil:
+                         np.float64_t right_edge[3]) noexcept nogil:
         with gil:
             for i in range(self.n_obj):
                 if (<SelectorObject>self.selectors[i]).select_bbox(
@@ -373,7 +373,7 @@ cdef class ChainedBooleanORSelector(ChainedBooleanSelector):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     cdef int select_bbox_edge(self, np.float64_t left_edge[3],
-                         np.float64_t right_edge[3]) nogil:
+                         np.float64_t right_edge[3]) noexcept nogil:
         cdef int selected = 0
         cdef int ret
         with gil:
@@ -391,7 +391,7 @@ cdef class ChainedBooleanORSelector(ChainedBooleanSelector):
     @cython.wraparound(False)
     cdef int select_grid(self, np.float64_t left_edge[3],
                          np.float64_t right_edge[3], np.int32_t level,
-                         Oct *o = NULL) nogil:
+                         Oct *o = NULL) noexcept nogil:
         with gil:
             for i in range(self.n_obj):
                 if (<SelectorObject>self.selectors[i]).select_grid(
@@ -402,7 +402,7 @@ cdef class ChainedBooleanORSelector(ChainedBooleanSelector):
     @cython.cdivision(True)
     @cython.boundscheck(False)
     @cython.wraparound(False)
-    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) nogil:
+    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) noexcept nogil:
         with gil:
             for i in range(self.n_obj):
                 if (<SelectorObject>self.selectors[i]).select_cell(
@@ -413,7 +413,7 @@ cdef class ChainedBooleanORSelector(ChainedBooleanSelector):
     @cython.cdivision(True)
     @cython.boundscheck(False)
     @cython.wraparound(False)
-    cdef int select_point(self, np.float64_t pos[3]) nogil:
+    cdef int select_point(self, np.float64_t pos[3]) noexcept nogil:
         with gil:
             for i in range(self.n_obj):
                 if (<SelectorObject>self.selectors[i]).select_point(pos) == 1:
@@ -423,7 +423,7 @@ cdef class ChainedBooleanORSelector(ChainedBooleanSelector):
     @cython.cdivision(True)
     @cython.boundscheck(False)
     @cython.wraparound(False)
-    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) nogil:
+    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) noexcept nogil:
         with gil:
             for i in range(self.n_obj):
                 if (<SelectorObject>self.selectors[i]).select_sphere(

--- a/yt/geometry/_selection_routines/compose_selector.pxi
+++ b/yt/geometry/_selection_routines/compose_selector.pxi
@@ -16,7 +16,7 @@ cdef class ComposeSelector(SelectorObject):
                     self.selector1.select_grids(left_edges, right_edges, levels),
                     self.selector2.select_grids(left_edges, right_edges, levels))
 
-    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) nogil:
+    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) noexcept nogil:
         if self.selector1.select_cell(pos, dds) and \
                 self.selector2.select_cell(pos, dds):
             return 1
@@ -25,21 +25,21 @@ cdef class ComposeSelector(SelectorObject):
 
     cdef int select_grid(self, np.float64_t left_edge[3],
                          np.float64_t right_edge[3], np.int32_t level,
-                         Oct *o = NULL) nogil:
+                         Oct *o = NULL) noexcept nogil:
         if self.selector1.select_grid(left_edge, right_edge, level, o) or \
                 self.selector2.select_grid(left_edge, right_edge, level, o):
             return 1
         else:
             return 0
 
-    cdef int select_point(self, np.float64_t pos[3]) nogil:
+    cdef int select_point(self, np.float64_t pos[3]) noexcept nogil:
         if self.selector1.select_point(pos) and \
                 self.selector2.select_point(pos):
             return 1
         else:
             return 0
 
-    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) nogil:
+    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) noexcept nogil:
         if self.selector1.select_sphere(pos, radius) and \
                 self.selector2.select_sphere(pos, radius):
             return 1
@@ -47,7 +47,7 @@ cdef class ComposeSelector(SelectorObject):
             return 0
 
     cdef int select_bbox(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
+                               np.float64_t right_edge[3]) noexcept nogil:
         if self.selector1.select_bbox(left_edge, right_edge) and \
                 self.selector2.select_bbox(left_edge, right_edge):
             return 1
@@ -55,7 +55,7 @@ cdef class ComposeSelector(SelectorObject):
             return 0
 
     cdef int select_bbox_edge(self, np.float64_t left_edge[3],
-                              np.float64_t right_edge[3]) nogil:
+                              np.float64_t right_edge[3]) noexcept nogil:
         cdef int rv1 = self.selector1.select_bbox_edge(left_edge, right_edge)
         if rv1 == 0: return 0
         cdef int rv2 = self.selector2.select_bbox_edge(left_edge, right_edge)

--- a/yt/geometry/_selection_routines/cut_region_selector.pxi
+++ b/yt/geometry/_selection_routines/cut_region_selector.pxi
@@ -11,24 +11,24 @@ cdef class CutRegionSelector(SelectorObject):
         self._positions = set(tuple(position) for position in positions)
 
     cdef int select_bbox(self,  np.float64_t left_edge[3],
-                     np.float64_t right_edge[3]) nogil:
+                     np.float64_t right_edge[3]) noexcept nogil:
         return 1
 
     cdef int select_bbox_dge(self,  np.float64_t left_edge[3],
-                     np.float64_t right_edge[3]) nogil:
+                     np.float64_t right_edge[3]) noexcept nogil:
         return 1
 
-    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) nogil:
+    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) noexcept nogil:
         with gil:
             if (pos[0], pos[1], pos[2]) in self._positions:
                 return 1
             else:
                 return 0
 
-    cdef int select_point(self, np.float64_t pos[3]) nogil:
+    cdef int select_point(self, np.float64_t pos[3]) noexcept nogil:
         return 1
 
-    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) nogil:
+    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) noexcept nogil:
         return 1
 
     def _hash_vals(self):

--- a/yt/geometry/_selection_routines/cutting_plane_selector.pxi
+++ b/yt/geometry/_selection_routines/cutting_plane_selector.pxi
@@ -11,7 +11,7 @@ cdef class CuttingPlaneSelector(SelectorObject):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) nogil:
+    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) noexcept nogil:
         cdef np.float64_t left_edge[3]
         cdef np.float64_t right_edge[3]
         cdef int i
@@ -20,14 +20,14 @@ cdef class CuttingPlaneSelector(SelectorObject):
             right_edge[i] = pos[i] + 0.5*dds[i]
         return self.select_bbox(left_edge, right_edge)
 
-    cdef int select_point(self, np.float64_t pos[3]) nogil:
+    cdef int select_point(self, np.float64_t pos[3]) noexcept nogil:
         # two 0-volume constructs don't intersect
         return 0
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) nogil:
+    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) noexcept nogil:
         cdef int i
         cdef np.float64_t height = self.d
         for i in range(3) :
@@ -39,7 +39,7 @@ cdef class CuttingPlaneSelector(SelectorObject):
     @cython.wraparound(False)
     @cython.cdivision(True)
     cdef int select_bbox(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
+                               np.float64_t right_edge[3]) noexcept nogil:
         cdef int i, j, k, n
         cdef np.float64_t *arr[2]
         cdef np.float64_t pos[3]
@@ -74,7 +74,7 @@ cdef class CuttingPlaneSelector(SelectorObject):
     @cython.wraparound(False)
     @cython.cdivision(True)
     cdef int select_bbox_edge(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
+                               np.float64_t right_edge[3]) noexcept nogil:
         cdef int i, j, k, n
         cdef np.float64_t *arr[2]
         cdef np.float64_t pos[3]

--- a/yt/geometry/_selection_routines/disk_selector.pxi
+++ b/yt/geometry/_selection_routines/disk_selector.pxi
@@ -16,13 +16,13 @@ cdef class DiskSelector(SelectorObject):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) nogil:
+    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) noexcept nogil:
         return self.select_point(pos)
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_point(self, np.float64_t pos[3]) nogil:
+    cdef int select_point(self, np.float64_t pos[3]) noexcept nogil:
         cdef np.float64_t h, d, r2, temp
         cdef int i
         h = d = 0
@@ -37,7 +37,7 @@ cdef class DiskSelector(SelectorObject):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) nogil:
+    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) noexcept nogil:
         cdef np.float64_t h, d, r2, temp
         cdef int i
         h = d = 0
@@ -54,7 +54,7 @@ cdef class DiskSelector(SelectorObject):
     @cython.wraparound(False)
     @cython.cdivision(True)
     cdef int select_bbox(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
+                               np.float64_t right_edge[3]) noexcept nogil:
         # Until we can get our OBB/OBB intersection correct, disable this.
         return 1
         # cdef np.float64_t *arr[2]
@@ -104,7 +104,7 @@ cdef class DiskSelector(SelectorObject):
     @cython.wraparound(False)
     @cython.cdivision(True)
     cdef int select_bbox_edge(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
+                               np.float64_t right_edge[3]) noexcept nogil:
         # Until we can get our OBB/OBB intersection correct, disable this.
         return 2
         # cdef np.float64_t *arr[2]

--- a/yt/geometry/_selection_routines/ellipsoid_selector.pxi
+++ b/yt/geometry/_selection_routines/ellipsoid_selector.pxi
@@ -24,13 +24,13 @@ cdef class EllipsoidSelector(SelectorObject):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) nogil:
+    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) noexcept nogil:
         return self.select_point(pos)
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_point(self, np.float64_t pos[3]) nogil:
+    cdef int select_point(self, np.float64_t pos[3]) noexcept nogil:
         cdef np.float64_t dot_evec[3]
         cdef np.float64_t dist
         cdef int i, j
@@ -49,7 +49,7 @@ cdef class EllipsoidSelector(SelectorObject):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) nogil:
+    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) noexcept nogil:
         # this is the sphere selection
         cdef int i
         cdef np.float64_t dist, dist2_max, dist2 = 0
@@ -65,7 +65,7 @@ cdef class EllipsoidSelector(SelectorObject):
     @cython.wraparound(False)
     @cython.cdivision(True)
     cdef int select_bbox(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
+                               np.float64_t right_edge[3]) noexcept nogil:
         # This is the sphere selection
         cdef int i
         cdef np.float64_t box_center, relcenter, closest, dist, edge, dist_max
@@ -90,7 +90,7 @@ cdef class EllipsoidSelector(SelectorObject):
     @cython.wraparound(False)
     @cython.cdivision(True)
     cdef int select_bbox_edge(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
+                               np.float64_t right_edge[3]) noexcept nogil:
         # This is the sphere selection
         cdef int i
         cdef np.float64_t box_center, relcenter, closest, farthest, cdist, fdist, edge

--- a/yt/geometry/_selection_routines/grid_selector.pxi
+++ b/yt/geometry/_selection_routines/grid_selector.pxi
@@ -25,10 +25,10 @@ cdef class GridSelector(SelectorObject):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) nogil:
+    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) noexcept nogil:
         return 1
 
-    cdef int select_point(self, np.float64_t pos[3]) nogil:
+    cdef int select_point(self, np.float64_t pos[3]) noexcept nogil:
         # we apparently don't check if the point actually lies in the grid..
         return 1
 

--- a/yt/geometry/_selection_routines/indexed_octree_subset_selector.pxi
+++ b/yt/geometry/_selection_routines/indexed_octree_subset_selector.pxi
@@ -32,19 +32,19 @@ cdef class IndexedOctreeSubsetSelector(SelectorObject):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) nogil:
+    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) noexcept nogil:
         return 1
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) nogil:
+    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) noexcept nogil:
         return 1
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_point(self, np.float64_t pos[3]) nogil:
+    cdef int select_point(self, np.float64_t pos[3]) noexcept nogil:
         cdef int i
         if self.filter_bbox == 0:
             return 1
@@ -57,12 +57,12 @@ cdef class IndexedOctreeSubsetSelector(SelectorObject):
     @cython.wraparound(False)
     @cython.cdivision(True)
     cdef int select_bbox(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
+                               np.float64_t right_edge[3]) noexcept nogil:
         return self.base_selector.select_bbox(left_edge, right_edge)
 
     cdef int select_grid(self, np.float64_t left_edge[3],
                          np.float64_t right_edge[3], np.int32_t level,
-                         Oct *o = NULL) nogil:
+                         Oct *o = NULL) noexcept nogil:
         # Because visitors now use select_grid, we should be explicitly
         # checking this.
         return self.base_selector.select_grid(left_edge, right_edge, level, o)

--- a/yt/geometry/_selection_routines/octree_subset_selector.pxi
+++ b/yt/geometry/_selection_routines/octree_subset_selector.pxi
@@ -19,26 +19,26 @@ cdef class OctreeSubsetSelector(SelectorObject):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) nogil:
+    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) noexcept nogil:
         return 1
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) nogil:
+    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) noexcept nogil:
         return 1
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_point(self, np.float64_t pos[3]) nogil:
+    cdef int select_point(self, np.float64_t pos[3]) noexcept nogil:
         return self.base_selector.select_point(pos)
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
     cdef int select_bbox(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
+                               np.float64_t right_edge[3]) noexcept nogil:
         # return 1
         return self.base_selector.select_bbox(left_edge, right_edge)
 
@@ -47,7 +47,7 @@ cdef class OctreeSubsetSelector(SelectorObject):
     @cython.cdivision(True)
     cdef int select_grid(self, np.float64_t left_edge[3],
                          np.float64_t right_edge[3], np.int32_t level,
-                         Oct *o = NULL) nogil:
+                         Oct *o = NULL) noexcept nogil:
         # Because visitors now use select_grid, we should be explicitly
         # checking this.
         cdef int res

--- a/yt/geometry/_selection_routines/ortho_ray_selector.pxi
+++ b/yt/geometry/_selection_routines/ortho_ray_selector.pxi
@@ -59,7 +59,7 @@ cdef class OrthoRaySelector(SelectorObject):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) nogil:
+    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) noexcept nogil:
         if self.px >= pos[self.px_ax] - 0.5*dds[self.px_ax] and \
            self.px <  pos[self.px_ax] + 0.5*dds[self.px_ax] and \
            self.py >= pos[self.py_ax] - 0.5*dds[self.py_ax] and \
@@ -67,14 +67,14 @@ cdef class OrthoRaySelector(SelectorObject):
             return 1
         return 0
 
-    cdef int select_point(self, np.float64_t pos[3]) nogil:
+    cdef int select_point(self, np.float64_t pos[3]) noexcept nogil:
         # two 0-volume constructs don't intersect
         return 0
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) nogil:
+    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) noexcept nogil:
         cdef np.float64_t dx = self.periodic_difference(
             pos[self.px_ax], self.px, self.px_ax)
         cdef np.float64_t dy = self.periodic_difference(
@@ -87,7 +87,7 @@ cdef class OrthoRaySelector(SelectorObject):
     @cython.wraparound(False)
     @cython.cdivision(True)
     cdef int select_bbox(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
+                               np.float64_t right_edge[3]) noexcept nogil:
         if left_edge[self.px_ax] <= self.px < right_edge[self.px_ax] and \
            left_edge[self.py_ax] <= self.py < right_edge[self.py_ax] :
             return 1
@@ -97,7 +97,7 @@ cdef class OrthoRaySelector(SelectorObject):
     @cython.wraparound(False)
     @cython.cdivision(True)
     cdef int select_bbox_edge(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
+                               np.float64_t right_edge[3]) noexcept nogil:
         if left_edge[self.px_ax] <= self.px < right_edge[self.px_ax] and \
            left_edge[self.py_ax] <= self.py < right_edge[self.py_ax] :
             return 2 # a box of non-zero volume can't be inside a ray

--- a/yt/geometry/_selection_routines/point_selector.pxi
+++ b/yt/geometry/_selection_routines/point_selector.pxi
@@ -18,7 +18,7 @@ cdef class PointSelector(SelectorObject):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) nogil:
+    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) noexcept nogil:
         if (pos[0] - 0.5*dds[0] <= self.p[0] < pos[0]+0.5*dds[0] and
             pos[1] - 0.5*dds[1] <= self.p[1] < pos[1]+0.5*dds[1] and
             pos[2] - 0.5*dds[2] <= self.p[2] < pos[2]+0.5*dds[2]):
@@ -29,7 +29,7 @@ cdef class PointSelector(SelectorObject):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) nogil:
+    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) noexcept nogil:
         cdef int i
         cdef np.float64_t dist, dist2 = 0
         for i in range(3):
@@ -42,7 +42,7 @@ cdef class PointSelector(SelectorObject):
     @cython.wraparound(False)
     @cython.cdivision(True)
     cdef int select_bbox(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
+                               np.float64_t right_edge[3]) noexcept nogil:
         # point definitely can only be in one cell
         if (left_edge[0] <= self.p[0] < right_edge[0] and
             left_edge[1] <= self.p[1] < right_edge[1] and
@@ -55,7 +55,7 @@ cdef class PointSelector(SelectorObject):
     @cython.wraparound(False)
     @cython.cdivision(True)
     cdef int select_bbox_edge(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
+                               np.float64_t right_edge[3]) noexcept nogil:
         # point definitely can only be in one cell
         # Return 2 in all cases to indicate that the point only overlaps
         # portion of box

--- a/yt/geometry/_selection_routines/ray_selector.pxi
+++ b/yt/geometry/_selection_routines/ray_selector.pxi
@@ -173,14 +173,14 @@ cdef class RaySelector(SelectorObject):
         free(ia)
         return dtr, tr
 
-    cdef int select_point(self, np.float64_t pos[3]) nogil:
+    cdef int select_point(self, np.float64_t pos[3]) noexcept nogil:
         # two 0-volume constructs don't intersect
         return 0
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) nogil:
+    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) noexcept nogil:
 
         cdef int i
         cdef np.float64_t length = norm(self.vec)
@@ -204,7 +204,7 @@ cdef class RaySelector(SelectorObject):
     @cython.wraparound(False)
     @cython.cdivision(True)
     cdef int select_bbox(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
+                               np.float64_t right_edge[3]) noexcept nogil:
         cdef int i, rv
         cdef VolumeContainer vc
         cdef IntegrationAccumulator *ia
@@ -235,7 +235,7 @@ cdef class RaySelector(SelectorObject):
     @cython.wraparound(False)
     @cython.cdivision(True)
     cdef int select_bbox_edge(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
+                               np.float64_t right_edge[3]) noexcept nogil:
         cdef int i
         cdef np.uint8_t cm = 1
         cdef VolumeContainer vc
@@ -261,7 +261,7 @@ cdef class RaySelector(SelectorObject):
     @cython.wraparound(False)
     @cython.cdivision(True)
     cdef int select_cell(self, np.float64_t pos[3],
-                               np.float64_t dds[3]) nogil:
+                               np.float64_t dds[3]) noexcept nogil:
         # This is terribly inefficient for Octrees.  For grids, it will never
         # get called.
         cdef int i

--- a/yt/geometry/_selection_routines/region_selector.pxi
+++ b/yt/geometry/_selection_routines/region_selector.pxi
@@ -82,7 +82,7 @@ cdef class RegionSelector(SelectorObject):
     @cython.wraparound(False)
     @cython.cdivision(True)
     cdef int select_bbox(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
+                               np.float64_t right_edge[3]) noexcept nogil:
         cdef int i
         for i in range(3):
             if (right_edge[i] < self.left_edge[i] and \
@@ -95,7 +95,7 @@ cdef class RegionSelector(SelectorObject):
     @cython.wraparound(False)
     @cython.cdivision(True)
     cdef int select_bbox_edge(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
+                               np.float64_t right_edge[3]) noexcept nogil:
         cdef int i
         for i in range(3):
             if (right_edge[i] < self.left_edge[i] and \
@@ -114,7 +114,7 @@ cdef class RegionSelector(SelectorObject):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) nogil:
+    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) noexcept nogil:
         cdef np.float64_t left_edge[3]
         cdef np.float64_t right_edge[3]
         cdef int i
@@ -128,7 +128,7 @@ cdef class RegionSelector(SelectorObject):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_point(self, np.float64_t pos[3]) nogil:
+    cdef int select_point(self, np.float64_t pos[3]) noexcept nogil:
         cdef int i
         for i in range(3):
             if (self.right_edge_shift[i] <= pos[i] < self.left_edge[i]) or \
@@ -139,7 +139,7 @@ cdef class RegionSelector(SelectorObject):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) nogil:
+    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) noexcept nogil:
         # adapted from http://stackoverflow.com/a/4579192/1382869
         cdef int i
         cdef np.float64_t p

--- a/yt/geometry/_selection_routines/selector_object.pxi
+++ b/yt/geometry/_selection_routines/selector_object.pxi
@@ -225,7 +225,7 @@ cdef class SelectorObject:
     @cython.cdivision(True)
     cdef int select_grid(self, np.float64_t left_edge[3],
                                np.float64_t right_edge[3],
-                               np.int32_t level, Oct *o = NULL) nogil:
+                               np.int32_t level, Oct *o = NULL) noexcept nogil:
         if level < self.min_level or level > self.max_level: return 0
         return self.select_bbox(left_edge, right_edge)
 
@@ -234,21 +234,21 @@ cdef class SelectorObject:
     @cython.cdivision(True)
     cdef int select_grid_edge(self, np.float64_t left_edge[3],
                                     np.float64_t right_edge[3],
-                                    np.int32_t level, Oct *o = NULL) nogil:
+                                    np.int32_t level, Oct *o = NULL) noexcept nogil:
         if level < self.min_level or level > self.max_level: return 0
         return self.select_bbox_edge(left_edge, right_edge)
 
-    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) nogil:
+    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) noexcept nogil:
         return 0
 
-    cdef int select_point(self, np.float64_t pos[3]) nogil:
+    cdef int select_point(self, np.float64_t pos[3]) noexcept nogil:
         return 0
 
-    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) nogil:
+    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) noexcept nogil:
         return 0
 
     cdef int select_bbox(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
+                               np.float64_t right_edge[3]) noexcept nogil:
         """
         Returns:
           0: If the selector does not touch the bounding box.
@@ -257,7 +257,7 @@ cdef class SelectorObject:
         return 0
 
     cdef int select_bbox_edge(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
+                               np.float64_t right_edge[3]) noexcept nogil:
         """
         Returns:
           0: If the selector does not touch the bounding box.

--- a/yt/geometry/_selection_routines/slice_selector.pxi
+++ b/yt/geometry/_selection_routines/slice_selector.pxi
@@ -66,7 +66,7 @@ cdef class SliceSelector(SelectorObject):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) nogil:
+    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) noexcept nogil:
         if self.reduced_dimensionality == 1:
             return 1
         if pos[self.axis] + 0.5*dds[self.axis] > self.coord \
@@ -74,14 +74,14 @@ cdef class SliceSelector(SelectorObject):
             return 1
         return 0
 
-    cdef int select_point(self, np.float64_t pos[3]) nogil:
+    cdef int select_point(self, np.float64_t pos[3]) noexcept nogil:
         # two 0-volume constructs don't intersect
         return 0
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) nogil:
+    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) noexcept nogil:
         if self.reduced_dimensionality == 1:
             return 1
         cdef np.float64_t dist = self.periodic_difference(
@@ -94,7 +94,7 @@ cdef class SliceSelector(SelectorObject):
     @cython.wraparound(False)
     @cython.cdivision(True)
     cdef int select_bbox(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
+                               np.float64_t right_edge[3]) noexcept nogil:
         if self.reduced_dimensionality == 1:
             return 1
         if left_edge[self.axis] - grid_eps <= self.coord < right_edge[self.axis]:
@@ -105,7 +105,7 @@ cdef class SliceSelector(SelectorObject):
     @cython.wraparound(False)
     @cython.cdivision(True)
     cdef int select_bbox_edge(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
+                               np.float64_t right_edge[3]) noexcept nogil:
         if self.reduced_dimensionality == 1:
             return 2
         if left_edge[self.axis] - grid_eps <= self.coord < right_edge[self.axis]:

--- a/yt/geometry/_selection_routines/sphere_selector.pxi
+++ b/yt/geometry/_selection_routines/sphere_selector.pxi
@@ -28,7 +28,7 @@ cdef class SphereSelector(SelectorObject):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) nogil:
+    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) noexcept nogil:
         # sphere center either inside cell or center of cell lies inside sphere
         if (pos[0] - 0.5*dds[0] <= self.center[0] <= pos[0]+0.5*dds[0] and
             pos[1] - 0.5*dds[1] <= self.center[1] <= pos[1]+0.5*dds[1] and
@@ -47,7 +47,7 @@ cdef class SphereSelector(SelectorObject):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_point(self, np.float64_t pos[3]) nogil:
+    cdef int select_point(self, np.float64_t pos[3]) noexcept nogil:
         cdef int i
         cdef np.float64_t dist, dist2 = 0
         for i in range(3):
@@ -64,7 +64,7 @@ cdef class SphereSelector(SelectorObject):
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) nogil:
+    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) noexcept nogil:
         cdef int i
         cdef np.float64_t dist, dist2 = 0
         for i in range(3):
@@ -78,7 +78,7 @@ cdef class SphereSelector(SelectorObject):
     @cython.wraparound(False)
     @cython.cdivision(True)
     cdef int select_bbox(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
+                               np.float64_t right_edge[3]) noexcept nogil:
         cdef np.float64_t box_center, relcenter, closest, dist, edge
         cdef int i
         if (left_edge[0] <= self.center[0] < right_edge[0] and
@@ -106,7 +106,7 @@ cdef class SphereSelector(SelectorObject):
     @cython.wraparound(False)
     @cython.cdivision(True)
     cdef int select_bbox_edge(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil:
+                               np.float64_t right_edge[3]) noexcept nogil:
         cdef np.float64_t box_center, relcenter, closest, farthest, cdist, fdist, edge
         cdef int i
         if (left_edge[0] <= self.center[0] <= right_edge[0] and

--- a/yt/geometry/selection_routines.pxd
+++ b/yt/geometry/selection_routines.pxd
@@ -42,18 +42,18 @@ cdef class SelectorObject:
                               OctVisitor visitor, int i, int j, int k)
     cdef int select_grid(self, np.float64_t left_edge[3],
                                np.float64_t right_edge[3],
-                               np.int32_t level, Oct *o = ?) nogil
+                               np.int32_t level, Oct *o = ?) noexcept nogil
     cdef int select_grid_edge(self, np.float64_t left_edge[3],
                                     np.float64_t right_edge[3],
-                                    np.int32_t level, Oct *o = ?) nogil
-    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) nogil
+                                    np.int32_t level, Oct *o = ?) noexcept nogil
+    cdef int select_cell(self, np.float64_t pos[3], np.float64_t dds[3]) noexcept nogil
 
-    cdef int select_point(self, np.float64_t pos[3]) nogil
-    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) nogil
+    cdef int select_point(self, np.float64_t pos[3]) noexcept nogil
+    cdef int select_sphere(self, np.float64_t pos[3], np.float64_t radius) noexcept nogil
     cdef int select_bbox(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil
+                               np.float64_t right_edge[3]) noexcept nogil
     cdef int select_bbox_edge(self, np.float64_t left_edge[3],
-                               np.float64_t right_edge[3]) nogil
+                               np.float64_t right_edge[3]) noexcept nogil
     cdef int fill_mask_selector_regular_grid(self, np.float64_t left_edge[3],
                                              np.float64_t right_edge[3],
                                              np.float64_t dds[3], int dim[3],

--- a/yt/utilities/lib/field_interpolation_tables.pxd
+++ b/yt/utilities/lib/field_interpolation_tables.pxd
@@ -43,7 +43,7 @@ cdef struct FieldInterpolationTable:
 @cython.cdivision(True)
 cdef inline void FIT_initialize_table(FieldInterpolationTable *fit, int nbins,
               np.float64_t *values, np.float64_t bounds1, np.float64_t bounds2,
-              int field_id, int weight_field_id, int weight_table_id) nogil:
+              int field_id, int weight_field_id, int weight_table_id) noexcept nogil:
     cdef int i
     fit.bounds[0] = bounds1; fit.bounds[1] = bounds2
     fit.nbins = nbins
@@ -64,7 +64,7 @@ cdef inline void FIT_initialize_table(FieldInterpolationTable *fit, int nbins,
 @cython.wraparound(False)
 @cython.cdivision(True)
 cdef inline np.float64_t FIT_get_value(const FieldInterpolationTable *fit,
-                                       np.float64_t dvs[6]) nogil:
+                                       np.float64_t dvs[6]) noexcept nogil:
     cdef np.float64_t dd, dout
     cdef int bin_id
     if dvs[fit.field_id] >= fit.bounds[1] or dvs[fit.field_id] <= fit.bounds[0]: return 0.0
@@ -86,7 +86,7 @@ cdef inline void FIT_eval_transfer(
         const np.float64_t dt, np.float64_t *dvs,
         np.float64_t *rgba, const int n_fits,
         const FieldInterpolationTable fits[6],
-        const int field_table_ids[6], const int grey_opacity) nogil:
+        const int field_table_ids[6], const int grey_opacity) noexcept nogil:
     cdef int i, fid
     cdef np.float64_t ta
     cdef np.float64_t istorage[6]
@@ -116,7 +116,7 @@ cdef inline void FIT_eval_transfer_with_light(np.float64_t dt, np.float64_t *dvs
         np.float64_t *grad, np.float64_t *l_dir, np.float64_t *l_rgba,
         np.float64_t *rgba, int n_fits,
         FieldInterpolationTable fits[6],
-        int field_table_ids[6], int grey_opacity) nogil:
+        int field_table_ids[6], int grey_opacity) noexcept nogil:
     cdef int i, fid
     cdef np.float64_t ta, dot_prod
     cdef np.float64_t istorage[6]

--- a/yt/utilities/lib/image_samplers.pxd
+++ b/yt/utilities/lib/image_samplers.pxd
@@ -66,7 +66,7 @@ cdef class ImageSampler:
                 np.float64_t enter_t,
                 np.float64_t exit_t,
                 int index[3],
-                void *data) nogil
+                void *data) noexcept nogil
 
 cdef class ProjectionSampler(ImageSampler):
     pass

--- a/yt/utilities/lib/image_samplers.pyx
+++ b/yt/utilities/lib/image_samplers.pyx
@@ -313,7 +313,7 @@ cdef class ImageSampler:
                  np.float64_t enter_t,
                  np.float64_t exit_t,
                  int index[3],
-                 void *data) nogil:
+                 void *data) noexcept nogil:
         return
 
     def ensure_code_unit_params(self, params):
@@ -337,7 +337,7 @@ cdef class ProjectionSampler(ImageSampler):
                  np.float64_t enter_t,
                  np.float64_t exit_t,
                  int index[3],
-                 void *data) nogil:
+                 void *data) noexcept nogil:
         cdef ImageAccumulator *im = <ImageAccumulator *> data
         cdef int i
         cdef np.float64_t dl = (exit_t - enter_t)
@@ -379,7 +379,7 @@ cdef class InterpolatedProjectionSampler(ImageSampler):
                      np.float64_t enter_t,
                      np.float64_t exit_t,
                      int index[3],
-                     void *data) nogil:
+                     void *data) noexcept nogil:
         cdef ImageAccumulator *im = <ImageAccumulator *> data
         cdef VolumeRenderAccumulator *vri = <VolumeRenderAccumulator *> \
                 im.supp_data
@@ -460,7 +460,7 @@ cdef class VolumeRenderSampler(ImageSampler):
                      np.float64_t enter_t,
                      np.float64_t exit_t,
                      int index[3],
-                     void *data) nogil:
+                     void *data) noexcept nogil:
         cdef ImageAccumulator *im = <ImageAccumulator *> data
         cdef VolumeRenderAccumulator *vri = <VolumeRenderAccumulator *> \
                 im.supp_data
@@ -561,7 +561,7 @@ cdef class LightSourceRenderSampler(ImageSampler):
                      np.float64_t enter_t,
                      np.float64_t exit_t,
                      int index[3],
-                     void *data) nogil:
+                     void *data) noexcept nogil:
         cdef ImageAccumulator *im = <ImageAccumulator *> data
         cdef VolumeRenderAccumulator *vri = <VolumeRenderAccumulator *> \
                 im.supp_data


### PR DESCRIPTION
## PR Summary

As tested on my fork, this resolves _most_ of the performance regressions seen in smoke tests with bleeding-edge CI (getting testing airtime from ~17min to ~8 min).

follow up to #4386 