### PR TITLE
PERF: delay rarely used imports (netcdf4, importlib, multiprocessing, tarfile, tomllib, tomli_w)

### DIFF
--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -30,11 +30,6 @@ from yt.utilities.exceptions import YTFieldNotFound, YTInvalidWidthError
 from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.on_demand_imports import _requests as requests
 
-if sys.version_info >= (3, 9):
-    import importlib.resources as importlib_resources
-else:
-    import importlib_resources
-
 # Some functions for handling sequences and other types
 
 
@@ -552,6 +547,10 @@ def get_git_version(path):
 
 
 def get_yt_version():
+    if sys.version_info >= (3, 9):
+        import importlib.resources as importlib_resources
+    else:
+        import importlib_resources
     version = get_git_version(os.path.dirname(importlib_resources.files("yt")))
     if version is None:
         return version
@@ -1003,6 +1002,10 @@ def matplotlib_style_context(style="yt.default", after_reset=False):
     """
     # FUTURE: this function should be deprecated in favour of matplotlib.style.context
     # after support for matplotlib 3.6 and older versions is dropped.
+    if sys.version_info >= (3, 9):
+        import importlib.resources as importlib_resources
+    else:
+        import importlib_resources
     import matplotlib as mpl
     import matplotlib.style
 

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -5,15 +5,11 @@ This module gathers all user-facing functions with a `load_` prefix.
 import atexit
 import os
 import sys
-import tarfile
 import time
 import types
 import warnings
-from importlib.metadata import entry_points
-from multiprocessing import Pipe, Process
-from multiprocessing.connection import Connection
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
 from urllib.parse import urlsplit
 
 import numpy as np
@@ -44,6 +40,8 @@ from yt.utilities.object_registries import (
 )
 from yt.utilities.on_demand_imports import _pooch as pooch, _ratarmount as ratarmount
 
+if TYPE_CHECKING:
+    from multiprocessing.connection import Connection
 # --- Loaders for known data formats ---
 
 
@@ -90,6 +88,8 @@ def load(
     yt.utilities.exceptions.YTAmbiguousDataType
         If the data format matches more than one class of similar specialization levels.
     """
+    from importlib.metadata import entry_points
+
     from yt.frontends import _all  # type: ignore [attr-defined] # noqa
 
     fn = os.path.expanduser(fn)
