### PR TITLE
Fix memory leakage

### DIFF
--- a/yt/utilities/lib/quad_tree.pyx
+++ b/yt/utilities/lib/quad_tree.pyx
@@ -413,8 +413,6 @@ cdef class QuadTree:
                         np.float64_t wtoadd,
                         np.int64_t level):
         cdef int i, j, n
-        cdef np.float64_t *vorig
-        vorig = <np.float64_t *> malloc(sizeof(np.float64_t) * self.nvals)
         if node.children[0][0] == NULL:
             if self.merged == -1:
                 for i in range(self.nvals):
@@ -432,6 +430,8 @@ cdef class QuadTree:
             iy[curpos] = node.pos[1]
             return 1
         cdef np.int64_t added = 0
+        cdef np.float64_t *vorig
+        vorig = <np.float64_t *> malloc(sizeof(np.float64_t) * self.nvals)
         if self.merged == 1:
             for i in range(self.nvals):
                 vorig[i] = vtoadd[i]


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

This is a bug that causes memory leakage in projections.

It forgot to free `vorig` when returning inside the if block.
Since `vorig` won't be used inside that if block anyway, it should be moved under the if block.
