### PR TITLE
BUG: Update GIZMO frontend to handle newer GIZMO versions

### DIFF
--- a/yt/frontends/gizmo/data_structures.py
+++ b/yt/frontends/gizmo/data_structures.py
@@ -16,7 +16,7 @@ class GizmoDataset(GadgetHDF5Dataset):
     @classmethod
     def _is_valid(cls, filename, *args, **kwargs):
         need_groups = ["Header"]
-        veto_groups = ["FOF", "Group", "Subhalo"]
+        veto_groups = ["Config", "Constants", "FOF", "Group", "Subhalo"]
         valid = True
         valid_fname = filename
         # If passed arg is a directory, look for the .0 file in that dir

--- a/yt/frontends/gizmo/data_structures.py
+++ b/yt/frontends/gizmo/data_structures.py
@@ -73,13 +73,9 @@ class GizmoDataset(GadgetHDF5Dataset):
 
         self.cosmological_simulation = 1
 
-        try:
-            self.current_redshift = hvals["Redshift"]
-        except KeyError:
-            # Probably not a cosmological dataset, we should just set
-            # z = 0 and let the user know
-            self.current_redshift = 0.0
-            only_on_root(mylog.info, "Redshift is not set in Header. Assuming z=0.")
+        self.current_redshift = hvals.get("Redshift", 0.0)
+        if "Redshift" not in hvals;
+            mylog.info("Redshift is not set in Header. Assuming z=0.")
 
         try:
             # In 1d8479, Nov 2020, public GIZMO updated the names of the Omegas

--- a/yt/frontends/gizmo/data_structures.py
+++ b/yt/frontends/gizmo/data_structures.py
@@ -81,9 +81,7 @@ class GizmoDataset(GadgetHDF5Dataset):
             # to include an _, added baryons and radiation and added the
             # ComovingIntegrationOn field. ComovingIntegrationOn is always set,
             # but the Omega's are only included if ComovingIntegrationOn is true
-            mylog.debug(
-                "Reading cosmological parameters using post-1d8479 format"
-            )
+            mylog.debug("Reading cosmological parameters using post-1d8479 format")
             self.cosmological_simulation = hvals["ComovingIntegrationOn"]
             if self.cosmological_simulation:
                 self.omega_lambda = hvals["Omega_Lambda"]
@@ -102,9 +100,7 @@ class GizmoDataset(GadgetHDF5Dataset):
             self.cosmological_simulation = self.omega_lambda != 0.0
         else:
             # If these are not set it is definitely not a cosmological dataset.
-            mylog.debug(
-                "No cosmological information found, assuming defaults"
-            )
+            mylog.debug("No cosmological information found, assuming defaults")
             self.omega_lambda = 0.0
             self.omega_matter = 0.0  # Just in case somebody asks for it.
             self.cosmological_simulation = 0

--- a/yt/frontends/gizmo/data_structures.py
+++ b/yt/frontends/gizmo/data_structures.py
@@ -95,9 +95,14 @@ class GizmoDataset(GadgetHDF5Dataset):
                 self.hubble_constant = hvals["HubbleParam"]
             else:
                 # Should still support old GIZMO versions too
+                only_on_root(
+                    mylog.info, 
+                    "ComovingIntegrationOn does not exist, falling back to OmegaLambda"
+                )
                 self.omega_lambda = hvals["OmegaLambda"]
                 self.omega_matter = hvals["Omega0"]
-                self.hubble_constant = self.omega_lambda == 0.0
+                self.hubble_constant = hvals["HubbleParam"]
+                self.cosmological_simulation = self.omega_lambda == 0.0
         except KeyError:
             # If these are not set it is definitely not a cosmological dataset.
             self.omega_lambda = 0.0

--- a/yt/frontends/gizmo/data_structures.py
+++ b/yt/frontends/gizmo/data_structures.py
@@ -42,9 +42,14 @@ class GizmoDataset(GadgetHDF5Dataset):
             valid = all(ng in fh["/"] for ng in need_groups) and not any(
                 vg in fh["/"] for vg in veto_groups
             )
