### PR TITLE
ENH: add check for finite values in extrema

### DIFF
--- a/yt/data_objects/derived_quantities.py
+++ b/yt/data_objects/derived_quantities.py
@@ -578,6 +578,9 @@ class Extrema(DerivedQuantity):
     non_zero : bool
         If True, only positive values are considered in the calculation.
         Default: False
+    check_finite : bool
+        If True, non-finite values will be explicitly exluded.
+        Default: False
 
     Examples
     --------
@@ -588,23 +591,25 @@ class Extrema(DerivedQuantity):
 
     """
 
-    def count_values(self, fields, non_zero):
+    def count_values(self, fields, non_zero, check_finite):
         self.num_vals = len(fields) * 2
 
-    def __call__(self, fields, non_zero=False):
+    def __call__(self, fields, non_zero=False, *, check_finite=False):
         fields = list(iter_fields(fields))
-        rv = super().__call__(fields, non_zero)
+        rv = super().__call__(fields, non_zero, check_finite)
         if len(rv) == 1:
             rv = rv[0]
         return rv
 
-    def process_chunk(self, data, fields, non_zero):
+    def process_chunk(self, data, fields, non_zero, check_finite):
         vals = []
         for field in fields:
             field = data._determine_fields(field)[0]
             fd = data[field]
             if non_zero:
                 fd = fd[fd > 0.0]
+            if check_finite:
+                fd = fd[np.isfinite(fd)]
             if fd.size > 0:
                 vals += [fd.min(), fd.max()]
             else:

--- a/yt/data_objects/derived_quantities.py
+++ b/yt/data_objects/derived_quantities.py
@@ -579,7 +579,7 @@ class Extrema(DerivedQuantity):
         If True, only positive values are considered in the calculation.
         Default: False
     check_finite : bool
-        If True, non-finite values will be explicitly exluded.
+        If True, non-finite values will be explicitly excluded.
         Default: False
 
     Examples
@@ -591,17 +591,17 @@ class Extrema(DerivedQuantity):
 
     """
 
-    def count_values(self, fields, non_zero, check_finite):
+    def count_values(self, fields, non_zero, *, check_finite=False):
         self.num_vals = len(fields) * 2
 
     def __call__(self, fields, non_zero=False, *, check_finite=False):
         fields = list(iter_fields(fields))
-        rv = super().__call__(fields, non_zero, check_finite)
+        rv = super().__call__(fields, non_zero, check_finite=check_finite)
         if len(rv) == 1:
             rv = rv[0]
         return rv
 
-    def process_chunk(self, data, fields, non_zero, check_finite):
+    def process_chunk(self, data, fields, non_zero, *, check_finite=False):
         vals = []
         for field in fields:
             field = data._determine_fields(field)[0]

--- a/yt/data_objects/tests/test_derived_quantities.py
+++ b/yt/data_objects/tests/test_derived_quantities.py
@@ -41,6 +41,20 @@ def test_extrema():
             assert_equal(ma, np.nanmax(dd[("gas", "radial_velocity")]))
 
 
+def test_extrema_with_nan():
+    dens = np.ones((16, 16, 16))
+    dens[0, 0, 0] = np.nan
+    data = {"density": dens}
+    ds = yt.load_uniform_grid(data, data["density"].shape)
+    ad = ds.all_data()
+    mi, ma = ad.quantities.extrema(("stream", "density"))
+    assert np.isnan(mi)
+    assert np.isnan(ma)
+    mi, ma = ad.quantities.extrema(("stream", "density"), check_finite=True)
+    assert mi == 1.0
+    assert ma == 1.0
+
+
 def test_average():
     for nprocs in [1, 2, 4, 8]:
         ds = fake_random_ds(16, nprocs=nprocs, fields=("density",), units=("g/cm**3",))


### PR DESCRIPTION
## PR Summary

This PR adds a `check_finite` kwarg to `quantities.extrema` so that you can find the extrema of fields that include `np.nan` values.  Default value is `False` so that default behavior does not change. 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
