### PR TITLE
TST: switch future-dependencies tests from daily to weekly frequency, add auto-reporting in case of failure

### DIFF
--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -15,8 +15,8 @@ on:
     paths:
       - .github/workflows/bleeding-edge.yaml
   schedule:
-    # run this every day at 3 am UTC
-    - cron: '0 3 * * *'
+    # run this every Wednesday at 3 am UTC
+    - cron: 0 3 * * 3
   workflow_dispatch:
 
 jobs:
@@ -67,3 +67,25 @@ jobs:
       run: |
         yt config set --local yt log_level 50  # Disable excessive output
         pytest -vvv --color=yes
+
+  create-issue:
+    if: ${{ failure() && github.event_name == 'schedule' }}
+    needs: [build]
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    name: Create issue on failure
+
+    steps:
+    - name: Create issue on failure
+      uses: imjohnbo/issue-bot@v3
+      with:
+        title: 'TST: Upcoming dependency test failures'
+        body: |
+          The weekly build with future dependencies has failed. Check the logs
+          https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
+        labels: 'tests: running tests,'
+        pinned: false
+        close-previous: false
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## PR Summary

Automate reporting of failures in scheduled tests with future dependencies, also reduce their frequency from daily to weekly. This technique is taken from matplotlib. As a test, I deployed it in a personal repo and found that it worked without any further configuration.

closes #3731 