### PR TITLE
BUG: make sure find_lowest_subclasses doesn't add extra classes

### DIFF
--- a/yt/utilities/hierarchy_inspection.py
+++ b/yt/utilities/hierarchy_inspection.py
@@ -39,4 +39,4 @@ def find_lowest_subclasses(candidates: List[Type]) -> List[Type]:
 
     count = reduce(lambda x, y: x + y, counters)
 
-    return [x for x in count.keys() if count[x] == 1]
+    return [x for x in candidates if count[x] == 1]

--- a/yt/utilities/tests/test_hierarchy_inspection.py
+++ b/yt/utilities/tests/test_hierarchy_inspection.py
@@ -55,3 +55,9 @@ def test_diverging_tree():
     result = find_lowest_subclasses([level1, level2, level3, level1a])
     assert len(result) == 2
     assert level1a in result and level3 in result
+
+
+def test_without_parents():
+    result = find_lowest_subclasses([level1, level3])
+    assert len(result) == 1
+    assert level3 in result


### PR DESCRIPTION
## PR Summary

If a child class and its grandparent (or another ancestor) are the only classes in `candidates`, the previous implementation of `find_lowest_subclasses` would return both the child class and the parent class. This PR changes the logic so that it will only return classes passed in as candidates.

Needed by #4402.

```python
>>> import inspect
>>> from collections import Counter
>>> from functools import reduce

>>> class Grandparent:
...     pass
... class Parent(Grandparent):
...     pass
... class Child(Parent):
...     pass

>>> candidates = [Grandparent, Child]
>>> mros = [inspect.getmro(c) for c in candidates]; mros
[(__main__.Grandparent, object),
 (__main__.Child, __main__.Parent, __main__.Grandparent, object)]

>>> counters = [Counter(mro) for mro in mros]; counters
[Counter({__main__.Grandparent: 1,
          object: 1}),
 Counter({__main__.Child: 1,
          __main__.Parent: 1,
          __main__.Grandparent: 1,
          object: 1})]

# Parent only appeared once, so the original code will include it
>>> count = reduce(lambda x, y: x + y, counters); count
Counter({__main__.Grandparent: 2,
         object: 2,
         __main__.Child: 1,
         __main__.Parent: 1})

>>> [x for x in count.keys() if count[x] == 1]
[__main__.Child, __main__.Parent]

>>> [x for x in candidates if count[x] == 1]
[__main__.Child]
```

## PR Checklist

- [x] Adds a test for any bugs fixed. Adds tests for new features.