### PR TITLE
[WIP] add depth-limiting to off-axis sph particle projections

### DIFF
--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -649,6 +649,7 @@ class OffAxisProjectionFixedResolutionBuffer(FixedResolutionBuffer):
             interpolated=dd.interpolated,
             north_vector=dd.north_vector,
             method=dd.method,
+            depth_set=dd.depth_set,
         )
         if self.data_source.moment == 2:
 

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -2446,6 +2446,12 @@ class OffAxisProjectionPlot(ProjectionPlot, PWViewerMPL):
                 f"currently supported geometries: {self._supported_geometries!r}"
             )
 
+        depth_set = depth is not None
+        if not depth_set:
+            # need a valid depth for calculating bounds, but those
+            # bounds will not be used to limit particles.
+            depth = (1, "1")
+
         (bounds, center_rot) = get_oblique_window_parameters(
             normal, center, width, ds, depth=depth
         )
@@ -2469,7 +2475,7 @@ class OffAxisProjectionPlot(ProjectionPlot, PWViewerMPL):
             method=method,
             data_source=data_source,
             moment=moment,
-            depth_set=depth is not None,
+            depth_set=depth_set,
         )
 
         validate_mesh_fields(OffAxisProj, fields)

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -2275,6 +2275,7 @@ class OffAxisProjectionDummyDataSource:
         data_source=None,
         *,
         moment=1,
+        depth_set=False,
     ):
         validate_moment(moment, weight)
         self.center = center
@@ -2300,6 +2301,11 @@ class OffAxisProjectionDummyDataSource:
         self.method = method
         self.orienter = Orientation(normal_vector, north_vector=north_vector)
         self.moment = moment
+
+        # note: the depth_set bool indicates whether we need to limit particles
+        # by the rotated z-bounds. If using all particles in the rotated x-y
+        # plane (depth_set is False), then we can avoid some computation.
+        self.depth_set = depth_set
 
     def _determine_fields(self, *args):
         return self.dd._determine_fields(*args)
@@ -2463,6 +2469,7 @@ class OffAxisProjectionPlot(ProjectionPlot, PWViewerMPL):
             method=method,
             data_source=data_source,
             moment=moment,
+            depth_set=depth is not None,
         )
 
         validate_mesh_fields(OffAxisProj, fields)

--- a/yt/visualization/tests/test_offaxisprojection.py
+++ b/yt/visualization/tests/test_offaxisprojection.py
@@ -12,6 +12,7 @@ from yt.testing import (
     assert_rel_equal,
     fake_octree_ds,
     fake_random_ds,
+    fake_sph_grid_ds,
 )
 from yt.visualization.api import OffAxisProjectionPlot, OffAxisSlicePlot
 from yt.visualization.image_writer import write_projection
@@ -246,3 +247,22 @@ def test_offaxis_moment():
         p2.frb["gas", "velocity_los"],
         10,
     )
+
+
+def test_off_axis_sph_depth():
+    ds = fake_sph_grid_ds()
+    p1 = OffAxisProjectionPlot(
+        ds,
+        [1, 1, 1],
+        ("io", "density"),
+        buff_size=(50, 50),
+    )
+    p2 = OffAxisProjectionPlot(
+        ds,
+        [1, 1, 1],
+        ("io", "density"),
+        buff_size=(50, 50),
+        depth=(0.1, "cm"),
+    )
+    # checks that fewer particles are picked up
+    assert p2.frb["io", "density"].sum() < p1.frb["io", "density"].sum()

--- a/yt/visualization/tests/test_offaxisprojection.py
+++ b/yt/visualization/tests/test_offaxisprojection.py
@@ -256,6 +256,7 @@ def test_off_axis_sph_depth():
         [1, 1, 1],
         ("io", "density"),
         buff_size=(50, 50),
