### PR TITLE
[WIP] Naive off-axis slice attempt for spherical-ish geometry

### DIFF
--- a/yt/geometry/coordinates/spherical_coordinates.py
+++ b/yt/geometry/coordinates/spherical_coordinates.py
@@ -128,6 +128,7 @@ class SphericalCoordinateHandler(CoordinateHandler):
     ):
         # use Aitoff projection
         # http://paulbourke.net/geometry/transformationprojection/
+        # We should be supplying an offset here, but it needs checking.
         bounds = tuple(_.ndview for _ in self._aitoff_bounds)
         buff, mask = pixelize_aitoff(
             azimuth=data_source["py"],
@@ -157,6 +158,7 @@ class SphericalCoordinateHandler(CoordinateHandler):
                 data_source[field],
                 bounds,
                 return_mask=True,
+                offset=data_source.offset,
             )
         elif name == "phi":
             # Note that we feed in buff.T here
@@ -169,6 +171,7 @@ class SphericalCoordinateHandler(CoordinateHandler):
                 data_source[field],
                 bounds,
                 return_mask=True,
+                offset=data_source.offset,
             ).T
         else:
             raise RuntimeError

--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -558,6 +558,7 @@ def pixelize_cylinder(np.float64_t[:,:] buff,
                       extents,
                       *,
                       int return_mask=0,
+                      offset=None,
 ):
 
     cdef np.float64_t x, y, dx, dy, r0, theta0
@@ -566,7 +567,11 @@ def pixelize_cylinder(np.float64_t[:,:] buff,
     cdef np.float64_t r_inc, theta_inc
     cdef np.float64_t costheta, sintheta
     cdef int i, i1, pi, pj
-
+    cdef np.float64_t voff[3]
+    if offset is None:
+        voff[0] = voff[1] = voff[2] = 0.0
+    else:
+        voff[0], voff[1], voff[2] = offset
     cdef int imin, imax
     imin = np.asarray(radius).argmin()
     imax = np.asarray(radius).argmax()
@@ -612,8 +617,8 @@ def pixelize_cylinder(np.float64_t[:,:] buff,
     r_inc = 0.5 * fmin(dx, dy)
 
     for i in range(radius.shape[0]):
-        r0 = radius[i]
-        theta0 = theta[i]
+        r0 = radius[i] + voff[0]
+        theta0 = theta[i] + voff[1]
         dr_i = dradius[i]
         dtheta_i = dtheta[i]
         # Skip out early if we're offsides, for zoomed in plots


### PR DESCRIPTION
This is an attempt at addressing #4750.  It works alright for offsets in theta, which seem to just rotate, but I'm confusing myself when attempting to test it for having a new normal vector that is set at some declination.

I think I've also confused myself yet again about how the r, theta, phi coordinates work, as my test script is not producing the types of plots I'd expect.  When slicing along the dimension that runs 0 .. pi, I'd expect to get a whole circle, and when slicing along 0 .. 2pi I'd expect half circle.  But that's not what's happening.

Here's an example script:

```python
import numpy as np
import yt, yt.testing

ds = yt.testing.fake_amr_ds(geometry = "spherical")

for i, phi_offset in enumerate(np.mgrid[ds.domain_left_edge[2]:ds.domain_right_edge[2]:100j]):
    s = ds.slice("theta", ds.domain_center[1], offset = [0.0, 0.0, phi_offset])
    s.to_pw("Density").save(f"frame_{i:04d}")
    print(i, phi_offset)
```
