### PR TITLE
MNT: All nogil into noexcept nogil

### DIFF
--- a/yt/frontends/artio/_artio_caller.pyx
+++ b/yt/frontends/artio/_artio_caller.pyx
@@ -40,19 +40,19 @@ cdef extern from "cosmology.h":
     void cosmology_set_h(CosmologyParameters *c, double value)
     void cosmology_set_DeltaDC(CosmologyParameters *c, double value)
 
-    double abox_from_auni(CosmologyParameters *c, double a) nogil
-    double tcode_from_auni(CosmologyParameters *c, double a) nogil
-    double tphys_from_auni(CosmologyParameters *c, double a) nogil
+    double abox_from_auni(CosmologyParameters *c, double a) noexcept nogil
+    double tcode_from_auni(CosmologyParameters *c, double a) noexcept nogil
+    double tphys_from_auni(CosmologyParameters *c, double a) noexcept nogil
 
-    double auni_from_abox(CosmologyParameters *c, double v) nogil
-    double auni_from_tcode(CosmologyParameters *c, double v) nogil
-    double auni_from_tphys(CosmologyParameters *c, double v) nogil
+    double auni_from_abox(CosmologyParameters *c, double v) noexcept nogil
+    double auni_from_tcode(CosmologyParameters *c, double v) noexcept nogil
+    double auni_from_tphys(CosmologyParameters *c, double v) noexcept nogil
 
-    double abox_from_tcode(CosmologyParameters *c, double tcode) nogil
-    double tcode_from_abox(CosmologyParameters *c, double abox) nogil
+    double abox_from_tcode(CosmologyParameters *c, double tcode) noexcept nogil
+    double tcode_from_abox(CosmologyParameters *c, double abox) noexcept nogil
 
-    double tphys_from_abox(CosmologyParameters *c, double abox) nogil
-    double tphys_from_tcode(CosmologyParameters *c, double tcode) nogil
+    double tphys_from_abox(CosmologyParameters *c, double abox) noexcept nogil
+    double tphys_from_tcode(CosmologyParameters *c, double tcode) noexcept nogil
 
 cdef extern from "artio.h":
     ctypedef struct artio_fileset_handle "artio_fileset" :
@@ -152,8 +152,8 @@ cdef extern from "artio.h":
 
 
 cdef extern from "artio_internal.h":
-    np.int64_t artio_sfc_index( artio_fileset_handle *handle, int coords[3] ) nogil
-    void artio_sfc_coords( artio_fileset_handle *handle, int64_t index, int coords[3] ) nogil
+    np.int64_t artio_sfc_index( artio_fileset_handle *handle, int coords[3] ) noexcept nogil
+    void artio_sfc_coords( artio_fileset_handle *handle, int64_t index, int coords[3] ) noexcept nogil
 
 cdef void check_artio_status(int status, char *fname="[unknown]"):
     if status != ARTIO_SUCCESS:
@@ -1294,7 +1294,7 @@ cdef class ARTIORootMeshContainer:
         free(self.sfc_mask)
 
     @cython.cdivision(True)
-    cdef np.int64_t pos_to_sfc(self, np.float64_t pos[3]) nogil:
+    cdef np.int64_t pos_to_sfc(self, np.float64_t pos[3]) noexcept nogil:
         # Calculate the index
         cdef int coords[3]
         cdef int i
@@ -1305,7 +1305,7 @@ cdef class ARTIORootMeshContainer:
         return sfc
 
     @cython.cdivision(True)
-    cdef void sfc_to_pos(self, np.int64_t sfc, np.float64_t pos[3]) nogil:
+    cdef void sfc_to_pos(self, np.int64_t sfc, np.float64_t pos[3]) noexcept nogil:
         cdef int coords[3]
         cdef int i
         artio_sfc_coords(self.handle, sfc, coords)

