### PR TITLE
RFC: simplify base CoordinateHandler implementation (cached properties)

### DIFF
--- a/yt/geometry/coordinates/coordinate_handler.py
+++ b/yt/geometry/coordinates/coordinate_handler.py
@@ -235,7 +235,7 @@ class CoordinateHandler(abc.ABC):
         return ya
 
     @property
-    @abc.abstractproperty
+    @abc.abstractmethod
     def period(self):
         pass
 

--- a/yt/geometry/coordinates/coordinate_handler.py
+++ b/yt/geometry/coordinates/coordinate_handler.py
@@ -1,5 +1,6 @@
 import abc
 import weakref
+from functools import cached_property
 from numbers import Number
 from typing import Optional, Tuple
 
@@ -184,94 +185,53 @@ class CoordinateHandler(abc.ABC):
     def convert_from_spherical(self, coord):
         pass
 
-    _data_projection = None
-
-    @property
+    @cached_property
     def data_projection(self):
-        if self._data_projection is not None:
-            return self._data_projection
-        dpj = {}
-        for ax in self.axis_order:
-            dpj[ax] = None
-        self._data_projection = dpj
-        return dpj
+        return {ax: None for ax in self.axis_order}
 
-    _data_transform = None
-
-    @property
+    @cached_property
     def data_transform(self):
-        if self._data_transform is not None:
-            return self._data_transform
-        dtx = {}
-        for ax in self.axis_order:
-            dtx[ax] = None
-        self._data_transform = dtx
-        return dtx
+        return {ax: None for ax in self.axis_order}
 
-    _axis_name = None
-
-    @property
+    @cached_property
     def axis_name(self):
-        if self._axis_name is not None:
-            return self._axis_name
         an = {}
         for axi, ax in enumerate(self.axis_order):
             an[axi] = ax
             an[ax] = ax
             an[ax.capitalize()] = ax
-        self._axis_name = an
         return an
 
-    _axis_id = None
-
-    @property
+    @cached_property
     def axis_id(self):
-        if self._axis_id is not None:
-            return self._axis_id
         ai = {}
         for axi, ax in enumerate(self.axis_order):
             ai[ax] = ai[axi] = axi
-        self._axis_id = ai
         return ai
-
-    _image_axis_name = None
 
     @property
     def image_axis_name(self):
-        # Default
-        if self._image_axis_name is not None:
-            return self._image_axis_name
-        self._image_axis_name = rv = {}
+        rv = {}
         for i in range(3):
             rv[i] = (self.axis_name[self.x_axis[i]], self.axis_name[self.y_axis[i]])
             rv[self.axis_name[i]] = rv[i]
             rv[self.axis_name[i].capitalize()] = rv[i]
         return rv
 
-    _x_axis = None
-
-    @property
+    @cached_property
     def x_axis(self):
-        if self._x_axis is not None:
-            return self._x_axis
         ai = self.axis_id
         xa = {}
         for a1, a2 in self._x_pairs:
             xa[a1] = xa[ai[a1]] = ai[a2]
-        self._x_axis = xa
         return xa
 
-    _y_axis = None
-
-    @property
+    @cached_property
     def y_axis(self):
-        if self._y_axis is not None:
-            return self._y_axis
         ai = self.axis_id
         ya = {}
         for a1, a2 in self._y_pairs:
             ya[a1] = ya[ai[a1]] = ai[a2]
-        self._y_axis = ya
         return ya
 
     @property

--- a/yt/utilities/minimal_representation.py
+++ b/yt/utilities/minimal_representation.py
@@ -85,7 +85,8 @@ class MinimalRepresentation(metaclass=abc.ABCMeta):
     def _generate_post(self):
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def _attr_list(self):
         pass
 


### PR DESCRIPTION
## PR Summary

Some low-hanging simplifications I found while working on #4179 
`functools.cached_property` wasn't available before Python 3.8 which explains why these properties didn't use it already.

As a side bonus, I also discovered and replaced two occurrences of `abc.abstractproperty`, which is deprecated since Python 3.3