@@ -1506,6 +1506,7 @@ def load_sample(
     - Corresponding sample data live at https://yt-project.org/data
 
     """
+    import tarfile
 
     if fn is None:
         print(
@@ -1639,7 +1640,7 @@ def load_sample(
 
 
 def _mount_helper(
-    archive: str, mountPoint: str, ratarmount_kwa: Dict, conn: Connection
+    archive: str, mountPoint: str, ratarmount_kwa: Dict, conn: "Connection"
 ):
     try:
         fuseOperationsObject = ratarmount.TarMount(
@@ -1700,6 +1701,8 @@ def load_archive(
     - This function requires ratarmount to be installed.
     - This function does not work on Windows system.
     """
+    import tarfile
+    from multiprocessing import Pipe, Process
 
     warnings.warn(
         "The 'load_archive' function is still experimental and may be unstable.",

--- a/yt/sample_data/api.py
+++ b/yt/sample_data/api.py
@@ -16,10 +16,6 @@ from yt.utilities.on_demand_imports import (
     _requests as requests,
 )
 
-if sys.version_info >= (3, 9):
-    import importlib.resources as importlib_resources
-else:
-    import importlib_resources
 
 num_exp = re.compile(r"\d*(\.\d*)?")
 byte_unit_exp = re.compile(r"[KMGT]?B")
@@ -83,6 +79,11 @@ def _parse_byte_size(s: str):
 
 
 def _get_sample_data_registry():
+    if sys.version_info >= (3, 9):
+        import importlib.resources as importlib_resources
+    else:
+        import importlib_resources
+
     return json.loads(
         importlib_resources.files("yt")
         .joinpath("sample_data_registry.json")

--- a/yt/tests/test_external_frontends.py
+++ b/yt/tests/test_external_frontends.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 import sys
 
 import pytest
@@ -39,7 +40,7 @@ def mock_external_frontend(monkeypatch):
         else:
             return {"yt.frontends": [MockEntryPoint]}
 
-    monkeypatch.setattr(yt.loaders, "entry_points", mock_entry_points)
+    monkeypatch.setattr(importlib.metadata, "entry_points", mock_entry_points)
     assert "ExtDataset" not in output_type_registry
 
     yield

--- a/yt/utilities/command_line.py
+++ b/yt/utilities/command_line.py
@@ -26,11 +26,6 @@ from yt.utilities.exceptions import YTFieldNotParseable, YTUnidentifiedDataType
 from yt.utilities.metadata import get_metadata
 from yt.visualization.plot_window import ProjectionPlot, SlicePlot
 
-if sys.version_info >= (3, 9):
-    import importlib.resources as importlib_resources
-else:
-    import importlib_resources
-
 # isort: off
 # This needs to be set before importing startup_tasks
 ytcfg["yt", "internals", "command_line"] = True  # isort: skip
@@ -665,6 +660,10 @@ class YTInstInfoCmd(YTCommand):
         """
 
     def __call__(self, opts):
+        if sys.version_info >= (3, 9):
+            import importlib.resources as importlib_resources
+        else:
+            import importlib_resources
         path = os.path.dirname(importlib_resources.files("yt"))
         vstring = _print_installation_information(path)
         if vstring is not None:
@@ -1185,6 +1184,10 @@ class YTUpdateCmd(YTCommand):
         """
 
     def __call__(self, opts):
+        if sys.version_info >= (3, 9):
+            import importlib.resources as importlib_resources
+        else:
+            import importlib_resources
         path = os.path.dirname(importlib_resources.files("yt"))
         vstring = _print_installation_information(path)
         if vstring is not None:

--- a/yt/utilities/configure.py
+++ b/yt/utilities/configure.py
@@ -4,15 +4,9 @@ import warnings
 from pathlib import Path
 from typing import Callable, List
 
-import tomli_w
 from more_itertools import always_iterable
 
 from yt.utilities.configuration_tree import ConfigLeaf, ConfigNode
-
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    import tomli as tomllib
 
 configuration_callbacks: List[Callable[["YTConfig"], None]] = []
 
@@ -89,6 +83,10 @@ class YTConfig:
             if not os.path.exists(fname):
                 continue
             metadata = {"source": f"file: {fname}"}
+            if sys.version_info >= (3, 11):
+                import tomllib
+            else:
+                import tomli as tomllib
             try:
                 with open(fname, "rb") as fh:
                     data = tomllib.load(fh)
@@ -104,6 +102,8 @@ class YTConfig:
         return file_names_read
 
     def write(self, file_handler):
+        import tomli_w
+
         value = self.config_root.as_dict()
         config_as_str = tomli_w.dumps(value)
 

--- a/yt/utilities/on_demand_imports.py
+++ b/yt/utilities/on_demand_imports.py
@@ -294,6 +294,8 @@ class h5py_imports(OnDemand):
         # imported first, can get file lock errors on some systems (including travis-ci)
         # so we need to do this before initializing h5py_imports()!
         # similar to this issue https://github.com/pydata/xarray/issues/2560
+        if find_spec("h5py") is None or find_spec("netCDF4") is None:
+            return
         try:
             import netCDF4  # noqa F401
         except ImportError:

--- a/yt/utilities/parameter_file_storage.py
+++ b/yt/utilities/parameter_file_storage.py
@@ -1,4 +1,3 @@
-import csv
 import os.path
 from itertools import islice
 
@@ -170,6 +169,8 @@ class ParameterFileStore:
 
     @parallel_simple_proxy
     def _write_out(self):
+        import csv
+
         if self._read_only:
             return
         fn = self._get_db_name()
@@ -187,6 +188,8 @@ class ParameterFileStore:
     @parallel_simple_proxy
     def read_db(self):
         """This will read the storage device from disk."""
+        import csv
+
         f = open(self._get_db_name())
         vals = csv.DictReader(f, _field_names)
         db = {}

--- a/yt/visualization/_commons.py
+++ b/yt/visualization/_commons.py
@@ -10,11 +10,6 @@ from more_itertools import always_iterable
 
 from yt.config import ytcfg
 
-if sys.version_info >= (3, 9):
-    import importlib.resources as importlib_resources
-else:
-    import importlib_resources
-
 if sys.version_info >= (3, 10):
     pass
 else:
@@ -24,14 +19,26 @@ if TYPE_CHECKING:
     from matplotlib.backend_bases import FigureCanvasBase
 
 
-_yt_style = mpl.rc_params_from_file(
-    importlib_resources.files("yt") / "default.mplstyle", use_default_template=False
-)
-DEFAULT_FONT_PROPERTIES = {
-    "family": _yt_style["font.family"][0],
-    "math_fontfamily": _yt_style["mathtext.fontset"],
-}
-del _yt_style
+_DEFAULT_FONT_PROPERTIES = None
+
+
+def get_default_font_properties():
+    global _DEFAULT_FONT_PROPERTIES
+    if _DEFAULT_FONT_PROPERTIES is None:
+        if sys.version_info >= (3, 9):
+            import importlib.resources as importlib_resources
+        else:
+            import importlib_resources
+        _yt_style = mpl.rc_params_from_file(
+            importlib_resources.files("yt") / "default.mplstyle",
+            use_default_template=False,
+        )
+        _DEFAULT_FONT_PROPERTIES = {
+            "family": _yt_style["font.family"][0],
+            "math_fontfamily": _yt_style["mathtext.fontset"],
+        }
+
+    return _DEFAULT_FONT_PROPERTIES
 
 
 def _get_supported_image_file_formats():

--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -10,7 +10,6 @@ from typing import Any, Dict, Final, List, Literal, Optional, Tuple, Type, Union
 
 import matplotlib
 from matplotlib.colors import LogNorm, Normalize, SymLogNorm
-from matplotlib.font_manager import FontProperties
 from unyt.dimensions import length
 
 from yt._maintenance.deprecation import issue_deprecation_warning
@@ -26,8 +25,8 @@ from yt.visualization._handlers import ColorbarHandler, NormHandler
 from yt.visualization.base_plot_types import PlotMPL
 
 from ._commons import (
-    DEFAULT_FONT_PROPERTIES,
     _get_units_label,
+    get_default_font_properties,
     invalidate_data,
     invalidate_figure,
     invalidate_plot,
@@ -123,6 +122,8 @@ class PlotContainer(abc.ABC):
     _default_font_size = 14.0
 
     def __init__(self, data_source, figure_size=None, fontsize: Optional[float] = None):
+        from matplotlib.font_manager import FontProperties
+
         self.data_source = data_source
         self.ds = data_source.ds
         self.ts = self._initialize_dataset(self.ds)
@@ -133,9 +134,9 @@ class PlotContainer(abc.ABC):
         if fontsize is None:
             fontsize = self.__class__._default_font_size
         if sys.version_info >= (3, 9):
-            font_dict = DEFAULT_FONT_PROPERTIES | {"size": fontsize}
+            font_dict = get_default_font_properties() | {"size": fontsize}
         else:
-            font_dict = {**DEFAULT_FONT_PROPERTIES, "size": fontsize}
+            font_dict = {**get_default_font_properties(), "size": fontsize}
 
         self._font_properties = FontProperties(**font_dict)
         self._font_color = None
@@ -448,6 +449,7 @@ class PlotContainer(abc.ABC):
         ... )
 
         """
+        from matplotlib.font_manager import FontProperties
 
         if font_dict is None:
             font_dict = {}
@@ -457,9 +459,9 @@ class PlotContainer(abc.ABC):
         # this prevents reverting to the matplotlib defaults.
         _default_size = {"size": self.__class__._default_font_size}
         if sys.version_info >= (3, 9):
-            font_dict = DEFAULT_FONT_PROPERTIES | _default_size | font_dict
+            font_dict = get_default_font_properties() | _default_size | font_dict
         else:
-            font_dict = {**DEFAULT_FONT_PROPERTIES, **_default_size, **font_dict}
+            font_dict = {**get_default_font_properties(), **_default_size, **font_dict}
         self._font_properties = FontProperties(**font_dict)
         return self
 


### PR DESCRIPTION
## PR Summary

- `import netCDF4` is responsible for ~6% startup overhead, let's delay it when we can afford it.

- `import importlib.metadata` is about ~3% (we still need to import it to determine matplotlib's version at runtime, which we'll be able to avoid [when support for mpl<3.5 is dropped](https://github.com/yt-project/yt/issues/4379))

- multiprocessing, tarfile, tomllib, tomli_w are (collectively) about ~1%

nothing life-changing here but every % counts (yt's CLI still takes a couple seconds to do *anything*).

