### PR TITLE
BUG: fix string interpolation (units double-printing) in GridIndex

### DIFF
--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -681,7 +681,7 @@ class RAMSESIndex(OctreeIndex):
         except Exception:
             pass
         print(
-            "t = {:0.8e} = {:0.8e} s = {:0.8e} years".format(
+            "t = {:0.8e} = {:0.8e} = {:0.8e}".format(
                 self.ds.current_time.in_units("code_time"),
                 self.ds.current_time.in_units("s"),
                 self.ds.current_time.in_units("yr"),

--- a/yt/geometry/grid_geometry_handler.py
+++ b/yt/geometry/grid_geometry_handler.py
@@ -229,7 +229,7 @@ class GridIndex(Index, abc.ABC):
         except Exception:
             pass
         print(
-            "t = {:0.8e} = {:0.8e} s = {:0.8e} years".format(
+            "t = {:0.8e} = {:0.8e} = {:0.8e}".format(
                 self.ds.current_time.in_units("code_time"),
                 self.ds.current_time.in_units("s"),
                 self.ds.current_time.in_units("yr"),


### PR DESCRIPTION
follow up #4443 and #4582