-            dmetal = "/PartType0/Metallicity"
-            if dmetal not in fh or (fh[dmetal].ndim > 1 and fh[dmetal].shape[1] < 11):
-                valid = False
+            # From Apr 2021, 7f1f06f, public gizmo includes a header variable
+            # GIZMO_version, which is set to the year of the most recent commit
+            # We should prefer this to checking the metallicity, which might 
+            # not exist
+            if "GIZMO_version" not in fh["/Header"].attrs:
+                dmetal = "/PartType0/Metallicity"
+                if dmetal not in fh or (fh[dmetal].ndim > 1 and fh[dmetal].shape[1] < 11):
+                    valid = False
             fh.close()
         except Exception:
             valid = False

--- a/yt/frontends/gizmo/data_structures.py
+++ b/yt/frontends/gizmo/data_structures.py
@@ -132,7 +132,7 @@ class GizmoDataset(GadgetHDF5Dataset):
             )
         self.parameters = hvals
 
-        prefix = os.path.join(self.directory, self.basename.split('.', 1)[0])
+        prefix = os.path.join(self.directory, self.basename.split(".", 1)[0])
 
         if hvals["NumFiles"] > 1:
             self.filename_template = f"{prefix}.%(num)s{self._suffix}"

--- a/yt/frontends/gizmo/data_structures.py
+++ b/yt/frontends/gizmo/data_structures.py
@@ -96,7 +96,7 @@ class GizmoDataset(GadgetHDF5Dataset):
                 self.omega_lambda = hvals["OmegaLambda"]
                 self.omega_matter = hvals["Omega0"]
                 self.hubble_constant = hvals["HubbleParam"]
-                self.cosmological_simulation = self.omega_lambda == 0.0
+                self.cosmological_simulation = self.omega_lambda != 0.0
         except KeyError:
             # If these are not set it is definitely not a cosmological dataset.
             self.omega_lambda = 0.0
@@ -110,7 +110,6 @@ class GizmoDataset(GadgetHDF5Dataset):
                 "and OmegaLambda is 0.0), so we are turning off Cosmology.",
             )
             self.hubble_constant = 1.0  # So that scaling comes out correct
-            self.cosmological_simulation = 0
             self.current_redshift = 0.0
             # This may not be correct.
             self.current_time = hvals["Time"]

--- a/yt/frontends/gizmo/data_structures.py
+++ b/yt/frontends/gizmo/data_structures.py
@@ -135,15 +135,7 @@ class GizmoDataset(GadgetHDF5Dataset):
         prefix = os.path.join(self.directory, self.basename.split('.', 1)[0])
 
         if hvals["NumFiles"] > 1:
-            for t in (
-                f"{prefix}.%(num)s{self._suffix}",
-                f"{prefix}.gad.%(num)s{self._suffix}",
-            ):
-                if os.path.isfile(t % {"num": 0}):
-                    self.filename_template = t
-                    break
-            else:
-                raise RuntimeError("Could not determine correct data file template.")
+            self.filename_template = f"{prefix}.%(num)s{self._suffix}"
         else:
             self.filename_template = self.parameter_filename
 

--- a/yt/frontends/gizmo/data_structures.py
+++ b/yt/frontends/gizmo/data_structures.py
@@ -82,7 +82,7 @@ class GizmoDataset(GadgetHDF5Dataset):
             only_on_root(mylog.info, "Redshift is not set in Header. Assuming z=0.")
 
         try:
-            # The current version of GIZMO has updated the names of the Omegas
+            # In 1d8479, Nov 2020, public GIZMO updated the names of the Omegas
             # to include an _, added baryons and radiation and added the
             # ComovingIntegrationOn field. ComovingIntegrationOn is always set,
             # but the Omega's are only included if ComovingIntegrationOn is true
@@ -94,7 +94,7 @@ class GizmoDataset(GadgetHDF5Dataset):
                 self.omega_radiation = hvals["Omega_Radiation"]
                 self.hubble_constant = hvals["HubbleParam"]
             else:
