### PR TITLE
BUG: unlock annotate_timestamp callback for polar and spherical geometries

### DIFF
--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -2473,7 +2473,13 @@ class TimestampCallback(PlotCallback):
     """
 
     _type_name = "timestamp"
-    _supported_geometries = ("cartesian", "spectral_cube", "cylindrical")
+    _supported_geometries = (
+        "cartesian",
+        "spectral_cube",
+        "cylindrical",
+        "polar",
+        "spherical",
+    )
 
     def __init__(
         self,

--- a/yt/visualization/tests/test_callbacks.py
+++ b/yt/visualization/tests/test_callbacks.py
@@ -141,7 +141,6 @@ def test_timestamp_callback():
     with _cleanup_fname() as prefix:
         ds = fake_amr_ds(fields=("density",), units=("g/cm**3",), geometry="spherical")
         p = ProjectionPlot(ds, "r", ("gas", "density"))
-        assert_raises(YTDataTypeUnsupported, p.annotate_timestamp, coord_system="data")
         p.annotate_timestamp(coord_system="axis")
         assert_fname(p.save(prefix)[0])
 


### PR DESCRIPTION
## PR Summary

This callback already works as intended with simple parametrization, I think it's worth unlocking now.

```python
import yt
from yt.testing import fake_amr_ds

ds = fake_amr_ds(geometry="spherical")
p = yt.SlicePlot(ds, "r", "Density")
p.annotate_timestamp(draw_inset_box=True)
p.save("/tmp/sph.png")
```
![sph](https://github.com/yt-project/yt/assets/14075922/0886c28b-597b-4629-8e45-d933cdb7654d)
