### PR TITLE
Reduce rendered images without considering opacity

### DIFF
--- a/yt/utilities/amr_kdtree/amr_kdtools.py
+++ b/yt/utilities/amr_kdtree/amr_kdtools.py
@@ -3,7 +3,7 @@ import numpy as np
 from yt.funcs import mylog
 
 
-def receive_and_reduce(comm, incoming_rank, image, add_to_front, use_opacity):
+def receive_and_reduce(comm, incoming_rank, image, add_to_front, *, use_opacity=True):
     mylog.debug("Receiving image from %04i", incoming_rank)
     # mylog.debug( '%04i receiving image from %04i'%(self.comm.rank,back.owner))
     arr2 = comm.recv_array(incoming_rank, incoming_rank).reshape(

--- a/yt/utilities/amr_kdtree/amr_kdtools.py
+++ b/yt/utilities/amr_kdtree/amr_kdtools.py
@@ -10,31 +10,31 @@ def receive_and_reduce(comm, incoming_rank, image, add_to_front, *, use_opacity=
         (image.shape[0], image.shape[1], image.shape[2])
     )
 
-    if use_opacity:
-        if add_to_front:
-            front = arr2
-            back = image
-        else:
-            front = image
-            back = arr2
-
-        if image.shape[2] == 3:
-            # Assume Projection Camera, Add
-            np.add(image, front, image)
-            return image
-
-        ta = 1.0 - front[:, :, 3]
-        np.maximum(ta, 0.0, ta)
-        # This now does the following calculation, but in a memory
-        # conservative fashion
-        # image[:,:,i  ] = front[:,:,i] + ta*back[:,:,i]
-        image = back.copy()
-        for i in range(4):
-            np.multiply(image[:, :, i], ta, image[:, :, i])
-        np.add(image, front, image)
-
-    else:
+    if not use_opacity:
         np.add(image, arr2, image)
+        return image
+
+    if add_to_front:
+        front = arr2
+        back = image
+    else:
+        front = image
+        back = arr2
+
+    if image.shape[2] == 3:
+        # Assume Projection Camera, Add
+        np.add(image, front, image)
+        return image
+
+    ta = 1.0 - front[:, :, 3]
+    np.maximum(ta, 0.0, ta)
+    # This now does the following calculation, but in a memory
+    # conservative fashion
+    # image[:,:,i  ] = front[:,:,i] + ta*back[:,:,i]
+    image = back.copy()
+    for i in range(4):
+        np.multiply(image[:, :, i], ta, image[:, :, i])
+    np.add(image, front, image)
 
     return image
 

--- a/yt/utilities/amr_kdtree/amr_kdtree.py
+++ b/yt/utilities/amr_kdtree/amr_kdtree.py
@@ -294,7 +294,7 @@ class AMRKDTree(ParallelAnalysisInterface):
                 owners[temp.node_id] = owners[temp.left.node_id]
         return owners
 
-    def reduce_tree_images(self, image, viewpoint, use_opacity):
+    def reduce_tree_images(self, image, viewpoint, use_opacity=True):
         if self.comm.size <= 1:
             return image
         myrank = self.comm.rank
@@ -307,7 +307,11 @@ class AMRKDTree(ParallelAnalysisInterface):
             split_pos = node.parent.get_split_pos()
             add_to_front = viewpoint[split_dim] >= split_pos
             image = receive_and_reduce(
-                self.comm, owners[node.parent.right.node_id], image, add_to_front, use_opacity,
+                self.comm,
+                owners[node.parent.right.node_id],
+                image,
+                add_to_front,
+                use_opacity,
             )
             if node.parent.node_id == 1:
                 break

--- a/yt/utilities/amr_kdtree/amr_kdtree.py
+++ b/yt/utilities/amr_kdtree/amr_kdtree.py
@@ -294,7 +294,7 @@ class AMRKDTree(ParallelAnalysisInterface):
                 owners[temp.node_id] = owners[temp.left.node_id]
         return owners
 
-    def reduce_tree_images(self, image, viewpoint):
+    def reduce_tree_images(self, image, viewpoint, use_opacity):
         if self.comm.size <= 1:
             return image
         myrank = self.comm.rank
@@ -307,7 +307,7 @@ class AMRKDTree(ParallelAnalysisInterface):
             split_pos = node.parent.get_split_pos()
             add_to_front = viewpoint[split_dim] >= split_pos
             image = receive_and_reduce(
-                self.comm, owners[node.parent.right.node_id], image, add_to_front
+                self.comm, owners[node.parent.right.node_id], image, add_to_front, use_opacity,
             )
             if node.parent.node_id == 1:
                 break

--- a/yt/utilities/amr_kdtree/amr_kdtree.py
+++ b/yt/utilities/amr_kdtree/amr_kdtree.py
@@ -294,7 +294,7 @@ class AMRKDTree(ParallelAnalysisInterface):
                 owners[temp.node_id] = owners[temp.left.node_id]
         return owners
 
-    def reduce_tree_images(self, image, viewpoint, use_opacity=True):
+    def reduce_tree_images(self, image, viewpoint, *, use_opacity=True):
         if self.comm.size <= 1:
             return image
         myrank = self.comm.rank
@@ -311,7 +311,7 @@ class AMRKDTree(ParallelAnalysisInterface):
                 owners[node.parent.right.node_id],
                 image,
                 add_to_front,
-                use_opacity,
+                use_opacity=use_opacity,
             )
             if node.parent.node_id == 1:
                 break

