### PR TITLE
TST: migrate module-level setup/teardown functions to pytest

### DIFF
--- a/nose_ignores.txt
+++ b/nose_ignores.txt
@@ -37,3 +37,7 @@
 --ignore-file=test_gadget_pytest\.py
 --ignore-file=test_vr_orientation\.py
 --ignore-file=test_particle_trajectories_pytest\.py
+--ignore-file=test_image_array\.py
+--ignore-file=test_alt_ray_tracers\.py
+--ignore-file=test_minimal_representation\.py
+--ignore-file=test_set_log_level\.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,7 +191,7 @@ doc = [
     "jupyter-client>=8.3.1",
     "nbsphinx>=0.9.3",
     "nose~=1.3.7; python_version < '3.10'",
-    "pytest>=6.1, <8.0",
+    "pytest>=6.1",
     "pyx>=0.15",
     "sphinx>=7.2.5",
     "sphinx-bootstrap-theme>=0.8.1",
@@ -217,7 +217,7 @@ minimal = [
 ]
 test = [
     "pyaml>=17.10.0",
-    "pytest>=6.1, <8.0",
+    "pytest>=6.1",
     "pytest-mpl>=0.16.1",
     "sympy!=1.10,!=1.9", # see https://github.com/sympy/sympy/issues/22241
     "nose~=1.3.7; python_version < '3.10'",

--- a/yt/data_objects/tests/test_compose.py
+++ b/yt/data_objects/tests/test_compose.py
@@ -6,7 +6,7 @@ from yt.units._numpy_wrapper_functions import uintersect1d
 from yt.units.yt_array import YTArray
 
 
-def setup():
+def setup_module():
     from yt.config import ytcfg
 
     ytcfg["yt", "internals", "within_testing"] = True

--- a/yt/data_objects/tests/test_covering_grid.py
+++ b/yt/data_objects/tests/test_covering_grid.py
@@ -16,7 +16,7 @@ cyl_2d = "WDMerger_hdf5_chk_1000/WDMerger_hdf5_chk_1000.hdf5"
 cyl_3d = "MHD_Cyl3d_hdf5_plt_cnt_0100/MHD_Cyl3d_hdf5_plt_cnt_0100.hdf5"
 
 
-def setup():
+def setup_module():
     from yt.config import ytcfg
 
     ytcfg["yt", "internals", "within_testing"] = True

--- a/yt/data_objects/tests/test_cutting_plane.py
+++ b/yt/data_objects/tests/test_cutting_plane.py
@@ -7,7 +7,7 @@ from yt.testing import fake_random_ds
 from yt.units.unit_object import Unit
 
 
-def setup():
+def setup_module():
     from yt.config import ytcfg
 
     ytcfg["yt", "internals", "within_testing"] = True

--- a/yt/data_objects/tests/test_data_collection.py
+++ b/yt/data_objects/tests/test_data_collection.py
@@ -4,7 +4,7 @@ from numpy.testing import assert_equal
 from yt.testing import assert_rel_equal, fake_random_ds
 
 
-def setup():
+def setup_module():
     from yt.config import ytcfg
 
     ytcfg["yt", "internals", "within_testing"] = True

--- a/yt/data_objects/tests/test_derived_quantities.py
+++ b/yt/data_objects/tests/test_derived_quantities.py
@@ -12,7 +12,7 @@ from yt.testing import (
 )
 
 
-def setup():
+def setup_module():
     from yt.config import ytcfg
 
     ytcfg["yt", "internals", "within_testing"] = True

--- a/yt/data_objects/tests/test_ellipsoid.py
+++ b/yt/data_objects/tests/test_ellipsoid.py
@@ -4,7 +4,7 @@ from numpy.testing import assert_array_less
 from yt.testing import fake_random_ds
 
 
-def setup():
+def setup_module():
     from yt.config import ytcfg
 
     ytcfg["yt", "log_level"] = 50

--- a/yt/data_objects/tests/test_extract_regions.py
+++ b/yt/data_objects/tests/test_extract_regions.py
@@ -10,7 +10,7 @@ from yt.testing import (
 )
 
 
-def setup():
+def setup_module():
     from yt.config import ytcfg
 
     ytcfg["yt", "internals", "within_testing"] = True

--- a/yt/data_objects/tests/test_fluxes.py
+++ b/yt/data_objects/tests/test_fluxes.py
@@ -9,7 +9,7 @@ from numpy.testing import assert_almost_equal, assert_equal
 from yt.testing import fake_random_ds
 
 
-def setup():
+def setup_module():
     from yt.config import ytcfg
 
     ytcfg["yt", "internals", "within_testing"] = True

--- a/yt/data_objects/tests/test_image_array.py
+++ b/yt/data_objects/tests/test_image_array.py
@@ -12,7 +12,7 @@ from yt.testing import requires_module
 old_settings = None
 
 
-def setup():
+def setup_module():
     global old_settings
     from yt.config import ytcfg
 
@@ -21,7 +21,7 @@ def setup():
     np.seterr(all="ignore")
 
 
-def teardown():
+def teardown_module():
     np.seterr(**old_settings)
 
 

--- a/yt/data_objects/tests/test_numpy_ops.py
+++ b/yt/data_objects/tests/test_numpy_ops.py
@@ -4,7 +4,7 @@ from numpy.testing import assert_equal
 from yt.testing import fake_amr_ds, fake_random_ds
 
 
-def setup():
+def setup_module():
     from yt.config import ytcfg
 
     ytcfg["yt", "internals", "within_testing"] = True

--- a/yt/data_objects/tests/test_particle_trajectories.py
+++ b/yt/data_objects/tests/test_particle_trajectories.py
@@ -6,7 +6,7 @@ from yt.data_objects.time_series import DatasetSeries
 from yt.utilities.answer_testing.framework import GenericArrayTest, requires_ds
 
 
-def setup():
+def setup_module():
     ytcfg["yt", "internals", "within_testing"] = True
 
 

--- a/yt/data_objects/tests/test_points.py
+++ b/yt/data_objects/tests/test_points.py
@@ -5,7 +5,7 @@ import yt
 from yt.testing import fake_random_ds
 
 
-def setup():
+def setup_module():
     from yt.config import ytcfg
 
     ytcfg["yt", "internals", "within_testing"] = True

--- a/yt/data_objects/tests/test_projection.py
+++ b/yt/data_objects/tests/test_projection.py
@@ -11,7 +11,7 @@ from yt.units.unit_object import Unit
 LENGTH_UNIT = 2.0
 
 
-def setup():
+def setup_module():
     from yt.config import ytcfg
 
     ytcfg["yt", "internals", "within_testing"] = True

--- a/yt/data_objects/tests/test_slice.py
+++ b/yt/data_objects/tests/test_slice.py
@@ -9,7 +9,7 @@ from yt.testing import fake_random_ds
 from yt.units.unit_object import Unit
 
 
-def setup():
+def setup_module():
     from yt.config import ytcfg
 
     ytcfg["yt", "internals", "within_testing"] = True

--- a/yt/data_objects/tests/test_spheres.py
+++ b/yt/data_objects/tests/test_spheres.py
@@ -6,7 +6,7 @@ from yt.testing import fake_random_ds, periodicity_cases, requires_module
 from yt.utilities.exceptions import YTException, YTFieldNotFound
 
 
-def setup():
+def setup_module():
     from yt.config import ytcfg
 
     ytcfg["yt", "internals", "within_testing"] = True

--- a/yt/fields/tests/test_magnetic_fields.py
+++ b/yt/fields/tests/test_magnetic_fields.py
@@ -5,7 +5,7 @@ from yt.loaders import load_uniform_grid
 from yt.utilities.physical_constants import mu_0
 
 
-def setup():
+def setup_module():
     from yt.config import ytcfg
 
     ytcfg["yt", "internals", "within_testing"] = True

--- a/yt/fields/tests/test_xray_fields.py
+++ b/yt/fields/tests/test_xray_fields.py
@@ -8,7 +8,7 @@ from yt.utilities.answer_testing.framework import (
 )
 
 
-def setup():
+def setup_module():
     from yt.config import ytcfg
 
     ytcfg["yt", "internals", "within_testing"] = True

--- a/yt/utilities/grid_data_format/tests/test_writer.py
+++ b/yt/utilities/grid_data_format/tests/test_writer.py
@@ -14,7 +14,7 @@ TEST_AUTHOR = "yt test runner"
 TEST_COMMENT = "Testing write_to_gdf"
 
 
-def setup():
+def setup_module():
     """Test specific setup."""
     from yt.config import ytcfg
 

--- a/yt/utilities/lib/tests/test_alt_ray_tracers.py
+++ b/yt/utilities/lib/tests/test_alt_ray_tracers.py
@@ -10,7 +10,7 @@ left_grid = right_grid = amr_levels = center_grid = data = None
 old_settings = None
 
 
-def setup():
+def setup_module():
     # set up some sample cylindrical grid data, radiating out from center
     global left_grid, right_grid, amr_levels, center_grid, data, old_settings
     old_settings = np.geterr()
@@ -24,7 +24,7 @@ def setup():
     data = np.cos(np.sqrt(np.sum(center_grid[:, :2] ** 2, axis=1))) ** 2  # cos^2
 
 
-def teardown():
+def teardown_module():
     np.seterr(**old_settings)
 
 

--- a/yt/utilities/lib/tests/test_sample.py
+++ b/yt/utilities/lib/tests/test_sample.py
@@ -4,10 +4,6 @@ from numpy.testing import assert_allclose
 from yt.utilities.lib.particle_mesh_operations import CICSample_3
 
 
-def setup():
-    pass
-
-
 def test_sample():
     grid = {}
 

--- a/yt/utilities/tests/test_decompose.py
+++ b/yt/utilities/tests/test_decompose.py
@@ -4,10 +4,6 @@ from numpy.testing import assert_almost_equal, assert_array_equal
 import yt.utilities.decompose as dec
 
 
-def setup():
-    pass
-
-
 def test_psize_2d():
     procs = dec.get_psize(np.array([5, 1, 7]), 6)
     assert_array_equal(procs, np.array([3, 1, 2]))

--- a/yt/utilities/tests/test_interpolators.py
+++ b/yt/utilities/tests/test_interpolators.py
@@ -6,10 +6,6 @@ from yt.testing import fake_random_ds
 from yt.utilities.lib.interpolators import ghost_zone_interpolate
 
 
-def setup():
-    pass
-
-
 def test_linear_interpolator_1d():
     random_data = np.random.random(64)
     fv = {"x": np.mgrid[0.0:1.0:64j]}

--- a/yt/utilities/tests/test_minimal_representation.py
+++ b/yt/utilities/tests/test_minimal_representation.py
@@ -8,13 +8,17 @@ from yt.testing import requires_file, requires_module
 
 G30 = "IsolatedGalaxy/galaxy0030/galaxy0030"
 
+old_serialize = None
 
-def setup():
+
+def setup_module():
+    global old_serialize
+    old_serialize = ytcfg.get("yt", "serialize")
     ytcfg["yt", "serialize"] = True
 
 
-def teardown():
-    ytcfg["yt", "serialize"] = False
+def teardown_module():
+    ytcfg["yt", "serialize"] = old_serialize
 
 
 @requires_module("h5py")

--- a/yt/utilities/tests/test_periodicity.py
+++ b/yt/utilities/tests/test_periodicity.py
@@ -5,7 +5,7 @@ from yt.testing import fake_random_ds
 from yt.utilities.math_utils import euclidean_dist, periodic_dist
 
 
-def setup():
+def setup_module():
     from yt.config import ytcfg
 
     ytcfg["yt", "internals", "within_testing"] = True

--- a/yt/utilities/tests/test_selectors.py
+++ b/yt/utilities/tests/test_selectors.py
@@ -5,7 +5,7 @@ from yt.testing import fake_random_ds
 from yt.utilities.math_utils import periodic_dist
 
 
-def setup():
+def setup_module():
     from yt.config import ytcfg
 
     ytcfg["yt", "internals", "within_testing"] = True

--- a/yt/utilities/tests/test_set_log_level.py
+++ b/yt/utilities/tests/test_set_log_level.py
@@ -5,14 +5,14 @@ from yt.utilities.logger import set_log_level
 old_level = None
 
 
-def setup():
+def setup_module():
     global old_level
     from yt.utilities.logger import ytLogger
 
     old_level = ytLogger.level
 
 
-def teardown():
+def teardown_module():
     set_log_level(old_level)
 
 

--- a/yt/visualization/tests/test_export_frb.py
+++ b/yt/visualization/tests/test_export_frb.py
@@ -4,7 +4,7 @@ from numpy.testing import assert_equal
 from yt.testing import assert_allclose_units, fake_random_ds
 
 
-def setup():
+def setup_module():
     """Test specific setup."""
     from yt.config import ytcfg
 

--- a/yt/visualization/tests/test_geo_projections.py
+++ b/yt/visualization/tests/test_geo_projections.py
@@ -7,7 +7,7 @@ from yt.testing import fake_amr_ds, requires_module
 from yt.visualization.geo_plot_utils import get_mpl_transform, transform_list
 
 
-def setup():
+def setup_module():
     """Test specific setup."""
     from yt.config import ytcfg
 

--- a/yt/visualization/tests/test_line_plots.py
+++ b/yt/visualization/tests/test_line_plots.py
@@ -6,7 +6,7 @@ from yt.testing import fake_random_ds
 from yt.visualization.line_plot import _validate_point
 
 
-def setup():
+def setup_module():
     """Test specific setup."""
     from yt.config import ytcfg
 

--- a/yt/visualization/tests/test_mesh_slices.py
+++ b/yt/visualization/tests/test_mesh_slices.py
@@ -7,7 +7,7 @@ from yt.utilities.lib.geometry_utils import triangle_plane_intersect
 from yt.utilities.lib.mesh_triangulation import triangulate_indices
 
 
-def setup():
+def setup_module():
     """Test specific setup."""
     from yt.config import ytcfg
 

--- a/yt/visualization/tests/test_particle_plot.py
+++ b/yt/visualization/tests/test_particle_plot.py
@@ -22,7 +22,7 @@ from yt.visualization.api import ParticlePhasePlot, ParticlePlot, ParticleProjec
 from yt.visualization.tests.test_plotwindow import ATTR_ARGS, WIDTH_SPECS
 
 
-def setup():
+def setup_module():
     """Test specific setup."""
     from yt.config import ytcfg
 

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -44,7 +44,7 @@ from yt.visualization.plot_window import (
 )
 
 
-def setup():
+def setup_module():
     """Test specific setup."""
     from yt.config import ytcfg
 

--- a/yt/visualization/tests/test_splat.py
+++ b/yt/visualization/tests/test_splat.py
@@ -11,7 +11,7 @@ import yt
 from yt.utilities.lib.api import add_rgba_points_to_image  # type: ignore
 
 
-def setup():
+def setup_module():
     """Test specific setup."""
     from yt.config import ytcfg
 

--- a/yt/visualization/volume_rendering/tests/test_composite.py
+++ b/yt/visualization/volume_rendering/tests/test_composite.py
@@ -15,7 +15,7 @@ from yt.visualization.volume_rendering.api import (
 )
 
 
-def setup():
+def setup_module():
     """Test specific setup."""
     from yt.config import ytcfg
 

--- a/yt/visualization/volume_rendering/tests/test_lenses.py
+++ b/yt/visualization/volume_rendering/tests/test_lenses.py
@@ -9,7 +9,7 @@ from yt.testing import fake_random_ds
 from yt.visualization.volume_rendering.api import Scene, create_volume_source
 
 
-def setup():
+def setup_module():
     """Test specific setup."""
     from yt.config import ytcfg
 

--- a/yt/visualization/volume_rendering/tests/test_points.py
+++ b/yt/visualization/volume_rendering/tests/test_points.py
@@ -13,7 +13,7 @@ from yt.visualization.volume_rendering.api import (
 )
 
 
-def setup():
+def setup_module():
     """Test specific setup."""
     from yt.config import ytcfg
 

--- a/yt/visualization/volume_rendering/tests/test_save_render.py
+++ b/yt/visualization/volume_rendering/tests/test_save_render.py
@@ -7,7 +7,7 @@ import yt
 from yt.testing import fake_random_ds
 
 
-def setup():
+def setup_module():
     """Test specific setup."""
     from yt.config import ytcfg
 

--- a/yt/visualization/volume_rendering/tests/test_scene.py
+++ b/yt/visualization/volume_rendering/tests/test_scene.py
@@ -13,7 +13,7 @@ from yt.visualization.volume_rendering.api import (
 )
 
 
-def setup():
+def setup_module():
     """Test specific setup."""
     from yt.config import ytcfg
 

--- a/yt/visualization/volume_rendering/tests/test_sigma_clip.py
+++ b/yt/visualization/volume_rendering/tests/test_sigma_clip.py
@@ -7,7 +7,7 @@ import yt
 from yt.testing import fake_random_ds
 
 
-def setup():
+def setup_module():
     """Test specific setup."""
     from yt.config import ytcfg
 

--- a/yt/visualization/volume_rendering/tests/test_simple_vr.py
+++ b/yt/visualization/volume_rendering/tests/test_simple_vr.py
@@ -7,7 +7,7 @@ import yt
 from yt.testing import fake_random_ds
 
 
-def setup():
+def setup_module():
     """Test specific setup."""
     from yt.config import ytcfg
 

--- a/yt/visualization/volume_rendering/tests/test_varia.py
+++ b/yt/visualization/volume_rendering/tests/test_varia.py
@@ -10,7 +10,7 @@ from yt.testing import fake_random_ds
 from yt.visualization.volume_rendering.api import Scene, create_volume_source
 
 
-def setup():
+def setup_module():
     """Test specific setup."""
     from yt.config import ytcfg
 

--- a/yt/visualization/volume_rendering/tests/test_vr_cameras.py
+++ b/yt/visualization/volume_rendering/tests/test_vr_cameras.py
@@ -20,7 +20,7 @@ from yt.visualization.volume_rendering.old_camera import (
 )
 
 
-def setup():
+def setup_module():
     """Test specific setup."""
     from yt.config import ytcfg
 

--- a/yt/visualization/volume_rendering/tests/test_zbuff.py
+++ b/yt/visualization/volume_rendering/tests/test_zbuff.py
@@ -24,7 +24,7 @@ class FakeOpaqueSource(OpaqueSource):
         pass
 
 
-def setup():
+def setup_module():
     """Test specific setup."""
     from yt.config import ytcfg
 


### PR DESCRIPTION
## PR Summary

This fixes part of #4850, and effectively migrates part of the test suite away from nosetest.
It's also based off of #4849 

xref https://github.com/pytest-dev/pytest/issues/12113


Opening with a simple find/replace. I'll see which affected modules are still run on nose and wether they can simply be ignored there. If more work is needed to migrate them I'll simply make them nose-only as a quick fix.