### PR TITLE
option to include min/max limits on the color field for export_sketchfab

### DIFF
--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -2495,10 +2495,12 @@ class YTSurface(YTSelectionContainer3D):
             color_log,
             sample_type,
             color_field_max=color_field_max,
-            color_field_min=color_field_min
+            color_field_min=color_field_min,
         )
 
-    def _color_samples(self, cs, color_log, color_map, color_field_max, color_field_min, arr):
+    def _color_samples(
+        self, cs, color_log, color_map, color_field_max, color_field_min, arr
+    ):
         if color_log:
             cs = np.log10(cs)
         if color_field_min is None:
@@ -2587,7 +2589,9 @@ class YTSurface(YTSelectionContainer3D):
             f.write(b"property uchar blue\n")
             v = np.empty(self.vertices.shape[1], dtype=vs)
             cs = self.vertex_samples[color_field]
-            self._color_samples(cs, color_log, color_map, color_field_max, color_field_min, v)
+            self._color_samples(
+                cs, color_log, color_map, color_field_max, color_field_min, v
+            )
         else:
             v = np.empty(self.vertices.shape[1], dtype=vs[:3])
         line = "element face %i\n" % (nv / 3)
@@ -2600,7 +2604,9 @@ class YTSurface(YTSelectionContainer3D):
             # Now we get our samples
             cs = self[color_field]
             arr = np.empty(cs.shape[0], dtype=np.dtype(fs))
-            self._color_samples(cs, color_log, color_map, color_field_max, color_field_min, arr)
+            self._color_samples(
+                cs, color_log, color_map, color_field_max, color_field_min, arr
+            )
         else:
             arr = np.empty(nv // 3, np.dtype(fs[:-3]))
         for i, ax in enumerate("xyz"):

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -2499,7 +2499,14 @@ class YTSurface(YTSelectionContainer3D):
         )
 
     def _color_samples(
-        self, cs, color_log, color_map, color_field_max, color_field_min, arr
+        self,
+        cs,
+        color_log,
+        color_map,
+        arr,
+        *,
+        color_field_max=None,
+        color_field_min=None,
     ):
         if color_log:
             cs = np.log10(cs)
@@ -2590,7 +2597,12 @@ class YTSurface(YTSelectionContainer3D):
             v = np.empty(self.vertices.shape[1], dtype=vs)
             cs = self.vertex_samples[color_field]
             self._color_samples(
-                cs, color_log, color_map, color_field_max, color_field_min, v
+                cs,
+                color_log,
+                color_map,
+                v,
+                color_field_max=color_field_max,
+                color_field_min=color_field_min,
             )
         else:
             v = np.empty(self.vertices.shape[1], dtype=vs[:3])
@@ -2605,7 +2617,12 @@ class YTSurface(YTSelectionContainer3D):
             cs = self[color_field]
             arr = np.empty(cs.shape[0], dtype=np.dtype(fs))
             self._color_samples(
-                cs, color_log, color_map, color_field_max, color_field_min, arr
+                cs,
+                color_log,
+                color_map,
+                arr,
+                color_field_max=color_field_max,
+                color_field_min=color_field_min,
             )
         else:
             arr = np.empty(nv // 3, np.dtype(fs[:-3]))

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -2437,10 +2437,11 @@ class YTSurface(YTSelectionContainer3D):
         color_field=None,
         color_map=None,
         color_log=True,
-        color_field_max=None,
-        color_field_min=None,
         sample_type="face",
         no_ghost=False,
+        *,
+        color_field_max=None,
+        color_field_min=None,
     ):
         r"""This exports the surface to the PLY format, suitable for visualization
         in many different programs (e.g., MeshLab).
@@ -2492,9 +2493,9 @@ class YTSurface(YTSelectionContainer3D):
             color_field,
             color_map,
             color_log,
+            sample_type,
             color_field_max,
-            color_field_min,
-            sample_type
+            color_field_min
         )
 
     def _color_samples(self, cs, color_log, color_map, color_field_max, color_field_min, arr):
@@ -2532,9 +2533,10 @@ class YTSurface(YTSelectionContainer3D):
         color_field=None,
         color_map=None,
         color_log=True,
+        sample_type="face",
+        *,
         color_field_max=None,
         color_field_min=None,
-        sample_type="face",
     ):
         if color_map is None:
             color_map = ytcfg.get("yt", "default_colormap")
@@ -2629,10 +2631,11 @@ class YTSurface(YTSelectionContainer3D):
         color_field=None,
         color_map=None,
         color_log=True,
-        color_field_max=None,
-        color_field_min=None,
         bounds=None,
         no_ghost=False,
+        *,
+        color_field_max=None,
+        color_field_min=None,
     ):
         r"""This exports Surfaces to SketchFab.com, where they can be viewed
         interactively in a web browser.
