### PR TITLE
BUG: fix compatibility with matplotlib 3.10 for images that have both a custom background color and a non-transparent 'bad' color

### DIFF
--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -326,6 +326,7 @@ class ImagePlotMPL(PlotMPL, ABC):
             aspect=aspect,
             cmap=self.colorbar_handler.cmap,
             interpolation="nearest",
+            interpolation_stage="data",
             transform=transform,
             alpha=alpha,
         )


### PR DESCRIPTION
## PR Summary
close #5082