### PR TITLE
PERF: Use bitarray to count grid cells

### DIFF
--- a/yt/geometry/grid_container.pyx
+++ b/yt/geometry/grid_container.pyx
@@ -204,11 +204,7 @@ cdef class GridTree:
         data.array = <void*>mask.buf
         self.visit_grids(&data, grid_visitors.mask_cells, selector)
         self.mask = mask
-        size = 0
-        self.setup_data(&data)
-        data.array = <void*>(&size)
-        self.visit_grids(&data,  grid_visitors.count_cells, selector)
-        return size
+        return mask.count()
 
     def select_icoords(self, SelectorObject selector, np.uint64_t size = -1):
         # Fill icoords with a selector


### PR DESCRIPTION
This requires #4525, and when used in combination with #4529 will result in using faster code paths for counting the number of cells included in a selector for patch grid datasets.

The place this could particularly result in selection-based speedups would be in ghost zone identification.
