### PR TITLE
TST: skip a flaky test on Windows

### DIFF
--- a/yt/tests/test_load_sample.py
+++ b/yt/tests/test_load_sample.py
@@ -109,6 +109,12 @@ def test_load_sample_small_dataset(
     )
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    # flakyness is probably due to Windows' infamous lack of time resolution
+    # overall, this test doesn't seem worth it.
+    reason="This test is flaky on Windows",
+)
 @requires_module_pytest("pandas", "pooch")
 @pytest.mark.usefixtures("capturable_logger")
 def test_load_sample_timeout(tmp_data_dir, caplog):


### PR DESCRIPTION
## PR Summary

This single test has been flaky for at least weeks and caused a lot of jobs to fail when really it's no big deal if this cannot be consistently tested on windows, so let's just skip it there.
[example logs](https://github.com/yt-project/yt/actions/runs/10027348660/job/27712898850?pr=4949)