### PR TITLE
BUG: Always use the coordinate system normal for computing angular momentum components for particles

### DIFF
--- a/yt/fields/particle_fields.py
+++ b/yt/fields/particle_fields.py
@@ -302,12 +302,7 @@ def particle_vector_functions(ptype, coord_names, vel_names, registry):
 
 
 def get_angular_momentum_components(ptype, data, spos, svel):
-    if data.has_field_parameter("normal"):
-        normal = data.get_field_parameter("normal")
-    else:
-        normal = data.ds.arr(
-            [0.0, 0.0, 1.0], "code_length"
-        )  # default to simulation axis
+    normal = data.ds.arr([0.0, 0.0, 1.0], "code_length")  # default to simulation axis
     pos = data.ds.arr([data[ptype, spos % ax] for ax in "xyz"]).T
     vel = data.ds.arr([data[ptype, f"relative_{svel % ax}"] for ax in "xyz"]).T
     return pos, vel, normal


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

The current code for computing angular momentum components for particle fields based on their positions and velocities has an incorrect assumption. That is, if there is a `normal` field parameter (such as in the case of disk objects), that this is the normal vector that should be considered in the computation of the angular momentum. If there is no normal parameter, the normal vector is assumed to be [0,0,1]. This normal vector along with the center position is used to compute the components of position and velocity for the computation of the angular momentum vector. 

The problem with using the `normal` vector from the field parameter (if it exists) is that it involves rotating the coordinate system to one other than the default cartesian coordinate system from the dataset, but in fact the latter is the coordinate system that we want the vector components in, so we do not want to rotate. The solution is to assume that normal is always [0,0,1] for Cartesian coordinate systems. 

FWIW, the computation of the gas angular momentum in `yt/fields/angular_momentum.py` does not use the normal vector at all and thus this change brings the calculation of the angular momentum for both particles and gas into agreement with each other. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
