### PR TITLE
ENH: fix notebook links

### DIFF
--- a/doc/source/analyzing/Particle_Trajectories.ipynb
+++ b/doc/source/analyzing/Particle_Trajectories.ipynb
@@ -4,6 +4,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Particle Trajectories"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "One can create particle trajectories from a `DatasetSeries` object for a specified list of particles identified by their unique indices using the `particle_trajectories` method. "
    ]
   },
@@ -11,7 +18,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -37,7 +47,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -56,7 +69,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -74,7 +90,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -95,7 +114,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -115,7 +137,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -134,7 +159,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -154,7 +182,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -174,7 +205,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -194,7 +228,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -215,7 +252,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -241,7 +281,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -260,7 +303,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -281,7 +327,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -315,7 +364,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -336,7 +388,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -354,7 +409,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -376,7 +434,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -392,7 +453,7 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -406,9 +467,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }

--- a/doc/source/analyzing/astropy_integrations.rst
+++ b/doc/source/analyzing/astropy_integrations.rst
@@ -33,8 +33,8 @@ Fixed-resolution two-dimensional images generated from datasets using yt (such a
 slices or projections) and fixed-resolution three-dimensional grids can be written
 to FITS files using yt's :class:`~yt.visualization.fits_image.FITSImageData` class
 and its subclasses. Multiple images can be combined into a single file, operations
-can be performed on the images and their coordinates, etc. See :ref:`writing_fits_images`
-for more information.
+can be performed on the images and their coordinates, etc. See
+:doc:`../visualizing/FITSImageData` for more information.
 
 Converting Field Container and 1D Profile Data to AstroPy Tables
 ----------------------------------------------------------------

--- a/doc/source/analyzing/domain_analysis/XrayEmissionFields.ipynb
+++ b/doc/source/analyzing/domain_analysis/XrayEmissionFields.ipynb
@@ -4,6 +4,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# X-ray Emission Fields"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "> Note: If you came here trying to figure out how to create simulated X-ray photons and observations,\n",
     "  you should go [here](http://hea-www.cfa.harvard.edu/~jzuhone/pyxsim/) instead."
    ]
@@ -34,9 +41,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import yt\n",
@@ -103,9 +108,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "slc = yt.SlicePlot(\n",
@@ -132,9 +135,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ds2 = yt.load(\"D9p_500/10MpcBox_HartGal_csf_a0.500.d\", default_species_fields=\"ionized\")\n",
@@ -178,9 +179,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "prj = yt.ProjectionPlot(\n",
@@ -228,9 +227,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "prj = yt.ProjectionPlot(\n",
@@ -248,7 +245,7 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -262,9 +259,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.1"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/doc/source/analyzing/domain_analysis/index.rst
+++ b/doc/source/analyzing/domain_analysis/index.rst
@@ -24,7 +24,7 @@ These modules exist within yt itself.
 
    cosmology_calculator
    clump_finding
-   xray_emission_fields
+   XrayEmissionFields
    xray_data_README
 
 External Analysis Modules

--- a/doc/source/analyzing/domain_analysis/xray_emission_fields.rst
+++ b/doc/source/analyzing/domain_analysis/xray_emission_fields.rst
@@ -1,6 +1,0 @@
-.. _xray_emission_fields:
-
-X-ray Emission Fields
-=====================
-
-.. notebook:: XrayEmissionFields.ipynb

--- a/doc/source/analyzing/filtering.rst
+++ b/doc/source/analyzing/filtering.rst
@@ -96,9 +96,7 @@ Cut Regions
 
 Cut regions are a more general solution to filtering mesh fields.  The output
 of a cut region is an entirely new data object, which can be treated like any
-other data object to generate images, examine its values, etc.
-
-.. notebook:: mesh_filter.ipynb
+other data object to generate images, examine its values, etc. See `this <mesh_filter>`_.
 
 In addition to inputting string parameters into cut_region to specify filters,
 wrapper functions exist that allow the user to use a simplified syntax for
@@ -252,7 +250,7 @@ to the dataset, it will also add ``stars`` filter to the dataset.
     ds.add_particle_filter("young_stars")
 
 
-.. notebook:: particle_filter.ipynb
+Additional example of particle filters can be found in the `notebook <particle_filter>`_.
 
 .. _particle-unions:
 

--- a/doc/source/analyzing/index.rst
+++ b/doc/source/analyzing/index.rst
@@ -22,6 +22,6 @@ multiple processors to accomplish tasks faster.
    generating_processed_data
    saving_data
    time_series_analysis
-   particle_trajectories
+   Particle_Trajectories
    parallel_computation
    astropy_integrations

--- a/doc/source/analyzing/mesh_filter.ipynb
+++ b/doc/source/analyzing/mesh_filter.ipynb
@@ -4,6 +4,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Filtering Grid Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Let us demonstrate this with an example using the same dataset as we used with the boolean masks."
    ]
   },

