### PR TITLE
TST: add missing `@requires_module` decorators in particle deposition tests

### DIFF
--- a/yt/geometry/tests/test_particle_deposit.py
+++ b/yt/geometry/tests/test_particle_deposit.py
@@ -2,7 +2,7 @@ from numpy.testing import assert_allclose, assert_array_less, assert_raises
 
 import yt
 from yt.loaders import load
-from yt.testing import fake_random_ds, requires_file
+from yt.testing import fake_random_ds, requires_file, requires_module
 from yt.utilities.exceptions import YTBoundsDefinitionError
 
 
@@ -34,6 +34,7 @@ def test_one_zone_octree_deposit():
     assert sp["deposit", "io_cic"].shape == (1,)
 
 
+@requires_module("h5py")
 @requires_file(RAMSES)
 @requires_file(ISOGAL)
 def test_mesh_sampling():
@@ -52,6 +53,7 @@ def test_mesh_sampling():
         assert_array_less(-dist, dx)
 
 
+@requires_module("h5py")
 @requires_file(RAMSES)
 @requires_file(ISOGAL)
 def test_mesh_sampling_for_filtered_particles():


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
