### PR TITLE
Add support for Enzo-E simulations with 0 ghost zones

### DIFF
--- a/yt/frontends/enzo_e/data_structures.py
+++ b/yt/frontends/enzo_e/data_structures.py
@@ -406,8 +406,9 @@ class EnzoEDataset(Dataset):
         ablock = fh[list(fh.keys())[0]]
         self.current_time = ablock.attrs["time"][0]
         self.parameters["current_cycle"] = ablock.attrs["cycle"][0]
-        gsi = ablock.attrs["enzo_GridStartIndex"]  # <- always has 3 elements
+        gsi = ablock.attrs["enzo_GridStartIndex"]
         gei = ablock.attrs["enzo_GridEndIndex"]
+        assert len(gsi) == len(gei) == 3  # sanity check
         # Enzo-E technically allows each axis to have different ghost zone
         # depths (this feature is not really used in practice)
         self.ghost_zones = gsi

--- a/yt/frontends/enzo_e/data_structures.py
+++ b/yt/frontends/enzo_e/data_structures.py
@@ -406,9 +406,12 @@ class EnzoEDataset(Dataset):
         ablock = fh[list(fh.keys())[0]]
         self.current_time = ablock.attrs["time"][0]
         self.parameters["current_cycle"] = ablock.attrs["cycle"][0]
-        gsi = ablock.attrs["enzo_GridStartIndex"]
+        gsi = ablock.attrs["enzo_GridStartIndex"]  # <- always has 3 elements
         gei = ablock.attrs["enzo_GridEndIndex"]
-        self.ghost_zones = gsi[0]
+        # Enzo-E technically allows each axis to have different ghost zone
+        # depths (this feature is not really used in practice)
+        self.ghost_zones = gsi
+        assert (self.ghost_zones[self.dimensionality :] == 0).all()  # sanity check
         self.root_block_dimensions = root_blocks
         self.active_grid_dimensions = gei - gsi + 1
         self.grid_dimensions = ablock.attrs["enzo_GridDimension"]


### PR DESCRIPTION
## PR Summary

The primary purpose of this PR was to add support for Enzo-E simulations with 0 ghost zones.

While I was here, I added support for Enzo-E simulations where the x, y, and z axes have different numbers of ghost zones (this is a feature that Enzo-E supports, but it's not really used). I also added some explanatory comments.