-                # Should still support old GIZMO versions too
+                # Should still support GIZMO versions prior to 1d8479 too
                 only_on_root(
                     mylog.info,
                     "ComovingIntegrationOn does not exist, falling back to OmegaLambda",
@@ -110,9 +110,6 @@ class GizmoDataset(GadgetHDF5Dataset):
             self.cosmological_simulation = 0
             # Hubble is set below for Omega Lambda = 0.
 
-        # Since new versions of GIZMO output the ComovingIntegrationOn flag
-        # we will rely on its presence to determine if this is a cosmological
-        # dataset.
         if not self.cosmological_simulation:
             only_on_root(
                 mylog.info,

--- a/yt/frontends/gizmo/data_structures.py
+++ b/yt/frontends/gizmo/data_structures.py
@@ -1,6 +1,11 @@
 import os
 
+import numpy as np
+
 from yt.frontends.gadget.data_structures import GadgetHDF5Dataset
+from yt.funcs import only_on_root
+from yt.utilities.cosmology import Cosmology
+from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.on_demand_imports import _h5py as h5py
 
 from .fields import GizmoFieldInfo
@@ -39,7 +44,7 @@ class GizmoDataset(GadgetHDF5Dataset):
                 vg in fh["/"] for vg in veto_groups
             )
             dmetal = "/PartType0/Metallicity"
-            if dmetal not in fh or fh[dmetal].shape[1] < 11:
+            if dmetal not in fh or (fh[dmetal].ndim > 1 and fh[dmetal].shape[1] < 11):
                 valid = False
             fh.close()
         except Exception:
@@ -49,3 +54,108 @@ class GizmoDataset(GadgetHDF5Dataset):
 
     def _set_code_unit_attributes(self):
         super()._set_code_unit_attributes()
+
+    def _parse_parameter_file(self):
+        hvals = self._get_hvals()
+
+        self.dimensionality = 3
+        self.refine_by = 2
+        self.parameters["HydroMethod"] = "sph"
+        # Set standard values
+
+        # We may have an overridden bounding box.
+        if self.domain_left_edge is None and hvals["BoxSize"] != 0:
+            self.domain_left_edge = np.zeros(3, "float64")
+            self.domain_right_edge = np.ones(3, "float64") * hvals["BoxSize"]
+
+        self.domain_dimensions = np.ones(3, "int32")
+        self._periodicity = (True, True, True)
+
+        self.cosmological_simulation = 1
+
+        try:
+            self.current_redshift = hvals["Redshift"]
+        except KeyError:
+            # Probably not a cosmological dataset, we should just set
+            # z = 0 and let the user know
+            self.current_redshift = 0.0
+            only_on_root(mylog.info, "Redshift is not set in Header. Assuming z=0.")
+
+        try:
+            # The current version of GIZMO has updated the names of the Omegas
+            # to include an _, added baryons and radiation and added the
+            # ComovingIntegrationOn field. ComovingIntegrationOn is always set,
+            # but the Omega's are only included if ComovingIntegrationOn is true
+            if "ComovingIntegrationOn" in hvals:
+                self.cosmological_simulation = hvals["ComovingIntegrationOn"]
+                self.omega_lambda = hvals["Omega_Lambda"]
+                self.omega_matter = hvals["Omega_Matter"]
+                self.omega_baryon = hvals["Omega_Baryon"]
+                self.omega_radiation = hvals["Omega_Radiation"]
+                self.hubble_constant = hvals["HubbleParam"]
+            else:
+                # Should still support old GIZMO versions too
+                self.omega_lambda = hvals["OmegaLambda"]
+                self.omega_matter = hvals["Omega0"]
+                self.hubble_constant = self.omega_lambda == 0.0
+        except KeyError:
+            # If these are not set it is definitely not a cosmological dataset.
+            self.omega_lambda = 0.0
+            self.omega_matter = 1.0  # Just in case somebody asks for it.
+            self.cosmological_simulation = 0
+            # Hubble is set below for Omega Lambda = 0.
+
+        # Since new versions of GIZMO output the ComovingIntegrationOn flag
+        # we will rely on its presence to determine if this is a cosmological
+        # dataset.
+        if not self.cosmological_simulation:
+            only_on_root(
+                mylog.info,
+                "ComovingIntegrationOn != 1 or (not found "
+                "and OmegaLambda is 0.0), so we are turning off Cosmology.",
+            )
+            self.hubble_constant = 1.0  # So that scaling comes out correct
+            self.cosmological_simulation = 0
+            self.current_redshift = 0.0
+            # This may not be correct.
+            self.current_time = hvals["Time"]
+        else:
+            # Now we calculate our time based on the cosmology, because in
+            # ComovingIntegration hvals["Time"] will in fact be the expansion
+            # factor, not the actual integration time, so we re-calculate
+            # global time from our Cosmology.
+            cosmo = Cosmology(
+                hubble_constant=self.hubble_constant,
+                omega_matter=self.omega_matter,
+                omega_lambda=self.omega_lambda,
+            )
+            self.current_time = cosmo.lookback_time(self.current_redshift, 1e6)
+            only_on_root(
+                mylog.info,
+                "Calculating time from %0.3e to be %0.3e seconds",
+                hvals["Time"],
+                self.current_time,
+            )
+        self.parameters = hvals
+
+        prefix = os.path.abspath(
+            os.path.join(
+                os.path.dirname(self.parameter_filename),
+                os.path.basename(self.parameter_filename).split(".", 1)[0],
+            )
+        )
+
+        if hvals["NumFiles"] > 1:
+            for t in (
+                f"{prefix}.%(num)s{self._suffix}",
+                f"{prefix}.gad.%(num)s{self._suffix}",
+            ):
+                if os.path.isfile(t % {"num": 0}):
+                    self.filename_template = t
+                    break
+            else:
+                raise RuntimeError("Could not determine correct data file template.")
+        else:
+            self.filename_template = self.parameter_filename
+
+        self.file_count = hvals["NumFiles"]

--- a/yt/frontends/gizmo/data_structures.py
+++ b/yt/frontends/gizmo/data_structures.py
@@ -140,12 +140,7 @@ class GizmoDataset(GadgetHDF5Dataset):
             )
         self.parameters = hvals
 
