### PR TITLE
[BUG] Allow smoothing of derived SPH fields onto covering grids

### DIFF
--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -952,8 +952,8 @@ class YTCoveringGrid(YTSelectionContainer3D):
 
     def _check_sph_type(self, finfo):
         """
-        This function checks if a particle field has an SPH
-        type. There are several ways that this can happen,
+        Check if a particle field has an SPH type.
+        There are several ways that this can happen,
         checked in this order:
         1. If the field type is a known particle filter, and
            is in the list of SPH ptypes, use this type

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -964,7 +964,7 @@ class YTCoveringGrid(YTSelectionContainer3D):
         If we get through without erroring out, we either have
         a known SPH particle filter, an alias of an SPH field,
         the default SPH ptype, or "gas" for an SPH field. Then
-        we return the particle type. 
+        we return the particle type.
         """
         ftype, fname = finfo.name
         sph_ptypes = self.ds._sph_ptypes

--- a/yt/data_objects/tests/test_sph_data_objects.py
+++ b/yt/data_objects/tests/test_sph_data_objects.py
@@ -1,7 +1,14 @@
 import numpy as np
 
-from yt import SlicePlot
-from yt.testing import assert_equal, fake_sph_grid_ds, fake_sph_orientation_ds
+from yt import SlicePlot, add_particle_filter
+from yt.loaders import load
+from yt.testing import (
+    assert_almost_equal,
+    assert_equal,
+    fake_sph_grid_ds,
+    fake_sph_orientation_ds,
+    requires_file,
+)
 
 
 def test_point():
@@ -347,3 +354,29 @@ def test_covering_grid_gather():
     cg_dens = cg[field].to("g*cm**-3").d
 
     assert_equal(ag_dens, cg_dens)
+
+
+@requires_file("TNGHalo/halo_59.hdf5")
+def test_covering_grid_derived_fields():
+    def hot_gas(pfilter, data):
+        return data[pfilter.filtered_type, "temperature"] > 1.0e6
+
+    add_particle_filter(
+        "hot_gas",
+        function=hot_gas,
+        filtered_type="gas",
+        requires=["temperature"],
+    )
+    bbox = [[40669.34, 56669.34], [45984.04, 61984.04], [54114.9, 70114.9]]
+    ds = load("TNGHalo/halo_59.hdf5", bounding_box=bbox)
+    ds.add_particle_filter("hot_gas")
+    w = ds.quan(0.2, "Mpc")
+    le = ds.domain_center - 0.5 * w
+    re = ds.domain_center + 0.5 * w
+    g = ds.r[le[0] : re[0] : 128j, le[1] : re[1] : 128j, le[2] : re[2] : 128j]
+    T1 = g["gas", "temperature"].to("keV", "thermal")
+    T2 = g["gas", "kT"]
+    assert_almost_equal(T1, T2)
+    T3 = g["hot_gas", "temperature"].to("keV", "thermal")
+    T4 = g["hot_gas", "kT"]
+    assert_almost_equal(T3, T4)

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -196,6 +196,13 @@ class FieldInfoContainer(UserDict):
                     (ptype, alias_name),
                 )
             )
+            if "particle_position_" in alias_name:
+                new_aliases.append(
+                    (
+                        (ftype, alias_name),
+                        (ptype, alias_name),
+                    )
+                )
             new_aliases.append(
                 (
                     (ptype, uni_alias_name),
@@ -204,6 +211,7 @@ class FieldInfoContainer(UserDict):
             )
             for alias, source in new_aliases:
                 self.alias(alias, source)
+        self.alias((ftype, "particle_position"), (ptype, "particle_position"))
 
     # Collect the names for all aliases if geometry is curvilinear
     def get_aliases_gallery(self) -> List[FieldName]:

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -212,6 +212,7 @@ class FieldInfoContainer(UserDict):
             for alias, source in new_aliases:
                 self.alias(alias, source)
         self.alias((ftype, "particle_position"), (ptype, "particle_position"))
+        self.alias((ftype, "particle_mass"), (ptype, "particle_mass"))
 
     # Collect the names for all aliases if geometry is curvilinear
     def get_aliases_gallery(self) -> List[FieldName]:


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

The following script fails on `main`:

```python
from yt import load
bbox = [[40669.34, 56669.34], [45984.04, 61984.04], [54114.9, 70114.9]]
ds = load("TNGHalo/halo_59.hdf5", bounding_box=bbox)
w = ds.quan(0.2, "Mpc")
le = ds.domain_center-0.5*w
re = ds.domain_center+0.5*w
g = ds.r[le[0]:re[0]:128j,le[1]:re[1]:128j,le[2]:re[2]:128j]
print(g["gas","temperature"].min())
print(g["gas","kT"].min())
```

with this error:

```pycon
  File "/Users/jzuhone/fix_grid.py", line 9, in <module>
    print(g["gas","kT"].min())
          ~^^^^^^^^^^^^
  File "/Users/jzuhone/Source/yt/yt/data_objects/data_containers.py", line 235, in __getitem__
    self.get_data(f)
  File "/Users/jzuhone/Source/yt/yt/data_objects/construction_data_containers.py", line 899, in get_data
    self._fill_sph_particles(fields)
  File "/Users/jzuhone/Source/yt/yt/data_objects/construction_data_containers.py", line 977, in _fill_sph_particles
    raise KeyError(f"{ptype} is not a SPH particle type!")
KeyError: 'gas is not a SPH particle type!'
```

It appears that derived fields were not supported for this operation. This PR addresses this issue by making extra checks to determine if a field is either an SPH on-disk field, derived field, or a particle filter type of an SPH field. 

However, in order to avoid many more onerous code changes, I had to provide for the creation of fields such as `("gas", "particle_position")`, `("gas", "particle_mass")`, and `("gas","particle_position_[xyz]")`, which currently do not exist because the SPH position fields are aliased to `("gas", "[xyz]")` and the mass field is aliased to `("gas", "mass")`. Happy to discuss if this doesn't feel right to anyone.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
