### PR TITLE
TST: update xarray integration test to use non-deprecated API

### DIFF
--- a/yt/data_objects/tests/test_covering_grid.py
+++ b/yt/data_objects/tests/test_covering_grid.py
@@ -153,9 +153,9 @@ def test_xarray_export():
         assert "x" in xarr.coords
         assert "y" in xarr.coords
         assert "z" in xarr.coords
-        assert xarr.dims["x"] == dn * ds.domain_dimensions[0]
-        assert xarr.dims["y"] == dn * ds.domain_dimensions[1]
-        assert xarr.dims["z"] == dn * ds.domain_dimensions[2]
+        assert xarr.sizes["x"] == dn * ds.domain_dimensions[0]
+        assert xarr.sizes["y"] == dn * ds.domain_dimensions[1]
+        assert xarr.sizes["z"] == dn * ds.domain_dimensions[2]
         assert_equal(xarr.x, cg[("index", "x")][:, 0, 0])
         assert_equal(xarr.y, cg[("index", "y")][0, :, 0])
         assert_equal(xarr.z, cg[("index", "z")][0, 0, :])


### PR DESCRIPTION
## PR Summary

Fix a `FutureWarning` emmited in all Python 3.12 CI jobs, from `xarray`.
```
FAILED yt/data_objects/tests/test_covering_grid.py::test_xarray_export - FutureWarning: The return type of `Dataset.dims` will be changed to return a set of dimension names in future, in order to be more consistent with `DataArray.dims`. To access a mapping from dimension names to lengths, please use `Dataset.sizes`.
```