--- a/yt/geometry/_selection_routines/selector_object.pxi
+++ b/yt/geometry/_selection_routines/selector_object.pxi
@@ -269,7 +269,7 @@ cdef class SelectorObject:
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    cdef np.float64_t periodic_difference(self, np.float64_t x1, np.float64_t x2, int d) nogil:
+    cdef np.float64_t periodic_difference(self, np.float64_t x1, np.float64_t x2, int d) noexcept nogil:
         # domain_width is already in code units, and we assume what is fed in
         # is too.
         cdef np.float64_t rel = x1 - x2

--- a/yt/geometry/oct_container.pxd
+++ b/yt/geometry/oct_container.pxd
@@ -63,8 +63,8 @@ cdef class OctreeContainer:
     cdef public np.int64_t nocts
     cdef public int num_domains
     cdef Oct *get(self, np.float64_t ppos[3], OctInfo *oinfo = ?,
-                  int max_level = ?) nogil
-    cdef int get_root(self, int ind[3], Oct **o) nogil
+                  int max_level = ?) noexcept nogil
+    cdef int get_root(self, int ind[3], Oct **o) noexcept nogil
     cdef Oct **neighbors(self, OctInfo *oinfo, np.int64_t *nneighbors,
                          Oct *o, bint periodicity[3])
     # This function must return the offset from global-to-local domains; i.e.,
@@ -88,7 +88,7 @@ cdef class SparseOctreeContainer(OctreeContainer):
     cdef int num_root
     cdef int max_root
     cdef void key_to_ipos(self, np.int64_t key, np.int64_t pos[3])
-    cdef np.int64_t ipos_to_key(self, int pos[3]) nogil
+    cdef np.int64_t ipos_to_key(self, int pos[3]) noexcept nogil
 
 cdef class RAMSESOctreeContainer(SparseOctreeContainer):
     pass

--- a/yt/geometry/oct_container.pyx
+++ b/yt/geometry/oct_container.pyx
@@ -196,7 +196,7 @@ cdef class OctreeContainer:
                         count += 1
         print("Missing total of %s out of %s" % (count, self.nn[0] * self.nn[1] * self.nn[2]))
 
-    cdef int get_root(self, int ind[3], Oct **o) nogil:
+    cdef int get_root(self, int ind[3], Oct **o) noexcept nogil:
         cdef int i
         for i in range(3):
             if ind[i] < 0 or ind[i] >= self.nn[i]:
@@ -209,7 +209,7 @@ cdef class OctreeContainer:
     @cython.wraparound(False)
     @cython.cdivision(True)
     cdef Oct *get(self, np.float64_t ppos[3], OctInfo *oinfo = NULL,
-                  int max_level = 99) nogil:
+                  int max_level = 99) noexcept nogil:
         #Given a floating point position, retrieve the most
         #refined oct at that time
         cdef int ind32[3]
@@ -993,7 +993,7 @@ cdef class SparseOctreeContainer(OctreeContainer):
     def save_octree(self):
         raise NotImplementedError
 
-    cdef int get_root(self, int ind[3], Oct **o) nogil:
+    cdef int get_root(self, int ind[3], Oct **o) noexcept nogil:
         o[0] = NULL
         cdef np.int64_t key = self.ipos_to_key(ind)
         cdef OctKey okey
@@ -1017,7 +1017,7 @@ cdef class SparseOctreeContainer(OctreeContainer):
             pos[2 - j] = (<np.int64_t>(key & ukey))
             key = key >> 20
 
-    cdef np.int64_t ipos_to_key(self, int pos[3]) nogil:
+    cdef np.int64_t ipos_to_key(self, int pos[3]) noexcept nogil:
         # We (hope) that 20 bits is enough for each index.
         cdef int i
         cdef np.int64_t key = 0

--- a/yt/geometry/oct_visitors.pxd
+++ b/yt/geometry/oct_visitors.pxd
@@ -140,7 +140,7 @@ cdef class MortonIndexOcts(OctVisitor):
     cdef np.uint8_t[:] level_arr
     cdef np.uint64_t[:] morton_ind
 
-cdef inline int cind(int i, int j, int k) nogil:
+cdef inline int cind(int i, int j, int k) noexcept nogil:
     # THIS ONLY WORKS FOR CHILDREN.  It is not general for zones.
     return (((i*2)+j)*2+k)
 

