### PR TITLE
ENH: tipsy use max_rows instead of skip_footer for ascii aux read

### DIFF
--- a/yt/frontends/tipsy/io.py
+++ b/yt/frontends/tipsy/io.py
@@ -178,14 +178,11 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
                         )
                     )
                 else:
-                    par = self.ds.parameters
-                    nlines = 1 + par["nsph"] + par["ndark"] + par["nstar"]
                     aux_fh[afield].seek(0)
                     sh = aux_fields_offsets[afield][ptype]
-                    sf = nlines - count - sh
                     if tp[ptype] > 0:
                         aux = np.genfromtxt(
-                            aux_fh[afield], skip_header=sh, skip_footer=sf
+                            aux_fh[afield], skip_header=sh, max_rows=count
                         )
                         if aux.ndim < 1:
                             aux = np.array([aux])


### PR DESCRIPTION
Using `skip_footer` in `np.genfromtxt` requires scanning the whole file and so slows down the tipsy ascii aux file reads **significantly** for large files. Switching to `max_rows` avoids this. 