### PR TITLE
BUG: fix a regression preventing loading of pyne/moab datasets

### DIFF
--- a/yt/frontends/moab/data_structures.py
+++ b/yt/frontends/moab/data_structures.py
@@ -133,7 +133,9 @@ class PyneMeshHex8Hierarchy(UnstructuredIndex):
                 )
             )
         vind = np.asarray(vind, dtype=np.int64)
-        vind = vind.reshape(len(vind) // 8, 8)
+        if vind.ndim == 1:
+            vind = vind.reshape(len(vind) // 8, 8)
+        assert vind.ndim == 2 and vind.shape[1] == 8
         self.meshes = [PyneHex8Mesh(0, self.index_filename, vind, coords, self)]
 
     def _detect_output_fields(self):

--- a/yt/frontends/moab/data_structures.py
+++ b/yt/frontends/moab/data_structures.py
@@ -1,5 +1,6 @@
 import os
 import weakref
+from functools import cached_property
 
 import numpy as np
 
@@ -167,6 +168,14 @@ class PyneMoabHex8Dataset(Dataset):
             unit_system=unit_system,
         )
         self.storage_filename = storage_filename
+
+    @property
+    def filename(self) -> str:
+        return self._input_filename
+
+    @cached_property
+    def unique_identifier(self) -> str:
+        return self.filename
 
     def _set_code_unit_attributes(self):
         # Almost everything is regarded as dimensionless in MOAB, so these will


### PR DESCRIPTION
## PR Summary

This fixes a couple issues with *loading* in-memory PyNE datasets, discussed in #4535 (one regression from #3772, and one compatibility issue).

At the time I'm opening this, it doesn't resolve *all* integration issues we're seeing with PyNE (`SlicePlot` is still broken), but it is possible that remaining problems should be resolved in PyNE rather than yt.

