### PR TITLE
BUG: ensure YTSlice.coord has units

### DIFF
--- a/yt/data_objects/selection_objects/slices.py
+++ b/yt/data_objects/selection_objects/slices.py
@@ -6,6 +6,7 @@ from yt.data_objects.selection_objects.data_selection_objects import (
 )
 from yt.data_objects.static_output import Dataset
 from yt.funcs import (
+    fix_length,
     is_sequence,
     iter_fields,
     validate_3d_array,
@@ -78,7 +79,7 @@ class YTSlice(YTSelectionContainer2D):
         validate_object(data_source, YTSelectionContainer)
         YTSelectionContainer2D.__init__(self, axis, ds, field_parameters, data_source)
         self._set_center(center)
-        self.coord = coord
+        self.coord = fix_length(coord, ds)
 
     def _generate_container_field(self, field):
         xax = self.ds.coordinates.x_axis[self.axis]

--- a/yt/data_objects/tests/test_sph_data_objects.py
+++ b/yt/data_objects/tests/test_sph_data_objects.py
@@ -64,6 +64,16 @@ REGION_ANSWERS = {
 }
 
 
+def test_slice_to_frb():
+    ds = fake_sph_orientation_ds()
+    frb = ds.slice(0, 0.5).to_frb(ds.domain_width[0], (64, 64))
+    ref_vals = frb["gas", "density"]
+    for center in ((0.5, "code_length"), (0.5, "cm"), ds.quan(0.5, "code_length")):
+        frb = ds.slice(0, center).to_frb(ds.domain_width[0], (64, 64))
+        vals = frb["gas", "density"]
+        assert_equal(vals, ref_vals)
+
+
 def test_region():
     ds = fake_sph_orientation_ds()
     for (left_edge, right_edge), answer in REGION_ANSWERS.items():

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -1106,7 +1106,7 @@ def validate_3d_array(obj):
 def validate_float(obj):
     """Validates if the passed argument is a float value.
 
-    Raises an exception if `obj` is a single float value
+    Raises an exception if `obj` is not a single float value
     or a YTQuantity of size 1.
 
     Parameters


### PR DESCRIPTION
## PR Summary

Found that for sph data, calling `ds.slice(axis, center).to_frb(...)[field]` would error if the `center` argument was a plain float. For other dataset types (and other data objects), a plain float is assumed to be in units of `code_length`. Easiest fix is to ensure that `YTSlice.coord` attribute is a unyt object, following the other data objects.

Here's the stack trace from the error on main:

```python
import yt
ds = yt.load_sample("snapshot_033")
frb = ds.slice(0, 0.25).to_frb(ds.domain_width[0], (64, 64))
print(frb["gas", "density"])
# Traceback (most recent call last):
#   File "/Users/chavlin/.pyenv/versions/yt_dev/lib/python3.10/site-packages/IPython/core/interactiveshell.py", line 3548, in run_code
#     exec(code_obj, self.user_global_ns, self.user_ns)
#   File "<ipython-input-3-76bca84cf85c>", line 6, in <module>
#     print(frb["gas", "density"])
#   File "/Users/chavlin/src/yt_/yt_dev/yt/yt/visualization/fixed_resolution.py", line 209, in __getitem__
#     return self.get_image(item)
#   File "/Users/chavlin/src/yt_/yt_dev/yt/yt/visualization/fixed_resolution.py", line 213, in get_image
#     self._generate_image_and_mask(key)
#   File "/Users/chavlin/src/yt_/yt_dev/yt/yt/visualization/fixed_resolution.py", line 179, in _generate_image_and_mask
#     buff, mask = self.ds.coordinates.pixelize(
#   File "/Users/chavlin/src/yt_/yt_dev/yt/yt/geometry/coordinates/cartesian_coordinates.py", line 238, in pixelize
#     buff, mask = self._ortho_pixelize(
#   File "/Users/chavlin/src/yt_/yt_dev/yt/yt/geometry/coordinates/cartesian_coordinates.py", line 554, in _ortho_pixelize
#     data_source.coord.to("code_length").v,
# AttributeError: 'float' object has no attribute 'to'
``` 



## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- ~~[ ] New features are documented, with docstrings and narrative docs~~ N/A
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
