### PR TITLE
ENH: Only call find_spec sometimes

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -131,7 +131,13 @@ class MutableAttribute:
 
     def __init__(self, display_array=False):
         self.data = weakref.WeakKeyDictionary()
-        self.display_array = display_array
+        # We can assume that ipywidgets will not be *added* to the system
+        # during the course of execution, and if it is, we will not wrap the
+        # array.
+        if display_array and find_spec("ipywidgets") is not None:
+            self.display_array = True
+        else:
+            self.display_array = False
 
     def __get__(self, instance, owner):
         if not instance:
@@ -141,7 +147,7 @@ class MutableAttribute:
             ret = ret.copy()
         except AttributeError:
             pass
-        if self.display_array and find_spec("ipywidgets") is not None:
+        if self.display_array:
             try:
                 ret._ipython_display_ = functools.partial(_wrap_display_ytarray, ret)
             # This will error out if the items have yet to be turned into


### PR DESCRIPTION
In some cases, particularly when instantiating lots of child masks, the way the `MutableAttribute` object is set up could lead to `find_spec` being called inside some tight loops.

But, the results of `find_spec` shouldn't change during the course of one interpreter's existence.  So we can move the checks to the outside of the `__get__` call, which reduces costs of grid indexing considerable in some cases.
