### PR TITLE
PERF: Use grid tree for counting grid cell inclusion

### DIFF
--- a/yt/geometry/grid_geometry_handler.py
+++ b/yt/geometry/grid_geometry_handler.py
@@ -1,6 +1,7 @@
 import abc
 import weakref
 from collections import defaultdict
+from functools import cached_property
 from typing import Optional, Tuple
 
 import numpy as np
@@ -287,12 +288,12 @@ class GridIndex(Index, abc.ABC):
         if not len(x) == len(y) == len(z):
             raise ValueError("Arrays of indices must be of the same size")
 
-        grid_tree = self._get_grid_tree()
-        pts = MatchPointsToGrids(grid_tree, len(x), x, y, z)
+        pts = MatchPointsToGrids(self.grid_tree, len(x), x, y, z)
         ind = pts.find_points_in_tree()
         return self.grids[ind], ind
 
-    def _get_grid_tree(self):
+    @cached_property
+    def grid_tree(self):
         left_edge = self.ds.arr(np.zeros((self.num_grids, 3)), "code_length")
         right_edge = self.ds.arr(np.zeros((self.num_grids, 3)), "code_length")
         level = np.zeros((self.num_grids), dtype="int64")
@@ -345,7 +346,7 @@ class GridIndex(Index, abc.ABC):
         # if dobj._type_name != "grid":
         #    fast_index = self._get_grid_tree()
         if getattr(dobj, "size", None) is None:
-            dobj.size = self._count_selection(dobj, fast_index=fast_index)
+            dobj.size = self._count_selection(dobj, fast_index=self.grid_tree)
         if getattr(dobj, "shape", None) is None:
             dobj.shape = (dobj.size,)
         dobj._current_chunk = list(

--- a/yt/geometry/tests/test_grid_container.py
+++ b/yt/geometry/tests/test_grid_container.py
@@ -58,7 +58,7 @@ def setup_test_ds():
 def test_grid_tree():
     """Main test suite for GridTree"""
     test_ds = setup_test_ds()
-    grid_tree = test_ds.index._get_grid_tree()
+    grid_tree = test_ds.index.grid_tree
     indices, levels, nchild, children = grid_tree.return_tree_info()
 
     grid_levels = [grid.Level for grid in test_ds.index.grids]
@@ -136,7 +136,7 @@ def test_find_points():
 
 def test_grid_arrays_view():
     ds = setup_test_ds()
-    tree = ds.index._get_grid_tree()
+    tree = ds.index.grid_tree
     grid_arr = tree.grid_arrays
     assert_equal(grid_arr["left_edge"], ds.index.grid_left_edge)
     assert_equal(grid_arr["right_edge"], ds.index.grid_right_edge)


### PR DESCRIPTION
Instead of using the grid objects, by default let's use the grid tree to count the number of cells included in a data object.

This is an independent PR, and may have test failures that can be corrected within this PR.  It's independent of #4525, but related.
