### PR TITLE
ytdata: check for `all_data` in particle selection

### DIFF
--- a/yt/frontends/ytdata/io.py
+++ b/yt/frontends/ytdata/io.py
@@ -228,7 +228,7 @@ class IOHandlerYTDataContainerHDF5(BaseIOHandler):
                         continue
 
                 for field in field_list:
-                    data = f[ptype][field][mask].astype("float64")
+                    data = f[ptype][field][mask].astype("float64", copy=False)
                     data_return[(ptype, field)] = data
 
         return data_return

--- a/yt/frontends/ytdata/io.py
+++ b/yt/frontends/ytdata/io.py
@@ -209,16 +209,14 @@ class IOHandlerYTDataContainerHDF5(BaseIOHandler):
                     )
                     yield ptype, (x, y, z), 0.0
 
-    def _read_particle_fields(self, chunks, ptf, selector):
-        # Now we have all the sizes, and we can allocate
-        chunks = list(chunks)
-        data_files = set()
-        for chunk in chunks:
-            for obj in chunk.objs:
-                data_files.update(obj.data_files)
-        for data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
-            with h5py.File(data_file.filename, mode="r") as f:
-                for ptype, field_list in sorted(ptf.items()):
+    def _read_particle_data_file(self, data_file, ptf, selector):
+        data_return = {}
+
+        with h5py.File(data_file.filename, mode="r") as f:
+            for ptype, field_list in sorted(ptf.items()):
+                if selector is None or getattr(selector, "is_all_data", False):
+                    mask = slice(None, None, None)
+                else:
                     units = _get_position_array_units(ptype, f, "x")
                     x, y, z = (
                         self.ds.arr(_get_position_array(ptype, f, ax), units)
@@ -228,9 +226,12 @@ class IOHandlerYTDataContainerHDF5(BaseIOHandler):
                     del x, y, z
                     if mask is None:
                         continue
-                    for field in field_list:
-                        data = f[ptype][field][mask].astype("float64")
-                        yield (ptype, field), data
+
+                for field in field_list:
+                    data = f[ptype][field][mask].astype("float64")
+                    data_return[(ptype, field)] = data
+
+        return data_return
 
     def _count_particles(self, data_file):
         si, ei = data_file.start, data_file.end


### PR DESCRIPTION
The main change in this PR is to avoid unnecessarily building a mask for particle selection when the selector is `all_data()`. This cuts down the load time **significantly** for particle counts in the range of 1e6+  (and probably lower, but I only tested above 1e6)

### testing this PR 

To test out this PR, I built some test particle datasets with 1e6 to 1e7 particles:

```python
import yt
from yt.testing import fake_particle_ds

def create_tst_data_on_disk(nparticles):
    nparticles = int(nparticles)
    ds = fake_particle_ds(npart=nparticles)
    ad = ds.all_data()
    fn = f"test_data_{nparticles}"
    ad.save_as_dataset(fn, fields = ds.field_list)
    return fn + ".h5"

fn = create_tst_data_on_disk(1e7)  # repeat for other particle counts...
```

and then reloaded each 

```python
ds = yt.load(fn)
ds.field_list
ds.index
```

and timed the following:

```python
ad = ds.all_data()
_ = ad['all', 'particle_velocity_x']
```

here's a plot

![image](https://github.com/yt-project/yt/assets/22038879/9d0e4da5-5ac6-40a6-a224-199c065e86db)

the dashed lines are +/-2*sigma on this PR's branch, didn't calculate for main cause it was too slow... so quite a significant speedup. 

### other changes

I also slightly refactored the particle selection to override `_read_particle_data_file` rather than `_read_particle_fields` to cut out the `chunk` to `data_file` code duplication. 
