### PR TITLE
MNT: bump ruff to v0.6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,12 +36,10 @@ repos:
         additional_dependencies: [black==24.3.0]
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.5.6
+  rev: v0.6.1
   hooks:
   - id: ruff-format
-    types_or: [ python, pyi, jupyter ]
   - id: ruff
-    types_or: [ python, pyi, jupyter ]
     args: [
       --fix,
       --show-fixes,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -272,7 +272,6 @@ exclude = '''
 '''
 
 [tool.ruff]
-extend-include = ["*.ipynb"]
 exclude = [
     "doc",
     "benchmarks",


### PR DESCRIPTION
Reading through the migration guide for ruff 0.6.0, and opening this PR while this is on my mind.
See https://astral.sh/blog/ruff-v0.6.0#jupyter-notebooks-are-now-linted-and-formatted-by-default