### PR TITLE
fix docs for annotate_contour

### DIFF
--- a/doc/source/visualizing/callbacks.rst
+++ b/doc/source/visualizing/callbacks.rst
@@ -257,7 +257,7 @@ Overplot Contours
    Add contours in ``field`` to the plot.  ``levels`` governs the number of
    contours generated, ``factor`` governs the number of points used in the
    interpolation, ``take_log`` governs how it is contoured and ``clim`` gives
-   the (upper, lower) limits for contouring.
+   the (lower, upper) limits for contouring.
 
 .. python-script::
 

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -919,7 +919,7 @@ class ContourCallback(PlotCallback):
     Add contours in *field* to the plot. *levels* governs the number of
     contours generated, *factor* governs the number of points used in the
     interpolation, *take_log* governs how it is contoured and *clim* gives
-    the (upper, lower) limits for contouring.  An alternate data source can be
+    the (lower, upper) limits for contouring.  An alternate data source can be
     specified with *data_source*, but by default the plot's data source will be
     queried.
     """


### PR DESCRIPTION
clim is (lower, upper), not (upper, lower)

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

in `plot_modifications.py` `ContourCallback`, we do the contours as:

```
levels = np.linspace(clim[0], clim[1], self.levels) 
```

so `clim[0]` is the lower limit, not upper.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
