### PR TITLE
DEPR: deprecate unnecessary functions in the yt.testing namespace, update docs

### DIFF
--- a/doc/source/analyzing/filtering.rst
+++ b/doc/source/analyzing/filtering.rst
@@ -265,7 +265,7 @@ union into a single ``darkmatter`` field.  The ``all`` particle type is a
 special case of this.
 
 To create a particle union, you need to import the ``ParticleUnion`` class from
-``yt.data_objects.particle_unions``, which you then create and pass into
+``yt.data_objects.unions``, which you then create and pass into
 ``add_particle_union`` on a dataset object.
 
 Here is an example, where we union the ``halo`` and ``disk`` particle types

--- a/doc/source/reference/api/api.rst
+++ b/doc/source/reference/api/api.rst
@@ -824,7 +824,10 @@ Cosmology Calculator
 Testing Infrastructure
 ----------------------
 
-The first set of functions are all provided by NumPy.
+The core set of testing functions are re-exported from NumPy,
+and are deprecated (prefer using
+`numpy.testing <https://numpy.org/doc/stable/reference/routines.testing.html>`_
+directly).
 
 .. autosummary::
 
@@ -839,14 +842,28 @@ The first set of functions are all provided by NumPy.
    ~yt.testing.assert_allclose
    ~yt.testing.assert_raises
 
-These are yt-provided functions:
+`unyt.testing <https://unyt.readthedocs.io/en/stable/modules/unyt.testing.html>`_
+also provides some specialized functions for comparing arrays in a units-aware
+fashion.
+
+Finally, yt provides the following functions:
 
 .. autosummary::
 
    ~yt.testing.assert_rel_equal
    ~yt.testing.amrspace
-   ~yt.testing.fake_random_ds
    ~yt.testing.expand_keywords
+   ~yt.testing.fake_random_ds
+   ~yt.testing.fake_amr_ds
+   ~yt.testing.fake_particle_ds
+   ~yt.testing.fake_tetrahedral_ds
+   ~yt.testing.fake_hexahedral_ds
+   ~yt.testing.small_fake_hexahedral_ds
+   ~yt.testing.fake_stretched_ds
+   ~yt.testing.fake_vr_orientation_test_ds
+   ~yt.testing.fake_sph_orientation_ds
+   ~yt.testing.fake_sph_grid_ds
+   ~yt.testing.fake_octree_ds
 
 These are for the pytest infrastructure:
 

--- a/yt/data_objects/tests/test_chunking.py
+++ b/yt/data_objects/tests/test_chunking.py
@@ -1,6 +1,6 @@
 from numpy.testing import assert_equal
 
-from yt.testing import assert_true, fake_random_ds
+from yt.testing import fake_random_ds
 from yt.units._numpy_wrapper_functions import uconcatenate
 
 
@@ -46,15 +46,15 @@ def test_ds_hold():
     ds1 = fake_random_ds(64)
     ds2 = fake_random_ds(128)
     dd = ds1.all_data()
-    assert_true(
-        dd.ds.__hash__() == ds1.__hash__()
-    )  # dd.ds is a weakref, so can't use "is"
-    assert_true(dd.index is ds1.index)
+    # dd.ds is a weakref, so can't use "is"
+    assert dd.ds.__hash__() == ds1.__hash__()
+
+    assert dd.index is ds1.index
     assert_equal(dd[("index", "ones")].size, 64**3)
     with dd._ds_hold(ds2):
-        assert_true(dd.ds.__hash__() == ds2.__hash__())
-        assert_true(dd.index is ds2.index)
+        assert dd.ds.__hash__() == ds2.__hash__()
+        assert dd.index is ds2.index
         assert_equal(dd[("index", "ones")].size, 128**3)
-    assert_true(dd.ds.__hash__() == ds1.__hash__())
-    assert_true(dd.index is ds1.index)
+    assert dd.ds.__hash__() == ds1.__hash__()
+    assert dd.index is ds1.index
     assert_equal(dd[("index", "ones")].size, 64**3)

