### PR TITLE
explicitly set minimum Python to 3.9.2

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -32,7 +32,7 @@ jobs:
         tests-type: [unit]
         test-runner: [pytest]
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             python-version: '3.9.2'
             dependencies: minimal
             tests-type: unit

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -33,7 +33,7 @@ jobs:
         test-runner: [pytest]
         include:
           - os: ubuntu-latest
-            python-version: '3.9'
+            python-version: '3.9.2'
             dependencies: minimal
             tests-type: unit
             test-runner: pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
 keywords = [
     "astronomy astrophysics visualization amr adaptivemeshrefinement",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.9.2"
 dependencies = [
     "cmyt>=1.1.2",
     "ewah-bool-utils>=1.0.2",


### PR DESCRIPTION
## PR Summary

This PR set's the minimum Python version explicitly to 3.9.2, which is currently the functional minimum version in the 3.9 series. 

## Why

Currently with Python 3.9.0 or 3.9.1, yt 4.3.0 errors on import:

```
>>> import yt
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/chavlin/.pyenv/versions/yt_391/lib/python3.9/site-packages/yt/__init__.py", line 12, in <module>
    import yt.utilities.physical_constants as physical_constants
  File "/home/chavlin/.pyenv/versions/yt_391/lib/python3.9/site-packages/yt/utilities/physical_constants.py", line 3, in <module>
    from yt.units.yt_array import YTQuantity
  File "/home/chavlin/.pyenv/versions/yt_391/lib/python3.9/site-packages/yt/units/yt_array.py", line 3, in <module>
    from yt.funcs import array_like_field  # NOQA: F401
  File "/home/chavlin/.pyenv/versions/yt_391/lib/python3.9/site-packages/yt/funcs.py", line 31, in <module>
    from yt.utilities.logger import ytLogger as mylog
  File "/home/chavlin/.pyenv/versions/yt_391/lib/python3.9/site-packages/yt/utilities/logger.py", line 9, in <module>
    _original_emitter: Optional[Callable[[logging.LogRecord], None]] = None
  File "/home/chavlin/.pyenv/versions/3.9.1/lib/python3.9/typing.py", line 262, in inner
    return func(*args, **kwds)
  File "/home/chavlin/.pyenv/versions/3.9.1/lib/python3.9/typing.py", line 339, in __getitem__
    return self._getitem(self, parameters)
  File "/home/chavlin/.pyenv/versions/3.9.1/lib/python3.9/typing.py", line 463, in Optional
    return Union[arg, type(None)]
  File "/home/chavlin/.pyenv/versions/3.9.1/lib/python3.9/typing.py", line 262, in inner
    return func(*args, **kwds)
  File "/home/chavlin/.pyenv/versions/3.9.1/lib/python3.9/typing.py", line 339, in __getitem__
    return self._getitem(self, parameters)
  File "/home/chavlin/.pyenv/versions/3.9.1/lib/python3.9/typing.py", line 451, in Union
    parameters = _remove_dups_flatten(parameters)
  File "/home/chavlin/.pyenv/versions/3.9.1/lib/python3.9/typing.py", line 231, in _remove_dups_flatten
    return tuple(_deduplicate(params))
  File "/home/chavlin/.pyenv/versions/3.9.1/lib/python3.9/typing.py", line 205, in _deduplicate
    all_params = set(params)
```

The type hint line that errors in yt above, 

```
  File "/home/chavlin/.pyenv/versions/yt_391/lib/python3.9/site-packages/yt/utilities/logger.py", line 9, in <module>
    _original_emitter: Optional[Callable[[logging.LogRecord], None]] = None
```
was fixed in Python 3.9.2 (and that line is new in yt 4.3.0). The relevant portion of the  [3.9.2 release notes](https://docs.python.org/3.9/whatsnew/changelog.html#python-3-9-2-release-candidate-1) is the following:

> [bpo-42195](https://bugs.python.org/issue?@action=redirect&bpo=42195): The __args__ of the parameterized generics for typing.Callable and collections.abc.Callable are now consistent. The __args__ for collections.abc.Callable are now flattened while typing.Callable’s have not changed. To allow this change, types.GenericAlias can now be subclassed and collections.abc.Callable’s __class_getitem__ will now return a subclass of types.GenericAlias. Tests for typing were also updated to not subclass things like Callable[..., T] as that is not a valid base class. Finally, both types no longer validate their argtypes, in Callable[[argtypes], resulttype] to prepare for [PEP 612](https://www.python.org/dev/peps/pep-0612). Patch by Ken Jin.

Per discussion on slack, it seemed better to just explicitly "bump" the minimum version rather than change the type hint. 

