### PR TITLE
PERF: release the GIL in cylindrical pixelizer

### DIFF
--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -663,13 +663,13 @@ def pixelize_cylinder(np.float64_t[:,:] buff,
                             ptbounds[0] = fmin(ptbounds[0], corners[i1])
                             ptbounds[1] = fmax(ptbounds[1], corners[i1])
 
-                        # shift to a [0, PI] interval
-                        ptbounds[0] = ptbounds[0] % twoPI
-                        if ptbounds[0] < 0:
-                            ptbounds[0] += NPY_PI
-                        ptbounds[1] = ptbounds[1] % twoPI
-                        if ptbounds[1] < 0:
-                            ptbounds[1] += NPY_PI
+                        # shift to a [0, 2*PI] interval
+                        # note: in cython, % is an alias to fmod and the sign
+                        # of the returned value matches the sign of the first
+                        # argument, so need to offset by 2pi to ensure we
+                        # always get a positive result in [0,2pi]
+                        ptbounds[0] = math.fmod(ptbounds[0]+twoPI, twoPI)
+                        ptbounds[1] = math.fmod(ptbounds[1]+twoPI, twoPI)
 
                         if prbounds[0] >= rmin and prbounds[1] <= rmax and \
                            ptbounds[0] >= tmin and ptbounds[1] <= tmax:

--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -664,8 +664,8 @@ def pixelize_cylinder(np.float64_t[:,:] buff,
                             ptbounds[1] = fmax(ptbounds[1], corners[i1])
 
                         # shift to a [0, 2*PI] interval
-                        # note: with fmod, the sign of the returned value 
-                        # matches the sign of the first argument, so need 
+                        # note: with fmod, the sign of the returned value
+                        # matches the sign of the first argument, so need
                         # to offset by 2pi to ensure a positive result in [0, 2pi]
                         ptbounds[0] = math.fmod(ptbounds[0]+twoPI, twoPI)
                         ptbounds[1] = math.fmod(ptbounds[1]+twoPI, twoPI)

--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -81,6 +81,8 @@ cdef extern from "pixelization_constants.hpp":
     int WEDGE_NF
     np.uint8_t wedge_face_defs[MAX_NUM_FACES][2][2]
 
+cdef extern from "numpy/npy_math.h":
+    double NPY_PI
 
 @cython.cdivision(True)
 @cython.boundscheck(False)
@@ -566,7 +568,7 @@ def pixelize_cylinder(np.float64_t[:,:] buff,
     cdef np.float64_t r_inc, theta_inc
     cdef np.float64_t costheta, sintheta
     cdef int i, i1, pi, pj
-    cdef np.float64_t twoPI = 2 * np.pi
+    cdef np.float64_t twoPI = 2 * NPY_PI
 
     cdef int imin, imax
     imin = np.asarray(radius).argmin()
@@ -578,7 +580,6 @@ def pixelize_cylinder(np.float64_t[:,:] buff,
     imax = np.asarray(theta).argmax()
     tmin = theta[imin] - dtheta[imin]
     tmax = theta[imax] + dtheta[imax]
-
     cdef np.ndarray[np.uint8_t, ndim=2] mask_arr = np.zeros_like(buff, dtype="uint8")
     cdef np.uint8_t[:, :] mask = mask_arr
 
@@ -664,7 +665,11 @@ def pixelize_cylinder(np.float64_t[:,:] buff,
 
                         # shift to a [0, PI] interval
                         ptbounds[0] = ptbounds[0] % twoPI
+                        if ptbounds[0] < 0:
+                            ptbounds[0] += NPY_PI
                         ptbounds[1] = ptbounds[1] % twoPI
+                        if ptbounds[1] < 0:
+                            ptbounds[1] += NPY_PI
 
                         if prbounds[0] >= rmin and prbounds[1] <= rmax and \
                            ptbounds[0] >= tmin and ptbounds[1] <= tmax:

--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -664,10 +664,9 @@ def pixelize_cylinder(np.float64_t[:,:] buff,
                             ptbounds[1] = fmax(ptbounds[1], corners[i1])
 
                         # shift to a [0, 2*PI] interval
-                        # note: in cython, % is an alias to fmod and the sign
-                        # of the returned value matches the sign of the first
-                        # argument, so need to offset by 2pi to ensure we
-                        # always get a positive result in [0,2pi]
+                        # note: with fmod, the sign of the returned value 
+                        # matches the sign of the first argument, so need 
+                        # to offset by 2pi to ensure a positive result in [0, 2pi]
                         ptbounds[0] = math.fmod(ptbounds[0]+twoPI, twoPI)
                         ptbounds[1] = math.fmod(ptbounds[1]+twoPI, twoPI)
 

--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -566,7 +566,7 @@ def pixelize_cylinder(np.float64_t[:,:] buff,
     cdef np.float64_t r_inc, theta_inc
     cdef np.float64_t costheta, sintheta
     cdef int i, i1, pi, pj
-    cdef np.float64_t npPI = np.pi
+    cdef np.float64_t twoPI = 2 * np.pi
 
     cdef int imin, imax
     imin = np.asarray(radius).argmin()

--- a/yt/utilities/lib/pixelization_routines.pyx
+++ b/yt/utilities/lib/pixelization_routines.pyx
@@ -663,8 +663,8 @@ def pixelize_cylinder(np.float64_t[:,:] buff,
                             ptbounds[1] = fmax(ptbounds[1], corners[i1])
 
                         # shift to a [0, PI] interval
-                        ptbounds[0] = ptbounds[0] % (2*npPI)
-                        ptbounds[1] = ptbounds[1] % (2*npPI)
+                        ptbounds[0] = ptbounds[0] % twoPI
+                        ptbounds[1] = ptbounds[1] % twoPI
 
                         if prbounds[0] >= rmin and prbounds[1] <= rmax and \
                            ptbounds[0] >= tmin and ptbounds[1] <= tmax:


### PR DESCRIPTION
release the gil!

This surprisingly seemed to work with minimal effort... took the pixelization time from 53s to 27s for one example (see [this slack thread](https://yt-project.slack.com/archives/C1YCPSX08/p1727899750601519)). 