### PR TITLE
STY: migrate formatting from black to ruff-format

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -47,3 +47,6 @@ ec8bb45ea1603f3862041fa9e8ec274afd9bbbfd
 
 # auto upgrade typing idioms from Python 3.8 to 3.9
 4cfd370a8445abd4620e3853c2c047ee3d649fd7
+
+# migration: black -> ruff-format
+3214662dc7d53f7ac56b3589c5a27ef075f83ab4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,21 +27,21 @@ repos:
     - id: check-executables-have-shebangs
     - id: check-yaml
 
--   repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 24.3.0
-    hooks:
-    - id: black-jupyter
-
+# TODO: replace this with ruff when it supports embedded python blocks
+# see https://github.com/astral-sh/ruff/issues/8237
 -   repo: https://github.com/adamchainz/blacken-docs
     rev: 1.16.0
     hooks:
     -   id: blacken-docs
-        additional_dependencies: [black==23.9.1]
+        additional_dependencies: [black==24.3.0]
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.3.4
+  rev: v0.4.0
   hooks:
+  - id: ruff-format
+    types_or: [ python, pyi, jupyter ]
   - id: ruff
+    types_or: [ python, pyi, jupyter ]
     args: [--fix, "--show-fixes"]
 
 -   repo: https://github.com/pre-commit/pygrep-hooks

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
 [![Build and Test](https://github.com/yt-project/yt/actions/workflows/build-test.yaml/badge.svg)](https://github.com/yt-project/yt/actions/workflows/build-test.yaml)
 [![CI (bleeding edge)](https://github.com/yt-project/yt/actions/workflows/bleeding-edge.yaml/badge.svg)](https://github.com/yt-project/yt/actions/workflows/bleeding-edge.yaml)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/yt-project/yt/main.svg)](https://results.pre-commit.ci/latest/github/yt-project/yt/main)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v2.json)](https://github.com/charliermarsh/ruff)
 
 <!--- [![codecov](https://codecov.io/gh/yt-project/yt/branch/main/graph/badge.svg)](https://codecov.io/gh/yt-project/yt) --->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,10 +242,9 @@ zip-safe = false
 [tool.setuptools.packages.find]
 namespaces = false
 
-
 [tool.black]
-line-length = 88
-target-version = ['py39']
+# TODO: drop this section when ruff supports embedded python blocks
+# see https://github.com/astral-sh/ruff/issues/8237
 include = '\.pyi?$'
 exclude = '''
 /(
@@ -278,6 +277,7 @@ exclude = [
     "yt/utilities/lodgeit.py",
     "yt/mods.py",
     "yt/visualization/_colormap_data.py",
+    "yt/exthook.py",
 ]
 
 [tool.ruff.lint]

--- a/tests/report_failed_answers.py
+++ b/tests/report_failed_answers.py
@@ -402,7 +402,7 @@ if __name__ == "__main__":
     COLOR_PURPLE = "\x1b[35;1m"
     COLOR_CYAN = "\x1b[36;1m"
     COLOR_RESET = "\x1b[0m"
-    FLAG_EMOJI = " \U0001F6A9 "
+    FLAG_EMOJI = " \U0001f6a9 "
 
     failed_answers = missing_answers = None
     if args.upload_failed_tests or args.upload_missing_answers:

--- a/yt/data_objects/construction_data_containers.py
+++ b/yt/data_objects/construction_data_containers.py
@@ -1136,22 +1136,19 @@ class YTCoveringGrid(YTSelectionContainer3D):
             np.multiply(rv, self.dds[2], rv)
         elif field == ("index", axis_name[0]):
             x = np.mgrid[
-                self.left_edge[0]
-                + 0.5 * self.dds[0] : self.right_edge[0]
+                self.left_edge[0] + 0.5 * self.dds[0] : self.right_edge[0]
                 - 0.5 * self.dds[0] : self.ActiveDimensions[0] * 1j
             ]
             np.multiply(rv, x[:, None, None], rv)
         elif field == ("index", axis_name[1]):
             y = np.mgrid[
-                self.left_edge[1]
-                + 0.5 * self.dds[1] : self.right_edge[1]
+                self.left_edge[1] + 0.5 * self.dds[1] : self.right_edge[1]
                 - 0.5 * self.dds[1] : self.ActiveDimensions[1] * 1j
             ]
             np.multiply(rv, y[None, :, None], rv)
         elif field == ("index", axis_name[2]):
             z = np.mgrid[
-                self.left_edge[2]
-                + 0.5 * self.dds[2] : self.right_edge[2]
+                self.left_edge[2] + 0.5 * self.dds[2] : self.right_edge[2]
                 - 0.5 * self.dds[2] : self.ActiveDimensions[2] * 1j
             ]
             np.multiply(rv, z[None, None, :], rv)

--- a/yt/data_objects/level_sets/clump_handling.py
+++ b/yt/data_objects/level_sets/clump_handling.py
@@ -334,9 +334,9 @@ class Clump(TreeContainer):
                                 np.int64
                             )
                             ftypes[cfield] = ptype
-                        field_data[cfield][
-                            clump.data._part_ind(ptype)
-                        ] = clump.contour_id
+                        field_data[cfield][clump.data._part_ind(ptype)] = (
+                            clump.contour_id
+                        )
 
             if need_grid_positions:
                 for ax in "xyz":

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -131,9 +131,9 @@ class ProfileND(ParallelAnalysisInterface):
 
         for i, _field in enumerate(fields):
             # q values are returned as q * weight but we want just q
-            temp_storage.qvalues[..., i][
-                temp_storage.used
-            ] /= temp_storage.weight_values[temp_storage.used]
+            temp_storage.qvalues[..., i][temp_storage.used] /= (
+                temp_storage.weight_values[temp_storage.used]
+            )
 
         # get the profile data from all procs
         all_store = {self.comm.rank: temp_storage}

--- a/yt/data_objects/tests/test_dataset_access.py
+++ b/yt/data_objects/tests/test_dataset_access.py
@@ -46,12 +46,12 @@ def test_region_from_d():
     assert_equal(reg1["gas", "density"], reg2["gas", "density"])
 
     # Now, string units in some -- 1.0 == cm
-    reg1 = ds.r[(0.1, "cm"):(0.5, "cm"), :, (0.25, "cm"):(0.35, "cm")]
+    reg1 = ds.r[(0.1, "cm") : (0.5, "cm"), :, (0.25, "cm") : (0.35, "cm")]
     reg2 = ds.region([0.3, 0.5, 0.3], [0.1, 0.0, 0.25], [0.5, 1.0, 0.35])
     assert_equal(reg1["gas", "density"], reg2["gas", "density"])
 
     # Now, string units in some -- 1.0 == cm
-    reg1 = ds.r[(0.1, "cm"):(0.5, "cm"), :, 0.25:0.35]
+    reg1 = ds.r[(0.1, "cm") : (0.5, "cm"), :, 0.25:0.35]
     reg2 = ds.region([0.3, 0.5, 0.3], [0.1, 0.0, 0.25], [0.5, 1.0, 0.35])
     assert_equal(reg1["gas", "density"], reg2["gas", "density"])
 
@@ -127,7 +127,7 @@ def test_point_from_r():
 
 def test_ray_from_r():
     ds = fake_amr_ds(fields=["density"], units=["g/cm**3"])
-    ray1 = ds.r[(0.1, 0.2, 0.3):(0.4, 0.5, 0.6)]
+    ray1 = ds.r[(0.1, 0.2, 0.3) : (0.4, 0.5, 0.6)]
     ray2 = ds.ray((0.1, 0.2, 0.3), (0.4, 0.5, 0.6))
     assert_equal(ray1["gas", "density"], ray2["gas", "density"])
 

--- a/yt/frontends/chimera/io.py
+++ b/yt/frontends/chimera/io.py
@@ -1,5 +1,5 @@
 """
-    Chimera-specific IO functions
+Chimera-specific IO functions
 
 
 

--- a/yt/frontends/chombo/data_structures.py
+++ b/yt/frontends/chombo/data_structures.py
@@ -511,8 +511,7 @@ class PlutoDataset(ChomboDataset):
             domain_right_edge = np.zeros(self.dimensionality)
             for il, ll in enumerate(
                 lines[
-                    lines.index("[Grid]")
-                    + 2 : lines.index("[Grid]")
+                    lines.index("[Grid]") + 2 : lines.index("[Grid]")
                     + 2
                     + self.dimensionality
                 ]
@@ -522,8 +521,7 @@ class PlutoDataset(ChomboDataset):
             self._periodicity = [0] * 3
             for il, ll in enumerate(
                 lines[
-                    lines.index("[Boundary]")
-                    + 2 : lines.index("[Boundary]")
+                    lines.index("[Boundary]") + 2 : lines.index("[Boundary]")
                     + 2
                     + 6 : 2
                 ]

--- a/yt/frontends/enzo/data_structures.py
+++ b/yt/frontends/enzo/data_structures.py
@@ -1017,9 +1017,8 @@ class EnzoDatasetInMemory(EnzoDataset):
 
     def _parse_parameter_file(self):
         enzo = self._obtain_enzo()
-        self._input_filename = "cycle%08i" % (
-            enzo.yt_parameter_file["NumberOfPythonCalls"]
-        )
+        ncalls = enzo.yt_parameter_file["NumberOfPythonCalls"]
+        self._input_filename = f"cycle{ncalls:08d}"
         self.parameters["CurrentTimeIdentifier"] = time.time()
         self.parameters.update(enzo.yt_parameter_file)
         self.conversion_factors.update(enzo.conversion_factors)

--- a/yt/frontends/enzo/simulation_handling.py
+++ b/yt/frontends/enzo/simulation_handling.py
@@ -264,8 +264,7 @@ class EnzoSimulation(SimulationTimeSeries):
             my_outputs = my_all_outputs[
                 int(
                     np.ceil(float(initial_cycle) / self.parameters["CycleSkipDataDump"])
-                ) : (final_cycle / self.parameters["CycleSkipDataDump"])
-                + 1
+                ) : (final_cycle / self.parameters["CycleSkipDataDump"]) + 1
             ]
 
         else:

--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -143,42 +143,31 @@ class GAMERHierarchy(GridIndex):
         for grid in self.grids:
             # parent->children == itself
             if grid.Parent is not None:
-                assert (
-                    grid in grid.Parent.Children
-                ), "Grid %d, Parent %d, Parent->Children[0] %d" % (
-                    grid.id,
-                    grid.Parent.id,
-                    grid.Parent.Children[0].id,
+                assert grid in grid.Parent.Children, (
+                    f"Grid {grid.id}, Parent {grid.Parent.id}, "
+                    f"Parent->Children[0] {grid.Parent.Children[0].id}"
                 )
 
             # children->parent == itself
             for c in grid.Children:
-                assert c.Parent is grid, "Grid %d, Children %d, Children->Parent %d" % (
-                    grid.id,
-                    c.id,
-                    c.Parent.id,
+                assert c.Parent is grid, (
+                    f"Grid {grid.id}, Children {c.id}, "
+                    f"Children->Parent {c.Parent.id}"
                 )
 
             # all refinement grids should have parent
             if grid.Level > 0:
-                assert (
-                    grid.Parent is not None and grid.Parent.id >= 0
-                ), "Grid %d, Level %d, Parent %d" % (
-                    grid.id,
-                    grid.Level,
-                    grid.Parent.id if grid.Parent is not None else -999,
+                assert grid.Parent is not None and grid.Parent.id >= 0, (
+                    f"Grid {grid.id}, Level {grid.Level}, "
+                    f"Parent {grid.Parent.id if grid.Parent is not None else -999}"
                 )
 
             # parent index is consistent with the loaded dataset
             if grid.Level > 0:
                 father_gid = father_list[grid.id * self.pgroup] // self.pgroup
-                assert (
-                    father_gid == grid.Parent.id
-                ), "Grid %d, Level %d, Parent_Found %d, Parent_Expect %d" % (
-                    grid.id,
-                    grid.Level,
-                    grid.Parent.id,
-                    father_gid,
+                assert father_gid == grid.Parent.id, (
+                    f"Grid {grid.id}, Level {grid.Level}, "
+                    f"Parent_Found {grid.Parent.id}, Parent_Expect {father_gid}"
                 )
 
             # edges between children and parent

--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -629,7 +629,8 @@ class RAMSESIndex(OctreeIndex):
     @cached_property
     def num_grids(self):
         return sum(
-            dom.local_oct_count for dom in self.domains  # + dom.ngridbound.sum()
+            dom.local_oct_count
+            for dom in self.domains  # + dom.ngridbound.sum()
         )
 
     def _detect_output_fields(self):

--- a/yt/frontends/ramses/io.py
+++ b/yt/frontends/ramses/io.py
@@ -231,11 +231,15 @@ class IOHandlerRAMSES(BaseIOHandler):
             for subset in chunk.objs:
                 rv = self._read_particle_subset(subset, fields)
                 for ptype in sorted(ptf):
-                    yield ptype, (
-                        rv[ptype, pn % "x"],
-                        rv[ptype, pn % "y"],
-                        rv[ptype, pn % "z"],
-                    ), 0.0
+                    yield (
+                        ptype,
+                        (
+                            rv[ptype, pn % "x"],
+                            rv[ptype, pn % "y"],
+                            rv[ptype, pn % "z"],
+                        ),
+                        0.0,
+                    )
 
     def _read_particle_fields(self, chunks, ptf, selector):
         pn = "particle_position_%s"

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -318,9 +318,7 @@ def test_ramses_part_count():
 @requires_file(ramsesCosmo)
 def test_custom_particle_def():
     ytcfg.add_section("ramses-particles")
-    ytcfg[
-        "ramses-particles", "fields"
-    ] = """particle_position_x, d
+    ytcfg["ramses-particles", "fields"] = """particle_position_x, d
          particle_position_y, d
          particle_position_z, d
          particle_velocity_x, d

--- a/yt/frontends/sdf/io.py
+++ b/yt/frontends/sdf/io.py
@@ -20,11 +20,15 @@ class IOHandlerSDF(BaseParticleIOHandler):
         data_files = self._get_data_files(chunks)
         assert len(data_files) == 1
         for _data_file in sorted(data_files, key=lambda x: (x.filename, x.start)):
-            yield "dark_matter", (
-                self._handle["x"],
-                self._handle["y"],
-                self._handle["z"],
-            ), 0.0
+            yield (
+                "dark_matter",
+                (
+                    self._handle["x"],
+                    self._handle["y"],
+                    self._handle["z"],
+                ),
+                0.0,
+            )
 
     def _read_particle_fields(self, chunks, ptf, selector):
         assert len(ptf) == 1
@@ -78,11 +82,15 @@ class IOHandlerHTTPSDF(IOHandlerSDF):
         assert len(data_files) == 1
         for _data_file in data_files:
             pcount = self._handle["x"].size
-            yield "dark_matter", (
-                self._handle["x"][:pcount],
-                self._handle["y"][:pcount],
-                self._handle["z"][:pcount],
-            ), 0.0
+            yield (
+                "dark_matter",
+                (
+                    self._handle["x"][:pcount],
+                    self._handle["y"][:pcount],
+                    self._handle["z"][:pcount],
+                ),
+                0.0,
+            )
 
     def _read_particle_fields(self, chunks, ptf, selector):
         chunks = list(chunks)

--- a/yt/frontends/stream/io.py
+++ b/yt/frontends/stream/io.py
@@ -108,11 +108,15 @@ class StreamParticleIOHandler(BaseParticleIOHandler):
             f = self.fields[data_file.filename]
             # This double-reads
             for ptype in sorted(ptf):
-                yield ptype, (
-                    f[ptype, "particle_position_x"],
-                    f[ptype, "particle_position_y"],
-                    f[ptype, "particle_position_z"],
-                ), 0.0
+                yield (
+                    ptype,
+                    (
+                        f[ptype, "particle_position_x"],
+                        f[ptype, "particle_position_y"],
+                        f[ptype, "particle_position_z"],
+                    ),
+                    0.0,
+                )
 
     def _read_smoothing_length(self, chunks, ptf, ptype):
         for data_file in self._sorted_chunk_iterator(chunks):

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -220,8 +220,7 @@ def rootonly(func):
     .. code-block:: python
 
        @rootonly
-       def some_root_only_function(*args, **kwargs):
-           ...
+       def some_root_only_function(*args, **kwargs): ...
     """
 
     @wraps(func)
@@ -1090,8 +1089,9 @@ def array_like_field(data, x, field):
 def validate_3d_array(obj):
     if not is_sequence(obj) or len(obj) != 3:
         raise TypeError(
-            "Expected an array of size (3,), received '{}' of "
-            "length {}".format(str(type(obj)).split("'")[1], len(obj))
+            "Expected an array of size (3,), received '{}' of length {}".format(
+                str(type(obj)).split("'")[1], len(obj)
+            )
         )
 
 

--- a/yt/geometry/coordinates/tests/test_geographic_coordinates.py
+++ b/yt/geometry/coordinates/tests/test_geographic_coordinates.py
@@ -74,7 +74,6 @@ def test_geographic_coordinates(geometry):
 
 @pytest.mark.parametrize("geometry", ("geographic", "internal_geographic"))
 def test_geographic_conversions(geometry):
-
     ds = fake_amr_ds(geometry=geometry)
     ad = ds.all_data()
     lats = ad["index", "latitude"]

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -613,7 +613,7 @@ class ProjectionValuesTest(AnswerTestingTest):
                 assert_equal(nres, ores, err_msg=err_msg)
             else:
                 assert_allclose_units(
-                    nres, ores, 10.0 ** -(self.decimals), err_msg=err_msg
+                    nres, ores, 10.0**-(self.decimals), err_msg=err_msg
                 )
 
 

--- a/yt/visualization/volume_rendering/render_source.py
+++ b/yt/visualization/volume_rendering/render_source.py
@@ -336,8 +336,8 @@ class VolumeSource(RenderSource, abc.ABC):
         if len(field) > 1:
             raise RuntimeError(
                 "VolumeSource.field can only be a single field but received "
-                "multiple fields: %s"
-            ) % field
+                f"multiple fields: {field}"
+            )
         field = field[0]
         if self._field != field:
             log_field = self.data_source.ds.field_info[field].take_log


### PR DESCRIPTION
## PR Summary

Closes #4748
The formatting commit is "semi-automated" because ruff was, in some places, somewhat akwardly moving around some strings formatted with `%`, but I found manually changing them to fstrings helped.