### PR TITLE
Backport PR #4859: BLD: add support for numpy 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ requires = [
   # for the upper pin in Cython
   # see https://github.com/yt-project/yt/issues/4044
   "Cython>=3.0.3, <3.1",
-  "numpy>=1.25, <2.0",
-  "ewah-bool-utils>=1.0.2",
+  "numpy>=2.0.0rc1",
+  "ewah-bool-utils>=1.2.0",
 ]
 build-backend = "setuptools.build_meta:__legacy__"
 
@@ -44,11 +44,11 @@ keywords = [
 requires-python = ">=3.9.2"
 dependencies = [
     "cmyt>=1.1.2",
-    "ewah-bool-utils>=1.0.2",
+    "ewah-bool-utils>=1.2.0",
     "ipywidgets>=8.0.0",
     "matplotlib>=3.5",
     "more-itertools>=8.4",
-    "numpy>=1.19.3, <2", # keep minimal requirement in sync with NPY_TARGET_VERSION
+    "numpy>=1.19.3, <3", # keep minimal requirement in sync with NPY_TARGET_VERSION
     "packaging>=20.9",
     "pillow>=8.0.0",
     "tomli-w>=0.4.0",
@@ -202,7 +202,7 @@ mapserver = [
 ]
 minimal = [
     "cmyt==1.1.2",
-    "ewah-bool-utils==1.0.2",
+    "ewah-bool-utils==1.2.0",
     "ipywidgets==8.0.0",
     "matplotlib==3.5",
     "more-itertools==8.4",


### PR DESCRIPTION
manual backport to  workaround a small conflict (numpy was pinned to <2 on the backport branch but not on main)