### PR TITLE
BUG: fix parameter parsing for Castro and MAESTRO

### DIFF
--- a/yt/frontends/boxlib/tests/test_outputs.py
+++ b/yt/frontends/boxlib/tests/test_outputs.py
@@ -443,3 +443,28 @@ def test_maestro_parameters():
     # Check an int parameter
     assert ds.parameters["s0_interp_type"] == 3
     assert type(ds.parameters["s0_interp_type"]) is int  # noqa: E721
+
+
+castro_1d_cyl = "castro_sedov_1d_cyl_plt00150"
+
+
+@requires_file(castro_1d_cyl)
+def test_castro_parameters():
+    ds = data_dir_load(castro_1d_cyl)
+    assert isinstance(ds, CastroDataset)
+
+    # Modified from default (leading [*])
+    assert ds.parameters["castro.do_hydro"] == 1
+    assert ds.parameters["castro.cfl"] == 0.5
+    assert ds.parameters["problem.p_ambient"] == float("1e-06")
+    # Leading [*] should be removed from the parameter name
+    assert "[*] castro.do_hydro" not in ds.parameters
+
+    # Not modified from default
+    assert ds.parameters["castro.pslope_cutoff_density"] == float("-1e+20")
+    assert ds.parameters["castro.do_sponge"] == 0
+    assert ds.parameters["problem.dens_ambient"] == 1
+    assert ds.parameters["eos.eos_assume_neutral"] == 1
+
+    # Empty string value
+    assert ds.parameters["castro.stopping_criterion_field"] is None


### PR DESCRIPTION
## PR Summary

Castro (since 18.04), MAESTROeX (since 20.09), and MAESTRO (since 2013) add a prefix `[*]` before runtime parameters that are changed from their defaults. This was being handled by the Dataset subclasses individually, leading to duplicated and inconsistent logic (CastroDataset wasn't stripping the parameter names, leading to duplicates with trailing spaces).

This PR moves the prefix handling into BoxlibDataset, and removes the prefix so analysis scripts don't need to check for both versions in `ds.parameters`.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