-        prefix = os.path.abspath(
-            os.path.join(
-                os.path.dirname(self.parameter_filename),
-                os.path.basename(self.parameter_filename).split(".", 1)[0],
-            )
-        )
+        prefix = os.path.join(ds.directory, ds.basename.split('.', 1)[0])
 
         if hvals["NumFiles"] > 1:
             for t in (

--- a/yt/frontends/gizmo/data_structures.py
+++ b/yt/frontends/gizmo/data_structures.py
@@ -44,11 +44,13 @@ class GizmoDataset(GadgetHDF5Dataset):
             )
             # From Apr 2021, 7f1f06f, public gizmo includes a header variable
             # GIZMO_version, which is set to the year of the most recent commit
-            # We should prefer this to checking the metallicity, which might 
+            # We should prefer this to checking the metallicity, which might
             # not exist
             if "GIZMO_version" not in fh["/Header"].attrs:
                 dmetal = "/PartType0/Metallicity"
-                if dmetal not in fh or (fh[dmetal].ndim > 1 and fh[dmetal].shape[1] < 11):
+                if dmetal not in fh or (
+                    fh[dmetal].ndim > 1 and fh[dmetal].shape[1] < 11
+                ):
                     valid = False
             fh.close()
         except Exception:

--- a/yt/frontends/gizmo/data_structures.py
+++ b/yt/frontends/gizmo/data_structures.py
@@ -96,8 +96,8 @@ class GizmoDataset(GadgetHDF5Dataset):
             else:
                 # Should still support old GIZMO versions too
                 only_on_root(
-                    mylog.info, 
-                    "ComovingIntegrationOn does not exist, falling back to OmegaLambda"
+                    mylog.info,
+                    "ComovingIntegrationOn does not exist, falling back to OmegaLambda",
                 )
                 self.omega_lambda = hvals["OmegaLambda"]
                 self.omega_matter = hvals["Omega0"]

--- a/yt/frontends/gizmo/data_structures.py
+++ b/yt/frontends/gizmo/data_structures.py
@@ -3,7 +3,6 @@ import os
 import numpy as np
 
 from yt.frontends.gadget.data_structures import GadgetHDF5Dataset
-from yt.funcs import only_on_root
 from yt.utilities.cosmology import Cosmology
 from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.on_demand_imports import _h5py as h5py
@@ -74,7 +73,7 @@ class GizmoDataset(GadgetHDF5Dataset):
         self.cosmological_simulation = 1
 
         self.current_redshift = hvals.get("Redshift", 0.0)
-        if "Redshift" not in hvals;
+        if "Redshift" not in hvals:
             mylog.info("Redshift is not set in Header. Assuming z=0.")
 
         try:
@@ -91,8 +90,7 @@ class GizmoDataset(GadgetHDF5Dataset):
                 self.hubble_constant = hvals["HubbleParam"]
             else:
                 # Should still support GIZMO versions prior to 1d8479 too
