### PR TITLE
Fix fake_dataset periodicity attribute in FieldDetector

### DIFF
--- a/yt/fields/field_detector.py
+++ b/yt/fields/field_detector.py
@@ -63,7 +63,7 @@ class FieldDetector(defaultdict):
             ds.domain_left_edge = np.zeros(3, "float64")
             ds.domain_right_edge = np.ones(3, "float64")
             ds.dimensionality = 3
-            ds.force_periodicity()
+            ds.periodicity = (True, True, True)
         self.ds = ds
 
         class fake_index:


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

The `FieldDetector` class mocks up a fake dataset from a `defaultdict` if a dataset is not passed. It has to attach a number of basic yt attributes to this `fake_dataset` class, but at the end it tries to use the `force_periodicity` method, which of course exists on the `Dataset` class but not here. I'm just setting the periodicity here by hand, which is the previous behavior and should never have been changed here. 

I ran into this bug on accident--not sure if it affects anything, but this is the right fix for now until we do something better.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
