### PR TITLE
BUG: tipsy, reading just smoothing length

### DIFF
--- a/yt/frontends/tipsy/io.py
+++ b/yt/frontends/tipsy/io.py
@@ -58,7 +58,10 @@ class IOHandlerTipsyBinary(IOHandlerSPH):
         if mask is None:
             size = 0
         elif isinstance(mask, slice):
-            size = vals[fields[0]].size
+            if fields[0] == "smoothing_length":
+                size = hsml.size
+            else:
+                size = vals[fields[0]].size
         else:
             size = mask.sum()
         rv = {}

--- a/yt/frontends/tipsy/tests/test_outputs.py
+++ b/yt/frontends/tipsy/tests/test_outputs.py
@@ -112,3 +112,9 @@ def test_tipsy_index():
     ds = data_dir_load(tipsy_gal)
     sl = ds.slice("z", 0.0)
     assert sl["gas", "density"].shape[0] != 0
+
+
+@requires_file(tipsy_gal)
+def test_tipsy_smoothing_length():
+    ds = data_dir_load(tipsy_gal)
+    _ = ds.all_data()["Gas", "smoothing_length"]


### PR DESCRIPTION
Partial fix for #4963 

This fixes the error when reading the smoothing length for tipsy. Does not address the question of the changing coordinate values when the bounding box changes.
