### PR TITLE
adjust platform_dep.h for recent MSVS versions

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [
           ubuntu-20.04,
-          windows-2019,
+          windows-2022,
           macos-13, # x86_64
           macos-14, # arm64
         ]

--- a/yt/utilities/lib/platform_dep.h
+++ b/yt/utilities/lib/platform_dep.h
@@ -3,7 +3,7 @@
 #include "malloc.h"
 /*
 note: the following implicitly sets a mininum VS version: conservative
-minumum is _MSC_VER >= 1928 (VS 2019, 16.8), but may work for VS 2015
+minimum is _MSC_VER >= 1928 (VS 2019, 16.8), but may work for VS 2015
 but that has not been tested. see https://github.com/yt-project/yt/pull/4980
 and https://learn.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance
 */

--- a/yt/utilities/lib/platform_dep.h
+++ b/yt/utilities/lib/platform_dep.h
@@ -1,59 +1,9 @@
 #include <math.h>
 #ifdef MS_WIN32
 #include "malloc.h"
+// note: the following implicitly requires _MSC_VER >= 1928 (VS 2019, 16.8)
 #include <float.h>
-typedef int int32_t;
-typedef long long int64_t;
-/* Taken from http://siliconandlithium.blogspot.com/2014/05/msvc-c99-mathh-header.html */
-#define isnormal(x) ((_fpclass(x) == _FPCLASS_NN) || (_fpclass(x) == _FPCLASS_PN))
-static __inline double rint(double x){
-    const double two_to_52 = 4.5035996273704960e+15;
-    double fa = fabs(x);
-    if(fa >= two_to_52){
-        return x;
-    } else{
-        return copysign(two_to_52 + fa - two_to_52, x);
-    }
-}
-#if _MSC_VER < 1928
-static __inline long int lrint(double x){
-    return (long)rint(x);
-}
-#endif
-static __inline double fmax(double x, double y){
-    return (x > y) ? x : y;
-}
-static __inline double fmin(double x, double y){
-    return (x < y) ? x : y;
-}
-
-/* adapted from http://www.johndcook.com/blog/cpp_erf/
-   code is under public domain license */
-
-double erf(double x)
-{
-    /* constants */
-    double a1 =  0.254829592;
-    double a2 = -0.284496736;
-    double a3 =  1.421413741;
-    double a4 = -1.453152027;
-    double a5 =  1.061405429;
-    double p  =  0.3275911;
-    double t;
-    double y;
-
-    /* Save the sign of x */
-    int sign = 1;
-    if (x < 0)
-        sign = -1;
-    x = fabs(x);
-
-    /* A&S formula 7.1.26 */
-    t = 1.0/(1.0 + p*x);
-    y = 1.0 - (((((a5*t + a4)*t) + a3)*t + a2)*t + a1)*t*exp(-x*x);
-
-    return sign*y;
-}
+#include <stdint.h>
 #elif defined(__FreeBSD__)
 #include <stdint.h>
 #include <stdlib.h>

--- a/yt/utilities/lib/platform_dep.h
+++ b/yt/utilities/lib/platform_dep.h
@@ -1,7 +1,12 @@
 #include <math.h>
 #ifdef MS_WIN32
 #include "malloc.h"
-// note: the following implicitly requires _MSC_VER >= 1928 (VS 2019, 16.8)
+/*
+note: the following implicitly sets a mininum VS version: conservative
+minumum is _MSC_VER >= 1928 (VS 2019, 16.8), but may work for VS 2015
+but that has not been tested. see https://github.com/yt-project/yt/pull/4980
+and https://learn.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance
+*/
 #include <float.h>
 #include <stdint.h>
 #elif defined(__FreeBSD__)


### PR DESCRIPTION
This is a tentative fix for #4972

Been working on this iteratively by reading MSVS documentation and running github actions on my fork since i don't have windows... but I'm fairly certain that we've been effectively pinning yt on windows to using at least Visual Studio 2019 version 16.8, 16.9 for a while now (based on my reading of https://learn.microsoft.com/en-us/cpp/overview/visual-cpp-language-conformance), which seems reasonable to me and in which case we can remove most of the windows-specific definitions (and fix the errors in #4972 ).

