### PR TITLE
BLD: fix bleeding-edge build script

### DIFF
--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -61,9 +61,7 @@ jobs:
       # are not installed by pip as specified from pyproject.toml, hence we get
       # to use the dev version of numpy at build time.
       run: |
-        python setup.py build_clib -q
-        python setup.py build_ext -q -j2
-        python -m pip install -e .[test] --no-build-isolation
+        python -m pip -v install -e .[test] --no-build-isolation
 
     - run: python -m pip list
 

--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -61,6 +61,7 @@ jobs:
       # are not installed by pip as specified from pyproject.toml, hence we get
       # to use the dev version of numpy at build time.
       run: |
+        python setup.py build_clib -q
         python setup.py build_ext -q -j2
         python -m pip install -e .[test] --no-build-isolation
 

--- a/setup.py
+++ b/setup.py
@@ -7,13 +7,13 @@ from importlib import resources as importlib_resources
 from setuptools import Distribution, setup
 
 from setupext import (
+    NUMPY_MACROS,
     check_CPP14_flags,
     check_for_openmp,
     check_for_pyembree,
     create_build_ext,
     get_python_include_dirs,
     install_ccompiler,
-    NUMPY_MACROS,
 )
 
 install_ccompiler()

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ from setupext import (
     create_build_ext,
     get_python_include_dirs,
     install_ccompiler,
+    NUMPY_MACROS,
 )
 
 install_ccompiler()
@@ -111,6 +112,7 @@ if __name__ == "__main__":
         {
             "sources": ["yt/utilities/lib/fixed_interpolator.cpp"],
             "include_dirs": clib_include_dirs,
+            "define_macros": NUMPY_MACROS,
         },
     )
 

--- a/setupext.py
+++ b/setupext.py
@@ -394,6 +394,13 @@ def get_python_include_dirs():
     return include_dirs
 
 
+NUMPY_MACROS = [
+    ("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION"),
+    # keep in sync with runtime requirements (pyproject.toml)
+    ("NPY_TARGET_VERSION", "NPY_1_19_API_VERSION"),
+]
+
+
 def create_build_ext(lib_exts, cythonize_aliases):
     class build_ext(_build_ext):
         # subclass setuptools extension builder to avoid importing cython and numpy
@@ -425,11 +432,7 @@ def create_build_ext(lib_exts, cythonize_aliases):
             self.include_dirs.append(numpy.get_include())
             self.include_dirs.append(ewah_bool_utils.get_include())
 
-            define_macros = [
-                ("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION"),
-                # keep in sync with runtime requirements (pyproject.toml)
-                ("NPY_TARGET_VERSION", "NPY_1_19_API_VERSION"),
-            ]
+            define_macros = NUMPY_MACROS
 
             if self.define is None:
                 self.define = define_macros

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -515,7 +515,7 @@ def update_git(path):
 def rebuild_modules(path, f):
     f.write("Rebuilding modules\n\n")
     p = subprocess.Popen(
-        [sys.executable, "setup.py", "build_ext", "-i"],
+        [sys.executable, "setup.py", "build_clib", "build_ext", "-i"],
         cwd=path,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,


### PR DESCRIPTION
## PR Summary

Updates the bleeding-edge CI workflow script to run only pip and adds the numpy API macros to the clib defines.

Fixes #4896.

## PR Checklist

- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.