### PR TITLE
BLD: fix segfault with manylinux2014

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -42,9 +42,7 @@ jobs:
           CIBW_ARCHS_MACOS: auto
           MACOSX_DEPLOYMENT_TARGET: "10.9" # as of CIBW 2.9, this is the default value, pin it so it can't be bumped silently
           CIBW_ARCHS_WINDOWS: auto64
-          CIBW_ENVIRONMENT: "LDFLAGS='-static-libstdc++'"
           CIBW_BUILD_VERBOSITY: 1
-          CIBW_TEST_SKIP: "*-manylinux*" # https://github.com/yt-project/yt/issues/4910
           CIBW_TEST_COMMAND: python -c "import yt"
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
## PR Summary

Follow-up to https://github.com/yt-project/yt/pull/4909.

We originally had static linking enabled due to ABI conflicts, as discussed in https://github.com/yt-project/yt/pull/3406. However, the cibuildwheel docs currently say that manylinux2014 supports all C++ standards up to C++17 (https://cibuildwheel.pypa.io/en/stable/cpp_standards/).

I think the segfaults may have to do with multiple versions of libstdc++ being loaded at the same time. A couple of compiled modules in matplotlib dynamically link to `libstdc++.so.6`, which seems like it could cause this sort of issue.