### PR TITLE
explicitly disallow imageio 2.35.0 in testing deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -230,6 +230,7 @@ test = [
     "nose~=1.3.7; python_version < '3.10'",
     "nose-exclude; python_version < '3.10'",
     "nose-timer~=1.0.0; python_version < '3.10'",
+    "imageio!=2.35.0", # see https://github.com/yt-project/yt/issues/4966
 ]
 typecheck = [
     "mypy==1.8.0",


### PR DESCRIPTION
~~probable~~ fix for #4966 

