### PR TITLE
BUG: avoid divide-by-zero runtime warning from np.log10 in AMRKDTree.get_brick_data

### DIFF
--- a/yt/utilities/amr_kdtree/amr_kdtree.py
+++ b/yt/utilities/amr_kdtree/amr_kdtree.py
@@ -342,7 +342,7 @@ class AMRKDTree(ParallelAnalysisInterface):
             for i, field in enumerate(self.fields):
                 if self.log_fields[i]:
                     v = vcd[field].astype("float64")
-                    v[v < 0] = np.nan
+                    v[v <= 0] = np.nan
                     dds.append(np.log10(v))
                 else:
                     dds.append(vcd[field].astype("float64"))


### PR DESCRIPTION
reprod: `python -Werror doc/source/cookbook/render_two_fields.py`

note that with numpy>=1.25.0, #4585 also gets in the way