### PR TITLE
ENH: make unused pixels actually transparent in all imshow-based 2D visualisations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
     "tqdm>=3.4.0",
     "unyt>=2.9.2,<3.0", # see https://github.com/yt-project/yt/issues/4162
     "tomli>=1.2.3;python_version < '3.11'",
-    "typing-extensions>=4.1.0;python_version < '3.11'",
+    "typing-extensions>=4.4.0;python_version < '3.12'",
 ]
 
 [project.readme]
@@ -219,7 +219,7 @@ minimal = [
     "tqdm==3.4.0",
     "unyt==2.9.2",
     "tomli==1.2.3;python_version < '3.11'",
-    "typing-extensions==4.1.0;python_version < '3.11'",
+    "typing-extensions==4.4.0;python_version < '3.12'",
 ]
 test = [
     "pyaml>=17.10.0",
@@ -235,7 +235,7 @@ typecheck = [
     "types-PyYAML==6.0.12.2",
     "types-chardet==5.0.4",
     "types-requests==2.28.11.5",
-    "typing-extensions==4.1.0;python_version < '3.11'",
+    "typing-extensions==4.4.0; python_version < '3.12'",
 ]
 
 [project.scripts]

--- a/yt/_typing.py
+++ b/yt/_typing.py
@@ -1,7 +1,7 @@
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
+import numpy as np
 import unyt as un
-from numpy import ndarray
 
 FieldDescT = tuple[str, tuple[str, list[str], Optional[str]]]
 KnownFieldsT = tuple[FieldDescT, ...]
@@ -12,12 +12,12 @@ FieldName = str
 FieldKey = tuple[FieldType, FieldName]
 ImplicitFieldKey = FieldName
 AnyFieldKey = Union[FieldKey, ImplicitFieldKey]
-DomainDimensions = Union[tuple[int, ...], list[int], ndarray]
+DomainDimensions = Union[tuple[int, ...], list[int], np.ndarray]
 
 ParticleCoordinateTuple = tuple[
     str,  # particle type
-    tuple[ndarray, ndarray, ndarray],  # xyz
-    Union[float, ndarray],  # hsml
+    tuple[np.ndarray, np.ndarray, np.ndarray],  # xyz
+    Union[float, np.ndarray],  # hsml
 ]
 
 # Geometry specific types
@@ -29,3 +29,9 @@ Unit = Union[un.Unit, str]
 
 # types that can be converted to un.unyt_quantity
 Quantity = Union[un.unyt_quantity, tuple[float, Unit]]
+
+# np.ndarray[...] syntax is runtime-valid from numpy 1.22, we quote it until our minimal
+# runtime requirement is bumped to, or beyond this version
+
+MaskT = Optional["np.ndarray[Any, np.dtype[np.bool_]]"]
+AlphaT = Optional["np.ndarray[Any, np.dtype[np.float64]]"]

--- a/yt/geometry/coordinates/coordinate_handler.py
+++ b/yt/geometry/coordinates/coordinate_handler.py
@@ -2,7 +2,7 @@ import abc
 import weakref
 from functools import cached_property
 from numbers import Number
-from typing import Optional
+from typing import Any, Literal, Optional, overload
 
 import numpy as np
 
@@ -146,8 +146,51 @@ class CoordinateHandler(abc.ABC):
         # This should return field definitions for x, y, z, r, theta, phi
         pass
 
+    @overload
+    def pixelize(
+        self,
+        dimension,
+        data_source,
+        field,
+        bounds,
+        size,
+        antialias=True,
+        periodic=True,
+        *,
+        return_mask: Literal[False],
+    ) -> "np.ndarray[Any, np.dtype[np.float64]]":
+        ...
+
+    @overload
+    def pixelize(
+        self,
+        dimension,
+        data_source,
+        field,
+        bounds,
+        size,
+        antialias=True,
+        periodic=True,
+        *,
+        return_mask: Literal[True],
+    ) -> tuple[
+        "np.ndarray[Any, np.dtype[np.float64]]", "np.ndarray[Any, np.dtype[np.bool_]]"
+    ]:
+        ...
+
     @abc.abstractmethod
-    def pixelize(self, dimension, data_source, field, bounds, size, antialias=True):
+    def pixelize(
+        self,
+        dimension,
+        data_source,
+        field,
+        bounds,
+        size,
+        antialias=True,
+        periodic=True,
+        *,
+        return_mask=False,
+    ):
         # This should *actually* be a pixelize call, not just returning the
         # pixelizer
         pass

--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -95,7 +95,10 @@ def pixelize_cartesian(np.float64_t[:,:] buff,
                        int antialias = 1,
                        period = None,
                        int check_period = 1,
-                       np.float64_t line_width = 0.0):
+                       np.float64_t line_width = 0.0,
+                       *,
+                       int return_mask = 0,
+):
     cdef np.float64_t x_min, x_max, y_min, y_max
     cdef np.float64_t period_x = 0.0, period_y = 0.0
     cdef np.float64_t width, height, px_dx, px_dy, ipx_dx, ipx_dy
