### PR TITLE
Use stamping approach to deposit off-axis cells

### DIFF
--- a/yt/utilities/lib/image_utilities.pyx
+++ b/yt/utilities/lib/image_utilities.pyx
@@ -92,8 +92,8 @@ cdef void _add_cell_to_image_offaxis(
         return
 
     depth = int(ceil(log2(dx * float(max(Nx, Ny)))))
-    if depth <= 0:
-        depth = 0
+    if depth < 1:
+        depth = 1
     if depth >= max_depth:
         depth = max_depth - 1
 

--- a/yt/utilities/lib/image_utilities.pyx
+++ b/yt/utilities/lib/image_utilities.pyx
@@ -1,5 +1,7 @@
 
 # distutils: libraries = STD_LIBS
+# distutils: extra_compile_args = OMP_ARGS
+# distutils: extra_link_args = OMP_ARGS
 """
 Utilities for images
 """
@@ -9,8 +11,11 @@ import numpy as np
 
 cimport numpy as np
 cimport cython
+from libc.math cimport M_PI, M_PI_2, atan2, ceil, floor, log2, sqrt
+from libc.stdlib cimport free, malloc
 
 from yt.utilities.lib.fp_utils cimport iclip
+from cython.parallel import prange, parallel
 
 @cython.wraparound(False)
 def add_points_to_greyscale_image(
@@ -35,6 +40,355 @@ def add_points_to_greyscale_image(
         buffer[i, j] += pv[pi]
         buffer_mask[i, j] = 1
     return
+
+# @cython.boundscheck(False)
+@cython.cdivision(True)
+@cython.wraparound(False)
+@cython.boundscheck(False)
+cdef void _add_cell_to_image_offaxis(
+    const np.float64_t dx,
+    const np.float64_t w,
+    const np.float64_t q,
+    const np.float64_t cell_max_width,
+    const np.float64_t x,
+    const np.float64_t y,
+    const int Nx,
+    const int Ny,
+    const int Nsx,
+    const int Nsy,
+    np.float64_t** buffer,
+    np.float64_t** buffer_weight,
+    const int max_depth,
+    const np.float64_t[:, :, ::1] stamp,
+    const np.uint8_t[:, :, ::1] stamp_mask,
+) noexcept nogil:
+    cdef np.float64_t lx, rx, ly, ry
+    cdef int j, k, depth
+    cdef int jmin, jmax, kmin, kmax, jj, kk
+    cdef np.float64_t cell_max_half_width = cell_max_width / 2
+    cdef np.float64_t xx, yy, dvx, dvy, sw, swq
+
+    lx = x - cell_max_half_width
+    rx = x + cell_max_half_width
+
+    ly = y - cell_max_half_width
+    ry = y + cell_max_half_width
+
+    # Compute the range of pixels that the cell may overlap
+    jmin = int(floor(lx * Nx))
+    if jmin < 0: jmin = 0
+    jmax = int(ceil(rx * Nx))
+    if jmax >= Nx: jmax = Nx - 1
+
+    kmin = int(floor(ly * Ny))
+    if kmin < 0: kmin = 0
+    kmax = int(ceil(ry * Ny))
+    if kmax >= Ny: kmax = Ny - 1
+
+    # If the cell is fully within one pixel
+    if (jmax == jmin + 1) and (kmax == kmin + 1):
+        buffer[jmin][kmin] += w * q
+        buffer_weight[jmin][kmin] += w
+        return
+
+    depth = int(ceil(log2(dx * float(max(Nx, Ny)))))
+    if depth <= 0:
+        depth = 0
+    if depth >= max_depth:
+        depth = max_depth - 1
+
+    jmax = min(Nsx, 1 << depth)
+    kmax = min(Nsy, 1 << depth)
+    for j in range(jmax):
+        xx = ((j + 0.5 - jmax / 2) / jmax * cell_max_width + x) * Nx
+        jj = int(xx)
+        if jj < 0 or jj >= Nx: continue
+
+        dvx = 1 - (xx - jj)
+        for k in range(kmax):
+            if stamp_mask[depth, j, k] == 0:
+                continue
+
+            yy = ((k + 0.5 - kmax / 2) / kmax * cell_max_width + y) * Ny
+            kk = int(yy)
+            if kk < 0 or kk >= Ny: continue
+
+            dvy = 1 - (yy - kk)
+
+            swq = stamp[depth, j, k] * w * q
+            sw =  stamp[depth, j, k] * w
+
+            buffer[jj][kk]        += swq * (dvx * dvy)
+            buffer_weight[jj][kk] +=  sw * (dvx * dvy)
+
+            if jj < Nx - 1:
+                buffer[jj + 1][kk]        += swq * (1 - dvx) * dvy
+                buffer_weight[jj + 1][kk] +=  sw * (1 - dvx) * dvy
+
+            if kk < Ny - 1:
+                buffer[jj][kk + 1]        += swq * dvx * (1 - dvy)
+                buffer_weight[jj][kk + 1] +=  sw * dvx * (1 - dvy)
+            if jj < Nx - 1 and kk < Ny - 1:
+                buffer[jj + 1][kk + 1]        += swq * (1 - dvx) * (1 - dvy)
+                buffer_weight[jj + 1][kk + 1] +=  sw * (1 - dvx) * (1 - dvy)
+
+
+@cython.boundscheck(False)
+@cython.cdivision(True)
+@cython.wraparound(False)
+def add_cells_to_image_offaxis(
+    *,
+    const np.float64_t[:, ::1] Xp,
+    const np.float64_t[::1] dXp,
+    const np.float64_t[::1] qty,
+    const np.float64_t[::1] weight,
+    const float theta,
+    const float phi,
+    np.float64_t[:, ::1] buffer,
+    np.float64_t[:, ::1] buffer_weight,
+    const int Nx,
+    const int Ny,
+    const int Npix_min = 4,
+):
+    from scipy.spatial.transform import Rotation
+
+    cdef np.ndarray[np.float64_t, ndim=1] center = np.array([0.5, 0.5, 0.5])
+    cdef np.float64_t w0 = 1 / sqrt(3.)
+    cdef int i, j, k
+
+    cdef np.ndarray[np.float64_t, ndim=1] a = np.array([1., 0, 0]) * w0
+    cdef np.ndarray[np.float64_t, ndim=1] b = np.array([0, 1., 0]) * w0
+    cdef np.ndarray[np.float64_t, ndim=1] c = np.array([0, 0, 1.]) * w0
+    cdef np.ndarray[np.float64_t, ndim=2] R = Rotation.from_euler('ZYX', [phi, theta, 0]).as_matrix()
+
+    a = np.dot(R, a)
+    b = np.dot(R, b)
+    c = np.dot(R, c)
+
+    cdef np.ndarray[np.float64_t, ndim=1] o = center - (a + b + c) / 2
+
+    cdef int Nsx, Nsy
+    cdef np.float64_t dx_max = np.max(dXp)
+    # The largest cell needs to be resolved by at least this number of pixels
+    Nsx = max(Npix_min, int(ceil(dx_max * float(Nx))))
+    Nsy = max(Npix_min, int(ceil(dx_max * float(Ny))))
+    cdef int max_depth = int(ceil(log2(max(Nsx, Nsy))))
+    cdef int depth
+
+    print(f"{Nsx=} {Nsy=}")
+
+    cdef np.ndarray[np.float64_t, ndim=3] stamp_arr = np.zeros((max_depth, Nsx, Nsy), dtype=float)
+    cdef np.ndarray[np.uint8_t, ndim=3] stamp_mask_arr = np.zeros((max_depth, Nsx, Nsy), dtype=np.uint8)
+    cdef np.float64_t[:, :, ::1] stamp = stamp_arr
+    cdef np.uint8_t[:, :, ::1] stamp_mask = stamp_mask_arr
+
+    cdef np.float64_t[:, ::1] Xrot
+    Xp_center = np.array([0.5, 0.5, 0.5])
+    Xrot = np.dot(R, (Xp - Xp_center).T).T.copy() + Xp_center
+
+    # Precompute the mip
+    for depth in range(max_depth):
+        if depth == 0:
+            stamp[0, 0, 0] = 1
+            continue
+        direct_integrate_cube(
+            o,
+            a,
+            b,
+            c,
+            stamp_arr[depth, :, :],
+            stamp_mask_arr[depth, :, :],
+            min(1 << depth, Nsx),
+            min(1 << depth, Nsy),
+        )
+
+        stamp_arr[depth] /= np.sum(stamp[depth])
+
+    # Iterate over all cells, applying the stamp
+    cdef np.float64_t x, y, dx
+
+    cdef np.float64_t w, q, cell_max_width, sq3
+
+    sq3 = sqrt(3.)
+
+    # Local buffers
+    cdef np.float64_t **lbuffer
+    cdef np.float64_t **lbuffer_weight
+
+    cdef int num_particles = len(Xp)
+
+    with nogil, parallel():
+        lbuffer = <np.float64_t**> malloc(sizeof(np.float64_t*) * Nx)
+        lbuffer_weight = <np.float64_t**> malloc(sizeof(np.float64_t*) * Nx)
+        for j in range(Nx):
+            lbuffer[j] = <np.float64_t*> malloc(sizeof(np.float64_t) * Ny)
+            lbuffer_weight[j] = <np.float64_t*> malloc(sizeof(np.float64_t) * Ny)
+            for k in range(Ny):
+                lbuffer[j][k] = 0
+                lbuffer_weight[j][k] = 0
+
+        for i in prange(num_particles, schedule="static"):
+            dx = dXp[i]
+            w = weight[i]
+            q = qty[i]
+            cell_max_width = dx * sq3
+            x = Xrot[i, 0]
+            y = Xrot[i, 1]
+
+            _add_cell_to_image_offaxis(
+                dx,
+                w,
+                q,
+                cell_max_width,
+                x,
+                y,
+                Nx,
+                Ny,
+                Nsx,
+                Nsy,
+                lbuffer,
+                lbuffer_weight,
+                max_depth,
+                stamp,
+                stamp_mask
+            )
+
+        # Copy back data in main buffer
+        with gil:
+            for j in range(Nx):
+                for k in range(Ny):
+                    buffer[j, k] += lbuffer[j][k]
+                    buffer_weight[j, k] += lbuffer_weight[j][k]
+        # Free memory
+        for j in range(Nx):
+            free(lbuffer[j])
+            free(lbuffer_weight[j])
+        free(lbuffer)
+        free(lbuffer_weight)
+
+
+@cython.boundscheck(False)
+cdef inline np.float64_t det2d(const np.float64_t[::1] a, const np.float64_t[::1] b) noexcept nogil:
+    return a[0] * b[1] - a[1] * b[0]
+
+@cython.cdivision(True)
+cdef bint check_in_parallelogram(
+    const np.float64_t[::1] PA,
+    const np.float64_t[::1] PQ,
+    const np.float64_t[::1] PR,
+    const int signPQ,
+    const int signPR,
+    np.float64_t[2] out
+) noexcept nogil:
+    cdef np.float64_t det_PQR = det2d(PQ, PR)
+    if det_PQR == 0:
+        out[0] = -1
+        out[1] = -1
+        return False
+
+    out[0] = -det2d(PA, PQ) / det_PQR
+    out[1] = det2d(PA, PR) / det_PQR
+
+    if 0 <= signPQ * out[0] <= 1 and 0 <= signPR * out[1] <= 1:
+        return True
+
+    out[0] = -1
+    out[1] = -1
+    return False
+
+@cython.boundscheck(False)
+@cython.cdivision(True)
+cdef int direct_integrate_cube(
+    np.ndarray[np.float64_t, ndim=1] O,
+    np.ndarray[np.float64_t, ndim=1] u,
+    np.ndarray[np.float64_t, ndim=1] v,
+    np.ndarray[np.float64_t, ndim=1] w,
+    np.ndarray[np.float64_t, ndim=2] buffer,
+    np.ndarray[np.uint8_t, ndim=2] buffer_mask,
+    const int Nx,
+    const int Ny,
+) except -1:
+    """
+    Compute depth of cube from direct integration of entry/exit points of rays
+    """
+    cdef np.float64_t[::1] u2d = u[:2]
+    cdef np.float64_t[::1] v2d = v[:2]
+    cdef np.float64_t[::1] w2d = w[:2]
+
+    cdef np.float64_t[::1] Oback = O + u + v + w
+
+    cdef np.float64_t[::1] X = np.zeros(2)
+    cdef np.float64_t[::1] OfrontA = np.zeros(2), ObackA = np.zeros(2)
+
+    cdef np.float64_t inv_dx = 1 / float(Nx)
+    cdef np.float64_t inv_dy = 1 / float(Ny)
+    cdef np.float64_t[2] nm
+    cdef bint within
+    cdef np.float64_t[::1] all_z = np.empty(6)
+    cdef np.float64_t zmin, zmax, z
+    cdef int Nhit, i, j
+    for i in range(Nx):
+        X[0] = (i + 0.5) * inv_dx
+        for j in range(Ny):
+            zmin = np.inf
+            zmax = -np.inf
+            Nhit = 0
+            X[1] = (j + 0.5) * inv_dy
+
+            OfrontA[0] = X[0] - O[0]
+            OfrontA[1] = X[1] - O[1]
+            all_z[:] = 0
+            within = check_in_parallelogram(OfrontA, v2d, u2d, 1, 1, nm)
+            if within:
+                z = O[2] + nm[0] * u[2] + nm[1] * v[2]
+                zmin = min(z, zmin)
+                zmax = max(z, zmax)
+                Nhit += 1
+
+            within = check_in_parallelogram(OfrontA, w2d, v2d, 1, 1, nm)
+            if within:
+                z = O[2] + nm[0] * v[2] + nm[1] * w[2]
+                zmin = min(z, zmin)
+                zmax = max(z, zmax)
+                Nhit += 1
+
+            within = check_in_parallelogram(OfrontA, w2d, u2d, 1, 1, nm)
+            if within:
+                z = O[2] + nm[0] * u[2] + nm[1] * w[2]
+                zmin = min(z, zmin)
+                zmax = max(z, zmax)
+                Nhit += 1
+
+            ObackA[0] = X[0] - Oback[0]
+            ObackA[1] = X[1] - Oback[1]
+            within = check_in_parallelogram(ObackA, v2d, u2d, -1, -1, nm)
+            if within:
+                z = Oback[2] + nm[0] * u[2] + nm[1] * v[2]
+                zmin = min(z, zmin)
+                zmax = max(z, zmax)
+                Nhit += 1
+
+            within = check_in_parallelogram(ObackA, w2d, v2d, -1, -1, nm)
+            if within:
+                z = Oback[2] + nm[0] * v[2] + nm[1] * w[2]
+                zmin = min(z, zmin)
+                zmax = max(z, zmax)
+                Nhit += 1
+
+            within = check_in_parallelogram(ObackA, w2d, u2d, -1, -1, nm)
+            if within:
+                z = Oback[2] + nm[0] * u[2] + nm[1] * w[2]
+                zmin = min(z, zmin)
+                zmax = max(z, zmax)
+                Nhit += 1
+
+            if Nhit == 0:
+                continue
+            elif Nhit == 1:
+                raise RuntimeError("This should not happen")
+            else:
+                buffer[i, j] += zmax - zmin
+                buffer_mask[i, j] |= 1
 
 def add_points_to_image(
         np.ndarray[np.uint8_t, ndim=3] buffer,

--- a/yt/utilities/lib/image_utilities.pyx
+++ b/yt/utilities/lib/image_utilities.pyx
@@ -91,7 +91,7 @@ cdef void _add_cell_to_image_offaxis(
         return
 
     # Our 'stamp' has multiple resolutions, select the one
-    # that allow that is at a higher resolution than the pixel
+    # that is at a higher resolution than the pixel
     # we are projecting onto with at least 4 pixels on the diagonal
     depth = iclip(
         <int> (ceil(log2(4 * sqrt(3) * dx * fmax(Nx, Ny)))),

--- a/yt/utilities/lib/image_utilities.pyx
+++ b/yt/utilities/lib/image_utilities.pyx
@@ -278,11 +278,13 @@ def add_cells_to_image_offaxis(
 
 
 @cython.boundscheck(False)
+@cython.wraparound(False)
 cdef inline np.float64_t det2d(const np.float64_t[::1] a, const np.float64_t[::1] b) noexcept nogil:
     return a[0] * b[1] - a[1] * b[0]
 
 @cython.cdivision(True)
 @cython.boundscheck(False)
+@cython.wraparound(False)
 cdef bint check_in_parallelogram(
     const np.float64_t[::1] PA,
     const np.float64_t[::1] PQ,

--- a/yt/utilities/lib/image_utilities.pyx
+++ b/yt/utilities/lib/image_utilities.pyx
@@ -341,26 +341,30 @@ cdef int direct_integrate_cube(
     cdef np.float64_t[::1] Oback = O + u + v + w
 
     cdef np.float64_t[::1] X = np.zeros(2)
-    cdef np.float64_t[::1] OfrontA = np.zeros(2), ObackA = np.zeros(2)
+    cdef np.float64_t[::1] OfrontA = np.zeros(2)
+    cdef np.float64_t[::1] ObackA = np.zeros(2)
 
     cdef np.float64_t inv_dx = 1. / Nx
     cdef np.float64_t inv_dy = 1. / Ny
     cdef np.float64_t[2] nm
     cdef bint within
-    cdef np.float64_t[::1] all_z = np.empty(6)
     cdef np.float64_t zmin, zmax, z
     cdef int Nhit, i, j
     for i in range(Nx):
         X[0] = (i + 0.5) * inv_dx
+
+        OfrontA[0] = X[0] - O[0]
+        ObackA[0] = X[0] - Oback[0]
+
         for j in range(Ny):
             zmin = np.inf
             zmax = -np.inf
             Nhit = 0
             X[1] = (j + 0.5) * inv_dy
 
-            OfrontA[0] = X[0] - O[0]
             OfrontA[1] = X[1] - O[1]
-            all_z[:] = 0
+            ObackA[1] = X[1] - Oback[1]
+
             within = check_in_parallelogram(OfrontA, v2d, u2d, 1, 1, nm)
             if within:
                 z = O[2] + nm[0] * u[2] + nm[1] * v[2]
@@ -382,8 +386,6 @@ cdef int direct_integrate_cube(
                 zmax = fmax(z, zmax)
                 Nhit += 1
 
-            ObackA[0] = X[0] - Oback[0]
-            ObackA[1] = X[1] - Oback[1]
             within = check_in_parallelogram(ObackA, v2d, u2d, -1, -1, nm)
             if within:
                 z = Oback[2] + nm[0] * u[2] + nm[1] * v[2]

--- a/yt/utilities/lib/image_utilities.pyx
+++ b/yt/utilities/lib/image_utilities.pyx
@@ -105,17 +105,17 @@ cdef void _add_cell_to_image_offaxis(
     dx_loc = cell_max_width / jmax
     dy_loc = cell_max_width / kmax
 
-    # with gil: print(jmax, kmax)
-
     for j in range(jmax):
         xx1 = ((j - jmax / 2.) * dx_loc + x) * Nx
         xx2 = ((j + 1 - jmax / 2.) * dx_loc + x) * Nx
 
         jj1 = <int> xx1
         jj2 = <int> xx2
+
         # The subcell is out of the projected area
         if jj2 < 0 or jj1 >= Nx: continue
 
+        # Fraction of overlap with the pixel in x direction
         dvx = fclip((jj2 - xx1) / (xx2 - xx1), 0., 1.)
 
         for k in range(kmax):
@@ -130,14 +130,11 @@ cdef void _add_cell_to_image_offaxis(
             # The subcell is out of the projected area
             if kk2 < 0 or kk1 >= Ny: continue
 
-            # with gil:
-            #     print(f"{j=} {k=} {xx1=} {xx2=} {yy1=} {yy2=} {jj1=} {jj2=} {kk1=} {kk2=}")
-
             tmp = stamp[depth, j, k] * dx3
-
             sw = tmp * w
             sq = tmp * q
 
+            # Fraction of overlap with the pixel in y direction
             dvy = fclip((kk2 - yy1) / (yy2 - yy1), 0., 1.)
 
             if jj1 >= 0 and kk1 >= 0:
@@ -228,7 +225,6 @@ def add_cells_to_image_offaxis(
     # Iterate over all cells, applying the stamp
     cdef np.float64_t x, y, dx
     cdef np.float64_t[:, ::1] rotation_view = np.ascontiguousarray(rotation)
-
     cdef np.float64_t w, q, cell_max_width, sq3
 
     sq3 = sqrt(3.)

--- a/yt/utilities/lib/interpolators.pyx
+++ b/yt/utilities/lib/interpolators.pyx
@@ -19,7 +19,7 @@ from yt.utilities.lib.fp_utils cimport iclip
 @cython.cdivision(True)
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def UnilinearlyInterpolate(np.ndarray[np.float64_t, ndim=1] table,
+cpdef void UnilinearlyInterpolate(np.ndarray[np.float64_t, ndim=1] table,
                            np.ndarray[np.float64_t, ndim=1] x_vals,
                            np.ndarray[np.float64_t, ndim=1] x_bins,
                            np.ndarray[np.int32_t, ndim=1] x_is,
@@ -38,7 +38,7 @@ def UnilinearlyInterpolate(np.ndarray[np.float64_t, ndim=1] table,
 @cython.cdivision(True)
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def BilinearlyInterpolate(np.ndarray[np.float64_t, ndim=2] table,
+cpdef void BilinearlyInterpolate(np.ndarray[np.float64_t, ndim=2] table,
                           np.ndarray[np.float64_t, ndim=1] x_vals,
                           np.ndarray[np.float64_t, ndim=1] y_vals,
                           np.ndarray[np.float64_t, ndim=1] x_bins,
@@ -69,7 +69,7 @@ def BilinearlyInterpolate(np.ndarray[np.float64_t, ndim=2] table,
 @cython.cdivision(True)
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def TrilinearlyInterpolate(np.ndarray[np.float64_t, ndim=3] table,
+cpdef void TrilinearlyInterpolate(np.ndarray[np.float64_t, ndim=3] table,
                            np.ndarray[np.float64_t, ndim=1] x_vals,
                            np.ndarray[np.float64_t, ndim=1] y_vals,
                            np.ndarray[np.float64_t, ndim=1] z_vals,
@@ -113,7 +113,7 @@ def TrilinearlyInterpolate(np.ndarray[np.float64_t, ndim=3] table,
 @cython.cdivision(True)
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def QuadrilinearlyInterpolate(np.ndarray[np.float64_t, ndim=4] table,
+cpdef void QuadrilinearlyInterpolate(np.ndarray[np.float64_t, ndim=4] table,
                               np.ndarray[np.float64_t, ndim=1] x_vals,
                               np.ndarray[np.float64_t, ndim=1] y_vals,
                               np.ndarray[np.float64_t, ndim=1] z_vals,
@@ -174,7 +174,7 @@ def QuadrilinearlyInterpolate(np.ndarray[np.float64_t, ndim=4] table,
 @cython.cdivision(True)
 @cython.wraparound(False)
 @cython.boundscheck(False)
-def ghost_zone_interpolate(int rf,
+cpdef void ghost_zone_interpolate(int rf,
                            np.ndarray[np.float64_t, ndim=3] input_field,
                            np.ndarray[np.float64_t, ndim=1] input_left,
                            np.ndarray[np.float64_t, ndim=3] output_field,

--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -383,12 +383,9 @@ def off_axis_projection(
         fields.append(vol.weight_field)
 
     mylog.debug("Casting rays")
-
-    if (
-        True
-        and isinstance(data_source.ds.index, OctreeIndex)
-        and isinstance(camera.lens, PlaneParallelLens)
-    ):
+    index = data_source.ds.index
+    lens = camera.lens
+    if isinstance(index, OctreeIndex) and isinstance(lens, PlaneParallelLens):
         fields.extend(("index", k) for k in "xyz")
         fields.append(("index", "dx"))
 

--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -407,36 +407,24 @@ def off_axis_projection(
         else:
             weight_field = data_source[vol.weight_field]
 
-        buffer = np.zeros(resolution)
-        dumpster = np.zeros(resolution)
-        buffer_weight = np.zeros(resolution)
+        projected_weighted_qty = np.zeros(resolution)
+        projected_weight = np.zeros(resolution)
 
         add_cells_to_image_offaxis(
             Xp=xyz,
             dXp=dx,
             qty=data_source[vol.field],
-            weight=np.ones_like(dx),
+            weight=weight_field,
             rotation=camera.inv_mat.T,
-            buffer=buffer,
-            buffer_weight=dumpster,
-            Nx=resolution[0],
-            Ny=resolution[1],
-        )
-        dumpster *= 0
-        add_cells_to_image_offaxis(
-            Xp=xyz,
-            dXp=dx,
-            qty=data_source[vol.field] * weight_field,
-            weight=np.ones_like(dx),
-            rotation=camera.inv_mat.T,
-            buffer=buffer_weight,
-            buffer_weight=dumpster,
+            buffer=projected_weighted_qty,
+            buffer_weight=projected_weight,
             Nx=resolution[0],
             Ny=resolution[1],
         )
         image = ImageArray(
             data_source.ds.arr(
-                np.stack([buffer_weight, buffer], axis=-1), "dimensionless"
+                np.stack([projected_weighted_qty, projected_weight], axis=-1),
+                "dimensionless",
             ),
             funits,
             registry=data_source.ds.unit_registry,

--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -385,7 +385,20 @@ def off_axis_projection(
     mylog.debug("Casting rays")
     index = data_source.ds.index
     lens = camera.lens
-    if isinstance(index, OctreeIndex) and isinstance(lens, PlaneParallelLens):
+
+    # This implementation is optimized for octrees with plane-parallel lenses
+    # and implicitely assumes that the cells are cubic.
+    # NOTE: we should be able to relax the cubic assumption to a rectangular
+    #       assumption (if all cells have the same aspect ratio) with some
+    #       renormalization of the coordinates and the projection axes.
+    #       This is NOT done in the following.
+    dom_width = data_source.ds.domain_width
+    cubic_domain = dom_width.max() == dom_width.min()
+    if (
+        isinstance(index, OctreeIndex)
+        and isinstance(lens, PlaneParallelLens)
+        and cubic_domain
+    ):
         fields.extend(("index", k) for k in "xyz")
         fields.append(("index", "dx"))
 

--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -393,14 +393,20 @@ def off_axis_projection(
         fields.append(("index", "dx"))
 
         data_source.get_data(fields)
+        # We need the width of the plot window in projected coordinates,
+        # i.e. we ignore the z-component
+        wmax = width[:2].max()
+
+        # Normalize the positions & dx so that they are in the range [-0.5, 0.5]
         xyz = np.stack(
             [
-                ((data_source["index", k] - center[i]) / width[i]).to("1").d
+                ((data_source["index", k] - center[i]) / wmax).to("1").d
                 for i, k in enumerate("xyz")
             ],
             axis=-1,
         )
-        dx = (data_source["index", "dx"] / width.max()).to("1").d
+
+        dx = (data_source["index", "dx"] / wmax).to("1").d
 
         if vol.weight_field is None:
             weight_field = np.ones_like(dx)

--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -406,6 +406,12 @@ def off_axis_projection(
             axis=-1,
         )
 
+        for idim, periodic in enumerate(data_source.ds.periodicity):
+            if not periodic:
+                continue
+            # Wrap into [-0.5, +0.5]
+            xyz[..., idim] = (xyz[..., idim] + 0.5) % 1 - 0.5
+
         dx = (data_source["index", "dx"] / wmax).to("1").d
 
         if vol.weight_field is None:


### PR DESCRIPTION
## PR Summary

On main, off-axis projections are very slow due to the need to cast rays through the domain.
This is particularly the case for octree-datasets to to the hot-loop [for grid, mask in data_source.blocks:](https://github.com/cphyc/yt/blob/f8d38de9fc71cd83b40ab74eb2527644bbc1f4be/yt/visualization/volume_rendering/off_axis_projection.py#L446-L464). Indeed, this iterates over all octs in the domain, one-by-one.

While one solution might be to move this chunk to a Cython-accelerated code, it will remain somewhat slow no matter what.

In this PR, I take a completely different approach.
In the first part of the code, I compute the projected depth of a cube as seen from the camera position (i.e. how long is the segment traversing the cube at different pixel locations). One way of seeing this is that we now have a precomputed kernel, which we can apply to each cell at a scale proportional to the cell size.

This yields good performances: ~2s on an i9 for an 800x800 simulation with 10,000,000 cells. Interestingly, this could also be used to offload the rendering to the GPU.

While the code is relatively stable, I still get slight differences between axis-aligned projections and this method, which suggests that there are some minor details that I got wrong (see below).

## Comparisons
Using the code
```python
import yt

ds = yt.load_sample("output_00080")
p = yt.ProjectionPlot(
    ds,
    "y",
    "density",
    weight_field="density"
)
p.set_zlim(("gas", "density"), 6e-31, 2e-26)
p.save("/tmp/projection.png")
p = yt.OffAxisProjectionPlot(
    ds,
    [0, 1, 0],
    "density",
    north_vector=[1, 0, 0],
    width=(1, "unitary"),
    center=[0.5, 0.5, 0.5],
    buff_size=(800, 800),
    weight_field="density",
)
p.set_zlim(("gas", "density"), 6e-31, 2e-26)
p.set_axes_unit("Mpc")
p.save("/tmp/new.png")
```

I obtain (as of #f8d38de) very similar performances as the on-axis projection (!!!)
|  | Result from `ProjectionPlot` | Result from new off-axis projection |
|--|---|---|
| Image | ![projection](https://github.com/yt-project/yt/assets/5411875/ac099469-fd8f-472a-af50-613efd529af8) | ![new](https://github.com/yt-project/yt/assets/5411875/ae80f903-bc61-4797-9777-331d73c08435) |
| Timing (s) | 1.45 | 2.14 (8 cores), 3.13 (1 core) |
