### PR TITLE
BUG: fix load_sample with no arguments

### DIFF
--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -1487,14 +1487,6 @@ def _get_sample_data(
     # broadcast to other processes during parallel execution).
     import tarfile
 
-    if fn is None:
-        print(
-            "One can see which sample datasets are available at: https://yt-project.org/data\n"
-            "or alternatively by running: yt.sample_data.api.get_data_registry_table()",
-            file=sys.stderr,
-        )
-        return None
-
     from yt.sample_data.api import (
         _download_sample_data_file,
         _get_test_data_dir_path,
@@ -1663,6 +1655,15 @@ def load_sample(
     - Corresponding sample data live at https://yt-project.org/data
 
     """
+
+    if fn is None:
+        print(
+            "One can see which sample datasets are available at: https://yt-project.org/data\n"
+            "or alternatively by running: yt.sample_data.api.get_data_registry_table()",
+            file=sys.stderr,
+        )
+        return None
+
     loadable_path, load_kwargs = _get_sample_data(
         fn, progressbar=progressbar, timeout=timeout, **kwargs
     )

--- a/yt/tests/test_load_sample.py
+++ b/yt/tests/test_load_sample.py
@@ -199,4 +199,4 @@ def test_data_dir_broken():
 
 
 def test_filename_none():
-    assert load_sample(None) is None
+    assert load_sample() is None

--- a/yt/tests/test_load_sample.py
+++ b/yt/tests/test_load_sample.py
@@ -198,5 +198,7 @@ def test_data_dir_broken():
         load_sample("ToroShockTube")
 
 
-def test_filename_none():
+def test_filename_none(capsys):
     assert load_sample() is None
+    captured = capsys.readouterr()
+    assert "yt.sample_data.api.get_data_registry_table" in captured.err

--- a/yt/tests/test_load_sample.py
+++ b/yt/tests/test_load_sample.py
@@ -196,3 +196,7 @@ def test_data_dir_broken():
     )
     with pytest.warns(UserWarning, match=msg):
         load_sample("ToroShockTube")
+
+
+def test_filename_none():
+    assert load_sample(None) is None


### PR DESCRIPTION
Closes #4691 

Was easiest to just move the check for `fn is None` out of `_get_sample_data` to the main `load_sample`. Also added a minimal test.