### PR TITLE
ENH: add support for Quokka datasets

### DIFF
--- a/yt/frontends/boxlib/data_structures.py
+++ b/yt/frontends/boxlib/data_structures.py
@@ -1334,6 +1334,12 @@ class NyxDataset(BoxlibDataset):
         setdefaultattr(self, "velocity_unit", self.length_unit / self.time_unit)
 
 
+class QuokkaDataset(AMReXDataset):
+    # match any plotfiles that have a metadata.yaml file in the root
+    _subtype_keyword = ""
+    _default_cparam_filename = "metadata.yaml"
+
+
 def _guess_pcast(vals):
     # Now we guess some things about the parameter and its type
     # Just in case there are multiple; we'll go


### PR DESCRIPTION
## PR Summary

This allows yt to recognize Quokka output files. They are handled by the AMReX reader, but the reader does not recognize the particle data when loading Quokka outputs using `yt.load`. (Manually creating an `AMReXDataset` object does work, but this should not be necessary for users to invoke directly.)

Unlike other AMReX/Boxlib codes, Quokka doesn't have a `job_info` file, but does have a `metadata.yaml` file (which may be empty). This PR detects this file, and this causes reader to then recognize any particle data that may be present.

Thanks to @BenWibking for noticing this and providing sample outputs!

## PR Checklist

- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.