### PR TITLE
Export standard deviation to pandas DataFrames and AstroPy QTables

### DIFF
--- a/doc/source/analyzing/generating_processed_data.rst
+++ b/doc/source/analyzing/generating_processed_data.rst
@@ -239,7 +239,9 @@ Exporting Profiles to DataFrame
 One-dimensional profile data can be exported to a :class:`~pandas.DataFrame` object
 using the :meth:`yt.data_objects.profiles.Profile1D.to_dataframe` method. Bins which
 do not have data will have their fields filled with ``NaN``, except for the bin field
-itself. If you only want to export the bins which are used, set ``only_used=True``.
+itself. If you only want to export the bins which are used, set ``only_used=True``,
+and if you want to export the standard deviation of the profile as well, set
+``include_std=True``:
 
 .. code-block:: python
 
@@ -249,6 +251,8 @@ itself. If you only want to export the bins which are used, set ``only_used=True
     df_used = profile.to_dataframe(only_used=True)
     # Only adds the density and temperature fields
     df2 = profile.to_dataframe(fields=[("gas", "density"), ("gas", "temperature")])
+    # Include standard deviation
+    df3 = profile.to_dataframe(include_std=True)
 
 The :class:`~pandas.DataFrame` can then analyzed and/or written to disk using pandas
 methods. Note that unit information is lost in this export.
@@ -262,8 +266,9 @@ One-dimensional profile data also can be exported to an AstroPy :class:`~astropy
 object. This table can then be written to disk in a number of formats, such as ASCII text
 or FITS files, and manipulated in a number of ways. Bins which do not have data
 will have their mask values set to ``False``. If you only want to export the bins
-which are used, set ``only_used=True``. Units are preserved in the table by converting
-each :class:`~yt.units.yt_array.YTArray` to an :class:`~astropy.units.Quantity`.
+which are used, set ``only_used=True``. If you want to include the standard deviation
+of the field in the export, set ``include_std=True``. Units are preserved in the table
+by converting each :class:`~yt.units.yt_array.YTArray` to an :class:`~astropy.units.Quantity`.
 
 To export the 1D profile to a Table object, simply call
 :meth:`yt.data_objects.profiles.Profile1D.to_astropy_table`:
@@ -276,6 +281,8 @@ To export the 1D profile to a Table object, simply call
     t_used = profile.to_astropy_table(only_used=True)
     # Only adds the density and temperature fields
     t2 = profile.to_astropy_table(fields=[("gas", "density"), ("gas", "temperature")])
+    # Export the standard deviation
+    t3 = profile.to_astropy_table(include_std=True)
 
 .. _generating-line-queries:
 

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -562,7 +562,7 @@ class Profile1D(ProfileND):
             fields = self.data_source._determine_fields(fields)
         return idxs, masked, fields
 
-    def to_dataframe(self, fields=None, only_used=False):
+    def to_dataframe(self, fields=None, only_used=False, include_std=False):
         r"""Export a profile object to a pandas DataFrame.
 
         This function will take a data object and construct from it and
@@ -577,8 +577,13 @@ class Profile1D(ProfileND):
             profile, along with the bin field, will be exported.
         only_used : boolean, default False
             If True, only the bins which have data will be exported. If False,
-            all of the bins will be exported, but the elements for those bins
+            all the bins will be exported, but the elements for those bins
             in the data arrays will be filled with NaNs.
+        include_std : boolean, optional
+            If True, include the standard deviotion of the profile
+            in the pandas DataFrame. It will appear in the table as the
+            field name with "_stddev" appended, e.g. "velocity_x_stddev".
+            Default: False
 
         Returns
         -------
@@ -600,6 +605,8 @@ class Profile1D(ProfileND):
         pdata = {self.x_field[-1]: self.x[idxs]}
         for field in fields:
             pdata[field[-1]] = self[field][idxs]
+            if include_std:
+                pdata[f"{field[-1]}_stddev"] = self.standard_deviation[field][idxs]
         df = pd.DataFrame(pdata)
         if masked:
             mask = np.zeros(df.shape, dtype="bool")
@@ -607,7 +614,7 @@ class Profile1D(ProfileND):
             df.mask(mask, inplace=True)
         return df
 
-    def to_astropy_table(self, fields=None, only_used=False):
+    def to_astropy_table(self, fields=None, only_used=False, include_std=False):
         """
         Export the profile data to a :class:`~astropy.table.table.QTable`,
         which is a Table object which is unit-aware. The QTable can then
@@ -627,10 +634,15 @@ class Profile1D(ProfileND):
             to the QTable as rows. If False, all bins are
             copied, but the bins which are not used are masked.
             Default: False
+        include_std : boolean, optional
+            If True, include the standard deviotion of the profile
+            in the AstroPy QTable. It will appear in the table as the
+            field name with "_stddev" appended, e.g. "velocity_x_stddev".
+            Default: False
 
         Returns
         -------
-        df : :class:`~astropy.table.QTable`
+        qt : :class:`~astropy.table.QTable`
             The data contained in the profile.
 
         Examples
@@ -653,6 +665,12 @@ class Profile1D(ProfileND):
             qt[field[-1]] = self[field][idxs].to_astropy()
             if masked:
                 qt[field[-1]].mask = self.used
+            if include_std:
+                qt[f"{field[-1]}_stddev"] = self.standard_deviation[field][
+                    idxs
+                ].to_astropy()
+                if masked:
+                    qt[f"{field[-1]}_stddev"].mask = self.used
         return qt
 
 

--- a/yt/data_objects/tests/test_profiles.py
+++ b/yt/data_objects/tests/test_profiles.py
@@ -706,6 +706,15 @@ def test_export_astropy():
     assert "velocity_x" not in at2.colnames
     assert_equal(prof.x.d[prof.used], at2["radius"].value)
     assert_equal(prof[("gas", "density")].d[prof.used], at2["density"].value)
+    at3 = prof.to_astropy_table(fields=("gas", "density"), include_std=True)
+    assert_equal(prof[("gas", "density")].d, at3["density"].value)
+    assert_equal(
+        prof.standard_deviation[("gas", "density")].d, at3["density_stddev"].value
+    )
+    assert (
+        prof.standard_deviation[("gas", "density")].units
+        == YTArray.from_astropy(at3["density_stddev"]).units
+    )
 
 
 @requires_module("pandas")
@@ -731,3 +740,8 @@ def test_export_pandas():
     assert "velocity_x" not in df2.columns
     assert_equal(prof.x.d[prof.used], df2["radius"])
     assert_equal(prof[("gas", "density")].d[prof.used], df2["density"])
+    df3 = prof.to_dataframe(fields=("gas", "density"), include_std=True)
+    assert_equal(
+        prof.standard_deviation[("gas", "density")].d,
+        np.nan_to_num(df3["density_stddev"]),
+    )


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

Profiles in yt can already export data to [pandas DataFrames](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html) and [AstroPy QTables](https://docs.astropy.org/en/stable/api/astropy.table.QTable.html).  This PR adds the capability to optionally export the standard deviation of the profile to the data frame or table. Docs and tests are added. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
