### PR TITLE
STY: autofix RUF031 (`incorrectly-parenthesized-tuple-in-subscript`)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,6 +267,7 @@ select = [
     "UP",   # pyupgrade
     "I",    # isort
     "NPY",  # numpy specific rules
+    "RUF031"# incorrectly-parenthesized-tuple-in-subscript
 ]
 ignore = [
     "E501",  # line too long


### PR DESCRIPTION
## PR Summary

Follow up to #4844: this new linting rule will allow auto-fixing deviations in the future.
For context, it's not a coincidence if this rule so closely matches what @cphyc did in #4844:
this rule was added to ruff after I requested it *in response* to his PR :)
