### PR TITLE
TST: add image tests for cylindrical pixelization of a box with rmin>0

### DIFF
--- a/yt/testing.py
+++ b/yt/testing.py
@@ -431,7 +431,14 @@ _fake_amr_ds_default_units = ("g/cm**3",)
 
 
 def fake_amr_ds(
-    fields=None, units=None, geometry="cartesian", particles=0, length_unit=None
+    fields=None,
+    units=None,
+    geometry="cartesian",
+    particles=0,
+    length_unit=None,
+    *,
+    domain_left_edge=None,
+    domain_right_edge=None,
 ):
     from yt.loaders import load_amr_grids
 
@@ -447,9 +454,10 @@ def fake_amr_ds(
     )
 
     prng = RandomState(0x4D3D3D3)
-    LE, RE = _geom_transforms[geometry]
-    LE = np.array(LE)
-    RE = np.array(RE)
+    default_LE, default_RE = _geom_transforms[geometry]
+
+    LE = np.array(domain_left_edge or default_LE, dtype="float64")
+    RE = np.array(domain_right_edge or default_RE, dtype="float64")
     data = []
     for gspec in _amr_grid_index:
         level, left_edge, right_edge, dims = gspec

--- a/yt/visualization/tests/test_image_comp_2D_plots.py
+++ b/yt/visualization/tests/test_image_comp_2D_plots.py
@@ -433,6 +433,34 @@ class TestCylindricalZSlicePlot:
         self.plot.set_log("noise0", False)
         return self.plot.plots[field].figure
 
+    @pytest.mark.parametrize(
+        "theta_min, theta_max",
+        [
+            pytest.param(0, 2 * np.pi, id="full_azimuthal_domain"),
+            pytest.param(3 / 4 * np.pi, 5 / 4 * np.pi, id="restricted_sector"),
+        ],
+    )
+    @pytest.mark.mpl_image_compare
+    def test_exclude_pixels_with_partial_bbox_intersection(self, theta_min, theta_max):
+        rmin = 1.0
+        rmax = 2.0
+        ds = fake_amr_ds(
+            geometry="cylindrical",
+            domain_left_edge=[rmin, 0, theta_min],
+            domain_right_edge=[rmax, 1, theta_max],
+        )
+        add_noise_fields(ds)
+        plot = SlicePlot(ds, "z", ("gas", "noise0"))
+        for radius in [rmin - 0.01, rmax]:
+            plot.annotate_sphere(
+                center=[0, 0, 0],
+                radius=radius,
+                circle_args={"color": "red", "alpha": 0.4, "linewidth": 3},
+            )
+        plot.annotate_title("all pixels beyond (or on) red lines should be white")
+        plot.render()
+        return plot.plots["gas", "noise0"].figure
+
 
 class TestSphericalPhiSlicePlot:
     @classmethod


### PR DESCRIPTION
## PR Summary

In support of #5035 after identifying such cases as blind spots in the test suite.

update: [companion PR](https://github.com/yt-project/yt_pytest_mpl_baseline/pull/8)