### PR TITLE
BUG: load_hdf5_file doesn't pass bounding box to load_amr_grids

### DIFF
--- a/yt/frontends/stream/tests/test_callable_grids.py
+++ b/yt/frontends/stream/tests/test_callable_grids.py
@@ -41,6 +41,10 @@ def test_load_hdf5_file():
     assert_almost_equal(ds2.r[:]["Density"].min(), ds1.r[:]["Density"].min())
     assert_almost_equal(ds2.r[:]["Density"].max(), ds1.r[:]["Density"].max())
     assert_almost_equal(ds2.r[:]["Density"].std(), ds1.r[:]["Density"].std())
+    # test that we can load this dataset with a different bounding box and length units
+    ds3 = load_hdf5_file(turb_vels, bbox=np.array([[-1.0, 1.0], [-1.0, 1.0], [-1.0, 1.0]]),
+                         dataset_arguments={"length_unit": (1.0, "kpc")})
+    assert_almost_equal(ds3.domain_width, ds3.arr([2, 2, 2], "kpc"))
 
 
 _x_coefficients = (100, 50, 30, 10, 20)

--- a/yt/frontends/stream/tests/test_callable_grids.py
+++ b/yt/frontends/stream/tests/test_callable_grids.py
@@ -42,8 +42,11 @@ def test_load_hdf5_file():
     assert_almost_equal(ds2.r[:]["Density"].max(), ds1.r[:]["Density"].max())
     assert_almost_equal(ds2.r[:]["Density"].std(), ds1.r[:]["Density"].std())
     # test that we can load this dataset with a different bounding box and length units
-    ds3 = load_hdf5_file(turb_vels, bbox=np.array([[-1.0, 1.0], [-1.0, 1.0], [-1.0, 1.0]]),
-                         dataset_arguments={"length_unit": (1.0, "kpc")})
+    ds3 = load_hdf5_file(
+        turb_vels,
+        bbox=np.array([[-1.0, 1.0], [-1.0, 1.0], [-1.0, 1.0]]),
+        dataset_arguments={"length_unit": (1.0, "kpc")},
+    )
     assert_almost_equal(ds3.domain_width, ds3.arr([2, 2, 2], "kpc"))
 
 

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -1901,4 +1901,4 @@ def load_hdf5_file(
         data = {_: reader for _ in fields}
         data.update({"left_edge": le, "right_edge": re, "dimensions": s, "level": 0})
         grid_data.append(data)
-    return load_amr_grids(grid_data, shape, **dataset_arguments)
+    return load_amr_grids(grid_data, shape, bbox=bbox, **dataset_arguments)


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

`load_hdf5_file` serves as a way to load arbitrary HDF5 files with the stream frontend as a wrapper around `load_amr_grids`. It accepts a bounding box argument `bbox` that can be used to determine the grid decomposition, but this bounding box is not passed to `load_amr_grids` itself and therefore the actual bounding box does not change. This PR addresses that issue and provides a test.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
