### PR TITLE
WHL: bump cibuildwheel to 2.21.3

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build wheels for CPython
-        uses: pypa/cibuildwheel@v2.21.2
+        uses: pypa/cibuildwheel@v2.21.3
         with:
           output-dir: dist
 


### PR DESCRIPTION
This release uses the stable version of Python 3.13 instead of release candidates, so might as well use that now that it's available.