### PR TITLE
add check for Sub_conventions for CFradial

### DIFF
--- a/yt/frontends/cf_radial/data_structures.py
+++ b/yt/frontends/cf_radial/data_structures.py
@@ -310,6 +310,9 @@ class CFRadialDataset(Dataset):
             nc4_file = NetCDF4FileHandler(filename)
             with nc4_file.open_ds(keepweakref=True) as ds:
                 con = "Conventions"  # the attribute to check for file conventions
+                # note that the attributes here are potentially space- or
+                # comma-delimited strings, so we concatenate a single string
+                # to search for a substring.
                 cons = ""  # the value of the Conventions attribute
                 for c in [con, con.lower(), "Sub_" + con.lower()]:
                     if hasattr(ds, c):

--- a/yt/frontends/cf_radial/data_structures.py
+++ b/yt/frontends/cf_radial/data_structures.py
@@ -311,10 +311,10 @@ class CFRadialDataset(Dataset):
             with nc4_file.open_ds(keepweakref=True) as ds:
                 con = "Conventions"  # the attribute to check for file conventions
                 cons = ""  # the value of the Conventions attribute
-                for c in [con, con.lower()]:
+                for c in [con, con.lower(), "Sub_" + con.lower()]:
                     if hasattr(ds, c):
                         cons += getattr(ds, c)
-                is_cfrad = "CF/Radial" in cons
+                is_cfrad = "CF/Radial" in cons or "CF-Radial" in cons
         except (OSError, AttributeError, ImportError):
             return False
 


### PR DESCRIPTION
This PR adjusts the cf_radial frontend `_is_valid` to look in an additional attribute (`Sub_conventions`). 

NEXRAD (https://cmr.earthdata.nasa.gov/search/concepts/C2020894988-GHRC_DAAC.html) uses CFradial but has slightly different metadata from what we're checking for. In this case it's got the following attributes:

```
Conventions :
    CF-1.7
Sub_conventions :
    CF-Radial instrument_parameters radar_parameters radar_calibration
```