### PR TITLE
MNT: build macOS amr64 wheels without cross-compiling

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -22,7 +22,8 @@ jobs:
         os: [
           ubuntu-20.04,
           windows-2019,
-          macos-11,
+          macos-13, # x86_64
+          macos-14, # arm64
         ]
       fail-fast: false
 
@@ -38,7 +39,7 @@ jobs:
           CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-*"
           CIBW_SKIP: "*-musllinux_*"  #  numpy doesn't have wheels for musllinux so we can't build some quickly and without bloating
           CIBW_ARCHS_LINUX: "x86_64"
-          CIBW_ARCHS_MACOS: x86_64 arm64
+          CIBW_ARCHS_MACOS: auto
           MACOSX_DEPLOYMENT_TARGET: "10.9" # as of CIBW 2.9, this is the default value, pin it so it can't be bumped silently
           CIBW_ARCHS_WINDOWS: auto64
           CIBW_ENVIRONMENT: "LDFLAGS='-static-libstdc++'"


### PR DESCRIPTION
## PR Summary
Now that GitHub Actions and cibuildwheel support amr64, we don't need cross compilation for these wheels, and we can lift that burden off of the macOS x86 job, which is by far the longest running job in the matrix (see for example https://github.com/yt-project/yt/actions/runs/8852696165/usage)
