### PR TITLE
TST: stop using conda on Windows CI

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -74,14 +74,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         submodules: true
-    - name: Set up Conda (windows only)
-      uses: s-weigand/setup-conda@v1
-      if: matrix.os == 'windows-latest'
-      with:
-        update-conda: true
-        conda-channels: conda-forge
-        activate-conda: true
-        python-version: ${{matrix.python-version}}
     - name: Install dependencies and yt
       shell: bash
       env:


### PR DESCRIPTION
## PR Summary

This is made possible by #4621
I tested it on my fork and saw that testing time for windows dropped from ~30min to ~20, with *less* tests being skipped.