### PR TITLE
TST: simplify cartopy integration testing (using cartopy 0.22)

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -117,19 +117,17 @@ jobs:
     - name: Install dependencies and yt
       shell: bash
       env:
-        dependencies: ''
-      # see https://github.com/SciTools/cartopy/issues/2199
-      # for why scipy is pinned here (this is meant a temporary measure)
+        dependencies: 'cartopy'
       run: |
         source ./tests/ci_install.sh
-        python -m pip install cartopy "scipy<1.11"
 
     - name: Run Image Tests
       run: |
         pytest --color=yes --mpl -m mpl_image_compare \
                --mpl-generate-summary=html \
                --mpl-results-path=pytest_mpl_results \
-               --mpl-baseline-path=tests/pytest_mpl_baseline
+               --mpl-baseline-path=tests/pytest_mpl_baseline \
+               -rxXs # show extra info on xfailed, xpassed, and skipped tests
 
     - name: Generate new image baseline
       if: failure()

--- a/conftest.py
+++ b/conftest.py
@@ -148,15 +148,6 @@ def pytest_configure(config):
         )
 
     if NUMPY_VERSION >= Version("1.25"):
-        if find_spec("cartopy") is not None and (
-            Version(version("cartopy")) <= Version("0.21.1")
-        ):
-            # https://github.com/SciTools/cartopy/pull/2194
-            config.addinivalue_line(
-                "filterwarnings",
-                "ignore:Conversion of an array with ndim > 0 to a scalar is deprecated"
-                ":DeprecationWarning",
-            )
         if find_spec("h5py") is not None and (
             Version(version("h5py")) < Version("3.9")
         ):
@@ -179,18 +170,6 @@ def pytest_configure(config):
                 " from PyObject:RuntimeWarning"
             ),
         )
-
-    if find_spec("cartopy") is not None:
-        # this warning is triggered from cartopy 0.21.1
-        # see https://github.com/SciTools/cartopy/issues/2113
-        SHAPELY_VERSION = Version(version("shapely"))
-        if SHAPELY_VERSION >= Version("2.0"):
-            config.addinivalue_line(
-                "filterwarnings",
-                (
-                    r"ignore:The 'geom_factory' function is deprecated in Shapely 2\.0:DeprecationWarning"
-                ),
-            )
 
 
 def pytest_collection_modifyitems(config, items):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,7 @@ ytdata = ["yt[HDF5]"]
 # "full" should contain all optional dependencies intended for users (not devs)
 # in particular it should enable support for all frontends
 full = [
+    "cartopy>=0.22.0; python_version >= '3.9'",
     "firefly>=3.2.0",
     "glueviz>=0.13.3",
     "ipython>=2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "cmyt>=1.1.2",
     "ewah-bool-utils>=1.0.2",
     "ipywidgets>=8.0.0",
-    "matplotlib>=3.5", # keep in sync with tests/windows_conda_requirements.txt
+    "matplotlib>=3.5",
     "more-itertools>=8.4",
     # https://github.com/scipy/oldest-supported-numpy/issues/76#issuecomment-1628865694
     "numpy>=1.17.5,<2.0",

--- a/tests/ci_install.sh
+++ b/tests/ci_install.sh
@@ -1,37 +1,30 @@
 set -x   # Show which command is being run
 
-# geos is needed for cartopy, see
-# https://scitools.org.uk/cartopy/docs/latest/installing.html?highlight=install#building-from-source
-case ${RUNNER_OS} in
-linux|Linux)
-    sudo apt-get -qqy update
-    sudo apt-get -qqy install \
-      libhdf5-serial-dev \
-      libnetcdf-dev \
-      libgeos-dev \
-      libopenmpi-dev \
-      libfuse2
-    ;;
-osx|macOS)
-    sudo mkdir -p /usr/local/man
-    sudo chown -R "${USER}:admin" /usr/local/man
-    HOMEBREW_NO_AUTO_UPDATE=1 brew install hdf5 geos open-mpi netcdf ccache macfuse
-    ;;
-esac
-
 # Sets default backend to Agg
 cp tests/matplotlibrc .
 
 # Step 1: pre-install required packages
