### PR TITLE
RFC: Replace np.random.random use with np.random.default_rng

### DIFF
--- a/yt/fields/field_detector.py
+++ b/yt/fields/field_detector.py
@@ -81,17 +81,18 @@ class FieldDetector(defaultdict):
         self.index = fake_index()
         self.requested = []
         self.requested_parameters = []
+        rng = np.random.default_rng()
         if not self.flat:
             defaultdict.__init__(
                 self,
                 lambda: np.ones((nd, nd, nd), dtype="float64")
-                + 1e-4 * np.random.random((nd, nd, nd)),
+                + 1e-4 * rng.random((nd, nd, nd)),
             )
         else:
             defaultdict.__init__(
                 self,
                 lambda: np.ones((nd * nd * nd), dtype="float64")
-                + 1e-4 * np.random.random(nd * nd * nd),
+                + 1e-4 * rng.random(nd * nd * nd),
             )
 
     def _reshape_vals(self, arr):
@@ -194,7 +195,8 @@ class FieldDetector(defaultdict):
         if kwargs["method"] == "mesh_id":
             if isinstance(self.ds, (StreamParticlesDataset, ParticleDataset)):
                 raise ValueError
-        return np.random.random((self.nd, self.nd, self.nd))
+        rng = np.random.default_rng()
+        return rng.random((self.nd, self.nd, self.nd))
 
     def mesh_sampling_particle_field(self, *args, **kwargs):
         pos = args[0]
@@ -203,7 +205,8 @@ class FieldDetector(defaultdict):
         return rng.random(npart)
 
     def smooth(self, *args, **kwargs):
-        tr = np.random.random((self.nd, self.nd, self.nd))
+        rng = np.random.default_rng()
+        tr = rng.random((self.nd, self.nd, self.nd))
         if kwargs["method"] == "volume_weighted":
             return [tr]
 
@@ -236,7 +239,8 @@ class FieldDetector(defaultdict):
                     unit = "G"
             else:
                 unit = fp_units[param]
-            return self.ds.arr(np.random.random(3) * 1e-2, unit)
+            rng = np.random.default_rng()
+            return self.ds.arr(rng.random(3) * 1e-2, unit)
         elif param in ["surface_height"]:
             return self.ds.quan(0.0, "code_length")
         elif param in ["axis"]:
@@ -280,7 +284,8 @@ class FieldDetector(defaultdict):
 
     @property
     def fcoords_vertex(self):
-        fc = np.random.random((self.nd, self.nd, self.nd, 8, 3))
+        rng = np.random.default_rng()
+        fc = rng.random((self.nd, self.nd, self.nd, 8, 3))
         if self.flat:
             fc.shape = (self.nd * self.nd * self.nd, 8, 3)
         return self.ds.arr(fc, units="code_length")

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -505,12 +505,13 @@ def small_fake_hexahedral_ds():
 def fake_stretched_ds(N=16):
     from yt.loaders import load_uniform_grid
 
-    np.random.RandomState().seed(0x4D3D3D3)
-    data = {"density": np.random.random((N, N, N))}
+    rng = np.random.default_rng(seed=0x4D3D3D3)
+
+    data = {"density": rng.random((N, N, N))}
 
     cell_widths = []
     for _ in range(3):
-        cw = np.random.random(N)
+        cw = rng.random(N)
         cw /= cw.sum()
         cell_widths.append(cw)
     return load_uniform_grid(

--- a/yt/utilities/initial_conditions.py
+++ b/yt/utilities/initial_conditions.py
@@ -97,7 +97,8 @@ class RandomFluctuation(FluidOperator):
     def __call__(self, grid, sub_select=None):
         if sub_select is None:
             sub_select = Ellipsis
+        rng = np.random.default_rng()
         for field, mag in self.fields.items():
             vals = grid[field][sub_select]
-            rc = 1.0 + (np.random.random(vals.shape) - 0.5) * mag
+            rc = 1.0 + (rng.random(vals.shape) - 0.5) * mag
             grid[field][sub_select] *= rc

--- a/yt/visualization/volume_rendering/zbuffer_array.py
+++ b/yt/visualization/volume_rendering/zbuffer_array.py
@@ -21,8 +21,9 @@ class ZBuffer:
     --------
     >>> import numpy as np
     >>> shape = (64, 64)
-    >>> b1 = Zbuffer(np.random.random(shape), np.ones(shape))
-    >>> b2 = Zbuffer(np.random.random(shape), np.zeros(shape))
+    >>> rng = np.random.default_rng()
+    >>> b1 = Zbuffer(rng.random(shape), np.ones(shape))
+    >>> b2 = Zbuffer(rng.random(shape), np.zeros(shape))
     >>> c = b1 + b2
     >>> np.all(c.rgba == b2.rgba)
     True
@@ -76,9 +77,10 @@ class ZBuffer:
 if __name__ == "__main__":
     shape: tuple[int, ...] = (64, 64)
     shapes: list[tuple[int, ...]] = [(64, 64), (16, 16, 4), (128,), (16, 32)]
+    rng = np.random.default_rng()
     for shape in shapes:
-        b1 = ZBuffer(np.random.random(shape), np.ones(shape))
-        b2 = ZBuffer(np.random.random(shape), np.zeros(shape))
+        b1 = ZBuffer(rng.random(shape), np.ones(shape))
+        b2 = ZBuffer(rng.random(shape), np.zeros(shape))
         c = b1 + b2
         assert np.all(c.rgba == b2.rgba)
         assert np.all(c.z == b2.z)


### PR DESCRIPTION
#4863 caught some uses of the legacy np.random.random api missed by #4733. Since one of the uses is within a test function, I thought it'd be clearer to create a separate PR instead of pushing to #4863 (in case there are failures related to changing the test function)