### PR TITLE
DOC: fix string interpolation (units double-printing) in particle_filter cookbook recipe

### DIFF
--- a/doc/source/cookbook/particle_filter.py
+++ b/doc/source/cookbook/particle_filter.py
@@ -56,9 +56,9 @@ ad = ds.all_data()
 mass_young = ad["stars_young", "particle_mass"].in_units("Msun").sum()
 mass_medium = ad["stars_medium", "particle_mass"].in_units("Msun").sum()
 mass_old = ad["stars_old", "particle_mass"].in_units("Msun").sum()
-print(f"Mass of young stars = {mass_young:g} Msun")
-print(f"Mass of medium stars = {mass_medium:g} Msun")
-print(f"Mass of old stars = {mass_old:g} Msun")
+print(f"Mass of young stars = {mass_young:g}")
+print(f"Mass of medium stars = {mass_medium:g}")
+print(f"Mass of old stars = {mass_old:g}")
 
 # Generate 4 projections: gas density, young stars, medium stars, old stars
 fields = [


### PR DESCRIPTION
reminiscent of #4443