--- a/yt/geometry/particle_deposit.pxd
+++ b/yt/geometry/particle_deposit.pxd
@@ -117,7 +117,7 @@ cdef inline np.float64_t sph_kernel_dummy(np.float64_t x) noexcept nogil:
 # So in order to mimic a registry functionality,
 # I manually created a function to lookup the kernel functions.
 ctypedef np.float64_t (*kernel_func) (np.float64_t) noexcept nogil
-cdef inline kernel_func get_kernel_func(str kernel_name) nogil:
+cdef inline kernel_func get_kernel_func(str kernel_name) noexcept nogil:
     with gil:
         if kernel_name == 'cubic':
             return sph_kernel_cubic

--- a/yt/geometry/selection_routines.pxd
+++ b/yt/geometry/selection_routines.pxd
@@ -72,7 +72,7 @@ cdef class SelectorObject:
     # compute periodic distance (if periodicity set)
     # assuming 0->domain_width[d] coordinates
     cdef np.float64_t periodic_difference(
-        self, np.float64_t x1, np.float64_t x2, int d) nogil
+        self, np.float64_t x1, np.float64_t x2, int d) noexcept nogil
 
 cdef class AlwaysSelector(SelectorObject):
     pass
@@ -86,7 +86,7 @@ cdef class BooleanSelector(SelectorObject):
     cdef public SelectorObject sel2
 
 cdef inline np.float64_t _periodic_dist(np.float64_t x1, np.float64_t x2,
-                                        np.float64_t dw, bint periodic) nogil:
+                                        np.float64_t dw, bint periodic) noexcept nogil:
     cdef np.float64_t rel = x1 - x2
     if not periodic: return rel
     if rel > dw * 0.5:

--- a/yt/geometry/selection_routines.pyx
+++ b/yt/geometry/selection_routines.pyx
@@ -27,15 +27,15 @@ from .oct_visitors cimport cind
 
 
 cdef extern from "math.h":
-    double exp(double x) nogil
-    float expf(float x) nogil
-    long double expl(long double x) nogil
-    double floor(double x) nogil
-    double ceil(double x) nogil
-    double fmod(double x, double y) nogil
-    double log2(double x) nogil
-    long int lrint(double x) nogil
-    double fabs(double x) nogil
+    double exp(double x) noexcept nogil
+    float expf(float x) noexcept nogil
+    long double expl(long double x) noexcept nogil
+    double floor(double x) noexcept nogil
+    double ceil(double x) noexcept nogil
+    double fmod(double x, double y) noexcept nogil
+    double log2(double x) noexcept nogil
+    long int lrint(double x) noexcept nogil
+    double fabs(double x) noexcept nogil
 
 # use this as an epsilon test for grids aligned with selector
 # define here to avoid the gil later
@@ -43,10 +43,10 @@ cdef np.float64_t grid_eps = np.finfo(np.float64).eps
 grid_eps = 0.0
 
 cdef inline np.float64_t dot(np.float64_t* v1,
-                             np.float64_t* v2) nogil:
+                             np.float64_t* v2) noexcept nogil:
     return v1[0]*v2[0] + v1[1]*v2[1] + v1[2]*v2[2]
 
-cdef inline np.float64_t norm(np.float64_t* v) nogil:
+cdef inline np.float64_t norm(np.float64_t* v) noexcept nogil:
     return sqrt(dot(v, v))
 
 # These routines are separated into a couple different categories:

--- a/yt/utilities/lib/bounding_volume_hierarchy.pxd
+++ b/yt/utilities/lib/bounding_volume_hierarchy.pxd
@@ -40,12 +40,12 @@ ctypedef np.int64_t (*intersect_func_type)(const void* primitives,
 # pointer to function that computes primitive centroids
 ctypedef void (*centroid_func_type)(const void *primitives,
                                     const np.int64_t item,
-                                    np.float64_t[3] centroid) nogil
+                                    np.float64_t[3] centroid) noexcept nogil
 
 # pointer to function that computes primitive bounding boxes
 ctypedef void (*bbox_func_type)(const void *primitives,
                                 const np.int64_t item,
-                                BBox* bbox) nogil
+                                BBox* bbox) noexcept nogil
 
 
 cdef class BVH:
