### PR TITLE
DEPR: avoid deprecated implicit casting of single element arrays to scalar types

### DIFF
--- a/yt/frontends/ramses/tests/test_hilbert.py
+++ b/yt/frontends/ramses/tests/test_hilbert.py
@@ -20,7 +20,7 @@ def test_hilbert3d():
     outputs = [0, 1, 7, 6, 3, 2, 4, 5]
 
     for i, o in zip(inputs, outputs):
-        assert_equal(int(hilbert3d(i, 3)), o)
+        assert_equal(hilbert3d(i, 3).item(), o)
 
 
 output_00080 = "output_00080/info_00080.txt"

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -585,7 +585,7 @@ def load_amr_grids(
         get_box_grids_level(
             grid_left_edges[gi, :],
             grid_right_edges[gi, :],
-            grid_levels[gi] + 1,
+            grid_levels[gi].item() + 1,
             grid_left_edges,
             grid_right_edges,
             grid_levels,

--- a/yt/visualization/volume_rendering/transfer_functions.py
+++ b/yt/visualization/volume_rendering/transfer_functions.py
@@ -687,7 +687,7 @@ class ColorTransferFunction(MultiVariateTransferFunction):
         ax.xaxis.set_major_formatter(FuncFormatter(y_format))
         ax.set_xlim(0.0, max_alpha)
         ax.get_xaxis().set_ticks([])
-        ax.set_ylim(visible[0], visible[-1])
+        ax.set_ylim(visible[0].item(), visible[-1].item())
         ax.tick_params(axis="y", colors="white", size=10)
         ax.set_ylabel(label, color="white", size=size * resolution / 512.0)
 


### PR DESCRIPTION
## PR Summary

closes #4421 

running bleeding-edge CI on my fork for validation at https://github.com/neutrinoceros/yt/actions/runs/4764348746