### PR TITLE
BUG: More robust detection and checking of EWAH files

### DIFF
--- a/nose_ignores.txt
+++ b/nose_ignores.txt
@@ -4,6 +4,7 @@
 --ignore-file=test_commons\.py
 --ignore-file=test_data_reload\.py
 --ignore-file=test_eps_writer\.py
+--ignore-file=test_ewah_write_load\.py
 --ignore-file=test_external_frontends\.py
 --ignore-file=test_field_access_pytest\.py
 --ignore-file=test_file_sanitizer\.py

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -176,6 +176,7 @@ other_tests:
      - "--ignore-file=test_commons\\.py"
      - "--ignore-file=test_data_reload\\.py"
      - "--ignore-file=test_eps_writer\\.py"
+     - "--ignore-file=test_ewah_write_load\\.py"
      - "--ignore-file=test_external_frontends\\.py"
      - "--ignore-file=test_field_access_pytest\\.py"
      - "--ignore-file=test_file_sanitizer\\.py"

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -48,7 +48,7 @@ from yt.data_objects.unions import ParticleUnion
 from yt.fields.derived_field import DerivedField, ValidateSpatial
 from yt.fields.field_type_container import FieldTypeContainer
 from yt.fields.fluid_fields import setup_gradient_fields
-from yt.funcs import is_sequence, iter_fields, mylog, set_intersection, setdefaultattr
+from yt.funcs import iter_fields, mylog, set_intersection, setdefaultattr
 from yt.geometry.api import Geometry
 from yt.geometry.coordinates.api import (
     CartesianCoordinateHandler,
@@ -2123,7 +2123,7 @@ class ParticleDataset(Dataset):
         index_filename=None,
         default_species_fields=None,
     ):
-        self.index_order = validate_index_order(index_order)
+        self.index_order = index_order
         self.index_filename = index_filename
         super().__init__(
             filename,
@@ -2132,19 +2132,3 @@ class ParticleDataset(Dataset):
             unit_system=unit_system,
             default_species_fields=default_species_fields,
         )
-
-
-def validate_index_order(index_order):
-    if index_order is None:
-        index_order = (6, 2)
-    elif not is_sequence(index_order):
-        index_order = (int(index_order), 1)
-    else:
-        if len(index_order) != 2:
-            raise RuntimeError(
-                "Tried to load a dataset with index_order={}, but "
-                "index_order\nmust be an integer or a two-element tuple of "
-                "integers.".format(index_order)
-            )
-        index_order = tuple(int(o) for o in index_order)
-    return index_order

--- a/yt/frontends/flash/data_structures.py
+++ b/yt/frontends/flash/data_structures.py
@@ -5,7 +5,7 @@ from typing import Type
 import numpy as np
 
 from yt.data_objects.index_subobjects.grid_patch import AMRGridPatch
-from yt.data_objects.static_output import Dataset, ParticleFile, validate_index_order
+from yt.data_objects.static_output import Dataset, ParticleFile
 from yt.funcs import mylog, setdefaultattr
 from yt.geometry.api import Geometry
 from yt.geometry.geometry_handler import Index
@@ -496,7 +496,7 @@ class FLASHParticleDataset(FLASHDataset):
         index_filename=None,
         unit_system="cgs",
     ):
-        self.index_order = validate_index_order(index_order)
+        self.index_order = index_order
         self.index_filename = index_filename
 
         if self._handle is not None:

--- a/yt/frontends/halo_catalog/data_structures.py
+++ b/yt/frontends/halo_catalog/data_structures.py
@@ -11,7 +11,6 @@ from yt.data_objects.selection_objects.data_selection_objects import (
 from yt.data_objects.static_output import (
     ParticleDataset,
     ParticleFile,
-    validate_index_order,
 )
 from yt.frontends.ytdata.data_structures import SavedDataset
 from yt.funcs import parse_h5_attr
@@ -121,7 +120,7 @@ class YTHaloCatalogDataset(SavedDataset):
         units_override=None,
         unit_system="cgs",
     ):
