### PR TITLE
RFC: rewrite find_lowest_subclasses to better match its intent

### DIFF
--- a/yt/utilities/hierarchy_inspection.py
+++ b/yt/utilities/hierarchy_inspection.py
@@ -1,7 +1,8 @@
 import inspect
 from collections import Counter
-from functools import reduce
 from typing import List, Type
+
+from more_itertools import flatten
 
 
 def find_lowest_subclasses(candidates: List[Type]) -> List[Type]:
@@ -22,21 +23,5 @@ def find_lowest_subclasses(candidates: List[Type]) -> List[Type]:
         A list of classes which are not super classes for any others in
         candidates.
     """
-
-    # If there is only one input, the input candidate is always the
-    # lowest class
-    if len(candidates) == 1:
-        return candidates
-    elif len(candidates) == 0:
-        return []
-
-    mros = [inspect.getmro(c) for c in candidates]
-
-    counters = [Counter(mro) for mro in mros]
-
-    if len(counters) == 0:
-        return []
-
-    count = reduce(lambda x, y: x + y, counters)
-
+    count = Counter(flatten(inspect.getmro(c) for c in candidates))
     return [x for x in candidates if count[x] == 1]

--- a/yt/utilities/tests/test_hierarchy_inspection.py
+++ b/yt/utilities/tests/test_hierarchy_inspection.py
@@ -27,6 +27,11 @@ class level4(level3):
     pass
 
 
+def test_empty():
+    result = find_lowest_subclasses([])
+    assert len(result) == 0
+
+
 def test_single():
     result = find_lowest_subclasses([level2])
     assert len(result) == 1
@@ -60,4 +65,10 @@ def test_diverging_tree():
 def test_without_parents():
     result = find_lowest_subclasses([level1, level3])
     assert len(result) == 1
-    assert level3 in result
+    assert result[0] is level3
+
+
+def test_without_grandparents():
+    result = find_lowest_subclasses([level1, level4])
+    assert len(result) == 1
+    assert result[0] is level4


### PR DESCRIPTION
## PR Summary

This implementation is more straightforward than the original one with fewer edge cases that need special handling.
It ended up being quite similar to the final implementation in #4405, except it can handle having the same class show up in candidates more than once.
It simply makes a set of all the superclasses of the candidates, and filters out any candidates that appear in that set.