### PR TITLE
Linear interpolators updates: refactor and new functionality

### DIFF
--- a/nose_ignores.txt
+++ b/nose_ignores.txt
@@ -36,3 +36,4 @@
 --ignore-file=test_version\.py
 --ignore-file=test_gadget_pytest\.py
 --ignore-file=test_vr_orientation\.py
+--ignore-file=test_interpolators\.py

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -207,6 +207,7 @@ other_tests:
      - "--ignore-file=test_version\\.py"
      - "--ignore-file=test_gadget_pytest\\.py"
      - "--ignore-file=test_vr_orientation\\.py"
+     - "--ignore-file=test_interpolators\\.py"
      - "--exclude-test=yt.frontends.gdf.tests.test_outputs.TestGDF"
      - "--exclude-test=yt.frontends.adaptahop.tests.test_outputs"
      - "--exclude-test=yt.frontends.stream.tests.test_stream_particles.test_stream_non_cartesian_particles"

--- a/yt/utilities/linear_interpolators.py
+++ b/yt/utilities/linear_interpolators.py
@@ -105,11 +105,7 @@ class UnilinearFieldInterpolator(_LinearInterpolator):
         super().__init__(table, field_names, truncate=truncate, store_table=store_table)
         self.x_name = field_names
         if isinstance(boundaries, np.ndarray):
-            self._validate_bin_boundaries(
-                [
-                    boundaries,
-                ]
-            )
+            self._validate_bin_boundaries((boundaries,))
             self.x_bins = boundaries
         else:
             x0, x1 = boundaries

--- a/yt/utilities/linear_interpolators.py
+++ b/yt/utilities/linear_interpolators.py
@@ -63,6 +63,7 @@ class _LinearInterpolator(abc.ABC):
         return return_arrays
 
     def _validate_bin_boundaries(self, boundaries):
+        # boundaries: tuple of ndarrays
         for idim in range(self._ndim):
             if boundaries[idim].size != self.table_shape[idim]:
                 msg = f"{self._field_names[idim]} bins array not the same length as the data."
@@ -161,8 +162,7 @@ class BilinearFieldInterpolator(_LinearInterpolator):
             self.y_bins = np.linspace(y0, y1, table.shape[1], dtype="float64")
         elif len(boundaries) == 2:
             self._validate_bin_boundaries(boundaries)