-        self.index_order = validate_index_order(index_order)
+        self.index_order = index_order
         super().__init__(
             filename,
             dataset_type,

--- a/yt/frontends/ytdata/data_structures.py
+++ b/yt/frontends/ytdata/data_structures.py
@@ -13,7 +13,7 @@ from yt.data_objects.profiles import (
     Profile2DFromDataset,
     Profile3DFromDataset,
 )
-from yt.data_objects.static_output import Dataset, ParticleFile, validate_index_order
+from yt.data_objects.static_output import Dataset, ParticleFile
 from yt.data_objects.unions import ParticleUnion
 from yt.fields.field_exceptions import NeedsGridType
 from yt.fields.field_info_container import FieldInfoContainer
@@ -252,7 +252,7 @@ class YTDataContainerDataset(YTDataset):
         units_override=None,
         unit_system="cgs",
     ):
-        self.index_order = validate_index_order(index_order)
+        self.index_order = index_order
         self.index_filename = index_filename
         super().__init__(
             filename,

--- a/yt/geometry/particle_geometry_handler.py
+++ b/yt/geometry/particle_geometry_handler.py
@@ -250,7 +250,7 @@ class ParticleIndex(Index):
         for data_file in self.data_files:
             self.regions._set_coarse_index_data_file(data_file.file_id)
         self.regions.find_collisions_coarse()
-        if max_hsml > 0.0 and len(self.data_files) > 1:
+        if max_hsml > 0.0 and self.pii.mutable_index:
             # By passing this in, we only allow index_order2 to be increased by
             # two at most, never increased.  One place this becomes particularly
             # useful is in the case of an extremely small section of gas
@@ -259,12 +259,14 @@ class ParticleIndex(Index):
             # domain, it will correspond to a very very high index order, which
             # is a large amount of memory!  Having multiple indexes, one for
             # each particle type, would fix this.
-            new_order2 = self.regions.update_mi2(max_hsml, ds.index_order[1] + 2)
+            new_order2 = self.regions.update_mi2(max_hsml, self.pii.order2 + 2)
             mylog.info(
-                "Updating index_order2 from %s to %s", ds.index_order[1], new_order2
+                "Updating index_order2 from %s to %s", self.pii.order2, new_order2
             )
             self.pii.order2 = new_order2
-            self.ds.index_order = (self.ds.index_order[0], new_order2)
+            return max_hsml
+        else:
+            return 0.0
 
     def _initialize_refined_index(self):
         mask = self.regions.masks.sum(axis=1).astype("uint8")

--- a/yt/geometry/particle_geometry_handler.py
+++ b/yt/geometry/particle_geometry_handler.py
@@ -34,10 +34,28 @@ def validate_index_order(index_order):
 
 class ParticleIndexInfo:
     def __init__(self, order1, order2, filename, mutable_index):
-        self.order1 = order1
-        self.order2 = order2
+        self._order1 = order1
+        self._order2 = order2
+        self._order2_orig = order2
         self.filename = filename
         self.mutable_index = mutable_index
+
+    @property
+    def order1(self):
+        return self._order1
+
+    @property
+    def order2(self):
+        return self._order2
+
+    @order2.setter
+    def order2(self, value):
+        mylog.debug("Updating index_order2 from %s to %s", self._order2, value)
+        self._order2 = value
+
+    @property
+    def order2_orig(self):
+        return self._order2_orig
 
 
 class ParticleIndex(Index):
@@ -194,8 +212,8 @@ class ParticleIndex(Index):
             ds.periodicity,
             self.ds._file_hash,
             len(self.data_files),
-            index_order1=order1,
-            index_order2=order2,
+            index_order1=self.pii.order1,
+            index_order2=self.pii.order2_orig,
         )
 
         dont_load = dont_cache and not hasattr(ds, "index_filename")
@@ -224,7 +242,6 @@ class ParticleIndex(Index):
             rflag = self.regions.check_bitmasks()
 
         self.ds.index_order = (self.pii.order1, self.pii.order2)
