### PR TITLE
TST: temporarily pin pytest<8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,7 +191,7 @@ doc = [
     "jupyter-client>=8.3.1",
     "nbsphinx>=0.9.3",
     "nose~=1.3.7; python_version < '3.10'",
-    "pytest>=6.1",
+    "pytest>=6.1, <8.0",
     "pyx>=0.15",
     "sphinx>=7.2.5",
     "sphinx-bootstrap-theme>=0.8.1",
@@ -217,7 +217,7 @@ minimal = [
 ]
 test = [
     "pyaml>=17.10.0",
-    "pytest>=6.1",
+    "pytest>=6.1, <8.0",
     "pytest-mpl>=0.16.1",
     "sympy!=1.10,!=1.9", # see https://github.com/sympy/sympy/issues/22241
     "nose~=1.3.7; python_version < '3.10'",


### PR DESCRIPTION
## PR Summary

In replacement of #4851
The proper fix is to migrate out of a compatibility shim for nosetest that was removed in pytest 8.0, but it turns out non trivial (see #4852) so I suggest just pinning for now to quickly get CI back to a useful state.