### PR TITLE
BUG: Turn range into a list for keyframes

### DIFF
--- a/yt/visualization/volume_rendering/camera_path.py
+++ b/yt/visualization/volume_rendering/camera_path.py
@@ -137,7 +137,7 @@ class Keyframes:
         Generates values in random order, equivalent to using shuffle
         in random without generation all values at once.
         """
-        values = range(self.nframes)
+        values = list(range(self.nframes))
         for i in range(self.nframes):
             # pick a random index into remaining values
             j = i + int(random.random() * (self.nframes - i))

--- a/yt/visualization/volume_rendering/camera_path.py
+++ b/yt/visualization/volume_rendering/camera_path.py
@@ -117,7 +117,7 @@ class Keyframes:
             path.  Default: False
         """
         # randomize tour
-        self.tour = range(self.nframes)
+        self.tour = list(range(self.nframes))
         np.random.shuffle(self.tour)
         if fixed_start:
             first = self.tour.index(0)


### PR DESCRIPTION
This fixes a minor issue with the `Keyframe` class.
