### PR TITLE
BLD: Ditch `np.int_t`, removed in numpy 2's C API (use `np.int64_t` instead)

### DIFF
--- a/yt/geometry/coordinates/cartesian_coordinates.py
+++ b/yt/geometry/coordinates/cartesian_coordinates.py
@@ -618,7 +618,7 @@ class CartesianCoordinateHandler(CoordinateHandler):
     def _oblique_pixelize(self, data_source, field, bounds, size, antialias):
         from yt.frontends.ytdata.data_structures import YTSpatialPlotDataset
 
-        indices = np.argsort(data_source["pdx"])[::-1].astype(np.int_)
+        indices = np.argsort(data_source["pdx"])[::-1].astype("int64", copy=False)
         buff = np.full((size[1], size[0]), np.nan, dtype="float64")
         ftype = "index"
         if isinstance(data_source.ds, YTSpatialPlotDataset):

--- a/yt/geometry/grid_container.pyx
+++ b/yt/geometry/grid_container.pyx
@@ -60,9 +60,9 @@ cdef class GridTree:
                   np.ndarray[np.int64_t, ndim=1] num_children):
 
         cdef int i, j, k
-        cdef np.ndarray[np.int_t, ndim=1] child_ptr
+        cdef np.ndarray[np.int64_t, ndim=1] child_ptr
 
-        child_ptr = np.zeros(num_grids, dtype='int')
+        child_ptr = np.zeros(num_grids, dtype='int64')
 
         self.num_grids = num_grids
         self.num_root_grids = 0

--- a/yt/geometry/grid_visitors.pxd
+++ b/yt/geometry/grid_visitors.pxd
@@ -31,7 +31,7 @@ cdef struct GridTreeNodePadded:
     np.float64_t right_edge_x
     np.float64_t right_edge_y
     np.float64_t right_edge_z
-    np.int_t children_pointers
+    np.int64_t children_pointers
     np.int64_t start_index_x
     np.int64_t start_index_y
     np.int64_t start_index_z

