### PR TITLE
allow annotate_grids to force cmap to respect max_levels

### DIFF
--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -1054,6 +1054,7 @@ class GridBoundaryCallback(PlotCallback):
         cmap="B-W LINEAR_r",
         edgecolors=None,
         linewidth=1.0,
+        use_max_level_in_cmap=False
     ):
         self.alpha = alpha
         self.min_pix = min_pix
@@ -1073,6 +1074,7 @@ class GridBoundaryCallback(PlotCallback):
         self.linewidth = linewidth
         self.cmap = cmap
         self.edgecolors = edgecolors
+        self.use_max_level_in_cmap = use_max_level_in_cmap
 
     def __call__(self, plot):
         if plot.data.ds.geometry == "cylindrical" and plot.data.ds.dimensionality == 3:
@@ -1135,7 +1137,10 @@ class GridBoundaryCallback(PlotCallback):
                 edgecolors = colorConverter.to_rgba(self.edgecolors, alpha=self.alpha)
             else:  # use colormap if not explicitly overridden by edgecolors
                 if self.cmap is not None:
-                    color_bounds = [0, plot.data.ds.index.max_level]
+                    if self.use_max_level_in_cmap:
+                        color_bounds = [0, max_level]
+                    else:
+                        color_bounds = [0, plot.data.ds.index.max_level]
                     edgecolors = (
                         apply_colormap(
                             levels[visible] * 1.0,

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -1054,7 +1054,6 @@ class GridBoundaryCallback(PlotCallback):
         cmap="B-W LINEAR_r",
         edgecolors=None,
         linewidth=1.0,
-        use_max_level_in_cmap=False
     ):
         self.alpha = alpha
         self.min_pix = min_pix
@@ -1074,7 +1073,6 @@ class GridBoundaryCallback(PlotCallback):
         self.linewidth = linewidth
         self.cmap = cmap
         self.edgecolors = edgecolors
-        self.use_max_level_in_cmap = use_max_level_in_cmap
 
     def __call__(self, plot):
         if plot.data.ds.geometry == "cylindrical" and plot.data.ds.dimensionality == 3:
@@ -1137,10 +1135,7 @@ class GridBoundaryCallback(PlotCallback):
                 edgecolors = colorConverter.to_rgba(self.edgecolors, alpha=self.alpha)
             else:  # use colormap if not explicitly overridden by edgecolors
                 if self.cmap is not None:
-                    if self.use_max_level_in_cmap:
-                        color_bounds = [0, max_level]
-                    else:
-                        color_bounds = [0, plot.data.ds.index.max_level]
+                    color_bounds = [0, max_level]
                     edgecolors = (
                         apply_colormap(
                             levels[visible] * 1.0,


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

At the moment, when you use `annotate_grids()` to show boxes and compare simulations with different
numbers of refinement levels, the colors don't correspond to one another across simulations.  For example,
here are 4 different simulations.  One has base + 1 level, then next 2 levels, then 3, and finally 4 levels of refinement
(all are jumps of 2x).  Notice that the color for level 1 is not the same across all simulations:

![subch_Temp_res_compare_orig](https://github.com/yt-project/yt/assets/7817509/1aa81e8c-03be-47b1-88f8-2032a1396690)

Here's the output with this PR if I pass `use_max_level_in_cmap=True` to `annocate_grids()`.

![subch_Temp_res_compare](https://github.com/yt-project/yt/assets/7817509/a207ad6d-7f56-4288-a216-c4bc57564b49)

Note: I am unsure why the original behavior was desired, but I left it in place.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
