### PR TITLE
DEP: stop requiring ewah-bool-utils at runtime

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -102,8 +102,8 @@ jobs:
       # keep in sync with pyproject.toml
       run: |
         python -m pip install "Cython>=3.0.3, <3.1"
-        python -m pip install numpy>=1.25
-        python -m pip install ewah-bool-utils>=1.0.2
+        python -m pip install "numpy>=2.0.0"
+        python -m pip install "ewah-bool-utils>=1.2.0"
         python -m pip install --upgrade wheel
         python -m pip install --upgrade setuptools
     - name: build yt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ keywords = [
 requires-python = ">=3.9.2"
 dependencies = [
     "cmyt>=1.1.2",
-    "ewah-bool-utils>=1.2.0",
     "ipywidgets>=8.0.0",
     "matplotlib>=3.5",
     "more-itertools>=8.4",
@@ -207,7 +206,6 @@ mapserver = [
 ]
 minimal = [
     "cmyt==1.1.2",
-    "ewah-bool-utils==1.2.0",
     "ipywidgets==8.0.0",
     "matplotlib==3.5",
     "more-itertools==8.4",

--- a/yt/geometry/particle_geometry_handler.py
+++ b/yt/geometry/particle_geometry_handler.py
@@ -5,12 +5,12 @@ import struct
 import weakref
 
 import numpy as np
-from ewah_bool_utils.ewah_bool_wrap import BoolArrayCollection
 
+# from ewah_bool_utils.ewah_bool_wrap import BoolArrayCollection
 from yt.data_objects.index_subobjects.particle_container import ParticleContainer
 from yt.funcs import get_pbar, is_sequence, only_on_root
 from yt.geometry.geometry_handler import Index, YTDataChunk
-from yt.geometry.particle_oct_container import ParticleBitmap
+from yt.geometry.particle_oct_container import BoolArrayCollection, ParticleBitmap
 from yt.utilities.lib.fnv_hash import fnv_hash
 from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.parallel_tools.parallel_analysis_interface import parallel_objects


### PR DESCRIPTION
## PR Summary

Scratching a long standing itch of mine: we only ever need a single from ewah-bool-utils at runtime and the import is done in a private module, so I feel like having the whole package as a dependency is a bit wasteful. We should really only need it at compile-time. 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
