### PR TITLE
BUG: fix an issue where NormalPlot.sanitize_normal_vector would raise an error when receiving a numpy integer

### DIFF
--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -1398,7 +1398,7 @@ class NormalPlot:
                 )
             return normal
 
-        if isinstance(normal, int):
+        if isinstance(normal, (int, np.integer)):
             if normal not in (0, 1, 2):
                 raise ValueError(
                     f"{normal} is not a valid axis identifier. Expected either 0, 1, or 2."


### PR DESCRIPTION
## PR Summary

I encountered a crash while trying to use yt's CLI to plot a dataset. I'm not sure what conditions lead to `normal` being a numpy integer yet but this patch fixes my problem.
