### PR TITLE
[BUG] Better logic for detection of particle handle for checkpoint files

### DIFF
--- a/yt/frontends/flash/data_structures.py
+++ b/yt/frontends/flash/data_structures.py
@@ -191,15 +191,19 @@ class FLASHDataset(Dataset):
 
         if self.particle_filename is None:
             # try to guess the particle filename
-            try:
-                self._particle_handle = HDF5FileHandler(
-                    filename.replace("plt_cnt", "part")
-                )
-                self.particle_filename = filename.replace("plt_cnt", "part")
-                mylog.info(
-                    "Particle file found: %s", self.particle_filename.split("/")[-1]
-                )
-            except OSError:
+            if "hdf5_plt_cnt" in filename:
+                # We have a plotfile, look for the particle file
+                try:
+                    pfn = filename.replace("plt_cnt", "part")
+                    self._particle_handle = HDF5FileHandler(pfn)
+                    self.particle_filename = pfn
+                    mylog.info(
+                        "Particle file found: %s", self.particle_filename.split("/")[-1]
+                    )
+                except OSError:
+                    self._particle_handle = self._handle
+            elif "hdf5_chk" in filename:
+                # This is a checkpoint file, should have the particles in it
                 self._particle_handle = self._handle
         else:
             # particle_filename is specified by user

--- a/yt/frontends/flash/data_structures.py
+++ b/yt/frontends/flash/data_structures.py
@@ -218,9 +218,8 @@ class FLASHDataset(Dataset):
 
         # Check if the particle file has the same time
         if self._particle_handle != self._handle:
-            part_time = self._particle_handle.handle.get("real scalars", None)
-            plot_time = self._handle.handle.get("real scalars", None)
-            if part_time is None:
+            plot_time = self._handle.handle.get("real scalars")
+            if (part_time := self._particle_handle.handle.get("real scalars")) is None:
                 raise RuntimeError("FLASH 2.x particle files are not supported!")
             if not np.isclose(part_time[0][1], plot_time[0][1]):
                 self._particle_handle = self._handle

--- a/yt/frontends/flash/data_structures.py
+++ b/yt/frontends/flash/data_structures.py
@@ -211,9 +211,11 @@ class FLASHDataset(Dataset):
 
         # Check if the particle file has the same time
         if self._particle_handle != self._handle:
-            part_time = self._particle_handle.handle.get("real scalars")[0][1]
-            plot_time = self._handle.handle.get("real scalars")[0][1]
-            if not np.isclose(part_time, plot_time):
+            part_time = self._particle_handle.handle.get("real scalars", None)
+            plot_time = self._handle.handle.get("real scalars", None)
+            if part_time is None:
+                raise RuntimeError("FLASH 2.x particle files are not supported!")
+            if not np.isclose(part_time[0][1], plot_time[0][1]):
                 self._particle_handle = self._handle
                 mylog.warning(
                     "%s and %s are not at the same time. "

--- a/yt/frontends/flash/data_structures.py
+++ b/yt/frontends/flash/data_structures.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import weakref
+from pathlib import Path
 
 import numpy as np
 
@@ -189,20 +190,26 @@ class FLASHDataset(Dataset):
 
         self.particle_filename = particle_filename
 
+        filepath = Path(filename)
+
         if self.particle_filename is None:
             # try to guess the particle filename
-            if "hdf5_plt_cnt" in filename:
+            if "hdf5_plt_cnt" in filepath.name:
                 # We have a plotfile, look for the particle file
                 try:
-                    pfn = filename.replace("plt_cnt", "part")
+                    pfn = str(
+                        filepath.parent.resolve()
+                        / filepath.name.replace("plt_cnt", "part")
+                    )
                     self._particle_handle = HDF5FileHandler(pfn)
                     self.particle_filename = pfn
                     mylog.info(
-                        "Particle file found: %s", self.particle_filename.split("/")[-1]
+                        "Particle file found: %s",
+                        os.path.basename(self.particle_filename),
                     )
                 except OSError:
                     self._particle_handle = self._handle
-            elif "hdf5_chk" in filename:
+            elif "hdf5_chk" in filepath.name:
                 # This is a checkpoint file, should have the particles in it
                 self._particle_handle = self._handle
         else:


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

## PR Summary

We do not support particle data in FLASH data before version 3, but we do support reading in FLASH 2.x datasets.

The current logic for detecting a FLASH particle file which corresponds to a FLASH plotfile checks the filename for the string `"hdf5_plt"` and replaces it with `"hdf5_part"`. It then generates a file handler for the particle file:

https://github.com/yt-project/yt/blob/7ebe857f9c38215976ca058142a78a107d39e1e8/yt/frontends/flash/data_structures.py#L192-L206

This works just fine for plot and particle files that match, but this logic completely misses checkpoint files with the string `"hdf5_chk"`.  But this falls through silently, because it will not change the filename at all in line 196 above and will open a separate file handler for the same input file. 

Then shortly after there is a check for the equality of the two file handles (which will fail because the same file has been opened two different times):

https://github.com/yt-project/yt/blob/7ebe857f9c38215976ca058142a78a107d39e1e8/yt/frontends/flash/data_structures.py#L208-L219

This does not create a problem for FLASH 3 files (aside from the extra and unnecessary file handle), but for FLASH 2.5 files we fail here because they do not have the `"real scalars"` HDF5 dataset:

```python
import yt
ds = yt.load("co2djj_hdf5_chk_2396")
```

```python-traceback
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[2], line 1
----> 1 ds = yt.load("co2djj_hdf5_chk_2396")

File ~/Source/yt/yt/_maintenance/deprecation.py:69, in future_positional_only.<locals>.outer.<locals>.inner(*args, **kwargs)
     60     value = kwargs[name]
     61     issue_deprecation_warning(
     62         f"Using the {name!r} argument as keyword (on position {no}) "
     63         "is deprecated. "
   (...)
     67         **depr_kwargs,
     68     )
---> 69 return func(*args, **kwargs)

File ~/Source/yt/yt/loaders.py:149, in load(fn, hint, *args, **kwargs)
    141     if missing := cls._missing_load_requirements():
    142         warnings.warn(
    143             f"This dataset appears to be of type {cls.__name__}, "
    144             "but the following requirements are currently missing: "
   (...)
    147             stacklevel=3,
    148         )
--> 149     return cls(fn, *args, **kwargs)
    151 if len(candidates) > 1:
    152     raise YTAmbiguousDataType(_input_fn, candidates)

File ~/Source/yt/yt/frontends/flash/data_structures.py:210, in FLASHDataset.__init__(self, filename, dataset_type, storage_filename, particle_filename, units_override, unit_system, default_species_fields)
    208 # Check if the particle file has the same time
    209 if self._particle_handle != self._handle:
--> 210     part_time = self._particle_handle.handle.get("real scalars")[0][1]
    211     plot_time = self._handle.handle.get("real scalars")[0][1]
    212     if not np.isclose(part_time, plot_time):

TypeError: 'NoneType' object is not subscriptable
``` 

This PR addresses this problem by 1) Making sure that files with `"hdf5_chk"` in the filename are properly handled and 2) checking explicitly for files without `"real scalars"`. 

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