@@ -82,4 +82,4 @@ cdef class BVH:
                              np.int64_t begin, np.int64_t end) noexcept nogil
     cdef void _recursive_intersect(self, Ray* ray, BVHNode* node) noexcept nogil
     cdef BVHNode* _recursive_build(self, np.int64_t begin, np.int64_t end) noexcept nogil
-    cdef void _recursive_free(self, BVHNode* node) nogil
+    cdef void _recursive_free(self, BVHNode* node) noexcept nogil

--- a/yt/utilities/lib/bounding_volume_hierarchy.pyx
+++ b/yt/utilities/lib/bounding_volume_hierarchy.pyx
@@ -249,7 +249,7 @@ cdef class BVH:
                               tri_index,
                               &(self.bboxes[tri_index]))
 
-    cdef void _recursive_free(self, BVHNode* node) nogil:
+    cdef void _recursive_free(self, BVHNode* node) noexcept nogil:
         if node.end - node.begin > LEAF_SIZE:
             self._recursive_free(node.left)
             self._recursive_free(node.right)

--- a/yt/utilities/lib/cykdtree/kdtree.pxd
+++ b/yt/utilities/lib/cykdtree/kdtree.pxd
@@ -78,10 +78,10 @@ cdef extern from "c_kdtree.hpp":
                bool use_sliding_midpoint)
         KDTree(istream &ist)
         void serialize(ostream &os)
-        double* wrap_pos(double* pos) nogil
-        vector[uint32_t] get_neighbor_ids(double* pos) nogil
-        Node* search(double* pos) nogil
-        Node* search(double* pos, bool dont_wrap) nogil
+        double* wrap_pos(double* pos) noexcept nogil
+        vector[uint32_t] get_neighbor_ids(double* pos) noexcept nogil
+        Node* search(double* pos) noexcept nogil
+        Node* search(double* pos, bool dont_wrap) noexcept nogil
         void consolidate_edges(double *leaves_le, double *leaves_re)
 
 

--- a/yt/utilities/lib/cyoctree.pyx
+++ b/yt/utilities/lib/cyoctree.pyx
@@ -697,7 +697,7 @@ cdef np.int64_t separate(
         double value,
         np.int64_t start,
         np.int64_t end
-    ) nogil:
+    ) noexcept nogil:
     """
     This is a simple utility function which takes a selection of particles and
     re-arranges them such that values below `value` are to the left of split and
@@ -783,7 +783,7 @@ cdef np.int64_t select(
         np.float64_t[::1] right_edge,
         np.int64_t start,
         np.int64_t end
-    ) nogil:
+    ) noexcept nogil:
     """
     Re-arrange the input particles such that those outside the bounds of the
     tree occur after the split index and can thus be ignored for the remainder

--- a/yt/utilities/lib/distance_queue.pyx
+++ b/yt/utilities/lib/distance_queue.pyx
@@ -15,7 +15,7 @@ import numpy as np
 cimport cython
 
 
-cdef int Neighbor_compare(void *on1, void *on2) nogil:
+cdef int Neighbor_compare(void *on1, void *on2) noexcept nogil:
     cdef NeighborList *n1
     cdef NeighborList *n2
     n1 = <NeighborList *> on1