--- a/doc/source/analyzing/particle_filter.ipynb
+++ b/doc/source/analyzing/particle_filter.ipynb
@@ -4,6 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Filtering Particle Data\n",
     "Let us go through a full worked example.  Here we have a Tipsy SPH dataset.  By general\n",
     "inspection, we see that there are stars present in the dataset, since\n",
     "there are fields with field type: `Stars` in the `ds.field_list`. Let's look \n",

--- a/doc/source/analyzing/particle_trajectories.rst
+++ b/doc/source/analyzing/particle_trajectories.rst
@@ -1,6 +1,0 @@
-.. _particle-trajectories:
-
-Particle Trajectories
----------------------
-
-.. notebook:: Particle_Trajectories.ipynb

--- a/doc/source/cookbook/fits_radio_cubes.ipynb
+++ b/doc/source/cookbook/fits_radio_cubes.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Analyzing FITS Radio Cubes"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/doc/source/cookbook/fits_xray_images.ipynb
+++ b/doc/source/cookbook/fits_xray_images.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# X-ray FITS Images"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/doc/source/cookbook/index.rst
+++ b/doc/source/cookbook/index.rst
@@ -42,9 +42,9 @@ Example Notebooks
    custom_colorbar_tickmarks
    yt_gadget_analysis
    yt_gadget_owls_analysis
-   ../visualizing/transfer_function_helper
+   ../visualizing/TransferFunctionHelper_Tutorial
    fits_radio_cubes
    fits_xray_images
    geographic_xforms_and_projections
    tipsy_and_yt
-   ../visualizing/volume_rendering_tutorial
+   ../visualizing/Volume_Rendering_Tutorial

