### PR TITLE
cf_radial: fix deprecated dims access, add pytest tests with mock ds

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -185,7 +185,9 @@ def pytest_configure(config):
             )
 
     if find_spec("datatree"):
-        # safe to remove after https://github.com/yt-project/yt/issues/5044
+        # the cf_radial dependency arm-pyart<=1.9.2 installs the now deprecated
+        # xarray-datatree package (which imports as datatree), which triggers
+        # a bunch of runtimewarnings when importing xarray.
         # https://github.com/yt-project/yt/pull/5042#issuecomment-2457797694
         config.addinivalue_line(
             "filterwarnings",

--- a/conftest.py
+++ b/conftest.py
@@ -184,6 +184,14 @@ def pytest_configure(config):
                 ":DeprecationWarning",
             )
 
+    if find_spec("datatree"):
+        # safe to remove after https://github.com/yt-project/yt/issues/5044
+        # https://github.com/yt-project/yt/pull/5042#issuecomment-2457797694
+        config.addinivalue_line(
+            "filterwarnings",
+            "ignore:" r"Engine.*loading failed.*" ":RuntimeWarning",
+        )
+
 
 def pytest_collection_modifyitems(config, items):
     r"""

--- a/nose_ignores.txt
+++ b/nose_ignores.txt
@@ -48,3 +48,4 @@
 --ignore-file=test_offaxisprojection_pytestonly\.py
 --ignore-file=test_sph_pixelization_pytestonly\.py
 --ignore-file=test_time_series\.py
+--ignore-file=test_cf_radial_pytest\.py

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -229,5 +229,6 @@ other_tests:
      - "--exclude-test=yt.frontends.stream.tests.test_stream_particles.test_stream_non_cartesian_particles"
      - "--ignore-file=test_offaxisprojection_pytestonly\\.py"
      - "--ignore-file=test_sph_pixelization_pytestonly\\.py"
+     - "--ignore-file=test_cf_radial_pytest\\.py"
   cookbook:
      - 'doc/source/cookbook/tests/test_cookbook.py'

--- a/yt/frontends/cf_radial/data_structures.py
+++ b/yt/frontends/cf_radial/data_structures.py
@@ -272,15 +272,19 @@ class CFRadialDataset(Dataset):
         with self._handle() as xr_ds_handle:
             x, y, z = (xr_ds_handle.coords[d] for d in "xyz")
 
-            self.origin_latitude = xr_ds_handle.origin_latitude[0]
-            self.origin_longitude = xr_ds_handle.origin_longitude[0]
-
             self.domain_left_edge = np.array([x.min(), y.min(), z.min()])
             self.domain_right_edge = np.array([x.max(), y.max(), z.max()])
             self.dimensionality = 3
             dims = [xr_ds_handle.sizes[d] for d in "xyz"]
             self.domain_dimensions = np.array(dims, dtype="int64")
             self._periodicity = (False, False, False)
+
+            # note: origin_latitude and origin_longitude arrays will have time
+            # as a dimension and the initial implementation here only handles
+            # the first index. Also, the time array may have a datetime dtype,
+            # so cast to float.
+            self.origin_latitude = xr_ds_handle.origin_latitude[0]
+            self.origin_longitude = xr_ds_handle.origin_longitude[0]
             self.current_time = float(xr_ds_handle.time.values[0])
 
         # Cosmological information set to zero (not in space).

--- a/yt/frontends/cf_radial/data_structures.py
+++ b/yt/frontends/cf_radial/data_structures.py
@@ -278,10 +278,10 @@ class CFRadialDataset(Dataset):
             self.domain_left_edge = np.array([x.min(), y.min(), z.min()])
             self.domain_right_edge = np.array([x.max(), y.max(), z.max()])
             self.dimensionality = 3
-            dims = [xr_ds_handle.dims[d] for d in "xyz"]
+            dims = [xr_ds_handle.sizes[d] for d in "xyz"]
             self.domain_dimensions = np.array(dims, dtype="int64")
             self._periodicity = (False, False, False)
-            self.current_time = float(xr_ds_handle.time.values)
+            self.current_time = float(xr_ds_handle.time.values[0])
 
         # Cosmological information set to zero (not in space).
         self.cosmological_simulation = 0

--- a/yt/frontends/cf_radial/tests/test_cf_radial_pytest.py
+++ b/yt/frontends/cf_radial/tests/test_cf_radial_pytest.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+import numpy as np
+
+import yt
+from yt.frontends.cf_radial.data_structures import CFRadialDataset
+from yt.testing import requires_module
+
+
+def create_cf_radial_mock_gridded_ds(savedir: Path) -> Path:
+    # a minimal xarray dataset that should be identified as valid
+    import xarray as xr
+
+    file_to_save = savedir / "mock_gridded_cfradial.nc"
+
+    shp = (16, 16, 16)
+    xyz = {dim: np.linspace(0.0, 1.0, shp[idim]) for idim, dim in enumerate("xyz")}
+    da = xr.DataArray(data=np.ones(shp), coords=xyz, name="reflectivity")
+    ds_xr = da.to_dataset()
+    ds_xr.attrs["conventions"] = "CF/Radial"
+    ds_xr.x.attrs["units"] = "m"
+    ds_xr.y.attrs["units"] = "m"
+    ds_xr.z.attrs["units"] = "m"
+    ds_xr.reflectivity.attrs["units"] = ""
+
+    t = np.array([0.0, 1.0])
+    ds_xr = ds_xr.assign_coords({"time": t})
+    ds_xr["origin_latitude"] = xr.DataArray(np.zeros(t.shape), dims=("time"))
+    ds_xr["origin_longitude"] = xr.DataArray(np.zeros(t.shape), dims=("time"))
+
+    ds_xr.to_netcdf(file_to_save)
+
+    return file_to_save
+
+
+@requires_module("xarray")
+@requires_module("netCDF4")
+@requires_module("pyart")
+def test_load_mock_gridded_cf_radial(tmp_path):
+    import xarray as xr
+
+    test_file = create_cf_radial_mock_gridded_ds(tmp_path)
+    assert test_file.exists()
+
+    # make sure that the mock dataset is valid and can be re-loaded with xarray
+    with xr.open_dataset(test_file) as ds_xr:
+        assert "CF/Radial" in ds_xr.conventions
+
+    ds_yt = yt.load(test_file)
+    assert isinstance(ds_yt, CFRadialDataset)


### PR DESCRIPTION
While working on #5042 I noticed a deprecation warning from cf_radial, e.g., from [this run](https://tests.yt-project.org/job/yt_py310_git/8572/testReport/yt.frontends.cf_radial.tests/test_outputs/test_cf_radial_gridded/):

```
/home/fido/workspace/yt_py310_git/yt/frontends/cf_radial/data_structures.py:281: FutureWarning: The return type of
`Dataset.dims` will be changed to return a set of dimension names in future, in order to be more consistent
with`DataArray.dims`. To access a mapping from dimension names to lengths, please use `Dataset.sizes`.
 
dims = [xr_ds_handle.dims[d] for d in "xyz"]
```

This PR fixes that warning, adds some pytest-only tests (using a mocked dataset), and fixes a subsequent deprecation warning that was revealed by the new pytest.