@@ -110,6 +113,10 @@ def pixelize_cartesian(np.float64_t[:,:] buff,
     cdef int yiter[2]
     cdef np.float64_t xiterv[2]
     cdef np.float64_t yiterv[2]
+
+    cdef np.ndarray[np.uint8_t, ndim=2] mask_arr = np.zeros_like(buff, dtype="uint8")
+    cdef np.uint8_t[:, :] mask = mask_arr
+
     if period is not None:
         period_x = period[0]
         period_y = period[1]
@@ -244,6 +251,7 @@ def pixelize_cartesian(np.float64_t[:,:] buff,
                                 ld_y *= ipx_dy
                                 if ld_x <= line_width or ld_y <= line_width:
                                     buff[i,j] = 1.0
+                                    mask[i,j] = 1
                             elif antialias == 1:
                                 overlap1 = ((fmin(rxpx, xsp+dxsp)
                                            - fmax(lxpx, (xsp-dxsp)))*ipx_dx)
@@ -259,8 +267,13 @@ def pixelize_cartesian(np.float64_t[:,:] buff,
                                 # make sure pixel value is not a NaN before incrementing it
                                 if buff[i,j] != buff[i,j]: buff[i,j] = 0.0
                                 buff[i,j] += (dsp * overlap1) * overlap2
+                                mask[i,j] = 1
                             else:
                                 buff[i,j] = dsp
+                                mask[i,j] = 1
+
+    if return_mask:
+        return mask_arr.astype("bool")
 
 @cython.cdivision(True)
 @cython.boundscheck(False)
@@ -277,7 +290,10 @@ def pixelize_cartesian_nodal(np.float64_t[:,:] buff,
                              bounds,
                              int antialias = 1,
                              period = None,
-                             int check_period = 1):
+                             int check_period = 1,
+                             *,
+                             int return_mask = 0,
+):
     cdef np.float64_t x_min, x_max, y_min, y_max
     cdef np.float64_t period_x = 0.0, period_y = 0.0
     cdef np.float64_t width, height, px_dx, px_dy, ipx_dx, ipx_dy
@@ -360,6 +376,10 @@ def pixelize_cartesian_nodal(np.float64_t[:,:] buff,
     #   So what we want here is to fill an array such that we fill:
     #       first axis : y_min .. y_max
     #       second axis: x_min .. x_max
+
+    cdef np.ndarray[np.uint8_t, ndim=2] mask_arr = np.zeros_like(buff, dtype="uint8")
+    cdef np.uint8_t[:, :] mask = mask_arr
+
     with nogil:
         for p in range(px.shape[0]):
             xiter[1] = yiter[1] = 999
@@ -426,6 +446,10 @@ def pixelize_cartesian_nodal(np.float64_t[:,:] buff,
                             ind = 4*ii + 2*jj + kk
 
                             buff[i,j] = data[p, ind]
+                            mask[i,j] = 1
+
+    if return_mask:
+        return mask_arr.astype("bool")
 
 
 @cython.cdivision(True)
@@ -445,7 +469,10 @@ def pixelize_off_axis_cartesian(
                        np.float64_t[:,:] inv_mat,
                        np.int_t[:] indices,
                        np.float64_t[:] data,
-                       bounds):
+                       bounds,
+                       *,
+                       int return_mask=0,
+):
     cdef np.float64_t x_min, x_max, y_min, y_max
     cdef np.float64_t width, height, px_dx, px_dy, ipx_dx, ipx_dy, md
     cdef int i, j, p, ip
@@ -516,6 +543,9 @@ def pixelize_off_axis_cartesian(
             if mask[i,j] == 0: continue
             buff[i,j] /= mask[i,j]
 
+    if return_mask:
+        return mask!=0
+
 @cython.cdivision(True)
 @cython.boundscheck(False)
 @cython.wraparound(False)
@@ -525,7 +555,10 @@ def pixelize_cylinder(np.float64_t[:,:] buff,
                       np.float64_t[:] theta,
                       np.float64_t[:] dtheta,
                       np.float64_t[:] field,
-                      extents):
+                      extents,
+                      *,
+                      int return_mask=0,
+):
 
     cdef np.float64_t x, y, dx, dy, r0, theta0
     cdef np.float64_t rmin, rmax, tmin, tmax, x0, y0, x1, y1, xp, yp
@@ -544,6 +577,9 @@ def pixelize_cylinder(np.float64_t[:,:] buff,
     imax = np.asarray(theta).argmax()
     tmin = theta[imin] - dtheta[imin]
     tmax = theta[imax] + dtheta[imax]
+
+    cdef np.ndarray[np.uint8_t, ndim=2] mask_arr = np.zeros_like(buff, dtype="uint8")
+    cdef np.uint8_t[:, :] mask = mask_arr
 
     x0, x1, y0, y1 = extents
     dx = (x1 - x0) / buff.shape[0]
@@ -631,8 +667,12 @@ def pixelize_cylinder(np.float64_t[:,:] buff,
                     if prbounds[0] >= rmin and prbounds[1] <= rmax and \
                        ptbounds[0] >= tmin and ptbounds[1] <= tmax:
                         buff[pi, pj] = field[i]
+                        mask[pi, pj] = 1
                 r_i += r_inc
             theta_i += theta_inc
+
+    if return_mask:
+        return mask_arr.astype("bool")
 
 cdef int aitoff_Lambda_btheta_to_xy(np.float64_t Lambda, np.float64_t btheta,
                                np.float64_t *x, np.float64_t *y) except -1:
@@ -653,7 +693,10 @@ def pixelize_aitoff(np.float64_t[:] azimuth,
                     bounds, # this is a 4-tuple
                     input_img = None,
                     np.float64_t azimuth_offset = 0.0,
-                    np.float64_t colatitude_offset = 0.0):
+                    np.float64_t colatitude_offset = 0.0,
+                    *,
+                    int return_mask = 0
+):
     # http://paulbourke.net/geometry/transformationprojection/
     # (Lambda) longitude is -PI to PI (longitude = azimuth - PI)
     # (btheta) latitude is -PI/2 to PI/2 (latitude = PI/2 - colatitude)
@@ -676,6 +719,10 @@ def pixelize_aitoff(np.float64_t[:] azimuth,
         img[:] = np.nan
     else:
         img = input_img
+
+    cdef np.ndarray[np.uint8_t, ndim=2] mask_arr = np.ones_like(img, dtype="uint8")
+    cdef np.uint8_t[:, :] mask = mask_arr
+
     # Okay, here's our strategy.  We compute the bounds in x and y, which will
     # be a rectangle, and then for each x, y position we check to see if it's
     # within our Lambda.  This will cost *more* computations of the
@@ -768,7 +815,12 @@ def pixelize_aitoff(np.float64_t[:] azimuth,
                 if not (btheta_p - dbtheta_p <= btheta0 <= btheta_p + dbtheta_p):
                     continue
                 img[i, j] = field[fi]
-    return img
+                mask[i, j] = 1
+
+    if return_mask:
+        return img, mask_arr.astype("bool")
+    else:
+        return img
 
 
 # This function accepts a set of vertices (for a polyhedron) that are
@@ -839,10 +891,17 @@ def pixelize_element_mesh(np.ndarray[np.float64_t, ndim=2] coords,
                           buff_size,
                           np.ndarray[np.float64_t, ndim=2] field,
                           extents,
-                          int index_offset = 0):
+                          int index_offset = 0,
+                          *,
+                          return_mask=False,
+):
     cdef np.ndarray[np.float64_t, ndim=3] img
     img = np.zeros(buff_size, dtype="float64")
     img[:] = np.nan
+
+    cdef np.ndarray[np.uint8_t, ndim=3] mask_arr = np.ones_like(img, dtype="uint8")
+    cdef np.uint8_t[:, :, :] mask = mask_arr
+
     # Two steps:
     #  1. Is image point within the mesh bounding box?
     #  2. Is image point within the mesh element?
@@ -968,9 +1027,13 @@ def pixelize_element_mesh(np.ndarray[np.float64_t, ndim=2] coords,
                         else:
                             img[pi, pj, pk] = sampler.sample_at_unit_point(mapped_coord,
                                                                            field_vals)
+                        mask[pi, pj, pk] = 1
     free(vertices)
     free(field_vals)
-    return img
+    if return_mask:
+        return img, mask_arr.astype("bool")
+    else:
+        return img
 
 # used as a cache to avoid repeatedly creating
 # instances of SPHKernelInterpolationTable
@@ -1057,6 +1120,7 @@ cdef class SPHKernelInterpolationTable:
 @cython.cdivision(True)
 def pixelize_sph_kernel_projection(
         np.float64_t[:, :] buff,
+        np.uint8_t[:, :] mask,
         any_float[:] posx,
         any_float[:] posy,
         any_float[:] hsml,
@@ -1206,6 +1270,7 @@ def pixelize_sph_kernel_projection(
                             # see equation 32 of the SPLASH paper
                             # now we just use the kernel projection
                             local_buff[xi + yi*xsize] +=  prefactor_j * itab.interpolate(q_ij2)
+                            mask[xi, yi] = 1
 
         with gil:
             for xxi in range(xsize):
@@ -1216,6 +1281,8 @@ def pixelize_sph_kernel_projection(
         free(yiterv)
         free(xiter)
         free(yiter)
+
+    return mask
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
@@ -1296,7 +1363,10 @@ def interpolate_sph_grid_gather(np.float64_t[:, :, :] buff,
         np.float64_t[:] hsml, np.float64_t[:] pmass, np.float64_t[:] pdens,
         np.float64_t[:] quantity_to_smooth, PyKDTree kdtree,
         int use_normalization=1, kernel_name="cubic", pbar=None,
-        int num_neigh=32):
+        int num_neigh=32,
+        *,
+        int return_mask=0,
+):
     """
     This function takes in the bounds and number of cells in a grid (well,
     actually we implicitly calculate this from the size of buff). Then we can
@@ -1332,6 +1402,9 @@ def interpolate_sph_grid_gather(np.float64_t[:, :, :] buff,
     pbar = get_pbar(title="Interpolating (gather) SPH field",
                     maxval=(buff.shape[0]*buff.shape[1]*buff.shape[2] //
                             10000)*10000)
+
+    cdef np.ndarray[np.uint8_t, ndim=3] mask_arr = np.zeros_like(buff, dtype="uint8")
+    cdef np.uint8_t[:, :, :] mask = mask_arr
 
     prog = 0
     with nogil:
@@ -1374,6 +1447,7 @@ def interpolate_sph_grid_gather(np.float64_t[:, :, :] buff,
 
                         # See equations 6, 9, and 11 of the SPLASH paper
                         buff[i, j, k] += smoothed_quantity_j
+                        mask[i, j, k] = 1
 
                         if use_normalization:
                             buff_den[i, j, k] += prefactor_j * kernel(q_ij)
@@ -1381,12 +1455,16 @@ def interpolate_sph_grid_gather(np.float64_t[:, :, :] buff,
     if use_normalization:
         normalization_3d_utility(buff, buff_den)
 
+    if return_mask:
+        return mask_arr.astype("bool")
+
 @cython.initializedcheck(False)
 @cython.boundscheck(False)
 @cython.wraparound(False)
 @cython.cdivision(True)
 def pixelize_sph_kernel_slice(
         np.float64_t[:, :] buff,
+        np.uint8_t[:, :] mask,
         np.float64_t[:] posx, np.float64_t[:] posy,
         np.float64_t[:] hsml, np.float64_t[:] pmass,
         np.float64_t[:] pdens,
@@ -1510,6 +1588,7 @@ def pixelize_sph_kernel_slice(
 
                             # see equations 6, 9, and 11 of the SPLASH paper
                             local_buff[xi + yi*xsize] += prefactor_j * kernel(q_ij)
+                            mask[xi, yi] = 1
 
         with gil:
             for xxi in range(xsize):
@@ -1844,6 +1923,7 @@ def off_axis_projection_SPH(np.float64_t[:] px,
                             width,
                             np.float64_t[:] quantity_to_smooth,
                             np.float64_t[:, :] projection_array,
+                            np.uint8_t[:, :] mask,
                             normal_vector,
                             north_vector,
                             weight_field=None):
@@ -1857,6 +1937,7 @@ def off_axis_projection_SPH(np.float64_t[:] px,
                                                          center, width, normal_vector, north_vector)
 
     pixelize_sph_kernel_projection(projection_array,
+                                   mask,
                                    px_rotated,
                                    py_rotated,
                                    smoothing_lengths,

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -2,6 +2,7 @@ import sys
 import warnings
 from abc import ABC
 from io import BytesIO
+from types import FunctionType
 from typing import TYPE_CHECKING, Optional, TypedDict, Union
 
 import matplotlib
@@ -9,12 +10,14 @@ import numpy as np
 from matplotlib.scale import SymmetricalLogTransform
 from matplotlib.ticker import LogFormatterMathtext
 
+from yt._typing import AlphaT
 from yt.funcs import (
     get_interactivity,
     is_sequence,
     matplotlib_style_context,
     mylog,
     setdefault_mpl_metadata,
+    setdefaultattr,
 )
 from yt.visualization._handlers import ColorbarHandler, NormHandler
 
@@ -245,6 +248,10 @@ class ImagePlotMPL(PlotMPL, ABC):
         cax: Optional["Axes"] = None,
     ):
         """Initialize ImagePlotMPL class object"""
+
+        self._transform: Optional[FunctionType]
+        setdefaultattr(self, "_transform", None)
+
         self.colorbar_handler = colorbar_handler
         _missing_layout_specs = [_ is None for _ in (fsize, axrect, caxrect)]
 
@@ -297,7 +304,7 @@ class ImagePlotMPL(PlotMPL, ABC):
         self.cax.set_position(caxrect)
         self.figure.set_size_inches(*size)
 
-    def _init_image(self, data, extent, aspect):
+    def _init_image(self, data, extent, aspect, *, alpha: AlphaT = None):
         """Store output of imshow in image variable"""
 
         norm = self.norm_handler.get_norm(data)
@@ -322,6 +329,7 @@ class ImagePlotMPL(PlotMPL, ABC):
             cmap=self.colorbar_handler.cmap,
             interpolation="nearest",
             transform=transform,
+            alpha=alpha,
         )
         self._set_axes()
 

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -1,3 +1,4 @@
+import sys
 import weakref
 from functools import partial
 from typing import TYPE_CHECKING, Optional
@@ -5,7 +6,7 @@ from typing import TYPE_CHECKING, Optional
 import numpy as np
 
 from yt._maintenance.deprecation import issue_deprecation_warning
-from yt._typing import FieldKey
+from yt._typing import FieldKey, MaskT
 from yt.data_objects.image_array import ImageArray
 from yt.frontends.ytdata.utilities import save_as_dataset
 from yt.funcs import get_output_filename, iter_fields, mylog
@@ -22,6 +23,11 @@ from yt.utilities.math_utils import compute_stddev_image
 from yt.utilities.on_demand_imports import _h5py as h5py
 
 from .volume_rendering.api import off_axis_projection
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 if TYPE_CHECKING:
     from yt.visualization.fixed_resolution_filters import FixedResolutionBufferFilter
@@ -116,7 +122,8 @@ class FixedResolutionBuffer:
         self.bounds = bounds
         self.buff_size = (int(buff_size[0]), int(buff_size[1]))
         self.antialias = antialias
-        self.data: dict[str, np.ndarray] = {}
+        self.data: dict[str, ImageArray] = {}
+        self.mask: dict[str, MaskT] = {}
         self.axis = data_source.axis
         self.periodic = periodic
         self._data_valid = False
@@ -155,9 +162,7 @@ class FixedResolutionBuffer:
     def __delitem__(self, item):
         del self.data[item]
 
-    def __getitem__(self, item):
-        if item in self.data and self._data_valid:
-            return self.data[item]
+    def _generate_image_and_mask(self, item) -> None:
         mylog.info(
             "Making a fixed resolution buffer of (%s) %d by %d",
             item,
@@ -170,13 +175,14 @@ class FixedResolutionBuffer:
                 b = float(b.in_units("code_length"))
             bounds.append(b)
 
-        buff = self.ds.coordinates.pixelize(
+        buff, mask = self.ds.coordinates.pixelize(
             self.data_source.axis,
             self.data_source,
             item,
             bounds,
             self.buff_size,
             int(self.antialias),
+            return_mask=True,
         )
 
         buff = self._apply_filters(buff)
@@ -193,10 +199,27 @@ class FixedResolutionBuffer:
         except (KeyError, AttributeError):
             units = self.data_source[item].units
 
-        ia = ImageArray(buff, units=units, info=self._get_info(item))
-        self.data[item] = ia
+        self.data[item] = ImageArray(buff, units=units, info=self._get_info(item))
+        self.mask[item] = mask
         self._data_valid = True
-        return self.data[item]
+
+    def __getitem__(self, item):
+        # backward compatibility
+        return self.get_image(item)
+
+    def get_image(self, key, /) -> ImageArray:
+        if not (key in self.data and self._data_valid):
+            self._generate_image_and_mask(key)
+        return self.data[key]
+
+    def get_mask(self, key, /) -> MaskT:
+        """Return the boolean array associated with an image with the same key.
+
+        Elements set to True indicate pixels that were updated by a pixelisation routine
+        """
+        if not (key in self.mask and self._data_valid):
+            self._generate_image_and_mask(key)
+        return self.mask[key]
 
     def render(self, item):
         # deleguate to __getitem__ for historical reasons
@@ -571,11 +594,10 @@ class CylindricalFixedResolutionBuffer(FixedResolutionBuffer):
         if ds is not None:
             ds.plots.append(weakref.proxy(self))
 
-    def __getitem__(self, item):
-        if item in self.data:
-            return self.data[item]
+    @override
+    def _generate_image_and_mask(self, item) -> None:
         buff = np.zeros(self.buff_size, dtype="f8")
-        pixelize_cylinder(
+        mask = pixelize_cylinder(
             buff,
             self.data_source["r"],
             self.data_source["dr"],
@@ -583,9 +605,12 @@ class CylindricalFixedResolutionBuffer(FixedResolutionBuffer):
             self.data_source["dtheta"],
             self.data_source[item].astype("float64"),
             self.radius,
+            return_mask=True,
         )
-        self[item] = buff
-        return buff
+        self.data[item] = ImageArray(
+            buff, units=self.data_source[item].units, info=self._get_info(item)
+        )
+        self.mask[item] = mask
 
 
 class OffAxisProjectionFixedResolutionBuffer(FixedResolutionBuffer):
@@ -595,9 +620,8 @@ class OffAxisProjectionFixedResolutionBuffer(FixedResolutionBuffer):
     that supports off axis projections.  This calls the volume renderer.
     """
 
-    def __getitem__(self, item):
-        if item in self.data:
-            return self.data[item]
+    @override
+    def _generate_image_and_mask(self, item) -> None:
         mylog.info(
             "Making a fixed resolution buffer of (%s) %d by %d",
             item,
@@ -661,8 +685,8 @@ class OffAxisProjectionFixedResolutionBuffer(FixedResolutionBuffer):
             self.ds.field_info.pop(item_sq)
 
         ia = ImageArray(buff.swapaxes(0, 1), info=self._get_info(item))
-        self[item] = ia
-        return ia
+        self.data[item] = ia
+        self.mask[item] = None
 
 
 class ParticleImageBuffer(FixedResolutionBuffer):
@@ -698,10 +722,8 @@ class ParticleImageBuffer(FixedResolutionBuffer):
             self.x_field = f"particle_position_{axis_name[self.xax]}"
             self.y_field = f"particle_position_{axis_name[self.yax]}"
 
-    def __getitem__(self, item):
-        if item in self.data:
-            return self.data[item]
-
+    @override
+    def _generate_image_and_mask(self, item) -> None:
         deposition = self.data_source.deposition
         density = self.data_source.density
 
@@ -831,7 +853,7 @@ class ParticleImageBuffer(FixedResolutionBuffer):
             buff[locs] /= weight_buff[locs]
 
         self.data[item] = ImageArray(buff, units=units, info=info)
-        return self.data[item]
+        self.mask[item] = buff_mask != 0
 
     # over-ride the base class version, since we don't want to exclude
     # particle fields

--- a/yt/visualization/tests/test_image_comp_2D_plots.py
+++ b/yt/visualization/tests/test_image_comp_2D_plots.py
@@ -1,6 +1,7 @@
 # image tests using pytest-mpl
 from itertools import chain
 
+import matplotlib as mpl
 import numpy as np
 import numpy.testing as npt
 import pytest
@@ -333,6 +334,17 @@ class TestSetBackgroundColor:
     def setup_class(cls):
         cls.ds = fake_random_ds(16)
 
+        def some_nans_field(field, data):
+            ret = data[("gas", "density")]
+            ret[::2] *= np.nan
+            return ret
+
+        cls.ds.add_field(
+            name=("gas", "polluted_field"),
+            function=some_nans_field,
+            sampling_type="local",
+        )
+
     @pytest.mark.mpl_image_compare
     def test_sliceplot_set_background_color_linear(self):
         field = ("gas", "density")
@@ -348,6 +360,21 @@ class TestSetBackgroundColor:
         field = ("gas", "density")
         p = SlicePlot(self.ds, "z", field, width=1.5)
         p.set_background_color(field, color="C0")
+
+        p.render()
+        return p.plots[field].figure
+
+    @pytest.mark.mpl_image_compare
+    def test_sliceplot_set_background_color_and_bad_value(self):
+        # see https://github.com/yt-project/yt/issues/4639
+        field = ("gas", "polluted_field")
+        p = SlicePlot(self.ds, "z", field, width=1.5)
+        p.set_background_color(field, color="black")
+
+        # copy the default colormap
+        cmap = mpl.colormaps["cmyt.arbre"]
+        cmap.set_bad("red")
+        p.set_cmap(field, cmap)
 
         p.render()
         return p.plots[field].figure

--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -198,6 +198,7 @@ def off_axis_projection(
 
         # if weight is None:
         buf = np.zeros((resolution[0], resolution[1]), dtype="float64")
+        mask = np.ones_like(buf, dtype="uint8")
 
         x_min = center[0] - width[0] / 2
         x_max = center[0] + width[0] / 2
@@ -223,6 +224,7 @@ def off_axis_projection(
                     width.to("code_length").d,
                     chunk[item].in_units(ounits),
                     buf,
+                    mask,
                     normal_vector,
                     north,
                 )
@@ -260,6 +262,7 @@ def off_axis_projection(
                     width.to("code_length").d,
                     chunk[item].in_units(ounits),
                     buf,
+                    mask,
                     normal_vector,
                     north,
                     weight_field=chunk[weight].in_units(wounits),
@@ -278,6 +281,7 @@ def off_axis_projection(
                     width.to("code_length").d,
                     chunk[weight].to(wounits),
                     weight_buff,
+                    mask,
                     normal_vector,
                     north,
                 )

--- a/yt/visualization/volume_rendering/tests/test_off_axis_SPH.py
+++ b/yt/visualization/volume_rendering/tests/test_off_axis_SPH.py
@@ -33,11 +33,12 @@ def test_no_rotation():
     bounds = [-4, 4, -4, 4, -4, 4]
 
     buf2 = np.zeros(resolution)
+    mask = np.ones_like(buf2, dtype="uint8")
     buf1 = OffAP.off_axis_projection(
         ds, center, normal_vector, width, resolution, ("gas", "density")
     )
     pixelize_sph_kernel_projection(
-        buf2, px, py, hsml, mass, density, quantity_to_smooth, bounds
+        buf2, mask, px, py, hsml, mass, density, quantity_to_smooth, bounds
     )
     assert_almost_equal(buf1.ndarray_view(), buf2)
 


### PR DESCRIPTION
## PR Summary

Close #4639

At the time of opening, this is at the proof-of-concept level and only works for the specific case that was used to illustrate the issue, but breaks pixelizing data in all other geometries.

I'll iterate some more until all tests are green again.

TODO:
- [x] pass existing tests
- [x] refactor (clean up interface, avoid breaking changes as much as possible)
- [x] add a new image test

*edit now that this is marked as ready for review:*

I've made my best to preserve backward compatibility and make the new behaviour in pixelizers opt-in. However there are a couple questions I would like to discuss with reviewers:
- would an actual masked array make more sense as a return type than a tuple (image, mask) ?
- should additional computations be made optional too ? In the present implementation, masks are computed in all cases, but may not be returned (to preserve backward compat).
- I know I broke backward compatibility in some particle-pixelizer functions (adding new arguments in the middle of the signature), is this acceptable ? if not, I'll need to think of a more complicated but backward compatible approach there too.