### PR TITLE
BLD: explicitly specify build-backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires = [
   "oldest-supported-numpy",
   "ewah-bool-utils>=1.0.2",
 ]
+build-backend = "setuptools.build_meta:__legacy__"
 
 [project]
 name = "yt"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,6 @@
 requires = [
   "setuptools>=61.2",
   "importlib_resources>=1.3;python_version < '3.9'",
-  # see https://github.com/numpy/numpy/pull/18389
-  "wheel>=0.36.2",
 
   # Cython 3.0 is the next version after 0.29, and a major change,
   # we forbid it until we can properly test against it


### PR DESCRIPTION
I'm setting [the implicit value `build-backend`](https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/#fallback-behaviour) explicitly, as recommended.
`setuptools`' doc also clarifies that `wheel` requirement isn't needed as it's *implied* by using the `setuptools_meta` backend, so I'm removing it. See https://setuptools.pypa.io/en/latest/userguide/quickstart.html#basic-use

>  You should only include wheel in requires if you need to explicitly access it during build time (e.g. if your project needs a setup.py script that imports wheel).