### PR TITLE
MNT: fix auto-reports for bleeding edge CI

### DIFF
--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -87,7 +87,6 @@ jobs:
         body: |
           The weekly build with future dependencies has failed. Check the logs
           https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}
-        labels: 'tests: running tests,'
         pinned: false
         close-previous: false
       env:


### PR DESCRIPTION
Goal: fix #4721
I suspect that the `labels` parameter is malformed (this is the only one I'm using that's not used in the matplotlib model workflow, and it's not well documented)

I'm going to test this by removing the conditional trigger.