--- a/doc/source/cookbook/tipsy_and_yt.ipynb
+++ b/doc/source/cookbook/tipsy_and_yt.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Loading Files"
+    "# Loading Tipsy Data"
    ]
   },
   {

--- a/doc/source/cookbook/yt_gadget_analysis.ipynb
+++ b/doc/source/cookbook/yt_gadget_analysis.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Loading the data"
+    "# Loading Gadget data"
    ]
   },
   {

--- a/doc/source/cookbook/yt_gadget_owls_analysis.ipynb
+++ b/doc/source/cookbook/yt_gadget_owls_analysis.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# OWLS Examples"
+    "# Loading Gadget OWLS Data"
    ]
   },
   {

--- a/doc/source/examining/Loading_Data_via_Functions.ipynb
+++ b/doc/source/examining/Loading_Data_via_Functions.ipynb
@@ -257,7 +257,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -271,7 +271,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,

--- a/doc/source/examining/Loading_Generic_Array_Data.ipynb
+++ b/doc/source/examining/Loading_Generic_Array_Data.ipynb
@@ -4,6 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Loading Generic Array Data\n",
+    "\n",
     "Even if your data is not strictly related to fields commonly used in\n",
     "astrophysical codes or your code is not supported yet, you can still feed it to\n",
     "yt to use its advanced visualization and analysis facilities. The only\n",
@@ -42,7 +44,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -65,7 +70,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -83,7 +91,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -135,7 +146,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -157,7 +171,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -192,7 +209,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -220,7 +240,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -249,7 +272,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -267,7 +293,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -298,7 +327,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -310,7 +342,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -335,7 +370,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -365,7 +403,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -387,7 +428,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -412,7 +456,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -441,7 +488,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -466,7 +516,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -484,7 +537,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -503,7 +559,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -525,7 +584,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -545,7 +607,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -577,7 +642,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -608,7 +676,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -627,7 +698,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -662,7 +736,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -680,7 +757,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -692,7 +772,10 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "source": [
     "## Species fields"
@@ -701,7 +784,10 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "source": [
     "One can also supply species fields to a stream dataset, in the form of mass fractions. These will then be used to generate derived fields for mass, number, and nuclei densities of the separate species. The naming conventions for the mass fractions should correspond to the format specified in [the yt documentation for species fields](https://yt-project.org/doc/analyzing/fields.html#species-fields)."
@@ -711,7 +797,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -818,7 +907,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -832,9 +921,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }

--- a/doc/source/examining/Loading_Generic_Particle_Data.ipynb
+++ b/doc/source/examining/Loading_Generic_Particle_Data.ipynb
@@ -4,6 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Loading Generic Particle Data\n",
+    "\n",
     "This example creates a fake in-memory particle dataset and then loads it as a yt dataset using the `load_particles` function.\n",
     "\n",
     "Our \"fake\" dataset will be numpy arrays filled with normally distributed randoml particle positions and uniform particle masses.  Since real data is often scaled, I arbitrarily multiply by 1e6 to show how to deal with scaled data."

--- a/doc/source/examining/generic_array_data.rst
+++ b/doc/source/examining/generic_array_data.rst
@@ -1,6 +1,0 @@
-.. _loading-numpy-array:
-
-Loading Generic Array Data
-==========================
-
-.. notebook:: Loading_Generic_Array_Data.ipynb

--- a/doc/source/examining/generic_particle_data.rst
+++ b/doc/source/examining/generic_particle_data.rst
@@ -1,6 +1,0 @@
-.. _generic-particle-data:
-
-Loading Generic Particle Data
------------------------------
-
-.. notebook:: Loading_Generic_Particle_Data.ipynb

--- a/doc/source/examining/index.rst
+++ b/doc/source/examining/index.rst
@@ -6,17 +6,17 @@ Loading and Examining Data
 Nominally, one should just be able to run ``yt.load()`` on a dataset and start
 computing; however, there may be additional notes associated with different
 data formats as described below.  Furthermore, we provide methods for loading
-data from unsupported data formats in :ref:`loading-numpy-array`,
-:ref:`generic-particle-data`, and :ref:`loading-spherical-data`.  Lastly, if
-you want to examine the raw data for your particular dataset, visit
+data from unsupported data formats in :doc:`Loading_Generic_Array_Data`,
+:doc:`Loading_Generic_Particle_Data`, and :doc:`Loading_Spherical_Data`.
+Lastly, if you want to examine the raw data for your particular dataset, visit
 :ref:`low-level-data-inspection`.
 
 .. toctree::
    :maxdepth: 2
 
    loading_data
-   generic_array_data
-   generic_particle_data
-   loading_via_functions
-   spherical_data
+   Loading_Generic_Array_Data
+   Loading_Generic_Particle_Data
+   Loading_Data_via_Functions
+   Loading_Spherical_Data
    low_level_inspection

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -70,7 +70,8 @@ Simple HDF5 Data
 .. note::
 
    This wrapper takes advantage of the functionality described in
-   :ref:`loading-via-functions` but the basics of setting up function handlers,
+   :doc:`Loading_Data_via_Functions`
+   but the basics of setting up function handlers,
    guessing fields, etc, are handled by yt.
 
 Using the function :func:`yt.loaders.load_hdf5_file`, you can load a generic
@@ -1014,7 +1015,7 @@ FITS images are fully-describing in that unit, parameter, and coordinate
 information is passed from the original dataset. These can be created via the
 :class:`~yt.visualization.fits_image.FITSImageData` class and its subclasses.
 For information about how to use these special classes, see
-:ref:`writing_fits_images`.
+:doc:`../visualizing/FITSImageData`.
 
 Once you have produced a FITS file in this fashion, you can load it using
 yt and it will be detected as a ``YTFITSDataset`` object, and it can be analyzed
@@ -1056,7 +1057,7 @@ particle fields in yt, but a grid will be constructed from the WCS
 information in the FITS header. There is a helper function,
 ``setup_counts_fields``, which may be used to make deposited image fields
 from the event data for different energy bands (for an example see
-:ref:`xray_fits`).
+:doc:`../cookbook/fits_xray_images`).
 
 Generic FITS Images
 """""""""""""""""""
@@ -1296,9 +1297,9 @@ Examples of Using FITS Data
 The following Jupyter notebooks show examples of working with FITS data in yt,
 which we recommend you look at in the following order:
 
-* :ref:`radio_cubes`
-* :ref:`xray_fits`
-* :ref:`writing_fits_images`
+* :doc:`../cookbook/fits_radio_cubes`
+* :doc:`../cookbook/fits_xray_images`
+* :doc:`../visualizing/FITSImageData`
 
 .. _loading-flash-data:
 
@@ -1385,9 +1386,10 @@ yt has support for reading Gadget data in both raw binary and HDF5 formats.  It
 is able to access the particles as it would any other particle dataset, and it
 can apply smoothing kernels to the data to produce both quantitative analysis
 and visualization. See :ref:`loading-sph-data` for more details and
-:ref:`gadget-notebook` for a detailed example of loading, analyzing, and
-visualizing a Gadget dataset.  An example which makes use of a Gadget snapshot
-from the OWLS project can be found at :ref:`owls-notebook`.
+:doc:`../cookbook/yt_gadget_analysis` for a detailed example
+of loading, analyzing, and visualizing a Gadget dataset.  An example which
+makes use of a Gadget snapshot from the OWLS project can be found in
+:doc:`../cookbook/yt_gadget_owls_analysis`.
 
 .. note::
 
@@ -1882,14 +1884,14 @@ to avoid catastrophic cancellations.
 Generic AMR Data
 ----------------
 
-See :ref:`loading-numpy-array` and
+See :doc:`Loading_Generic_Array_Data` and
 :func:`~yt.frontends.stream.data_structures.load_amr_grids` for more detail.
 
 .. note::
 
    It is now possible to load data using *only functions*, rather than using the
    fully-in-memory method presented here.  For more information and examples,
-   see :ref:`loading-via-functions`.
+   see :doc:`Loading_Data_via_Functions`.
 
 It is possible to create native yt dataset from Python's dictionary
 that describes set of rectangular patches of data of possibly varying
@@ -1946,7 +1948,7 @@ Particle fields are supported by adding 1-dimensional arrays to each
 Generic Array Data
 ------------------
 
-See :ref:`loading-numpy-array` and
+See :doc:`Loading_Generic_Array_Data` and
 :func:`~yt.frontends.stream.data_structures.load_uniform_grid` for more detail.
 
 Even if your data is not strictly related to fields commonly used in
@@ -2010,7 +2012,7 @@ Semi-Structured Grid Data
 
    See :ref:`loading-stretched-grids` for more information.
 
-See :ref:`loading-numpy-array`,
+See :doc:`Loading_Generic_Array_Data`,
 :func:`~yt.frontends.stream.data_structures.hexahedral_connectivity`,
 :func:`~yt.frontends.stream.data_structures.load_hexahedral_mesh` for
 more detail.
@@ -2124,7 +2126,7 @@ fewer) cells.
 Unstructured Grid Data
 ----------------------
 
