### PR TITLE
BUG: fix confusing error message when yt fails to locate data

### DIFF
--- a/yt/sample_data/api.py
+++ b/yt/sample_data/api.py
@@ -172,7 +172,7 @@ def lookup_on_disk_data(fn) -> Path:
     FileNotFoundError
     """
 
-    path = Path(fn).expanduser()
+    path = Path(fn).expanduser().resolve()
 
     if path.exists():
         return path
@@ -182,7 +182,7 @@ def lookup_on_disk_data(fn) -> Path:
     if not test_data_dir.is_dir():
         raise FileNotFoundError(err_msg)
 
-    alt_path = _get_test_data_dir_path() / fn
+    alt_path = _get_test_data_dir_path().joinpath(fn).resolve()
     if alt_path != path:
         if alt_path.exists():
             return alt_path


### PR DESCRIPTION
## PR Summary

Reprod: leaving `test_data_dir` unset, and running
```python
import yt

ds = yt.load("not_a_file")
```

output
```python-traceback
FileNotFoundError: No such file or directory: 'not_a_file'.
(Also tried '/Users/robcleme/dev/yt-project/yt/not_a_file').
```
where `/Users/robcleme/dev/yt-project/yt/` is the current work directory, so it looks like yt is considering the *absolute* version of cwd as an alternative, which is both confusing and unintended.

with this patch, the error is reduced to 
```python-traceback
FileNotFoundError: No such file or directory: 'not_a_file'.
```