### PR TITLE
BUG: fix internal divide-by-zero warnings

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -94,7 +94,6 @@ def pytest_configure(config):
         # to deal with in a reasonable time at the moment.
         "ignore:invalid value encountered in log10:RuntimeWarning",
         "ignore:divide by zero encountered in log10:RuntimeWarning",
-        "ignore:invalid value encountered in true_divide:RuntimeWarning",
         #
         # >>> there are many places in yt (most notably at the frontend level)
         # where we open files but never explicitly close them

--- a/conftest.py
+++ b/conftest.py
@@ -95,7 +95,6 @@ def pytest_configure(config):
         "ignore:invalid value encountered in log10:RuntimeWarning",
         "ignore:divide by zero encountered in log10:RuntimeWarning",
         "ignore:invalid value encountered in true_divide:RuntimeWarning",
-        "ignore:invalid value encountered in divide:RuntimeWarning",
         #
         # >>> there are many places in yt (most notably at the frontend level)
         # where we open files but never explicitly close them

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -1491,7 +1491,10 @@ def create_profile(
             if weight_field is None:
                 temp = temp.cumsum(axis=0)
             else:
-                temp = (temp * temp_weight).cumsum(axis=0) / temp_weight.cumsum(axis=0)
+                # avoid 0-division warnings by nan-masking
+                _denom = temp_weight.cumsum(axis=0)
+                _denom[_denom == 0.0] = np.nan
+                temp = (temp * temp_weight).cumsum(axis=0) / _denom
             if acc < 0:
                 temp = temp[::-1]
                 if weight_field is not None:

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1599,7 +1599,7 @@ class Dataset(abc.ABC):
                     "Inconsistent dimensionality in units_override. "
                     f"Received {key} = {uo[key]}"
                 ) from err
-            if 1 / uo[key].value == np.inf:
+            if uo[key].value == 0.0:
                 raise ValueError(
                     f"Invalid 0 normalisation factor in units_override for {key}."
                 )


### PR DESCRIPTION
## PR Summary

I am (perhaps naively) thinking this may be a low hanging fruit, let's see how many tests actually raise this warning and if they're fixable.