### PR TITLE
BUGFIX: Enzo testing framework - ignore units for ShockTube tests

### DIFF
--- a/yt/frontends/enzo/answer_testing_support.py
+++ b/yt/frontends/enzo/answer_testing_support.py
@@ -104,7 +104,7 @@ class ShockTubeTest:
             field = ad[k].d
             for xmin, xmax in zip(self.left_edges, self.right_edges):
                 mask = (position >= xmin) * (position <= xmax)
-                exact_field = np.interp(position[mask].value, exact["pos"], exact[k])
+                exact_field = np.interp(position[mask].ndview, exact["pos"], exact[k])
                 myname = f"ShockTubeTest_{k}"
                 # yield test vs analytical solution
                 yield AssertWrapper(

--- a/yt/frontends/enzo/answer_testing_support.py
+++ b/yt/frontends/enzo/answer_testing_support.py
@@ -104,7 +104,7 @@ class ShockTubeTest:
             field = ad[k].d
             for xmin, xmax in zip(self.left_edges, self.right_edges):
                 mask = (position >= xmin) * (position <= xmax)
-                exact_field = np.interp(position[mask], exact["pos"], exact[k])
+                exact_field = np.interp(position[mask].value, exact["pos"], exact[k])
                 myname = f"ShockTubeTest_{k}"
                 # yield test vs analytical solution
                 yield AssertWrapper(


### PR DESCRIPTION
## PR Summary

This bug was found while [fixing the Enzo CI testing](https://github.com/enzo-project/enzo-dev/pull/223). It seems to have been induced by the upgrade to unyt v3. The bug is as follows: 

The `ShockTubeTest` class supports comparing simulation results to an exact solution saved to file; however, the solution in that file doesn't have any units associated with it. When trying to compare solutions, unyt complains. 

This is a very simple change that removes units from the simulation data before comparing. 
The test for it is essentially the Enzo test infrastructure over at https://github.com/enzo-project/enzo-dev? So I'm not sure how I would add a test for this within yt.