--- a/yt/data_objects/tests/test_sph_data_objects.py
+++ b/yt/data_objects/tests/test_sph_data_objects.py
@@ -1,14 +1,9 @@
 import numpy as np
-from numpy.testing import assert_equal
+from numpy.testing import assert_almost_equal, assert_equal
 
 from yt import SlicePlot, add_particle_filter
 from yt.loaders import load
-from yt.testing import (
-    assert_almost_equal,
-    fake_sph_grid_ds,
-    fake_sph_orientation_ds,
-    requires_file,
-)
+from yt.testing import fake_sph_grid_ds, fake_sph_orientation_ds, requires_file
 
 
 def test_point():

--- a/yt/frontends/cholla/tests/test_outputs.py
+++ b/yt/frontends/cholla/tests/test_outputs.py
@@ -1,6 +1,8 @@
+from numpy.testing import assert_equal
+
 import yt
 from yt.frontends.cholla.api import ChollaDataset
-from yt.testing import assert_equal, requires_file, requires_module
+from yt.testing import requires_file, requires_module
 from yt.utilities.answer_testing.framework import (
     data_dir_load,
     requires_ds,

--- a/yt/frontends/chombo/tests/test_outputs.py
+++ b/yt/frontends/chombo/tests/test_outputs.py
@@ -1,10 +1,7 @@
+from numpy.testing import assert_equal
+
 from yt.frontends.chombo.api import ChomboDataset, Orion2Dataset, PlutoDataset
-from yt.testing import (
-    assert_equal,
-    requires_file,
-    requires_module,
-    units_override_check,
-)
+from yt.testing import requires_file, requires_module, units_override_check
 from yt.utilities.answer_testing.framework import (
     data_dir_load,
     requires_ds,

--- a/yt/frontends/enzo/tests/test_outputs.py
+++ b/yt/frontends/enzo/tests/test_outputs.py
@@ -1,12 +1,10 @@
 import numpy as np
+from numpy.testing import assert_almost_equal, assert_array_equal, assert_equal
 
 from yt.frontends.enzo.api import EnzoDataset
 from yt.frontends.enzo.fields import NODAL_FLAGS
 from yt.testing import (
     assert_allclose_units,
-    assert_almost_equal,
-    assert_array_equal,
-    assert_equal,
     requires_file,
     requires_module,
     units_override_check,

--- a/yt/frontends/enzo_e/tests/test_outputs.py
+++ b/yt/frontends/enzo_e/tests/test_outputs.py
@@ -1,8 +1,9 @@
 import numpy as np
+from numpy.testing import assert_array_equal, assert_equal
 
 from yt.frontends.enzo_e.api import EnzoEDataset
 from yt.frontends.enzo_e.fields import NODAL_FLAGS
-from yt.testing import assert_array_equal, assert_equal, requires_file, requires_module
+from yt.testing import requires_file, requires_module
 from yt.utilities.answer_testing.framework import (
     FieldValuesTest,
     PixelizedProjectionValuesTest,

--- a/yt/frontends/exodus_ii/tests/test_outputs.py
+++ b/yt/frontends/exodus_ii/tests/test_outputs.py
@@ -1,4 +1,6 @@
-from yt.testing import assert_array_equal, assert_equal, requires_file
+from numpy.testing import assert_array_equal, assert_equal
+
+from yt.testing import requires_file
 from yt.utilities.answer_testing.framework import (
     GenericArrayTest,
     data_dir_load,

--- a/yt/frontends/fits/tests/test_outputs.py
+++ b/yt/frontends/fits/tests/test_outputs.py
@@ -1,9 +1,6 @@
-from yt.testing import (
-    assert_equal,
-    requires_file,
-    requires_module,
-    units_override_check,
-)
+from numpy.testing import assert_equal
+
+from yt.testing import requires_file, requires_module, units_override_check
 from yt.utilities.answer_testing.framework import (
     data_dir_load,
     requires_ds,

--- a/yt/frontends/flash/tests/test_outputs.py
+++ b/yt/frontends/flash/tests/test_outputs.py
@@ -1,13 +1,12 @@
 from collections import OrderedDict
 
 import numpy as np
+from numpy.testing import assert_allclose, assert_equal
 
 from yt.frontends.flash.api import FLASHDataset, FLASHParticleDataset
 from yt.loaders import load
 from yt.testing import (
     ParticleSelectionComparison,
-    assert_allclose,
-    assert_equal,
     disable_dataset_cache,
     requires_file,
     requires_module,

--- a/yt/frontends/gadget_fof/tests/test_outputs.py
+++ b/yt/frontends/gadget_fof/tests/test_outputs.py
@@ -1,13 +1,8 @@
 import numpy as np
+from numpy.testing import assert_array_equal, assert_equal
 
 from yt.frontends.gadget_fof.api import GadgetFOFDataset
-from yt.testing import (
-    ParticleSelectionComparison,
-    assert_array_equal,
-    assert_equal,
-    requires_file,
-    requires_module,
-)
+from yt.testing import ParticleSelectionComparison, requires_file, requires_module
 from yt.utilities.answer_testing.framework import (
     FieldValuesTest,
     data_dir_load,

--- a/yt/frontends/gamer/tests/test_outputs.py
+++ b/yt/frontends/gamer/tests/test_outputs.py
@@ -1,10 +1,7 @@
+from numpy.testing import assert_array_almost_equal, assert_equal
+
 from yt.frontends.gamer.api import GAMERDataset
-from yt.testing import (
-    assert_array_almost_equal,
-    assert_equal,
-    requires_file,
-    units_override_check,
-)
+from yt.testing import requires_file, units_override_check
 from yt.utilities.answer_testing.framework import (
     data_dir_load,
     requires_ds,

--- a/yt/frontends/gdf/tests/test_outputs_nose.py
+++ b/yt/frontends/gdf/tests/test_outputs_nose.py
@@ -1,10 +1,7 @@
+from numpy.testing import assert_equal
+
 from yt.frontends.gdf.api import GDFDataset
-from yt.testing import (
-    assert_equal,
-    requires_file,
-    requires_module,
-    units_override_check,
-)
+from yt.testing import requires_file, requires_module, units_override_check
 from yt.utilities.answer_testing.framework import (
     data_dir_load,
     requires_ds,

--- a/yt/frontends/halo_catalog/tests/test_outputs.py
+++ b/yt/frontends/halo_catalog/tests/test_outputs.py
@@ -1,15 +1,10 @@
 import numpy as np
+from numpy.testing import assert_array_equal, assert_equal
 
 from yt.frontends.halo_catalog.data_structures import YTHaloCatalogDataset
 from yt.frontends.ytdata.utilities import save_as_dataset
 from yt.loaders import load as yt_load
-from yt.testing import (
-    TempDirTest,
-    assert_array_equal,
-    assert_equal,
-    requires_file,
-    requires_module,
-)
+from yt.testing import TempDirTest, requires_file, requires_module
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.answer_testing.framework import data_dir_load
 

--- a/yt/frontends/moab/tests/test_c5.py
+++ b/yt/frontends/moab/tests/test_c5.py
@@ -1,13 +1,8 @@
 import numpy as np
+from numpy.testing import assert_almost_equal, assert_equal
 
 from yt.frontends.moab.api import MoabHex8Dataset
-from yt.testing import (
-    assert_almost_equal,
-    assert_equal,
-    requires_file,
-    requires_module,
-    units_override_check,
-)
+from yt.testing import requires_file, requires_module, units_override_check
 from yt.utilities.answer_testing.framework import (
     FieldValuesTest,
     data_dir_load,

--- a/yt/frontends/nc4_cm1/tests/test_outputs.py
+++ b/yt/frontends/nc4_cm1/tests/test_outputs.py
@@ -1,5 +1,7 @@
+from numpy.testing import assert_equal
+
 from yt.frontends.nc4_cm1.api import CM1Dataset
-from yt.testing import assert_equal, requires_file, units_override_check
+from yt.testing import requires_file, units_override_check
 from yt.utilities.answer_testing.framework import (
     FieldValuesTest,
     GridValuesTest,

--- a/yt/frontends/open_pmd/tests/test_outputs.py
+++ b/yt/frontends/open_pmd/tests/test_outputs.py
@@ -1,16 +1,11 @@
 from itertools import product
 
 import numpy as np
+from numpy.testing import assert_almost_equal, assert_array_equal, assert_equal
 
 from yt.frontends.open_pmd.data_structures import OpenPMDDataset
 from yt.loaders import load
-from yt.testing import (
-    assert_almost_equal,
-    assert_array_equal,
-    assert_equal,
-    requires_file,
-    requires_module,
-)
+from yt.testing import requires_file, requires_module
 from yt.utilities.answer_testing.framework import data_dir_load
 
 twoD = "example-2d/hdf5/data00000100.h5"

--- a/yt/frontends/owls_subfind/tests/test_outputs.py
+++ b/yt/frontends/owls_subfind/tests/test_outputs.py
@@ -1,6 +1,8 @@
 import os.path
 
-from yt.testing import assert_equal, requires_module
+from numpy.testing import assert_equal
+
+from yt.testing import requires_module
 from yt.utilities.answer_testing.framework import (
     FieldValuesTest,
     data_dir_load,

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -1,19 +1,14 @@
 import os
 
 import numpy as np
+from numpy.testing import assert_equal, assert_raises
 
 import yt
 from yt.config import ytcfg
 from yt.fields.field_detector import FieldDetector
 from yt.frontends.ramses.api import RAMSESDataset
 from yt.frontends.ramses.field_handlers import DETECTED_FIELDS, HydroFieldFileHandler
-from yt.testing import (
-    assert_equal,
-    assert_raises,
-    requires_file,
-    requires_module,
-    units_override_check,
-)
+from yt.testing import requires_file, requires_module, units_override_check
 from yt.utilities.answer_testing.framework import (
     FieldValuesTest,
     PixelizedProjectionValuesTest,

--- a/yt/frontends/rockstar/tests/test_outputs.py
+++ b/yt/frontends/rockstar/tests/test_outputs.py
@@ -1,7 +1,9 @@
 import os.path
 
+from numpy.testing import assert_equal
+
 from yt.frontends.rockstar.api import RockstarDataset
-from yt.testing import ParticleSelectionComparison, assert_equal, requires_file
+from yt.testing import ParticleSelectionComparison, requires_file
 from yt.utilities.answer_testing.framework import (
     FieldValuesTest,
     data_dir_load,

--- a/yt/frontends/swift/tests/test_outputs.py
+++ b/yt/frontends/swift/tests/test_outputs.py
@@ -1,13 +1,9 @@
 import numpy as np
+from numpy.testing import assert_almost_equal
 
 from yt import load
 from yt.frontends.swift.api import SwiftDataset
-from yt.testing import (
-    ParticleSelectionComparison,
-    assert_almost_equal,
-    requires_file,
-    requires_module,
-)
+from yt.testing import ParticleSelectionComparison, requires_file, requires_module
 from yt.utilities.on_demand_imports import _h5py as h5py
 
 keplerian_ring = "KeplerianRing/keplerian_ring_0020.hdf5"

--- a/yt/frontends/ytdata/tests/test_unit.py
+++ b/yt/frontends/ytdata/tests/test_unit.py
@@ -3,10 +3,10 @@ import shutil
 import tempfile
 
 import numpy as np
+from numpy.testing import assert_array_equal
 
 from yt.loaders import load, load_uniform_grid
 from yt.testing import (
-    assert_array_equal,
     assert_fname,
     fake_random_ds,
     requires_file,

--- a/yt/geometry/coordinates/tests/test_spherical_coordinates.py
+++ b/yt/geometry/coordinates/tests/test_spherical_coordinates.py
@@ -1,8 +1,9 @@
 # Some tests for the Spherical coordinates handler
 
 import numpy as np
+from numpy.testing import assert_almost_equal, assert_equal
 
-from yt.testing import assert_almost_equal, assert_equal, fake_amr_ds
+from yt.testing import fake_amr_ds
 
 # Our canonical tests are that we can access all of our fields and we can
 # compute our volume correctly.

--- a/yt/geometry/tests/test_particle_octree.py
+++ b/yt/geometry/tests/test_particle_octree.py
@@ -7,7 +7,7 @@ import yt.units.dimensions as dimensions
 from yt.geometry.oct_container import _ORDER_MAX
 from yt.geometry.particle_oct_container import ParticleBitmap, ParticleOctreeContainer
 from yt.geometry.selection_routines import RegionSelector
-from yt.testing import assert_true, requires_module
+from yt.testing import requires_module
 from yt.units.unit_registry import UnitRegistry
 from yt.units.yt_array import YTArray
 from yt.utilities.lib.geometry_utils import (
@@ -302,7 +302,7 @@ def test_bitmap_save_load():
         left_edge, right_edge, periodicity, file_hash, nfiles, order1, order2
     )
     reg1.load_bitmasks(fname)
-    assert_true(reg0.iseq_bitmask(reg1))
+    assert reg0.iseq_bitmask(reg1)
     # Remove file
     os.remove(fname)
 

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -840,6 +840,10 @@ def expand_keywords(keywords, full=False):
     ...     write_projection(*args, **kwargs)
     """
 
+    issue_deprecation_warning(
+        "yt.testing.expand_keywords is deprecated", since="4.2", stacklevel=2
+    )
+
     # if we want every possible combination of keywords, use iter magic
     if full:
         keys = sorted(keywords)

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -30,6 +30,19 @@ ANSWER_TEST_TAG = "answer_test"
 # Expose assert_true and assert_less_equal from unittest.TestCase
 # this is adopted from nose. Doing this here allows us to avoid importing
 # nose at the top level.
+def _deprecated_assert_func(func):
+    @wraps(func)
+    def retf(*args, **kwargs):
+        issue_deprecation_warning(
+            f"yt.testing.{func.__name__} is deprecated",
+            since="4.2",
+            stacklevel=3,
+        )
+        return func(*args, **kwargs)
+
+    return retf
+
+
 class _Dummy(unittest.TestCase):
     def nop(self):
         pass
@@ -37,8 +50,8 @@ class _Dummy(unittest.TestCase):
 
 _t = _Dummy("nop")
 
-assert_true = _t.assertTrue
-assert_less_equal = _t.assertLessEqual
+assert_true = _deprecated_assert_func(_t.assertTrue)
+assert_less_equal = _deprecated_assert_func(_t.assertLessEqual)
 
 
 def assert_rel_equal(a1, a2, decimals, err_msg="", verbose=True):

--- a/yt/tests/test_funcs.py
+++ b/yt/tests/test_funcs.py
@@ -1,7 +1,8 @@
 from nose.tools import assert_raises
+from numpy.testing import assert_equal
 
 from yt.funcs import just_one, levenshtein_distance, validate_axis, validate_center
-from yt.testing import assert_equal, fake_amr_ds
+from yt.testing import fake_amr_ds
 from yt.units import YTArray, YTQuantity
 
 

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -21,6 +21,7 @@ import numpy as np
 from matplotlib import image as mpimg
 from matplotlib.testing.compare import compare_images
 from nose.plugins import Plugin
+from numpy.testing import assert_almost_equal, assert_equal
 
 from yt.config import ytcfg
 from yt.data_objects.static_output import Dataset
@@ -28,8 +29,6 @@ from yt.funcs import get_pbar, get_yt_version
 from yt.loaders import load, load_simulation
 from yt.testing import (
     assert_allclose_units,
-    assert_almost_equal,
-    assert_equal,
     assert_rel_equal,
     skipif,
 )

--- a/yt/utilities/answer_testing/level_sets_tests.py
+++ b/yt/utilities/answer_testing/level_sets_tests.py
@@ -1,6 +1,6 @@
 import numpy as np
+from numpy.testing import assert_equal
 
-from yt.testing import assert_equal
 from yt.utilities.answer_testing.framework import AnswerTestingTest
 
 

--- a/yt/utilities/lib/cykdtree/tests/test_utils.py
+++ b/yt/utilities/lib/cykdtree/tests/test_utils.py
@@ -1,5 +1,5 @@
 import numpy as np
-from nose.tools import assert_equal
+from numpy.testing import assert_equal
 
 from yt.utilities.lib.cykdtree import utils  # type: ignore
 from yt.utilities.lib.cykdtree.tests import assert_less_equal, parametrize

--- a/yt/utilities/lib/tests/test_alt_ray_tracers.py
+++ b/yt/utilities/lib/tests/test_alt_ray_tracers.py
@@ -2,7 +2,7 @@
 import numpy as np
 from numpy.testing import assert_equal
 
-from yt.testing import amrspace, assert_less_equal, assert_true
+from yt.testing import amrspace
 from yt.utilities.lib.alt_ray_tracers import _cyl2cart, cylindrical_ray_trace
 
 left_grid = right_grid = amr_levels = center_grid = data = None
@@ -51,12 +51,12 @@ point_pairs = np.array(
 
 
 def check_monotonic_inc(arr):
-    assert_true(np.all(0.0 <= (arr[1:] - arr[:-1])))
+    assert np.all(0.0 <= (arr[1:] - arr[:-1]))
 
 
 def check_bounds(arr, blower, bupper):
-    assert_true(np.all(blower <= arr))
-    assert_true(np.all(bupper >= arr))
+    assert np.all(blower <= arr)
+    assert np.all(bupper >= arr)
 
 
 def test_cylindrical_ray_trace():
@@ -69,12 +69,12 @@ def test_cylindrical_ray_trace():
         npoints = len(t)
 
         check_monotonic_inc(t)
-        assert_less_equal(0.0, t[0])
-        assert_less_equal(t[-1], 1.0)
+        assert 0.0 <= t[0]
+        assert t[-1] <= 1.0
 
         check_monotonic_inc(s)
-        assert_less_equal(0.0, s[0])
-        assert_less_equal(s[-1], pathlen)
+        assert 0.0 <= s[0]
+        assert s[-1] <= pathlen
         assert_equal(npoints, len(s))
 
         assert_equal((npoints, 3), rztheta.shape)

--- a/yt/utilities/tests/test_cosmology.py
+++ b/yt/utilities/tests/test_cosmology.py
@@ -1,14 +1,9 @@
 import os
 
 import numpy as np
+from numpy.testing import assert_almost_equal, assert_equal
 
-from yt.testing import (
-    assert_almost_equal,
-    assert_equal,
-    assert_rel_equal,
-    requires_file,
-    requires_module,
-)
+from yt.testing import assert_rel_equal, requires_file, requires_module
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.answer_testing.framework import data_dir_load
 from yt.utilities.cosmology import Cosmology

--- a/yt/visualization/tests/test_color_maps.py
+++ b/yt/visualization/tests/test_color_maps.py
@@ -6,9 +6,10 @@ import unittest
 import matplotlib.pyplot as plt
 import numpy as np
 from nose.tools import assert_raises
+from numpy.testing import assert_almost_equal, assert_equal
 
 from yt import make_colormap, show_colormaps
-from yt.testing import assert_almost_equal, assert_equal, requires_backend
+from yt.testing import requires_backend
 
 
 class TestColorMaps(unittest.TestCase):

--- a/yt/visualization/tests/test_offaxisprojection.py
+++ b/yt/visualization/tests/test_offaxisprojection.py
@@ -1,3 +1,4 @@
+import itertools as it
 import os
 import shutil
 import tempfile
@@ -9,13 +10,119 @@ from numpy.testing import assert_equal
 from yt.testing import (
     assert_fname,
     assert_rel_equal,
-    expand_keywords,
     fake_octree_ds,
     fake_random_ds,
 )
 from yt.visualization.api import OffAxisProjectionPlot, OffAxisSlicePlot
 from yt.visualization.image_writer import write_projection
 from yt.visualization.volume_rendering.api import off_axis_projection
+
+
+# TODO: replace this with pytest.mark.parametrize
+def expand_keywords(keywords, full=False):
+    """
+    expand_keywords is a means for testing all possible keyword
+    arguments in the nosetests.  Simply pass it a dictionary of all the
+    keyword arguments and all of the values for these arguments that you
+    want to test.
+
+    It will return a list of kwargs dicts containing combinations of
+    the various kwarg values you passed it.  These can then be passed
+    to the appropriate function in nosetests.
+
+    If full=True, then every possible combination of keywords is produced,
+    otherwise, every keyword option is included at least once in the output
+    list.  Be careful, by using full=True, you may be in for an exponentially
+    larger number of tests!
+
+    Parameters
+    ----------
+
+    keywords : dict
+        a dictionary where the keys are the keywords for the function,
+        and the values of each key are the possible values that this key
+        can take in the function
+
+    full : bool
+        if set to True, every possible combination of given keywords is
+        returned
+
+    Returns
+    -------
+
+    array of dicts
+        An array of dictionaries to be individually passed to the appropriate
+        function matching these kwargs.
+
+    Examples
+    --------
+
+    >>> keywords = {}
+    >>> keywords["dpi"] = (50, 100, 200)
+    >>> keywords["cmap"] = ("cmyt.arbre", "cmyt.kelp")
+    >>> list_of_kwargs = expand_keywords(keywords)
+    >>> print(list_of_kwargs)
+
+    array([{'cmap': 'cmyt.arbre', 'dpi': 50},
+           {'cmap': 'cmyt.kelp', 'dpi': 100},
+           {'cmap': 'cmyt.arbre', 'dpi': 200}], dtype=object)
+
+    >>> list_of_kwargs = expand_keywords(keywords, full=True)
+    >>> print(list_of_kwargs)
+
+    array([{'cmap': 'cmyt.arbre', 'dpi': 50},
+           {'cmap': 'cmyt.arbre', 'dpi': 100},
+           {'cmap': 'cmyt.arbre', 'dpi': 200},
+           {'cmap': 'cmyt.kelp', 'dpi': 50},
+           {'cmap': 'cmyt.kelp', 'dpi': 100},
+           {'cmap': 'cmyt.kelp', 'dpi': 200}], dtype=object)
+
+    >>> for kwargs in list_of_kwargs:
+    ...     write_projection(*args, **kwargs)
+    """
+    # if we want every possible combination of keywords, use iter magic
+    if full:
+        keys = sorted(keywords)
+        list_of_kwarg_dicts = np.array(
+            [
+                dict(zip(keys, prod))
+                for prod in it.product(*(keywords[key] for key in keys))
+            ]
+        )
+
+    # if we just want to probe each keyword, but not necessarily every
+    # combination
+    else:
+        # Determine the maximum number of values any of the keywords has
+        num_lists = 0
+        for val in keywords.values():
+            if isinstance(val, str):
+                num_lists = max(1.0, num_lists)
+            else:
+                num_lists = max(len(val), num_lists)
+
+        # Construct array of kwargs dicts, each element of the list is a different
+        # **kwargs dict.  each kwargs dict gives a different combination of
+        # the possible values of the kwargs
+
+        # initialize array
+        list_of_kwarg_dicts = np.array([dict() for x in range(num_lists)])
+
+        # fill in array
+        for i in np.arange(num_lists):
+            list_of_kwarg_dicts[i] = {}
+            for key in keywords.keys():
+                # if it's a string, use it (there's only one)
+                if isinstance(keywords[key], str):
+                    list_of_kwarg_dicts[i][key] = keywords[key]
+                # if there are more options, use the i'th val
+                elif i < len(keywords[key]):
+                    list_of_kwarg_dicts[i][key] = keywords[key][i]
+                # if there are not more options, use the 0'th val
+                else:
+                    list_of_kwarg_dicts[i][key] = keywords[key][0]
+
+    return list_of_kwarg_dicts
 
 
 class TestOffAxisProjection(unittest.TestCase):

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -19,7 +19,6 @@ from yt.testing import (
     assert_allclose_units,
     assert_fname,
     assert_rel_equal,
-    assert_true,
     fake_amr_ds,
     fake_random_ds,
     requires_file,
@@ -275,7 +274,7 @@ class TestSetWidth(unittest.TestCase):
             [self.slc.xlim, self.slc.ylim, self.slc.width],
             [(0.0, 1.0), (0.0, 1.0), (1.0, 1.0)],
         )
-        assert_true(self.slc._axes_unit_names is None)
+        assert self.slc._axes_unit_names is None
 
     def test_set_width_nonequal(self):
         self.slc.set_width((0.5, 0.8))
@@ -284,22 +283,22 @@ class TestSetWidth(unittest.TestCase):
             [(0.25, 0.75), (0.1, 0.9), (0.5, 0.8)],
             15,
         )
-        assert_true(self.slc._axes_unit_names is None)
+        assert self.slc._axes_unit_names is None
 
     def test_twoargs_eq(self):
         self.slc.set_width(0.5, "cm")
         self._assert_05cm()
-        assert_true(self.slc._axes_unit_names == ("cm", "cm"))
+        assert self.slc._axes_unit_names == ("cm", "cm")
 
     def test_tuple_eq(self):
         self.slc.set_width((0.5, "cm"))
         self._assert_05cm()
-        assert_true(self.slc._axes_unit_names == ("cm", "cm"))
+        assert self.slc._axes_unit_names == ("cm", "cm")
 
     def test_tuple_of_tuples_neq(self):
         self.slc.set_width(((0.5, "cm"), (0.75, "cm")))
         self._assert_05_075cm()
-        assert_true(self.slc._axes_unit_names == ("cm", "cm"))
+        assert self.slc._axes_unit_names == ("cm", "cm")
 
 
 class TestPlotWindowSave(unittest.TestCase):
@@ -390,7 +389,7 @@ class TestPlotWindowSave(unittest.TestCase):
             [assert_array_almost_equal(px, x, 14) for px, x in zip(plot.xlim, xlim)]
             [assert_array_almost_equal(py, y, 14) for py, y in zip(plot.ylim, ylim)]
             [assert_array_almost_equal(pw, w, 14) for pw, w in zip(plot.width, pwidth)]
-            assert_true(aun == plot._axes_unit_names)
+            assert aun == plot._axes_unit_names
 
 
 class TestPerFieldConfig(unittest.TestCase):


### PR DESCRIPTION
## PR Summary

follow up to #4434, let's trim out the remaining fat in `yt.testing`, and clean up some import statements that I missed in the first PR

half of the "added" lines are from copying `yt.testing.expand_keywords` into the only test module that uses it