-        del self.pii
 
     def _order2_update(self, max_hsml):
         # By passing this in, we only allow index_order2 to be increased by

--- a/yt/geometry/particle_geometry_handler.py
+++ b/yt/geometry/particle_geometry_handler.py
@@ -164,15 +164,13 @@ class ParticleIndex(Index):
             ds.domain_right_edge = ds.arr(1.05 * max_ppos, "code_length")
             ds.domain_width = ds.domain_right_edge - ds.domain_left_edge
 
-        mutable_index = True
-
         # use a trivial morton index for datasets containing a single chunk
         if len(self.data_files) == 1:
             order1 = 1
             order2 = 1
             mutable_index = False
         else:
-            mutable_index = ds.index_order is not None
+            mutable_index = ds.index_order is None
             index_order = validate_index_order(ds.index_order)
             order1 = index_order[0]
             order2 = index_order[1]

--- a/yt/geometry/particle_geometry_handler.py
+++ b/yt/geometry/particle_geometry_handler.py
@@ -39,6 +39,7 @@ class ParticleIndexInfo:
         self._order2_orig = order2
         self.filename = filename
         self.mutable_index = mutable_index
+        self.loaded = False
 
     @property
     def order1(self):
@@ -230,6 +231,7 @@ class ParticleIndex(Index):
             self._initialize_frontend_specific()
             if rflag == 0:
                 raise OSError
+            self.pii.loaded = True
         except (OSError, struct.error):
             self.regions.reset_bitmasks()
             max_hsml = self._initialize_coarse_index()

--- a/yt/geometry/particle_geometry_handler.py
+++ b/yt/geometry/particle_geometry_handler.py
@@ -50,6 +50,9 @@ class ParticleIndexInfo:
 
     @order2.setter
     def order2(self, value):
+        if value == self._order2:
+            # do nothing if nothing changes
+            return
         mylog.debug("Updating index_order2 from %s to %s", self._order2, value)
         self._order2 = value
 
@@ -253,7 +256,6 @@ class ParticleIndex(Index):
         # is a large amount of memory!  Having multiple indexes, one for
         # each particle type, would fix this.
         new_order2 = self.regions.update_mi2(max_hsml, self.pii.order2 + 2)
-        mylog.info("Updating index_order2 from %s to %s", self.pii.order2, new_order2)
         self.pii.order2 = new_order2
 
     def _initialize_coarse_index(self):

--- a/yt/geometry/particle_geometry_handler.py
+++ b/yt/geometry/particle_geometry_handler.py
@@ -39,7 +39,7 @@ class ParticleIndexInfo:
         self._order2_orig = order2
         self.filename = filename
         self.mutable_index = mutable_index
-        self.loaded = False
+        self._is_loaded = False
 
     @property
     def order1(self):
@@ -231,7 +231,7 @@ class ParticleIndex(Index):
             self._initialize_frontend_specific()
             if rflag == 0:
                 raise OSError
-            self.pii.loaded = True
+            self.pii._is_loaded = True
         except (OSError, struct.error):
             self.regions.reset_bitmasks()
             max_hsml = self._initialize_coarse_index()

--- a/yt/geometry/particle_oct_container.pyx
+++ b/yt/geometry/particle_oct_container.pyx
@@ -994,7 +994,7 @@ cdef class ParticleBitmap:
     def iseq_bitmask(self, solf):
         return self.bitmasks._iseq(solf.get_bitmasks())
 
-    def save_bitmasks(self, fname):
+    def save_bitmasks(self, fname, max_hsml):
         import h5py
         cdef bytes serial_BAC
         cdef np.uint64_t ifile
@@ -1007,6 +1007,7 @@ cdef class ParticleBitmap:
 
             grp.attrs["bitmask_version"] = _bitmask_version
             grp.attrs["nfiles"] = self.nfiles
+            grp.attrs["max_hsml"] = max_hsml
             # Add some attrs for convenience. They're not read back.
             grp.attrs["file_hash"] = self.file_hash
             grp.attrs["left_edge"] = self.left_edge
