### PR TITLE
TYP: fix type-checking incompatibilities with matplotlib 3.8

### DIFF
--- a/yt/visualization/volume_rendering/scene.py
+++ b/yt/visualization/volume_rendering/scene.py
@@ -345,7 +345,7 @@ class Scene:
             fig = Figure((shape[0] / 100.0, shape[1] / 100.0))
             canvas = get_canvas(fig, fname)
 
-            ax = fig.add_axes([0, 0, 1, 1])
+            ax = fig.add_axes((0, 0, 1, 1))
             ax.set_axis_off()
             out = self._last_render
             if sigma_clip is not None:


### PR DESCRIPTION
~this is a test-only PR, not meant to be merged.
In particular, test newly supported type-checking for Python >= 3.9~

edit: this has now survived type-checking with matplotlib 3.8.0rc1, so I rewrote the branch history to preserve dependencies and fix newly discovered type-checking incompatibilities instead.