### PR TITLE
BUG: fix a crash with certain combinations of kwargs for adding dimensionless derived fields to datasets

### DIFF
--- a/yt/data_objects/selection_objects/data_selection_objects.py
+++ b/yt/data_objects/selection_objects/data_selection_objects.py
@@ -225,6 +225,17 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface, abc.ABC):
 
     def _generate_fields(self, fields_to_generate):
         index = 0
+
+        def dimensions_compare_equal(a, b, /) -> bool:
+            if a == b:
+                return True
+            try:
+                if (a == 1 and b.is_dimensionless) or (a.is_dimensionless and b == 1):
+                    return True
+            except AttributeError:
+                return False
+            return False
+
         with self._field_lock():
             # At this point, we assume that any fields that are necessary to
             # *generate* a field are in fact already available to us.  Note
@@ -266,7 +277,7 @@ class YTSelectionContainer(YTDataContainer, ParallelAnalysisInterface, abc.ABC):
                                 fi.name,
                                 sunits or "dimensionless",
                             )
-                        elif fi.dimensions != dimensions:
+                        elif not dimensions_compare_equal(fi.dimensions, dimensions):
                             raise YTDimensionalityError(fi.dimensions, dimensions)
                         fi.units = sunits
                         fi.dimensions = dimensions

--- a/yt/data_objects/tests/test_add_field.py
+++ b/yt/data_objects/tests/test_add_field.py
@@ -1,7 +1,9 @@
 from functools import partial
 
 import pytest
+import unyt
 
+import yt
 from yt import derived_field
 from yt.fields import local_fields
 from yt.testing import fake_random_ds
@@ -106,3 +108,38 @@ def test_derived_field(monkeypatch):
             * data["gas", "density"]
             * data["gas", "specific_thermal_energy"]
         )
+
+
+@pytest.mark.parametrize(
+    "add_field_kwargs",
+    [
+        # full default: auto unit detection, no (in)validation
+        {},
+        # explicit "auto", should be identical to default behaviour
+        {"units": "auto"},
+        # explicitly requesting dimensionless units
+        {"units": "dimensionless"},
+        # explicitly requesting dimensionless units (short hand)
+        {"units": ""},
+        # explictly requesting no dimensions
+        {"dimensions": yt.units.dimensionless},
+        # should work with unyt.dimensionless too
+        {"dimensions": unyt.dimensionless},
+        # supported short hand
+        {"dimensions": "dimensionless"},
+    ],
+)
+def test_dimensionless_field(add_field_kwargs):
+    ds = fake_random_ds(16)
+
+    def _dimensionless_field(field, data):
+        return data["gas", "density"] / data["gas", "density"].units
+
+    ds.add_field(
+        name=("gas", "dimensionless_density"),
+        function=_dimensionless_field,
+        sampling_type="local",
+        **add_field_kwargs,
+    )
+    # check access
+    ds.all_data()["gas", "dimensionless_density"]


### PR DESCRIPTION
close #4636
Opening as a draft with just the tests, patch incoming.