-See :ref:`loading-numpy-array`,
+See :doc:`Loading_Generic_Array_Data`,
 :func:`~yt.frontends.stream.data_structures.load_unstructured_mesh` for
 more detail.
 
@@ -2250,7 +2252,7 @@ Generic Particle Data
    For more information about how yt indexes and reads particle data, set the
    section :ref:`demeshening`.
 
-See :ref:`generic-particle-data` and
+See :doc:`Loading_Generic_Particle_Data` and
 :func:`~yt.frontends.stream.data_structures.load_particles` for more detail.
 
 You can also load generic particle data using the same ``stream`` functionality
@@ -3202,7 +3204,7 @@ Tipsy Data
    For more information about how yt indexes and reads particle data, set the
    section :ref:`demeshening`.
 
-See :ref:`tipsy-notebook` and :ref:`loading-sph-data` for more details.
+See :doc:`../cookbook/tipsy_and_yt` and :ref:`loading-sph-data` for more details.
 
 yt also supports loading Tipsy data.  Many of its characteristics are similar
 to how Gadget data is loaded.

--- a/doc/source/examining/loading_via_functions.rst
+++ b/doc/source/examining/loading_via_functions.rst
@@ -1,6 +1,0 @@
-.. _loading-via-functions:
-
-Loading Data via Functions
-==========================
-
-.. notebook:: Loading_Data_via_Functions.ipynb

