### PR TITLE
BUG: fix loading of AMReX datasets with `~` in the filename

### DIFF
--- a/yt/frontends/amrex/data_structures.py
+++ b/yt/frontends/amrex/data_structures.py
@@ -652,7 +652,7 @@ class BoxlibDataset(Dataset):
 
         cparam_filename = cparam_filename or self.__class__._default_cparam_filename
         self.cparam_filename = self._lookup_cparam_filepath(
-            output_dir, cparam_filename=cparam_filename
+            self.output_dir, cparam_filename=cparam_filename
         )
         self.fparam_filename = self._localize_check(fparam_filename)
         self.storage_filename = storage_filename


### PR DESCRIPTION
## PR Summary

One of our group members ran into this today when doing `ds = CastroDataset('~/delta_ims/en_20/planar_plt02346')`, with an error like:
```
yt/frontends/boxlib/data_structures.py", line 1116, in _parse_parameter_file
    jobinfo_filename = os.path.join(self.output_dir, self.cparam_filename)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen posixpath>", line 90, in join
  File "<frozen genericpath>", line 164, in _check_arg_types
TypeError: join() argument must be str, bytes, or os.PathLike object, not 'NoneType'
```
`self._lookup_cparam_filepath()` was being passed the version of `output_dir` before having the tilde expanded, and was returning `None` as `./~/` doesn't exist.

I'm not sure how to add a test for this.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] Adds a test for any bugs fixed. Adds tests for new features.