### PR TITLE
MNT: add pep723 metadata to test helper script

### DIFF
--- a/tests/unpin_requirements.py
+++ b/tests/unpin_requirements.py
@@ -1,3 +1,10 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "tomli ; python_full_version < '3.11'",
+#     "tomli-w",
+# ]
+# ///
 import re
 import sys
 


### PR DESCRIPTION
## PR Summary

This allows running this script as `uvx run tests/unpin_requirements.py` without manually managing virtual environments.
Note that this format isn't specific to `uv/uvx`, but a standard defined by an official PEP ([723](https://peps.python.org/pep-0723/)) 