### PR TITLE
BLD: switch to stable setuptools build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires = [
   "numpy>=2.0.0",
   "ewah-bool-utils>=1.2.0",
 ]
-build-backend = "setuptools.build_meta:__legacy__"
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "yt"

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,15 @@
 import glob
 import os
+import sys
 from collections import defaultdict
 from distutils.ccompiler import get_default_compiler
 from importlib import resources as importlib_resources
 
 from setuptools import Distribution, setup
+
+# ensure enclosing directory is in PYTHON_PATH to allow importing from setupext.py
+if (script_dir := os.path.dirname(__file__)) not in sys.path:
+    sys.path.insert(0, script_dir)
 
 from setupext import (
     NUMPY_MACROS,


### PR DESCRIPTION
## PR Summary

This is a continuation of #4583.
`setuptools.build_meta:__legacy__` is not considered stable:
https://github.com/pypa/setuptools/blob/48f95c0a1b8aa033d5a489eff8c4a6abc881b743/setuptools/build_meta.py#L468-L4778

The only reason we need it is that we need to ensure that `setupext.py` can be imported from `setup.py`, so migration is actually quite simple. 
