### PR TITLE
TST: filter numpy 1.25 deprecation warnings triggered by other deps

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -172,14 +172,6 @@ def pytest_configure(config):
                 "ignore:`product` is deprecated as of NumPy 1.25.0"
                 ":DeprecationWarning",
             )
-        if find_spec("pandas") is not None and (
-            Version(version("pandas")) < Version("2.0.2")
-        ):
-            # https://github.com/pandas-dev/pandas/pull/53343
-            config.addinivalue_line(
-                "filterwarnings",
-                "ignore:np.find_common_type is deprecated.:DeprecationWarning",
-            )
 
     if find_spec("astropy") is not None:
         # at the time of writing, astropy's wheels are behind numpy's latest

--- a/conftest.py
+++ b/conftest.py
@@ -153,6 +153,34 @@ def pytest_configure(config):
             "ignore:invalid value encountered in less_equal:RuntimeWarning",
         )
 
+    if NUMPY_VERSION >= Version("1.25"):
+        if find_spec("cartopy") is not None and (
+            Version(version("cartopy")) <= Version("0.21.1")
+        ):
+            # https://github.com/SciTools/cartopy/pull/2194
+            config.addinivalue_line(
+                "filterwarnings",
+                "ignore:Conversion of an array with ndim > 0 to a scalar is deprecated"
+                ":DeprecationWarning",
+            )
+        if find_spec("h5py") is not None and (
+            Version(version("h5py")) < Version("3.9")
+        ):
+            # https://github.com/h5py/h5py/pull/2242
+            config.addinivalue_line(
+                "filterwarnings",
+                "ignore:`product` is deprecated as of NumPy 1.25.0"
+                ":DeprecationWarning",
+            )
+        if find_spec("pandas") is not None and (
+            Version(version("pandas")) < Version("2.0.2")
+        ):
+            # https://github.com/pandas-dev/pandas/pull/53343
+            config.addinivalue_line(
+                "filterwarnings",
+                "ignore:np.find_common_type is deprecated.:DeprecationWarning",
+            )
+
     if find_spec("astropy") is not None:
         # at the time of writing, astropy's wheels are behind numpy's latest
         # version but this doesn't cause actual problems in our test suite
@@ -167,7 +195,7 @@ def pytest_configure(config):
         )
 
     if find_spec("cartopy") is not None:
-        # this warning is triggered from cartopy 21.1
+        # this warning is triggered from cartopy 0.21.1
         # see https://github.com/SciTools/cartopy/issues/2113
         SHAPELY_VERSION = Version(version("shapely"))
         if SHAPELY_VERSION >= Version("2.0"):


### PR DESCRIPTION
## PR Summary

closes #4515

These filters *should* quickly become unneeded, as discussed in #4515 , but they should get CI working again in the mean time.

