### PR TITLE
RFC: refactor geometry matching clauses with Python 3.10's pattern matching

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -798,28 +798,29 @@ class Dataset(abc.ABC):
                 f"Got {self.geometry=} with type {type(self.geometry)}"
             )
 
-        if self.geometry is Geometry.CARTESIAN:
-            cls = CartesianCoordinateHandler
-        elif self.geometry is Geometry.CYLINDRICAL:
-            cls = CylindricalCoordinateHandler
-        elif self.geometry is Geometry.POLAR:
-            cls = PolarCoordinateHandler
-        elif self.geometry is Geometry.SPHERICAL:
-            cls = SphericalCoordinateHandler
-            # It shouldn't be required to reset self.no_cgs_equiv_length
-            # to the default value (False) here, but it's still necessary
-            # see https://github.com/yt-project/yt/pull/3618
-            self.no_cgs_equiv_length = False
-        elif self.geometry is Geometry.GEOGRAPHIC:
-            cls = GeographicCoordinateHandler
-            self.no_cgs_equiv_length = True
-        elif self.geometry is Geometry.INTERNAL_GEOGRAPHIC:
-            cls = InternalGeographicCoordinateHandler
-            self.no_cgs_equiv_length = True
-        elif self.geometry is Geometry.SPECTRAL_CUBE:
-            cls = SpectralCubeCoordinateHandler
-        else:
-            assert_never(self.geometry)
+        match self.geometry:
+            case Geometry.CARTESIAN:
+                cls = CartesianCoordinateHandler
+            case Geometry.CYLINDRICAL:
+                cls = CylindricalCoordinateHandler
+            case Geometry.POLAR:
+                cls = PolarCoordinateHandler
+            case Geometry.SPHERICAL:
+                cls = SphericalCoordinateHandler
+                # It shouldn't be required to reset self.no_cgs_equiv_length
+                # to the default value (False) here, but it's still necessary
+                # see https://github.com/yt-project/yt/pull/3618
+                self.no_cgs_equiv_length = False
+            case Geometry.GEOGRAPHIC:
+                cls = GeographicCoordinateHandler
+                self.no_cgs_equiv_length = True
+            case Geometry.INTERNAL_GEOGRAPHIC:
+                cls = InternalGeographicCoordinateHandler
+                self.no_cgs_equiv_length = True
+            case Geometry.SPECTRAL_CUBE:
+                cls = SpectralCubeCoordinateHandler
+            case _:
+                assert_never(self.geometry)
 
         self.coordinates = cls(self, ordering=axis_order)
 
@@ -1948,9 +1949,9 @@ class Dataset(abc.ABC):
         ...     ("gas", "density_gradient_magnitude"),
         ... ]
 
