### PR TITLE
MNT: cleanup cibuildwheel configuration and move it to `pyproject.toml`

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -35,16 +35,6 @@ jobs:
         uses: pypa/cibuildwheel@v2.19.1
         with:
           output-dir: dist
-        env:
-          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-*"
-          CIBW_SKIP: "*-musllinux_*"  #  numpy doesn't have wheels for musllinux so we can't build some quickly and without bloating
-          CIBW_ARCHS_LINUX: "x86_64"
-          CIBW_ARCHS_MACOS: auto
-          MACOSX_DEPLOYMENT_TARGET: "10.9" # as of CIBW 2.9, this is the default value, pin it so it can't be bumped silently
-          CIBW_ARCHS_WINDOWS: auto64
-          CIBW_BUILD_VERBOSITY: 1
-          CIBW_TEST_EXTRAS: test
-          CIBW_TEST_COMMAND: pytest -c {project}/pyproject.toml --rootdir . --color=yes --pyargs yt
 
       - uses: actions/upload-artifact@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -492,3 +492,21 @@ warn_unused_ignores = true
 warn_unreachable = true
 show_error_context = true
 exclude = "(test_*|lodgeit)"
+
+[tool.cibuildwheel]
+build = "cp39-* cp310-* cp311-* cp312-*"
+build-verbosity = 1
+test-skip = "*-musllinux*"
+test-extras = "test"
+test-command = [
+    "pytest -c {project}/pyproject.toml --rootdir . --color=yes --pyargs yt -ra",
+]
+
+[tool.cibuildwheel.linux]
+archs = "x86_64"
+
+[tool.cibuildwheel.macos]
+archs = "auto"
+
+[tool.cibuildwheel.windows]
+archs = "auto64"


### PR DESCRIPTION
## PR Summary

This should help testing wheel building locally, and was also an opportunity to clean up our cibuildwheel configuration.