-            self.x_bins = boundaries[0]
-            self.y_bins = boundaries[1]
+            self.x_bins, self.y_bins = boundaries
         else:
             mylog.error(
                 "Boundaries must be given as (x0, x1, y0, y1) or as (x_bins, y_bins)"
@@ -225,9 +225,7 @@ class TrilinearFieldInterpolator(_LinearInterpolator):
             self.z_bins = np.linspace(z0, z1, table.shape[2], dtype="float64")
         elif len(boundaries) == 3:
             self._validate_bin_boundaries(boundaries)
-            self.x_bins = boundaries[0]
-            self.y_bins = boundaries[1]
-            self.z_bins = boundaries[2]
+            self.x_bins, self.y_bins, self.z_bins = boundaries
         else:
             mylog.error(
                 "Boundaries must be given as (x0, x1, y0, y1, z0, z1) "
@@ -302,10 +300,7 @@ class QuadrilinearFieldInterpolator(_LinearInterpolator):
             self.w_bins = np.linspace(w0, w1, table.shape[3]).astype("float64")
         elif len(boundaries) == 4:
             self._validate_bin_boundaries(boundaries)
-            self.x_bins = boundaries[0]
-            self.y_bins = boundaries[1]
-            self.z_bins = boundaries[2]
-            self.w_bins = boundaries[3]
+            self.x_bins, self.y_bins, self.z_bins, self.w_bins = boundaries
         else:
             mylog.error(
                 "Boundaries must be given as (x0, x1, y0, y1, z0, z1, w0, w1) "

--- a/yt/utilities/linear_interpolators.py
+++ b/yt/utilities/linear_interpolators.py
@@ -10,13 +10,14 @@ class _LinearInterpolator(abc.ABC):
     _ndim: int
     _dim_i_type = "int32"
 
-    def __init__(self, table, truncate=False, *, store_table=True):
+    def __init__(self, table, field_names, truncate=False, *, store_table=True):
         if store_table:
             self.table = table.astype("float64")
         else:
             self.table = None
         self.table_shape = table.shape
         self.truncate = truncate
+        self._field_names = field_names
 
     def _raise_truncation_error(self, data_object):
         mylog.error(
@@ -61,6 +62,13 @@ class _LinearInterpolator(abc.ABC):
 
         return return_arrays
 
+    def _validate_bin_boundaries(self, boundaries):
+        for idim in range(self._ndim):
+            if boundaries[idim].size != self.table_shape[idim]:
+                msg = f"{self._field_names[idim]} bins array not the same length as the data."
+                mylog.error(msg)
+                raise ValueError(msg)
+
 
 class UnilinearFieldInterpolator(_LinearInterpolator):
     _ndim = 1
@@ -94,12 +102,14 @@ class UnilinearFieldInterpolator(_LinearInterpolator):
         field_data = interp(ad)
 
         """
-        super().__init__(table, truncate=truncate, store_table=store_table)
+        super().__init__(table, field_names, truncate=truncate, store_table=store_table)
         self.x_name = field_names
         if isinstance(boundaries, np.ndarray):
-            if boundaries.size != table.shape[0]:
-                mylog.error("Bins array not the same length as the data.")
-                raise ValueError
+            self._validate_bin_boundaries(
+                [
+                    boundaries,
+                ]
+            )
             self.x_bins = boundaries
         else:
             x0, x1 = boundaries
@@ -147,19 +157,14 @@ class BilinearFieldInterpolator(_LinearInterpolator):
         field_data = interp(ad)
 
         """
-        super().__init__(table, truncate=truncate, store_table=store_table)
+        super().__init__(table, field_names, truncate=truncate, store_table=store_table)
         self.x_name, self.y_name = field_names
         if len(boundaries) == 4:
             x0, x1, y0, y1 = boundaries
             self.x_bins = np.linspace(x0, x1, table.shape[0], dtype="float64")
             self.y_bins = np.linspace(y0, y1, table.shape[1], dtype="float64")
         elif len(boundaries) == 2:
-            if boundaries[0].size != table.shape[0]:
-                mylog.error("X bins array not the same length as the data.")
-                raise ValueError
-            if boundaries[1].size != table.shape[1]:
-                mylog.error("Y bins array not the same length as the data.")
-                raise ValueError
+            self._validate_bin_boundaries(boundaries)
             self.x_bins = boundaries[0]
             self.y_bins = boundaries[1]
         else:
@@ -215,7 +220,7 @@ class TrilinearFieldInterpolator(_LinearInterpolator):
         field_data = interp(ad)
 
         """
-        super().__init__(table, truncate=truncate, store_table=store_table)
+        super().__init__(table, field_names, truncate=truncate, store_table=store_table)
         self.x_name, self.y_name, self.z_name = field_names
         if len(boundaries) == 6:
             x0, x1, y0, y1, z0, z1 = boundaries
@@ -223,15 +228,7 @@ class TrilinearFieldInterpolator(_LinearInterpolator):
             self.y_bins = np.linspace(y0, y1, table.shape[1], dtype="float64")
             self.z_bins = np.linspace(z0, z1, table.shape[2], dtype="float64")
         elif len(boundaries) == 3:
-            if boundaries[0].size != table.shape[0]:
-                mylog.error("X bins array not the same length as the data.")
-                raise ValueError
-            if boundaries[1].size != table.shape[1]:
-                mylog.error("Y bins array not the same length as the data.")
-                raise ValueError
-            if boundaries[2].size != table.shape[2]:
-                mylog.error("Z bins array not the same length as the data.")
-                raise ValueError
+            self._validate_bin_boundaries(boundaries)
             self.x_bins = boundaries[0]
             self.y_bins = boundaries[1]
             self.z_bins = boundaries[2]
@@ -299,7 +296,7 @@ class QuadrilinearFieldInterpolator(_LinearInterpolator):
         field_data = interp(ad)
 
         """
-        super().__init__(table, truncate=truncate, store_table=store_table)
+        super().__init__(table, field_names, truncate=truncate, store_table=store_table)
         self.x_name, self.y_name, self.z_name, self.w_name = field_names
         if len(boundaries) == 8:
             x0, x1, y0, y1, z0, z1, w0, w1 = boundaries
@@ -308,18 +305,7 @@ class QuadrilinearFieldInterpolator(_LinearInterpolator):
             self.z_bins = np.linspace(z0, z1, table.shape[2]).astype("float64")
             self.w_bins = np.linspace(w0, w1, table.shape[3]).astype("float64")
         elif len(boundaries) == 4:
-            if boundaries[0].size != table.shape[0]:
-                mylog.error("X bins array not the same length as the data.")
-                raise ValueError
-            if boundaries[1].size != table.shape[1]:
-                mylog.error("Y bins array not the same length as the data.")
-                raise ValueError
-            if boundaries[2].size != table.shape[2]:
-                mylog.error("Z bins array not the same length as the data.")
-                raise ValueError
-            if boundaries[3].size != table.shape[3]:
-                mylog.error("W bins array not the same length as the data.")
-                raise ValueError
+            self._validate_bin_boundaries(boundaries)
             self.x_bins = boundaries[0]
             self.y_bins = boundaries[1]
             self.z_bins = boundaries[2]

--- a/yt/utilities/linear_interpolators.py
+++ b/yt/utilities/linear_interpolators.py
@@ -8,6 +8,7 @@ from yt.funcs import mylog
 
 class _LinearInterpolator(abc.ABC):
     _ndim: int
+    _dim_i_type = "int32"
 
     def __init__(self, table, truncate=False, *, store_table=True):
         if store_table:
@@ -49,14 +50,14 @@ class _LinearInterpolator(abc.ABC):
             dim_bins = getattr(self, f"{dim}_bins")
 
             dim_vals = data_object[dim_name].ravel().astype("float64")
-            dim_i = (np.digitize(dim_vals, dim_bins) - 1).astype("int32")
+            dim_i = (np.digitize(dim_vals, dim_bins) - 1).astype(self._dim_i_type)
             if np.any((dim_i == -1) | (dim_i == len(dim_bins) - 1)):
                 if not self.truncate:
                     self._raise_truncation_error(data_object)
                 else:
                     dim_i = np.minimum(np.maximum(dim_i, 0), len(dim_bins) - 2)
-            return_arrays.append(dim_i)
             return_arrays.append(dim_vals)
+            return_arrays.append(dim_i)
 
         return return_arrays
 
@@ -182,6 +183,7 @@ class BilinearFieldInterpolator(_LinearInterpolator):
 
 class TrilinearFieldInterpolator(_LinearInterpolator):
     _ndim = 3
+    _dim_i_type = "int_"
 
     def __init__(
         self, table, boundaries, field_names, truncate=False, *, store_table=True
@@ -266,6 +268,7 @@ class TrilinearFieldInterpolator(_LinearInterpolator):
 
 class QuadrilinearFieldInterpolator(_LinearInterpolator):
     _ndim = 4
+    _dim_i_type = "int_"
 
     def __init__(
         self, table, boundaries, field_names, truncate=False, *, store_table=True

--- a/yt/utilities/linear_interpolators.py
+++ b/yt/utilities/linear_interpolators.py
@@ -31,15 +31,15 @@ class _LinearInterpolator(abc.ABC):
         if table_override is None:
             if self.table is None:
                 msg = (
-                    f"You must either store the table used when initializing "
-                    f"{type(self).__name__} (set `store_table=True`) or you must provide a `table_override` when "
+                    f"You must either store the table used when initializing a new "
+                    f"{type(self).__name__} (set `store_table=True`) or you must provide a `table` when "
                     f"calling {type(self).__name__}"
                 )
-                raise RuntimeError(msg)
+                raise ValueError(msg)
             return self.table
 
-        if table_override.shape != self.table.shape:
-            msg = f"The table_override shape, {table_override.shape}, must match the base table shape, {self.table.shape}"
+        if table_override.shape != self.table_shape:
+            msg = f"The table_override shape, {table_override.shape}, must match the base table shape, {self.table_shape}"
             raise ValueError(msg)
 
         return table_override.astype("float64")
@@ -92,15 +92,25 @@ class UnilinearFieldInterpolator(_LinearInterpolator):
             If False, an exception is raised if the input values are
             outside the bounds of the table.  If True, extrapolation is
             performed.
+        store_table: bool
+            If False, only the shape of the input table is stored and
+            a full table must be provided when calling the interpolator.
 
         Examples
         --------
 
-        ad = ds.all_data()
-        table_data = np.random.random(64)
-        interp = UnilinearFieldInterpolator(table_data, (0.0, 1.0), "x",
-                                            truncate=True)
-        field_data = interp(ad)
+        >>> ad = ds.all_data()
+        >>> table_data = np.random.random(64)
+        >>> interp = UnilinearFieldInterpolator(table_data, (0.0, 1.0), "x",
+                                                truncate=True)
+        >>> field_data = interp(ad)
+
+        If you want to re-use the interpolator with table_data of the same shape
+        but different values, you can also supply the `table` keyword argument when
+        calling the interpolator:
+
+        >>> new_table_data = np.random.random(64)
+        >>> field_data = interp(ad, table=new_table_data)
 
         """
         super().__init__(table, field_names, truncate=truncate, store_table=store_table)
@@ -112,8 +122,8 @@ class UnilinearFieldInterpolator(_LinearInterpolator):
             x0, x1 = boundaries
             self.x_bins = np.linspace(x0, x1, table.shape[0], dtype="float64")
 
-    def __call__(self, data_object, *, table_override=None):
-        table = self._validate_table(table_override)
+    def __call__(self, data_object, *, table=None):
+        table = self._validate_table(table)
         orig_shape = data_object[self.x_name].shape
         x_vals, x_i = self._get_digitized_arrays(data_object)
         my_vals = np.zeros(x_vals.shape, dtype="float64")
@@ -142,16 +152,26 @@ class BilinearFieldInterpolator(_LinearInterpolator):
             If False, an exception is raised if the input values are
             outside the bounds of the table.  If True, extrapolation is
             performed.
+        store_table: bool
+            If False, only the shape of the input table is stored and
+            a full table must be provided when calling the interpolator.
 
         Examples
         --------
 
-        ad = ds.all_data()
-        table_data = np.random.random((64, 64))
-        interp = BilinearFieldInterpolator(table_data, (0.0, 1.0, 0.0, 1.0),
-                                           ["x", "y"],
-                                           truncate=True)
-        field_data = interp(ad)
+        >>> ad = ds.all_data()
+        >>> table_data = np.random.random((64, 64))
+        >>> interp = BilinearFieldInterpolator(table_data, (0.0, 1.0, 0.0, 1.0),
+                                              ["x", "y"],
+                                              truncate=True)
+        >>> field_data = interp(ad)
+
+        If you want to re-use the interpolator with table_data of the same shape
+        but different values, you can also supply the `table` keyword argument when
+        calling the interpolator:
+
+        >>> new_table_data = np.random.random((64, 64))
+        >>> field_data = interp(ad, table=new_table_data)
 
         """
         super().__init__(table, field_names, truncate=truncate, store_table=store_table)
@@ -169,8 +189,8 @@ class BilinearFieldInterpolator(_LinearInterpolator):
             )
             raise ValueError
 
-    def __call__(self, data_object, *, table_override=None):
-        table = self._validate_table(table_override)
+    def __call__(self, data_object, *, table=None):
+        table = self._validate_table(table)
 
         orig_shape = data_object[self.x_name].shape
         x_vals, x_i, y_vals, y_i = self._get_digitized_arrays(data_object)
@@ -203,17 +223,27 @@ class TrilinearFieldInterpolator(_LinearInterpolator):
             If False, an exception is raised if the input values are
             outside the bounds of the table.  If True, extrapolation is
             performed.
+        store_table: bool
+            If False, only the shape of the input table is stored and
+            a full table must be provided when calling the interpolator.
 
         Examples
         --------
 
-        ad = ds.all_data()
-        table_data = np.random.random((64, 64, 64))
-        interp = TrilinearFieldInterpolator(table_data,
-                                            (0.0, 1.0, 0.0, 1.0, 0.0, 1.0),
-                                            ["x", "y", "z"],
-                                            truncate=True)
-        field_data = interp(ad)
+        >>> ad = ds.all_data()
+        >>> table_data = np.random.random((64, 64, 64))
+        >>> interp = TrilinearFieldInterpolator(table_data,
+                                               (0.0, 1.0, 0.0, 1.0, 0.0, 1.0),
+                                               ["x", "y", "z"],
+                                               truncate=True)
+        >>> field_data = interp(ad)
+
+        If you want to re-use the interpolator with table_data of the same shape
+        but different values, you can also supply the `table` keyword argument when
+        calling the interpolator:
+
+        >>> new_table_data = np.random.random((64, 64, 64))
+        >>> field_data = interp(ad, table=new_table_data)
 
         """
         super().__init__(table, field_names, truncate=truncate, store_table=store_table)
@@ -233,8 +263,8 @@ class TrilinearFieldInterpolator(_LinearInterpolator):
             )
             raise ValueError
 
-    def __call__(self, data_object, *, table_override=None):
-        table = self._validate_table(table_override)
+    def __call__(self, data_object, *, table=None):
+        table = self._validate_table(table)
 
         orig_shape = data_object[self.x_name].shape
         x_vals, x_i, y_vals, y_i, z_vals, z_i = self._get_digitized_arrays(data_object)
@@ -278,16 +308,26 @@ class QuadrilinearFieldInterpolator(_LinearInterpolator):
             If False, an exception is raised if the input values are
             outside the bounds of the table.  If True, extrapolation is
             performed.
+        store_table: bool
+            If False, only the shape of the input table is stored and
+            a full table must be provided when calling the interpolator.
 
         Examples
         --------
-        ad = ds.all_data()
-        table_data = np.random.random((64, 64, 64, 64))
-        interp = BilinearFieldInterpolator(table_data,
-                                           (0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0),
-                                           ["x", "y", "z", "w"],
-                                           truncate=True)
-        field_data = interp(ad)
+        >>> ad = ds.all_data()
+        >>> table_data = np.random.random((64, 64, 64, 64))
+        >>> interp = QuadrilinearFieldInterpolator(table_data,
+                                                  (0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0),
+                                                  ["x", "y", "z", "w"],
+                                                  truncate=True)
+        >>> field_data = interp(ad)
+
+        If you want to re-use the interpolator with table_data of the same shape
+        but different values, you can also supply the `table` keyword argument when
+        calling the interpolator:
+
+        >>> new_table_data = np.random.random((64, 64, 64, 64))
+        >>> field_data = interp(ad, table=new_table_data)
 
         """
         super().__init__(table, field_names, truncate=truncate, store_table=store_table)
@@ -308,8 +348,8 @@ class QuadrilinearFieldInterpolator(_LinearInterpolator):
             )
             raise ValueError
 
-    def __call__(self, data_object, *, table_override=None):
-        table = self._validate_table(table_override)
+    def __call__(self, data_object, *, table=None):
+        table = self._validate_table(table)
 
         orig_shape = data_object[self.x_name].shape
         x_vals, x_i, y_vals, y_i, z_vals, z_i, w_vals, w_i = self._get_digitized_arrays(

--- a/yt/utilities/linear_interpolators.py
+++ b/yt/utilities/linear_interpolators.py
@@ -1,11 +1,72 @@
+import abc
+
 import numpy as np
 
 import yt.utilities.lib.interpolators as lib
 from yt.funcs import mylog
 
 
-class UnilinearFieldInterpolator:
-    def __init__(self, table, boundaries, field_names, truncate=False):
+class _LinearInterpolator(abc.ABC):
+    _ndim: int
+
+    def __init__(self, table, truncate=False, *, store_table=True):
+        if store_table:
+            self.table = table.astype("float64")
+        else:
+            self.table = None
+        self.table_shape = table.shape
+        self.truncate = truncate
+
+    def _raise_truncation_error(self, data_object):
+        mylog.error(
+            "Sorry, but your values are outside "
+            "the table!  Dunno what to do, so dying."
+        )
+        mylog.error("Error was in: %s", data_object)
+        raise ValueError
+
+    def _validate_table(self, table_override):
+        if table_override is None:
+            if self.table is None:
+                msg = (
+                    f"You must either store the table used when initializing "
+                    f"{type(self).__name__} (set `store_table=True`) or you must provide a `table_override` when "
+                    f"calling {type(self).__name__}"
+                )
+                raise RuntimeError(msg)
+            return self.table
+
+        if table_override.shape != self.table.shape:
+            msg = f"The table_override shape, {table_override.shape}, must match the base table shape, {self.table.shape}"
+            raise ValueError(msg)
+
+        return table_override.astype("float64")
+
+    def _get_digitized_arrays(self, data_object):
+        return_arrays = []
+        for dim in "xyzw"[: self._ndim]:
+            dim_name = getattr(self, f"{dim}_name")
+            dim_bins = getattr(self, f"{dim}_bins")
+
+            dim_vals = data_object[dim_name].ravel().astype("float64")
+            dim_i = (np.digitize(dim_vals, dim_bins) - 1).astype("int32")
+            if np.any((dim_i == -1) | (dim_i == len(dim_bins) - 1)):
+                if not self.truncate:
+                    self._raise_truncation_error(data_object)
+                else:
+                    dim_i = np.minimum(np.maximum(dim_i, 0), len(dim_bins) - 2)
+            return_arrays.append(dim_i)
+            return_arrays.append(dim_vals)
+
+        return return_arrays
+
+
+class UnilinearFieldInterpolator(_LinearInterpolator):
+    _ndim = 1
+
+    def __init__(
+        self, table, boundaries, field_names, truncate=False, *, store_table=True
+    ):
         r"""Initialize a 1D interpolator for field data.
 
         table : array
@@ -32,8 +93,7 @@ class UnilinearFieldInterpolator:
         field_data = interp(ad)
 
         """
-        self.table = table.astype("float64")
-        self.truncate = truncate
+        super().__init__(table, truncate=truncate, store_table=store_table)
         self.x_name = field_names
         if isinstance(boundaries, np.ndarray):
             if boundaries.size != table.shape[0]:
@@ -44,30 +104,22 @@ class UnilinearFieldInterpolator:
             x0, x1 = boundaries
             self.x_bins = np.linspace(x0, x1, table.shape[0], dtype="float64")
 
-    def __call__(self, data_object):
+    def __call__(self, data_object, *, table_override=None):
+        table = self._validate_table(table_override)
         orig_shape = data_object[self.x_name].shape
-        x_vals = data_object[self.x_name].ravel().astype("float64")
-
-        x_i = (np.digitize(x_vals, self.x_bins) - 1).astype("int32")
-        if np.any((x_i == -1) | (x_i == len(self.x_bins) - 1)):
-            if not self.truncate:
-                mylog.error(
-                    "Sorry, but your values are outside "
-                    "the table!  Dunno what to do, so dying."
-                )
-                mylog.error("Error was in: %s", data_object)
-                raise ValueError
-            else:
-                x_i = np.minimum(np.maximum(x_i, 0), len(self.x_bins) - 2)
-
+        x_vals, x_i = self._get_digitized_arrays(data_object)
         my_vals = np.zeros(x_vals.shape, dtype="float64")
-        lib.UnilinearlyInterpolate(self.table, x_vals, self.x_bins, x_i, my_vals)
+        lib.UnilinearlyInterpolate(table, x_vals, self.x_bins, x_i, my_vals)
         my_vals.shape = orig_shape
         return my_vals
 
 
-class BilinearFieldInterpolator:
-    def __init__(self, table, boundaries, field_names, truncate=False):
+class BilinearFieldInterpolator(_LinearInterpolator):
+    _ndim = 2
+
+    def __init__(
+        self, table, boundaries, field_names, truncate=False, *, store_table=True
+    ):
         r"""Initialize a 2D interpolator for field data.
 
         table : array
@@ -94,8 +146,7 @@ class BilinearFieldInterpolator:
         field_data = interp(ad)
 
         """
-        self.table = table.astype("float64")
-        self.truncate = truncate
+        super().__init__(table, truncate=truncate, store_table=store_table)
         self.x_name, self.y_name = field_names
         if len(boundaries) == 4:
             x0, x1, y0, y1 = boundaries
@@ -116,37 +167,25 @@ class BilinearFieldInterpolator:
             )
             raise ValueError
 
-    def __call__(self, data_object):
+    def __call__(self, data_object, *, table_override=None):
+        table = self._validate_table(table_override)
+
         orig_shape = data_object[self.x_name].shape
-        x_vals = data_object[self.x_name].ravel().astype("float64")
-        y_vals = data_object[self.y_name].ravel().astype("float64")
-
-        x_i = (np.digitize(x_vals, self.x_bins) - 1).astype("int32")
-        y_i = (np.digitize(y_vals, self.y_bins) - 1).astype("int32")
-        if np.any((x_i == -1) | (x_i == len(self.x_bins) - 1)) or np.any(
-            (y_i == -1) | (y_i == len(self.y_bins) - 1)
-        ):
-            if not self.truncate:
-                mylog.error(
-                    "Sorry, but your values are outside "
-                    "the table!  Dunno what to do, so dying."
-                )
-                mylog.error("Error was in: %s", data_object)
-                raise ValueError
-            else:
-                x_i = np.minimum(np.maximum(x_i, 0), len(self.x_bins) - 2)
-                y_i = np.minimum(np.maximum(y_i, 0), len(self.y_bins) - 2)
-
+        x_vals, x_i, y_vals, y_i = self._get_digitized_arrays(data_object)
         my_vals = np.zeros(x_vals.shape, dtype="float64")
         lib.BilinearlyInterpolate(
-            self.table, x_vals, y_vals, self.x_bins, self.y_bins, x_i, y_i, my_vals
+            table, x_vals, y_vals, self.x_bins, self.y_bins, x_i, y_i, my_vals
         )
         my_vals.shape = orig_shape
         return my_vals
 
 
-class TrilinearFieldInterpolator:
-    def __init__(self, table, boundaries, field_names, truncate=False):
+class TrilinearFieldInterpolator(_LinearInterpolator):
+    _ndim = 3
+
+    def __init__(
+        self, table, boundaries, field_names, truncate=False, *, store_table=True
+    ):
         r"""Initialize a 3D interpolator for field data.
 
         table : array
@@ -174,8 +213,7 @@ class TrilinearFieldInterpolator:
         field_data = interp(ad)
 
         """
-        self.table = table.astype("float64")
-        self.truncate = truncate
+        super().__init__(table, truncate=truncate, store_table=store_table)
         self.x_name, self.y_name, self.z_name = field_names
         if len(boundaries) == 6:
             x0, x1, y0, y1, z0, z1 = boundaries
@@ -202,35 +240,15 @@ class TrilinearFieldInterpolator:
             )
             raise ValueError
 
-    def __call__(self, data_object):
-        orig_shape = data_object[self.x_name].shape
-        x_vals = data_object[self.x_name].ravel().astype("float64")
-        y_vals = data_object[self.y_name].ravel().astype("float64")
-        z_vals = data_object[self.z_name].ravel().astype("float64")
+    def __call__(self, data_object, *, table_override=None):
+        table = self._validate_table(table_override)
 
-        x_i = np.digitize(x_vals, self.x_bins).astype("int_") - 1
-        y_i = np.digitize(y_vals, self.y_bins).astype("int_") - 1
-        z_i = np.digitize(z_vals, self.z_bins).astype("int_") - 1
-        if (
-            np.any((x_i == -1) | (x_i == len(self.x_bins) - 1))
-            or np.any((y_i == -1) | (y_i == len(self.y_bins) - 1))
-            or np.any((z_i == -1) | (z_i == len(self.z_bins) - 1))
-        ):
-            if not self.truncate:
-                mylog.error(
-                    "Sorry, but your values are outside "
-                    "the table!  Dunno what to do, so dying."
-                )
-                mylog.error("Error was in: %s", data_object)
-                raise ValueError
-            else:
-                x_i = np.minimum(np.maximum(x_i, 0), len(self.x_bins) - 2)
-                y_i = np.minimum(np.maximum(y_i, 0), len(self.y_bins) - 2)
-                z_i = np.minimum(np.maximum(z_i, 0), len(self.z_bins) - 2)
+        orig_shape = data_object[self.x_name].shape
+        x_vals, x_i, y_vals, y_i, z_vals, z_i = self._get_digitized_arrays(data_object)
 
         my_vals = np.zeros(x_vals.shape, dtype="float64")
         lib.TrilinearlyInterpolate(
-            self.table,
+            table,
             x_vals,
             y_vals,
             z_vals,
@@ -246,8 +264,12 @@ class TrilinearFieldInterpolator:
         return my_vals
 
 
-class QuadrilinearFieldInterpolator:
-    def __init__(self, table, boundaries, field_names, truncate=False):
+class QuadrilinearFieldInterpolator(_LinearInterpolator):
+    _ndim = 4
+
+    def __init__(
+        self, table, boundaries, field_names, truncate=False, *, store_table=True
+    ):
         r"""Initialize a 4D interpolator for field data.
 
         table : array
@@ -274,8 +296,7 @@ class QuadrilinearFieldInterpolator:
         field_data = interp(ad)
 
         """
-        self.table = table.astype("float64")
-        self.truncate = truncate
+        super().__init__(table, truncate=truncate, store_table=store_table)
         self.x_name, self.y_name, self.z_name, self.w_name = field_names
         if len(boundaries) == 8:
             x0, x1, y0, y1, z0, z1, w0, w1 = boundaries
@@ -307,39 +328,17 @@ class QuadrilinearFieldInterpolator:
             )
             raise ValueError
 
-    def __call__(self, data_object):
-        orig_shape = data_object[self.x_name].shape
-        x_vals = data_object[self.x_name].ravel().astype("float64")
-        y_vals = data_object[self.y_name].ravel().astype("float64")
-        z_vals = data_object[self.z_name].ravel().astype("float64")
-        w_vals = data_object[self.w_name].ravel().astype("float64")
+    def __call__(self, data_object, *, table_override=None):
+        table = self._validate_table(table_override)
 
-        x_i = np.digitize(x_vals, self.x_bins).astype("int") - 1
-        y_i = np.digitize(y_vals, self.y_bins).astype("int") - 1
-        z_i = np.digitize(z_vals, self.z_bins).astype("int") - 1
-        w_i = np.digitize(w_vals, self.w_bins).astype("int") - 1
-        if (
-            np.any((x_i == -1) | (x_i == len(self.x_bins) - 1))
-            or np.any((y_i == -1) | (y_i == len(self.y_bins) - 1))
-            or np.any((z_i == -1) | (z_i == len(self.z_bins) - 1))
-            or np.any((w_i == -1) | (w_i == len(self.w_bins) - 1))
-        ):
-            if not self.truncate:
-                mylog.error(
-                    "Sorry, but your values are outside "
-                    "the table!  Dunno what to do, so dying."
-                )
-                mylog.error("Error was in: %s", data_object)
-                raise ValueError
-            else:
-                x_i = np.minimum(np.maximum(x_i, 0), len(self.x_bins) - 2)
-                y_i = np.minimum(np.maximum(y_i, 0), len(self.y_bins) - 2)
-                z_i = np.minimum(np.maximum(z_i, 0), len(self.z_bins) - 2)
-                w_i = np.minimum(np.maximum(w_i, 0), len(self.w_bins) - 2)
+        orig_shape = data_object[self.x_name].shape
+        x_vals, x_i, y_vals, y_i, z_vals, z_i, w_vals, w_i = self._get_digitized_arrays(
+            data_object
+        )
 
         my_vals = np.zeros(x_vals.shape, dtype="float64")
         lib.QuadrilinearlyInterpolate(
-            self.table,
+            table,
             x_vals,
             y_vals,
             z_vals,

--- a/yt/utilities/tests/test_interpolators.py
+++ b/yt/utilities/tests/test_interpolators.py
@@ -168,7 +168,6 @@ def test_table_override(ndim):
     sz = 8
 
     random_data = np.random.random((sz,) * ndim)
-    # evenly spaced bins
 
     field_names = "xyzw"[:ndim]
     slc = slice(0.0, 1.0, complex(0, sz))
@@ -176,7 +175,30 @@ def test_table_override(ndim):
     boundaries = (0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0)[: ndim * 2]
 
     interp_class = _lin_interpolators_by_dim[ndim]
-    tfi = interp_class(random_data, boundaries, field_names, True)
-    assert_array_almost_equal(tfi(fv), random_data)
+    interpolator = interp_class(random_data, boundaries, field_names, True)
+    assert_array_almost_equal(interpolator(fv), random_data)
     table_2 = random_data * 2
-    assert_array_almost_equal(tfi(fv, table_override=table_2), table_2)
+    assert_array_almost_equal(interpolator(fv, table_override=table_2), table_2)
+
+
+@pytest.mark.parametrize("ndim", list(range(1, 5)))
+def test_bin_validation(ndim):
+    interp_class = _lin_interpolators_by_dim[ndim]
+
+    sz = 8
+    random_data = np.random.random((sz,) * ndim)
+    field_names = "xyzw"[:ndim]
+
+    bad_bounds = np.linspace(0.0, 1.0, sz - 1)
+    good_bounds = np.linspace(0.0, 1.0, sz)
+    if ndim == 1:
+        bounds = bad_bounds
+    else:
+        bounds = [
+            good_bounds,
+        ] * ndim
+        bounds[0] = bad_bounds
+        bounds = tuple(bounds)
+
+    with pytest.raises(ValueError, match=f"{field_names[0]} bins array not"):
+        _ = interp_class(random_data, bounds, field_names)

--- a/yt/utilities/tests/test_interpolators.py
+++ b/yt/utilities/tests/test_interpolators.py
@@ -178,7 +178,18 @@ def test_table_override(ndim):
     interpolator = interp_class(random_data, boundaries, field_names, True)
     assert_array_almost_equal(interpolator(fv), random_data)
     table_2 = random_data * 2
-    assert_array_almost_equal(interpolator(fv, table_override=table_2), table_2)
+    assert_array_almost_equal(interpolator(fv, table=table_2), table_2)
+
+    # check that we can do it without storing the initial table
+    interpolator = interp_class(
+        random_data, boundaries, field_names, True, store_table=False
+    )
+    assert_array_almost_equal(interpolator(fv, table=table_2), table_2)
+
+    with pytest.raises(
+        ValueError, match="You must either store the table used when initializing"
+    ):
+        _ = interpolator(fv)
 
 
 @pytest.mark.parametrize("ndim", list(range(1, 5)))

--- a/yt/utilities/tests/test_interpolators.py
+++ b/yt/utilities/tests/test_interpolators.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 
 import yt.utilities.linear_interpolators as lin
@@ -152,3 +153,30 @@ def test_get_vertex_centered_data():
     ds = fake_random_ds(16)
     g = ds.index.grids[0]
     g.get_vertex_centered_data([("gas", "density")], no_ghost=True)
+
+
+_lin_interpolators_by_dim = {
+    1: lin.UnilinearFieldInterpolator,
+    2: lin.BilinearFieldInterpolator,
+    3: lin.TrilinearFieldInterpolator,
+    4: lin.QuadrilinearFieldInterpolator,
+}
+
+
+@pytest.mark.parametrize("ndim", list(range(1, 5)))
+def test_table_override(ndim):
+    sz = 8
+
+    random_data = np.random.random((sz,) * ndim)
+    # evenly spaced bins
+
+    field_names = "xyzw"[:ndim]
+    slc = slice(0.0, 1.0, complex(0, sz))
+    fv = dict(zip(field_names, np.mgrid[(slc,) * ndim]))
+    boundaries = (0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0)[: ndim * 2]
+
+    interp_class = _lin_interpolators_by_dim[ndim]
+    tfi = interp_class(random_data, boundaries, field_names, True)
+    assert_array_almost_equal(tfi(fv), random_data)
+    table_2 = random_data * 2
+    assert_array_almost_equal(tfi(fv, table_override=table_2), table_2)


### PR DESCRIPTION
I started using the linear interpolators yesterday and for my purposes it'd be a tab bit easier to re-use the interpolator objects but swap out different table data, so this PR adds that functionality. To do that though, it was easier to refactor the interpolators to have a common base class (and cut out some repetitive code structures in the process). Everything here should be fully backwards compatible. Also happy to split this PR to pull out the refactor from the new functionality (but the new functionality is pretty simple, most of the PR is the refactor).

