### PR TITLE
Support for cosmic ray fields in GAMER

### DIFF
--- a/yt/frontends/gamer/cfields.pyx
+++ b/yt/frontends/gamer/cfields.pyx
@@ -7,7 +7,7 @@ cimport numpy as np
 import numpy as np
 
 
-cdef np.float64_t h_eos4(np.float64_t kT, np.float64_t g) noexcept nogil:
+cdef np.float64_t h_eos_tb(np.float64_t kT, np.float64_t g) noexcept nogil:
     cdef np.float64_t x
     x = 2.25 * kT * kT
     return 2.5 * kT + x / (1.0 + math.sqrt(x + 1.0))
@@ -18,14 +18,14 @@ cdef np.float64_t h_eos(np.float64_t kT, np.float64_t g) noexcept nogil:
 cdef np.float64_t gamma_eos(np.float64_t kT, np.float64_t g) noexcept nogil:
     return g
 
-cdef np.float64_t gamma_eos4(np.float64_t kT, np.float64_t g) noexcept nogil:
+cdef np.float64_t gamma_eos_tb(np.float64_t kT, np.float64_t g) noexcept nogil:
     cdef np.float64_t x, c_p, c_v
     x = 2.25 * kT / math.sqrt(2.25 * kT * kT + 1.0)
     c_p = 2.5 + x
     c_v = 1.5 + x
     return c_p / c_v
 
-cdef np.float64_t cs_eos4(np.float64_t kT, np.float64_t c, np.float64_t g) noexcept nogil:
+cdef np.float64_t cs_eos_tb(np.float64_t kT, np.float64_t c, np.float64_t g) noexcept nogil:
     cdef np.float64_t hp, cs2
     hp = h_eos4(kT, 0.0) + 1.0
     cs2 = kT / (3.0 * hp)
@@ -52,14 +52,14 @@ cdef class SRHDFields:
         self._c = clight
         self._c2 = clight * clight
         # Select aux functions based on eos no.
-        if (eos == 4):
-            self.h = h_eos4
-            self.gamma = gamma_eos4
-            self.cs = cs_eos4
-        else:
+        if eos == 1:
             self.h = h_eos
             self.gamma = gamma_eos
             self.cs = cs_eos
