### PR TITLE
ENH: add support for passing field keys for colors and linewidth in streamline plot annotations

### DIFF
--- a/doc/source/visualizing/callbacks.rst
+++ b/doc/source/visualizing/callbacks.rst
@@ -577,9 +577,8 @@ Overplot a Circle on a Plot
 Overplot Streamlines
 ~~~~~~~~~~~~~~~~~~~~
 
-.. function:: annotate_streamlines(self, field_x, field_y, *, factor=16, \
-                                   density=1, display_threshold=None, \
-                                   **kwargs)
+.. function:: annotate_streamlines(self, field_x, field_y, *, linewidth=1.0, linewidth_upscaling=1.0, \
+                                   color=None, color_threshold=float('-inf'), factor=16, **kwargs)
 
    (This is a proxy for
    :class:`~yt.visualization.plot_modifications.StreamlineCallback`.)
@@ -590,6 +589,9 @@ Overplot Streamlines
    plot, set ``start_at_xedge`` to ``True``; for the bottom edge, use
    ``start_at_yedge``.  A line with the qmean vector magnitude will cover
    1.0/``factor`` of the image.
+
+   Additional keyword arguments are passed down to
+   `matplotlib.axes.Axes.streamplot <https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.streamplot.html>`_
 
 .. python-script::
 

--- a/yt/visualization/tests/test_callbacks.py
+++ b/yt/visualization/tests/test_callbacks.py
@@ -913,17 +913,20 @@ def test_streamline_callback():
             p.annotate_streamlines(
                 ("gas", "velocity_x"),
                 ("gas", "velocity_y"),
-                field_color=("stream", "magvel"),
+                color=("stream", "magvel"),
             )
             assert_fname(p.save(prefix)[0])
             check_axis_manipulation(p, prefix)
 
+            # a more thorough example involving many keyword arguments
             p = SlicePlot(ds, ax, ("gas", "density"))
             p.annotate_streamlines(
                 ("gas", "velocity_x"),
                 ("gas", "velocity_y"),
-                field_color=("stream", "magvel"),
-                display_threshold=0.5,
+                linewidth=("gas", "density"),
+                linewidth_upscaling=3,
+                color=("stream", "magvel"),
+                color_threshold=0.5,
                 cmap="viridis",
                 arrowstyle="->",
             )


### PR DESCRIPTION
## PR Summary
Closes #4454, incidentally fix a couple small issues with `StreamlineCallback`'s implementation.

demo:

```python
import yt

ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
p = yt.ProjectionPlot(ds, "z", ("gas", "density"))
p.annotate_streamlines(
    ("gas", "velocity_x"),
    ("gas", "velocity_y"),
    linewidth=("gas", "velocity_z"),
    linewidth_upscaling=3,
    color=("gas", "velocity_magnitude"),
    cmap="turbo",
)
p.zoom(20)
p.save("/tmp/")
```

![galaxy0030_Projection_z_density](https://github.com/yt-project/yt/assets/14075922/2953a0c0-6d51-4bfa-9389-f8fa163b8c10)


## PR Checklist

- [x] write error and deprecation messages
- [x] extra validation of input types (in particular, check consistency with MPL)
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.
