### PR TITLE
TST: start testing nightlies on CPython 3.12

### DIFF
--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -37,23 +37,30 @@ jobs:
     - name: Set up Python (newest testable version)
       uses: actions/setup-python@v4
       with:
-        # the '-dev' suffix allows to use alphas and betas if no final release is available yet
-        # this version should be upgraded as often as possible, typically once a year when numpy
-        # and Cython are known to be compatible
-        python-version: '3.11-dev'
+        # the '-dev' suffix allows to use pre-releases if no final release is available yet
+        # this version should be upgraded as often as possible, typically once a year when
+        # Cython, numpy and matplotlib are known to be compatible
+        python-version: '3.12-dev'
 
     - name: Install dependencies
       # PyYAML needs to be installed in isolation for now, because of a known
       # incompatibility with Cython 3
       # see https://github.com/yaml/pyyaml/issues/601
       # and https://github.com/cython/cython/issues/4568
+      # Cython 3.0.2 has a defect on Python 3.12, so we install the -fixed- dev version
+      # from source for now.
+      # see https://github.com/cython/cython/issues/5724
+      # Cython can be installed from PyPI binaries again when the patch is included
+      # in a release (likely in version 3.0.3)
       run: |
         python -m pip install --upgrade pip
         python -m pip install --upgrade setuptools wheel
-        python -m pip install --pre --upgrade --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple numpy matplotlib
-        python -m pip install --pre cython ewah-bool-utils
+        python -m pip install --pre --only-binary ":all:" numpy matplotlib \
+         --extra-index https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+        python -m pip install --pre ewah-bool-utils
         python -m pip install git+https://github.com/yt-project/unyt.git
         python -m pip install --pre pytest PyYAML
+        python -m pip install git+https://github.com/cython/cython.git
 
     - name: Build
       # --no-build-isolation is used to guarantee that build time dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,10 @@
 requires = [
   "setuptools>=61.2",
 
+  # for the upper pin in Cython
   # see https://github.com/yt-project/yt/issues/4044
+  # TODO: bump minimal Cython version to 3.0.3 when released
+  # see https://github.com/yt-project/yt/issues/4675
   "Cython>=3.0, <3.1",
   "numpy>=1.25, <2.0",
   "ewah-bool-utils>=1.0.2",
@@ -32,6 +35,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Astronomy",
     "Topic :: Scientific/Engineering :: Physics",
     "Topic :: Scientific/Engineering :: Visualization",


### PR DESCRIPTION
matplotlib started shipping (unstable) wheels on pypi.anaconda.org, let's try and see where we're at.

edit: no they didn't, I just misread [the index](https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/matplotlib/). I'll refresh this PR when it actually happens.