### PR TITLE
[WIP] Experimentally turn off precounting AMR datasets

### DIFF
--- a/yt/data_objects/index_subobjects/grid_patch.py
+++ b/yt/data_objects/index_subobjects/grid_patch.py
@@ -406,10 +406,12 @@ class AMRGridPatch(YTSelectionContainer):
         dim = np.squeeze(self.ds.dimensionality)
         nodal_flag = source.shape[:dim] - self.ActiveDimensions[:dim]
         if sum(nodal_flag) == 0:
+            dest.resize(offset + count, refcheck=False)
             dest[offset : offset + count] = source[mask]
         else:
             slices = get_nodal_slices(source.shape, nodal_flag, dim)
             for i, sl in enumerate(slices):
+                dest.resize((offset + count, i), refcheck=False)
                 dest[offset : offset + count, i] = source[tuple(sl)][np.squeeze(mask)]
         return count
 

--- a/yt/geometry/grid_geometry_handler.py
+++ b/yt/geometry/grid_geometry_handler.py
@@ -440,7 +440,8 @@ class GridIndex(Index, abc.ABC):
                     dobj,
                     "io",
                     grids,
-                    self._count_selection(dobj, grids),
+                    # self._count_selection(dobj, grids),
+                    None,
                     cache=cache,
                     fast_index=fast_index,
                 )


### PR DESCRIPTION
Tests done by me, @cindytsai and @chrishavlin suggest that parallelism *in particular* is greatly limited by the amount of duplicated indexing that goes on across MPI tasks.

This is an experiment to see how we fare with turning off pre-counting, which should greatly reduce the amount of time spent in the counting routines, and potentially speed things up overall.
