### PR TITLE
DOC: handle broken builds

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -12,7 +12,6 @@ yt supports :ref:`many different code formats <code-support>`, and we provide
 :ref:`instructions on how to load and examine each data type <examining-data>`.
 
 
-
 Table of Contents
 -----------------
 


### PR DESCRIPTION
## PR Summary
In the context of #4939 we saw that doc builds were currently broken due to a change in at least one sphinx extension (one of `sphinxcontrib-htmlhelp` or `sphinxcontrib-qthelp`.
In this PR I want to first demonstrate that builds are broken independently, and then nail down the breaking change so I can report it upstream.

