### PR TITLE
pin xradar<0.8.0 in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,6 +200,7 @@ test = [
     "pytest-mpl>=0.16.1",
     "sympy!=1.10,!=1.9", # see https://github.com/sympy/sympy/issues/22241
     "imageio!=2.35.0", # see https://github.com/yt-project/yt/issues/4966
+    "xradar<0.8.0",  # see https://github.com/yt-project/yt/issues/5041
 ]
 
 [project.scripts]


### PR DESCRIPTION
This is a temporary fix for #5041 on yt's side that should get tests passing but will need to be updated when a fix on the the arm-pyart side is released (at which point we could pin a min version for arm-pyart for the tests). 