### PR TITLE
[BUG] Fix off-axis rendering when center is not [0.5, 0.5, 0.5], fix periodicity

### DIFF
--- a/yt/visualization/plot_window.py
+++ b/yt/visualization/plot_window.py
@@ -26,6 +26,7 @@ from yt.funcs import (
     validate_moment,
 )
 from yt.geometry.api import Geometry
+from yt.geometry.oct_geometry_handler import OctreeIndex
 from yt.units.unit_object import Unit  # type: ignore
 from yt.units.unit_registry import UnitParseError  # type: ignore
 from yt.units.yt_array import YTArray, YTQuantity
@@ -2494,7 +2495,12 @@ class OffAxisProjectionPlot(ProjectionPlot, PWViewerMPL):
         is_sph_field = finfo.is_sph_field
         particle_datasets = (ParticleDataset, StreamParticlesDataset)
 
-        if isinstance(data_source.ds, particle_datasets) and is_sph_field:
+        dom_width = data_source.ds.domain_width
+        cubic_domain = dom_width.max() == dom_width.min()
+
+        if (isinstance(data_source.ds, particle_datasets) and is_sph_field) or (
+            isinstance(data_source.ds.index, OctreeIndex) and cubic_domain
+        ):
             center_use = parse_center_array(center, ds=data_source.ds, axis=None)
         else:
             center_use = center_rot

--- a/yt/visualization/tests/test_offaxisprojection.py
+++ b/yt/visualization/tests/test_offaxisprojection.py
@@ -16,6 +16,7 @@ from yt.testing import (
 from yt.visualization.api import (
     OffAxisProjectionPlot,
     OffAxisSlicePlot,
+    ProjectionPlot,
 )
 from yt.visualization.image_writer import write_projection
 from yt.visualization.volume_rendering.api import off_axis_projection
@@ -208,6 +209,35 @@ def test_field_cut_off_axis_octree():
     assert_equal((p3.frb["gas", "density"] == p4.frb["gas", "density"]).all(), False)
     p4rho = p4.frb["gas", "density"]
     assert_equal(np.nanmin(p4rho[p4rho > 0.0]) >= 0.5, True)
+
+
+def test_off_axis_octree():
+    ds = fake_octree_ds()
+    p1 = ProjectionPlot(
+        ds,
+        "x",
+        ("gas", "density"),
+        center=[0.6] * 3,
+        width=0.8,
+        weight_field=("gas", "density"),
+    )
+    p2 = OffAxisProjectionPlot(
+        ds,
+        [1, 0, 0],
+        ("gas", "density"),
+        center=[0.6] * 3,
+        width=0.8,
+        weight_field=("gas", "density"),
+    )
+
+    # Note: due to our implementation, the off-axis projection will have a
+    # slightly blurred cell edges so we can't do an exact comparison
+    v1, v2 = p1.frb["gas", "density"], p2.frb["gas", "density"]
+    diff = (v1 - v2) / (v1 + v2) * 2
+
+    # Make sure the difference is zero-centered with a small standard deviation
+    assert np.mean(diff).max() < 1e-3  # 0.1%: very little bias
+    assert np.std(diff) < 0.05  # <2% error on average
 
 
 def test_offaxis_moment():


### PR DESCRIPTION
## PR Summary

The off-axis renderer introduced in #4741 has an issue when the center and the center in rotated frame do not coincide (which happens when it isn't 0.5, 0.5, 0.5 afaik).

In addition, it wraps around the boundaries of the width of the plotting window rather than the simulation domain (if required).

This PR fixes both.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->

## Bug reproduction:

```python
import numpy as np
import yt

ds = yt.load_sample("output_00080")
ad = ds.all_data()

center = ds.arr(ad.argmax("density"))

sp = ds.sphere(center, (200, "kpc"))

n = np.array([1, 1, 1.])
n /= np.linalg.norm(n)
p = yt.ProjectionPlot(ds, n, "density", center=center, data_source=sp, width=(400, "kpc"), weight_field=("gas", "density"))
p.set_zlim(("gas", "density"), 1e-4, 5)
p.save("frames/")
```

| Before | With this PR |
|---|---|
| ![info_00080_OffAxisProjection_density_density](https://github.com/user-attachments/assets/26af06ef-6fff-407d-9d9b-9afe0ec258f4)|  ![info_00080_OffAxisProjection_density_density](https://github.com/user-attachments/assets/808eb172-1a38-4fd4-91ab-ca1502727631) |
