### PR TITLE
PERF: return the count from fill_mask_regular_grid

### DIFF
--- a/yt/data_objects/index_subobjects/grid_patch.py
+++ b/yt/data_objects/index_subobjects/grid_patch.py
@@ -388,14 +388,14 @@ class AMRGridPatch(YTSelectionContainer):
         if self._cache_mask and hash(selector) == self._last_selector_id:
             mask = self._last_mask
         else:
-            mask = selector.fill_mask_regular_grid(self)
+            mask, count = selector.fill_mask_regular_grid(self)
             if self._cache_mask:
                 self._last_mask = mask
             self._last_selector_id = hash(selector)
             if mask is None:
                 self._last_count = 0
             else:
-                self._last_count = mask.sum()
+                self._last_count = count
         return mask
 
     def select(self, selector, source, dest, offset):

--- a/yt/geometry/_selection_routines/data_collection_selector.pxi
+++ b/yt/geometry/_selection_routines/data_collection_selector.pxi
@@ -28,7 +28,7 @@ cdef class DataCollectionSelector(SelectorObject):
     def fill_mask_regular_grid(self, gobj):
         cdef np.ndarray[np.uint8_t, ndim=3] mask
         mask = np.ones(gobj.ActiveDimensions, dtype='uint8')
-        return mask.astype("bool")
+        return mask.astype("bool"), mask.size
 
     def _hash_vals(self):
         return (hash(self.obj_ids.tobytes()), self.nids)

--- a/yt/geometry/_selection_routines/grid_selector.pxi
+++ b/yt/geometry/_selection_routines/grid_selector.pxi
@@ -20,7 +20,8 @@ cdef class GridSelector(SelectorObject):
     @cython.wraparound(False)
     @cython.cdivision(True)
     def fill_mask_regular_grid(self, gobj):
-        return np.ones(gobj.ActiveDimensions, dtype='bool'), gobj.ActiveDimensions
+        mask = np.ones(gobj.ActiveDimensions, dtype='bool')
+        return mask, mask.size
 
     @cython.boundscheck(False)
     @cython.wraparound(False)

--- a/yt/geometry/_selection_routines/grid_selector.pxi
+++ b/yt/geometry/_selection_routines/grid_selector.pxi
@@ -20,7 +20,7 @@ cdef class GridSelector(SelectorObject):
     @cython.wraparound(False)
     @cython.cdivision(True)
     def fill_mask_regular_grid(self, gobj):
-        return np.ones(gobj.ActiveDimensions, dtype='bool')
+        return np.ones(gobj.ActiveDimensions, dtype='bool'), gobj.ActiveDimensions
 
     @cython.boundscheck(False)
     @cython.wraparound(False)

--- a/yt/geometry/_selection_routines/ortho_ray_selector.pxi
+++ b/yt/geometry/_selection_routines/ortho_ray_selector.pxi
@@ -53,8 +53,8 @@ cdef class OrthoRaySelector(SelectorObject):
                             if this_level == 1 or child_mask[i, j, k]:
                                 mask[i, j, k] = 1
                                 total += 1
-            if total == 0: return None
-            return mask.astype("bool")
+            if total == 0: return None, 0
+            return mask.astype("bool"), total
 
     @cython.boundscheck(False)
     @cython.wraparound(False)

--- a/yt/geometry/_selection_routines/ray_selector.pxi
+++ b/yt/geometry/_selection_routines/ray_selector.pxi
@@ -71,8 +71,8 @@ cdef class RaySelector(SelectorObject):
                         mask[i, j, k] = 1
                         total += 1
         free(ia)
-        if total == 0: return None
-        return mask.astype("bool")
+        if total == 0: return None, 0
+        return mask.astype("bool"), total
 
     @cython.boundscheck(False)
     @cython.wraparound(False)

--- a/yt/geometry/_selection_routines/selector_object.pxi
+++ b/yt/geometry/_selection_routines/selector_object.pxi
@@ -377,8 +377,8 @@ cdef class SelectorObject:
         total = self.fill_mask_selector_regular_grid(left_edge, right_edge,
                                                      dds, dim, child_mask,
                                                      mask, level)
-        if total == 0: return None
-        return mask.astype("bool")
+        if total == 0: return None, 0
+        return mask.astype("bool"), total
 
     @cython.boundscheck(False)
     @cython.wraparound(False)

--- a/yt/geometry/_selection_routines/slice_selector.pxi
+++ b/yt/geometry/_selection_routines/slice_selector.pxi
@@ -60,8 +60,8 @@ cdef class SliceSelector(SelectorObject):
                             if this_level == 1 or child_mask[i, j, k]:
                                 mask[i, j, k] = 1
                                 total += 1
-            if total == 0: return None
-            return mask.astype("bool")
+            if total == 0: return None, 0
+            return mask.astype("bool"), total
 
     @cython.boundscheck(False)
     @cython.wraparound(False)

--- a/yt/utilities/amr_kdtree/amr_kdtree.py
+++ b/yt/utilities/amr_kdtree/amr_kdtree.py
@@ -352,10 +352,8 @@ class AMRKDTree(ParallelAnalysisInterface):
         if self.data_source.selector is None:
             mask = np.ones(dims, dtype="uint8")
         else:
-            mask, _ = self.data_source.selector.fill_mask_regular_grid(grid)[
-                li[0] : ri[0], li[1] : ri[1], li[2] : ri[2]
-            ]
-            mask = mask.astype("uint8")
+            mask, _ = self.data_source.selector.fill_mask_regular_grid(grid)
+            mask = mask[li[0] : ri[0], li[1] : ri[1], li[2] : ri[2]].astype("uint8")
 
         data = [
             d[li[0] : ri[0] + 1, li[1] : ri[1] + 1, li[2] : ri[2] + 1].copy()

--- a/yt/utilities/amr_kdtree/amr_kdtree.py
+++ b/yt/utilities/amr_kdtree/amr_kdtree.py
@@ -352,9 +352,10 @@ class AMRKDTree(ParallelAnalysisInterface):
         if self.data_source.selector is None:
             mask = np.ones(dims, dtype="uint8")
         else:
-            mask = self.data_source.selector.fill_mask_regular_grid(grid)[
+            mask, _ = self.data_source.selector.fill_mask_regular_grid(grid)[
                 li[0] : ri[0], li[1] : ri[1], li[2] : ri[2]
-            ].astype("uint8")
+            ]
+            mask = mask.astype("uint8")
 
         data = [
             d[li[0] : ri[0] + 1, li[1] : ri[1] + 1, li[2] : ri[2] + 1].copy()


### PR DESCRIPTION
While working on #4630 , I noticed that we could avoid an np.sum() by having fill_mask_regular_grid return the selection count that it's already tracking. Savings are small, but I thought it was worth the change to avoid recalculating a number we already have. 