### PR TITLE
ENH: Support line-of-sight fields for particle types

### DIFF
--- a/doc/source/analyzing/fields.rst
+++ b/doc/source/analyzing/fields.rst
@@ -702,16 +702,20 @@ you want to examine a line-of-sight vector within a 3-D data object, set the
     # Set to a three-vector for an off-axis component
     dd.set_field_parameter("axis", [0.3, 0.4, -0.7])
     print(dd["gas", "velocity_los"])
+    # particle fields are supported too!
+    print(dd["all", "particle_velocity_los"])
 
 .. warning::
 
     If you need to change the axis of the line of sight on the *same* data container
-    (sphere, box, cylinder, or whatever), you will need to delete the field using
+    (sphere, box, cylinder, or whatever), you will need to delete the field using (e.g.)
     ``del dd['velocity_los']`` and re-generate it.
 
 At this time, this functionality is enabled for the velocity and magnetic vector
-fields, ``('gas', 'velocity_los')`` and ``('gas', 'magnetic_field_los')``. The
-following fields built into yt make use of these line-of-sight fields:
+fields, ``('gas', 'velocity_los')`` and ``('gas', 'magnetic_field_los')`` for
+the ``"gas"`` field type, and it is also enabled for every particle type with
+a velocity field, e.g. ``("all", "particle_velocity_los")``. The following fields
+built into yt make use of these line-of-sight fields:
 
 * ``('gas', 'sz_kinetic')`` uses ``('gas', 'velocity_los')``
 * ``('gas', 'rotation_measure')`` uses ``('gas', 'magnetic_field_los')``

--- a/doc/source/analyzing/fields.rst
+++ b/doc/source/analyzing/fields.rst
@@ -713,7 +713,7 @@ you want to examine a line-of-sight vector within a 3-D data object, set the
 
 At this time, this functionality is enabled for the velocity and magnetic vector
 fields, ``('gas', 'velocity_los')`` and ``('gas', 'magnetic_field_los')`` for
-the ``"gas"`` field type, and it is also enabled for every particle type with
+the ``"gas"`` field type, as well as every particle type with
 a velocity field, e.g. ``("all", "particle_velocity_los")``. The following fields
 built into yt make use of these line-of-sight fields:
 

--- a/yt/data_objects/tests/test_data_containers.py
+++ b/yt/data_objects/tests/test_data_containers.py
@@ -160,6 +160,7 @@ class TestDataContainers(unittest.TestCase):
         # their parent field to be created
         ds = fake_particle_ds()
         dd = ds.all_data()
+        dd.set_field_parameter("axis", 0)
 
         @particle_filter(requires=["particle_mass"], filtered_type="io")
         def massive(pfilter, data):

--- a/yt/fields/particle_fields.py
+++ b/yt/fields/particle_fields.py
@@ -22,7 +22,7 @@ from yt.utilities.math_utils import (
 )
 
 from .field_functions import get_radius
