### PR TITLE
ENH: support installing yt_idefix as `pip install yt[idefix]`; plug it in docs

### DIFF
--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -665,8 +665,8 @@ volume rendering, and many of the analysis modules will not work.
 
 .. _loading-pluto-data:
 
-Pluto Data
-----------
+Pluto Data (AMR)
+----------------
 
 Support for Pluto AMR data is provided through the Chombo frontend, which
 is currently maintained by Andrew Myers. Pluto output files that don't use
@@ -690,6 +690,18 @@ To load it, you can navigate into that directory and do:
 
 The ``pluto.ini`` file must also be present alongside the HDF5 file.
 By default, all of the Pluto fields will be in code units.
+
+
+.. _loading-idefix-data:
+
+Idefix, Pluto VTK and Pluto XDMF Data
+-------------------------------------
+
+Support for Idefix ``.dmp``, ``.vtk`` data is provided through the ``yt_idefix``
+extension.
+It also supports monogrid ``.vtk`` and ``.h5`` data from Pluto.
+See `the PyPI page <https://pypi.org/project/yt-idefix/>`_ for details.
+
 
 .. _loading-enzo-data:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ gdf = ["yt[HDF5]"]
 gizmo = ["yt[HDF5]"]
 halo-catalog = ["yt[HDF5]"]
 http-stream = ["requests>=2.20.0"]
+idefix = ["yt_idefix[HDF5]>=2.3.0"] # externally packaged frontend
 moab = ["yt[HDF5]"]
 nc4-cm1 = ["yt[netCDF4]"]
 open-pmd = ["yt[HDF5]"]
@@ -169,6 +170,7 @@ full = [
     "yt[gizmo]",
     "yt[halo_catalog]",
     "yt[http_stream]",
+    "yt[idefix]",
     "yt[moab]",
     "yt[nc4_cm1]",
     "yt[open_pmd]",


### PR DESCRIPTION
This external frontend has been stable for a couple years, but is hardly discoverable, so I'd like to make it more visible in yt docs.
It also seems that pretty nice to me that, combining https://github.com/yt-project/yt/pull/4272 and https://github.com/yt-project/yt/pull/4285, we're actually able to make `pip install 'yt[idefix]'` seamlessly provide as much functionality as `pip install 'yt[ramses]'` at a very low maintenance cost. However, there's no precedent for doing this so this is just a proposal, please *do* raise any objection !