### PR TITLE
BLD: only compile fixed_interpolator.cpp once

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ from setupext import (
     check_for_openmp,
     check_for_pyembree,
     create_build_ext,
+    get_python_include_dirs,
     install_ccompiler,
 )
 
@@ -40,6 +41,8 @@ else:
 CPP14_FLAG = CPP14_CONFIG[_COMPILER]
 CPP11_FLAG = CPP11_CONFIG[_COMPILER]
 
+FIXED_INTERP = "fixed_interpolator"
+
 cythonize_aliases = {
     "LIB_DIR": "yt/utilities/lib/",
     "LIB_DIR_GEOM": ["yt/utilities/lib/", "yt/geometry/"],
@@ -52,7 +55,7 @@ cythonize_aliases = {
     "EWAH_LIBS": std_libs
     + [os.path.abspath(importlib_resources.files("ewah_bool_utils"))],
     "OMP_ARGS": omp_args,
-    "FIXED_INTERP": "yt/utilities/lib/fixed_interpolator.cpp",
+    "FIXED_INTERP": FIXED_INTERP,
     "ARTIO_SOURCE": sorted(glob.glob("yt/frontends/artio/artio_headers/*.c")),
     "CPP14_FLAG": CPP14_FLAG,
     "CPP11_FLAG": CPP11_FLAG,
@@ -88,8 +91,32 @@ class BinaryDistribution(Distribution):
 
 
 if __name__ == "__main__":
+    # Avoid a race condition on fixed_interpolator.o during parallel builds by
+    # building it only once and storing it in a static library.
+    # See https://github.com/yt-project/yt/issues/4278 and
+    # https://github.com/pypa/setuptools/issues/3119#issuecomment-2076922303
+    # for the inspiration for this fix.
+
+    # build_clib doesn't add the Python include dirs (for Python.h) by default,
+    # as opposed to build_ext, so we need to add them manually.
+    clib_include_dirs = get_python_include_dirs()
+
+    # fixed_interpolator.cpp uses Numpy types
+    import numpy
+
+    clib_include_dirs.append(numpy.get_include())
+
+    fixed_interp_lib = (
+        FIXED_INTERP,
+        {
+            "sources": ["yt/utilities/lib/fixed_interpolator.cpp"],
+            "include_dirs": clib_include_dirs,
+        },
+    )
+
     setup(
         cmdclass={"sdist": sdist, "build_ext": build_ext},
         distclass=BinaryDistribution,
+        libraries=[fixed_interp_lib],
         ext_modules=[],  # !!! We override this inside build_ext above
     )

--- a/setupext.py
+++ b/setupext.py
@@ -370,7 +370,7 @@ def install_ccompiler():
 
 
 def get_python_include_dirs():
-    """Extracted from distutils.command.build_ext.build_ext#finalize_options(),
+    """Extracted from distutils.command.build_ext.build_ext.finalize_options(),
     https://github.com/python/cpython/blob/812245ecce2d8344c3748228047bab456816180a/Lib/distutils/command/build_ext.py#L148-L167
     """
     include_dirs = []

--- a/yt/utilities/lib/grid_traversal.pyx
+++ b/yt/utilities/lib/grid_traversal.pyx
@@ -1,5 +1,5 @@
 # distutils: include_dirs = LIB_DIR
-# distutils: libraries = STD_LIBS FIXED_INTERP
+# distutils: libraries = STD_LIBS
 # distutils: language = c++
 # distutils: extra_compile_args = CPP14_FLAG
 # distutils: extra_link_args = CPP14_FLAG
@@ -18,8 +18,6 @@ cimport numpy as np
 from libc.math cimport atan2, cos, fabs, floor, sin, sqrt
 
 from yt.utilities.lib.fp_utils cimport fmin
-
-from .fixed_interpolator cimport *
 
 
 @cython.boundscheck(False)

--- a/yt/utilities/lib/grid_traversal.pyx
+++ b/yt/utilities/lib/grid_traversal.pyx
@@ -1,6 +1,5 @@
 # distutils: include_dirs = LIB_DIR
-# distutils: libraries = STD_LIBS
-# distutils: sources = FIXED_INTERP
+# distutils: libraries = STD_LIBS FIXED_INTERP
 # distutils: language = c++
 # distutils: extra_compile_args = CPP14_FLAG
 # distutils: extra_link_args = CPP14_FLAG

--- a/yt/utilities/lib/image_samplers.pyx
+++ b/yt/utilities/lib/image_samplers.pyx
@@ -1,8 +1,7 @@
 # distutils: include_dirs = LIB_DIR
 # distutils: extra_compile_args = CPP14_FLAG OMP_ARGS
 # distutils: extra_link_args = CPP14_FLAG OMP_ARGS
-# distutils: libraries = STD_LIBS
-# distutils: sources = FIXED_INTERP
+# distutils: libraries = STD_LIBS FIXED_INTERP
 # distutils: language = c++
 """
 Image sampler definitions

--- a/yt/utilities/lib/marching_cubes.pyx
+++ b/yt/utilities/lib/marching_cubes.pyx
@@ -1,6 +1,5 @@
 # distutils: include_dirs = LIB_DIR
-# distutils: libraries = STD_LIBS
-# distutils: sources = FIXED_INTERP
+# distutils: libraries = STD_LIBS FIXED_INTERP
 # distutils: language = c++
 """
 Marching cubes implementation

--- a/yt/utilities/lib/partitioned_grid.pyx
+++ b/yt/utilities/lib/partitioned_grid.pyx
@@ -1,6 +1,5 @@
-# distutils: sources = FIXED_INTERP
 # distutils: include_dirs = LIB_DIR
-# distutils: libraries = STD_LIBS
+# distutils: libraries = STD_LIBS FIXED_INTERP
 # distutils: language = c++
 # distutils: extra_compile_args = CPP14_FLAG
 # distutils: extra_link_args = CPP14_FLAG


### PR DESCRIPTION
## PR Summary

Avoid a race condition on fixed_interpolator.o during parallel builds by building it only once and storing it in a static library.

Hopefully fixes #4278.

## PR Checklist

- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.