### PR TITLE
BUG: create duplicate of MPI communicator, to avoid double comm.Free

### DIFF
--- a/yt/utilities/parallel_tools/parallel_analysis_interface.py
+++ b/yt/utilities/parallel_tools/parallel_analysis_interface.py
@@ -100,7 +100,9 @@ def enable_parallelism(suppress_logging: bool = False, communicator=None) -> boo
 
     # if no communicator specified, set to COMM_WORLD
     if communicator is None:
-        communicator = MPI.COMM_WORLD
+        communicator = MPI.COMM_WORLD.Dup()
+    else:
+        communicator = communicator.Dup()
 
     parallel_capable = communicator.size > 1
     if not parallel_capable:


### PR DESCRIPTION
…codes

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

This PR modifies `yt.enable_parallelism()` to create a duplicate of the MPI communicator it uses. That communicator is either passed in via the named argument, or the communicator `MPI.COMM_WORLD` is used internally by default. To create the duplicate, the MPI call `comm.Dup()` is used.

Issue description: In the original implementation, a copy of the handle of the original MPI communicator was kept. Internally an instance of `class Communicator()` is created.  However, this class has a destructor which explicitly calls the method `Free()` of the communicator. This is clearly not wanted in case the global communicator `MPI.COMM_WORLD` is used. In that case `mpi4py` should do the cleanup internally. In case a communicator was passed in by the user, the call to `Free()` is also not wanted because the user might want to use the communicator elsewhere in the program.
By creating a local duplicate of the communicator we sidestep these issues. The cleanup of the original communicator should better be handled by the destructor implemented by `mpi4py` when the communicator object goes out of scope.

Background: This PR also fixes a double `free()` memory issue which we observed using OpenMPI (versions 4 and 4.1) on an InfiniBand HPC system, causing any code using `mpi4py` explicitly in combination with `yt` to crash at the end of the program. I could trace this back to the issue previously described and can confirm that the double `free()` vanishes with the proposed fix.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
