### PR TITLE
BUG: Don't access `data_source[field]` to get units

### DIFF
--- a/yt/visualization/plot_container.py
+++ b/yt/visualization/plot_container.py
@@ -1103,7 +1103,9 @@ class BaseLinePlot(PlotContainer, abc.ABC):
             return self.plots[field]
         axrect = self._get_axrect()
 
-        pnh = NormHandler(self.data_source, display_units=self.data_source[field].units)
+        pnh = NormHandler(
+            self.data_source, display_units=self.data_source.ds.field_info[field].units
+        )
         finfo = self.data_source.ds._get_field_info(field)
         if not finfo.take_log:
             pnh.norm_type = Normalize


### PR DESCRIPTION
This is a fun one.  After profiling profiling operations for both memory and time, I noticed that the memory was doubling right at the end.  (Turns out, so was the time, but that's not as obvious always.)  What was happening was that the profile, which was being created using chunked IO/processing, was not sufficient for computing the units -- instead, the base `plot_container.py:1106` line would access the field inside the base object.  This has the effect of, on every processor, doing a `chunk_all` on the `data_source`, which means now we have every element resident in memory.

This uses the `field_info` container instead.
