### PR TITLE
BUG: Fix cm1 chunk reader

### DIFF
--- a/yt/frontends/nc4_cm1/io.py
+++ b/yt/frontends/nc4_cm1/io.py
@@ -43,10 +43,11 @@ class CM1IOHandler(BaseIOHandler):
         # np_array.swapaxes(0,2)).
 
         data = {}
-        offset = 0
+        chunks = list(chunks)
         with self._handle.open_ds() as ds:
             for field in fields:
                 data[field] = np.empty(size, dtype="float64")
+                offset = 0
                 for chunk in chunks:
                     for grid in chunk.objs:
                         variable = ds.variables[field[1]][:][0]


### PR DESCRIPTION
Fixes 4512.

We need to convert chunks to a list so we don't exhaust it the first time we iterate, and we also need to reset offset to 0 every loop over fields.
