### PR TITLE
TST: fix fortran IO test for big-endian architectures

### DIFF
--- a/yt/utilities/tests/test_cython_fortran_utils.py
+++ b/yt/utilities/tests/test_cython_fortran_utils.py
@@ -1,3 +1,5 @@
+import struct
+
 import numpy as np
 import pytest
 
@@ -12,9 +14,11 @@ def test_raise_error_when_file_does_not_exist():
 def test_read(tmp_path):
     dummy_file = tmp_path / "test.bin"
     # Write a Fortran-formatted file containing one record with 4 doubles
-    dummy_file.write_bytes(
-        b" \x00\x00\x00\x00\x00\x00\x00\x00\x00\xf0?\x00\x00\x00\x00\x00\x00\x00@\x00\x00\x00\x00\x00\x00\x08@\x00\x00\x00\x00\x00\x00\x10@ \x00\x00\x00"
-    )
+    # The format is a 32bit integer with value 4*sizeof(double)=32
+    # followed by 4 doubles and another 32bit integer with value 32
+    # Note that there is no memory alignment, hence the "=" below
+    buff = struct.pack("=i 4d i", 32, 1.0, 2.0, 3.0, 4.0, 32)
+    dummy_file.write_bytes(buff)
     with FortranFile(str(dummy_file)) as f:
         np.testing.assert_equal(
             f.read_vector("d"),


### PR DESCRIPTION
closes #4569
patch by @cphyc 