--- a/yt/utilities/lib/alt_ray_tracers.pyx
+++ b/yt/utilities/lib/alt_ray_tracers.pyx
@@ -91,7 +91,7 @@ def cylindrical_ray_trace(np.ndarray[np.float64_t, ndim=1] p1,
         indexes into the grid cells which the ray crosses in order.
 
     """
-    cdef np.int_t i, I
+    cdef np.int64_t i, I
     cdef np.float64_t a, b, bsqrd, twoa
     cdef np.ndarray[np.float64_t, ndim=1] p1cart, p2cart, dpcart, t, s, \
                                           rleft, rright, zleft, zright, \

--- a/yt/utilities/lib/interpolators.pyx
+++ b/yt/utilities/lib/interpolators.pyx
@@ -76,9 +76,9 @@ def TrilinearlyInterpolate(np.ndarray[np.float64_t, ndim=3] table,
                            np.ndarray[np.float64_t, ndim=1] x_bins,
                            np.ndarray[np.float64_t, ndim=1] y_bins,
                            np.ndarray[np.float64_t, ndim=1] z_bins,
-                           np.ndarray[np.int_t, ndim=1] x_is,
-                           np.ndarray[np.int_t, ndim=1] y_is,
-                           np.ndarray[np.int_t, ndim=1] z_is,
+                           np.ndarray[np.int64_t, ndim=1] x_is,
+                           np.ndarray[np.int64_t, ndim=1] y_is,
+                           np.ndarray[np.int64_t, ndim=1] z_is,
                            np.ndarray[np.float64_t, ndim=1] output):
     cdef double x, xp, xm
     cdef double y, yp, ym
@@ -122,10 +122,10 @@ def QuadrilinearlyInterpolate(np.ndarray[np.float64_t, ndim=4] table,
                               np.ndarray[np.float64_t, ndim=1] y_bins,
                               np.ndarray[np.float64_t, ndim=1] z_bins,
                               np.ndarray[np.float64_t, ndim=1] w_bins,
-                              np.ndarray[np.int_t, ndim=1] x_is,
-                              np.ndarray[np.int_t, ndim=1] y_is,
-                              np.ndarray[np.int_t, ndim=1] z_is,
-                              np.ndarray[np.int_t, ndim=1] w_is,
+                              np.ndarray[np.int64_t, ndim=1] x_is,
+                              np.ndarray[np.int64_t, ndim=1] y_is,
+                              np.ndarray[np.int64_t, ndim=1] z_is,
+                              np.ndarray[np.int64_t, ndim=1] w_is,
                               np.ndarray[np.float64_t, ndim=1] output):
     cdef double x, xp, xm
     cdef double y, yp, ym

--- a/yt/utilities/lib/mesh_triangulation.pyx
+++ b/yt/utilities/lib/mesh_triangulation.pyx
@@ -184,7 +184,7 @@ cdef class MeshInfoHolder:
     cdef np.int64_t TPE  # num tris per element
     cdef int[MAX_NUM_TRI][3] tri_array
 
-    def __cinit__(self, np.int_t[:, ::1] indices):
+    def __cinit__(self, np.int64_t[:, ::1] indices):
         '''
 
         This class is used to store metadata about the type of mesh being used.
@@ -301,7 +301,7 @@ def triangulate_mesh(np.float64_t[:, ::1] coords,
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
-def triangulate_indices(np.int_t[:, ::1] indices):
+def triangulate_indices(np.int64_t[:, ::1] indices):
     '''
 
     This is like triangulate_mesh, except it only considers the
@@ -311,9 +311,9 @@ def triangulate_indices(np.int_t[:, ::1] indices):
     '''
 
     cdef MeshInfoHolder m = MeshInfoHolder(indices)
-    cdef np.int_t[:, ::1] tri_indices = np.empty((m.num_tri, 3), dtype=np.int_)
+    cdef np.int64_t[:, ::1] tri_indices = np.empty((m.num_tri, 3), dtype=np.int_)
 
-    cdef np.int_t i, j, k
+    cdef np.int64_t i, j, k
     for i in range(m.num_elem):
         for j in range(m.TPE):
             for k in range(3):

--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -467,7 +467,7 @@ def pixelize_off_axis_cartesian(
                        np.float64_t[:] pdz,
                        np.float64_t[:] center,
                        np.float64_t[:,:] inv_mat,
-                       np.int_t[:] indices,
+                       np.int64_t[:] indices,
                        np.float64_t[:] data,
                        bounds,
                        *,

--- a/yt/utilities/linear_interpolators.py
+++ b/yt/utilities/linear_interpolators.py
@@ -208,9 +208,9 @@ class TrilinearFieldInterpolator:
         y_vals = data_object[self.y_name].ravel().astype("float64")
         z_vals = data_object[self.z_name].ravel().astype("float64")
 
-        x_i = np.digitize(x_vals, self.x_bins).astype("int_") - 1
-        y_i = np.digitize(y_vals, self.y_bins).astype("int_") - 1
-        z_i = np.digitize(z_vals, self.z_bins).astype("int_") - 1
+        x_i = np.digitize(x_vals, self.x_bins).astype("int64") - 1
+        y_i = np.digitize(y_vals, self.y_bins).astype("int64") - 1
+        z_i = np.digitize(z_vals, self.z_bins).astype("int64") - 1
         if (
             np.any((x_i == -1) | (x_i == len(self.x_bins) - 1))
             or np.any((y_i == -1) | (y_i == len(self.y_bins) - 1))
@@ -314,10 +314,10 @@ class QuadrilinearFieldInterpolator:
         z_vals = data_object[self.z_name].ravel().astype("float64")
         w_vals = data_object[self.w_name].ravel().astype("float64")
 
-        x_i = np.digitize(x_vals, self.x_bins).astype("int") - 1
-        y_i = np.digitize(y_vals, self.y_bins).astype("int") - 1
-        z_i = np.digitize(z_vals, self.z_bins).astype("int") - 1
-        w_i = np.digitize(w_vals, self.w_bins).astype("int") - 1
+        x_i = np.digitize(x_vals, self.x_bins).astype("int64") - 1
+        y_i = np.digitize(y_vals, self.y_bins).astype("int64") - 1
+        z_i = np.digitize(z_vals, self.z_bins).astype("int64") - 1
+        w_i = np.digitize(w_vals, self.w_bins).astype("int64") - 1
         if (
             np.any((x_i == -1) | (x_i == len(self.x_bins) - 1))
             or np.any((y_i == -1) | (y_i == len(self.y_bins) - 1))


### PR DESCRIPTION
## PR Summary

This fixes *building* yt against numpy 2.0
Context:
The `np.int_t` alias was removed from numpy's C API

example error:
```
Error compiling Cython file:
------------------------------------------------------------
...
    np.float64_t left_edge_y
    np.float64_t left_edge_z
    np.float64_t right_edge_x
    np.float64_t right_edge_y
    np.float64_t right_edge_z
    np.int_t children_pointers
    ^
------------------------------------------------------------

yt/geometry/grid_visitors.pxd:34:4: 'int_t' is not a type identifier
```

Replacing it with a fixed-size portable `int64` fixes building.
This might not be an exact replacement on Windows where, historically, numpy used int32 by default, but numpy 2.0 will consistently use int64 everywhere so this change feels in line with future behaviour. Furthermore it only affects private API so it shouldn't be classified as breaking for our users.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
