### PR TITLE
CLN: cleanup unused internal conf parameter `within_pytest`

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -85,7 +85,6 @@ def pytest_configure(config):
     Reads in the tests/tests.yaml file. This file contains a list of
     each answer test's answer file (including the changeset number).
     """
-    ytcfg["yt", "internals", "within_pytest"] = True
     # Register custom marks for answer tests and big data
     config.addinivalue_line("markers", "answer_test: Run the answer tests.")
     config.addinivalue_line(

--- a/yt/config.py
+++ b/yt/config.py
@@ -45,7 +45,6 @@ ytcfg_defaults["yt"] = {
     "ray_tracing_engine": "yt",
     "internals": {
         "within_testing": False,
-        "within_pytest": False,
         "parallel": False,
         "strict_requires": False,
         "global_parallel_rank": 0,


### PR DESCRIPTION
## PR Summary
This doesn't seem to be used anywhere and the release notes for pytest 8.3.0 make it clear that it's even redundant so we shouldn't ever actually need it.
See https://github.com/pytest-dev/pytest/pull/12153
