### PR TITLE
BUG: fix error message when trying to load a Parthenon dataset without h5py installed

### DIFF
--- a/yt/frontends/parthenon/data_structures.py
+++ b/yt/frontends/parthenon/data_structures.py
@@ -129,6 +129,7 @@ class ParthenonHierarchy(GridIndex):
 
 
 class ParthenonDataset(Dataset):
+    _load_requirements = ["h5py"]
     _field_info_class = ParthenonFieldInfo
     _dataset_type = "parthenon"
     _index_class = ParthenonHierarchy
@@ -312,6 +313,8 @@ class ParthenonDataset(Dataset):
 
     @classmethod
     def _is_valid(cls, filename: str, *args, **kwargs) -> bool:
+        if cls._missing_load_requirements():
+            return False
         return filename.endswith((".phdf", ".rhdf"))
 
     @property


### PR DESCRIPTION
## PR Summary
Fix a small oversight from #4323

reprod:
install pooch, pandas, uninstall h5py
```python
import yt
yt.load_sample("parthenon_advection")
```

error message on main:

```python-traceback
Traceback (most recent call last):
  File "<python-input-1>", line 1, in <module>
    yt.load_sample("parthenon_advection")
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/clm/dev/yt-project/yt/yt/loaders.py", line 1684, in load_sample
    return load(loadable_path, **load_kwargs)
  File "/Users/clm/dev/yt-project/yt/yt/_maintenance/deprecation.py", line 68, in inner
    return func(*args, **kwargs)
  File "/Users/clm/dev/yt-project/yt/yt/loaders.py", line 141, in load
    return cls(fn, *args, **kwargs)
  File "/Users/clm/dev/yt-project/yt/yt/frontends/parthenon/data_structures.py", line 153, in __init__
    self._handle = HDF5FileHandler(filename)
                   ~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/Users/clm/dev/yt-project/yt/yt/utilities/file_handler.py", line 32, in __init__
    self.handle = h5py.File(filename, mode="r")
                  ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/Users/clm/dev/yt-project/yt/yt/utilities/on_demand_imports.py", line 39, in __call__
    raise self.error
  File "/Users/clm/dev/yt-project/yt/yt/utilities/on_demand_imports.py", line 77, in inner
    return func(self)
  File "/Users/clm/dev/yt-project/yt/yt/utilities/on_demand_imports.py", line 305, in File
    from h5py import File
ModuleNotFoundError: No module named 'h5py'
Something went wrong while trying to lazy-import h5py. Please make sure that h5py is properly installed.
If the problem persists, please file an issue at https://github.com/yt-project/yt/issues/new
```

this branch
```python-traceback
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import yt; yt.load_sample('parthenon_advection')
               ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/clm/dev/yt-project/yt/yt/loaders.py", line 1684, in load_sample
    return load(loadable_path, **load_kwargs)
  File "/Users/clm/dev/yt-project/yt/yt/_maintenance/deprecation.py", line 68, in inner
    return func(*args, **kwargs)
  File "/Users/clm/dev/yt-project/yt/yt/loaders.py", line 146, in load
    raise YTUnidentifiedDataType(_input_fn, *args, **kwargs)
yt.utilities.exceptions.YTUnidentifiedDataType: Could not determine input format from PosixPath('/Users/clm/dev/yt-project/test-data-dir/parthenon_advection/advection_2d.out0.final.phdf')
The following types could not be thorougly checked against your data because their requirements are missing. You may want to inspect this list and check your installation:
- ArepoHDF5Dataset (requires: h5py)
- CFRadialDataset (requires: xarray, pyart)
- CM1Dataset (requires: netCDF4)
- ChimeraDataset (requires: h5py)
- ChollaDataset (requires: h5py)
- ChomboDataset (requires: h5py)
- ChomboPICDataset (requires: h5py)
- EagleDataset (requires: h5py)
- EagleNetworkDataset (requires: h5py)
- EnzoDataset (requires: h5py)
- EnzoDatasetInMemory (requires: h5py)
- EnzoEDataset (requires: h5py, libconf)
- EventsFITSDataset (requires: astropy)
- ExodusIIDataset (requires: netCDF4)
- FITSDataset (requires: astropy)
- FLASHDataset (requires: h5py)
- FLASHParticleDataset (requires: h5py)
- GAMERDataset (requires: h5py)
- GDFDataset (requires: h5py)
- GadgetFOFDataset (requires: h5py)
- GadgetHDF5Dataset (requires: h5py)
- GizmoDataset (requires: h5py)
- MoabHex8Dataset (requires: h5py)
- OWLSDataset (requires: h5py)
- OWLSSubfindDataset (requires: h5py)
- OpenPMDDataset (requires: h5py)
- OpenPMDGroupBasedDataset (requires: h5py)
- Orion2Dataset (requires: h5py)
- ParthenonDataset (requires: h5py)
- PlutoDataset (requires: h5py)
- SkyDataFITSDataset (requires: astropy)
- SpectralCubeFITSDataset (requires: astropy)
- SwiftDataset (requires: h5py)
- YTClumpTreeDataset (requires: h5py)
- YTDataContainerDataset (requires: h5py)
- YTDataLightRayDataset (requires: h5py)
- YTFITSDataset (requires: astropy)
- YTGridDataset (requires: h5py)
- YTHaloCatalogDataset (requires: h5py)
- YTNonspatialDataset (requires: h5py)
- YTProfileDataset (requires: h5py)
- YTSpatialPlotDataset (requires: h5py)

Please make sure you are running a sufficiently recent version of yt.
```

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
