### PR TITLE
[WIP] ENH: Cartesian fields in spherical geometry

### DIFF
--- a/yt/geometry/coordinates/spherical_coordinates.py
+++ b/yt/geometry/coordinates/spherical_coordinates.py
@@ -81,6 +81,53 @@ class SphericalCoordinateHandler(CoordinateHandler):
             units="code_length",
         )
 
+        self.setup_cartesian_fields(registry)
+
+    def setup_cartesian_fields(self, registry):
+        def _cartesian_x(field, data):
+            return (
+                data[("index", "r")]
+                * np.sin(data[("index", "theta")])
+                * np.cos(data[("index", "phi")])
+            )
+
+        def _cartesian_y(field, data):
+            return (
+                data[("index", "r")]
+                * np.sin(data[("index", "theta")])
+                * np.sin(data[("index", "phi")])
+            )
+
+        def _cartesian_z(field, data):
+            return data[("index", "r")] * np.cos(data[("index", "theta")])
+
+        registry.add_field(
+            ("index", "cartesian_x"),
+            sampling_type="local",
+            function=_cartesian_x,
+            units="code_length",
+            display_field=True,
+            take_log=False,
+        )
+
+        registry.add_field(
+            ("index", "cartesian_y"),
+            sampling_type="local",
+            function=_cartesian_y,
+            units="code_length",
+            display_field=True,
+            take_log=False,
+        )
+
+        registry.add_field(
+            ("index", "cartesian_z"),
+            sampling_type="local",
+            function=_cartesian_z,
+            units="code_length",
+            display_field=True,
+            take_log=False,
+        )
+
     def pixelize(
         self, dimension, data_source, field, bounds, size, antialias=True, periodic=True
     ):


### PR DESCRIPTION
## PR Summary

This adds some cartesian fields (`cartesian_x` etc) to the spherical coordinate handler.

Here is a script that plots what these look like:

```python
import yt
import yt.testing

ds = yt.testing.fake_amr_ds(geometry="spherical")

c = ds.domain_center

ds.r[c[0],:,:].plot("cartesian_x").set_log("all", False).save()
ds.r[c[0],:,:].plot("cartesian_y").set_log("all", False).save()
ds.r[c[0],:,:].plot("cartesian_z").set_log("all", False).save()

ds.r[:,c[1],:].plot("cartesian_x").set_log("all", False).save()
ds.r[:,c[1],:].plot("cartesian_y").set_log("all", False).save()
ds.r[:,c[1],:].plot("cartesian_z").set_log("all", False).save()

ds.r[:,:,c[2]].plot("cartesian_x").set_log("all", False).save()
ds.r[:,:,c[2]].plot("cartesian_y").set_log("all", False).save()
ds.r[:,:,c[2]].plot("cartesian_z").set_log("all", False).save()
```

The images that result (which I will attach momentarily to this PR) look correct, I *think*, except where the AMR regions interact.  In those areas, I'm much less certain, as it's *possible* that they are correct because we are doing cell-centering and the slicing cuts oddly, but I'm genuinely not sure because they do also look out of place.  It would be very helpful to have some other thoughts on that.