+        depth=None,
     )
     p2 = OffAxisProjectionPlot(
         ds,

--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -29,6 +29,8 @@ def off_axis_projection(
     north_vector=None,
     num_threads=1,
     method="integrate",
+    *,
+    depth_set=False,
 ):
     r"""Project through a dataset, off-axis, and return the image plane.
 
@@ -94,6 +96,10 @@ def off_axis_projection(
         This should only be used for uniform resolution grid datasets, as other
         datasets may result in unphysical images.
         or camera movements.
+    depth_set : bool
+        If True, will check the rotated z bounds and limit particles included.
+        If False (the default), will use all particles in the rotated x-y plane.
+
     Returns
     -------
     image : array
@@ -210,6 +216,7 @@ def off_axis_projection(
         ounits = finfo.output_units
         bounds = [x_min, x_max, y_min, y_max, z_min, z_max]
 
+        print(f"depth_set is {depth_set}")
         if weight is None:
             for chunk in data_source.chunks([], "io"):
                 off_axis_projection_SPH(
@@ -227,6 +234,7 @@ def off_axis_projection(
                     mask,
                     normal_vector,
                     north,
+                    depth_set=depth_set,
                 )
 
             # Assure that the path length unit is in the default length units
@@ -266,6 +274,7 @@ def off_axis_projection(
                     normal_vector,
                     north,
                     weight_field=chunk[weight].in_units(wounits),
+                    depth_set=depth_set,
                 )
 
             for chunk in data_source.chunks([], "io"):
@@ -284,6 +293,7 @@ def off_axis_projection(
                     mask,
                     normal_vector,
                     north,
+                    depth_set=depth_set,
                 )
 
             normalization_2d_utility(buf, weight_buff)

--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -216,7 +216,6 @@ def off_axis_projection(
         ounits = finfo.output_units
         bounds = [x_min, x_max, y_min, y_max, z_min, z_max]
 
-        print(f"depth_set is {depth_set}")
         if weight is None:
             for chunk in data_source.chunks([], "io"):
                 off_axis_projection_SPH(


### PR DESCRIPTION
Closes #4711 

The initial push does indeed work for sph particle projections, but I intend to refactor... 

that said, 

```python
import yt  
import numpy as np

ds = yt.load_sample("gizmo_64")  

z_hat_original = ds.arr([0.3, 0.3, 0.3], 'kpc')
y_hat_original = ds.arr([1., 0., 0.], 'kpc')

for d in [2, 20]: 
    prj = yt.ProjectionPlot(ds, - z_hat_original, 
                                       center = ds.domain_center, 
                                       fields=('gas', 'density'),                   
                                       depth = (d, 'Mpc'), 
                                       north_vector = - y_hat_original, 
                                       )
    prj.save(f"depth_{str(d).zfill(2)}_proj.png")
```
returns 
![depth_02_proj](https://github.com/yt-project/yt/assets/22038879/4236846c-fca5-49dd-bfa8-ab28d07fcdda)

and 
![depth_20_proj](https://github.com/yt-project/yt/assets/22038879/46823916-a544-4a6a-a389-da659f4ef0ce)

which seems to make sense (first image is 2 Mpc depth, second is 20 Mpc depth).

Still to do:

- [ ] consider default behavior... i'm expecting answer tests to fail because the default `depth` in `OffAxisProjectionPlot` is `(1, '1')` instead of `None`, so it may drop some particles, changing what the plots with default values look like? **UPDATE**: didn't actually break tests, but that may be a function of test coverage and there could be a change in behavior introduced here? 
- [ ] make sure I'm not introducing confusing or diverging behavior between the particle and non-particle projections (which both use the same `OffAxisProjectionDummyDataSource`). I think it's fine, but want to double check... **UPDATE**: I think I'm coming back around on this ... now thinking that it'd be better to simply always apply the depth limitation, following how the off axis projection for gridded data works. Will marinate on this for a bit .... 
- [ ] refactor: in the initial push I created new versions of the pixelation routines based on the existing `pixelize_sph_kernel_projection` and `rotate_particle_coord` and introduced a ton of code duplication in the process. I mainly wanted to avoid creating extra arrays for the rotated z coordinates and running extra checks on z bounds in the case where it's not limiting by z, so started off by simply creating separate functions... but will go back and refactor this now that I have it nominally working.
- [x] add tests  
- [ ] add note in docs
