### PR TITLE
ENH: Add a TwoSlopeNorm to the norm_handler

### DIFF
--- a/yt/visualization/_handlers.py
+++ b/yt/visualization/_handlers.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 import matplotlib as mpl
 import numpy as np
 import unyt as un
-from matplotlib.colors import Colormap, LogNorm, Normalize, SymLogNorm
+from matplotlib.colors import Colormap, LogNorm, Normalize, SymLogNorm, TwoSlopeNorm
 from unyt import unyt_quantity
 
 from yt._typing import Quantity, Unit
@@ -61,6 +61,7 @@ class NormHandler:
         "_dynamic_range",
         "_norm_type",
         "_linthresh",
+        "_vcenter",
         "_norm_type",
         "_norm",
         "prefer_log",
@@ -68,6 +69,7 @@ class NormHandler:
     _constraint_attrs: list[str] = [
         "vmin",
         "vmax",
+        "vcenter",
         "dynamic_range",
         "norm_type",
         "linthresh",
@@ -84,6 +86,7 @@ class NormHandler:
         norm_type: Optional[type[Normalize]] = None,
         norm: Optional[Normalize] = None,
         linthresh: Optional[float] = None,
+        vcenter: Optional[float] = None,
     ):
         self.data_source = weakref.proxy(data_source)
         self.ds = data_source.ds  # should already be a weakref proxy
@@ -95,6 +98,7 @@ class NormHandler:
         self._dynamic_range = dynamic_range
         self._norm_type = norm_type
         self._linthresh = linthresh
+        self._vcenter = vcenter
         self.prefer_log = True
 
         if self.norm is not None and self.has_constraints:
@@ -195,6 +199,22 @@ class NormHandler:
             self._vmax = "max"
         else:
             self._set_quan_attr("_vmax", newval)
+
+    @property
+    def vcenter(self) -> Optional[Union[un.unyt_quantity, Literal["zero"], float]]:
+        return self._vcenter
+
+    @vcenter.setter
+    def vcenter(
+        self, newval: Optional[Union[un.unyt_quantity, Literal["zero"], float]]
+    ) -> None:
+        self._reset_norm()
+        if newval == "zero":
+            self._vcenter = 0.0
+        else:
+            self._set_quan_attr("_vcenter", newval)
+        if newval is not None:
+            self.norm_type = TwoSlopeNorm
 
     @property
     def dynamic_range(self) -> Optional[float]:
@@ -364,6 +384,12 @@ class NormHandler:
 
             kw.setdefault("linthresh", linthresh)
             kw.setdefault("base", 10)
+        elif norm_type is TwoSlopeNorm:
+            if self.vcenter is not None:
+                vcenter = self.to_float(self.vcenter)
+            else:
+                vcenter = 0.0
+            kw.setdefault("vcenter", vcenter)
 
         return norm_type(*args, **kw)
 


### PR DESCRIPTION
I think that the code works, but I need suggestions on how to more easily expose this behavior.  I'd also like to see how we could potentially describe setting the min/max to be mirrors; for instance, right now the ramp on either side of vcenter changes, but it would be nice to set it to the maximum extent.  (i.e., vmax = -vmin or something).
