### PR TITLE
BLD: minimally test wheels and sdist

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -44,6 +44,8 @@ jobs:
           CIBW_ARCHS_WINDOWS: auto64
           CIBW_ENVIRONMENT: "LDFLAGS='-static-libstdc++'"
           CIBW_BUILD_VERBOSITY: 1
+          CIBW_TEST_SKIP: "*-manylinux*" # https://github.com/yt-project/yt/issues/4910
+          CIBW_TEST_COMMAND: python -c "import yt"
 
       - uses: actions/upload-artifact@v4
         with:
@@ -57,8 +59,21 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.9'
+
       - name: Build sdist
         run: pipx run build --sdist
+
+      - name: Test sdist
+        run: |
+          python -m pip install "$(echo dist/*.tar.gz)"
+          python -m pip list
+          project_dir=$(pwd)
+          cd ../../
+          python -c "import yt"
 
       - name: Upload sdist
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## PR Summary

A quick alternative to #4906, since I cannot seem to figure out (yet) how to run properly pytest from outside the repository, this will at least implement *some* level of safety regarding distributed artifacts (which we need in order to implement stuff like #4905)