### PR TITLE
TST: ignore deprecation warning from pandas (Pyarrow will become a required dependency)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -31,6 +31,11 @@ if find_spec("setuptools") is not None:
 else:
     SETUPTOOLS_VERSION = None
 
+if find_spec("pandas") is not None:
+    PANDAS_VERSION = Version(version("pandas"))
+else:
+    PANDAS_VERSION = None
+
 
 def pytest_addoption(parser):
     """
@@ -167,6 +172,12 @@ def pytest_configure(config):
                 r"(80 from C header, got 88|88 from C header, got 96|80 from C header, got 96)"
                 " from PyObject:RuntimeWarning"
             ),
+        )
+
+    if PANDAS_VERSION is not None and PANDAS_VERSION >= Version("2.2.0"):
+        config.addinivalue_line(
+            "filterwarnings",
+            r"ignore:\s*Pyarrow will become a required dependency of pandas:DeprecationWarning",
         )
 
     if sys.version_info >= (3, 12):


### PR DESCRIPTION
## PR Summary

As noted by @jzuhone in #4782, this warning makes half of CI red.

I don't think we care about it, but for completion, here it is in full:
```
DeprecationWarning: 
Pyarrow will become a required dependency of pandas in the next major release of pandas (pandas 3.0),
(to allow more performant data types, such as the Arrow string type, and better interoperability with other libraries)
but was not found to be installed on your system.
If this would cause problems for you,
please provide us feedback at https://github.com/pandas-dev/pandas/issues/54466
```
