### PR TITLE
BUG: fix ParamFileStore for on-demand frontend imports

### DIFF
--- a/yt/utilities/parameter_file_storage.py
+++ b/yt/utilities/parameter_file_storage.py
@@ -8,7 +8,16 @@ from yt.utilities.parallel_tools.parallel_analysis_interface import (
     parallel_simple_proxy,
 )
 
-_field_names = ("hash", "bn", "fp", "tt", "ctid", "class_name", "last_seen")
+_field_names = (
+    "hash",
+    "bn",
+    "fp",
+    "tt",
+    "ctid",
+    "class_name",
+    "module_name",
+    "last_seen",
+)
 
 
 class NoParameterShelf(Exception):
@@ -104,6 +113,7 @@ class ParameterFileStore:
             "tt": ds.current_time,
             "ctid": ds.unique_identifier,
             "class_name": ds.__class__.__name__,
+            "module_name": ds.__module__,
             "last_seen": ds._instantiated,
         }
 
@@ -114,7 +124,17 @@ class ParameterFileStore:
         fn = os.path.join(fp, bn)
         class_name = ds_dict["class_name"]
         if class_name not in output_type_registry:
-            raise UnknownDatasetType(class_name)
+            # first check that the relevant frontend is imported:
+            # the output_type_registry is refreshed between sessions as
+            # frontends are imported on-demand now.
+            import importlib
+
+            module = ds_dict["module_name"]
+            fe_api = ".".join(module.split(".")[0:3]) + ".api"
+            _ = importlib.import_module(fe_api)
+            # if it is **still** not in the registry, error
+            if class_name not in output_type_registry:
+                raise UnknownDatasetType(class_name)
         mylog.info("Checking %s", fn)
         if os.path.exists(fn):
             ds = output_type_registry[class_name](os.path.join(fp, bn))


### PR DESCRIPTION
Currently, the `Dataset` pickling is broken between python sessions when using `store_parameter_files = true`. For example, given two scripts, `create_a_pickle.py` and `load_a_pickle.py`:

```python
# create_a_pickle.py
import yt
import pickle

if __name__ == '__main__':

    fname = 'IsolatedGalaxy/galaxy0030/galaxy0030'
    ds = yt.load(fname)

    with open('yt_ds.pickle', 'wb') as handle:
        pickle.dump(ds, handle, protocol=pickle.HIGHEST_PROTOCOL)
```

```python
# load_a_pickle.py
import pickle

if __name__ == '__main__':

    with open('yt_ds.pickle', 'rb') as handle:
        ds = pickle.load(handle)
   _ =  ds.index

```
The following fails on the attempt to load:
```
$ python create_a_pickle.py
$ python load_a_pickle.py
Traceback (most recent call last):
  File "/home/chavlin/src/yt_general/performance/yt_perf_testing/miscelleaneous_tests/dask_pickles_etc/pickle_from_file.py", line 5, in <module>
    ds = pickle.load(handle)
  File "/home/chavlin/src/yt_general/yt/yt/data_objects/static_output.py", line 2053, in _reconstruct_ds
    ds = datasets.get_ds_hash(*args)
  File "/home/chavlin/src/yt_general/yt/yt/utilities/parameter_file_storage.py", line 91, in get_ds_hash
    return self._convert_ds(self._records[hash])
  File "/home/chavlin/src/yt_general/yt/yt/utilities/parameter_file_storage.py", line 117, in _convert_ds
    raise UnknownDatasetType(class_name)
yt.utilities.parameter_file_storage.UnknownDatasetType: EnzoDataset
```
(I also ran into this problem when experimenting with some dask functionality...). 

The issue comes how yt now imports frontends on demand (`output_type_registry` is reset between sessions). 

 