### PR TITLE
Revert "Backport PR #4802 on branch yt-4.3.x (Fix bug where race condition results in incorrect fields categorization when computing particle_trajectories)"

### DIFF
--- a/yt/data_objects/particle_trajectories.py
+++ b/yt/data_objects/particle_trajectories.py
@@ -234,7 +234,7 @@ class ParticleTrajectories:
             fds[field] = dd_first._determine_fields(field)[0]
             if field not in self.particle_fields:
                 ftype = fds[field][0]
-                if ftype in ds_first.particle_types:
+                if ftype in self.data_series[0].particle_types:
                     self.particle_fields.append(field)
                     new_particle_fields.append(field)
 


### PR DESCRIPTION
Reverts yt-project/yt#4811 (see my comment therein)