### PR TITLE
ENH: allow cell_widths and nproc > 1 for load_uniform_grid

### DIFF
--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -2084,9 +2084,8 @@ widths are provided in advance.
 
 .. note::
 
-   At present, support is available for a single grid with varying cell-widths,
-   loaded through the stream handler.  Future versions of yt will have more
-   complete and flexible support!
+   At present, stretched grids are restricted to a single level of refinement.
+   Future versions of yt will have more complete and flexible support!
 
 To load a stretched grid, you use the standard (and now rather-poorly named)
 ``load_uniform_grid`` function, but supplying a ``cell_widths`` argument.  This
@@ -2121,7 +2120,8 @@ demonstrates loading a simple "random" dataset with a random set of cell-widths.
 
 
 This can be modified to load data from a file, as well as to use more (or
-fewer) cells.
+fewer) cells. Like with a standard uniform grid, providing ``nprocs>1`` will
+decompose the domain into multiple grids (without refinement).
 
 Unstructured Grid Data
 ----------------------

--- a/yt/frontends/athena/data_structures.py
+++ b/yt/frontends/athena/data_structures.py
@@ -360,7 +360,7 @@ class AthenaHierarchy(GridIndex):
                 )
                 bbox = np.array([[le, re] for le, re in zip(gle_orig, gre_orig)])
                 psize = get_psize(self.ds.domain_dimensions, self.ds.nprocs)
-                gle, gre, shapes, slices = decompose_array(gdims[i], psize, bbox)
+                gle, gre, shapes, slices, _ = decompose_array(gdims[i], psize, bbox)
                 gle_all += gle
                 gre_all += gre
                 shapes_all += shapes

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -213,7 +213,7 @@ class FITSHierarchy(GridIndex):
         ).transpose()
         dims = self.ds.domain_dimensions
         psize = get_psize(dims, self.num_grids)
-        gle, gre, shapes, slices = decompose_array(dims, psize, bbox)
+        gle, gre, shapes, slices, _ = decompose_array(dims, psize, bbox)
         self.grid_left_edge = self.ds.arr(gle, "code_length")
         self.grid_right_edge = self.ds.arr(gre, "code_length")
         self.grid_dimensions = np.array(shapes, dtype="int32")

