### PR TITLE
RFC: enable `flake8-type-checking` ruleset

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -294,6 +294,7 @@ select = [
     "C4",   # flake8-comprehensions
     "B",    # flake8-bugbear
     "G",    # flake8-logging-format
+    "TCH",  # flake8-type-checking
     "YTT",  # flake8-2020
     "UP",   # pyupgrade
     "I",    # isort

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -13,12 +13,11 @@ from collections.abc import MutableMapping
 from functools import cached_property
 from importlib.util import find_spec
 from stat import ST_CTIME
-from typing import Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 
 import numpy as np
 import unyt as un
 from more_itertools import unzip
-from sympy import Symbol
 from unyt import Unit, UnitSystem, unyt_quantity
 from unyt.exceptions import UnitConversionError, UnitParseError
 
@@ -74,6 +73,9 @@ from yt.utilities.minimal_representation import MinimalDataset
 from yt.utilities.object_registries import data_object_registry, output_type_registry
 from yt.utilities.parallel_tools.parallel_analysis_interface import parallel_root_only
 from yt.utilities.parameter_file_storage import NoParameterShelf, ParameterFileStore
+
+if TYPE_CHECKING:
+    from sympy import Symbol
 
 if sys.version_info >= (3, 11):
     from typing import assert_never

--- a/yt/frontends/ramses/io.py
+++ b/yt/frontends/ramses/io.py
@@ -1,7 +1,6 @@
-import os
 from collections import defaultdict
 from functools import lru_cache
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
 import numpy as np
 
@@ -16,6 +15,9 @@ from yt.utilities.exceptions import (
 from yt.utilities.io_handler import BaseIOHandler
 from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.physical_ratios import cm_per_km, cm_per_mpc
+
+if TYPE_CHECKING:
+    import os
 
 
 def convert_ramses_ages(ds, conformal_ages):

--- a/yt/visualization/fixed_resolution.py
+++ b/yt/visualization/fixed_resolution.py
@@ -134,7 +134,7 @@ class FixedResolutionBuffer:
         # the filter methods for the present class are defined only when
         # fixed_resolution_filters is imported, so we need to guarantee
         # that it happens no later than instantiation
-        from yt.visualization.fixed_resolution_filters import (
+        from yt.visualization.fixed_resolution_filters import (  # noqa
             FixedResolutionBufferFilter,
         )
 

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -2,7 +2,7 @@ import abc
 import sys
 from collections import defaultdict
 from numbers import Number
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import matplotlib
 import numpy as np
@@ -54,6 +54,9 @@ from .plot_container import (
     invalidate_figure,
     invalidate_plot,
 )
+
+if TYPE_CHECKING:
+    from yt.visualization.plot_modifications import PlotCallback
 
 if sys.version_info < (3, 10):
     from yt._maintenance.backports import zip
@@ -866,7 +869,6 @@ class PWViewerMPL(PlotWindow):
         # the filter methods for the present class are defined only when
         # fixed_resolution_filters is imported, so we need to guarantee
         # that it happens no later than instantiation
-        from yt.visualization.plot_modifications import PlotCallback
 
         self._callbacks: list[PlotCallback] = []
 

--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -1,8 +1,7 @@
 import base64
 import os
-from collections.abc import Iterable
 from functools import wraps
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import matplotlib
 import numpy as np
@@ -27,6 +26,11 @@ from .plot_container import (
     invalidate_plot,
     validate_plot,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from yt._typing import FieldKey
 
 
 def invalidate_profile(f):


### PR DESCRIPTION
## PR Summary

Changeset obtained with
```shell
ruff check yt --fix --unsafe-fixes --select TCH
```

This helps with making sure (potentially expensive) type-check-only import statements do not impact startup time (see  for instance matplotlib imports moved in #4265)