### PR TITLE
BLD: require numpy 2.0.0 (stable) at build time

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
   # for the upper pin in Cython
   # see https://github.com/yt-project/yt/issues/4044
   "Cython>=3.0.3, <3.1",
-  "numpy>=2.0.0rc1",
+  "numpy>=2.0.0",
   "ewah-bool-utils>=1.2.0",
 ]
 build-backend = "setuptools.build_meta:__legacy__"

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -69,7 +69,7 @@ answer_tests:
     - yt/frontends/chombo/tests/test_outputs.py:test_zp
     - yt/frontends/chombo/tests/test_outputs.py:test_kho
 
-  local_enzo_009:  # PR 3856
+  local_enzo_010:  # PR 4930
     - yt/frontends/enzo/tests/test_outputs.py:test_moving7
     - yt/frontends/enzo/tests/test_outputs.py:test_galaxy0030
     - yt/frontends/enzo/tests/test_outputs.py:test_toro1d

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -69,7 +69,7 @@ answer_tests:
     - yt/frontends/chombo/tests/test_outputs.py:test_zp
     - yt/frontends/chombo/tests/test_outputs.py:test_kho
 
-  local_enzo_010:  # PR 4930
+  local_enzo_011:  # PR 4930
     - yt/frontends/enzo/tests/test_outputs.py:test_moving7
     - yt/frontends/enzo/tests/test_outputs.py:test_galaxy0030
     - yt/frontends/enzo/tests/test_outputs.py:test_toro1d

--- a/yt/_maintenance/numpy2_compat.py
+++ b/yt/_maintenance/numpy2_compat.py
@@ -9,4 +9,4 @@ NUMPY_VERSION = Version(version("numpy"))
 if NUMPY_VERSION >= Version("2.0.0dev0"):
     from numpy import trapezoid as trapezoid  # type: ignore [attr-defined]
 else:
-    from numpy import trapz as trapezoid  # noqa: F401
+    from numpy import trapz as trapezoid  # type: ignore [attr-defined] # noqa: F401

--- a/yt/fields/vector_operations.py
+++ b/yt/fields/vector_operations.py
@@ -362,7 +362,7 @@ def create_vector_fields(
             ds = div_fac * just_one(data["index", "dz"])
             f += data[zn[0], f"relative_{zn[1]}"][1:-1, 1:-1, sl_right] / ds
             f -= data[zn[0], f"relative_{zn[1]}"][1:-1, 1:-1, sl_left] / ds
-            new_field = data.ds.arr(np.zeros(data[xn].shape, dtype=np.float64), f.units)
+            new_field = data.ds.arr(np.zeros(data[xn].shape, dtype="f8"), str(f.units))
             new_field[1:-1, 1:-1, 1:-1] = f
             return new_field
 


### PR DESCRIPTION
## PR Summary
Numpy 2.0 just dropped on PyPI (🎉). This change is a pretext to make sure everything still runs smoothly. From the conversation on #4874, I expect I'll need to bump a couple answer tests but everything else I expect to stay green.

Closes #4874 