### PR TITLE
TST: restore global state modified during tests

### DIFF
--- a/yt/data_objects/tests/test_image_array.py
+++ b/yt/data_objects/tests/test_image_array.py
@@ -9,12 +9,20 @@ from numpy.testing import assert_equal
 from yt.data_objects.image_array import ImageArray
 from yt.testing import requires_module
 
+old_settings = None
+
 
 def setup():
+    global old_settings
     from yt.config import ytcfg
 
     ytcfg["yt", "internals", "within_testing"] = True
+    old_settings = np.geterr()
     np.seterr(all="ignore")
+
+
+def teardown():
+    np.seterr(**old_settings)
 
 
 def dummy_image(kstep, nlayers):

--- a/yt/utilities/lib/tests/test_alt_ray_tracers.py
+++ b/yt/utilities/lib/tests/test_alt_ray_tracers.py
@@ -6,11 +6,13 @@ from yt.testing import amrspace
 from yt.utilities.lib.alt_ray_tracers import _cyl2cart, cylindrical_ray_trace
 
 left_grid = right_grid = amr_levels = center_grid = data = None
+old_settings = None
 
 
 def setup():
     # set up some sample cylindrical grid data, radiating out from center
-    global left_grid, right_grid, amr_levels, center_grid, data
+    global left_grid, right_grid, amr_levels, center_grid, data, old_settings
+    old_settings = np.geterr()
     np.seterr(all="ignore")
     l1, r1, lvl1 = amrspace([0.0, 1.0, 0.0, -1.0, 0.0, 2 * np.pi], levels=(7, 7, 0))
     l2, r2, lvl2 = amrspace([0.0, 1.0, 0.0, 1.0, 0.0, 2 * np.pi], levels=(7, 7, 0))
@@ -19,6 +21,10 @@ def setup():
     amr_levels = np.concatenate([lvl1, lvl2], axis=0)
     center_grid = (left_grid + right_grid) / 2.0
     data = np.cos(np.sqrt(np.sum(center_grid[:, :2] ** 2, axis=1))) ** 2  # cos^2
+
+
+def teardown():
+    np.seterr(**old_settings)
 
 
 point_pairs = np.array(

--- a/yt/utilities/tests/test_set_log_level.py
+++ b/yt/utilities/tests/test_set_log_level.py
@@ -2,6 +2,19 @@ from numpy.testing import assert_raises
 
 from yt.utilities.logger import set_log_level
 
+old_level = None
+
+
+def setup():
+    global old_level
+    from yt.utilities.logger import ytLogger
+
+    old_level = ytLogger.level
+
+
+def teardown():
+    set_log_level(old_level)
+
 
 def test_valid_level():
     # test a subset of valid entries to cover

--- a/yt/visualization/image_writer.py
+++ b/yt/visualization/image_writer.py
@@ -149,6 +149,9 @@ def write_bitmap(bitmap_array, filename, max_val=None, transpose=False):
             alpha_channel.shape = s1, s2, 1
         if max_val is None:
             max_val = bitmap_array[:, :, :3].max()
+            if max_val == 0.0:
+                # avoid dividing by zero for blank images
+                max_val = 1.0
         bitmap_array = np.clip(bitmap_array[:, :, :3] / max_val, 0.0, 1.0) * 255
         bitmap_array = np.concatenate(
             [bitmap_array.astype("uint8"), alpha_channel], axis=-1


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

Restore numpy's error handling settings and yt's logging level during module teardown.

I found that `test_fisheye` in `yt/visualization/volume_rendering/tests/test_vr_cameras.py` was failing when I ran just the visualization tests, but not the full test suite.
<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
