### PR TITLE
Catch Py312+ warning when using ratarmount

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -187,14 +187,16 @@ def pytest_configure(config):
             "filterwarnings",
             r"ignore:datetime\.datetime\.utcfromtimestamp\(\) is deprecated:DeprecationWarning",
         )
-        # On Python 3.12+, there is a deprecation warning when calling os.fork()
-        # in a multi-threaded process
-        config.addinivalue_line(
-            "filterwarnings",
-            r"ignore:This process \(pid=\d+\) is multi-threaded, use of fork\(\) "
-            r"may lead to deadlocks in the child\."
-            ":DeprecationWarning",
-        )
+
+        if find_spec("ratarmount"):
+            # On Python 3.12+, there is a deprecation warning when calling os.fork()
+            # in a multi-threaded process. We use this mechanism to mount archives.
+            config.addinivalue_line(
+                "filterwarnings",
+                r"ignore:This process \(pid=\d+\) is multi-threaded, use of fork\(\) "
+                r"may lead to deadlocks in the child\."
+                ":DeprecationWarning",
+            )
 
 
 def pytest_collection_modifyitems(config, items):

--- a/conftest.py
+++ b/conftest.py
@@ -187,6 +187,14 @@ def pytest_configure(config):
             "filterwarnings",
             r"ignore:datetime\.datetime\.utcfromtimestamp\(\) is deprecated:DeprecationWarning",
         )
+        # On Python 3.12+, there is a deprecation warning when calling os.fork()
+        # in a multi-threaded process
+        config.addinivalue_line(
+            "filterwarnings",
+            r"ignore:This process \(pid=\d+\) is multi-threaded, use of fork\(\) "
+            r"may lead to deadlocks in the child\."
+            ":DeprecationWarning",
+        )
 
 
 def pytest_collection_modifyitems(config, items):


### PR DESCRIPTION
## PR Summary

Since Python 3.12, `os.fork()` throws a deprecation warning when called from multiple threads.
This causes the tests relying on ratarmount (to mount archives) to fail. In this PR, I superficially address the issue by catching the warning on the test side.

The long-term solution would be to update `ratarmount` to a more recent version.
