### PR TITLE
TST: do not use broken pytest 8.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,7 +217,7 @@ minimal = [
 ]
 test = [
     "pyaml>=17.10.0",
-    "pytest>=6.1",
+    "pytest>=6.1, !=8.1.1",
     "pytest-mpl>=0.16.1",
     "sympy!=1.10,!=1.9", # see https://github.com/sympy/sympy/issues/22241
     "nose~=1.3.7; python_version < '3.10'",


### PR DESCRIPTION
## PR Summary

A temporary measure to mitigate one of the failures reported in #4850
I believe the bug is upstream and reported as https://github.com/pytest-dev/pytest/issues/12113
I'll undraft this PR when CI is green in the event the problem isn't promptly resolved upstream to unblock other developments.