### PR TITLE
Fix bug where race condition results in incorrect fields categorization when computing particle_trajectories

### DIFF
--- a/yt/data_objects/particle_trajectories.py
+++ b/yt/data_objects/particle_trajectories.py
@@ -234,7 +234,7 @@ class ParticleTrajectories:
             fds[field] = dd_first._determine_fields(field)[0]
             if field not in self.particle_fields:
                 ftype = fds[field][0]
-                if ftype in self.data_series[0].particle_types:
+                if ftype in ds_first.particle_types:
                     self.particle_fields.append(field)
                     new_particle_fields.append(field)
 


### PR DESCRIPTION
In the `_get_data` method of `particle_trajectories`, `self.data_series[0]` might still be unloaded (not sure if that's the right word?) when running in parallel. That was causing the `if` statement that checks if the particle_type of missing field exists to fail, incorrectly adding fields to the `grid_fields` list. Since `ds_first` is loaded (because we called all_data() on it earlier), this is now more likely to succeed.

Essentially
```python
ds_first = self.data_series[0]
dd_first = ds_first.all_data()
# ds_first is now loaded, with fields generated correctly

fds = {}
new_particle_fields = []
for field in missing_fields:
    fds[field] = dd_first._determine_fields(field)[0]
    if field not in self.particle_fields:
        ftype = fds[field][0]
        #### race condition here:
        # if ftype in self.data_series[0].particle_types:
        # even though ds_first is loaded, this may not have propagated back 
        # to self.data_series[0]. 
        # So self.data_series[0].particle_types != ds_first.particle_types
        #### fix:
        if ftype in ds_first.particle_types:
            self.particle_fields.append(field)
            new_particle_fields.append(field)
```

In my case, `self.data_series[0].particle_types` didn't even have the `all` particle_type, even though `ds_first` had `all` and several others. Let me know if you need more information.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

Unfortunately, I don't know why this wasn't picked up in the tests, I would expect it to be picked up by 
`test_default_field_tuple`.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
