### PR TITLE
use .render instead of ._setup_plots in docs

### DIFF
--- a/doc/source/cookbook/custom_colorbar_tickmarks.ipynb
+++ b/doc/source/cookbook/custom_colorbar_tickmarks.ipynb
@@ -71,7 +71,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, we call `_setup_plots()` to ensure the plot is properly initialized. Without this, the custom tickmarks we are adding will be ignored."
+    "Next, we call `render()` to ensure the plot is properly rendered. Without this, the custom tickmarks we are adding will be ignored."
    ]
   },
   {
@@ -82,7 +82,7 @@
    },
    "outputs": [],
    "source": [
-    "slc._setup_plots()"
+    "slc.render()"
    ]
   },
   {

--- a/doc/source/cookbook/geographic_xforms_and_projections.ipynb
+++ b/doc/source/cookbook/geographic_xforms_and_projections.ipynb
@@ -174,7 +174,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that this doesn't have a lot of contextual information. We can add annotations for the coastlines just as we would with matplotlib. Before the annotations are set, we need to call `p._setup_plots` to make the axes available for annotation. "
+    "Note that this doesn't have a lot of contextual information. We can add annotations for the coastlines just as we would with matplotlib. Before the annotations are set, we need to call `p.render` to make the axes available for annotation. "
    ]
   },
   {
@@ -184,7 +184,7 @@
    "outputs": [],
    "source": [
     "p = yt.SlicePlot(ds, \"altitude\", \"AIRDENS\")\n",
-    "p._setup_plots()\n",
+    "p.render()\n",
     "p.plots[\"AIRDENS\"].axes.set_global()\n",
     "p.plots[\"AIRDENS\"].axes.coastlines()\n",
     "p.show()"
@@ -212,7 +212,7 @@
    "source": [
     "p = yt.SlicePlot(ds, \"altitude\", \"AIRDENS\")\n",
     "p.set_mpl_projection(\"Robinson\")\n",
-    "p._setup_plots()\n",
+    "p.render()\n",
     "p.plots[\"AIRDENS\"].axes.set_global()\n",
     "p.plots[\"AIRDENS\"].axes.coastlines()\n",
     "p.show()"
@@ -233,7 +233,7 @@
    "source": [
     "p = yt.SlicePlot(ds, \"altitude\", \"AIRDENS\")\n",
     "p.set_mpl_projection((\"Robinson\", (37.5,)))\n",
-    "p._setup_plots()\n",
+    "p.render()\n",
     "p.plots[\"AIRDENS\"].axes.set_global()\n",
     "p.plots[\"AIRDENS\"].axes.coastlines()\n",
     "p.show()"
@@ -253,7 +253,7 @@
    "outputs": [],
    "source": [
     "p.set_mpl_projection(\"Orthographic\")\n",
-    "p._setup_plots()\n",
+    "p.render()\n",
     "p.plots[\"AIRDENS\"].axes.set_global()\n",
     "p.plots[\"AIRDENS\"].axes.coastlines()\n",
     "p.show()"
@@ -289,7 +289,7 @@
    "outputs": [],
    "source": [
     "p.set_mpl_projection((\"Orthographic\", (90, 45)))\n",
-    "p._setup_plots()\n",
+    "p.render()\n",
     "p.plots[\"AIRDENS\"].axes.set_global()\n",
     "p.plots[\"AIRDENS\"].axes.coastlines()\n",
     "p.show()"
@@ -311,7 +311,7 @@
     "p.set_mpl_projection(\n",
     "    (\"Orthographic\", (), {\"central_latitude\": -45, \"central_longitude\": 275})\n",
     ")\n",
-    "p._setup_plots()\n",
+    "p.render()\n",
     "p.plots[\"AIRDENS\"].axes.set_global()\n",
     "p.plots[\"AIRDENS\"].axes.coastlines()\n",
     "p.show()"
@@ -338,7 +338,7 @@
    "outputs": [],
    "source": [
     "p.set_mpl_projection((\"RotatedPole\", (177.5, 37.5)))\n",
-    "p._setup_plots()\n",
+    "p.redner()\n",
     "p.plots[\"AIRDENS\"].axes.set_global()\n",
     "p.plots[\"AIRDENS\"].axes.coastlines()\n",
     "p.show()"
@@ -353,7 +353,7 @@
     "p.set_mpl_projection(\n",
     "    (\"RotatedPole\", (), {\"pole_latitude\": 37.5, \"pole_longitude\": 177.5})\n",
     ")\n",
-    "p._setup_plots()\n",
+    "p.render()\n",
     "p.plots[\"AIRDENS\"].axes.set_global()\n",
     "p.plots[\"AIRDENS\"].axes.coastlines()\n",
     "p.show()"
@@ -366,7 +366,7 @@
    "outputs": [],
    "source": [
     "p.set_mpl_projection(\"NorthPolarStereo\")\n",
-    "p._setup_plots()\n",
+    "p.render()\n",
     "p.plots[\"AIRDENS\"].axes.set_global()\n",
     "p.plots[\"AIRDENS\"].axes.coastlines()\n",
     "p.show()"
@@ -379,7 +379,7 @@
    "outputs": [],
    "source": [
     "p.set_mpl_projection(\"AlbersEqualArea\")\n",
-    "p._setup_plots()\n",
+    "p.render()\n",
     "p.plots[\"AIRDENS\"].axes.set_global()\n",
     "p.plots[\"AIRDENS\"].axes.coastlines()\n",
     "p.show()"
@@ -392,7 +392,7 @@
    "outputs": [],
    "source": [
     "p.set_mpl_projection(\"InterruptedGoodeHomolosine\")\n",
-    "p._setup_plots()\n",
+    "p.render()\n",
     "p.plots[\"AIRDENS\"].axes.set_global()\n",
     "p.plots[\"AIRDENS\"].axes.coastlines()\n",
     "p.show()"
@@ -405,7 +405,7 @@
    "outputs": [],
    "source": [
     "p.set_mpl_projection(\"Robinson\")\n",
-    "p._setup_plots()\n",
+    "p.render()\n",
     "p.plots[\"AIRDENS\"].axes.set_global()\n",
     "p.plots[\"AIRDENS\"].axes.coastlines()\n",
     "p.show()"
@@ -418,7 +418,7 @@
    "outputs": [],
    "source": [
     "p.set_mpl_projection(\"Gnomonic\")\n",
-    "p._setup_plots()\n",
+    "p.render()\n",
     "p.plots[\"AIRDENS\"].axes.set_global()\n",
     "p.plots[\"AIRDENS\"].axes.coastlines()\n",
     "p.show()"
@@ -465,7 +465,7 @@
    "outputs": [],
    "source": [
     "p.set_mpl_projection(\"Robinson\")\n",
-    "p._setup_plots()\n",
+    "p.render()\n",
     "p.plots[\"AIRDENS\"].axes.set_global()\n",
     "p.plots[\"AIRDENS\"].axes.coastlines()\n",
     "p.show()"


### PR DESCRIPTION
## PR Summary
Since we already have the public API `.render`, it’s recommended for users to rely on it rather than using the private method `._setup_plots` in the docs.