### PR TITLE
ENH: add support for molecular fields (AMRex)

### DIFF
--- a/nose_ignores.txt
+++ b/nose_ignores.txt
@@ -43,3 +43,4 @@
 --ignore-file=test_alt_ray_tracers\.py
 --ignore-file=test_minimal_representation\.py
 --ignore-file=test_set_log_level\.py
+--ignore-file=test_field_parsing\.py

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -187,6 +187,7 @@ other_tests:
      - "--ignore-file=test_ewah_write_load\\.py"
      - "--ignore-file=test_external_frontends\\.py"
      - "--ignore-file=test_field_access_pytest\\.py"
+     - "--ignore-file=test_field_parsing\\.py"
      - "--ignore-file=test_file_sanitizer\\.py"
      - "--ignore-file=test_firefly\\.py"
      - "--ignore-file=test_geometries\\.py"

--- a/yt/frontends/amrex/tests/test_field_parsing.py
+++ b/yt/frontends/amrex/tests/test_field_parsing.py
@@ -1,0 +1,51 @@
+import pytest
+
+from yt.frontends.amrex.fields import Substance
+
+
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        pytest.param("X(He5)", [("He", 5)], id="isotope_1"),
+        pytest.param("X(C12)", [("C", 12)], id="isotope_2"),
+        pytest.param("X(A1B2C3)", [("A", 1), ("B", 2), ("C", 3)], id="molecule_1"),
+        pytest.param("X(C12H24)", [("C", 12), ("H", 24)], id="molecule_2"),
+        pytest.param("X(H2O)", [("H", 2), ("O", 1)], id="molecule_3"),
+        pytest.param("X(ash)", [("ash", 0)], id="descriptive_name"),
+    ],
+)
+def test_Substance_spec(data, expected):
+    assert Substance(data)._spec == expected
+
+
+@pytest.mark.parametrize(
+    "data, expected_type",
+    [
+        pytest.param("X(He5)", "isotope", id="isotope_1"),
+        pytest.param("X(C12)", "isotope", id="isotope_2"),
+        pytest.param("X(A1B2C3)", "molecule", id="molecule_1"),
+        pytest.param("X(C12H24)", "molecule", id="molecule_2"),
+        pytest.param("X(H2O)", "molecule", id="molecule_3"),
+        pytest.param("X(ash)", "descriptive_name", id="descriptive_name"),
+    ],
+)
+def test_Substance_type(data, expected_type):
+    sub = Substance(data)
+    assert getattr(sub, f"is_{expected_type}")()
+
+
+@pytest.mark.parametrize(
+    "data, expected_str, expected_tex",
+    [
+        pytest.param("X(He5)", "He5", "^{5}He", id="isotope_1"),
+        pytest.param("X(C12)", "C12", "^{12}C", id="isotope_2"),
+        pytest.param("X(A1B2C3)", "AB2C3", "A_{}B_{2}C_{3}", id="molecule_1"),
+        pytest.param("X(C12H24)", "C12H24", "C_{12}H_{24}", id="molecule_2"),
+        pytest.param("X(H2O)", "H2O", "H_{2}O_{}", id="molecule_2"),
+        pytest.param("X(ash)", "ash", "ash", id="descriptive_name"),
+    ],
+)
+def test_Substance_to_str(data, expected_str, expected_tex):
+    sub = Substance(data)
+    assert str(sub) == expected_str
+    assert sub.to_tex() == expected_tex


### PR DESCRIPTION
## PR Summary

The boxlib dataset parsing (for CASTRO/MAESTROeX) are currently set up for usual atomic species like "He4" or "C12", or descriptive names like "ash" with no numbers.  The parsing breaks for e.g. molecules like "H2O" or "C6H6".  This fix escapes those cases.

Ideally, we could have some fancy regex to correctly parse the molecules (and create proper a TeX string), but this is a very niche use of those codes.

## PR Checklist

- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.