@@ -1043,6 +1044,7 @@ cdef class ParticleBitmap:
                 raise OSError(f"Index not found in the {fname}")
 
             ver = grp.attrs["bitmask_version"]
+            max_hsml = grp.attrs["max_hsml"]
             if ver == self.nfiles and ver != _bitmask_version:
                 overwrite = 1
                 ver = 0 # Original bitmaps had number of files first
@@ -1067,7 +1069,7 @@ cdef class ParticleBitmap:
         # Save in correct format
         if overwrite == 1:
             self.save_bitmasks(fname)
-        return read_flag
+        return read_flag, max_hsml
 
     def print_info(self):
         cdef np.uint64_t ifile

--- a/yt/geometry/particle_oct_container.pyx
+++ b/yt/geometry/particle_oct_container.pyx
@@ -1071,7 +1071,7 @@ cdef class ParticleBitmap:
 
         # Save in correct format
         if overwrite == 1:
-            self.save_bitmasks(fname)
+            self.save_bitmasks(fname, max_hsml)
         return read_flag, max_hsml
 
     def print_info(self):

--- a/yt/geometry/particle_oct_container.pyx
+++ b/yt/geometry/particle_oct_container.pyx
@@ -1044,7 +1044,10 @@ cdef class ParticleBitmap:
                 raise OSError(f"Index not found in the {fname}")
 
             ver = grp.attrs["bitmask_version"]
-            max_hsml = grp.attrs["max_hsml"]
+            try:
+                max_hsml = grp.attrs["max_hsml"]
+            except KeyError:
+                raise OSError(f"'max_hsml' not found in the {fname}")
             if ver == self.nfiles and ver != _bitmask_version:
                 overwrite = 1
                 ver = 0 # Original bitmaps had number of files first

--- a/yt/geometry/tests/test_ewah_write_load.py
+++ b/yt/geometry/tests/test_ewah_write_load.py
@@ -1,0 +1,32 @@
+from yt.loaders import load
+from yt.sample_data.api import _get_test_data_dir_path
+from yt.testing import assert_array_equal, requires_file
+
+
+@requires_file("TNGHalo/halo_59.hdf5")
+def test_ewah_write_load(tmp_path):
+    mock_file = tmp_path / "halo_59.hdf5"
+    mock_file.symlink_to(_get_test_data_dir_path() / "TNGHalo" / "halo_59.hdf5")
+
+    masses = []
+    opts = [
+        (None, True, (6, 2, 4), False),
+        (None, True, (6, 2, 4), True),
+        ((5, 3), False, (5, 3, 3), False),
+        ((5, 3), False, (5, 3, 3), True),
+    ]
+
+    for opt in opts:
+        ds = load(mock_file, index_order=opt[0])
+        _, c = ds.find_max(("gas", "density"))
+        assert ds.index.pii.mutable_index is opt[1]
+        assert ds.index.pii.order1 == opt[2][0]
+        assert ds.index.pii.order2_orig == opt[2][1]
+        assert ds.index.pii.order2 == opt[2][2]
+        assert ds.index.pii._is_loaded is opt[3]
+        c += ds.quan(0.5, "Mpc")
+        sp = ds.sphere(c, (20.0, "kpc"))
+        mass = sp.sum(("gas", "mass"))
+        masses.append(mass)
+
+    assert_array_equal(masses[0], masses[1:])

--- a/yt/geometry/tests/test_particle_octree.py
+++ b/yt/geometry/tests/test_particle_octree.py
@@ -6,13 +6,10 @@ import yt.units.dimensions as dimensions
 from yt.geometry.oct_container import _ORDER_MAX
 from yt.geometry.particle_oct_container import ParticleBitmap, ParticleOctreeContainer
 from yt.geometry.selection_routines import RegionSelector
-from yt.loaders import load
-from yt.sample_data.api import _get_test_data_dir_path
 from yt.testing import (
     assert_array_equal,
     assert_equal,
     assert_true,
-    requires_file,
     requires_module,
 )
 from yt.units.unit_registry import UnitRegistry
