### PR TITLE
DEP: set upper limit to runtime numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,8 @@ dependencies = [
     "ipywidgets>=8.0.0",
     "matplotlib>=3.5", # keep in sync with tests/windows_conda_requirements.txt
     "more-itertools>=8.4",
-    "numpy>=1.17.5",
+    # https://github.com/scipy/oldest-supported-numpy/issues/76#issuecomment-1628865694
+    "numpy>=1.17.5,<2.0",
     "packaging>=20.9",
     "pillow>=6.2.1", # transitive dependency via MPL (>=3.3)
     "tomli-w>=0.4.0",


### PR DESCRIPTION
## PR Summary

Following recommendations from numpy and oldest-supported-numpy devs
https://github.com/scipy/oldest-supported-numpy/issues/76#issuecomment-1628684683
