### PR TITLE
BUG: fix a regression preventing loading of fits datasets

### DIFF
--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -426,9 +426,16 @@ class FITSDataset(Dataset):
         self.magnetic_unit.convert_to_units("gauss")
         self.velocity_unit = self.length_unit / self.time_unit
 
+    @property
+    def filename(self) -> str:
+        if self._input_filename.startswith("InMemory"):
+            return self._input_filename
+        else:
+            return super().filename
+
     @cached_property
     def unique_identifier(self) -> str:
-        if self.parameter_filename.startswith("InMemory"):
+        if self.filename.startswith("InMemory"):
             return str(time.time())
         else:
             return super().unique_identifier


### PR DESCRIPTION
closes #4532 (regression from #3772)

Explanation: #3772 made a change to `ds.parameter_filename` causing it to always be a "resolved path", which in the case of in-memory fits dataset makes no sense, and breaks `FitsDataset.unique_identifier`.
