### PR TITLE
MNT: simplify build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,14 +5,8 @@ requires = [
 
   # see https://github.com/yt-project/yt/issues/4044
   "Cython>=3.0, <3.1",
-
-  # TODO: simplify requirement after numpy 1.26.0 final is released
-  "numpy>=1.25, <2.0 ; python_version < '3.12.0rc1'",
-  "numpy>=1.26.0b1, <2.0; python_version >= '3.12.0rc1'",
-
-  # TODO: simplify requirement after ewah-bool-utils 1.1.0 final is released
-  "ewah-bool-utils>=1.0.2 ; python_version < '3.12.0rc1'",
-  "ewah-bool-utils>=1.1.0rc1 ; python_version >= '3.12.0rc1'",
+  "numpy>=1.25, <2.0",
+  "ewah-bool-utils>=1.0.2",
 ]
 build-backend = "setuptools.build_meta:__legacy__"
 


### PR DESCRIPTION
Following the release of numpy 1.26.0 and ewah-bool-utils 1.1.0