### PR TITLE
BLD: add support for numpy 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ keywords = [
 requires-python = ">=3.9.2"
 dependencies = [
     "cmyt>=1.1.2",
-    "ewah-bool-utils>=1.0.2",
+    "ewah-bool-utils>=1.2.0",
     "ipywidgets>=8.0.0",
     "matplotlib>=3.5",
     "more-itertools>=8.4",
@@ -202,7 +202,7 @@ mapserver = [
 ]
 minimal = [
     "cmyt==1.1.2",
-    "ewah-bool-utils==1.0.2",
+    "ewah-bool-utils==1.2.0",
     "ipywidgets==8.0.0",
     "matplotlib==3.5",
     "more-itertools==8.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ requires = [
   # for the upper pin in Cython
   # see https://github.com/yt-project/yt/issues/4044
   "Cython>=3.0.3, <3.1",
-  "numpy>=1.25, <2.0",
-  "ewah-bool-utils>=1.0.2",
+  "numpy>=2.0.0rc1",
+  "ewah-bool-utils>=1.2.0",
 ]
 build-backend = "setuptools.build_meta:__legacy__"
 
@@ -48,7 +48,7 @@ dependencies = [
     "ipywidgets>=8.0.0",
     "matplotlib>=3.5",
     "more-itertools>=8.4",
-    "numpy>=1.19.3", # keep minimal requirement in sync with NPY_TARGET_VERSION
+    "numpy>=1.19.3, <3", # keep minimal requirement in sync with NPY_TARGET_VERSION
     "packaging>=20.9",
     "pillow>=8.0.0",
     "tomli-w>=0.4.0",


### PR DESCRIPTION
## PR Summary

numpy 2.0.0rc1 was just released, meaning it's now ABI stable, so we can (and should) start publishing wheels built against.
This is the last blocker for yt 4.3.1


## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
