### PR TITLE
PERF: add explicit noexcept qualifiers to resolve perf regressions in volume rendering (Cython 3)

### DIFF
--- a/yt/geometry/_selection_routines/ray_selector.pxi
+++ b/yt/geometry/_selection_routines/ray_selector.pxi
@@ -11,7 +11,7 @@ cdef void dt_sampler(
              np.float64_t enter_t,
              np.float64_t exit_t,
              int index[3],
-             void *data) nogil:
+             void *data) noexcept nogil:
     cdef IntegrationAccumulator *am = <IntegrationAccumulator *> data
     cdef int di = (index[0]*vc.dims[1]+index[1])*vc.dims[2]+index[2]
     if am.child_mask[di] == 0 or enter_t == exit_t:

--- a/yt/utilities/lib/grid_traversal.pxd
+++ b/yt/utilities/lib/grid_traversal.pxd
@@ -22,7 +22,7 @@ ctypedef void sampler_function(
                 np.float64_t enter_t,
                 np.float64_t exit_t,
                 int index[3],
-                void *data) nogil
+                void *data) noexcept nogil
 
 #-----------------------------------------------------------------------------
 # walk_volume(VolumeContainer *vc,  np.float64_t v_pos[3], np.float64_t v_dir[3], sampler_function *sample,
@@ -50,4 +50,4 @@ cdef int walk_volume(VolumeContainer *vc,
                      sampler_function *sampler,
                      void *data,
                      np.float64_t *return_t = *,
-                     np.float64_t max_t = *) nogil
+                     np.float64_t max_t = *) noexcept nogil

--- a/yt/utilities/lib/grid_traversal.pyx
+++ b/yt/utilities/lib/grid_traversal.pyx
@@ -33,7 +33,7 @@ cdef int walk_volume(VolumeContainer *vc,
                      sampler_function *sample,
                      void *data,
                      np.float64_t *return_t = NULL,
-                     np.float64_t max_t = 1.0) nogil:
+                     np.float64_t max_t = 1.0) noexcept nogil:
     cdef int cur_ind[3]
     cdef int step[3]
     cdef int x, y, i, hit, direction


### PR DESCRIPTION
## PR Summary
Follow up to #4386 and #4390
As far as I can tell, this is the last change in this series to bring perfs back to their baseline level with Cython 0.29.*, as -loosely- measured from the bleeding-edge CI airtime
