### PR TITLE
correct issue ?

### DIFF
--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -975,7 +975,7 @@ class RAMSESDataset(Dataset):
         setdefaultattr(self, "temperature_unit", temperature_unit.in_units("K"))
 
         # Only the length unit get scales by a factor of boxlen
-        setdefaultattr(self, "length_unit", self.quan(length_unit * boxlen, "cm"))
+        setdefaultattr(self, "length_unit", self.quan(length_unit, "cm"))
 
     def _parse_parameter_file(self):
         # hardcoded for now
@@ -1044,7 +1044,7 @@ class RAMSESDataset(Dataset):
         self.parameters.update(rheader)
         self.domain_left_edge = np.zeros(3, dtype="float64")
         self.domain_dimensions = np.ones(3, dtype="int32") * 2 ** (self.min_level + 1)
-        self.domain_right_edge = np.ones(3, dtype="float64")
+        self.domain_right_edge = np.ones(3, dtype="float64") * self.parameters["boxlen"]
         # This is likely not true, but it's not clear
         # how to determine the boundary conditions
         self._periodicity = (True, True, True)


### PR DESCRIPTION
Hello, 
It seems there is an issue with length unit for ramses output. 

The bug has already been identified in [2866](https://github.com/yt-project/yt/issues/2866) and [4787](https://github.com/yt-project/yt/issues/4787). 

Here I propose a modification of two lines in `data_structure`. 

I don't understand why the length_unit is scaled with the boxlen. To me, it should not as then, we loose the units if `boxlen != 1`. The correction induced is to change the yt's boxlen which should be different from 1 if we change the units. 

Thanks,
Romain