--- a/doc/source/examining/low_level_inspection.rst
+++ b/doc/source/examining/low_level_inspection.rst
@@ -13,7 +13,7 @@ access to the raw data.
           the attendant properties.
 
 For a more basic introduction, see :ref:`quickstart` and more specifically
-:ref:`data_inspection`.
+:doc:`../quickstart/2)_Data_Inspection`.
 
 .. _examining-grid-hierarchies:
 

--- a/doc/source/examining/spherical_data.rst
+++ b/doc/source/examining/spherical_data.rst
@@ -1,6 +1,0 @@
-.. _loading-spherical-data:
-
-Loading Spherical Data
-======================
-
-.. notebook:: Loading_Spherical_Data.ipynb

--- a/doc/source/quickstart/data_inspection.rst
+++ b/doc/source/quickstart/data_inspection.rst
@@ -1,6 +1,0 @@
-.. _data_inspection:
-
-Data Inspection
----------------
-
-.. notebook:: 2)_Data_Inspection.ipynb

--- a/doc/source/quickstart/data_objects_and_time_series.rst
+++ b/doc/source/quickstart/data_objects_and_time_series.rst
@@ -1,4 +1,0 @@
-Data Objects and Time Series
-----------------------------
-
-.. notebook:: 4)_Data_Objects_and_Time_Series.ipynb

--- a/doc/source/quickstart/derived_fields_and_profiles.rst
+++ b/doc/source/quickstart/derived_fields_and_profiles.rst
@@ -1,4 +1,0 @@
-Derived Fields and Profiles
----------------------------
-
-.. notebook:: 5)_Derived_Fields_and_Profiles.ipynb

--- a/doc/source/quickstart/index.rst
+++ b/doc/source/quickstart/index.rst
@@ -55,17 +55,17 @@ Here are the notebooks, which have been filled in for inspection:
 .. toctree::
    :maxdepth: 1
 
-   introduction
-   data_inspection
-   simple_visualization
-   data_objects_and_time_series
-   derived_fields_and_profiles
-   volume_rendering
+   1)_Introduction
+   2)_Data_Inspection
+   3)_Simple_Visualization
+   4)_Data_Objects_and_Time_Series
+   5)_Derived_Fields_and_Profiles
+   6)_Volume_Rendering
 
 .. note::
 
    The notebooks use sample datasets that are available for download at
-   https://yt-project.org/data.  See :ref:`quickstart-introduction` for more
+   https://yt-project.org/data.  See :doc:`1)_Introduction` for more
    details.
 
 Let us know if you would like to contribute other example notebooks, or have

--- a/doc/source/quickstart/introduction.rst
+++ b/doc/source/quickstart/introduction.rst
@@ -1,6 +1,0 @@
-.. _quickstart-introduction:
-
-Introduction
-------------
-
-.. notebook:: 1)_Introduction.ipynb

--- a/doc/source/quickstart/simple_visualization.rst
+++ b/doc/source/quickstart/simple_visualization.rst
@@ -1,4 +1,0 @@
-Simple Visualization
---------------------
-
-.. notebook:: 3)_Simple_Visualization.ipynb

--- a/doc/source/quickstart/volume_rendering.rst
+++ b/doc/source/quickstart/volume_rendering.rst
@@ -1,4 +1,0 @@
-Volume Rendering
-----------------
-
-.. notebook:: 6)_Volume_Rendering.ipynb

--- a/doc/source/reference/code_support.rst
+++ b/doc/source/reference/code_support.rst
@@ -92,6 +92,6 @@ each supported output format using yt.
          CFRadial coordinates will be gridded on load, see :ref:`loading-cfradial-data`.
 
 If you have a dataset that uses an output format not yet supported by yt, you
