### PR TITLE
MNT: restrict dependabot pip updates to requirements/typecheck.txt

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
   groups:
     actions:
       patterns:
-      - '*'
+      - 'typecheck.txt'
 
 - package-ecosystem: github-actions
   directory: /.github/workflows

--- a/requirements/typecheck.txt
+++ b/requirements/typecheck.txt
@@ -1,5 +1,5 @@
-mypy==1.8.0
-types-PyYAML==6.0.12.12
+mypy==1.11.2
+types-PyYAML==6.0.12.20240808
 types-chardet==5.0.4.6
-types-requests==2.31.0.20240125
+types-requests==2.32.0.20240907
 typing-extensions==4.4.0; python_version < '3.12'


### PR DESCRIPTION
## PR Summary
Follow up to #4983, after closing unwanted PRs #4985 #4987 and #4988
I also included the desirable part of #4988