### PR TITLE
RFC: explicitly set strict flag in `zip` calls (enforce `B905`), and ignore `UP038`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,12 @@ repos:
     types_or: [ python, pyi, jupyter ]
   - id: ruff
     types_or: [ python, pyi, jupyter ]
-    args: [--fix, "--show-fixes"]
+    args: [
+      --fix,
+      --show-fixes,
+      # the following line can be removed after support for Python 3.9 is dropped
+      --extend-select=B905, # zip-without-explicit-strict
+    ]
 
 -   repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -302,6 +302,7 @@ ignore = [
     "E501",  # line too long
     "E741",  # Do not use variables named 'I', 'O', or 'l'
     "B018",  # Found useless expression. # disabled because ds.index is idiomatic
+    "UP038", # non-pep604-isinstance
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/yt/data_objects/analyzer_objects.py
+++ b/yt/data_objects/analyzer_objects.py
@@ -1,6 +1,10 @@
 import inspect
+import sys
 
 from yt.utilities.object_registries import analysis_task_registry
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 class AnalysisTask:
@@ -14,7 +18,7 @@ class AnalysisTask:
         # does not override
         if len(args) + len(kwargs) != len(self._params):
             raise RuntimeError
-        self.__dict__.update(zip(self._params, args))
+        self.__dict__.update(zip(self._params, args, strict=False))
         self.__dict__.update(kwargs)
 
     def __repr__(self):

--- a/yt/data_objects/data_containers.py
+++ b/yt/data_objects/data_containers.py
@@ -1,4 +1,5 @@
 import abc
+import sys
 import weakref
 from collections import defaultdict
 from contextlib import contextmanager
@@ -27,6 +28,9 @@ from yt.utilities.exceptions import (
 from yt.utilities.object_registries import data_object_registry
 from yt.utilities.on_demand_imports import _firefly as firefly
 from yt.utilities.parameter_file_storage import ParameterFileStore
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 if TYPE_CHECKING:
     from yt.data_objects.static_output import Dataset
@@ -797,7 +801,7 @@ class YTDataContainer(abc.ABC):
             # tuples containing some sort of special "any" ParticleGroup
             unambiguous_fields_to_include = []
             unambiguous_fields_units = []
-            for field, field_unit in zip(fields_to_include, fields_units):
+            for field, field_unit in zip(fields_to_include, fields_units, strict=True):
                 if isinstance(field, tuple):
                     # skip tuples, they'll be checked with _determine_fields
                     unambiguous_fields_to_include.append(field)
@@ -849,7 +853,7 @@ class YTDataContainer(abc.ABC):
             field_names = []
 
             ## explicitly go after the fields we want
-            for field, units in zip(fields_to_include, fields_units):
+            for field, units in zip(fields_to_include, fields_units, strict=True):
                 ## Only interested in fields with the current particle type,
                 ## whether that means general fields or field tuples
                 ftype, fname = field

--- a/yt/data_objects/derived_quantities.py
+++ b/yt/data_objects/derived_quantities.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy as np
 
 from yt.funcs import camelcase_to_underscore, iter_fields
@@ -10,6 +12,9 @@ from yt.utilities.parallel_tools.parallel_analysis_interface import (
 )
 from yt.utilities.physical_constants import gravitational_constant_cgs
 from yt.utilities.physical_ratios import HUGE
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 def get_position_fields(field, data):
@@ -415,7 +420,7 @@ class WeightedStandardDeviation(DerivedQuantity):
         fields = list(iter_fields(fields))
         units = [self.data_source.ds._get_field_info(field).units for field in fields]
         rv = super().__call__(fields, weight)
-        rv = [self.data_source.ds.arr(v, u) for v, u in zip(rv, units)]
+        rv = [self.data_source.ds.arr(v, u) for v, u in zip(rv, units, strict=True)]
         if len(rv) == 1:
             rv = rv[0]
         return rv
@@ -431,7 +436,7 @@ class WeightedStandardDeviation(DerivedQuantity):
         my_var2s = [
             (data[weight].d * (data[field].d - my_mean) ** 2).sum(dtype=np.float64)
             / my_weight
-            for field, my_mean in zip(fields, my_means)
+            for field, my_mean in zip(fields, my_means, strict=True)
         ]
         return my_means + my_var2s + [my_weight]
 
@@ -623,7 +628,7 @@ class Extrema(DerivedQuantity):
         # The values get turned into arrays here.
         return [
             self.data_source.ds.arr([mis.min(), mas.max()])
-            for mis, mas in zip(values[::2], values[1::2])
+            for mis, mas in zip(values[::2], values[1::2], strict=True)
         ]
 
 

--- a/yt/data_objects/level_sets/tests/test_clump_finding.py
+++ b/yt/data_objects/level_sets/tests/test_clump_finding.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import sys
 import tempfile
 
 import numpy as np
@@ -11,6 +12,9 @@ from yt.fields.derived_field import ValidateParameter
 from yt.loaders import load, load_uniform_grid
 from yt.testing import requires_file, requires_module
 from yt.utilities.answer_testing.framework import data_dir_load
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 def test_clump_finding():
@@ -132,7 +136,7 @@ def test_clump_tree_save():
     it2 = np.argsort(mt2).astype("int64")
     assert_array_equal(mt1[it1], mt2[it2])
 
-    for i1, i2 in zip(it1, it2):
+    for i1, i2 in zip(it1, it2, strict=True):
         ct1 = t1[i1]
         ct2 = t2[i2]
         assert_array_equal(ct1["gas", "density"], ct2["grid", "density"])
@@ -191,5 +195,5 @@ def test_clump_field_parameters():
     leaf_clumps_1 = master_clump_1.leaves
     leaf_clumps_2 = master_clump_2.leaves
 
-    for c1, c2 in zip(leaf_clumps_1, leaf_clumps_2):
+    for c1, c2 in zip(leaf_clumps_1, leaf_clumps_2, strict=True):
         assert_array_equal(c1["gas", "density"], c2["gas", "density"])

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy as np
 from more_itertools import collapse
 
@@ -22,6 +24,9 @@ from yt.utilities.parallel_tools.parallel_analysis_interface import (
     ParallelAnalysisInterface,
     parallel_objects,
 )
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 def _sanitize_min_max_units(amin, amax, finfo, registry):
@@ -217,7 +222,7 @@ class ProfileND(ParallelAnalysisInterface):
         # cut_points is set to be everything initially, but
         # we also want to apply a filtering based on min/max
         pfilter = np.ones(bin_fields[0].shape, dtype="bool")
-        for (mi, ma), data in zip(self.bounds, bin_fields):
+        for (mi, ma), data in zip(self.bounds, bin_fields, strict=True):
             pfilter &= data > mi
             pfilter &= data < ma
         return pfilter, [data[pfilter] for data in bin_fields]
@@ -1313,7 +1318,9 @@ def create_profile(
                 data_source.ds.field_info[f].sampling_type == "local"
                 for f in bin_fields + fields
             ]
-            is_local_or_pfield = [pf or lf for (pf, lf) in zip(is_pfield, is_local)]
+            is_local_or_pfield = [
+                pf or lf for (pf, lf) in zip(is_pfield, is_local, strict=True)
+            ]
             if not all(is_local_or_pfield):
                 raise YTIllDefinedProfile(
                     bin_fields, data_source._determine_fields(fields), wf, is_pfield
@@ -1370,7 +1377,7 @@ def create_profile(
     if extrema is None or not any(collapse(extrema.values())):
         ex = [
             data_source.quantities["Extrema"](f, non_zero=l)
-            for f, l in zip(bin_fields, logs)
+            for f, l in zip(bin_fields, logs, strict=True)
         ]
         # pad extrema by epsilon so cells at bin edges are not excluded
         for i, (mi, ma) in enumerate(ex):
@@ -1456,7 +1463,7 @@ def create_profile(
             o_bins.append(field_obin)
 
     args = [data_source]
-    for f, n, (mi, ma), l in zip(bin_fields, n_bins, ex, logs):
+    for f, n, (mi, ma), l in zip(bin_fields, n_bins, ex, logs, strict=True):
         if mi <= 0 and l:
             raise YTIllDefinedBounds(mi, ma)
         args += [f, n, mi, ma, l]
@@ -1464,7 +1471,7 @@ def create_profile(
     if cls is ParticleProfile:
         kwargs["deposition"] = deposition
     if override_bins is not None:
-        for o_bin, ax in zip(o_bins, ["x", "y", "z"]):
+        for o_bin, ax in zip(o_bins, ["x", "y", "z"], strict=False):
             kwargs[f"override_bins_{ax}"] = o_bin
     obj = cls(*args, **kwargs)
     obj.accumulation = accumulation

--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -1318,6 +1318,8 @@ def create_profile(
                 data_source.ds.field_info[f].sampling_type == "local"
                 for f in bin_fields + fields
             ]
+            if wf is not None:
+                is_local.append(wf.sampling_type == "local")
             is_local_or_pfield = [
                 pf or lf for (pf, lf) in zip(is_pfield, is_local, strict=True)
             ]

--- a/yt/data_objects/region_expression.py
+++ b/yt/data_objects/region_expression.py
@@ -1,3 +1,4 @@
+import sys
 import weakref
 from functools import cached_property
 
@@ -11,6 +12,9 @@ from yt.utilities.exceptions import (
 from yt.visualization.line_plot import LineBuffer
 
 from .data_containers import _get_ipython_key_completion
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 class RegionExpression:
@@ -166,7 +170,7 @@ class RegionExpression:
             if d is not None:
                 d = int(d)
             dims[ax] = d
-        center = [(cl + cr) / 2.0 for cl, cr in zip(left_edge, right_edge)]
+        center = [(cl + cr) / 2.0 for cl, cr in zip(left_edge, right_edge, strict=True)]
         if None not in dims:
             return self.ds.arbitrary_grid(left_edge, right_edge, dims)
         return self.ds.region(center, left_edge, right_edge)

--- a/yt/data_objects/region_expression.py
+++ b/yt/data_objects/region_expression.py
@@ -1,4 +1,3 @@
-import sys
 import weakref
 from functools import cached_property
 
@@ -12,9 +11,6 @@ from yt.utilities.exceptions import (
 from yt.visualization.line_plot import LineBuffer
 
 from .data_containers import _get_ipython_key_completion
-
-if sys.version_info < (3, 10):
-    from yt._maintenance.backports import zip
 
 
 class RegionExpression:
@@ -170,7 +166,7 @@ class RegionExpression:
             if d is not None:
                 d = int(d)
             dims[ax] = d
-        center = [(cl + cr) / 2.0 for cl, cr in zip(left_edge, right_edge, strict=True)]
+        center = (left_edge + right_edge) / 2.0
         if None not in dims:
             return self.ds.arbitrary_grid(left_edge, right_edge, dims)
         return self.ds.region(center, left_edge, right_edge)

--- a/yt/data_objects/tests/test_covering_grid.py
+++ b/yt/data_objects/tests/test_covering_grid.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_equal, assert_equal
 
@@ -10,6 +12,10 @@ from yt.testing import (
     requires_module,
 )
 from yt.units import kpc
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
+
 
 # cylindrical data for covering_grid test
 cyl_2d = "WDMerger_hdf5_chk_1000/WDMerger_hdf5_chk_1000.hdf5"
@@ -354,7 +360,7 @@ def test_arbitrary_grid_edge():
         [1.0, 1.0, 1.0] * kpc,
     ]
 
-    for le, re, le_ans, re_ans in zip(ledge, redge, ledge_ans, redge_ans):
+    for le, re, le_ans, re_ans in zip(ledge, redge, ledge_ans, redge_ans, strict=True):
         ag = ds.arbitrary_grid(left_edge=le, right_edge=re, dims=dims)
         assert np.array_equal(ag.left_edge, le_ans)
         assert np.array_equal(ag.right_edge, re_ans)

--- a/yt/data_objects/tests/test_derived_quantities.py
+++ b/yt/data_objects/tests/test_derived_quantities.py
@@ -191,9 +191,11 @@ def test_in_memory_sph_derived_quantities():
     for fex, ans in zip(ex, [[0, 1], [0, 2], [0, 3]], strict=True):
         assert_equal(fex, ans)
 
-    for d, v, l in zip(
-        "xyz", [1, 2, 3], [[1, 0, 0], [0, 2, 0], [0, 0, 3]], strict=False
-    ):
+    for d, v, l in [
+        ("x", 1, [1, 0, 0]),
+        ("y", 2, [0, 2, 0]),
+        ("z", 3, [0, 0, 3]),
+    ]:
         max_d, x, y, z = ad.quantities.max_location(("io", d))
         assert_equal(max_d, v)
         assert_equal([x, y, z], l)

--- a/yt/data_objects/tests/test_derived_quantities.py
+++ b/yt/data_objects/tests/test_derived_quantities.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal
 
@@ -10,6 +12,9 @@ from yt.testing import (
     fake_sph_orientation_ds,
     requires_file,
 )
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 def setup_module():
@@ -183,10 +188,12 @@ def test_in_memory_sph_derived_quantities():
     assert_equal(com, [1 / 7, (1 + 2) / 7, (1 + 2 + 3) / 7])
 
     ex = ad.quantities.extrema([("io", "x"), ("io", "y"), ("io", "z")])
-    for fex, ans in zip(ex, [[0, 1], [0, 2], [0, 3]]):
+    for fex, ans in zip(ex, [[0, 1], [0, 2], [0, 3]], strict=True):
         assert_equal(fex, ans)
 
-    for d, v, l in zip("xyz", [1, 2, 3], [[1, 0, 0], [0, 2, 0], [0, 0, 3]]):
+    for d, v, l in zip(
+        "xyz", [1, 2, 3], [[1, 0, 0], [0, 2, 0], [0, 0, 3]], strict=False
+    ):
         max_d, x, y, z = ad.quantities.max_location(("io", d))
         assert_equal(max_d, v)
         assert_equal([x, y, z], l)

--- a/yt/data_objects/tests/test_sph_data_objects.py
+++ b/yt/data_objects/tests/test_sph_data_objects.py
@@ -1,16 +1,9 @@
-import sys
-
 import numpy as np
 from numpy.testing import assert_allclose, assert_almost_equal, assert_equal
 
 from yt import SlicePlot, add_particle_filter
 from yt.loaders import load
 from yt.testing import fake_sph_grid_ds, fake_sph_orientation_ds, requires_file
-
-if sys.version_info >= (3, 10):
-    pass
-else:
-    from yt._maintenance.backports import zip
 
 
 def test_point():
@@ -99,7 +92,7 @@ def test_periodic_region():
         for y in coords:
             for z in coords:
                 center = np.array([x, y, z])
-                for n, w in zip((8, 27), (1.0, 2.0), strict=True):
+                for n, w in [(8, 1.0), (27, 2.0)]:
                     le = center - 0.5 * w
                     re = center + 0.5 * w
                     box = ds.box(le, re)

--- a/yt/data_objects/tests/test_sph_data_objects.py
+++ b/yt/data_objects/tests/test_sph_data_objects.py
@@ -1,9 +1,16 @@
+import sys
+
 import numpy as np
 from numpy.testing import assert_allclose, assert_almost_equal, assert_equal
 
 from yt import SlicePlot, add_particle_filter
 from yt.loaders import load
 from yt.testing import fake_sph_grid_ds, fake_sph_orientation_ds, requires_file
+
+if sys.version_info >= (3, 10):
+    pass
+else:
+    from yt._maintenance.backports import zip
 
 
 def test_point():
@@ -92,7 +99,7 @@ def test_periodic_region():
         for y in coords:
             for z in coords:
                 center = np.array([x, y, z])
-                for n, w in zip((8, 27), (1.0, 2.0)):
+                for n, w in zip((8, 27), (1.0, 2.0), strict=True):
                     le = center - 0.5 * w
                     re = center + 0.5 * w
                     box = ds.box(le, re)

--- a/yt/fields/derived_field.py
+++ b/yt/fields/derived_field.py
@@ -1,6 +1,7 @@
 import contextlib
 import inspect
 import re
+import sys
 from collections.abc import Iterable
 from typing import Optional, Union
 
@@ -24,6 +25,9 @@ from .field_exceptions import (
     NeedsParameter,
     NeedsProperty,
 )
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 def TranslationFunc(field_name):
@@ -255,7 +259,7 @@ class DerivedField:
             else:
                 params.extend(val.parameters)
                 values.extend([fd.get_field_parameter(fp) for fp in val.parameters])
-        return dict(zip(params, values)), permute_params
+        return dict(zip(params, values, strict=True)), permute_params
 
     _unit_registry = None
 

--- a/yt/fields/magnetic_field.py
+++ b/yt/fields/magnetic_field.py
@@ -10,6 +10,9 @@ from yt.units import dimensions
 
 from .field_plugin_registry import register_field_plugin
 
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
+
 if sys.version_info >= (3, 11):
     from typing import assert_never
 else:
@@ -330,7 +333,7 @@ def setup_magnetic_field_aliases(registry, ds_ftype, ds_fields, ftype="gas"):
 
             return _mag_field
 
-        for ax, fd in zip(registry.ds.coordinates.axis_order, ds_fields):
+        for ax, fd in zip(registry.ds.coordinates.axis_order, ds_fields, strict=False):
             registry.add_field(
                 (ftype, f"magnetic_field_{ax}"),
                 sampling_type=sampling_type,

--- a/yt/fields/particle_fields.py
+++ b/yt/fields/particle_fields.py
@@ -1,5 +1,3 @@
-import sys
-
 import numpy as np
 
 from yt.fields.derived_field import ValidateParameter, ValidateSpatial
@@ -25,12 +23,6 @@ from yt.utilities.math_utils import (
 
 from .field_functions import get_radius
 from .vector_operations import create_magnitude_field
-
-if sys.version_info >= (3, 10):
-    pass
-else:
-    from yt._maintenance.backports import zip
-
 
 sph_whitelist_fields = (
     "density",
@@ -192,7 +184,7 @@ def particle_deposition_functions(ptype, coord_name, mass_name, registry):
         return _deposit_field
 
     for ax in "xyz":
-        for method, name in zip(("cic", "sum"), ("cic", "nn"), strict=True):
+        for method, name in [("cic", "cic"), ("sum", "nn")]:
             function = _get_density_weighted_deposit_field(
                 f"particle_velocity_{ax}", "code_velocity", method
             )
@@ -205,7 +197,7 @@ def particle_deposition_functions(ptype, coord_name, mass_name, registry):
                 validators=[ValidateSpatial(0)],
             )
 
-    for method, name in zip(("cic", "sum"), ("cic", "nn"), strict=True):
+    for method, name in [("cic", "cic"), ("sum", "nn")]:
         function = _get_density_weighted_deposit_field("age", "code_time", method)
         registry.add_field(
             ("deposit", ("%s_" + name + "_age") % (ptype)),

--- a/yt/fields/particle_fields.py
+++ b/yt/fields/particle_fields.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy as np
 
 from yt.fields.derived_field import ValidateParameter, ValidateSpatial
@@ -23,6 +25,12 @@ from yt.utilities.math_utils import (
 
 from .field_functions import get_radius
 from .vector_operations import create_magnitude_field
+
+if sys.version_info >= (3, 10):
+    pass
+else:
+    from yt._maintenance.backports import zip
+
 
 sph_whitelist_fields = (
     "density",
@@ -184,7 +192,7 @@ def particle_deposition_functions(ptype, coord_name, mass_name, registry):
         return _deposit_field
 
     for ax in "xyz":
-        for method, name in zip(("cic", "sum"), ("cic", "nn")):
+        for method, name in zip(("cic", "sum"), ("cic", "nn"), strict=True):
             function = _get_density_weighted_deposit_field(
                 f"particle_velocity_{ax}", "code_velocity", method
             )
@@ -197,7 +205,7 @@ def particle_deposition_functions(ptype, coord_name, mass_name, registry):
                 validators=[ValidateSpatial(0)],
             )
 
-    for method, name in zip(("cic", "sum"), ("cic", "nn")):
+    for method, name in zip(("cic", "sum"), ("cic", "nn"), strict=True):
         function = _get_density_weighted_deposit_field("age", "code_time", method)
         registry.add_field(
             ("deposit", ("%s_" + name + "_age") % (ptype)),

--- a/yt/fields/vector_operations.py
+++ b/yt/fields/vector_operations.py
@@ -19,6 +19,9 @@ from yt.utilities.math_utils import (
 
 from .derived_field import NeedsParameter, ValidateParameter, ValidateSpatial
 
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
+
 if sys.version_info >= (3, 11):
     from typing import assert_never
 else:
@@ -676,7 +679,7 @@ def create_averaged_field(
         )
         i_i, j_i, k_i = np.mgrid[0:3, 0:3, 0:3]
 
-        for i, j, k in zip(i_i.ravel(), j_i.ravel(), k_i.ravel()):
+        for i, j, k in zip(i_i.ravel(), j_i.ravel(), k_i.ravel(), strict=True):
             sl = (
                 slice(i, nx - (2 - i)),
                 slice(j, ny - (2 - j)),

--- a/yt/frontends/amrex/data_structures.py
+++ b/yt/frontends/amrex/data_structures.py
@@ -1,6 +1,7 @@
 import glob
 import os
 import re
+import sys
 from collections import namedtuple
 from functools import cached_property
 from stat import ST_CTIME
@@ -24,6 +25,11 @@ from .fields import (
     NyxFieldInfo,
     WarpXFieldInfo,
 )
+
+if sys.version_info >= (3, 10):
+    pass
+else:
+    from yt._maintenance.backports import zip
 
 # This is what we use to find scientific notation that might include d's
 # instead of e's.
@@ -833,7 +839,7 @@ class BoxlibDataset(Dataset):
         # in a slightly hidden variable.
         self._max_level = int(header_file.readline())
 
-        for side, init in zip(["left", "right"], [np.zeros, np.ones]):
+        for side, init in zip(["left", "right"], [np.zeros, np.ones], strict=True):
             domain_edge = init(3, dtype="float64")
             domain_edge[: self.dimensionality] = header_file.readline().split()
             setattr(self, f"domain_{side}_edge", domain_edge)

--- a/yt/frontends/amrex/data_structures.py
+++ b/yt/frontends/amrex/data_structures.py
@@ -1,7 +1,6 @@
 import glob
 import os
 import re
-import sys
 from collections import namedtuple
 from functools import cached_property
 from stat import ST_CTIME
@@ -25,11 +24,6 @@ from .fields import (
     NyxFieldInfo,
     WarpXFieldInfo,
 )
-
-if sys.version_info >= (3, 10):
-    pass
-else:
-    from yt._maintenance.backports import zip
 
 # This is what we use to find scientific notation that might include d's
 # instead of e's.
@@ -839,7 +833,7 @@ class BoxlibDataset(Dataset):
         # in a slightly hidden variable.
         self._max_level = int(header_file.readline())
 
-        for side, init in zip(["left", "right"], [np.zeros, np.ones], strict=True):
+        for side, init in [("left", np.zeros), ("right", np.ones)]:
             domain_edge = init(3, dtype="float64")
             domain_edge[: self.dimensionality] = header_file.readline().split()
             setattr(self, f"domain_{side}_edge", domain_edge)

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -7,6 +7,7 @@ AMRVAC data structures
 
 import os
 import struct
+import sys
 import warnings
 import weakref
 from pathlib import Path
@@ -25,6 +26,9 @@ from yt.utilities.physical_constants import boltzmann_constant_cgs as kb_cgs
 from .datfile_utils import get_header, get_tree_info
 from .fields import AMRVACFieldInfo
 from .io import read_amrvac_namelist
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 def _parse_geometry(geometry_tag: str) -> Geometry:
@@ -142,7 +146,9 @@ class AMRVACHierarchy(GridIndex):
         dim = self.dataset.dimensionality
 
         self.grids = np.empty(self.num_grids, dtype="object")
-        for igrid, (ytlevel, morton_index) in enumerate(zip(ytlevels, morton_indices)):
+        for igrid, (ytlevel, morton_index) in enumerate(
+            zip(ytlevels, morton_indices, strict=True)
+        ):
             dx = dx0 / self.dataset.refine_by**ytlevel
             left_edge = xmin + (morton_index - 1) * block_nx * dx
 

--- a/yt/frontends/amrvac/datfile_utils.py
+++ b/yt/frontends/amrvac/datfile_utils.py
@@ -1,6 +1,10 @@
 import struct
+import sys
 
 import numpy as np
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 # Size of basic types (in bytes)
 SIZE_LOGICAL = 4
@@ -98,7 +102,7 @@ def get_header(istream):
     ]
 
     # Store the values corresponding to the names
-    for val, name in zip(vals, names):
+    for val, name in zip(vals, names, strict=True):
         h[name] = val
     return h
 

--- a/yt/frontends/art/io.py
+++ b/yt/frontends/art/io.py
@@ -1,5 +1,6 @@
 import os
 import os.path
+import sys
 from collections import defaultdict
 from functools import partial
 
@@ -15,6 +16,9 @@ from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.fortran_utils import read_vector, skip
 from yt.utilities.io_handler import BaseIOHandler
 from yt.utilities.logger import ytLogger as mylog
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 class IOHandlerART(BaseIOHandler):
@@ -125,7 +129,7 @@ class IOHandlerART(BaseIOHandler):
         if fname.startswith("particle_mass"):
             a = 0
             data = np.zeros(npa, dtype="f8")
-            for ptb, size, m in zip(pbool, sizes, self.ws):
+            for ptb, size, m in zip(pbool, sizes, self.ws, strict=True):
                 if ptb:
                     data[a : a + size] = m
                     a += size
@@ -135,7 +139,7 @@ class IOHandlerART(BaseIOHandler):
         elif fname == "particle_type":
             a = 0
             data = np.zeros(npa, dtype="int64")
-            for i, (ptb, size) in enumerate(zip(pbool, sizes)):
+            for i, (ptb, size) in enumerate(zip(pbool, sizes, strict=True)):
                 if ptb:
                     data[a : a + size] = i
                     a += size
@@ -218,7 +222,7 @@ class IOHandlerDarkMatterART(IOHandlerART):
         if fname.startswith("particle_mass"):
             a = 0
             data = np.zeros(npa, dtype="f8")
-            for ptb, size, m in zip(pbool, sizes, self.ws):
+            for ptb, size, m in zip(pbool, sizes, self.ws, strict=True):
                 if ptb:
                     data[a : a + size] = m
                     a += size
@@ -228,7 +232,7 @@ class IOHandlerDarkMatterART(IOHandlerART):
         elif fname == "particle_type":
             a = 0
             data = np.zeros(npa, dtype="int64")
-            for i, (ptb, size) in enumerate(zip(pbool, sizes)):
+            for i, (ptb, size) in enumerate(zip(pbool, sizes, strict=True)):
                 if ptb:
                     data[a : a + size] = i
                     a += size

--- a/yt/frontends/artio/data_structures.py
+++ b/yt/frontends/artio/data_structures.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import weakref
 from collections import defaultdict
 from typing import Optional
@@ -20,6 +21,9 @@ from yt.funcs import mylog, setdefaultattr
 from yt.geometry import particle_deposit as particle_deposit
 from yt.geometry.geometry_handler import Index, YTDataChunk
 from yt.utilities.exceptions import YTParticleDepositionNotImplemented
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 class ARTIOOctreeSubset(OctreeSubset):
@@ -72,7 +76,7 @@ class ARTIOOctreeSubset(OctreeSubset):
         self.oct_handler.fill_sfc(
             levels, cell_inds, file_inds, domain_counts, field_indices, tr
         )
-        tr = dict(zip(fields, tr))
+        tr = dict(zip(fields, tr, strict=True))
         return tr
 
     def fill_particles(self, fields):
@@ -118,7 +122,7 @@ class ARTIORootMeshSubset(ARTIOOctreeSubset):
         ]
         tr = self.oct_handler.fill_sfc(selector, field_indices)
         self.data_size = tr[0].size
-        tr = dict(zip(fields, tr))
+        tr = dict(zip(fields, tr, strict=True))
         return tr
 
     def deposit(self, positions, fields=None, method=None, kernel_name="cubic"):

--- a/yt/frontends/artio/definitions.py
+++ b/yt/frontends/artio/definitions.py
@@ -1,3 +1,9 @@
+import sys
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
+
+
 yt_to_art = {
     "Density": "HVAR_GAS_DENSITY",
     "TotalEnergy": "HVAR_GAS_ENERGY",
@@ -27,7 +33,7 @@ yt_to_art = {
     "stars": "STAR",
     "nbody": "N-BODY",
 }
-art_to_yt = dict(zip(yt_to_art.values(), yt_to_art.keys()))
+art_to_yt = dict(zip(yt_to_art.values(), yt_to_art.keys(), strict=True))
 
 
 class ARTIOconstants:

--- a/yt/frontends/athena/data_structures.py
+++ b/yt/frontends/athena/data_structures.py
@@ -1,5 +1,6 @@
 import os
 import re
+import sys
 import weakref
 
 import numpy as np
@@ -16,6 +17,9 @@ from yt.utilities.decompose import decompose_array, get_psize
 from yt.utilities.lib.misc_utilities import get_box_grids_level
 
 from .fields import AthenaFieldInfo
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 def chk23(strin):
@@ -359,7 +363,9 @@ class AthenaHierarchy(GridIndex):
                 gre_orig = self.ds.arr(
                     np.round(gle_orig + dx * gdims[i], decimals=12), "code_length"
                 )
-                bbox = np.array([[le, re] for le, re in zip(gle_orig, gre_orig)])
+                bbox = np.array(
+                    [[le, re] for le, re in zip(gle_orig, gre_orig, strict=True)]
+                )
                 psize = get_psize(self.ds.domain_dimensions, self.ds.nprocs)
                 gle, gre, shapes, slices, _ = decompose_array(gdims[i], psize, bbox)
                 gle_all += gle

--- a/yt/frontends/athena/io.py
+++ b/yt/frontends/athena/io.py
@@ -1,9 +1,15 @@
+import sys
+
 import numpy as np
 
 from yt.funcs import mylog
 from yt.utilities.io_handler import BaseIOHandler
 
 from .data_structures import chk23
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
+
 
 float_size = {"float": np.dtype(">f4").itemsize, "double": np.dtype(">f8").itemsize}
 
@@ -19,7 +25,7 @@ class IOHandlerAthena(BaseIOHandler):
     def _field_dict(self, fhandle):
         keys = fhandle["field_types"].keys()
         val = fhandle["field_types"].keys()
-        return dict(zip(keys, val))
+        return dict(zip(keys, val, strict=True))
 
     def _read_field_names(self, grid):
         pass

--- a/yt/frontends/athena/io.py
+++ b/yt/frontends/athena/io.py
@@ -24,7 +24,7 @@ class IOHandlerAthena(BaseIOHandler):
 
     def _field_dict(self, fhandle):
         keys = fhandle["field_types"].keys()
-        val = fhandle["field_types"].keys()
+        val = fhandle["field_types"].values()
         return dict(zip(keys, val, strict=True))
 
     def _read_field_names(self, grid):

--- a/yt/frontends/athena/io.py
+++ b/yt/frontends/athena/io.py
@@ -8,7 +8,7 @@ from yt.utilities.io_handler import BaseIOHandler
 from .data_structures import chk23
 
 if sys.version_info < (3, 10):
-    from yt._maintenance.backports import zip
+    pass
 
 
 float_size = {"float": np.dtype(">f4").itemsize, "double": np.dtype(">f8").itemsize}
@@ -21,11 +21,6 @@ class IOHandlerAthena(BaseIOHandler):
     _offset_string = "data:offsets=0"
     _data_string = "data:datatype=0"
     _read_table_offset = None
-
-    def _field_dict(self, fhandle):
-        keys = fhandle["field_types"].keys()
-        val = fhandle["field_types"].values()
-        return dict(zip(keys, val, strict=True))
 
     def _read_field_names(self, grid):
         pass

--- a/yt/frontends/athena/io.py
+++ b/yt/frontends/athena/io.py
@@ -1,15 +1,9 @@
-import sys
-
 import numpy as np
 
 from yt.funcs import mylog
 from yt.utilities.io_handler import BaseIOHandler
 
 from .data_structures import chk23
-
-if sys.version_info < (3, 10):
-    pass
-
 
 float_size = {"float": np.dtype(">f4").itemsize, "double": np.dtype(">f8").itemsize}
 

--- a/yt/frontends/athena_pp/data_structures.py
+++ b/yt/frontends/athena_pp/data_structures.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import weakref
 
 import numpy as np
@@ -14,6 +15,9 @@ from yt.utilities.chemical_formulas import compute_mu
 from yt.utilities.file_handler import HDF5FileHandler
 
 from .fields import AthenaPPFieldInfo
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 geom_map = {
     "cartesian": "cartesian",
@@ -215,7 +219,9 @@ class AthenaPPDataset(Dataset):
         self._field_map = {}
         k = 0
         for dname, num_var in zip(
-            self._handle.attrs["DatasetNames"], self._handle.attrs["NumVariables"]
+            self._handle.attrs["DatasetNames"],
+            self._handle.attrs["NumVariables"],
+            strict=True,
         ):
             for j in range(num_var):
                 fname = self._handle.attrs["VariableNames"][k].decode("ascii", "ignore")

--- a/yt/frontends/chombo/io.py
+++ b/yt/frontends/chombo/io.py
@@ -1,10 +1,14 @@
 import re
+import sys
 
 import numpy as np
 
 from yt.geometry.selection_routines import GridSelector
 from yt.utilities.io_handler import BaseIOHandler
 from yt.utilities.logger import ytLogger as mylog
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 class IOHandlerChomboHDF5(BaseIOHandler):
@@ -101,7 +105,9 @@ class IOHandlerChomboHDF5(BaseIOHandler):
         stop = start + boxsize
         data = lev[self._data_string][start:stop]
         data_no_ghost = data.reshape(shape, order="F")
-        ghost_slice = tuple(slice(g, d + g, None) for g, d in zip(self.ghost, dims))
+        ghost_slice = tuple(
+            slice(g, d + g, None) for g, d in zip(self.ghost, dims, strict=True)
+        )
         ghost_slice = ghost_slice[0 : self.dim]
         return data_no_ghost[ghost_slice]
 

--- a/yt/frontends/chombo/io.py
+++ b/yt/frontends/chombo/io.py
@@ -106,7 +106,7 @@ class IOHandlerChomboHDF5(BaseIOHandler):
         data = lev[self._data_string][start:stop]
         data_no_ghost = data.reshape(shape, order="F")
         ghost_slice = tuple(
-            slice(g, d + g, None) for g, d in zip(self.ghost, dims, strict=True)
+            slice(g, g + d) for g, d in zip(self.ghost, dims, strict=True)
         )
         ghost_slice = ghost_slice[0 : self.dim]
         return data_no_ghost[ghost_slice]

--- a/yt/frontends/enzo/answer_testing_support.py
+++ b/yt/frontends/enzo/answer_testing_support.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from functools import wraps
 
 import numpy as np
@@ -14,6 +15,9 @@ from yt.utilities.answer_testing.framework import (
     can_run_ds,
     temp_cwd,
 )
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 class AssertWrapper:
@@ -102,7 +106,7 @@ class ShockTubeTest:
         position = ad["index", "x"]
         for k in self.fields:
             field = ad[k].d
-            for xmin, xmax in zip(self.left_edges, self.right_edges):
+            for xmin, xmax in zip(self.left_edges, self.right_edges, strict=True):
                 mask = (position >= xmin) * (position <= xmax)
                 exact_field = np.interp(position[mask].ndview, exact["pos"], exact[k])
                 myname = f"ShockTubeTest_{k}"

--- a/yt/frontends/enzo/data_structures.py
+++ b/yt/frontends/enzo/data_structures.py
@@ -1,6 +1,7 @@
 import os
 import re
 import string
+import sys
 import time
 import weakref
 from collections import defaultdict
@@ -20,6 +21,9 @@ from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.on_demand_imports import _h5py as h5py, _libconf as libconf
 
 from .fields import EnzoFieldInfo
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 class EnzoGrid(AMRGridPatch):
@@ -342,7 +346,7 @@ class EnzoHierarchy(GridIndex):
         mylog.info("Finished rebuilding")
 
     def _populate_grid_objects(self):
-        for g, f in zip(self.grids, self.filenames):
+        for g, f in zip(self.grids, self.filenames, strict=True):
             g._prepare_grid()
             g._setup_dx()
             g.set_filename(f[0])

--- a/yt/frontends/enzo_e/data_structures.py
+++ b/yt/frontends/enzo_e/data_structures.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from functools import cached_property
 
 import numpy as np
@@ -23,11 +22,6 @@ from yt.geometry.grid_geometry_handler import GridIndex
 from yt.utilities.cosmology import Cosmology
 from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.on_demand_imports import _h5py as h5py, _libconf as libconf
-
-if sys.version_info >= (3, 10):
-    pass
-else:
-    from yt._maintenance.backports import zip
 
 
 class EnzoEGrid(AMRGridPatch):
@@ -481,7 +475,7 @@ class EnzoEDataset(Dataset):
             setdefaultattr(self, "velocity_unit", self.quan(k["uvel"], "cm/s"))
         else:
             p = self.parameters
-            for d, u in zip(("length", "time"), ("cm", "s"), strict=True):
+            for d, u in [("length", "cm"), ("time", "s")]:
                 val = nested_dict_get(p, ("Units", d), default=1)
                 setdefaultattr(self, f"{d}_unit", self.quan(val, u))
             mass = nested_dict_get(p, ("Units", "mass"))

--- a/yt/frontends/enzo_e/data_structures.py
+++ b/yt/frontends/enzo_e/data_structures.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from functools import cached_property
 
 import numpy as np
@@ -22,6 +23,11 @@ from yt.geometry.grid_geometry_handler import GridIndex
 from yt.utilities.cosmology import Cosmology
 from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.on_demand_imports import _h5py as h5py, _libconf as libconf
+
+if sys.version_info >= (3, 10):
+    pass
+else:
+    from yt._maintenance.backports import zip
 
 
 class EnzoEGrid(AMRGridPatch):
@@ -475,7 +481,7 @@ class EnzoEDataset(Dataset):
             setdefaultattr(self, "velocity_unit", self.quan(k["uvel"], "cm/s"))
         else:
             p = self.parameters
-            for d, u in zip(("length", "time"), ("cm", "s")):
+            for d, u in zip(("length", "time"), ("cm", "s"), strict=True):
                 val = nested_dict_get(p, ("Units", d), default=1)
                 setdefaultattr(self, f"{d}_unit", self.quan(val, u))
             mass = nested_dict_get(p, ("Units", "mass"))

--- a/yt/frontends/enzo_e/misc.py
+++ b/yt/frontends/enzo_e/misc.py
@@ -1,5 +1,10 @@
+import sys
+
 import numpy as np
 from more_itertools import always_iterable
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 def bdecode(block):
@@ -89,7 +94,7 @@ def get_root_block_id(block, min_dim=3):
 
 def get_child_index(anc_id, desc_id):
     cid = ""
-    for aind, dind in zip(anc_id.split("_"), desc_id.split("_")):
+    for aind, dind in zip(anc_id.split("_"), desc_id.split("_"), strict=True):
         cid += dind[len(aind)]
     cid = int(cid, 2)
     return cid
@@ -100,7 +105,7 @@ def is_parent(anc_block, desc_block):
     if (len(desc_block.replace(":", "")) - len(anc_block.replace(":", ""))) / dim != 1:
         return False
 
-    for aind, dind in zip(anc_block.split("_"), desc_block.split("_")):
+    for aind, dind in zip(anc_block.split("_"), desc_block.split("_"), strict=True):
         if not dind.startswith(aind):
             return False
     return True

--- a/yt/frontends/exodus_ii/data_structures.py
+++ b/yt/frontends/exodus_ii/data_structures.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy as np
 
 from yt.data_objects.index_subobjects.unstructured_mesh import UnstructuredMesh
@@ -10,6 +12,9 @@ from yt.utilities.logger import ytLogger as mylog
 
 from .fields import ExodusIIFieldInfo
 from .util import get_num_pseudo_dims, load_info_records, sanitize_string
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 class ExodusIIUnstructuredMesh(UnstructuredMesh):
@@ -220,7 +225,7 @@ class ExodusIIDataset(Dataset):
             return
         with self._handle.open_ds() as ds:
             values = ds.variables["vals_glo_var"][:].transpose()
-            for name, value in zip(names, values):
+            for name, value in zip(names, values, strict=True):
                 self.parameters[name] = value
 
     def _load_info_records(self):

--- a/yt/frontends/exodus_ii/io.py
+++ b/yt/frontends/exodus_ii/io.py
@@ -1,7 +1,12 @@
+import sys
+
 import numpy as np
 
 from yt.utilities.file_handler import NetCDF4FileHandler
 from yt.utilities.io_handler import BaseIOHandler
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 class IOHandlerExodusII(BaseIOHandler):
@@ -69,7 +74,7 @@ class IOHandlerExodusII(BaseIOHandler):
                         ind += g.select(selector, data, rv[field], ind)  # caches
                 if fname in self.elem_fields:
                     field_ind = self.elem_fields.index(fname)
-                    for g, mesh_id in zip(objs, mesh_ids):
+                    for g, mesh_id in zip(objs, mesh_ids, strict=True):
                         fdata = ds.variables[
                             "vals_elem_var%deb%s" % (field_ind + 1, mesh_id)
                         ][:]

--- a/yt/frontends/fits/fields.py
+++ b/yt/frontends/fits/fields.py
@@ -1,5 +1,12 @@
+import sys
+
 from yt._typing import KnownFieldsT
 from yt.fields.field_info_container import FieldInfoContainer
+
+if sys.version_info >= (3, 10):
+    pass
+else:
+    from yt._maintenance.backports import zip
 
 
 class FITSFieldInfo(FieldInfoContainer):
@@ -73,6 +80,7 @@ class WCSFITSFieldInfo(FITSFieldInfo):
         for (i, axis), name in zip(
             enumerate([self.ds.lon_axis, self.ds.lat_axis]),
             [self.ds.lon_name, self.ds.lat_name],
+            strict=True,
         ):
             unit = str(wcs_2d.wcs.cunit[i])
             if unit.lower() == "deg":

--- a/yt/frontends/fits/fields.py
+++ b/yt/frontends/fits/fields.py
@@ -1,12 +1,5 @@
-import sys
-
 from yt._typing import KnownFieldsT
 from yt.fields.field_info_container import FieldInfoContainer
-
-if sys.version_info >= (3, 10):
-    pass
-else:
-    from yt._maintenance.backports import zip
 
 
 class FITSFieldInfo(FieldInfoContainer):
@@ -77,11 +70,10 @@ class WCSFITSFieldInfo(FITSFieldInfo):
 
             return _world_f
 
-        for (i, axis), name in zip(
-            enumerate([self.ds.lon_axis, self.ds.lat_axis]),
-            [self.ds.lon_name, self.ds.lat_name],
-            strict=True,
-        ):
+        for i, axis, name in [
+            (0, self.ds.lon_axis, self.ds.lon_name),
+            (1, self.ds.lat_axis, self.ds.lat_name),
+        ]:
             unit = str(wcs_2d.wcs.cunit[i])
             if unit.lower() == "deg":
                 unit = "degree"

--- a/yt/frontends/flash/data_structures.py
+++ b/yt/frontends/flash/data_structures.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import weakref
 
 import numpy as np
@@ -14,6 +15,9 @@ from yt.utilities.file_handler import HDF5FileHandler, valid_hdf5_signature
 from yt.utilities.physical_ratios import cm_per_mpc
 
 from .fields import FLASHFieldInfo
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 class FLASHGrid(AMRGridPatch):
@@ -274,7 +278,9 @@ class FLASHDataset(Dataset):
         if nn not in self._handle:
             raise KeyError(nn)
         for tpname, pval in zip(
-            self._handle[nn][:, "name"], self._handle[nn][:, "value"]
+            self._handle[nn][:, "name"],
+            self._handle[nn][:, "value"],
+            strict=True,
         ):
             if tpname.decode("ascii", "ignore").strip() == pname:
                 if hasattr(pval, "decode"):
@@ -306,7 +312,9 @@ class FLASHDataset(Dataset):
                 if hn not in self._handle:
                     continue
                 for varname, val in zip(
-                    self._handle[hn][:, "name"], self._handle[hn][:, "value"]
+                    self._handle[hn][:, "name"],
+                    self._handle[hn][:, "value"],
+                    strict=True,
                 ):
                     vn = varname.strip()
                     if hn.startswith("string"):
@@ -333,7 +341,9 @@ class FLASHDataset(Dataset):
                     )
                 else:
                     zipover = zip(
-                        self._handle[hn][:, "name"], self._handle[hn][:, "value"]
+                        self._handle[hn][:, "name"],
+                        self._handle[hn][:, "value"],
+                        strict=True,
                     )
                 for varname, val in zipover:
                     vn = varname.strip()

--- a/yt/frontends/gadget/io.py
+++ b/yt/frontends/gadget/io.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from collections import defaultdict
 from functools import cached_property
 
@@ -11,6 +12,9 @@ from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.on_demand_imports import _h5py as h5py
 
 from .definitions import SNAP_FORMAT_2_OFFSET, gadget_hdf5_ptypes
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 class IOHandlerGadgetHDF5(IOHandlerSPH):
@@ -509,7 +513,7 @@ class IOHandlerGadgetBinary(IOHandlerSPH):
             pos = offset
         fs = self._field_size
         offsets = {}
-        pcount = dict(zip(self._ptypes, pcount))
+        pcount = dict(zip(self._ptypes, pcount, strict=True))
 
         for field in self._fields:
             if field == "ParticleIDs" and self.ds.long_ids:

--- a/yt/frontends/gadget/testing.py
+++ b/yt/frontends/gadget/testing.py
@@ -1,8 +1,13 @@
+import sys
+
 import numpy as np
 
 from .data_structures import GadgetBinaryHeader, GadgetDataset
 from .definitions import gadget_field_specs, gadget_ptype_specs
 from .io import IOHandlerGadgetBinary
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 vector_fields = dict(IOHandlerGadgetBinary._vector_fields)
 
@@ -72,7 +77,7 @@ def fake_gadget_binary(
                 header["HubbleParam"] = 1
             write_block(fp, header, endian, fmt, "HEAD")
 
-        npart = dict(zip(ptype_spec, npart))
+        npart = dict(zip(ptype_spec, npart, strict=True))
         for fs in field_spec:
             # Parse field name and particle type
             if isinstance(fs, str):

--- a/yt/frontends/halo_catalog/tests/test_outputs.py
+++ b/yt/frontends/halo_catalog/tests/test_outputs.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy as np
 from numpy.testing import assert_array_equal, assert_equal
 
@@ -7,6 +9,9 @@ from yt.loaders import load as yt_load
 from yt.testing import TempDirTest, requires_file, requires_module
 from yt.units.yt_array import YTArray, YTQuantity
 from yt.utilities.answer_testing.framework import data_dir_load
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 def fake_halo_catalog(data):
@@ -38,7 +43,7 @@ class HaloCatalogTest(TempDirTest):
         units = ["g"] + ["cm"] * 3
         data = {
             field: YTArray(rs.random_sample(n_halos), unit)
-            for field, unit in zip(fields, units)
+            for field, unit in zip(fields, units, strict=True)
         }
 
         fn = fake_halo_catalog(data)
@@ -61,7 +66,7 @@ class HaloCatalogTest(TempDirTest):
         units = ["g"] + ["cm"] * 3
         data = {
             field: YTArray(rs.random_sample(n_halos), unit)
-            for field, unit in zip(fields, units)
+            for field, unit in zip(fields, units, strict=True)
         }
 
         data["particle_position_x"][0] = 1.0

--- a/yt/frontends/ramses/tests/test_hilbert.py
+++ b/yt/frontends/ramses/tests/test_hilbert.py
@@ -1,9 +1,14 @@
+import sys
+
 import numpy as np
 from numpy.testing import assert_equal
 
 import yt
 from yt.frontends.ramses.hilbert import get_cpu_list_cuboid, hilbert3d
 from yt.testing import requires_file
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 def test_hilbert3d():
@@ -20,7 +25,7 @@ def test_hilbert3d():
     ]
     outputs = [0, 1, 7, 6, 3, 2, 4, 5]
 
-    for i, o in zip(inputs, outputs):
+    for i, o in zip(inputs, outputs, strict=True):
         assert_equal(hilbert3d(i, 3).item(), o)
 
 
@@ -48,7 +53,7 @@ def test_get_cpu_list():
         + [ds.hilbert_indices[ds.parameters["ncpu"]][1]],
         dtype="float64",
     )
-    for i, o in zip(inputs, outputs):
+    for i, o in zip(inputs, outputs, strict=True):
         bbox = i
         ls = list(get_cpu_list_cuboid(ds, bbox, bound_keys=bound_keys))
         assert len(ls) > 0

--- a/yt/frontends/stream/data_structures.py
+++ b/yt/frontends/stream/data_structures.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 import uuid
 import weakref
@@ -45,6 +46,9 @@ from yt.utilities.logger import ytLogger as mylog
 
 from .definitions import process_data, set_particle_types
 from .fields import StreamFieldInfo
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 class StreamGrid(AMRGridPatch):
@@ -422,7 +426,7 @@ class StreamDataset(Dataset):
             "magnetic_unit",
         )
         cgs_units = ("cm", "g", "s", "cm/s", "gauss")
-        for unit, attr, cgs_unit in zip(base_units, attrs, cgs_units):
+        for unit, attr, cgs_unit in zip(base_units, attrs, cgs_units, strict=True):
             if isinstance(unit, str):
                 if unit == "code_magnetic":
                     # If no magnetic unit was explicitly specified

--- a/yt/frontends/stream/definitions.py
+++ b/yt/frontends/stream/definitions.py
@@ -1,3 +1,4 @@
+import sys
 from collections import defaultdict
 
 import numpy as np
@@ -12,6 +13,9 @@ from yt.utilities.exceptions import (
 from yt.utilities.logger import ytLogger as mylog
 
 from .fields import StreamFieldInfo
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 def assign_particle_data(ds, pdata, bbox):
@@ -135,7 +139,7 @@ def assign_particle_data(ds, pdata, bbox):
     else:
         grid_pdata = [pdata]
 
-    for pd, gi in zip(grid_pdata, sorted(ds.stream_handler.fields)):
+    for pd, gi in zip(grid_pdata, sorted(ds.stream_handler.fields), strict=True):
         ds.stream_handler.fields[gi].update(pd)
         ds.stream_handler.particle_types.update(set_particle_types(pd))
         npart = ds.stream_handler.fields[gi].pop("number_of_particles", 0)

--- a/yt/frontends/tipsy/data_structures.py
+++ b/yt/frontends/tipsy/data_structures.py
@@ -1,6 +1,7 @@
 import glob
 import os
 import struct
+import sys
 
 import numpy as np
 
@@ -11,6 +12,9 @@ from yt.utilities.physical_constants import G
 from yt.utilities.physical_ratios import cm_per_kpc
 
 from .fields import TipsyFieldInfo
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 class TipsyFile(ParticleFile):
@@ -122,7 +126,9 @@ class TipsyDataset(SPHDataset):
         hvals = {
             a: c
             for (a, b), c in zip(
-                self._header_spec, struct.unpack(hh, f.read(struct.calcsize(hh)))
+                self._header_spec,
+                struct.unpack(hh, f.read(struct.calcsize(hh))),
+                strict=True,
             )
         }
         self.parameters.update(hvals)

--- a/yt/frontends/tipsy/io.py
+++ b/yt/frontends/tipsy/io.py
@@ -1,6 +1,7 @@
 import glob
 import os
 import struct
+import sys
 
 import numpy as np
 
@@ -8,6 +9,9 @@ from yt.frontends.sph.io import IOHandlerSPH
 from yt.frontends.tipsy.definitions import npart_mapping
 from yt.utilities.lib.particle_kdtree_tools import generate_smoothing_length
 from yt.utilities.logger import ytLogger as mylog
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 class IOHandlerTipsyBinary(IOHandlerSPH):
@@ -325,7 +329,7 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
         if None not in (si, ei):
             np.clip(pcount - si, 0, ei - si, out=pcount)
         ptypes = ["Gas", "Stars", "DarkMatter"]
-        npart = dict(zip(ptypes, pcount))
+        npart = dict(zip(ptypes, pcount, strict=True))
         return npart
 
     @classmethod

--- a/yt/frontends/ytdata/data_structures.py
+++ b/yt/frontends/ytdata/data_structures.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import weakref
 from collections import defaultdict
 from functools import cached_property
@@ -32,6 +33,9 @@ from yt.utilities.parallel_tools.parallel_analysis_interface import parallel_roo
 from yt.utilities.tree_container import TreeContainer
 
 from .fields import YTDataContainerFieldInfo, YTGridFieldInfo
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 _grid_data_containers = ["arbitrary_grid", "covering_grid", "smoothed_covering_grid"]
 _set_attrs = {"periodicity": "_periodicity"}
@@ -146,7 +150,7 @@ class SavedDataset(Dataset):
         )
         cgs_units = ("cm", "g", "s", "cm/s", "gauss")
         base_units = np.ones(len(attrs))
-        for unit, attr, cgs_unit in zip(base_units, attrs, cgs_units):
+        for unit, attr, cgs_unit in zip(base_units, attrs, cgs_units, strict=True):
             if attr in self.parameters and isinstance(
                 self.parameters[attr], YTQuantity
             ):

--- a/yt/geometry/tests/test_grid_container.py
+++ b/yt/geometry/tests/test_grid_container.py
@@ -1,9 +1,13 @@
 import random
+import sys
 
 import numpy as np
 from numpy.testing import assert_equal, assert_raises
 
 from yt.loaders import load_amr_grids
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 def setup_test_ds():
@@ -102,7 +106,7 @@ def test_find_points():
 
     grid_inds = np.zeros((num_points), dtype="int64")
 
-    for ind, ixx, iyy, izz in zip(range(num_points), randx, randy, randz):
+    for ind, ixx, iyy, izz in zip(range(num_points), randx, randy, randz, strict=True):
         pos = np.array([ixx, iyy, izz])
         pt_level = -1
 

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -44,6 +44,9 @@ from yt.utilities.parallel_tools.parallel_analysis_interface import (
     parallel_root_only_then_broadcast,
 )
 
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
+
 if TYPE_CHECKING:
     from multiprocessing.connection import Connection
 
@@ -798,7 +801,7 @@ def load_particles(
         le, re = data_source.get_bbox()
         le = le.to_value("code_length")
         re = re.to_value("code_length")
-        bbox = list(zip(le, re))
+        bbox = list(zip(le, re, strict=True))
     if bbox is None:
         bbox = np.array([[0.0, 1.0], [0.0, 1.0], [0.0, 1.0]], "float64")
     else:
@@ -1382,10 +1385,10 @@ def load_unstructured_mesh(
     node_data = list(always_iterable(node_data, base_type=dict)) or [{}] * num_meshes
 
     data = [{} for i in range(num_meshes)]  # type: ignore [var-annotated]
-    for elem_dict, data_dict in zip(elem_data, data):
+    for elem_dict, data_dict in zip(elem_data, data, strict=True):
         for field, values in elem_dict.items():
             data_dict[field] = values
-    for node_dict, data_dict in zip(node_data, data):
+    for node_dict, data_dict in zip(node_data, data, strict=True):
         for field, values in node_dict.items():
             data_dict[field] = values
 
@@ -1918,7 +1921,7 @@ def load_hdf5_file(
     grid_data = []
     psize = get_psize(np.array(shape), nchunks)
     left_edges, right_edges, shapes, _, _ = decompose_array(shape, psize, bbox)
-    for le, re, s in zip(left_edges, right_edges, shapes):
+    for le, re, s in zip(left_edges, right_edges, shapes, strict=True):
         data = {_: reader for _ in fields}
         data.update({"left_edge": le, "right_edge": re, "dimensions": s, "level": 0})
         grid_data.append(data)

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -23,6 +23,9 @@ from yt.funcs import is_sequence
 from yt.loaders import load
 from yt.units.yt_array import YTArray, YTQuantity
 
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
+
 ANSWER_TEST_TAG = "answer_test"
 
 
@@ -270,14 +273,14 @@ def fake_random_ds(
         else:
             offsets.append(0.0)
     data = {}
-    for field, offset, u in zip(fields, offsets, units):
+    for field, offset, u in zip(fields, offsets, units, strict=True):
         v = (prng.random_sample(ndims) - offset) * peak_value
         if field[0] == "all":
             v = v.ravel()
         data[field] = (v, u)
     if particles:
         if particle_fields is not None:
-            for field, unit in zip(particle_fields, particle_field_units):
+            for field, unit in zip(particle_fields, particle_field_units, strict=True):
                 if field in ("particle_position", "particle_velocity"):
                     data["io", field] = (prng.random_sample((int(particles), 3)), unit)
                 else:
@@ -347,7 +350,7 @@ def fake_amr_ds(
             "right_edge": right_edge,
             "dimensions": dims,
         }
-        for f, u in zip(fields, units):
+        for f, u in zip(fields, units, strict=True):
             gdata[f] = (prng.random_sample(dims), u)
         if particles:
             for i, f in enumerate(f"particle_position_{ax}" for ax in "xyz"):
@@ -412,7 +415,7 @@ def fake_particle_ds(
         else:
             offsets.append(0.0)
     data = data if data else {}
-    for field, offset, u in zip(fields, offsets, units):
+    for field, offset, u in zip(fields, offsets, units, strict=True):
         if field in data:
             v = data[field]
             continue
@@ -856,7 +859,7 @@ def expand_keywords(keywords, full=False):
         keys = sorted(keywords)
         list_of_kwarg_dicts = np.array(
             [
-                dict(zip(keys, prod))
+                dict(zip(keys, prod, strict=True))
                 for prod in it.product(*(keywords[key] for key in keys))
             ]
         )

--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -47,6 +47,10 @@ from yt.visualization import (
     profile_plotter as profile_plotter,
 )
 
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
+
+
 mylog = logging.getLogger("nose.plugins.answer-testing")
 run_big_data = False
 
@@ -769,9 +773,17 @@ class ParentageRelationshipsTest(AnswerTestingTest):
         return result
 
     def compare(self, new_result, old_result):
-        for newp, oldp in zip(new_result["parents"], old_result["parents"]):
+        for newp, oldp in zip(
+            new_result["parents"],
+            old_result["parents"],
+            strict=True,
+        ):
             assert newp == oldp
-        for newc, oldc in zip(new_result["children"], old_result["children"]):
+        for newc, oldc in zip(
+            new_result["children"],
+            old_result["children"],
+            strict=True,
+        ):
             assert newc == oldc
 
 
@@ -840,7 +852,10 @@ def compare_image_lists(new_result, old_result, decimals):
                 line.strip() for line in results.split("\n") if line.endswith(".png")
             ]
             for fn, img, padded in zip(
-                tempfiles, (expected, actual), (expected_p, actual_p)
+                tempfiles,
+                (expected, actual),
+                (expected_p, actual_p),
+                strict=True,
             ):
                 # padded images are convenient for comparison
                 # but what we really want to store and upload

--- a/yt/utilities/fortran_utils.py
+++ b/yt/utilities/fortran_utils.py
@@ -1,12 +1,8 @@
 import io
 import os
 import struct
-import sys
 
 import numpy as np
-
-if sys.version_info < (3, 10):
-    from yt._maintenance.backports import zip
 
 
 def read_attrs(f, attrs, endian="="):
@@ -77,9 +73,7 @@ def read_attrs(f, attrs, endian="="):
                 raise OSError(
                     "An error occurred while reading a Fortran "
                     "record. Record length is not equal to expected "
-                    "length: %s %s",
-                    len(a),
-                    len(v),
+                    f"length: {len(a)} {len(v)}"
                 )
             for k, val in zip(a, v, strict=True):
                 vv[k] = val
@@ -144,11 +138,8 @@ def read_cattrs(f, attrs, endian="="):
                 raise OSError(
                     "An error occurred while reading a Fortran "
                     "record. Record length is not equal to expected "
-                    "length: %s %s",
-                    len(a),
-                    len(v),
+                    f"length: {len(a)} {len(v)}"
                 )
-
             for k, val in zip(a, v, strict=True):
                 vv[k] = val
         else:

--- a/yt/utilities/fortran_utils.py
+++ b/yt/utilities/fortran_utils.py
@@ -1,8 +1,12 @@
 import io
 import os
 import struct
+import sys
 
 import numpy as np
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 def read_attrs(f, attrs, endian="="):
@@ -77,7 +81,7 @@ def read_attrs(f, attrs, endian="="):
                     len(a),
                     len(v),
                 )
-            for k, val in zip(a, v):
+            for k, val in zip(a, v, strict=True):
                 vv[k] = val
         else:
             vv[a] = v
@@ -145,7 +149,7 @@ def read_cattrs(f, attrs, endian="="):
                     len(v),
                 )
 
-            for k, val in zip(a, v):
+            for k, val in zip(a, v, strict=True):
                 vv[k] = val
         else:
             vv[a] = v

--- a/yt/utilities/lib/tests/test_fill_region.py
+++ b/yt/utilities/lib/tests/test_fill_region.py
@@ -1,7 +1,12 @@
+import sys
+
 import numpy as np
 from numpy.testing import assert_equal
 
 from yt.utilities.lib.misc_utilities import fill_region
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 NDIM = 32
 
@@ -38,5 +43,5 @@ def test_fill_region():
             np.array([2, 2, 2], dtype="i8"),
         )
         for r in range(level + 1):
-            for o, i in zip(output_fields, v):
+            for o, i in zip(output_fields, v, strict=True):
                 assert_equal(o[r::rf, r::rf, r::rf], i)

--- a/yt/utilities/sdf.py
+++ b/yt/utilities/sdf.py
@@ -1,10 +1,14 @@
 import os
+import sys
 from collections import UserDict
 from io import StringIO
 
 import numpy as np
 
 from yt.funcs import mylog
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 def get_thingking_deps():
@@ -1175,7 +1179,7 @@ class SDFIndex:
 
     def iter_slice_data(self, slice_dim, slice_index, fields):
         mask, offsets, lengths = self.get_slice_chunks(slice_dim, slice_index)
-        for off, l in zip(offsets, lengths):
+        for off, l in zip(offsets, lengths, strict=True):
             data = {}
             chunk = slice(off, off + l)
             for field in fields:

--- a/yt/utilities/tests/test_chemical_formulas.py
+++ b/yt/utilities/tests/test_chemical_formulas.py
@@ -1,7 +1,12 @@
+import sys
+
 from numpy.testing import assert_allclose, assert_equal
 
 from yt.utilities.chemical_formulas import ChemicalFormula, compute_mu
 from yt.utilities.periodic_table import periodic_table
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 _molecules = (
     ("H2O_p1", (("H", 2), ("O", 1)), 1),
@@ -19,7 +24,7 @@ def test_formulas():
         w = sum(n * periodic_table[e].weight for e, n in components)
         assert_equal(f.charge, charge)
         assert_equal(f.weight, w)
-        for (n, c1), (e, c2) in zip(components, f.elements):
+        for (n, c1), (e, c2) in zip(components, f.elements, strict=True):
             assert_equal(n, e.symbol)
             assert_equal(c1, c2)
 

--- a/yt/utilities/tests/test_interpolators.py
+++ b/yt/utilities/tests/test_interpolators.py
@@ -1,9 +1,14 @@
+import sys
+
 import numpy as np
 from numpy.testing import assert_array_almost_equal, assert_array_equal
 
 import yt.utilities.linear_interpolators as lin
 from yt.testing import fake_random_ds
 from yt.utilities.lib.interpolators import ghost_zone_interpolate
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 def test_linear_interpolator_1d():
@@ -26,7 +31,7 @@ def test_linear_interpolator_1d():
 def test_linear_interpolator_2d():
     random_data = np.random.random((64, 64))
     # evenly spaced bins
-    fv = dict(zip("xyz", np.mgrid[0.0:1.0:64j, 0.0:1.0:64j]))
+    fv = dict(zip("xy", np.mgrid[0.0:1.0:64j, 0.0:1.0:64j], strict=True))
     bfi = lin.BilinearFieldInterpolator(random_data, (0.0, 1.0, 0.0, 1.0), "xy", True)
     assert_array_equal(bfi(fv), random_data)
 
@@ -45,7 +50,7 @@ def test_linear_interpolator_2d():
 def test_linear_interpolator_3d():
     random_data = np.random.random((64, 64, 64))
     # evenly spaced bins
-    fv = dict(zip("xyz", np.mgrid[0.0:1.0:64j, 0.0:1.0:64j, 0.0:1.0:64j]))
+    fv = dict(zip("xyz", np.mgrid[0.0:1.0:64j, 0.0:1.0:64j, 0.0:1.0:64j], strict=True))
     tfi = lin.TrilinearFieldInterpolator(
         random_data, (0.0, 1.0, 0.0, 1.0, 0.0, 1.0), "xyz", True
     )
@@ -70,7 +75,13 @@ def test_linear_interpolator_3d():
 def test_linear_interpolator_4d():
     random_data = np.random.random((64, 64, 64, 64))
     # evenly spaced bins
-    fv = dict(zip("xyzw", np.mgrid[0.0:1.0:64j, 0.0:1.0:64j, 0.0:1.0:64j, 0.0:1.0:64j]))
+    fv = dict(
+        zip(
+            "xyzw",
+            np.mgrid[0.0:1.0:64j, 0.0:1.0:64j, 0.0:1.0:64j, 0.0:1.0:64j],
+            strict=True,
+        )
+    )
     tfi = lin.QuadrilinearFieldInterpolator(
         random_data, (0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0), "xyzw", True
     )

--- a/yt/visualization/_commons.py
+++ b/yt/visualization/_commons.py
@@ -10,9 +10,7 @@ from more_itertools import always_iterable
 
 from yt.config import ytcfg
 
-if sys.version_info >= (3, 10):
-    pass
-else:
+if sys.version_info < (3, 10):
     from yt._maintenance.backports import zip
 
 if TYPE_CHECKING:

--- a/yt/visualization/fits_image.py
+++ b/yt/visualization/fits_image.py
@@ -25,6 +25,9 @@ from yt.visualization.particle_plots import (
 )
 from yt.visualization.volume_rendering.off_axis_projection import off_axis_projection
 
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
+
 
 class UnitfulHDU:
     def __init__(self, hdu):
@@ -250,7 +253,7 @@ class FITSImageData:
                     self.fields[i] = f"{ftype}_{fname}"
 
         for is_first, _is_last, (i, (name, field)) in mark_ends(
-            enumerate(zip(self.fields, fields))
+            enumerate(zip(self.fields, fields, strict=True))
         ):
             if name not in exclude_fields:
                 this_img = img_data[field]
@@ -345,10 +348,13 @@ class FITSImageData:
                     width = [width] * self.dimensionality
                 if isinstance(width[0], YTQuantity):
                     cdelt = [
-                        wh.to_value(wcs_unit) / n for wh, n in zip(width, self.shape)
+                        wh.to_value(wcs_unit) / n
+                        for wh, n in zip(width, self.shape, strict=True)
                     ]
                 else:
-                    cdelt = [float(wh) / n for wh, n in zip(width, self.shape)]
+                    cdelt = [
+                        float(wh) / n for wh, n in zip(width, self.shape, strict=True)
+                    ]
                 center = img_ctr[: self.dimensionality]
             w.wcs.crpix = 0.5 * (np.array(self.shape) + 1)
             w.wcs.crval = center
@@ -390,7 +396,7 @@ class FITSImageData:
             "magnetic_unit",
         )
         cgs_units = ("cm", "g", "s", "cm/s", "gauss")
-        for unit, attr, cgs_unit in zip(base_units, attrs, cgs_units):
+        for unit, attr, cgs_unit in zip(base_units, attrs, cgs_units, strict=True):
             if unit is None:
                 if ds is not None:
                     u = getattr(ds, attr, None)

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -51,6 +51,8 @@ if sys.version_info >= (3, 10):
 else:
     from typing_extensions import TypeGuard
 
+    from yt._maintenance.backports import zip
+
 if sys.version_info >= (3, 11):
     from typing import assert_never
 else:
@@ -745,7 +747,7 @@ class BaseQuiverCallback(PlotCallback, ABC):
             # do the transformation. Also check for the exact bounds of the transform
             # which can cause issues with projections.
             tform_bnds = plot._transform.x_limits + plot._transform.y_limits
-            if any(b.d == tb for b, tb in zip(bounds, tform_bnds)):
+            if any(b.d == tb for b, tb in zip(bounds, tform_bnds, strict=True)):
                 # note: cartopy will also raise its own warning, but it is useful to add this
                 # warning as well since the only way to avoid the exact bounds is to change the
                 # extent of the plot.
@@ -1167,7 +1169,7 @@ class GridBoundaryCallback(PlotCallback):
         GRE = GRE[new_indices]
         block_ids = np.array(block_ids)[new_indices]
 
-        for px_off, py_off in zip(pxs.ravel(), pys.ravel()):
+        for px_off, py_off in zip(pxs.ravel(), pys.ravel(), strict=True):
             pxo = px_off * DW[px_index]
             pyo = py_off * DW[py_index]
             left_edge_x = np.array((GLE[:, px_index] + pxo - x0) * dx) + xx0

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -55,9 +55,7 @@ from .plot_container import (
     invalidate_plot,
 )
 
-if sys.version_info >= (3, 10):
-    pass
-else:
+if sys.version_info < (3, 10):
     from yt._maintenance.backports import zip
 
 if sys.version_info >= (3, 11):

--- a/yt/visualization/tests/test_offaxisprojection.py
+++ b/yt/visualization/tests/test_offaxisprojection.py
@@ -1,6 +1,7 @@
 import itertools as it
 import os
 import shutil
+import sys
 import tempfile
 import unittest
 
@@ -16,6 +17,9 @@ from yt.testing import (
 from yt.visualization.api import OffAxisProjectionPlot, OffAxisSlicePlot
 from yt.visualization.image_writer import write_projection
 from yt.visualization.volume_rendering.api import off_axis_projection
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 # TODO: replace this with pytest.mark.parametrize
@@ -85,7 +89,7 @@ def expand_keywords(keywords, full=False):
         keys = sorted(keywords)
         list_of_kwarg_dicts = np.array(
             [
-                dict(zip(keys, prod))
+                dict(zip(keys, prod, strict=True))
                 for prod in it.product(*(keywords[key] for key in keys))
             ]
         )

--- a/yt/visualization/tests/test_particle_plot.py
+++ b/yt/visualization/tests/test_particle_plot.py
@@ -460,18 +460,12 @@ class TestParticleProjectionPlotSave(unittest.TestCase):
             ylim = [plot.ds.quan(el[0], el[1]) for el in ylim]
             pwidth = [plot.ds.quan(el[0], el[1]) for el in pwidth]
 
-            [
+            for px, x in zip(plot.xlim, xlim, strict=True):
                 assert_array_almost_equal(px, x, 14)
-                for px, x in zip(plot.xlim, xlim, strict=True)
-            ]
-            [
+            for py, y in zip(plot.ylim, ylim, strict=True):
                 assert_array_almost_equal(py, y, 14)
-                for py, y in zip(plot.ylim, ylim, strict=True)
-            ]
-            [
+            for pw, w in zip(plot.width, pwidth, strict=True):
                 assert_array_almost_equal(pw, w, 14)
-                for pw, w in zip(plot.width, pwidth, strict=True)
-            ]
 
 
 def test_particle_plot_instance():

--- a/yt/visualization/tests/test_particle_plot.py
+++ b/yt/visualization/tests/test_particle_plot.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import sys
 import tempfile
 import unittest
 from unittest import mock
@@ -20,6 +21,9 @@ from yt.utilities.answer_testing.framework import (
 )
 from yt.visualization.api import ParticlePhasePlot, ParticlePlot, ParticleProjectionPlot
 from yt.visualization.tests.test_plotwindow import ATTR_ARGS, WIDTH_SPECS
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 def setup_module():
@@ -431,7 +435,7 @@ class TestParticleProjectionPlotSave(unittest.TestCase):
         test_ds = fake_particle_ds()
         Ls = [[1, 1, 1], [0, 1, -0.5]]
         Ns = [None, [1, 1, 1]]
-        for L, N in zip(Ls, Ns):
+        for L, N in zip(Ls, Ns, strict=True):
             for weight_field in WEIGHT_FIELDS:
                 pplot_off = ParticleProjectionPlot(
                     test_ds,
@@ -456,9 +460,18 @@ class TestParticleProjectionPlotSave(unittest.TestCase):
             ylim = [plot.ds.quan(el[0], el[1]) for el in ylim]
             pwidth = [plot.ds.quan(el[0], el[1]) for el in pwidth]
 
-            [assert_array_almost_equal(px, x, 14) for px, x in zip(plot.xlim, xlim)]
-            [assert_array_almost_equal(py, y, 14) for py, y in zip(plot.ylim, ylim)]
-            [assert_array_almost_equal(pw, w, 14) for pw, w in zip(plot.width, pwidth)]
+            [
+                assert_array_almost_equal(px, x, 14)
+                for px, x in zip(plot.xlim, xlim, strict=True)
+            ]
+            [
+                assert_array_almost_equal(py, y, 14)
+                for py, y in zip(plot.ylim, ylim, strict=True)
+            ]
+            [
+                assert_array_almost_equal(pw, w, 14)
+                for pw, w in zip(plot.width, pwidth, strict=True)
+            ]
 
 
 def test_particle_plot_instance():

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -390,18 +390,13 @@ class TestPlotWindowSave(unittest.TestCase):
             ylim = [plot.ds.quan(el[0], el[1]) for el in ylim]
             pwidth = [plot.ds.quan(el[0], el[1]) for el in pwidth]
 
-            [
+            for px, x in zip(plot.xlim, xlim, strict=True):
                 assert_array_almost_equal(px, x, 14)
-                for px, x in zip(plot.xlim, xlim, strict=True)
-            ]
-            [
+            for py, y in zip(plot.ylim, ylim, strict=True):
                 assert_array_almost_equal(py, y, 14)
-                for py, y in zip(plot.ylim, ylim, strict=True)
-            ]
-            [
+            for pw, w in zip(plot.width, pwidth, strict=True):
                 assert_array_almost_equal(pw, w, 14)
-                for pw, w in zip(plot.width, pwidth, strict=True)
-            ]
+
             assert aun == plot._axes_unit_names
 
 

--- a/yt/visualization/tests/test_plotwindow.py
+++ b/yt/visualization/tests/test_plotwindow.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import sys
 import tempfile
 import unittest
 from collections import OrderedDict
@@ -42,6 +43,9 @@ from yt.visualization.plot_window import (
     SlicePlot,
     plot_2d,
 )
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 def setup_module():
@@ -386,9 +390,18 @@ class TestPlotWindowSave(unittest.TestCase):
             ylim = [plot.ds.quan(el[0], el[1]) for el in ylim]
             pwidth = [plot.ds.quan(el[0], el[1]) for el in pwidth]
 
-            [assert_array_almost_equal(px, x, 14) for px, x in zip(plot.xlim, xlim)]
-            [assert_array_almost_equal(py, y, 14) for py, y in zip(plot.ylim, ylim)]
-            [assert_array_almost_equal(pw, w, 14) for pw, w in zip(plot.width, pwidth)]
+            [
+                assert_array_almost_equal(px, x, 14)
+                for px, x in zip(plot.xlim, xlim, strict=True)
+            ]
+            [
+                assert_array_almost_equal(py, y, 14)
+                for py, y in zip(plot.ylim, ylim, strict=True)
+            ]
+            [
+                assert_array_almost_equal(pw, w, 14)
+                for pw, w in zip(plot.width, pwidth, strict=True)
+            ]
             assert aun == plot._axes_unit_names
 
 

--- a/yt/visualization/volume_rendering/old_camera.py
+++ b/yt/visualization/volume_rendering/old_camera.py
@@ -1,4 +1,5 @@
 import builtins
+import sys
 from copy import deepcopy
 
 import numpy as np
@@ -33,6 +34,9 @@ from yt.visualization.image_writer import apply_colormap, write_bitmap, write_im
 from yt.visualization.volume_rendering.blenders import enhance_rgba
 
 from .transfer_functions import ProjectionTransferFunction
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 def get_corners(le, re):
@@ -410,7 +414,7 @@ class Camera(ParallelAnalysisInterface):
 
         # we flipped it in snapshot to get the orientation correct, so
         # flip the lines
-        for vec, color in zip(coord_vectors, colors):
+        for vec, color in zip(coord_vectors, colors, strict=True):
             dx = int(np.dot(vec, self.orienter.unit_vectors[0]))
             dy = int(np.dot(vec, self.orienter.unit_vectors[1]))
             px = np.array([px0, px0 + dx], dtype="int64")
@@ -1921,7 +1925,7 @@ class MosaicCamera(Camera):
     def snapshot(self, fn=None, clip_ratio=None, double_check=False, num_threads=0):
         my_storage = {}
         offx, offy = np.meshgrid(range(self.nimx), range(self.nimy))
-        offxy = zip(offx.ravel(), offy.ravel())
+        offxy = zip(offx.ravel(), offy.ravel(), strict=True)
 
         for sto, xy in parallel_objects(
             offxy, self.procs_per_wg, storage=my_storage, dynamic=True
@@ -1957,7 +1961,7 @@ class MosaicCamera(Camera):
         final_image = 0
         if self.comm.rank == 0:
             offx, offy = np.meshgrid(range(self.nimx), range(self.nimy))
-            offxy = zip(offx.ravel(), offy.ravel())
+            offxy = zip(offx.ravel(), offy.ravel(), strict=True)
             nx, ny = self.resolution
             final_image = np.empty(
                 (nx * self.nimx, ny * self.nimy, 4), dtype="float64", order="C"

--- a/yt/visualization/volume_rendering/transfer_functions.py
+++ b/yt/visualization/volume_rendering/transfer_functions.py
@@ -1,8 +1,13 @@
+import sys
+
 import numpy as np
 from more_itertools import always_iterable
 
 from yt.funcs import mylog
 from yt.utilities.physical_constants import clight, hcgs, kboltz
+
+if sys.version_info < (3, 10):
+    from yt._maintenance.backports import zip
 
 
 class TransferFunction:
@@ -433,7 +438,7 @@ class ColorTransferFunction(MultiVariateTransferFunction):
         >>> tf = ColorTransferFunction((-10.0, -5.0))
         >>> tf.add_gaussian(-9.0, 0.01, [1.0, 0.0, 0.0, 1.0])
         """
-        for tf, v in zip(self.funcs, height):
+        for tf, v in zip(self.funcs, height, strict=True):
             tf.add_gaussian(location, width, v)
         self.features.append(
             (
@@ -474,7 +479,7 @@ class ColorTransferFunction(MultiVariateTransferFunction):
         >>> tf = ColorTransferFunction((-10.0, -5.0))
         >>> tf.add_step(-6.0, -5.0, [1.0, 1.0, 1.0, 1.0])
         """
-        for tf, v in zip(self.funcs, value):
+        for tf, v in zip(self.funcs, value, strict=True):
             tf.add_step(start, stop, v)
         self.features.append(
             (
@@ -890,7 +895,7 @@ class ColorTransferFunction(MultiVariateTransferFunction):
             alpha = np.ones(N, dtype="float64")
         elif alpha is None and not self.grey_opacity:
             alpha = np.logspace(-3, 0, N)
-        for v, a in zip(np.mgrid[mi : ma : N * 1j], alpha):
+        for v, a in zip(np.mgrid[mi : ma : N * 1j], alpha, strict=True):
             self.sample_colormap(v, w, a, colormap=colormap, col_bounds=col_bounds)
 
     def get_colormap_image(self, height, width):


### PR DESCRIPTION
Close #4749

This is a mostly automated style change, but I'm using the test suite to detect places where `strict=False` is either the intended behavior or a bug.

I'll also carefully review this myself to improve coverage.