### PR TITLE
Stop using deprecated `urllib.request.FancyURLopener`

### DIFF
--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -618,14 +618,15 @@ def fancy_download_file(url, filename, requests=None):
 
 def simple_download_file(url, filename):
     import urllib.request
+    import urllib.error
 
-    class MyURLopener(urllib.request.FancyURLopener):
-        def http_error_default(self, url, fp, errcode, errmsg, headers):
-            raise RuntimeError(
-                f"Attempt to download file from {url} failed with error {errcode}: {errmsg}."
-            )
+    try:
+        fn, h = urllib.request.urlretrieve(url, filename)
+    except urllib.error.HTTPError as err:
+        raise RuntimeError(
+            f"Attempt to download file from {url} failed with error {err.code}: {err.msg}."
+        ) from None
 
-    fn, h = MyURLopener().retrieve(url, filename)
     return fn
 
 

--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -617,8 +617,8 @@ def fancy_download_file(url, filename, requests=None):
 
 
 def simple_download_file(url, filename):
-    import urllib.request
     import urllib.error
+    import urllib.request
 
     try:
         fn, h = urllib.request.urlretrieve(url, filename)

--- a/yt/tests/test_funcs.py
+++ b/yt/tests/test_funcs.py
@@ -1,5 +1,5 @@
-from os import unlink
-from os.path import exists
+import os
+
 from nose.tools import assert_raises
 from numpy.testing import assert_equal
 
@@ -104,11 +104,11 @@ def test_simple_download_file():
     fn = simple_download_file("http://yt-project.org", "simple-download-file")
     try:
         assert fn == "simple-download-file"
-        assert exists("simple-download-file")
+        assert os.path.exists("simple-download-file")
     finally:
         # Clean up after ourselves.
         try:
-            unlink("simple-download-file")
+            os.unlink("simple-download-file")
         except FileNotFoundError:
             pass
 
@@ -118,4 +118,4 @@ def test_simple_download_file():
     desired = "Attempt to download file from http://yt-project.org/404 failed with error 404: Not Found."
     actual = str(ex.exception)
     assert actual == desired
-    assert not exists("simple-download-file")
+    assert not os.path.exists("simple-download-file")

--- a/yt/tests/test_funcs.py
+++ b/yt/tests/test_funcs.py
@@ -1,7 +1,9 @@
+from os import unlink
+from os.path import exists
 from nose.tools import assert_raises
 from numpy.testing import assert_equal
 
-from yt.funcs import just_one, levenshtein_distance, validate_axis, validate_center
+from yt.funcs import just_one, levenshtein_distance, simple_download_file, validate_axis, validate_center
 from yt.testing import fake_amr_ds
 from yt.units import YTArray, YTQuantity
 
@@ -96,3 +98,24 @@ def test_levenshtein():
     assert_equal(levenshtein_distance("abcd", "ad", max_dist=2), 2)
     assert_equal(levenshtein_distance("abcd", "abd", max_dist=2), 1)
     assert_equal(levenshtein_distance("abcd", "abcd", max_dist=2), 0)
+
+
+def test_simple_download_file():
+    fn = simple_download_file("http://yt-project.org", "simple-download-file")
+    try:
+        assert fn == "simple-download-file"
+        assert exists("simple-download-file")
+    finally:
+        # Clean up after ourselves.
+        try:
+            unlink("simple-download-file")
+        except FileNotFoundError:
+            pass
+
+    with assert_raises(RuntimeError) as ex:
+        simple_download_file("http://yt-project.org/404", "simple-download-file")
+
+    desired = "Attempt to download file from http://yt-project.org/404 failed with error 404: Not Found."
+    actual = str(ex.exception)
+    assert actual == desired
+    assert not exists("simple-download-file")

--- a/yt/tests/test_funcs.py
+++ b/yt/tests/test_funcs.py
@@ -3,7 +3,13 @@ import os
 from nose.tools import assert_raises
 from numpy.testing import assert_equal
 
-from yt.funcs import just_one, levenshtein_distance, simple_download_file, validate_axis, validate_center
+from yt.funcs import (
+    just_one,
+    levenshtein_distance,
+    simple_download_file,
+    validate_axis,
+    validate_center,
+)
 from yt.testing import fake_amr_ds
 from yt.units import YTArray, YTQuantity
 


### PR DESCRIPTION
## PR Summary

Replace use of `urllib.request.FancyURLopener` with `urlretrieve()`. The former has been deprecated since Python 3.3.

Fixes #5027 

## PR Checklist

- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
