### PR TITLE
[BUGFIX] The f90nml package is *optional* to load RAMSES

### DIFF
--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -693,7 +693,6 @@ class RAMSESIndex(OctreeIndex):
 
 
 class RAMSESDataset(Dataset):
-    _load_requirements = ["f90nml"]
     _index_class = RAMSESIndex
     _field_info_class = RAMSESFieldInfo
     gamma = 1.4  # This will get replaced on hydro_fn open


### PR DESCRIPTION
The f90nml package is only required to parse the parameter file for RAMSES dataset, but that's not a hard requirement of the RAMSES frontend.