### PR TITLE
BUG: avoid a noisy self-triggered warning about libconf being a hard dependency to load any enzo data

### DIFF
--- a/yt/frontends/enzo/data_structures.py
+++ b/yt/frontends/enzo/data_structures.py
@@ -666,7 +666,7 @@ class EnzoDataset(Dataset):
     Enzo-specific output, set at a fixed time.
     """
 
-    _load_requirements = ["h5py", "libconf"]
+    _load_requirements = ["h5py"]
     _index_class = EnzoHierarchy
     _field_info_class = EnzoFieldInfo
 


### PR DESCRIPTION
## PR Summary

similar to #4708, follow up to #4275
The issue here is that `EnzoDataset` is used for Enzo 2 *and* Enzo 3 data, but `libconf` is only required with the latter, so warning about `libconf` not being installed is just noisy when working with Enzo 2 data (including everyone's favourite dataset, IsolatedGalaxy).
