### PR TITLE
BUG: Update Qt backend entries in BACKEND_SPECS

### DIFF
--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -49,8 +49,8 @@ BACKEND_SPECS = {
     "GTKAgg": ["backend_gtkagg", "FigureCanvasGTKAgg", None],
     "GTKCairo": ["backend_gtkcairo", "FigureCanvasGTKCairo", None],
     "MacOSX": ["backend_macosx", "FigureCanvasMac", "FigureManagerMac"],
-    "Qt4Agg": ["backend_qt4agg", "FigureCanvasQTAgg", None],
     "Qt5Agg": ["backend_qt5agg", "FigureCanvasQTAgg", None],
+    "QtAgg": ["backend_qtagg", "FigureCanvasQTAgg", None],
     "TkAgg": ["backend_tkagg", "FigureCanvasTkAgg", None],
     "WX": ["backend_wx", "FigureCanvasWx", None],
     "WXAgg": ["backend_wxagg", "FigureCanvasWxAgg", None],
@@ -157,8 +157,9 @@ class PlotMPL:
 
         try:
             module, fig_canvas, fig_manager = BACKEND_SPECS[key]
-        except KeyError:
-            return
+        except KeyError as err:
+            msg = f"{key} is not in list of valid backends: {list(BACKEND_SPECS)}."
+            raise KeyError(msg) from err
 
         mod = __import__(
             "matplotlib.backends",

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -155,11 +155,7 @@ class PlotMPL:
         else:
             key = "agg"
 
-        try:
-            module, fig_canvas, fig_manager = BACKEND_SPECS[key]
-        except KeyError as err:
-            msg = f"{key} is not in list of valid backends: {list(BACKEND_SPECS)}."
-            raise KeyError(msg) from err
+        module, fig_canvas, fig_manager = BACKEND_SPECS[key]
 
         mod = __import__(
             "matplotlib.backends",


### PR DESCRIPTION
Closes #4881 

This adds `QtAgg` to `BACKEND_SPECS`, removes `Qt4agg` (which is no longer valid as of matplotlib 3.5.0, yt's current minimum matplotlib version) and raises an error when a backend is not present in `BACKEND_SPECS` (rather than silently returning `None`).

I'm not sure there's a way to add a test for this, but locally I was able to reproduce the error in #4881 and verify that this PR fixes the error by running the following from ipython:

```python
%matplotlib qt

import yt 
yt.toggle_interactivity()

ds = yt.load_sample("IsolatedGalaxy")

slc = yt.SlicePlot(ds, 'x', 'Density')
slc.show()
```