-from .vector_operations import create_magnitude_field
+from .vector_operations import create_los_field, create_magnitude_field
 
 sph_whitelist_fields = (
     "density",
@@ -327,6 +327,14 @@ def standard_particle_fields(
         function=_particle_velocity_magnitude,
         take_log=False,
         units=unit_system["velocity"],
+    )
+
+    create_los_field(
+        registry,
+        "particle_velocity",
+        unit_system["velocity"],
+        ftype=ptype,
+        sampling_type="particle",
     )
 
     def _particle_specific_angular_momentum(field, data):

--- a/yt/fields/tests/test_particle_fields.py
+++ b/yt/fields/tests/test_particle_fields.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from yt.testing import assert_allclose_units, requires_file, requires_module
 from yt.utilities.answer_testing.framework import data_dir_load
 
@@ -19,3 +21,26 @@ def test_relative_particle_fields():
     assert_allclose_units(
         sp["all", "relative_particle_velocity"], sp["all", "particle_velocity"] - bv
     )
+
+
+@requires_module("h5py")
+@requires_file(g30)
+def test_los_particle_fields():
+    ds = data_dir_load(g30)
+    offset = ds.arr([0.1, -0.2, 0.3], "code_length")
+    c = ds.domain_center + offset
+    sp = ds.sphere(c, (10, "kpc"))
+    bv = ds.arr([1.0, 2.0, 3.0], "code_velocity")
+    sp.set_field_parameter("bulk_velocity", bv)
+    ax = [0.1, 0.2, -0.3]
+    sp.set_field_parameter("axis", ax)
+    ax /= np.sqrt(np.dot(ax, ax))
+    vlos = sp["all", "relative_particle_velocity_x"] * ax[0]
+    vlos += sp["all", "relative_particle_velocity_y"] * ax[1]
+    vlos += sp["all", "relative_particle_velocity_z"] * ax[2]
+    assert_allclose_units(sp["all", "particle_velocity_los"], vlos)
+    sp.clear_data()
+    ax = 2
+    sp.set_field_parameter("axis", ax)
+    vlos = sp["all", "relative_particle_velocity_z"]
+    assert_allclose_units(sp["all", "particle_velocity_los"], vlos)

--- a/yt/fields/tests/test_particle_fields.py
+++ b/yt/fields/tests/test_particle_fields.py
@@ -34,10 +34,12 @@ def test_los_particle_fields():
     sp.set_field_parameter("bulk_velocity", bv)
     ax = [0.1, 0.2, -0.3]
     sp.set_field_parameter("axis", ax)
-    ax /= np.sqrt(np.dot(ax, ax))
-    vlos = sp["all", "relative_particle_velocity_x"] * ax[0]
-    vlos += sp["all", "relative_particle_velocity_y"] * ax[1]
-    vlos += sp["all", "relative_particle_velocity_z"] * ax[2]
+    ax /= np.linalg.norm(ax)
+    vlos = (
+        sp["all", "relative_particle_velocity_x"] * ax[0]
+        + sp["all", "relative_particle_velocity_y"] * ax[1]
+        + sp["all", "relative_particle_velocity_z"] * ax[2]
+    )
     assert_allclose_units(sp["all", "particle_velocity_los"], vlos)
     sp.clear_data()
     ax = 2

--- a/yt/fields/vector_operations.py
+++ b/yt/fields/vector_operations.py
@@ -118,7 +118,7 @@ def create_los_field(
     # Here we need to check if we are a particle field, so that we can
     # correctly identify the "bulk" field parameter corresponding to
     # this vector field.
-    if sampling_type == "particle" and basename.startswith("particle_"):
+    if sampling_type == "particle":
         basenm = basename.removeprefix("particle_")
     else:
         basenm = basename

--- a/yt/fields/vector_operations.py
+++ b/yt/fields/vector_operations.py
@@ -105,16 +105,21 @@ def create_relative_field(
 
 
 def create_los_field(
-    registry, basename, field_units, ftype="gas", slice_info=None, *, sampling_type="local",
+    registry,
+    basename,
+    field_units,
+    ftype="gas",
+    slice_info=None,
+    *,
+    sampling_type="local",
 ):
     axis_order = registry.ds.coordinates.axis_order
-
 
     # Here we need to check if we are a particle field, so that we can
     # correctly identify the "bulk" field parameter corresponding to
     # this vector field.
     if sampling_type == "particle" and basename.startswith("particle_"):
-        basenm = basename.split("_", 1)[1]
+        basenm = basename.removeprefix("particle_")
     else:
         basenm = basename
 

--- a/yt/fields/vector_operations.py
+++ b/yt/fields/vector_operations.py
@@ -112,6 +112,9 @@ def create_los_field(
     if sampling_type is None:
         sampling_type = "local"
 
+    # Here we need to check if we are a particle field, so that we can
+    # correctly identify the "bulk" field parameter corresponding to
+    # this vector field.
     if sampling_type == "particle" and basename.startswith("particle_"):
         basenm = basename.split("_", 1)[1]
     else:

--- a/yt/fields/vector_operations.py
+++ b/yt/fields/vector_operations.py
@@ -104,18 +104,28 @@ def create_relative_field(
         )
 
 
-def create_los_field(registry, basename, field_units, ftype="gas", slice_info=None):
+def create_los_field(
+    registry, basename, field_units, ftype="gas", sampling_type=None, slice_info=None
+):
     axis_order = registry.ds.coordinates.axis_order
 
+    if sampling_type is None:
+        sampling_type = "local"
+
+    if sampling_type == "particle" and basename.startswith("particle_"):
+        basenm = basename.split("_", 1)[1]
+    else:
+        basenm = basename
+
     validators = [
-        ValidateParameter(f"bulk_{basename}"),
+        ValidateParameter(f"bulk_{basenm}"),
         ValidateParameter("axis", {"axis": [0, 1, 2]}),
     ]
 
     field_comps = [(ftype, f"{basename}_{ax}") for ax in axis_order]
 
     def _los_field(field, data):
-        if data.has_field_parameter(f"bulk_{basename}"):
+        if data.has_field_parameter(f"bulk_{basenm}"):
             fns = [(fc[0], f"relative_{fc[1]}") for fc in field_comps]
         else:
             fns = field_comps
@@ -132,7 +142,7 @@ def create_los_field(registry, basename, field_units, ftype="gas", slice_info=No
 
     registry.add_field(
         (ftype, f"{basename}_los"),
-        sampling_type="local",
+        sampling_type=sampling_type,
         function=_los_field,
         units=field_units,
         validators=validators,

--- a/yt/fields/vector_operations.py
+++ b/yt/fields/vector_operations.py
@@ -105,12 +105,10 @@ def create_relative_field(
 
 
 def create_los_field(
-    registry, basename, field_units, ftype="gas", sampling_type=None, slice_info=None
+    registry, basename, field_units, ftype="gas", slice_info=None, *, sampling_type="local",
 ):
     axis_order = registry.ds.coordinates.axis_order
 
-    if sampling_type is None:
-        sampling_type = "local"
 
     # Here we need to check if we are a particle field, so that we can
     # correctly identify the "bulk" field parameter corresponding to


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

yt already supports ["line-of-sight" fields](https://yt-project.org/doc/analyzing/fields.html#line-of-sight-fields) for gas field types. These are fields that result from taking the component of a vector field along a particular sight line (such as in a projection, but it can be more general). This PR enables the same functionality for particle fields, and turns it on for the particle velocity. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
