### PR TITLE
add override_bins to data_container.profile

### DIFF
--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1169,6 +1169,7 @@ class YTDataContainer(abc.ABC):
         accumulation=False,
         fractional=False,
         deposition="ngp",
+        override_bins=None,
     ):
         r"""
         Create a 1, 2, or 3D profile object from this data_source.
@@ -1214,8 +1215,11 @@ class YTDataContainer(abc.ABC):
             distribution function.
         deposition : Controls the type of deposition used for ParticlePhasePlots.
             Valid choices are 'ngp' and 'cic'. Default is 'ngp'. This parameter is
-            ignored the if the input fields are not of particle type.
-
+            ignored if the input fields are not of particle type.
+        override_bins : dict of bins to profile plot with
+            If set, ignores n_bins and extrema settings and uses the
+            supplied bins to profile the field. If a units dict is provided,
+            bins are understood to be in the units specified in the dictionary.
 
         Examples
         --------
@@ -1246,6 +1250,7 @@ class YTDataContainer(abc.ABC):
             accumulation,
             fractional,
             deposition,
+            override_bins=override_bins,
         )
         return p
 

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1169,6 +1169,7 @@ class YTDataContainer(abc.ABC):
         accumulation=False,
         fractional=False,
         deposition="ngp",
+        *,
         override_bins=None,
     ):
         r"""

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -1263,7 +1263,7 @@ def create_profile(
     deposition : strings
         Controls the type of deposition used for ParticlePhasePlots.
         Valid choices are 'ngp' and 'cic'. Default is 'ngp'. This parameter is
-        ignored the if the input fields are not of particle type.
+        ignored if the input fields are not of particle type.
     override_bins : dict of bins to profile plot with
         If set, ignores n_bins and extrema settings and uses the
         supplied bins to profile the field. If a units dict is provided,


### PR DESCRIPTION
The `YTDataContainer.profile` wrapper of `create_profile` is missing the `override_bins` argument. Maybe could be considered a bug since the docs imply this should work (https://yt-project.org/doc/analyzing/generating_processed_data.html#profiles-and-histograms). 

Thanks to @BenWibking for pointing this out.