### PR TITLE
DOC: added note that answer tests are currently run with nose

### DIFF
--- a/doc/source/developing/testing.rst
+++ b/doc/source/developing/testing.rst
@@ -155,7 +155,7 @@ Answer Testing
 .. note::
     This section documents answer tests run with ``pytest``. The plan is to
     switch to using ``pytest`` for answer tests at some point in the future,
-    but currently (July 2024), answer tests are actually run using ``nose``. 
+    but currently (July 2024), answer tests are actually run using ``nose``.
 
 What Do Answer Tests Do
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/developing/testing.rst
+++ b/doc/source/developing/testing.rst
@@ -155,7 +155,12 @@ Answer Testing
 .. note::
     This section documents answer tests run with ``pytest``. The plan is to
     switch to using ``pytest`` for answer tests at some point in the future,
-    but currently (July 2024), answer tests are still implemented and run with ``nose``.
+    but currently (July 2024), answer tests are still implemented and run with
+    ``nose``. We generally encourage developers to use ``pytest`` for any new
+    tests, but if you need to change or update one of the older ``nose``
+    tests, or are, e.g., writing a new frontend,
+    an `older version of this documentation <https://yt-project.org/docs/4.0.0/developing/testing.html#answer-testing>`_ 
+    decribes how the ``nose`` tests work.
 
 What Do Answer Tests Do
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/developing/testing.rst
+++ b/doc/source/developing/testing.rst
@@ -152,6 +152,10 @@ More pytest options can be found by using the ``--help`` flag
 
 Answer Testing
 --------------
+.. note::
+    This section documents answer tests run with ``pytest``. The plan is to
+    switch to using ``pytest`` for answer tests at some point in the future,
+    but currently (July 2024), answer tests are actually run using ``nose``. 
 
 What Do Answer Tests Do
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/developing/testing.rst
+++ b/doc/source/developing/testing.rst
@@ -159,7 +159,7 @@ Answer Testing
     ``nose``. We generally encourage developers to use ``pytest`` for any new
     tests, but if you need to change or update one of the older ``nose``
     tests, or are, e.g., writing a new frontend,
-    an `older version of this documentation <https://yt-project.org/docs/4.0.0/developing/testing.html#answer-testing>`_ 
+    an `older version of this documentation <https://yt-project.org/docs/4.0.0/developing/testing.html#answer-testing>`_
     decribes how the ``nose`` tests work.
 
 What Do Answer Tests Do

--- a/doc/source/developing/testing.rst
+++ b/doc/source/developing/testing.rst
@@ -155,7 +155,7 @@ Answer Testing
 .. note::
     This section documents answer tests run with ``pytest``. The plan is to
     switch to using ``pytest`` for answer tests at some point in the future,
-    but currently (July 2024), answer tests are actually run using ``nose``.
+    but currently (July 2024), answer tests are still implemented and run with ``nose``.
 
 What Do Answer Tests Do
 ^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

I added a note to the development -> testing page of the docs, [Answer Testing](https://yt-project.org/docs/dev/developing/testing.html#answer-testing) section, indicating that the current instructions do not reflect current practice, as described [here](https://github.com/yt-project/yt/pull/4939#issuecomment-2241559129) by @neutrinoceros. This will hopefully save people some time when working on pull requests. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

I added this text to the very beginning of the 'Answer Tests' section, in a note (`.. note::`):
    "This section documents answer tests run with `pytest`. The plan is to switch to using `pytest` for answer tests at some point in the future, but currently (July 2024), answer tests are actually run using `nose`."

<!--If it fixes an open issue, please link to the issue here.-->

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
