### PR TITLE
MNT: switch to faster black pre-commit hook, and upgrade black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,8 +27,8 @@ repos:
     - id: check-executables-have-shebangs
     - id: check-yaml
 
--   repo: https://github.com/psf/black
-    rev: 23.7.0
+-   repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.9.0
     hooks:
     - id: black-jupyter
 
@@ -36,7 +36,7 @@ repos:
     rev: 1.16.0
     hooks:
     -   id: blacken-docs
-        additional_dependencies: [black==23.1.0]
+        additional_dependencies: [black==23.9.0]
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.0.287


### PR DESCRIPTION
As per https://github.com/psf/black/releases/tag/23.9.0, the new mirror repo makes black 2x faster when run through pre-commit using mypyc-compiled wheels