### PR TITLE
Ramses-speedup

### DIFF
--- a/yt/frontends/ramses/field_handlers.py
+++ b/yt/frontends/ramses/field_handlers.py
@@ -272,7 +272,7 @@ class FieldFileHandler(abc.ABC, HandlerMixin):
                 self.domain.domain_id,
                 self.parameters["nvar"],
                 self.domain.amr_header,
-                skip_len=nvars * 8,
+                Nskip=nvars * 8,
             )
 
         self._offset = offset

--- a/yt/frontends/ramses/io_utils.pyx
+++ b/yt/frontends/ramses/io_utils.pyx
@@ -88,7 +88,7 @@ def read_amr(FortranFile f, dict headers,
     return max_level
 
 
-cdef inline int skip_len(int Nskip, int record_len) noexcept:
+cdef inline int skip_len(int Nskip, int record_len) noexcept nogil:
     return Nskip * (record_len * DOUBLE_SIZE + INT64_SIZE)
 
 @cython.cpow(True)

--- a/yt/frontends/ramses/io_utils.pyx
+++ b/yt/frontends/ramses/io_utils.pyx
@@ -188,7 +188,7 @@ def fill_hydro(FortranFile f,
             jump_len += 1
     jumps[j] = jump_len
 
-    cdef int nc_largest = 0
+    buffer = np.empty((level_count.max(), twotondim, nfields_selected), dtype="float64", order='F')
     # Loop over levels
     for ilevel in range(nlevels):
         # Loop over cpu domains
@@ -201,11 +201,6 @@ def fill_hydro(FortranFile f,
             if offset == -1:
                 continue
             f.seek(offset)
-            # Initialize temporary data container for io
-            # note: we use Fortran ordering to reflect the in-file ordering
-            if nc > nc_largest:
-                nc_largest = nc
-                buffer = np.empty((nc, twotondim, nfields_selected), dtype="float64", order='F')
 
             jump_len = 0
             for i in range(twotondim):

--- a/yt/frontends/ramses/io_utils.pyx
+++ b/yt/frontends/ramses/io_utils.pyx
@@ -138,7 +138,7 @@ cpdef read_offset(FortranFile f, INT64_t min_level, INT64_t domain_id, INT64_t n
 
     return offset, level_count
 
-cdef inline int skip_len(int Nskip, int record_len):
+cdef inline int skip_len(int Nskip, int record_len) noexcept:
     return Nskip * (record_len * DOUBLE_SIZE + INT64_SIZE)
 
 @cython.cpow(True)
@@ -162,6 +162,7 @@ def fill_hydro(FortranFile f,
     cdef str field
     cdef INT64_t twotondim
     cdef int ilevel, icpu, nlevels, nc, ncpu_selected, nfields_selected
+    cdef int i, j
 
     twotondim = 2**ndim
     nfields_selected = len(fields)
@@ -171,6 +172,7 @@ def fill_hydro(FortranFile f,
 
     cdef np.int64_t[:] jumps = np.zeros(nfields_selected + 1, dtype=np.int64)
     cdef int jump_len
+    cdef np.ndarray[np.float64_t, ndim=3] buffer
 
     jump_len = 0
     j = 0
@@ -206,7 +208,7 @@ def fill_hydro(FortranFile f,
                     if jump_len > 0:
                         f.seek(skip_len(jump_len, nc), 1)
                         jump_len = 0
-                    buffer[:, i, j] = f.read_vector('d')
+                    f.read_vector_inplace('d', <void*> &buffer[0, i, j])
 
                 jump_len += jumps[nfields_selected]
 

--- a/yt/frontends/ramses/io_utils.pyx
+++ b/yt/frontends/ramses/io_utils.pyx
@@ -187,6 +187,7 @@ def fill_hydro(FortranFile f,
         else:
             jump_len += 1
     jumps[j] = jump_len
+    cdef int first_field_index = jumps[0]
 
     buffer = np.empty((level_count.max(), twotondim, nfields_selected), dtype="float64", order='F')
     # Loop over levels
@@ -200,9 +201,11 @@ def fill_hydro(FortranFile f,
             offset = offsets[icpu, ilevel]
             if offset == -1:
                 continue
-            f.seek(offset)
+            f.seek(offset + skip_len(first_field_index, nc))
 
-            jump_len = 0
+            # We have already skipped the first fields (if any)
+            # so we "rewind" (this will cancel the first seek)
+            jump_len = -first_field_index
             for i in range(twotondim):
                 # Read the selected fields
                 for j in range(nfields_selected):

--- a/yt/frontends/ramses/io_utils.pyx
+++ b/yt/frontends/ramses/io_utils.pyx
@@ -220,8 +220,8 @@ def fill_hydro(FortranFile f,
                 jump_len += jumps[nfields_selected]
 
             # In principle, we may be left with some fields to skip
-            # but since we're doing an absolute seek above,
-            # we don't need to do anything here
+            # but since we're doing an absolute seek at the beginning of
+            # the loop on CPUs, we can spare one seek here
             ## if jump_len > 0:
             ##     f.seek(skip_len(jump_len, nc), 1)
 

--- a/yt/geometry/oct_container.pxd
+++ b/yt/geometry/oct_container.pxd
@@ -82,6 +82,29 @@ cdef class OctreeContainer:
     cdef public object fill_style
     cdef public int max_level
 
+    cpdef void fill_level(
+        self,
+        const int level,
+        const np.uint8_t[:] levels,
+        const np.uint8_t[:] cell_inds,
+        const np.int64_t[:] file_inds,
+        dict dest_fields,
+        dict source_fields,
+        np.int64_t offset = ?
+    )
+    cpdef int fill_level_with_domain(
+        self,
+        const int level,
+        const np.uint8_t[:] levels,
+        const np.uint8_t[:] cell_inds,
+        const np.int64_t[:] file_inds,
+        const np.int32_t[:] domains,
+        dict dest_fields,
+        dict source_fields,
+        const np.int32_t domain,
+        np.int64_t offset = ?
+    )
+
 cdef class SparseOctreeContainer(OctreeContainer):
     cdef OctKey *root_nodes
     cdef void *tree_root

--- a/yt/geometry/oct_container.pyx
+++ b/yt/geometry/oct_container.pyx
@@ -742,12 +742,16 @@ cdef class OctreeContainer:
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    def fill_level(self, int level,
-                   np.ndarray[np.uint8_t, ndim=1] levels,
-                   np.ndarray[np.uint8_t, ndim=1] cell_inds,
-                   np.ndarray[np.int64_t, ndim=1] file_inds,
-                   dest_fields, source_fields,
-                   np.int64_t offset = 0):
+    cpdef void fill_level(
+        self,
+        const int level,
+        const np.uint8_t[:] levels,
+        const np.uint8_t[:] cell_inds,
+        const np.int64_t[:] file_inds,
+        dict dest_fields,
+        dict source_fields,
+        np.int64_t offset = 0
+    ):
         cdef np.ndarray[np.float64_t, ndim=2] source
         cdef np.ndarray[np.float64_t, ndim=1] dest
         cdef int i, lvl
@@ -824,17 +828,18 @@ cdef class OctreeContainer:
     @cython.boundscheck(False)
     @cython.wraparound(False)
     @cython.cdivision(True)
-    def fill_level_with_domain(
-                   self, int level,
-                   np.uint8_t[:] levels,
-                   np.uint8_t[:] cell_inds,
-                   np.int64_t[:] file_inds,
-                   np.int32_t[:] domains,
-                   dict dest_fields,
-                   dict source_fields,
-                   np.int32_t domain,
-                   np.int64_t offset = 0
-                   ):
+    cpdef int fill_level_with_domain(
+        self,
+        const int level,
+        const np.uint8_t[:] levels,
+        const np.uint8_t[:] cell_inds,
+        const np.int64_t[:] file_inds,
+        const np.int32_t[:] domains,
+        dict dest_fields,
+        dict source_fields,
+        const np.int32_t domain,
+        np.int64_t offset = 0
+    ):
         """Similar to fill_level but accepts a domain argument.
 
         This is particularly useful for frontends that have buffer zones at CPU boundaries.

--- a/yt/utilities/cython_fortran_utils.pxd
+++ b/yt/utilities/cython_fortran_utils.pxd
@@ -13,6 +13,7 @@ cdef class FortranFile:
     cdef INT64_t get_size(self, str dtype)
     cpdef INT32_t read_int(self) except? -1
     cpdef np.ndarray read_vector(self, str dtype)
+    cdef int read_vector_inplace(self, str dtype, void *data)
     cpdef INT64_t tell(self) except -1
     cpdef INT64_t seek(self, INT64_t pos, INT64_t whence=*) except -1
     cpdef void close(self)

--- a/yt/utilities/cython_fortran_utils.pyx
+++ b/yt/utilities/cython_fortran_utils.pyx
@@ -142,6 +142,38 @@ cdef class FortranFile:
 
         return data
 
+    cdef int read_vector_inplace(self, str dtype, void *data):
+        """Reads a record from the file and return it as numpy array.
+
+        Parameters
+        ----------
+        d : data type
+            This is the datatype (from the struct module) that we should read.
+        data : void*
+            The pointer to the data to be read.
+
+        """
+        cdef INT32_t s1, s2, size
+
+        if self._closed:
+            raise ValueError("I/O operation on closed file.")
+
+        size = self.get_size(dtype)
+
+        fread(&s1, INT32_SIZE, 1, self.cfile)
+
+        # Check record is compatible with data type
+        if s1 % size != 0:
+            raise ValueError('Size obtained (%s) does not match with the expected '
+                             'size (%s) of multi-item record' % (s1, size))
+
+        fread(data, size, s1 // size, self.cfile)
+        fread(&s2, INT32_SIZE, 1, self.cfile)
+
+        if s1 != s2:
+            raise IOError('Sizes do not agree in the header and footer for '
+                          'this record - check header dtype')
+
     cpdef INT32_t read_int(self) except? -1:
         """Reads a single int32 from the file and return it.
 

--- a/yt/utilities/cython_fortran_utils.pyx
+++ b/yt/utilities/cython_fortran_utils.pyx
@@ -143,15 +143,15 @@ cdef class FortranFile:
         return data
 
     cdef int read_vector_inplace(self, str dtype, void *data):
-        """Reads a record from the file and return it as numpy array.
+        """Reads a record from the file.
 
         Parameters
         ----------
         d : data type
             This is the datatype (from the struct module) that we should read.
         data : void*
-            The pointer to the data to be read.
-
+            The pointer where to store the data.
+            It should be preallocated and have the correct size.
         """
         cdef INT32_t s1, s2, size
 


### PR DESCRIPTION
## PR Summary

RAMSES files require lots of random access in the file. In particular, when you have a lot of fields in the outputs, the performance drastically decreases if you're skipping most of them. In this PR,  I precompute how many "jumps" one needs to do ahead of time, and then do all jumps at once.

The code should be functionally equivalent but results in fewer reads.

### Performances

| slice | Timing on `main` [s] | Timing with this PR [s]|
|-------|----------------------|------------------------|
| all   | 52                   | 23|
| ::2   | 43 | 17 |
| ::4   | 39 | 12 |
| :4    | 35 | 9 |

To estimate the timings, the following code is being run, with the slice as reported in the table above. This is run on [Dial 3](https://dial3-docs.dirac.ac.uk/).

```python
import yt

# This is a (very) large simulation - 500Gib/output, 110 fields on-disk
p = "/lustre/dirac3/home/dc-cadi1/dp265/dc-katz1/MEGATRON/PRODUCTION_CP/output_00048"

# Only load the innermost part of the simulation (sufficient for benchmarking)
bbox = [[0.499]*3, [0.501]*3]

ds = yt.load(p, bbox=bbox)
ad = ds.all_data()

# Retain only the hydro fields + level
fields = [
    ("index", "grid_level"),
    *((ft, fn) for (ft, fn) in ds.field_list if ft == "ramses")
]

from time import time
before = time()
ad.get_data(fields[<slice>])
after = time()
print(f"Took {after-before:.2s}s")
```