-                only_on_root(
-                    mylog.info,
+                mylog.info(
                     "ComovingIntegrationOn does not exist, falling back to OmegaLambda",
                 )
                 self.omega_lambda = hvals["OmegaLambda"]
@@ -102,13 +100,12 @@ class GizmoDataset(GadgetHDF5Dataset):
         except KeyError:
             # If these are not set it is definitely not a cosmological dataset.
             self.omega_lambda = 0.0
-            self.omega_matter = 1.0  # Just in case somebody asks for it.
+            self.omega_matter = 0.0  # Just in case somebody asks for it.
             self.cosmological_simulation = 0
             # Hubble is set below for Omega Lambda = 0.
 
         if not self.cosmological_simulation:
-            only_on_root(
-                mylog.info,
+            mylog.info(
                 "ComovingIntegrationOn != 1 or (not found "
                 "and OmegaLambda is 0.0), so we are turning off Cosmology.",
             )
@@ -128,15 +125,14 @@ class GizmoDataset(GadgetHDF5Dataset):
                 omega_lambda=self.omega_lambda,
             )
             self.current_time = cosmo.lookback_time(self.current_redshift, 1e6)
-            only_on_root(
-                mylog.info,
+            mylog.info(
                 "Calculating time from %0.3e to be %0.3e seconds",
                 hvals["Time"],
                 self.current_time,
             )
         self.parameters = hvals
 
-        prefix = os.path.join(ds.directory, ds.basename.split('.', 1)[0])
+        prefix = os.path.join(self.directory, self.basename.split('.', 1)[0])
 
         if hvals["NumFiles"] > 1:
             for t in (

--- a/yt/sample_data_registry.json
+++ b/yt/sample_data_registry.json
@@ -724,6 +724,12 @@
     "load_name": "gizmo_mhd_mwdisk.hdf5",
     "url": "https://yt-project.org/data/gizmo_mhd_mwdisk.tar.gz"
   },
+  "gizmo_zeldovich.tar.gz": {
+    "hash": "5f1a73ead736024ffb6c099f84e834ec927d2818c93d7c775d9ff625adaa7c51",
+    "load_kwargs": {},
+    "load_name": "snapshot_076_wi_gizver.hdf5",
+    "url": "https://yt-project.org/data/gizmo_zeldovich.tar.gz"
+  },
   "grs-50-cube.fits.gz": {
     "hash": "1aff152f616d2626c8515c1493e65f07843d9b5f2ba73b7e4271a2dc6a9e6da7",
     "load_kwargs": {},


### PR DESCRIPTION
I'd like to suggest two changes to the GIZMO frontend to fix what I believe is a potential bug and to handle updates to the hdf5 interface (this was mentioned on the Slack #help channel in December(?) but I no longer have access to that post and can't reference it). I'm starting with a draft because a) technically these are two separate issues and could go into two separate PR's, but the first is so minor it seemed unnecessary and b) I'm not sure I've resolved the 2nd issue in the proper yt fashion.

1. dmetal check - GIZMO runs with METALS flag enabled but without COOL_METAL_LINES_BY_SPECIES, GALSF_FB_FIRE_RPROCESS, GALSF_FB_FIRE_AGE_TRACERS, or STARFORGE_FEEDBACK_TRACERS enabled will have a per-particle metallicity field (loaded as dmetal) with shape `(NUM_PARTICLES, )`.  Thus, the `fh[dmetal].shape[1]` call will fail with an IndexError.  I've added a check to ensure `fh[dmetal]` is 2d first (`fh[dmetal].ndim>1`).

2. Overriding Gadget _parse_parameter_file - newer versions of GIZMO have changed some of the header fields (described uner Reading Snapshots in the GIZMO doc) used by yt for determining the cosmology of the simulation. I've copied this function from the Gadget/data_structures.py with modifications. Now it checks if the ComovingIntegrationOn flag exists - if so, use that to determine if this is a cosmological run and pull cosmological parameters using updated names. Otherwise, fall back to checking for OmegaLambda and setting cosmological flag from that. Copying the whole function seems overkill though, is there a better way to do this?

Creating tests for both bugs should be straightforward (I think they'd be similar to the `test_gizmo_64` test), but it doesn't look like the sample datasets are made with the newer GIZMO versions and I'm not sure how to provide any. I'll figure out the tests if that can get resolved. 

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