+        else:
+            self.h = h_eos_tb
+            self.gamma = gamma_eos_tb
+            self.cs = cs_eos_tb
 
     cdef np.float64_t _lorentz_factor(
             self,

--- a/yt/frontends/gamer/cfields.pyx
+++ b/yt/frontends/gamer/cfields.pyx
@@ -27,7 +27,7 @@ cdef np.float64_t gamma_eos_tb(np.float64_t kT, np.float64_t g) noexcept nogil:
 
 cdef np.float64_t cs_eos_tb(np.float64_t kT, np.float64_t c, np.float64_t g) noexcept nogil:
     cdef np.float64_t hp, cs2
-    hp = h_eos4(kT, 0.0) + 1.0
+    hp = h_eos_tb(kT, 0.0) + 1.0
     cs2 = kT / (3.0 * hp)
     cs2 *= (5.0 * hp - 8.0 * kT) / (hp - kT)
     return c * math.sqrt(cs2)

--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -356,6 +356,7 @@ class GAMERDataset(Dataset):
         # make aliases to some frequently used variables
         if parameters["Model"] == "Hydro":
             self.gamma = parameters["Gamma"]
+            self.gamma_cr = self.parameters.get("CR_Gamma", None)
             self.eos = parameters.get("EoS", 1)  # Assume gamma-law by default
             # default to 0.6 for old data format
             self.mu = parameters.get(

--- a/yt/frontends/gamer/fields.py
+++ b/yt/frontends/gamer/fields.py
@@ -62,10 +62,12 @@ class GAMERFieldInfo(FieldInfoContainer):
         if self.ds.srhd:
             c2 = pc.clight * pc.clight
             c = pc.clight.in_units("code_length / code_time")
-            if self.ds.eos == 4:
-                fgen = SRHDFields(self.ds.eos, 0.0, c.d)
-            else:
+            if self.ds.eos == 1:
+                # gamma-law EOS
                 fgen = SRHDFields(self.ds.eos, self.ds.gamma, c.d)
+            else:
+                # Taub-Mathews EOS
+                fgen = SRHDFields(self.ds.eos, 0.0, c.d)
 
             def _sound_speed(field, data):
                 out = fgen.sound_speed(data["gamer", "Temp"].d)

--- a/yt/frontends/gamer/fields.py
+++ b/yt/frontends/gamer/fields.py
@@ -292,7 +292,7 @@ class GAMERFieldInfo(FieldInfoContainer):
                 if self.ds.mhd:
                     # magnetic_energy is a yt internal field
                     Et -= data["gas", "magnetic_energy_density"]
-                if self.ds.gamma_cr is not None:
+                if getattr(self.ds, "gamma_cr", None):
                     # cosmic rays are included in this dataset
                     Et -= data["gas", "cosmic_ray_energy_density"]
                 return Et
@@ -340,7 +340,7 @@ class GAMERFieldInfo(FieldInfoContainer):
             units=unit_system["pressure"],
         )
 
-        if self.ds.gamma_cr is not None:
+        if getattr(self.ds, "gamma_cr", None):
 
             def _cr_pressure(field, data):
                 return (data.ds.gamma_cr - 1.0) * data[

--- a/yt/frontends/gamer/fields.py
+++ b/yt/frontends/gamer/fields.py
@@ -109,15 +109,22 @@ class GAMERFieldInfo(FieldInfoContainer):
                 )
 
             # lorentz factor
-            def _lorentz_factor(field, data):
-                out = fgen.lorentz_factor(
-                    data["gamer", "Dens"].d,
-                    data["gamer", "MomX"].d,
-                    data["gamer", "MomY"].d,
-                    data["gamer", "MomZ"].d,
-                    data["gamer", "Temp"].d,
-                )
-                return data.ds.arr(out, "dimensionless")
+            if ("gamer", "Lrtz") in self.field_list:
+
+                def _lorentz_factor(field, data):
+                    return data["gamer", "Lrtz"]
+
+            else:
+
+                def _lorentz_factor(field, data):
+                    out = fgen.lorentz_factor(
+                        data["gamer", "Dens"].d,
+                        data["gamer", "MomX"].d,
+                        data["gamer", "MomY"].d,
+                        data["gamer", "MomZ"].d,
+                        data["gamer", "Temp"].d,
+                    )
+                    return data.ds.arr(out, "dimensionless")
 
             self.add_field(
                 ("gas", "lorentz_factor"),
@@ -128,16 +135,27 @@ class GAMERFieldInfo(FieldInfoContainer):
 
             # velocity
             def velocity_xyz(v):
-                def _velocity(field, data):
-                    out = fgen.velocity_xyz(
-                        data["gamer", "Dens"].d,
-                        data["gamer", "MomX"].d,
-                        data["gamer", "MomY"].d,
-                        data["gamer", "MomZ"].d,
-                        data["gamer", "Temp"].d,
-                        data["gamer", f"Mom{v.upper()}"].d,
-                    )
-                    return data.ds.arr(out, "code_velocity").to(unit_system["velocity"])
+                if ("gamer", f"Vel{v.upper()}") in self.field_list:
+
+                    def _velocity(field, data):
+                        return data.ds.arr(data["gamer", f"Vel{v.upper()}"].d, "c").to(
+                            unit_system["velocity"]
+                        )
+
+                else:
+
+                    def _velocity(field, data):
+                        out = fgen.velocity_xyz(
+                            data["gamer", "Dens"].d,
+                            data["gamer", "MomX"].d,
+                            data["gamer", "MomY"].d,
+                            data["gamer", "MomZ"].d,
+                            data["gamer", "Temp"].d,
+                            data["gamer", f"Mom{v.upper()}"].d,
+                        )
+                        return data.ds.arr(out, "code_velocity").to(
+                            unit_system["velocity"]
+                        )
 
                 return _velocity
 

--- a/yt/frontends/gamer/tests/test_outputs.py
+++ b/yt/frontends/gamer/tests/test_outputs.py
@@ -125,3 +125,20 @@ def test_stress_energy():
                 else:
                     Tmunu += p
                 assert_array_almost_equal(sp[f"T{mu}{nu}"], Tmunu)
+
+
+cr_shock = "CRShockTube/Data_000005"
+
+
+@requires_ds(cr_shock)
+def test_cosmic_rays():
+    ds = data_dir_load(cr_shock)
+    assert_array_almost_equal(ds.gamma_cr, 4.0 / 3.0)
+    ad = ds.all_data()
+    p_cr = ad["gas", "cosmic_ray_pressure"]
+    e_cr = ad["gas", "cosmic_ray_energy_density"]
+    assert_array_almost_equal(p_cr, e_cr / 3.0)
+    e_kin = ad["gas", "kinetic_energy_density"]
+    e_int = ad["gas", "thermal_energy_density"]
+    e_tot = ad["gas", "total_energy_density"]
+    assert_array_almost_equal(e_tot, e_kin + e_int + e_cr)


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

GAMER recently included support for cosmic ray fluids. This PR supports these fields by adding a `gamma_cr` attribute to the GAMER `Dataset` if it is found in the runtime parameters, adds the fields `("gas", "cosmic_ray_energy_density")` and `("gas", "cosmic_ray_pressure")`, and modifies the computation of the non-cosmic ray gas thermal energy, pressure, and temperature to account for the existence of the cosmic ray energy if it is available.

Will add a test, but I tried this out on the cosmic ray shock tube problem in GAMER and it seems to work. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
