### PR TITLE
enh: store basic software info in png metadata

### DIFF
--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -564,6 +564,7 @@ def get_yt_version():
 
 def get_version_stack():
     import matplotlib
+
     from yt._version import __version__ as yt_version
 
     version_info = {}

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -24,7 +24,6 @@ import numpy as np
 from more_itertools import always_iterable, collapse, first
 
 from yt._maintenance.deprecation import issue_deprecation_warning
-from yt._version import __version__ as yt_version
 from yt.config import ytcfg
 from yt.units import YTArray, YTQuantity
 from yt.utilities.exceptions import YTFieldNotFound, YTInvalidWidthError
@@ -565,6 +564,7 @@ def get_yt_version():
 
 def get_version_stack():
     import matplotlib
+    from yt._version import __version__ as yt_version
 
     version_info = {}
     version_info["yt"] = yt_version
@@ -1450,7 +1450,7 @@ def validate_moment(moment, weight_field):
         )
 
 
-def setdefault_mpl_metadata(mpl_kwargs: Dict[str, Any], name: str) -> None:
+def setdefault_mpl_metadata(save_kwargs: Dict[str, Any], name: str) -> None:
     """
     Set a default Software metadata entry for use with Matplotlib outputs.
     """
@@ -1463,10 +1463,9 @@ def setdefault_mpl_metadata(mpl_kwargs: Dict[str, Any], name: str) -> None:
         return
     default_software = (
         "Matplotlib version{matplotlib}, https://matplotlib.org|NumPy-{numpy}|yt-{yt}"
-    )
-    if "metadata" in mpl_kwargs:
-        mpl_kwargs["metadata"].setdefault(
-            key, default_software.format(**get_version_stack())
-        )
+    ).format(**get_version_stack())
+
+    if "metadata" in save_kwargs:
+        save_kwargs["metadata"].setdefault(key, default_software)
     else:
-        mpl_kwargs["metadata"] = {key: default_software.format(**get_version_stack())}
+        save_kwargs["metadata"] = {key: default_software}

--- a/yt/utilities/png_writer.py
+++ b/yt/utilities/png_writer.py
@@ -9,7 +9,7 @@ from .._version import __version__ as yt_version
 
 def call_png_write_png(buffer, fileobj, dpi):
     metadata = PngInfo()
-    metadata.add_text("Software", f"{PIL.__name__}-{PIL.__version__}|yt-{yt_version}")
+    metadata.add_text("Software", f"PIL-{PIL.__version__}|yt-{yt_version}")
     Image.fromarray(buffer).save(
         fileobj, dpi=(dpi, dpi), format="png", pnginfo=metadata
     )

--- a/yt/utilities/png_writer.py
+++ b/yt/utilities/png_writer.py
@@ -1,10 +1,18 @@
 from io import BytesIO
 
+import PIL
 from PIL import Image
+from PIL.PngImagePlugin import PngInfo
+
+from .._version import __version__ as yt_version
 
 
 def call_png_write_png(buffer, fileobj, dpi):
-    Image.fromarray(buffer).save(fileobj, dpi=(dpi, dpi), format="png")
+    metadata = PngInfo()
+    metadata.add_text("Software", f"{PIL.__name__}-{PIL.__version__}|yt-{yt_version}")
+    Image.fromarray(buffer).save(
+        fileobj, dpi=(dpi, dpi), format="png", pnginfo=metadata
+    )
 
 
 def write_png(buffer, filename, dpi=100):

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -8,7 +8,13 @@ import matplotlib
 import numpy as np
 from matplotlib.ticker import LogFormatterMathtext
 
-from yt.funcs import get_interactivity, is_sequence, matplotlib_style_context, mylog
+from yt.funcs import (
+    get_interactivity,
+    is_sequence,
+    matplotlib_style_context,
+    mylog,
+    setdefault_mpl_metadata,
+)
 from yt.visualization._handlers import ColorbarHandler, NormHandler
 
 from ._commons import (
@@ -162,6 +168,7 @@ class PlotMPL:
             mpl_kwargs = {}
 
         name = validate_image_name(name)
+        setdefault_mpl_metadata(mpl_kwargs, name)
 
         try:
             canvas = get_canvas(self.figure, name)

--- a/yt/visualization/tests/test_save.py
+++ b/yt/visualization/tests/test_save.py
@@ -2,6 +2,7 @@ import os
 import re
 
 import pytest
+from PIL import Image
 
 import yt
 from yt.testing import fake_amr_ds
@@ -21,6 +22,16 @@ def test_save_to_path(simple_sliceplot, tmp_path):
     p = simple_sliceplot
     p.save(f"{tmp_path}/")
     assert len(list((tmp_path).glob("*.png"))) == 1
+
+
+def test_metadata(simple_sliceplot, tmp_path):
+    simple_sliceplot.save(tmp_path / "ala.png")
+    with Image.open(tmp_path / "ala.png") as img:
+        assert "Software" in img.info
+        assert "yt-" in img.info["Software"]
+    simple_sliceplot.save(tmp_path / "ala.pdf")
+    with open(tmp_path / "ala.pdf", "rb") as f:
+        assert b"|yt-" in f.read()
 
 
 def test_save_to_missing_path(simple_sliceplot, tmp_path):


### PR DESCRIPTION
## PR Summary

Store information about used software (yt, matplotlib, numpy, PIL) in metadata of generated plots.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

## How to test?
1. Generate simple SlicePlot, ProjectionPlot, off-axis projection / VR png.
2. Use e.g. ImageMagick to inspect resuting pngs:
```
$ identify -verbose galaxy0030_offaxis_projection.png | grep Software
    Software: PIL-9.5.0|yt-4.3.dev0
$ identify -verbose *.png | grep Software
    Software: Matplotlib version3.7.1, https://matplotlib.org|NumPy-1.24.2|yt-4.3.dev0
```