--- a/yt/visualization/volume_rendering/render_source.py
+++ b/yt/visualization/volume_rendering/render_source.py
@@ -607,7 +607,9 @@ class KDTreeVolumeSource(VolumeSource):
 
     def finalize_image(self, camera, image):
         if self._volume is not None:
-            image = self.volume.reduce_tree_images(image, camera.lens.viewpoint)
+            image = self.volume.reduce_tree_images(
+                image, camera.lens.viewpoint, self.transfer_function.grey_opacity
+                )
 
         return super().finalize_image(camera, image)
 

--- a/yt/visualization/volume_rendering/render_source.py
+++ b/yt/visualization/volume_rendering/render_source.py
@@ -608,8 +608,10 @@ class KDTreeVolumeSource(VolumeSource):
     def finalize_image(self, camera, image):
         if self._volume is not None:
             image = self.volume.reduce_tree_images(
-                image, camera.lens.viewpoint, self.transfer_function.grey_opacity
-                )
+                image,
+                camera.lens.viewpoint,
+                use_opacity=self.transfer_function.grey_opacity,
+            )
 
         return super().finalize_image(camera, image)
 


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->
### Issue
This addresses issue #4871, where volume renders of multiple fields with MPI would only produce a portion of the second field in the final image. 

I believe I have found where this bug occurs. It mainly has to do with the combining of image arrays in `yt/utilities/amr_kdtree/amr_kdtools.py:receive_and_reduce()` and how the alpha channel is set in `yt/visualization/volume_rendering/render_source.py:VolumeSource.finialize_image()`

After the first source is rendered, the last step of `finalize_image()` sets the alpha channel of the image array to `1`'s 

https://github.com/yt-project/yt/blob/6d121f58543bedb1f587492cd0601a69f06a736a/yt/visualization/volume_rendering/render_source.py#L535-L537

This causes issues when the second source is combining the image arrays in `recieve_and_reduce()` as these two arrays are combined by scaling the `back` image by `ta`, `1` minus the `front` alpha channel. Since the alpha channel was already set by the first source, `ta` is a zeros array. This eliminates any contribution of `back` to the final image.

https://github.com/yt-project/yt/blob/6d121f58543bedb1f587492cd0601a69f06a736a/yt/utilities/amr_kdtree/amr_kdtools.py#L25-L34

### Solution
My proposed solution is to add a pathway to combine image arrays without the consideration of opacity. This would be used when `transfer_function.grey_opacity=False`. In this case, `front` and `back` don't have any relevance and we can simply add the two image arrays.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