--- a/yt/frontends/stream/misc.py
+++ b/yt/frontends/stream/misc.py
@@ -6,7 +6,7 @@ from yt._typing import DomainDimensions
 def _validate_cell_widths(
     cell_widths: list[np.ndarray],
     domain_dimensions: DomainDimensions,
-) -> list[list[np.ndarray]]:
+) -> list[np.ndarray]:
     # check dimensionality
     if (nwids := len(cell_widths)) != (ndims := len(domain_dimensions)):
         raise ValueError(
@@ -18,6 +18,4 @@ def _validate_cell_widths(
     for idim in range(len(cell_widths)):
         cell_widths[idim] = cell_widths[idim].astype(np.float64, copy=False)
 
-    # finally, need to return a list of the cell_widths for each grid object.
-    # since there is only a single grid, just wrap it in a list.
-    return [cell_widths]
+    return cell_widths

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -287,7 +287,7 @@ def load_uniform_grid(
     cell_widths: list, optional
         If set, cell_widths is a list of arrays with an array for each dimension,
         specificing the cell spacing in that dimension. Must be consistent with
-        the domain_dimensions. nprocs must remain 1 to set cell_widths.
+        the domain_dimensions.
     parameters: dictionary, optional
         Optional dictionary used to populate the dataset parameters, useful
         for storing dataset metadata.
@@ -354,16 +354,30 @@ def load_uniform_grid(
     else:
         particle_types = {}
 
+    if cell_widths is not None:
+        cell_widths = _validate_cell_widths(cell_widths, domain_dimensions)
+
     if nprocs > 1:
         temp = {}
         new_data = {}  # type: ignore [var-annotated]
         for key in data.keys():
             psize = get_psize(np.array(data[key].shape), nprocs)
-            grid_left_edges, grid_right_edges, shapes, slices = decompose_array(
-                data[key].shape, psize, bbox
+            (
+                grid_left_edges,
+                grid_right_edges,
+                shapes,
+                slices,
+                grid_cell_widths,
+            ) = decompose_array(
+                data[key].shape,
+                psize,
+                bbox,
+                cell_widths=cell_widths,
             )
+            cell_widths = grid_cell_widths
             grid_dimensions = np.array(list(shapes), dtype="int32")
             temp[key] = [data[key][slice] for slice in slices]
+
         for gid in range(nprocs):
             new_data[gid] = {}
             for key in temp.keys():
@@ -375,13 +389,10 @@ def load_uniform_grid(
         grid_left_edges = domain_left_edge
         grid_right_edges = domain_right_edge
         grid_dimensions = domain_dimensions.reshape(nprocs, 3).astype("int32")
-
-    if cell_widths is not None:
-        # cell_widths left as an empty guard value if None
-        if nprocs != 1:
-            # see https://github.com/yt-project/yt/issues/4330
-            raise NotImplementedError("nprocs must equal 1 if supplying cell_widths.")
-        cell_widths = _validate_cell_widths(cell_widths, domain_dimensions)
+        if cell_widths is not None:
+            cell_widths = [
+                cell_widths,
+            ]
 
     if length_unit is None:
         length_unit = "code_length"
@@ -1897,7 +1908,7 @@ def load_hdf5_file(
         mylog.info("Auto-guessing %s chunks from a size of %s", nchunks, full_size)
     grid_data = []
     psize = get_psize(np.array(shape), nchunks)
-    left_edges, right_edges, shapes, _ = decompose_array(shape, psize, bbox)
+    left_edges, right_edges, shapes, _, _ = decompose_array(shape, psize, bbox)
     for le, re, s in zip(left_edges, right_edges, shapes):
         data = {_: reader for _ in fields}
         data.update({"left_edge": le, "right_edge": re, "dimensions": s, "level": 0})

--- a/yt/utilities/decompose.py
+++ b/yt/utilities/decompose.py
@@ -103,7 +103,7 @@ def get_psize(n_d, pieces):
     return p_size
 
 
-def split_array(gle, gre, shape, psize, cell_widths=None):
+def split_array(gle, gre, shape, psize, *, cell_widths=None):
     """Split array into px*py*pz subarrays."""
     n_d = np.array(shape, dtype=np.int64)
     dds = (gre - gle) / shape
@@ -111,12 +111,11 @@ def split_array(gle, gre, shape, psize, cell_widths=None):
     right_edges = []
     shapes = []
     slices = []
+
     if cell_widths is None:
         cell_widths_by_grid = None
     else:
         cell_widths_by_grid = []
-    if isinstance(cell_widths, list) and len(cell_widths) == 0:
-        cell_widths = None
 
     for i in range(psize[0]):
         for j in range(psize[1]):
@@ -130,7 +129,6 @@ def split_array(gle, gre, shape, psize, cell_widths=None):
                     offset_le = []
                     offset_re = []
                     for idim in range(3):
-                        # round off error issues here maybe?
                         cws.append(cell_widths[idim][lei[idim] : rei[idim]])
                         offset_le.append(np.sum(cell_widths[idim][0 : lei[idim]]))
                         offset_re.append(offset_le[idim] + np.sum(cws[idim]))

--- a/yt/utilities/decompose.py
+++ b/yt/utilities/decompose.py
@@ -17,11 +17,11 @@ def decompose_to_primes(max_prime):
         yield max_prime
 
 
-def decompose_array(shape, psize, bbox):
+def decompose_array(shape, psize, bbox, *, cell_widths=None):
     """Calculate list of product(psize) subarrays of arr, along with their
     left and right edges
     """
-    return split_array(bbox[:, 0], bbox[:, 1], shape, psize)
+    return split_array(bbox[:, 0], bbox[:, 1], shape, psize, cell_widths=cell_widths)
 
 
 def evaluate_domain_decomposition(n_d, pieces, ldom):
@@ -103,7 +103,7 @@ def get_psize(n_d, pieces):
     return p_size
 
 
-def split_array(gle, gre, shape, psize):
+def split_array(gle, gre, shape, psize, cell_widths=None):
     """Split array into px*py*pz subarrays."""
     n_d = np.array(shape, dtype=np.int64)
     dds = (gre - gle) / shape
@@ -111,17 +111,40 @@ def split_array(gle, gre, shape, psize):
     right_edges = []
     shapes = []
     slices = []
+    if cell_widths is None:
+        cell_widths_by_grid = None
+    else:
+        cell_widths_by_grid = []
+    if isinstance(cell_widths, list) and len(cell_widths) == 0:
+        cell_widths = None
+
     for i in range(psize[0]):
         for j in range(psize[1]):
             for k in range(psize[2]):
                 piece = np.array((i, j, k), dtype=np.int64)
                 lei = n_d * piece // psize
                 rei = n_d * (piece + np.ones(3, dtype=np.int64)) // psize
-                lle = gle + lei * dds
-                lre = gle + rei * dds
+
+                if cell_widths is not None:
+                    cws = []
+                    offset_le = []
+                    offset_re = []
+                    for idim in range(3):
+                        # round off error issues here maybe?
+                        cws.append(cell_widths[idim][lei[idim] : rei[idim]])
+                        offset_le.append(np.sum(cell_widths[idim][0 : lei[idim]]))
+                        offset_re.append(offset_le[idim] + np.sum(cws[idim]))
+                    cell_widths_by_grid.append(cws)
+                    offset_re = np.array(offset_re)
+                    offset_le = np.array(offset_le)
+                else:
+                    offset_le = lei * dds
+                    offset_re = rei * dds
+                lle = gle + offset_le
+                lre = gle + offset_re
                 left_edges.append(lle)
                 right_edges.append(lre)
                 shapes.append(rei - lei)
                 slices.append(np.s_[lei[0] : rei[0], lei[1] : rei[1], lei[2] : rei[2]])
 
-    return left_edges, right_edges, shapes, slices
+    return left_edges, right_edges, shapes, slices, cell_widths_by_grid

--- a/yt/utilities/tests/test_decompose.py
+++ b/yt/utilities/tests/test_decompose.py
@@ -25,7 +25,7 @@ def test_psize_3d():
 def test_decomposition_2d():
     array = np.ones((7, 5, 1))
     bbox = np.array([[-0.7, 0.0], [1.5, 2.0], [0.0, 0.7]])
-    ledge, redge, shapes, slices = dec.decompose_array(
+    ledge, redge, shapes, slices, _ = dec.decompose_array(
         array.shape, np.array([2, 3, 1]), bbox
     )
 
@@ -61,7 +61,7 @@ def test_decomposition_3d():
     array = np.ones((33, 35, 37))
     bbox = np.array([[0.0, 1.0], [-1.5, 1.5], [1.0, 2.5]])
 
-    ledge, redge, shapes, slices = dec.decompose_array(
+    ledge, redge, shapes, slices, _ = dec.decompose_array(
         array.shape, np.array([3, 2, 2]), bbox
     )
     data = [array[slice] for slice in slices]
@@ -103,3 +103,25 @@ def test_decomposition_3d():
         ]
     )
     assert_almost_equal(redge, gold_re, 5)
+
+
+def test_decomposition_with_cell_widths():
+    array = np.ones((33, 35, 37))
+    bbox = np.array([[0.0, 1.0], [-1.5, 1.5], [1.0, 2.5]])
+
+    # build some cell widths, rescale to match bounding box
+    cell_widths = []
+    for idim in range(3):
+        wid = bbox[idim][1] - bbox[idim][0]
+        cws = np.random.random((array.shape[idim],))
+        factor = wid / cws.sum()
+        cell_widths.append(factor * cws)
+
+    ledge, redge, _, _, widths_by_grid = dec.decompose_array(
+        array.shape, np.array([3, 2, 2]), bbox, cell_widths=cell_widths
+    )
+    for grid_id in range(len(ledge)):
+        grid_wid = redge[grid_id] - ledge[grid_id]
+        cws = widths_by_grid[grid_id]
+        cws_wid = np.array([np.sum(cws[dim]) for dim in range(3)])
+        assert_almost_equal(grid_wid, cws_wid, 5)


### PR DESCRIPTION
## PR Summary

Working on getting `load_uniform_grid` to work with nproc > 1 for stretched grids (when `cell_widths` is allowed). Most the changes here are to the grid decomposition. 

Closes #4330 

## PR Checklist

- [x] New features are documented, with docstrings and narrative docs
- [x] Adds tests for new features.

Sample from the version just pushed:

```python
import numpy as np
import yt

N = 64
data = {"density": np.random.random((N, N, N))}

cell_widths = []
for _ in range(3):
    cw = 0.1 + np.random.random(N)
    cw /= cw.sum()
    cell_widths.append(cw)

ds = yt.load_uniform_grid(
        data,
        data["density"].shape,
        bbox=np.array([[0.0, 1.0], [0.0, 1.0], [0.0, 1.0]]),
        cell_widths=cell_widths,
        nprocs=32,
    )

slc = yt.SlicePlot(ds, 'x', 'density')
slc.set_log('density', False)
slc.annotate_grids(edgecolors='w', linewidth=4)
```

![image](https://github.com/yt-project/yt/assets/22038879/085e46ac-22e1-4104-bcfe-ad6c46a60db7)


