### PR TITLE
Whitelist the SPH star_formation_rate field

### DIFF
--- a/yt/fields/particle_fields.py
+++ b/yt/fields/particle_fields.py
@@ -30,6 +30,7 @@ sph_whitelist_fields = (
     "metallicity",
     "thermal_energy",
     "smoothing_length",
+    "star_formation_rate",
     "H_fraction",
     "He_fraction",
     "C_fraction",


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

All this PR does is whitelist the SPH `star_formation_rate` field so that it automatically gets aliased to `"gas"` from its SPH particle type.
<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
