### PR TITLE
BLD: add wheels for CPython 3.12

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -31,11 +31,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build wheels for CPython
-        uses: pypa/cibuildwheel@v2.14.1
+        uses: pypa/cibuildwheel@v2.15.0
         with:
           output-dir: dist
         env:
-          CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-*"
+          CIBW_BUILD: "cp38-* cp39-* cp310-* cp311-* cp312-*"
           CIBW_SKIP: "*-musllinux_*"  #  numpy doesn't have wheels for musllinux so we can't build some quickly and without bloating
           CIBW_ARCHS_LINUX: "x86_64"
           CIBW_ARCHS_MACOS: x86_64 arm64

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,9 @@ requires = [
 
   # see https://github.com/yt-project/yt/issues/4044
   "Cython>=3.0, <3.1",
-  "oldest-supported-numpy",
+  # TODO: simplify numpy requirement after numpy 1.26.0 final is released
+  "oldest-supported-numpy ; python_version < '3.12.0rc1'",
+  "numpy>=1.26.0b1 ; python_version >= '3.12.0rc1'",
   "ewah-bool-utils>=1.0.2",
 ]
 build-backend = "setuptools.build_meta:__legacy__"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,13 @@ requires = [
 
   # see https://github.com/yt-project/yt/issues/4044
   "Cython>=3.0, <3.1",
-  # TODO: simplify numpy requirement after numpy 1.26.0 final is released
+  # TODO: simplify requirement after numpy 1.26.0 final is released
   "oldest-supported-numpy ; python_version < '3.12.0rc1'",
   "numpy>=1.26.0b1 ; python_version >= '3.12.0rc1'",
-  "ewah-bool-utils>=1.0.2",
+
+  # TODO: simplify requirement after ewah-bool-utils 1.1.0 final is released
+  "ewah-bool-utils>=1.0.2 ; python_version < '3.12.0rc1'",
+  "ewah-bool-utils>=1.1.0rc1 ; python_version >= '3.12.0rc1'",
 ]
 build-backend = "setuptools.build_meta:__legacy__"
 


### PR DESCRIPTION
celebrating Python 3.12.0rc1 + cibuildwheel 2.15.0

requires numpy wheels (probably won't happen before numpy 1.26)