-if [[ "${RUNNER_OS}" == "Windows" ]] && [[ ${dependencies} != "minimal" ]]; then
-    # windows_conda_requirements.txt is a survivance of test_requirements.txt
-    # keep in sync: pyproject.toml
-    conda install --yes --file=tests/windows_conda_requirements.txt
-else
+if [[ ${dependencies} == "full" || ${dependencies} == "cartopy" ]]; then
     # upgrading pip to guarantee installing extra dependencies with [full] is supported
     # this is only necessary for some versions of Python 3.8 and 3.9
     # see https://github.com/yt-project/yt/issues/4270
-    python -m pip install --upgrade pip
+    python -m pip install 'pip>=21.2'
+
+    case ${RUNNER_OS} in
+    linux|Linux)
+        sudo apt-get -qqy update
+        sudo apt-get -qqy install \
+        libhdf5-serial-dev \
+        libnetcdf-dev \
+        libopenmpi-dev \
+        libfuse2
+        ;;
+    osx|macOS)
+        sudo mkdir -p /usr/local/man
+        sudo chown -R "${USER}:admin" /usr/local/man
+        HOMEBREW_NO_AUTO_UPDATE=1 brew install hdf5 open-mpi netcdf ccache macfuse
+        ;;
+    esac
 fi
 
 # Step 2: install deps and yt
@@ -40,12 +33,14 @@ fi
 if [[ ${dependencies} == "minimal" ]]; then
     # test with minimal versions of runtime dependencies
     python -m pip install -e ".[test,minimal]"
+elif [[ ${dependencies} == "cartopy" ]]; then
+    python -m pip install 'cartopy>=0.22'
+    # scipy is an optional dependency to cartopy
+    python -m pip install scipy
+    python -m pip install -e ".[test]"
 elif [[ ${dependencies} == "full" ]]; then
     # test with all optional runtime dependencies
-
-    # this is required for cartopy. see
-    # https://scitools.org.uk/cartopy/docs/latest/installing.html?highlight=install#building-from-source
-    python -m pip install shapely --no-binary=shapely
+    python -m pip install 'cartopy>=0.22'
     python -m pip install -e ".[test,full]"
 else
    # test with no special requirements

--- a/tests/ci_install.sh
+++ b/tests/ci_install.sh
@@ -40,7 +40,6 @@ elif [[ ${dependencies} == "cartopy" ]]; then
     python -m pip install -e ".[test]"
 elif [[ ${dependencies} == "full" ]]; then
     # test with all optional runtime dependencies
-    python -m pip install 'cartopy>=0.22'
     python -m pip install -e ".[test,full]"
 else
    # test with no special requirements

--- a/tests/windows_conda_requirements.txt
+++ b/tests/windows_conda_requirements.txt
@@ -1,5 +1,0 @@
-numpy>=1.19.4
-cartopy>=0.21.0
-h5py>=3.1.0
-matplotlib>=3.5  # keep in sync with pyproject.toml
-scipy>=1.5.0

--- a/yt/geometry/tests/test_geometries.py
+++ b/yt/geometry/tests/test_geometries.py
@@ -1,3 +1,5 @@
+from importlib.util import find_spec
+
 import pytest
 
 import yt
@@ -21,7 +23,7 @@ def test_testable_geometries(geometry):
     ds = fake_amr_ds(fields=[("gas", "density")], units=["g/cm**3"], geometry=geometry)
     # make sure basic plotting works
     for axis in range(3):
-        if "geographic" in geometry and axis == 2:
+        if "geographic" in geometry and axis == 2 and find_spec("cartopy") is None:
             pytest.skip(
                 reason=(
                     "cannot test this case with vanilla yt (requires cartopy) "


### PR DESCRIPTION
Cartopy 0.22 was just released and is supposed to resolve a couple workarounds we've been using to test it.
Most notably, this version doesn't depend on GEOS, and as such, it can afford to have *wheels*, which should allow us to properly test it on all platforms for cheap !