### PR TITLE
RFC: avoid double-copies of cmyt colormaps

### DIFF
--- a/yt/visualization/color_maps.py
+++ b/yt/visualization/color_maps.py
@@ -48,7 +48,8 @@ def register_yt_colormaps_from_cmyt():
     """
 
     for hist_name, alias in _HISTORICAL_ALIASES.items():
-        cmap = mpl.colormaps[alias].copy()
+        # note that mpl.colormaps.__getitem__ returns *copies*
+        cmap = mpl.colormaps[alias]
         cmap.name = hist_name
         mpl.colormaps.register(cmap)
         mpl.colormaps.register(cmap.reversed())


### PR DESCRIPTION
## PR Summary

Taking only the objectively-better part of #4538