### PR TITLE
MNT: move ruff configuration to non-deprecated namespaces

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
   rev: v0.2.0
   hooks:
   - id: ruff
-    args: [--fix]
+    args: [--fix, "--show-fixes"]
 
 -   repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -279,6 +279,8 @@ exclude = [
     "yt/mods.py",
     "yt/visualization/_colormap_data.py",
 ]
+
+[tool.ruff.lint]
 select = [
     "E",
     "F",
@@ -297,10 +299,10 @@ ignore = [
     "B018",  # Found useless expression. # disabled because ds.index is idiomatic
 ]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "test_*" = ["NPY002"]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 combine-as-imports = true
 known-third-party = [
   "IPython",


### PR DESCRIPTION
Following #4807, this avoids seeing deprecation warnings in ruff messages.

see release notes https://github.com/astral-sh/ruff/releases/tag/v0.2.0


While I'm in there I also added *useful* verbosity to ruff fixes so now you get to *see* what's being fixed, not just that some file was edited.