--- a/yt/utilities/lib/embree_mesh/mesh_intersection.pxd
+++ b/yt/utilities/lib/embree_mesh/mesh_intersection.pxd
@@ -8,16 +8,16 @@ from .mesh_construction cimport Patch, Tet_Patch
 
 cdef void patchIntersectFunc(Patch* patches,
                              rtcr.RTCRay& ray,
-                             size_t item) nogil
+                             size_t item) noexcept nogil
 
 cdef void patchBoundsFunc(Patch* patches,
                           size_t item,
-                          rtcg.RTCBounds* bounds_o) nogil
+                          rtcg.RTCBounds* bounds_o) noexcept nogil
 
 cdef void tet_patchIntersectFunc(Tet_Patch* tet_patches,
                              rtcr.RTCRay& ray,
-                             size_t item) nogil
+                             size_t item) noexcept nogil
 
 cdef void tet_patchBoundsFunc(Tet_Patch* tet_patches,
                           size_t item,
-                          rtcg.RTCBounds* bounds_o) nogil
+                          rtcg.RTCBounds* bounds_o) noexcept nogil

--- a/yt/utilities/lib/embree_mesh/mesh_intersection.pyx
+++ b/yt/utilities/lib/embree_mesh/mesh_intersection.pyx
@@ -30,7 +30,7 @@ from .mesh_samplers cimport sample_hex20, sample_tet10
 @cython.cdivision(True)
 cdef void patchBoundsFunc(Patch* patches,
                           size_t item,
-                          rtcg.RTCBounds* bounds_o) nogil:
+                          rtcg.RTCBounds* bounds_o) noexcept nogil:
 
     cdef Patch patch = patches[item]
 
@@ -64,7 +64,7 @@ cdef void patchBoundsFunc(Patch* patches,
 @cython.cdivision(True)
 cdef void patchIntersectFunc(Patch* patches,
                              rtcr.RTCRay& ray,
-                             size_t item) nogil:
+                             size_t item) noexcept nogil:
 
     cdef Patch patch = patches[item]
 
@@ -93,7 +93,7 @@ cdef void patchIntersectFunc(Patch* patches,
 @cython.cdivision(True)
 cdef void tet_patchBoundsFunc(Tet_Patch* tet_patches,
                           size_t item,
-                          rtcg.RTCBounds* bounds_o) nogil:
+                          rtcg.RTCBounds* bounds_o) noexcept nogil:
 
     cdef Tet_Patch tet_patch = tet_patches[item]
 
@@ -127,7 +127,7 @@ cdef void tet_patchBoundsFunc(Tet_Patch* tet_patches,
 @cython.cdivision(True)
 cdef void tet_patchIntersectFunc(Tet_Patch* tet_patches,
                              rtcr.RTCRay& ray,
-                             size_t item) nogil:
+                             size_t item) noexcept nogil:
 
     cdef Tet_Patch tet_patch = tet_patches[item]
 

--- a/yt/utilities/lib/embree_mesh/mesh_samplers.pxd
+++ b/yt/utilities/lib/embree_mesh/mesh_samplers.pxd
@@ -4,16 +4,16 @@ cimport pyembree.rtcore_ray as rtcr
 
 
 cdef void sample_hex(void* userPtr,
-                     rtcr.RTCRay& ray) nogil
+                     rtcr.RTCRay& ray) noexcept nogil
 
 cdef void sample_wedge(void* userPtr,
-                       rtcr.RTCRay& ray) nogil
+                       rtcr.RTCRay& ray) noexcept nogil
 
 cdef void sample_tetra(void* userPtr,
-                       rtcr.RTCRay& ray) nogil
+                       rtcr.RTCRay& ray) noexcept nogil
 
 cdef void sample_hex20(void* userPtr,
-                       rtcr.RTCRay& ray) nogil
+                       rtcr.RTCRay& ray) noexcept nogil
 
 cdef void sample_tet10(void* userPtr,
-                       rtcr.RTCRay& ray) nogil
+                       rtcr.RTCRay& ray) noexcept nogil

--- a/yt/utilities/lib/embree_mesh/mesh_samplers.pyx
+++ b/yt/utilities/lib/embree_mesh/mesh_samplers.pyx
@@ -40,7 +40,7 @@ cdef ElementSampler Tet2Sampler = Tet2Sampler3D()
 @cython.cdivision(True)
 cdef void get_hit_position(double* position,
                            void* userPtr,
-                           rtcr.RTCRay& ray) nogil:
+                           rtcr.RTCRay& ray) noexcept nogil:
     cdef int primID, i
     cdef double[3][3] vertex_positions
     cdef Triangle tri