-        Note that the above example assumes ds.geometry == 'cartesian'. In general,
-        the function will create gradient components along the axes of the dataset
-        coordinate system.
+        Note that the above example assumes ds.geometry is Geometry.CARTESIAN.
+        In general, the function will create gradient components along the axes
+        of the dataset coordinate system.
         For instance, with cylindrical data, one gets 'density_gradient_<r,theta,z>'
 
         """

--- a/yt/fields/field_info_container.py
+++ b/yt/fields/field_info_container.py
@@ -222,29 +222,26 @@ class FieldInfoContainer(UserDict):
         if self.ds is None:
             return aliases_gallery
 
-        geometry: Geometry = self.ds.geometry
-        if (
-            geometry is Geometry.POLAR
-            or geometry is Geometry.CYLINDRICAL
-            or geometry is Geometry.SPHERICAL
-        ):
-            aliases: list[FieldName]
-            for field in sorted(self.field_list):
-                if field[0] in self.ds.particle_types:
-                    continue
-                args = known_other_fields.get(field[1], ("", [], None))
-                units, aliases, display_name = args
-                aliases_gallery.extend(aliases)
-        elif (
-            geometry is Geometry.CARTESIAN
-            or geometry is Geometry.GEOGRAPHIC
-            or geometry is Geometry.INTERNAL_GEOGRAPHIC
-            or geometry is Geometry.SPECTRAL_CUBE
-        ):
-            # nothing to do
-            pass
-        else:
-            assert_never(geometry)
+        match self.ds.geometry:
+            case Geometry.POLAR | Geometry.CYLINDRICAL | Geometry.SPHERICAL:
+                aliases: list[FieldName]
+                for field in sorted(self.field_list):
+                    if field[0] in self.ds.particle_types:
+                        continue
+                    args = known_other_fields.get(field[1], ("", [], None))
+                    units, aliases, display_name = args
+                    aliases_gallery.extend(aliases)
+            case (
+                Geometry.CARTESIAN
+                | Geometry.GEOGRAPHIC
+                | Geometry.INTERNAL_GEOGRAPHIC
+                | Geometry.SPECTRAL_CUBE
+            ):
+                # nothing to do
+                pass
+            case _:
+                assert_never(self.ds.geometry)
+
         return aliases_gallery
 
     def setup_fluid_aliases(self, ftype: FieldType = "gas") -> None:
@@ -280,38 +277,34 @@ class FieldInfoContainer(UserDict):
                 field, sampling_type="cell", units=units, display_name=display_name
             )
             axis_names = self.ds.coordinates.axis_order
-            geometry: Geometry = self.ds.geometry
             for alias in aliases:
-                if (
-                    geometry is Geometry.POLAR
-                    or geometry is Geometry.CYLINDRICAL
-                    or geometry is Geometry.SPHERICAL
-                ):
-                    if alias[-2:] not in ["_x", "_y", "_z"]:
-                        to_convert = False
-                    else:
-                        for suffix in ["x", "y", "z"]:
-                            if f"{alias[:-2]}_{suffix}" not in aliases_gallery:
-                                to_convert = False
-                                break
-                        to_convert = True
-                    if to_convert:
-                        if alias[-2:] == "_x":
-                            alias = f"{alias[:-2]}_{axis_names[0]}"
-                        elif alias[-2:] == "_y":
-                            alias = f"{alias[:-2]}_{axis_names[1]}"
-                        elif alias[-2:] == "_z":
-                            alias = f"{alias[:-2]}_{axis_names[2]}"
-                elif (
-                    geometry is Geometry.CARTESIAN
-                    or geometry is Geometry.GEOGRAPHIC
-                    or geometry is Geometry.INTERNAL_GEOGRAPHIC
-                    or geometry is Geometry.SPECTRAL_CUBE
-                ):
-                    # nothing to do
-                    pass
-                else:
-                    assert_never(geometry)
+                match self.ds.geometry:
+                    case Geometry.POLAR | Geometry.CYLINDRICAL | Geometry.SPHERICAL:
+                        if alias[-2:] not in ["_x", "_y", "_z"]:
+                            to_convert = False
+                        else:
+                            for suffix in ["x", "y", "z"]:
+                                if f"{alias[:-2]}_{suffix}" not in aliases_gallery:
+                                    to_convert = False
+                                    break
+                            to_convert = True
+                        if to_convert:
+                            if alias[-2:] == "_x":
+                                alias = f"{alias[:-2]}_{axis_names[0]}"
+                            elif alias[-2:] == "_y":
+                                alias = f"{alias[:-2]}_{axis_names[1]}"
+                            elif alias[-2:] == "_z":
+                                alias = f"{alias[:-2]}_{axis_names[2]}"
+                    case (
+                        Geometry.CARTESIAN
+                        | Geometry.GEOGRAPHIC
+                        | Geometry.INTERNAL_GEOGRAPHIC
+                        | Geometry.SPECTRAL_CUBE
+                    ):
+                        # nothing to do
+                        pass
+                    case _:
+                        assert_never(self.ds.geometry)
                 self.alias((ftype, alias), field)
 
     @staticmethod

--- a/yt/frontends/amrex/data_structures.py
+++ b/yt/frontends/amrex/data_structures.py
@@ -370,23 +370,24 @@ class BoxlibHierarchy(GridIndex):
                 dx[i].append(DRE[2] - DLE[2])
         self.level_dds = np.array(dx, dtype="float64")
         next(header_file)
-        if self.ds.geometry == "cartesian":
-            default_ybounds = (0.0, 1.0)
-            default_zbounds = (0.0, 1.0)
-        elif self.ds.geometry == "cylindrical":
-            self.level_dds[:, 2] = 2 * np.pi
-            default_ybounds = (0.0, 1.0)
-            default_zbounds = (0.0, 2 * np.pi)
-        elif self.ds.geometry == "spherical":
-            # BoxLib only supports 1D spherical, so ensure
-            # the other dimensions have the right extent.
-            self.level_dds[:, 1] = np.pi
-            self.level_dds[:, 2] = 2 * np.pi
-            default_ybounds = (0.0, np.pi)
-            default_zbounds = (0.0, 2 * np.pi)
-        else:
-            header_file.close()
-            raise RuntimeError("Unknown BoxLib coordinate system.")
+        match self.ds.geometry:
+            case Geometry.CARTESIAN:
+                default_ybounds = (0.0, 1.0)
+                default_zbounds = (0.0, 1.0)
+            case Geometry.CYLINDRICAL:
+                self.level_dds[:, 2] = 2 * np.pi
+                default_ybounds = (0.0, 1.0)
+                default_zbounds = (0.0, 2 * np.pi)
+            case Geometry.SPHERICAL:
+                # BoxLib only supports 1D spherical, so ensure
+                # the other dimensions have the right extent.
+                self.level_dds[:, 1] = np.pi
+                self.level_dds[:, 2] = 2 * np.pi
+                default_ybounds = (0.0, np.pi)
+                default_zbounds = (0.0, 2 * np.pi)
+            case _:
+                header_file.close()
+                raise RuntimeError("Unknown BoxLib coordinate system.")
         if int(next(header_file)) != 0:
             header_file.close()
             raise RuntimeError("INTERNAL ERROR! This should be a zero.")
@@ -904,7 +905,7 @@ class BoxlibDataset(Dataset):
         else:
             self.geometry = Geometry(geom_str)
 
-        if self.geometry == "cylindrical":
+        if self.geometry is Geometry.CYLINDRICAL:
             dre = self.domain_right_edge.copy()
             dre[2] = 2.0 * np.pi
             self.domain_right_edge = dre

--- a/yt/frontends/athena_pp/data_structures.py
+++ b/yt/frontends/athena_pp/data_structures.py
@@ -156,7 +156,7 @@ class AthenaPPDataset(Dataset):
 
         geom = self._handle.attrs["Coordinates"].decode("utf-8")
         self.geometry = Geometry(geom_map[geom])
-        if self.geometry == "cylindrical":
+        if self.geometry is Geometry.CYLINDRICAL:
             axis_order = ("r", "theta", "z")
         else:
             axis_order = None

--- a/yt/frontends/flash/data_structures.py
+++ b/yt/frontends/flash/data_structures.py
@@ -428,18 +428,22 @@ class FLASHDataset(Dataset):
                         d,
                     )
                     dre[d] = dle[d] + 1.0
-        if self.dimensionality < 3 and self.geometry == "cylindrical":
-            mylog.warning("Extending theta dimension to 2PI + left edge.")
-            dre[2] = dle[2] + 2 * np.pi
-        elif self.dimensionality < 3 and self.geometry == "polar":
-            mylog.warning("Extending theta dimension to 2PI + left edge.")
-            dre[1] = dle[1] + 2 * np.pi
-        elif self.dimensionality < 3 and self.geometry == "spherical":
-            mylog.warning("Extending phi dimension to 2PI + left edge.")
-            dre[2] = dle[2] + 2 * np.pi
-        if self.dimensionality == 1 and self.geometry == "spherical":
-            mylog.warning("Extending theta dimension to PI + left edge.")
-            dre[1] = dle[1] + np.pi
+
+        if self.dimensionality < 3:
+            match self.geometry:
+                case Geometry.CYLINDRICAL:
+                    mylog.warning("Extending theta dimension to 2PI + left edge.")
+                    dre[2] = dle[2] + 2 * np.pi
+                case Geometry.POLAR:
+                    mylog.warning("Extending theta dimension to 2PI + left edge.")
+                    dre[1] = dle[1] + 2 * np.pi
+                case Geometry.SPHERICAL:
+                    mylog.warning("Extending phi dimension to 2PI + left edge.")
+                    dre[2] = dle[2] + 2 * np.pi
+                    if self.dimensionality == 1:
+                        mylog.warning("Extending theta dimension to PI + left edge.")
+                        dre[1] = dle[1] + np.pi
+
         self.domain_left_edge = dle
         self.domain_right_edge = dre
         self.domain_dimensions = np.array([nblockx * nxb, nblocky * nyb, nblockz * nzb])

--- a/yt/frontends/parthenon/data_structures.py
+++ b/yt/frontends/parthenon/data_structures.py
@@ -163,7 +163,7 @@ class ParthenonDataset(Dataset):
 
         self.geometry = _geom_map[self._handle["Info"].attrs["Coordinates"]]
 
-        if self.geometry == "cylindrical":
+        if self.geometry is Geometry.CYLINDRICAL:
             axis_order = ("r", "theta", "z")
         else:
             axis_order = None

--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -463,21 +463,22 @@ class VelocityCallback(PlotCallback):
         # Instantiation of these is cheap
         geometry: Geometry = plot.data.ds.geometry
         if plot._type_name == "CuttingPlane":
-            if geometry is Geometry.CARTESIAN:
-                pass
-            elif (
-                geometry is Geometry.POLAR
-                or geometry is Geometry.CYLINDRICAL
-                or geometry is Geometry.SPHERICAL
-                or geometry is Geometry.GEOGRAPHIC
-                or geometry is Geometry.INTERNAL_GEOGRAPHIC
-                or geometry is Geometry.SPECTRAL_CUBE
-            ):
-                raise NotImplementedError(
-                    f"annotate_velocity is not supported for cutting plane for {geometry=}"
-                )
-            else:
-                assert_never(geometry)
+            match geometry:
+                case Geometry.CARTESIAN:
+                    pass
+                case (
+                    Geometry.POLAR
+                    | Geometry.CYLINDRICAL
+                    | Geometry.SPHERICAL
+                    | Geometry.GEOGRAPHIC
+                    | Geometry.INTERNAL_GEOGRAPHIC
+                    | Geometry.SPECTRAL_CUBE
+                ):
+                    raise NotImplementedError(
+                        f"annotate_velocity is not supported for cutting plane for {geometry=}"
+                    )
+                case _:
+                    assert_never(geometry)
         qcb: BaseQuiverCallback
         if plot._type_name == "CuttingPlane":
             qcb = CuttingQuiverCallback(
@@ -501,39 +502,40 @@ class VelocityCallback(PlotCallback):
             else:
                 bv_x = bv_y = 0
 
-            if geometry is Geometry.POLAR or geometry is Geometry.CYLINDRICAL:
-                if axis_names[plot.data.axis] == "z":
-                    # polar_z and cyl_z is aligned with cartesian_z
-                    # should convert r-theta plane to x-y plane
-                    xv = (ftype, "velocity_cartesian_x")
-                    yv = (ftype, "velocity_cartesian_y")
-                else:
+            match geometry:
+                case Geometry.POLAR | Geometry.CYLINDRICAL:
+                    if axis_names[plot.data.axis] == "z":
+                        # polar_z and cyl_z is aligned with cartesian_z
+                        # should convert r-theta plane to x-y plane
+                        xv = (ftype, "velocity_cartesian_x")
+                        yv = (ftype, "velocity_cartesian_y")
+                    else:
+                        xv = (ftype, f"velocity_{axis_names[xax]}")
+                        yv = (ftype, f"velocity_{axis_names[yax]}")
+                case Geometry.SPHERICAL:
+                    if axis_names[plot.data.axis] == "phi":
+                        xv = (ftype, "velocity_cylindrical_radius")
+                        yv = (ftype, "velocity_cylindrical_z")
+                    elif axis_names[plot.data.axis] == "theta":
+                        xv = (ftype, "velocity_conic_x")
+                        yv = (ftype, "velocity_conic_y")
+                    else:
+                        raise NotImplementedError(
+                            f"annotate_velocity is missing support for normal={axis_names[plot.data.axis]!r}"
+                        )
+                case Geometry.CARTESIAN:
                     xv = (ftype, f"velocity_{axis_names[xax]}")
                     yv = (ftype, f"velocity_{axis_names[yax]}")
-            elif geometry is Geometry.SPHERICAL:
-                if axis_names[plot.data.axis] == "phi":
-                    xv = (ftype, "velocity_cylindrical_radius")
-                    yv = (ftype, "velocity_cylindrical_z")
-                elif axis_names[plot.data.axis] == "theta":
-                    xv = (ftype, "velocity_conic_x")
-                    yv = (ftype, "velocity_conic_y")
-                else:
+                case (
+                    Geometry.GEOGRAPHIC
+                    | Geometry.INTERNAL_GEOGRAPHIC
+                    | Geometry.SPECTRAL_CUBE
+                ):
                     raise NotImplementedError(
-                        f"annotate_velocity is missing support for normal={axis_names[plot.data.axis]!r}"
+                        f"annotate_velocity is not supported for {geometry=}"
                     )
-            elif geometry is Geometry.CARTESIAN:
-                xv = (ftype, f"velocity_{axis_names[xax]}")
-                yv = (ftype, f"velocity_{axis_names[yax]}")
-            elif (
-                geometry is Geometry.GEOGRAPHIC
-                or geometry is Geometry.INTERNAL_GEOGRAPHIC
-                or geometry is Geometry.SPECTRAL_CUBE
-            ):
-                raise NotImplementedError(
-                    f"annotate_velocity is not supported for {geometry=}"
-                )
-            else:
-                assert_never(geometry)
+                case _:
+                    assert_never(geometry)
 
             # determine the full fields including field type
             xv = plot.data._determine_fields(xv)[0]
@@ -606,21 +608,22 @@ class MagFieldCallback(PlotCallback):
         geometry: Geometry = plot.data.ds.geometry
         qcb: BaseQuiverCallback
         if plot._type_name == "CuttingPlane":
-            if geometry is Geometry.CARTESIAN:
-                pass
-            elif (
-                geometry is Geometry.POLAR
-                or geometry is Geometry.CYLINDRICAL
-                or geometry is Geometry.SPHERICAL
-                or geometry is Geometry.GEOGRAPHIC
-                or geometry is Geometry.INTERNAL_GEOGRAPHIC
-                or geometry is Geometry.SPECTRAL_CUBE
-            ):
-                raise NotImplementedError(
-                    f"annotate_magnetic_field is not supported for cutting plane for {geometry=}"
-                )
-            else:
-                assert_never(geometry)
+            match geometry:
+                case Geometry.CARTESIAN:
+                    pass
+                case (
+                    Geometry.POLAR
+                    | Geometry.CYLINDRICAL
+                    | Geometry.SPHERICAL
+                    | Geometry.GEOGRAPHIC
+                    | Geometry.INTERNAL_GEOGRAPHIC
+                    | Geometry.SPECTRAL_CUBE
+                ):
+                    raise NotImplementedError(
+                        f"annotate_magnetic_field is not supported for cutting plane for {geometry=}"
+                    )
+                case _:
+                    assert_never(geometry)
             qcb = CuttingQuiverCallback(
                 (ftype, "cutting_plane_magnetic_field_x"),
                 (ftype, "cutting_plane_magnetic_field_y"),
@@ -635,39 +638,40 @@ class MagFieldCallback(PlotCallback):
             yax = plot.data.ds.coordinates.y_axis[plot.data.axis]
             axis_names = plot.data.ds.coordinates.axis_name
 
-            if geometry is Geometry.POLAR or geometry is Geometry.CYLINDRICAL:
-                if axis_names[plot.data.axis] == "z":
-                    # polar_z and cyl_z is aligned with cartesian_z
-                    # should convert r-theta plane to x-y plane
-                    xv = (ftype, "magnetic_field_cartesian_x")
-                    yv = (ftype, "magnetic_field_cartesian_y")
-                else:
+            match geometry:
+                case Geometry.POLAR | Geometry.CYLINDRICAL:
+                    if axis_names[plot.data.axis] == "z":
+                        # polar_z and cyl_z is aligned with cartesian_z
+                        # should convert r-theta plane to x-y plane
+                        xv = (ftype, "magnetic_field_cartesian_x")
+                        yv = (ftype, "magnetic_field_cartesian_y")
+                    else:
+                        xv = (ftype, f"magnetic_field_{axis_names[xax]}")
+                        yv = (ftype, f"magnetic_field_{axis_names[yax]}")
+                case Geometry.SPHERICAL:
+                    if axis_names[plot.data.axis] == "phi":
+                        xv = (ftype, "magnetic_field_cylindrical_radius")
+                        yv = (ftype, "magnetic_field_cylindrical_z")
+                    elif axis_names[plot.data.axis] == "theta":
+                        xv = (ftype, "magnetic_field_conic_x")
+                        yv = (ftype, "magnetic_field_conic_y")
+                    else:
+                        raise NotImplementedError(
+                            f"annotate_magnetic_field is missing support for normal={axis_names[plot.data.axis]!r}"
+                        )
+                case Geometry.CARTESIAN:
                     xv = (ftype, f"magnetic_field_{axis_names[xax]}")
                     yv = (ftype, f"magnetic_field_{axis_names[yax]}")
-            elif geometry is Geometry.SPHERICAL:
-                if axis_names[plot.data.axis] == "phi":
-                    xv = (ftype, "magnetic_field_cylindrical_radius")
-                    yv = (ftype, "magnetic_field_cylindrical_z")
-                elif axis_names[plot.data.axis] == "theta":
-                    xv = (ftype, "magnetic_field_conic_x")
-                    yv = (ftype, "magnetic_field_conic_y")
-                else:
+                case (
+                    Geometry.GEOGRAPHIC
+                    | Geometry.INTERNAL_GEOGRAPHIC
+                    | Geometry.SPECTRAL_CUBE
+                ):
                     raise NotImplementedError(
-                        f"annotate_magnetic_field is missing support for normal={axis_names[plot.data.axis]!r}"
+                        f"annotate_magnetic_field is not supported for {geometry=}"
                     )
-            elif geometry is Geometry.CARTESIAN:
-                xv = (ftype, f"magnetic_field_{axis_names[xax]}")
-                yv = (ftype, f"magnetic_field_{axis_names[yax]}")
-            elif (
-                geometry is Geometry.GEOGRAPHIC
-                or geometry is Geometry.INTERNAL_GEOGRAPHIC
-                or geometry is Geometry.SPECTRAL_CUBE
-            ):
-                raise NotImplementedError(
-                    f"annotate_magnetic_field is not supported for {geometry=}"
-                )
-            else:
-                assert_never(geometry)
+                case _:
+                    assert_never(geometry)
 
             qcb = QuiverCallback(
                 xv,

--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -232,19 +232,20 @@ class PlotWindow(ImagePlotContainer, abc.ABC):
         self._set_window(bounds)  # this automatically updates the data and plot
 
         if origin != "native":
-            if geometry is Geometry.CARTESIAN or geometry is Geometry.SPECTRAL_CUBE:
-                pass
-            elif (
-                geometry is Geometry.CYLINDRICAL
-                or geometry is Geometry.POLAR
-                or geometry is Geometry.SPHERICAL
-                or geometry is Geometry.GEOGRAPHIC
-                or geometry is Geometry.INTERNAL_GEOGRAPHIC
-            ):
-                mylog.info("Setting origin='native' for %s geometry.", geometry)
-                origin = "native"
-            else:
-                assert_never(geometry)
+            match geometry:
+                case Geometry.CARTESIAN | Geometry.SPECTRAL_CUBE:
+                    pass
+                case (
+                    Geometry.CYLINDRICAL
+                    | Geometry.POLAR
+                    | Geometry.SPHERICAL
+                    | Geometry.GEOGRAPHIC
+                    | Geometry.INTERNAL_GEOGRAPHIC
+                ):
+                    mylog.info("Setting origin='native' for %s geometry.", geometry)
+                    origin = "native"
+                case _:
+                    assert_never(geometry)
 
         self.origin = origin
         if self.data_source.center is not None and not oblique:
@@ -2724,25 +2725,20 @@ def plot_2d(
     """
     if ds.dimensionality != 2:
         raise RuntimeError("plot_2d only plots 2D datasets!")