@@ -404,35 +401,6 @@ def test_bitmap_select():
                         gf_ans.append(rf_ghost % nfiles)
                     gf_ans = np.array(sorted(gf_ans))
                     assert_array_equal(gf, gf_ans, f"selector {i}, ghost file array")
-
-
-@requires_file("TNGHalo/halo_59.hdf5")
-def test_ewah_write_load(tmp_path):
-    mock_file = tmp_path / "halo_59.hdf5"
-    mock_file.symlink_to(_get_test_data_dir_path() / "TNGHalo" / "halo_59.hdf5")
-
-    masses = []
-    opts = [
-        (None, True, (6, 2, 4), False),
-        (None, True, (6, 2, 4), True),
-        ((5, 3), False, (5, 3, 3), False),
-        ((5, 3), False, (5, 3, 3), True),
-    ]
-
-    for opt in opts:
-        ds = load(mock_file, index_order=opt[0])
-        _, c = ds.find_max(("gas", "density"))
-        assert ds.index.pii.mutable_index is opt[1]
-        assert ds.index.pii.order1 == opt[2][0]
-        assert ds.index.pii.order2_orig == opt[2][1]
-        assert ds.index.pii.order2 == opt[2][2]
-        assert ds.index.pii._is_loaded is opt[3]
-        c += ds.quan(0.5, "Mpc")
-        sp = ds.sphere(c, (20.0, "kpc"))
-        mass = sp.sum(("gas", "mass"))
-        masses.append(mass)
-
-    assert_array_equal(masses[0], masses[1:])
 
 
 def cell_centers(order, left_edge, right_edge):

--- a/yt/geometry/tests/test_particle_octree.py
+++ b/yt/geometry/tests/test_particle_octree.py
@@ -6,7 +6,15 @@ import yt.units.dimensions as dimensions
 from yt.geometry.oct_container import _ORDER_MAX
 from yt.geometry.particle_oct_container import ParticleBitmap, ParticleOctreeContainer
 from yt.geometry.selection_routines import RegionSelector
