### PR TITLE
DOC: fix typo in the debugging signal names

### DIFF
--- a/doc/source/developing/debugdrive.rst
+++ b/doc/source/developing/debugdrive.rst
@@ -66,7 +66,7 @@ will induce the requested behavior.
    SIGUSR1
      This will cause the python code to print a stack trace, showing exactly
      where in the function stack it is currently executing.
-   SIGUSR1
+   SIGUSR2
      This will cause the python code to insert an IPython session wherever it
      currently is, with all local variables in the local namespace.  It should
      allow you to change the state variables.


### PR DESCRIPTION
## PR Summary

The relevant code is here: https://github.com/yt-project/yt/blob/13dc4fbcba564439c90e9bdd8db013f797dfc9a9/yt/startup_tasks.py#L45-L55