-    if (
-        ds.geometry is Geometry.CARTESIAN
-        or ds.geometry is Geometry.POLAR
-        or ds.geometry is Geometry.SPECTRAL_CUBE
-    ):
-        axis = "z"
-    elif ds.geometry is Geometry.CYLINDRICAL:
-        axis = "theta"
-    elif ds.geometry is Geometry.SPHERICAL:
-        axis = "phi"
-    elif (
-        ds.geometry is Geometry.GEOGRAPHIC
-        or ds.geometry is Geometry.INTERNAL_GEOGRAPHIC
-    ):
-        raise NotImplementedError(
-            f"plot_2d does not yet support datasets with {ds.geometry} geometries"
-        )
-    else:
-        assert_never(ds.geometry)
+    match ds.geometry:
+        case Geometry.CARTESIAN | Geometry.POLAR | Geometry.SPECTRAL_CUBE:
+            axis = "z"
+        case Geometry.CYLINDRICAL:
+            axis = "theta"
+        case Geometry.SPHERICAL:
+            axis = "phi"
+        case Geometry.GEOGRAPHIC | Geometry.INTERNAL_GEOGRAPHIC:
+            raise NotImplementedError(
+                f"plot_2d does not yet support datasets with {ds.geometry} geometries"
+            )
+        case _:
+            assert_never(ds.geometry)
+
     # Part of the convenience of plot_2d is to eliminate the use of the
     # superfluous coordinate, so we do that also with the center argument
     if not isinstance(center, str) and obj_length(center) == 2:


### PR DESCRIPTION
## PR Summary

Now that we don't support 3.9 anymore we have access to `match`/`case` statements (pattern matching). Arguably this improves readability in these instances, albeit at the cost of an additional indentation level.