@@ -72,7 +72,7 @@ cdef void get_hit_position(double* position,
 @cython.wraparound(False)
 @cython.cdivision(True)
 cdef void sample_hex(void* userPtr,
-                     rtcr.RTCRay& ray) nogil:
+                     rtcr.RTCRay& ray) noexcept nogil:
     cdef int ray_id, elem_id, i
     cdef double val
     cdef double[8] field_data
@@ -123,7 +123,7 @@ cdef void sample_hex(void* userPtr,
 @cython.wraparound(False)
 @cython.cdivision(True)
 cdef void sample_wedge(void* userPtr,
-                       rtcr.RTCRay& ray) nogil:
+                       rtcr.RTCRay& ray) noexcept nogil:
     cdef int ray_id, elem_id, i
     cdef double val
     cdef double[6] field_data
@@ -171,7 +171,7 @@ cdef void sample_wedge(void* userPtr,
 @cython.initializedcheck(False)
 @cython.cdivision(True)
 cdef void sample_hex20(void* userPtr,
-                       rtcr.RTCRay& ray) nogil:
+                       rtcr.RTCRay& ray) noexcept nogil:
     cdef int ray_id, i
     cdef double val
     cdef double[3] position
@@ -206,7 +206,7 @@ cdef void sample_hex20(void* userPtr,
 @cython.wraparound(False)
 @cython.cdivision(True)
 cdef void sample_tetra(void* userPtr,
-                       rtcr.RTCRay& ray) nogil:
+                       rtcr.RTCRay& ray) noexcept nogil:
 
     cdef int ray_id, elem_id, i
     cdef double val
@@ -253,7 +253,7 @@ cdef void sample_tetra(void* userPtr,
 @cython.initializedcheck(False)
 @cython.cdivision(True)
 cdef void sample_tet10(void* userPtr,
-                       rtcr.RTCRay& ray) nogil:
+                       rtcr.RTCRay& ray) noexcept nogil:
     cdef int ray_id, i
     cdef double val
     cdef double[3] position

--- a/yt/utilities/lib/field_interpolation_tables.pxd
+++ b/yt/utilities/lib/field_interpolation_tables.pxd
@@ -17,11 +17,11 @@ from yt.utilities.lib.fp_utils cimport fabs, fclip, fmax, fmin, iclip, imax, imi
 
 
 cdef extern from "<cmath>" namespace "std":
-    bint isnormal(double x) nogil
+    bint isnormal(double x) noexcept nogil
 
 
 cdef extern from "platform_dep_math.hpp":
-    bint __isnormal(double) nogil
+    bint __isnormal(double) noexcept nogil
 
 
 cdef struct FieldInterpolationTable:

--- a/yt/utilities/lib/fnv_hash.pxd
+++ b/yt/utilities/lib/fnv_hash.pxd
@@ -13,4 +13,4 @@ import numpy as np
 cimport numpy as np
 
 
-cdef np.int64_t c_fnv_hash(unsigned unsigned char[:] octets) nogil
+cdef np.int64_t c_fnv_hash(unsigned unsigned char[:] octets) noexcept nogil

--- a/yt/utilities/lib/fnv_hash.pyx
+++ b/yt/utilities/lib/fnv_hash.pyx
@@ -15,7 +15,7 @@ cimport numpy as np
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-cdef np.int64_t c_fnv_hash(unsigned char[:] octets) nogil:
+cdef np.int64_t c_fnv_hash(unsigned char[:] octets) noexcept nogil:
     # https://bitbucket.org/yt_analysis/yt/issues/1052/field-access-tests-fail-under-python3
     # FNV hash cf. http://www.isthe.com/chongo/tech/comp/fnv/index.html
     cdef np.int64_t hash_val = 2166136261

--- a/yt/utilities/lib/geometry_utils.pyx
+++ b/yt/utilities/lib/geometry_utils.pyx
@@ -30,16 +30,16 @@ DEF YSHIFT=1
 DEF ZSHIFT=0
 
 cdef extern from "math.h":
