### PR TITLE
MNT: opt-in ruff's builtin support for jupyter notebooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,12 +44,6 @@ repos:
   - id: ruff
     args: [--fix]
 
-- repo: https://github.com/nbQA-dev/nbQA
-  rev: 1.7.0
-  hooks:
-  - id: nbqa-ruff
-    args: [--fix, --extend-ignore=E402]
-
 -   repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -265,6 +265,7 @@ exclude = '''
 '''
 
 [tool.ruff]
+extend-include = ["*.ipynb"]
 exclude = [
     "doc",
     "benchmarks",


### PR DESCRIPTION
One less hook required to accomplish the same thing. Ruff has had builtin support for *.ipynb files since [v0.0.276](https://github.com/astral-sh/ruff/releases/tag/v0.0.276)
See https://docs.astral.sh/ruff/faq/#does-ruff-support-jupyter-notebooks