-from yt.testing import assert_array_equal, assert_equal, assert_true, requires_module
+from yt.loaders import load
+from yt.sample_data.api import _get_test_data_dir_path
+from yt.testing import (
+    assert_array_equal,
+    assert_equal,
+    assert_true,
+    requires_file,
+    requires_module,
+)
 from yt.units.unit_registry import UnitRegistry
 from yt.units.yt_array import YTArray
 from yt.utilities.lib.geometry_utils import (
@@ -396,6 +404,70 @@ def test_bitmap_select():
                         gf_ans.append(rf_ghost % nfiles)
                     gf_ans = np.array(sorted(gf_ans))
                     assert_array_equal(gf, gf_ans, f"selector {i}, ghost file array")
+
+
+@requires_file("TNGHalo/halo_59.hdf5")
+def test_ewah_write_load(tmp_path):
+    mock_file = tmp_path / "halo_59.hdf5"
+    mock_file.symlink_to(_get_test_data_dir_path() / "TNGHalo" / "halo_59.hdf5")
+
+    ds = load(mock_file)
+    _, c = ds.find_max(("gas", "density"))
+    assert ds.index.pii.mutable_index
+    assert ds.index.pii.order1 == 6
+    assert ds.index.pii.order2_orig == 2
+    assert ds.index.pii.order2 == 4
+    assert not ds.index.pii.loaded
+    c += ds.quan(0.5, "Mpc")
+    sp = ds.sphere(c, (20.0, "kpc"))
+    mass = sp.sum(("gas", "mass"))
+
+    del ds
+
+    ds2 = load(mock_file)
+    _, c2 = ds2.find_max(("gas", "density"))
+    assert ds2.index.pii.mutable_index
+    assert ds2.index.pii.order1 == 6
+    assert ds2.index.pii.order2_orig == 2
+    assert ds2.index.pii.order2 == 4
+    assert ds2.index.pii.loaded
+    c2 += ds2.quan(0.5, "Mpc")
+    sp2 = ds2.sphere(c, (20.0, "kpc"))
+    mass2 = sp2.sum(("gas", "mass"))
+
+    assert_array_equal(mass, mass2)
+
+    del ds2
+
+    ds3 = load(mock_file, index_order=(5, 3))
+    _, c3 = ds3.find_max(("gas", "density"))
+    assert not ds3.index.pii.mutable_index
+    assert ds3.index.pii.order1 == 5
+    assert ds3.index.pii.order2_orig == 3
+    assert ds3.index.pii.order2 == 3
+    assert not ds3.index.pii.loaded
+    c3 += ds3.quan(0.5, "Mpc")
+    sp3 = ds3.sphere(c, (20.0, "kpc"))
+    mass3 = sp3.sum(("gas", "mass"))
+
+    assert_array_equal(mass, mass3)
+
+    del ds3
+
+    ds4 = load(mock_file, index_order=(5, 3))
+    _, c4 = ds4.find_max(("gas", "density"))
+    assert not ds4.index.pii.mutable_index
+    assert ds4.index.pii.order1 == 5
+    assert ds4.index.pii.order2_orig == 3
+    assert ds4.index.pii.order2 == 3
+    assert ds4.index.pii.loaded
+    c4 += ds4.quan(0.5, "Mpc")
+    sp4 = ds4.sphere(c, (20.0, "kpc"))
+    mass4 = sp4.sum(("gas", "mass"))
+
+    assert_array_equal(mass, mass4)
+
+    del ds4
 
 
 def cell_centers(order, left_edge, right_edge):

--- a/yt/geometry/tests/test_particle_octree.py
+++ b/yt/geometry/tests/test_particle_octree.py
@@ -295,7 +295,7 @@ def test_bitmap_save_load():
         fname = fname_fmt.format(i)
     # Create bitmap and save to file
     reg0 = FakeBitmap(npart, nfiles, order1, order2, left_edge, right_edge, periodicity)
-    reg0.save_bitmasks(fname)
+    reg0.save_bitmasks(fname, 0.0)
     # Attempt to load bitmap
     reg1 = ParticleBitmap(
         left_edge, right_edge, periodicity, file_hash, nfiles, order1, order2


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

Issue #4371 highlighted some problems with EWAH files for SPH data and @matthewturk outlined a possible route to fix them. 

The following script fails on `main`, assuming no EWAH file has been written:

```python
import yt
from yt.testing import assert_almost_equal

ds = yt.load("TNGHalo/halo_59.hdf5")

_, c = ds.find_max(("gas","density"))
c += ds.quan(0.5, "Mpc")

sp = ds.sphere(c, (20.0, "kpc"))

mass = sp.sum(("gas","mass"))

#print(ds.index.pii.filename)

del ds

ds2 = yt.load("TNGHalo/halo_59.hdf5")

_, c2 = ds2.find_max(("gas","density"))
c2 += ds2.quan(0.5, "Mpc")

sp2 = ds2.sphere(c, (20.0, "kpc"))

mass2 = sp2.sum(("gas","mass"))

assert_almost_equal(mass, mass2)
```

In the first load of the dataset, there is no EWAH file, and it creates the bitmasks, caches them in the new EWAH file, and then computes the mass within the sphere. In the second load of the dataset, it reads the bitmasks from the EWAH file, which don't match up with the `index_order2` that was used to create them, different particles are selected for the sphere, and the mass calculation fails.

What this PR does is follow @matthewturk's suggestions to resolve the issue. 

* Create a new `ParticleIndexInfo` class to store information about the index order (and if one has been specified), if there is a filename, what the original `index_order2` was before it may or may not have been updated later, and if we are allowed to change the index order. 
* Store the maximum smoothing length to the file and use it to potentially update the index order whether we are loading from an EWAH file or not. 

With these changes, the above script does not fail anymore. I would like to change the above script into a test, but we need to find some way to guarantee that the test starts cold--i.e. there is no EWAH file that exists at the beginning of the test for this dataset, which won't work if we have already run this test on a file. Any clever suggestions here would be appreciated.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

Closes Issue #4371. 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
