### PR TITLE
new prefix for images produced in testing: baseline_ or thisPR_

### DIFF
--- a/yt/utilities/answer_testing/framework.py
+++ b/yt/utilities/answer_testing/framework.py
@@ -776,9 +776,9 @@ class ParentageRelationshipsTest(AnswerTestingTest):
 
 
 def dump_images(new_result, old_result, decimals=10):
-    tmpfd, old_image = tempfile.mkstemp(suffix=".png")
+    tmpfd, old_image = tempfile.mkstemp(prefix="baseline_", suffix=".png")
     os.close(tmpfd)
-    tmpfd, new_image = tempfile.mkstemp(suffix=".png")
+    tmpfd, new_image = tempfile.mkstemp(prefix="thisPR_", suffix=".png")
     os.close(tmpfd)
     image_writer.write_projection(new_result, new_image)
     image_writer.write_projection(old_result, old_image)


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->
I'm adding prefixes to the file names produced in `yt/yt/utilities/answer_testing/framework.py`, `dump_images` function. This should make it straightforward to see which image is the baseline for the comparison and which has been produced by the pull request branch in the `nose` testing output.

<!--If it fixes an open issue, please link to the issue here.-->
This addresses issue #4954.


<!-- Note that some of these check boxes may not apply to all pull requests -->

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
