### PR TITLE
correct domain_dimensions in non-fixed block size uniform grid FLASH output

### DIFF
--- a/yt/frontends/flash/data_structures.py
+++ b/yt/frontends/flash/data_structures.py
@@ -383,6 +383,10 @@ class FLASHDataset(Dataset):
             nblockx = self.parameters["nblockx"]
             nblocky = self.parameters["nblocky"]
             nblockz = self.parameters["nblockz"]
+        elif self.parameters["globalnumblocks"] == 1: # non-fixed block size UG
+            nblockx = 1
+            nblocky = 1
+            nblockz = 1
         else:  # Uniform Grid
             nblockx = self.parameters["iprocs"]
             nblocky = self.parameters["jprocs"]

--- a/yt/frontends/flash/data_structures.py
+++ b/yt/frontends/flash/data_structures.py
@@ -383,7 +383,7 @@ class FLASHDataset(Dataset):
             nblockx = self.parameters["nblockx"]
             nblocky = self.parameters["nblocky"]
             nblockz = self.parameters["nblockz"]
-        elif self.parameters["globalnumblocks"] == 1: # non-fixed block size UG
+        elif self.parameters["globalnumblocks"] == 1:  # non-fixed block size UG
             nblockx = 1
             nblocky = 1
             nblockz = 1


### PR DESCRIPTION


<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->
In non-fixed block size grids FLASH output the domain is output as a single block, rather than being domain decomposed as is assumed for the fixed block size UG. This PR checks for this case
so that yt correctly determines `domain_dimensions`.
<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
