### PR TITLE
DOC: remove unused north_vector in off_axis_projection example

### DIFF
--- a/doc/source/visualizing/plots.rst
+++ b/doc/source/visualizing/plots.rst
@@ -454,7 +454,6 @@ projection through a simulation.
 
    ds = yt.load("IsolatedGalaxy/galaxy0030/galaxy0030")
    L = [1, 1, 0]  # vector normal to cutting plane
-   north_vector = [-1, 1, 0]
    W = [0.02, 0.02, 0.02]
    c = [0.5, 0.5, 0.5]
    N = 512


### PR DESCRIPTION
`north_vector` was being defined but not used, so removing it in this PR. Could instead supply it to `off_axis_projection`, but a `north_vector` gets used in the next example. 