### PR TITLE
[BUG] RAMSES: allow reading datasets with slightly broken records.

### DIFF
--- a/yt/frontends/ramses/particle_handlers.py
+++ b/yt/frontends/ramses/particle_handlers.py
@@ -266,7 +266,7 @@ class DefaultParticleFileHandler(ParticleFileHandler):
                     if record_len != exp_len:
                         # Guess record vtype from length
                         nbytes = record_len // hvals["npart"]
-                        vtype = _default_dtypes[nbytes]
+                        vtype = _default_dtypes.get(nbytes, "d")
 
                         mylog.warning(
                             "Supposed that `%s` has type %s given record size",

--- a/yt/frontends/ramses/particle_handlers.py
+++ b/yt/frontends/ramses/particle_handlers.py
@@ -266,6 +266,9 @@ class DefaultParticleFileHandler(ParticleFileHandler):
                     if record_len != exp_len:
                         # Guess record vtype from length
                         nbytes = record_len // hvals["npart"]
+                        # NOTE: in some simulations (e.g. New Horizon), the record length is not
+                        # a multiple of 1, 2, 4 or 8. In this case, fallback onto assuming
+                        # double precision.
                         vtype = _default_dtypes.get(nbytes, "d")
 
                         mylog.warning(


### PR DESCRIPTION
Some simulations (like NewHorizon and Horizon-AGN) have weird record lengths that aren't multiple of 1, 2, 4 or 8. This allows to read the dataset nonetheless (but the corresponding records won't work though)

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
