### PR TITLE
BLD: fix wheels workflow (sync build requirements with pyproject.toml)

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -83,8 +83,10 @@ jobs:
         python -m pip install check-manifest
     - name: Install build time dependencies
       shell: bash
+
+      # keep in sync with pyproject.toml
       run: |
-        python -m pip install "Cython>=0.29.33,<3.0"
+        python -m pip install "Cython>=3.0,<3.1"
         python -m pip install oldest-supported-numpy
         python -m pip install ewah-bool-utils>=1.0.2
         python -m pip install --upgrade wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,5 @@
 [build-system]
+# keep in sync with .github/workflows/wheels.yaml
 requires = [
   "setuptools>=61.2",
   "importlib_resources>=1.3;python_version < '3.9'",


### PR DESCRIPTION
follow up to #4575 , fix wheels workflow (see the latest broken run on https://github.com/yt-project/yt/actions/runs/5764087947)