### PR TITLE
ENH: cleanup empty cache directory after a successful call to load_sample

### DIFF
--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -1516,6 +1516,7 @@ def load_sample(
         _download_sample_data_file,
         _get_test_data_dir_path,
         get_data_registry_table,
+        get_download_cache_dir,
     )
 
     pooch_logger = pooch.utils.get_logger()
@@ -1623,6 +1624,13 @@ def load_sample(
     loadable_path = Path.joinpath(save_dir, fn)
     if load_name not in str(loadable_path):
         loadable_path = loadable_path.joinpath(load_name, specific_file)
+
+    try:
+        # clean cache dir
+        get_download_cache_dir().rmdir()
+    except OSError:
+        # cache dir isn't empty
+        pass
 
     return load(loadable_path, **kwargs)
 

--- a/yt/sample_data/api.py
+++ b/yt/sample_data/api.py
@@ -5,13 +5,11 @@ import json
 import re
 import sys
 from functools import lru_cache
-from itertools import chain
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional
 from warnings import warn
 
 from yt.config import ytcfg
-from yt.funcs import mylog
 from yt.utilities.on_demand_imports import (
     _pandas as pd,
     _pooch as pooch,

--- a/yt/tests/test_load_sample.py
+++ b/yt/tests/test_load_sample.py
@@ -9,7 +9,10 @@ import pytest
 
 from yt.config import ytcfg
 from yt.loaders import load_sample
-from yt.sample_data.api import get_data_registry_table
+from yt.sample_data.api import (
+    get_data_registry_table,
+    get_download_cache_dir,
+)
 from yt.testing import requires_module_pytest
 from yt.utilities.logger import ytLogger
 
@@ -77,8 +80,12 @@ def capturable_logger(caplog):
 def test_load_sample_small_dataset(
     fn, archive, exact_loc, class_: str, tmp_data_dir, caplog
 ):
+    cache_path = get_download_cache_dir()
+    assert not cache_path.exists()
+
     ds = load_sample(fn, progressbar=False, timeout=30)
     assert type(ds).__name__ == class_
+    assert not cache_path.exists()
 
     text = textwrap.dedent(
         f"""


### PR DESCRIPTION
## PR Summary

Context: internally, `yt.load_sample` uses `pooch` to retrieve data from the hub server. Because data is obtained most often as compressed archives, we first download it to a temporary directory (`yt_download_cache`). This is an implementation detail that should not be directly visible to users.
This PR does two things:
- clean up the directory after it's served its purpose (this doesn't prevent pooch from re-creating it during the same session if needed)
- ~prepend a `.` to its name so its "hidden" in the conventional POSIX sense~