### PR TITLE
TST: cleanup unnecessary warning filter

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -161,19 +161,6 @@ def pytest_configure(config):
                 ":DeprecationWarning",
             )
 
-    if find_spec("astropy") is not None:
-        # at the time of writing, astropy's wheels are behind numpy's latest
-        # version but this doesn't cause actual problems in our test suite
-        # last updated with astropy 5.0 + numpy 1.22 + pytest 6.2.5
-        config.addinivalue_line(
-            "filterwarnings",
-            (
-                "ignore:numpy.ndarray size changed, may indicate binary incompatibility. Expected "
-                r"(80 from C header, got 88|88 from C header, got 96|80 from C header, got 96)"
-                " from PyObject:RuntimeWarning"
-            ),
-        )
-
     if PANDAS_VERSION is not None and PANDAS_VERSION >= Version("2.2.0"):
         config.addinivalue_line(
             "filterwarnings",


### PR DESCRIPTION
## PR Summary

I am now almost sure that the comment I wrote for this filter (circa 2021) was ill-informed and misleading. Astropy's wheels in fact were already being built in a forward-compatible way with `oldest-supported-numpy` at the time and continue to be (now using the more modern mechanism introduced in numpy 1.25). I suspect the real reason why we were seeing this warning was that we installed numpy from conda and then astropy from PyPI, which we haven't been doing since https://github.com/yt-project/yt/pull/4624