-can either input your data following :ref:`loading-numpy-array` or
-:ref:`generic-particle-data`, or help us by :ref:`creating_frontend` for this
-new format.
+can either input your data following :doc:`../examining/Loading_Generic_Array_Data` or
+:doc:`../examining/Loading_Generic_Particle_Data`, or help us by :ref:`creating_frontend`
+for this new format.

--- a/doc/source/visualizing/FITSImageData.ipynb
+++ b/doc/source/visualizing/FITSImageData.ipynb
@@ -4,6 +4,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Writing FITS Images"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "yt has capabilities for writing 2D and 3D uniformly gridded data generated from datasets to FITS files. This is via the `FITSImageData` class. We'll test these capabilities out on an Athena dataset."
    ]
   },
@@ -133,7 +140,10 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "source": [
     "## Making FITS images from Particle Projections"
@@ -141,17 +151,26 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "source": [
     "To create a FITS image from a particle field which is smeared onto the image, we can use\n",
     "`FITSParticleProjection`:"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "dsp = yt.load(\"gizmo_64/output/snap_N64L16_135.hdf5\")\n",
@@ -159,50 +178,62 @@
     "    dsp, \"x\", (\"PartType1\", \"particle_mass\"), deposition=\"cic\"\n",
     ")\n",
     "prjp_fits.writeto(\"prjp.fits\", overwrite=True)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "source": [
     "Note that we used the \"Cloud-In-Cell\" interpolation method (`\"cic\"`) instead of the default\n",
     "\"Nearest-Grid-Point\" (`\"ngp\"`) method. \n",
     "\n",
     "If you want the projection to be divided by the pixel area (to make a projection of mass density, \n",
     "for example), supply the ``density`` keyword argument:"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "prjpd_fits = yt.FITSParticleProjection(\n",
     "    dsp, \"x\", (\"PartType1\", \"particle_mass\"), density=True, deposition=\"cic\"\n",
     ")\n",
     "prjpd_fits.writeto(\"prjpd.fits\", overwrite=True)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "source": [
     "`FITSParticleOffAxisProjection` can be used to make a projection along any arbitrary sight line:"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "L = [1, -1, 1]  # normal or \"line of sight\" vector\n",
@@ -211,19 +242,19 @@
     "    dsp, L, (\"PartType1\", \"particle_mass\"), deposition=\"cic\", north_vector=N\n",
     ")\n",
     "poff_fits.writeto(\"poff.fits\", overwrite=True)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "source": [
     "## Using `HDUList` Methods"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -632,7 +663,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
    },
    "outputs": [],
    "source": [
@@ -777,7 +811,7 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -791,9 +825,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/doc/source/visualizing/TransferFunctionHelper_Tutorial.ipynb
+++ b/doc/source/visualizing/TransferFunctionHelper_Tutorial.ipynb
@@ -4,6 +4,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Transfer Function Helper Tutorial"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Here, we explain how to use TransferFunctionHelper to visualize and interpret yt volume rendering transfer functions.  Creating a custom transfer function is a process that usually involves some trial-and-error. TransferFunctionHelper is a utility class designed to help you visualize the probability density functions of yt fields that you might want to volume render.  This makes it easier to choose a nice transfer function that highlights interesting physical regimes.\n",
     "\n",
     "First, we set up our namespace and define a convenience function to display volume renderings inline in the notebook.  Using `%matplotlib inline` makes it so matplotlib plots display inline in the notebook."
@@ -13,7 +20,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -46,7 +56,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -64,7 +77,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -82,7 +98,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -107,7 +126,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -125,7 +147,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -160,7 +185,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -184,7 +212,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -219,7 +250,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
    },
    "outputs": [],
    "source": [
@@ -239,7 +273,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -253,9 +287,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }

--- a/doc/source/visualizing/Volume_Rendering_Tutorial.ipynb
+++ b/doc/source/visualizing/Volume_Rendering_Tutorial.ipynb
@@ -362,7 +362,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -376,9 +376,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.3"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/doc/source/visualizing/geographic_projections_and_transforms.rst
+++ b/doc/source/visualizing/geographic_projections_and_transforms.rst
@@ -78,7 +78,7 @@ with this functionality.
 
 The next few examples will use a GEOS dataset accessible from the ``yt`` data
 downloads page. For details about loading this data, please
-see :ref:`cookbook-geographic_projections`.
+see :doc:`../cookbook/geographic_xforms_and_projections`.
 
 If a geographic dataset is loaded without any defined projection the default
 option of ``Mollweide`` will be displayed.
@@ -141,4 +141,4 @@ levels of customization:
     set_mpl_projection(cartopy.crs.PlateCarree())
 
 Further examples of using the geographic transforms with this dataset
-can be found in :ref:`cookbook-geographic_projections`.
+can be found in :doc:`../cookbook/geographic_xforms_and_projections`.

--- a/doc/source/visualizing/index.rst
+++ b/doc/source/visualizing/index.rst
@@ -23,4 +23,4 @@ interactively.
    streamlines
    colormaps/index
    geographic_projections_and_transforms
-   writing_fits_images
+   FITSImageData

--- a/doc/source/visualizing/streamlines.rst
+++ b/doc/source/visualizing/streamlines.rst
@@ -9,7 +9,7 @@ velocity flow or magnetic field lines, they can be defined to follow
 any three-dimensional vector field.  Once an initial condition and
 total length of the streamline are specified, the streamline is
 uniquely defined.  Relatedly, yt also has the ability to follow
-:ref:`particle-trajectories`.
+:doc:`../analyzing/Particle_Trajectories`.
 
 Method
 ------

--- a/doc/source/visualizing/transfer_function_helper.rst
+++ b/doc/source/visualizing/transfer_function_helper.rst
@@ -1,6 +1,0 @@
-.. _transfer-function-helper-tutorial:
-
-Transfer Function Helper Tutorial
-=================================
-
-.. notebook:: TransferFunctionHelper_Tutorial.ipynb

--- a/doc/source/visualizing/volume_rendering.rst
+++ b/doc/source/visualizing/volume_rendering.rst
@@ -15,8 +15,8 @@ processors are being actively developed.
 
 .. note::
 
-   There is a Jupyter notebook containing a volume rendering tutorial available
-   at :ref:`volume-rendering-tutorial`.
+   There is a Jupyter notebook containing a volume rendering tutorial:
+   :doc:`Volume_Rendering_Tutorial`.
 
 Volume Rendering Introduction
 -----------------------------
@@ -237,7 +237,7 @@ For fun, let's make the same volume_rendering, but this time setting
    sc.save("rendering.png", sigma_clip=4.0)
 
 To see a full example on how to use the ``TransferFunctionHelper`` interface,
-follow the annotated :ref:`transfer-function-helper-tutorial`.
+follow the annotated :doc:`TransferFunctionHelper_Tutorial`.
 
 Color Transfer Functions
 ++++++++++++++++++++++++
@@ -696,7 +696,7 @@ function. Example:
     sc.save("rendering.png")
 
 For an in-depth tutorial on how to create a Scene and modify its contents,
-see this annotated :ref:`volume-rendering-tutorial`.
+see this annotated :doc:`Volume_Rendering_Tutorial`.
 
 
 .. _volume-rendering-method:

--- a/doc/source/visualizing/volume_rendering_tutorial.rst
+++ b/doc/source/visualizing/volume_rendering_tutorial.rst
@@ -1,6 +1,0 @@
-.. _volume-rendering-tutorial:
-
-Volume Rendering Tutorial
-=========================
-
-.. notebook:: Volume_Rendering_Tutorial.ipynb

--- a/doc/source/visualizing/writing_fits_images.rst
+++ b/doc/source/visualizing/writing_fits_images.rst
@@ -1,6 +1,0 @@
-.. _writing_fits_images:
-
-Writing FITS Images
-==========================
-
-.. notebook:: FITSImageData.ipynb


### PR DESCRIPTION
## PR Summary

Fix most of orphaned `.. notebook` directives

Stub `.rst` with just a label and `.. notebook` are no longer necessary (won't work anyway). In order to link to in TOC use name of the notebook file directly. In order to link within text use `` `:doc:<relative/path/to/notebook>` ``.

`.. notebook-cell` are still not resolved by this PR, but I haven't figured out how to do them (except for using myst and markdown instead).