### PR TITLE
correct errors in capital letter

### DIFF
--- a/yt/frontends/ramses/fields.py
+++ b/yt/frontends/ramses/fields.py
@@ -137,7 +137,7 @@ class RAMSESFieldInfo(FieldInfoContainer):
         ("particle_angular_momentum_y", (ang_mom_units, [], None)),
         ("particle_angular_momentum_z", (ang_mom_units, [], None)),
         ("particle_formation_time", ("code_time", [], None)),
-        ("particle_accretion_Rate", ("code_mass/code_time", [], None)),
+        ("particle_accretion_rate", ("code_mass/code_time", [], None)),
         ("particle_delta_mass", ("code_mass", [], None)),
         ("particle_rho_gas", (rho_units, [], None)),
         ("particle_cs**2", (vel_units, [], None)),

--- a/yt/frontends/ramses/io.py
+++ b/yt/frontends/ramses/io.py
@@ -388,7 +388,7 @@ def _read_part_csv_file_descriptor(fname: Union[str, "os.PathLike[str]"]):
         "ly": "particle_angular_momentum_y",
         "lz": "particle_angular_momentum_z",
         "tform": "particle_formation_time",
-        "acc_Rate": "particle_accretion_Rate",
+        "acc_rate": "particle_accretion_rate",
         "del_mass": "particle_delta_mass",
         "rho_gas": "particle_rho_gas",
         "cs**2": "particle_sound_speed",


### PR DESCRIPTION
Hello, 
I correct some mistakes in this PR in the reader for Ramses sink files. 
I add this in the code 1yr ago and I just realize there were a mistake with a capital letter. 

In Ramses, the header of the csv file for the sinks has the header `acc_rate` and not `acc_Rate` as was in yt.
Here, I correct this mistake (line 391 of io.py)

Also for consistency I modify the name of the `particle_accretion_rate` field. It use to be called `particle_accretion_Rate` with a capital letter. But none of the others fields has a capital letter in it, so it seems more logical to me to delete this capital letter.

Best regards
Romain Lenoble