### PR TITLE
minor bugfix in cholla frontend

### DIFF
--- a/yt/frontends/cholla/data_structures.py
+++ b/yt/frontends/cholla/data_structures.py
@@ -103,7 +103,9 @@ class ChollaDataset(Dataset):
             attrs = h5f.attrs
             self.parameters = dict(attrs.items())
             self.domain_left_edge = attrs["bounds"][:].astype("=f8")
-            self.domain_right_edge = self.domain_left_edge + attrs["domain"][:].astype("=f8")
+            self.domain_right_edge = self.domain_left_edge + attrs["domain"][:].astype(
+                "=f8"
+            )
             self.dimensionality = len(attrs["dims"][:])
             self.domain_dimensions = attrs["dims"][:].astype("=f8")
             self.current_time = attrs["t"][:]

--- a/yt/frontends/cholla/data_structures.py
+++ b/yt/frontends/cholla/data_structures.py
@@ -103,7 +103,7 @@ class ChollaDataset(Dataset):
             attrs = h5f.attrs
             self.parameters = dict(attrs.items())
             self.domain_left_edge = attrs["bounds"][:].astype("=f8")
-            self.domain_right_edge = attrs["domain"][:].astype("=f8")
+            self.domain_right_edge = self.domain_left_edge + attrs["domain"][:].astype("=f8")
             self.dimensionality = len(attrs["dims"][:])
             self.domain_dimensions = attrs["dims"][:].astype("=f8")
             self.current_time = attrs["t"][:]


### PR DESCRIPTION
## PR Summary

Previously, the ``domain_right_edge`` attribute of ``ChollaDataset`` was initialized by assigning it the values of the ``"domain"`` attribute stored in the hdf5 file. This patch adjusts the logic so that the ``domain_right_edge`` attribute is now the sum of that array and the array stored in the ``domain_left_edge`` attribute.

## PR Checklist

Given the simplicity of this fix, I don't really think there's any need for new documentation. Plus adding a test is probably not worth the effort (we would need to either introduce a new cholla dataset OR duplicate and mutate the existing dataset).