-    double exp(double x) nogil
-    float expf(float x) nogil
-    long double expl(long double x) nogil
-    double floor(double x) nogil
-    double ceil(double x) nogil
-    double fmod(double x, double y) nogil
-    double fabs(double x) nogil
+    double exp(double x) noexcept nogil
+    float expf(float x) noexcept nogil
+    long double expl(long double x) noexcept nogil
+    double floor(double x) noexcept nogil
+    double ceil(double x) noexcept nogil
+    double fmod(double x, double y) noexcept nogil
+    double fabs(double x) noexcept nogil
 
 cdef extern from "platform_dep.h":
-    long int lrint(double x) nogil
+    long int lrint(double x) noexcept nogil
 
 @cython.cdivision(True)
 @cython.boundscheck(False)

--- a/yt/utilities/lib/image_samplers.pyx
+++ b/yt/utilities/lib/image_samplers.pyx
@@ -36,7 +36,7 @@ from ._octree_raytracing cimport RayInfo, _OctreeRayTracing
 
 
 cdef extern from "platform_dep.h":
-    long int lrint(double x) nogil
+    long int lrint(double x) noexcept nogil
 
 DEF Nch = 4
 

--- a/yt/utilities/lib/lenses.pxd
+++ b/yt/utilities/lib/lenses.pxd
@@ -38,7 +38,7 @@ from .volume_container cimport VolumeContainer
 
 
 cdef extern from "platform_dep.h":
-    long int lrint(double x) nogil
+    long int lrint(double x) noexcept nogil
 
 cdef extern from "limits.h":
     cdef int SHRT_MAX

--- a/yt/utilities/lib/mesh_triangulation.pyx
+++ b/yt/utilities/lib/mesh_triangulation.pyx
@@ -43,7 +43,7 @@ cdef struct TriNode:
     np.int64_t tri[3]
     TriNode* next_node
 
-cdef np.int64_t triangles_are_equal(np.int64_t tri1[3], np.int64_t tri2[3]) nogil:
+cdef np.int64_t triangles_are_equal(np.int64_t tri1[3], np.int64_t tri2[3]) noexcept nogil:
     cdef np.int64_t found
     for i in range(3):
         found = False
@@ -54,7 +54,7 @@ cdef np.int64_t triangles_are_equal(np.int64_t tri1[3], np.int64_t tri2[3]) nogi
             return 0
     return 1
 
-cdef np.uint64_t triangle_hash(np.int64_t tri[3]) nogil:
+cdef np.uint64_t triangle_hash(np.int64_t tri[3]) noexcept nogil:
     # http://stackoverflow.com/questions/1536393/good-hash-function-for-permutations
     cdef np.uint64_t h = 1
     for i in range(3):
@@ -126,7 +126,7 @@ cdef class TriSet:
     cdef TriNode* _allocate_new_node(self,
                                      np.int64_t tri[3],
                                      np.uint64_t key,
-                                     np.int64_t elem) nogil:
+                                     np.int64_t elem) noexcept nogil:
         cdef TriNode* new_node = <TriNode* > malloc(sizeof(TriNode))
         new_node.key = key
         new_node.elem = elem
@@ -138,7 +138,7 @@ cdef class TriSet:
         return new_node
 
     @cython.cdivision(True)
-    cdef void update(self, np.int64_t tri[3], np.int64_t elem) nogil:
+    cdef void update(self, np.int64_t tri[3], np.int64_t elem) noexcept nogil:
         cdef np.uint64_t key = triangle_hash(tri)
         cdef np.uint64_t index = key % TABLE_SIZE
         cdef TriNode *node = self.table[index]


### PR DESCRIPTION
With the release of Cython 3.0, we've had some issues with performance regressions due to missing `noexcept` declarations.  This goes through and changes all functions that are `nogil` into `noexcept nogil`.  Earlier PRs had done a fair bit of this, but this does the remainder.
