### PR TITLE
ENH: allow boxlib frontend to read 1D cylindrical datasets

### DIFF
--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -374,10 +374,8 @@ class BoxlibHierarchy(GridIndex):
             default_ybounds = (0.0, 1.0)
             default_zbounds = (0.0, 1.0)
         elif self.ds.geometry == "cylindrical":
-            # Now we check for dimensionality issues
-            if self.dimensionality != 2:
-                raise RuntimeError("yt needs cylindrical to be 2D")
             self.level_dds[:, 2] = 2 * np.pi
+            default_ybounds = (0.0, 1.0)
             default_zbounds = (0.0, 2 * np.pi)
         elif self.ds.geometry == "spherical":
             # BoxLib only supports 1D spherical, so ensure
@@ -892,7 +890,7 @@ class BoxlibDataset(Dataset):
             self.geometry = Geometry(geom_str)
 
         if self.geometry == "cylindrical":
-            dre = self.domain_right_edge
+            dre = self.domain_right_edge.copy()
             dre[2] = 2.0 * np.pi
             self.domain_right_edge = dre
 

--- a/yt/frontends/boxlib/tests/test_outputs.py
+++ b/yt/frontends/boxlib/tests/test_outputs.py
@@ -321,6 +321,11 @@ def test_CastroDataset_2():
     assert isinstance(data_dir_load("castro_sod_x_plt00036"), CastroDataset)
 
 
+@requires_file("castro_sedov_1d_cyl_plt00150")
+def test_CastroDataset_3():
+    assert isinstance(data_dir_load("castro_sedov_1d_cyl_plt00150"), CastroDataset)
+
+
 @requires_file(plasma)
 def test_WarpXDataset():
     assert isinstance(data_dir_load(plasma), WarpXDataset)

--- a/yt/sample_data_registry.json
+++ b/yt/sample_data_registry.json
@@ -622,6 +622,12 @@
     "load_name": "c5.h5m",
     "url": "https://yt-project.org/data/c5.tar.gz"
   },
+  "castro_sedov_1d_cyl_plt00150.tar.gz": {
+    "hash": "c96a8fdf3cd43563a88e34569a6b37e57a0349692a9100ea65252506a167f08f",
+    "load_kwargs": {},
+    "load_name": "castro_sedov_1d_cyl_plt00150",
+    "url": "https://yt-project.org/data/castro_sedov_1d_cyl_plt00150.tar.gz"
+  },
   "castro_sedov_2d_cyl_in_cart_plt00150.tar.gz": {
     "hash": "8b73a37a0503dba593af65f8bf16dfcc11ac825d671f11e5a364a2dee63c9047",
     "load_kwargs": {},

--- a/yt/sample_data_registry.json
+++ b/yt/sample_data_registry.json
@@ -625,7 +625,7 @@
   "castro_sedov_1d_cyl_plt00150.tar.gz": {
     "hash": "c96a8fdf3cd43563a88e34569a6b37e57a0349692a9100ea65252506a167f08f",
     "load_kwargs": {},
-    "load_name": "castro_sedov_1d_cyl_plt00150",
+    "load_name": "",
     "url": "https://yt-project.org/data/castro_sedov_1d_cyl_plt00150.tar.gz"
   },
   "castro_sedov_2d_cyl_in_cart_plt00150.tar.gz": {


### PR DESCRIPTION
## PR Summary

Removes the check that disallows cylindrical coordinates in 1D. It looks like yt learned how to support these sometime since this code was added in 2014. It also fixes an error in `_parse_header_file()` introduced by #4641.

I tested against an example dataset output by https://github.com/AMReX-Astro/Castro/tree/main/Exec/hydro_tests/Sedov using `inputs.1d.cyl`, and the cell volumes checked out (proportional to 1/r).

## PR Checklist

- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.