### PR TITLE
BUG: handle deprecation warnings from numpy 2.0.0dev0 (np.row_stack -> np.vstack and np.in1d -> np.isin)

### DIFF
--- a/yt/data_objects/particle_trajectories.py
+++ b/yt/data_objects/particle_trajectories.py
@@ -99,9 +99,9 @@ class ParticleTrajectories:
         ):
             dd = ds.all_data()
             newtags = dd[fds["particle_index"]].d.astype("int64")
-            mask = np.in1d(newtags, indices, assume_unique=True)
+            mask = np.isin(newtags, indices, assume_unique=True)
             sort = np.argsort(newtags[mask])
-            array_indices = np.where(np.in1d(indices, newtags, assume_unique=True))[0]
+            array_indices = np.where(np.isin(indices, newtags, assume_unique=True))[0]
             self.array_indices.append(array_indices)
             self.masks.append(mask)
             self.sorts.append(sort)
@@ -333,7 +333,7 @@ class ParticleTrajectories:
         ... )
         >>> plt.savefig("orbit")
         """
-        mask = np.in1d(self.indices, (index,), assume_unique=True)
+        mask = np.isin(self.indices, (index,), assume_unique=True)
         if not np.any(mask):
             print("The particle index %d is not in the list!" % (index))
             raise IndexError

--- a/yt/frontends/adaptahop/data_structures.py
+++ b/yt/frontends/adaptahop/data_structures.py
@@ -348,7 +348,7 @@ class AdaptaHOPHaloContainer(YTSelectionContainer):
 
         # Build subregion that only contains halo particles
         reg = sph.cut_region(
-            ['np.in1d(obj[("io", "particle_identity")].astype("int64"), members)'],
+            ['np.isin(obj[("io", "particle_identity")].astype("int64"), members)'],
             locals={"members": members, "np": np},
         )
 

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -2480,8 +2480,8 @@ class TriangleFacetsCallback(PlotCallback):
             # more convenient to swap the x, y values here before final roll
             x0, y0 = l_cy[0]  # x, y values of start points
             x1, y1 = l_cy[1]  # x, y values of end points
-            l_cy[0] = np.row_stack([y0, x0])  # swap x, y for start points
-            l_cy[1] = np.row_stack([y1, x1])  # swap x, y for end points
+            l_cy[0] = np.vstack([y0, x0])  # swap x, y for start points
+            l_cy[1] = np.vstack([y1, x1])  # swap x, y for end points
         # convert back to shape (nlines, 2, 2)
         l_cy = np.rollaxis(l_cy, 2, 0)
         # create line collection and add it to the plot


### PR DESCRIPTION
## PR Summary

Fix remaining usage of deprecated API. See https://numpy.org/devdocs/release/2.0.0-notes.html#deprecations