### PR TITLE
Fix order of Athena++ cylindrical coords

### DIFF
--- a/yt/frontends/athena_pp/data_structures.py
+++ b/yt/frontends/athena_pp/data_structures.py
@@ -155,7 +155,7 @@ class AthenaPPDataset(Dataset):
 
         geom = self._handle.attrs["Coordinates"].decode("utf-8")
         self.geometry = Geometry(geom_map[geom])
-        if geom_map[geom] == "cylindrical":
+        if self.geometry == "cylindrical":
             axis_order = ("r","theta","z")
         else:
             axis_order = None

--- a/yt/frontends/athena_pp/data_structures.py
+++ b/yt/frontends/athena_pp/data_structures.py
@@ -15,22 +15,16 @@ from yt.utilities.file_handler import HDF5FileHandler
 
 from .fields import AthenaPPFieldInfo
 
-#geom_map = {
-#    "cartesian": "cartesian",
-#    "cylindrical": "cylindrical",
-#    "spherical_polar": "spherical",
-#    "minkowski": "cartesian",
-#    "tilted": "cartesian",
-#    "sinusoidal": "cartesian",
-#    "schwarzschild": "spherical",
-#    "kerr-schild": "spherical",
-#}
 geom_map = {
-    "cartesian": (Geometry.CARTESIAN,("x","y","z")),
-    "cylindrical": (Geometry.CYLINDRICAL,("r","theta","z")),
-    "spherical_polar": (Geometry.SPHERICAL,("r","theta","phi")),
+    "cartesian": "cartesian",
+    "cylindrical": "cylindrical",
+    "spherical_polar": "spherical",
+    "minkowski": "cartesian",
+    "tilted": "cartesian",
+    "sinusoidal": "cartesian",
+    "schwarzschild": "spherical",
+    "kerr-schild": "spherical",
 }
-
 
 class AthenaPPGrid(AMRGridPatch):
     _id_offset = 0
@@ -160,8 +154,11 @@ class AthenaPPDataset(Dataset):
         self._magnetic_factor = get_magnetic_normalization(magnetic_normalization)
 
         geom = self._handle.attrs["Coordinates"].decode("utf-8")
-        self.geometry = geom_map[geom][0]
-        axis_order = geom_map[geom][1]
+        self.geometry = Geometry(geom_map[geom])
+        if geom_map[geom] == "cylindrical":
+            axis_order = ("r","theta","z")
+        else:
+            axis_order = None
 
         Dataset.__init__(
             self,

--- a/yt/frontends/athena_pp/data_structures.py
+++ b/yt/frontends/athena_pp/data_structures.py
@@ -26,6 +26,7 @@ geom_map = {
     "kerr-schild": "spherical",
 }
 
+
 class AthenaPPGrid(AMRGridPatch):
     _id_offset = 0
 
@@ -156,7 +157,7 @@ class AthenaPPDataset(Dataset):
         geom = self._handle.attrs["Coordinates"].decode("utf-8")
         self.geometry = Geometry(geom_map[geom])
         if self.geometry == "cylindrical":
-            axis_order = ("r","theta","z")
+            axis_order = ("r", "theta", "z")
         else:
             axis_order = None
 
@@ -167,7 +168,7 @@ class AthenaPPDataset(Dataset):
             units_override=units_override,
             unit_system=unit_system,
             default_species_fields=default_species_fields,
-            axis_order=axis_order
+            axis_order=axis_order,
         )
         if storage_filename is None:
             storage_filename = self.basename + ".yt"


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

Changes the ordering of coordinates for Athena++ cylindrical datasets to $(r,\theta,z)$ within the Athena++ frontend.

<!--If it fixes an open issue, please link to the issue here.-->

Addresses #4796 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
