### PR TITLE
TYP: fix type-check incompatibilities with matplotlib 3.8

### DIFF
--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -2,7 +2,6 @@ import sys
 import warnings
 from abc import ABC
 from io import BytesIO
-from types import FunctionType
 from typing import TYPE_CHECKING, Optional, TypedDict, Union
 
 import matplotlib
@@ -37,6 +36,7 @@ if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from matplotlib.axis import Axis
     from matplotlib.figure import Figure
+    from matplotlib.transforms import Transform
 
     class FormatKwargs(TypedDict):
         style: Literal["scientific"]
@@ -249,7 +249,7 @@ class ImagePlotMPL(PlotMPL, ABC):
     ):
         """Initialize ImagePlotMPL class object"""
 
-        self._transform: Optional[FunctionType]
+        self._transform: Optional["Transform"]
         setdefaultattr(self, "_transform", None)
 
         self.colorbar_handler = colorbar_handler


### PR DESCRIPTION
follow up to #4629 now that matplotlib 3.8.0 is finalised.