### PR TITLE
BUG: Make sure fields are read in the order they appear in the file

### DIFF
--- a/yt/frontends/ramses/io_utils.pyx
+++ b/yt/frontends/ramses/io_utils.pyx
@@ -192,6 +192,9 @@ def fill_hydro(FortranFile f,
     cdef int jump_len, Ncells
     cdef np.uint8_t[::1] mask_level = np.zeros(nlevels, dtype=np.uint8)
 
+    # First, make sure fields are in the same order
+    fields = sorted(fields, key=lambda f: all_fields.index(f))
+
     # The ordering is very important here, as we'll write directly into the memory
     # address the content of the files.
     cdef np.float64_t[::1, :, :] buffer

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -646,21 +646,21 @@ def test_print_stats():
     # FIXME #3197: use `capsys` with pytest to make sure the print_stats function works as intended
 
 
-def _dummy_field(field, data):
-    # Note: this is a dummy field
-    # that doesn't really have any physical meaning
-    # but may trigger some bug in the field
-    # handling.
-    T = data["gas", "temperature"]
-    Z = data["gas", "metallicity"]
-    return T * 1**Z
-
-
 @requires_file(output_00080)
 def test_reading_order():
     # This checks the bug unvovered in #4880
     # This checks that the result of field accession doesn't
     # depend on the order
+
+    def _dummy_field(field, data):
+        # Note: this is a dummy field
+        # that doesn't really have any physical meaning
+        # but may trigger some bug in the field
+        # handling.
+        T = data["gas", "temperature"]
+        Z = data["gas", "metallicity"]
+        return T * 1**Z
+
     fields = [
         "Density",
         "x-velocity",

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -644,3 +644,42 @@ def test_print_stats():
     ds.print_stats()
 
     # FIXME #3197: use `capsys` with pytest to make sure the print_stats function works as intended
+
+
+def _dummy_field(field, data):
+    # Note: this is a dummy field
+    # that doesn't really have any physical meaning
+    # but may trigger some bug in the field
+    # handling.
+    T = data["gas", "temperature"]
+    Z = data["gas", "metallicity"]
+    return T * 1**Z
+
+
+@requires_file(output_00080)
+def test_reading_order():
+    # This checks the bug unvovered in #4880
+    # This checks that the result of field accession doesn't
+    # depend on the order
+    fields = [
+        "Density",
+        "x-velocity",
+        "y-velocity",
+        "z-velocity",
+        "Pressure",
+        "Metallicity",
+    ]
+    ds = yt.load(output_00080, fields=fields)
+
+    ds.add_field(
+        ("gas", "test"), function=_dummy_field, units=None, sampling_type="cell"
+    )
+
+    ad = ds.all_data()
+    v0 = ad["gas", "test"]
+
+    ad = ds.all_data()
+    ad["gas", "temperature"]
+    v1 = ad["gas", "test"]
+
+    np.testing.assert_allclose(v0, v1)


### PR DESCRIPTION
## PR Summary

This fixes #4880.

The issue was that the reader would assume fields were passed in the order they appeared on file, so that depending on the order in which one would load the data, we'd get different results.