### PR TITLE
BUG: fix indexing error in fill_region_float

### DIFF
--- a/yt/utilities/lib/misc_utilities.pyx
+++ b/yt/utilities/lib/misc_utilities.pyx
@@ -921,7 +921,7 @@ def fill_region_float(np.ndarray[np.float64_t, ndim=2] fcoords,
                     if (sp[1] + odsp[1] < LE[1]) or (sp[1] - odsp[1] > RE[1]): continue
                     for zi in range(2):
                         if diter[2][zi] == 999: continue
-                        sp[2] = osp[2] + diterv[2][yi]
+                        sp[2] = osp[2] + diterv[2][zi]
                         if (sp[2] + odsp[2] < LE[2]) or (sp[2] - odsp[2] > RE[2]): continue
                         for i in range(3):
                             ld[i] = <np.int64_t> fmax(((sp[i]-odsp[i]-LE[i])*box_idds[i]),0)


### PR DESCRIPTION
I was trying to figure out why the final row of pixels in the following plot seem to have elevated values:

```python
import yt 
import matplotlib.pyplot as plt 
import numpy as np
ds = yt.load_sample("DeeplyNestedZoom")

le = ds.domain_left_edge
re = ds.arr([0.1,]*3, 'code_length')
res = (100,)*3
reg = ds.r[le[0]:re[0]:res[0]*1j, 
           le[1]:re[1]:res[1]*1j, 
           le[2]:re[2]:res[2]*1j,]
dens = reg['gas', 'density']
plt.imshow(np.log10(dens[:,50,:]), origin='lower')
```
![fill_region_main](https://github.com/user-attachments/assets/3d58a1ce-9ad5-4cfa-93b6-14bb86cdcd70)

The elevated values are not super obvious here... but i've been doing some experiments stitching together arbitrary grid objects into zarr files (over in https://github.com/yt-project/yt_experiments/pull/10) and found some artifacts aligned with the boundaries of my chunks: 

![tiled_grids](https://github.com/user-attachments/assets/8c7dfbec-172e-4ff2-b44a-7131fa16f7ff)

In any case, reading through `fill_region_float`, I noticed this line where there seems to be an indexing error. With the change on this branch, the above plots become

![fill_region_new](https://github.com/user-attachments/assets/c2496e2b-46df-4428-8fa2-d9f45e02c821)
![fixed_tiles](https://github.com/user-attachments/assets/fdbbc4df-1a29-4235-a8fa-2a5aa62ee8a1)
