### PR TITLE
BUG: fix load_uniform_grid with cell_widths and multiple fields

### DIFF
--- a/yt/frontends/stream/tests/test_stream_stretched.py
+++ b/yt/frontends/stream/tests/test_stream_stretched.py
@@ -60,7 +60,10 @@ def test_variable_dx():
 def data_cell_widths_N16():
     np.random.seed(0x4D3D3D3)
     N = 16
-    data = {"density": np.random.random((N, N, N))}
+    data = {
+        "density": np.random.random((N, N, N)),
+        "temperature": np.random.random((N, N, N)),
+    }
 
     cell_widths = []
     for _ in range(3):

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -369,9 +369,9 @@ def load_uniform_grid(
                 bbox,
                 cell_widths=cell_widths,
             )
-            cell_widths = grid_cell_widths
             grid_dimensions = np.array(list(shapes), dtype="int32")
             temp[key] = [data[key][slice] for slice in slices]
+        cell_widths = grid_cell_widths
 
         for gid in range(nprocs):
             new_data[gid] = {}


### PR DESCRIPTION
Turns out #4732 did not test out what happens when the data dict supplied to `load_uniform_grid` contains multiple fields... and it turns out that it errors. But it's a simple fix to indentation level. 