### PR TITLE
ENH: allow hint keyword for yt.load to select superclasses

### DIFF
--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -116,8 +116,12 @@ def load(
         if cls._is_valid(fn, *args, **kwargs):
             candidates.append(cls)
 
+    # Filter the candidates if a hint was given
+    if hint is not None:
+        candidates = [c for c in candidates if hint.lower() in c.__name__.lower()]
+
     # Find only the lowest subclasses, i.e. most specialised front ends
-    candidates = find_lowest_subclasses(candidates, hint=hint)
+    candidates = find_lowest_subclasses(candidates)
 
     if len(candidates) == 1:
         return candidates[0](fn, *args, **kwargs)

--- a/yt/tests/test_load_errors.py
+++ b/yt/tests/test_load_errors.py
@@ -96,6 +96,10 @@ def ambiguous_dataset_classes():
             self.mass_unit = self.quan(1, "kg")
             self.time_unit = self.quan(1, "s")
 
+        @classmethod
+        def _is_valid(cls, *args, **kwargs):
+            return True
+
     class AlphaDataset(MockDataset):
         @classmethod
         def _is_valid(cls, *args, **kwargs):
@@ -139,6 +143,8 @@ def test_load_ambiguous_data(tmp_path):
         ("beta", "BetaDataset"),
         ("BeTA", "BetaDataset"),
         ("b", "BetaDataset"),
+        ("mock", "MockDataset"),
+        ("MockDataset", "MockDataset"),
     ],
 )
 @pytest.mark.usefixtures("ambiguous_dataset_classes")

--- a/yt/utilities/hierarchy_inspection.py
+++ b/yt/utilities/hierarchy_inspection.py
@@ -1,12 +1,10 @@
 import inspect
 from collections import Counter
 from functools import reduce
-from typing import List, Optional, Type
+from typing import List, Type
 
 
-def find_lowest_subclasses(
-    candidates: List[Type], *, hint: Optional[str] = None
-) -> List[Type]:
+def find_lowest_subclasses(candidates: List[Type]) -> List[Type]:
     """
     This function takes a list of classes, and returns only the ones that are
     are not super classes of any others in the list. i.e. the ones that are at
@@ -17,9 +15,6 @@ def find_lowest_subclasses(
     candidates : Iterable
         An iterable object that is a collection of classes to find the lowest
         subclass of.
-
-    hint : str, optional
-        Only keep candidates classes that have `hint` in their name (case insensitive)
 
     Returns
     -------
@@ -44,7 +39,4 @@ def find_lowest_subclasses(
 
     count = reduce(lambda x, y: x + y, counters)
 
-    retv = [x for x in count.keys() if count[x] == 1]
-    if hint is not None:
-        retv = [x for x in retv if hint.lower() in x.__name__.lower()]
-    return retv
+    return [x for x in count.keys() if count[x] == 1]


### PR DESCRIPTION
## PR Summary

This PR allows users to explicitly select a specific class in a `Dataset` hierarchy, even if one or more of its subclasses are valid. I'm currently trying to improve the boxlib detection code by adjusting the class hierarchy (as brought up in https://github.com/yt-project/yt/issues/3005#issuecomment-809182817), but making e.g. `NyxDataset` inherit from `AMReXDataset` would break cases like #3510.

## PR Checklist

- [ ] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.