@@ -2661,13 +2664,13 @@ class YTSurface(YTSelectionContainer3D):
             The name of the color map to use to map the color field
         color_log : bool
             Should the field be logged before being mapped to RGB?
+        bounds : list of tuples
+            [ (xmin, xmax), (ymin, ymax), (zmin, zmax) ] within which the model
+            will be scaled and centered.  Defaults to the full domain.
         color_field_max : float
             Maximum value of the color field across all surfaces.
         color_field_min : float
             Minimum value of the color field across all surfaces.
-        bounds : list of tuples
-            [ (xmin, xmax), (ymin, ymax), (zmin, zmax) ] within which the model
-            will be scaled and centered.  Defaults to the full domain.
 
         Returns
         -------
@@ -2709,10 +2712,10 @@ class YTSurface(YTSelectionContainer3D):
             color_field,
             color_map,
             color_log,
-            color_field_max,
-            color_field_min,
             sample_type="vertex",
             no_ghost=no_ghost,
+            color_field_max,
+            color_field_min,
         )
         ply_file.seek(0)
         # Greater than ten million vertices and we throw an error but dump

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -2516,7 +2516,7 @@ class YTSurface(YTSelectionContainer3D):
             ma = color_field_max
             if color_log:
                 ma = np.log10(ma)
-         cs = (cs - mi) / (ma - mi)
+        cs = (cs - mi) / (ma - mi)
         from yt.visualization.image_writer import map_to_colors
 
         cs = map_to_colors(cs, color_map)

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -2494,8 +2494,8 @@ class YTSurface(YTSelectionContainer3D):
             color_map,
             color_log,
             sample_type,
-            color_field_max,
-            color_field_min
+            color_field_max=color_field_max,
+            color_field_min=color_field_min
         )
 
     def _color_samples(self, cs, color_log, color_map, color_field_max, color_field_min, arr):
@@ -2714,8 +2714,8 @@ class YTSurface(YTSelectionContainer3D):
             color_log,
             sample_type="vertex",
             no_ghost=no_ghost,
-            color_field_max,
-            color_field_min,
+            color_field_max=color_field_max,
+            color_field_min=color_field_min,
         )
         ply_file.seek(0)
         # Greater than ten million vertices and we throw an error but dump

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -2508,19 +2508,16 @@ class YTSurface(YTSelectionContainer3D):
         color_field_max=None,
         color_field_min=None,
     ):
+        cs = np.asarray(cs)
         if color_log:
             cs = np.log10(cs)
         if color_field_min is None:
-            cs = [float(field) for field in cs]
-            cs = np.array(cs)
             mi = cs.min()
         else:
             mi = color_field_min
             if color_log:
                 mi = np.log10(mi)
         if color_field_max is None:
-            cs = [float(field) for field in cs]
-            cs = np.array(cs)
             ma = cs.max()
         else:
             ma = color_field_max


### PR DESCRIPTION
## PR Summary

For exporting surfaces to 3D objects there are a few options, for example `export_blender` and `export_sketchfab.`  `export_sketchfab` does not include the ability to limit the range of the color field (`export_blender` does).  This PR brings that functionality to `export_sketchfab` through optional arguments.

## PR Checklist

- [ x ] New features are documented, with docstrings and narrative docs
