### PR TITLE
TST: remove unused warning filter

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -138,15 +138,6 @@ def pytest_configure(config):
             r"Use Palette\.ADAPTIVE instead\.:DeprecationWarning",
         )
 
-    if NUMPY_VERSION < Version("1.19") and MPL_VERSION < Version("3.6"):
-        # This warning is triggered from matplotlib in exactly one test at the time of writing
-        # and exclusively on the minimal test env. Upgrading numpy or matplotlib resolves
-        # the issue, so we can afford to ignore it.
-        config.addinivalue_line(
-            "filterwarnings",
-            "ignore:invalid value encountered in less_equal:RuntimeWarning",
-        )
-
     if NUMPY_VERSION >= Version("1.25"):
         if find_spec("h5py") is not None and (
             Version(version("h5py")) < Version("3.9")


### PR DESCRIPTION
This filter should never be used anymore since we now require numpy >= 1.19.3 (first version with Python 3.9 support)