### PR TITLE
UX: add info about supported simulation types in YTSimulationNotIdentified

### DIFF
--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -196,7 +196,12 @@ class YTSimulationNotIdentified(YTException):
         self.sim_type = sim_type
 
     def __str__(self):
-        return f"Simulation time-series type {self.sim_type!r} not defined."
+        from yt.utilities.object_registries import simulation_time_series_registry
+
+        return (
+            f"Simulation time-series type {self.sim_type!r} not defined. "
+            f"Supported types are {list(simulation_time_series_registry)}"
+        )
 
 
 class YTCannotParseFieldDisplayName(YTException):


### PR DESCRIPTION
## PR Summary

A recent question on slack revealed that the error message left users confused about what to do. It should be very clear which strings are considered valid values to the `simulation_type` argument in `yt.load_simulation`, especially since it happens to be case sensitive.