### PR TITLE
BUG: fix confusing formatting in log message when allocating <10k particles

### DIFF
--- a/yt/geometry/particle_geometry_handler.py
+++ b/yt/geometry/particle_geometry_handler.py
@@ -156,7 +156,7 @@ class ParticleIndex(Index):
         ds = self.dataset
         only_on_root(
             mylog.info,
-            "Allocating for %0.3e particles",
+            "Allocating for %0.4g particles",
             self.total_particles,
             global_rootonly=True,
         )


### PR DESCRIPTION
## PR Summary
see https://github.com/yt-project/yt/issues/3825#issuecomment-1050746232