### PR TITLE
BUG: Removing code that removes field type in set_title() 

### DIFF
--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -1319,8 +1319,6 @@ class PhasePlot(ImagePlotContainer):
 
         """
         for f in self._profile.field_data:
-            if isinstance(f, tuple):
-                f = f[1]
             self.plot_title[self.data_source._determine_fields(f)[0]] = title
         return self
 

--- a/yt/visualization/tests/test_image_comp_2D_plots.py
+++ b/yt/visualization/tests/test_image_comp_2D_plots.py
@@ -9,13 +9,7 @@ from matplotlib.colors import SymLogNorm
 
 from yt.data_objects.profiles import create_profile
 from yt.loaders import load_uniform_grid
-from yt.testing import (
-    add_noise_fields,
-    fake_amr_ds,
-    fake_particle_ds,
-    fake_random_ds,
-)
-
+from yt.testing import add_noise_fields, fake_amr_ds, fake_particle_ds, fake_random_ds
 from yt.visualization.api import (
     LinePlot,
     ParticleProjectionPlot,

--- a/yt/visualization/tests/test_image_comp_2D_plots.py
+++ b/yt/visualization/tests/test_image_comp_2D_plots.py
@@ -14,7 +14,6 @@ from yt.testing import (
     fake_amr_ds,
     fake_particle_ds,
     fake_random_ds,
-    fake_random_sph_ds
 )
 
 from yt.visualization.api import (
@@ -397,61 +396,6 @@ class TestPhasePlotSetZlim:
         p.set_zlim(field, zmin=(1e36, "kg/AU**3"))
         p.render()
         return p.plots[field].figure
-
-
-class TestPhasePlotParticleAPI:
-    @classmethod
-    def setup_class(cls):
-        bbox = np.array([[-1.0, 3.0], [1.0, 5.2], [-1.0, 3.0]])
-        cls.ds = fake_random_sph_ds(50, bbox)
-
-    def get_plot(self):
-        return PhasePlot(
-            self.ds, ("gas", "density"), ("gas", "density"), ("gas", "mass")
-        )
-
-    @pytest.mark.parametrize("kwargs", [{}, {"color": "b"}])
-    @pytest.mark.mpl_image_compare
-    def test_phaseplot_annotate_text(self, kwargs):
-        p = self.get_plot()
-        p.annotate_text(1e-4, 1e-2, "Test text annotation", **kwargs)
-        p.render()
-        return p.plots["gas", "mass"].figure
-
-    @pytest.mark.mpl_image_compare
-    def test_phaseplot_set_title(self):
-        p = self.get_plot()
-        p.annotate_title("Test Title")
-        p.render()
-        return p.plots["gas", "mass"].figure
-
-    @pytest.mark.mpl_image_compare
-    def test_phaseplot_set_log(self):
-        p = self.get_plot()
-        p.set_log(("gas", "mass"), False)
-        p.render()
-        return p.plots["gas", "mass"].figure
-
-    @pytest.mark.mpl_image_compare
-    def test_phaseplot_set_unit(self):
-        p = self.get_plot()
-        p.set_unit(("gas", "mass"), "Msun")
-        p.render()
-        return p.plots["gas", "mass"].figure
-
-    @pytest.mark.mpl_image_compare
-    def test_phaseplot_set_xlim(self):
-        p = self.get_plot()
-        p.set_xlim(1e-3, 1e0)
-        p.render()
-        return p.plots["gas", "mass"].figure
-
-    @pytest.mark.mpl_image_compare
-    def test_phaseplot_set_ylim(self):
-        p = self.get_plot()
-        p.set_ylim(1e-2, 1e0)
-        p.render()
-        return p.plots["gas", "mass"].figure
 
 
 class TestSetBackgroundColor:

--- a/yt/visualization/tests/test_image_comp_2D_plots.py
+++ b/yt/visualization/tests/test_image_comp_2D_plots.py
@@ -9,7 +9,14 @@ from matplotlib.colors import SymLogNorm
 
 from yt.data_objects.profiles import create_profile
 from yt.loaders import load_uniform_grid
-from yt.testing import add_noise_fields, fake_amr_ds, fake_particle_ds, fake_random_ds
+from yt.testing import (
+    add_noise_fields,
+    fake_amr_ds,
+    fake_particle_ds,
+    fake_random_ds,
+    fake_random_sph_ds
+)
+
 from yt.visualization.api import (
     LinePlot,
     ParticleProjectionPlot,
@@ -390,6 +397,61 @@ class TestPhasePlotSetZlim:
         p.set_zlim(field, zmin=(1e36, "kg/AU**3"))
         p.render()
         return p.plots[field].figure
+
+
+class TestPhasePlotParticleAPI:
+    @classmethod
+    def setup_class(cls):
+        bbox = np.array([[-1.0, 3.0], [1.0, 5.2], [-1.0, 3.0]])
+        cls.ds = fake_random_sph_ds(50, bbox)
+
+    def get_plot(self):
+        return PhasePlot(
+            self.ds, ("gas", "density"), ("gas", "density"), ("gas", "mass")
+        )
+
+    @pytest.mark.parametrize("kwargs", [{}, {"color": "b"}])
+    @pytest.mark.mpl_image_compare
+    def test_phaseplot_annotate_text(self, kwargs):
+        p = self.get_plot()
+        p.annotate_text(1e-4, 1e-2, "Test text annotation", **kwargs)
+        p.render()
+        return p.plots["gas", "mass"].figure
+
+    @pytest.mark.mpl_image_compare
+    def test_phaseplot_set_title(self):
+        p = self.get_plot()
+        p.annotate_title("Test Title")
+        p.render()
+        return p.plots["gas", "mass"].figure
+
+    @pytest.mark.mpl_image_compare
+    def test_phaseplot_set_log(self):
+        p = self.get_plot()
+        p.set_log(("gas", "mass"), False)
+        p.render()
+        return p.plots["gas", "mass"].figure
+
+    @pytest.mark.mpl_image_compare
+    def test_phaseplot_set_unit(self):
+        p = self.get_plot()
+        p.set_unit(("gas", "mass"), "Msun")
+        p.render()
+        return p.plots["gas", "mass"].figure
+
+    @pytest.mark.mpl_image_compare
+    def test_phaseplot_set_xlim(self):
+        p = self.get_plot()
+        p.set_xlim(1e-3, 1e0)
+        p.render()
+        return p.plots["gas", "mass"].figure
+
+    @pytest.mark.mpl_image_compare
+    def test_phaseplot_set_ylim(self):
+        p = self.get_plot()
+        p.set_ylim(1e-2, 1e0)
+        p.render()
+        return p.plots["gas", "mass"].figure
 
 
 class TestSetBackgroundColor:

--- a/yt/visualization/tests/test_profile_plots.py
+++ b/yt/visualization/tests/test_profile_plots.py
@@ -2,11 +2,12 @@ import os
 import shutil
 import tempfile
 import unittest
+import numpy as np
 
 import pytest
 
 import yt
-from yt.testing import assert_allclose_units, fake_random_ds
+from yt.testing import assert_allclose_units, fake_random_ds, fake_random_sph_ds
 from yt.visualization.api import PhasePlot
 
 
@@ -64,6 +65,63 @@ class TestPhasePlotAPI:
         p.set_ylim(1e-2, 1e0)
         p.render()
         return p.plots["gas", "mass"].figure
+
+class TestPhasePlotParticleAPI:
+    @classmethod
+    def setup_class(cls):
+        bbox = np.array([[-1.0, 3.0], [1.0, 5.2], [-1.0, 3.0]])
+        cls.ds = fake_random_sph_ds(
+            50, bbox
+        )
+
+    def get_plot(self):
+        return PhasePlot(
+            self.ds, ("gas", "density"), ("gas", "density"), ("gas", "mass")
+        )
+
+    @pytest.mark.parametrize("kwargs", [{}, {"color": "b"}])
+    @pytest.mark.mpl_image_compare
+    def test_phaseplot_annotate_text(self, kwargs):
+        p = self.get_plot()
+        p.annotate_text(1e-4, 1e-2, "Test text annotation", **kwargs)
+        p.render()
+        return p.plots["gas", "mass"].figure
+
+    @pytest.mark.mpl_image_compare
+    def test_phaseplot_set_title(self):
+        p = self.get_plot()
+        p.annotate_title("Test Title")
+        p.render()
+        return p.plots["gas", "mass"].figure
+
+    @pytest.mark.mpl_image_compare
+    def test_phaseplot_set_log(self):
+        p = self.get_plot()
+        p.set_log(("gas", "mass"), False)
+        p.render()
+        return p.plots["gas", "mass"].figure
+
+    @pytest.mark.mpl_image_compare
+    def test_phaseplot_set_unit(self):
+        p = self.get_plot()
+        p.set_unit(("gas", "mass"), "Msun")
+        p.render()
+        return p.plots["gas", "mass"].figure
+
+    @pytest.mark.mpl_image_compare
+    def test_phaseplot_set_xlim(self):
+        p = self.get_plot()
+        p.set_xlim(1e-3, 1e0)
+        p.render()
+        return p.plots["gas", "mass"].figure
+
+    @pytest.mark.mpl_image_compare
+    def test_phaseplot_set_ylim(self):
+        p = self.get_plot()
+        p.set_ylim(1e-2, 1e0)
+        p.render()
+        return p.plots["gas", "mass"].figure
+
 
 
 def test_set_units():

--- a/yt/visualization/tests/test_profile_plots.py
+++ b/yt/visualization/tests/test_profile_plots.py
@@ -3,11 +3,9 @@ import shutil
 import tempfile
 import unittest
 
-import numpy as np
 import pytest
 
 import yt
-from yt.testing import assert_allclose_units, fake_random_ds, fake_random_sph_ds
 from yt.visualization.api import PhasePlot
 
 

--- a/yt/visualization/tests/test_profile_plots.py
+++ b/yt/visualization/tests/test_profile_plots.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import tempfile
 import unittest
+import numpy as np
 
 import pytest
 

--- a/yt/visualization/tests/test_profile_plots.py
+++ b/yt/visualization/tests/test_profile_plots.py
@@ -2,8 +2,8 @@ import os
 import shutil
 import tempfile
 import unittest
-import numpy as np
 
+import numpy as np
 import pytest
 
 import yt
@@ -66,13 +66,12 @@ class TestPhasePlotAPI:
         p.render()
         return p.plots["gas", "mass"].figure
 
+
 class TestPhasePlotParticleAPI:
     @classmethod
     def setup_class(cls):
         bbox = np.array([[-1.0, 3.0], [1.0, 5.2], [-1.0, 3.0]])
-        cls.ds = fake_random_sph_ds(
-            50, bbox
-        )
+        cls.ds = fake_random_sph_ds(50, bbox)
 
     def get_plot(self):
         return PhasePlot(
@@ -121,7 +120,6 @@ class TestPhasePlotParticleAPI:
         p.set_ylim(1e-2, 1e0)
         p.render()
         return p.plots["gas", "mass"].figure
-
 
 
 def test_set_units():

--- a/yt/visualization/tests/test_profile_plots.py
+++ b/yt/visualization/tests/test_profile_plots.py
@@ -84,42 +84,36 @@ class TestPhasePlotParticleAPI:
         p = self.get_plot()
         p.annotate_text(1e-4, 1e-2, "Test text annotation", **kwargs)
         p.render()
-        return p.plots["gas", "mass"].figure
 
     @pytest.mark.mpl_image_compare
     def test_phaseplot_set_title(self):
         p = self.get_plot()
         p.annotate_title("Test Title")
         p.render()
-        return p.plots["gas", "mass"].figure
 
     @pytest.mark.mpl_image_compare
     def test_phaseplot_set_log(self):
         p = self.get_plot()
         p.set_log(("gas", "mass"), False)
         p.render()
-        return p.plots["gas", "mass"].figure
 
     @pytest.mark.mpl_image_compare
     def test_phaseplot_set_unit(self):
         p = self.get_plot()
         p.set_unit(("gas", "mass"), "Msun")
         p.render()
-        return p.plots["gas", "mass"].figure
 
     @pytest.mark.mpl_image_compare
     def test_phaseplot_set_xlim(self):
         p = self.get_plot()
         p.set_xlim(1e-3, 1e0)
         p.render()
-        return p.plots["gas", "mass"].figure
 
     @pytest.mark.mpl_image_compare
     def test_phaseplot_set_ylim(self):
         p = self.get_plot()
         p.set_ylim(1e-2, 1e0)
         p.render()
-        return p.plots["gas", "mass"].figure
 
 
 def test_set_units():

--- a/yt/visualization/tests/test_profile_plots.py
+++ b/yt/visualization/tests/test_profile_plots.py
@@ -10,7 +10,6 @@ from yt.testing import assert_allclose_units, fake_random_ds, fake_random_sph_ds
 from yt.visualization.api import PhasePlot
 
 
-
 class TestPhasePlotAPI:
     @classmethod
     def setup_class(cls):

--- a/yt/visualization/tests/test_profile_plots.py
+++ b/yt/visualization/tests/test_profile_plots.py
@@ -79,37 +79,31 @@ class TestPhasePlotParticleAPI:
         )
 
     @pytest.mark.parametrize("kwargs", [{}, {"color": "b"}])
-    @pytest.mark.mpl_image_compare
     def test_phaseplot_annotate_text(self, kwargs):
         p = self.get_plot()
         p.annotate_text(1e-4, 1e-2, "Test text annotation", **kwargs)
         p.render()
 
-    @pytest.mark.mpl_image_compare
     def test_phaseplot_set_title(self):
         p = self.get_plot()
         p.annotate_title("Test Title")
         p.render()
 
-    @pytest.mark.mpl_image_compare
     def test_phaseplot_set_log(self):
         p = self.get_plot()
         p.set_log(("gas", "mass"), False)
         p.render()
 
-    @pytest.mark.mpl_image_compare
     def test_phaseplot_set_unit(self):
         p = self.get_plot()
         p.set_unit(("gas", "mass"), "Msun")
         p.render()
 
-    @pytest.mark.mpl_image_compare
     def test_phaseplot_set_xlim(self):
         p = self.get_plot()
         p.set_xlim(1e-3, 1e0)
         p.render()
 
-    @pytest.mark.mpl_image_compare
     def test_phaseplot_set_ylim(self):
         p = self.get_plot()
         p.set_ylim(1e-2, 1e0)

--- a/yt/visualization/tests/test_profile_plots.py
+++ b/yt/visualization/tests/test_profile_plots.py
@@ -2,8 +2,8 @@ import os
 import shutil
 import tempfile
 import unittest
-import numpy as np
 
+import numpy as np
 import pytest
 
 import yt

--- a/yt/visualization/tests/test_profile_plots.py
+++ b/yt/visualization/tests/test_profile_plots.py
@@ -6,6 +6,7 @@ import unittest
 import pytest
 
 import yt
+from yt.testing import assert_allclose_units, fake_random_ds
 from yt.visualization.api import PhasePlot
 
 

--- a/yt/visualization/tests/test_profile_plots.py
+++ b/yt/visualization/tests/test_profile_plots.py
@@ -6,8 +6,9 @@ import unittest
 import pytest
 
 import yt
-from yt.testing import assert_allclose_units, fake_random_ds
+from yt.testing import assert_allclose_units, fake_random_ds, fake_random_sph_ds
 from yt.visualization.api import PhasePlot
+
 
 
 class TestPhasePlotAPI:
@@ -34,6 +35,61 @@ class TestPhasePlotAPI:
     def test_phaseplot_set_title(self):
         p = self.get_plot()
         p.set_title(("gas", "mass"), "Test Title")
+        p.render()
+        return p.plots["gas", "mass"].figure
+
+    @pytest.mark.mpl_image_compare
+    def test_phaseplot_set_log(self):
+        p = self.get_plot()
+        p.set_log(("gas", "mass"), False)
+        p.render()
+        return p.plots["gas", "mass"].figure
+
+    @pytest.mark.mpl_image_compare
+    def test_phaseplot_set_unit(self):
+        p = self.get_plot()
+        p.set_unit(("gas", "mass"), "Msun")
+        p.render()
+        return p.plots["gas", "mass"].figure
+
+    @pytest.mark.mpl_image_compare
+    def test_phaseplot_set_xlim(self):
+        p = self.get_plot()
+        p.set_xlim(1e-3, 1e0)
+        p.render()
+        return p.plots["gas", "mass"].figure
+
+    @pytest.mark.mpl_image_compare
+    def test_phaseplot_set_ylim(self):
+        p = self.get_plot()
+        p.set_ylim(1e-2, 1e0)
+        p.render()
+        return p.plots["gas", "mass"].figure
+
+
+class TestPhasePlotParticleAPI:
+    @classmethod
+    def setup_class(cls):
+        bbox = np.array([[-1.0, 3.0], [1.0, 5.2], [-1.0, 3.0]])
+        cls.ds = fake_random_sph_ds(50, bbox)
+
+    def get_plot(self):
+        return PhasePlot(
+            self.ds, ("gas", "density"), ("gas", "density"), ("gas", "mass")
+        )
+
+    @pytest.mark.parametrize("kwargs", [{}, {"color": "b"}])
+    @pytest.mark.mpl_image_compare
+    def test_phaseplot_annotate_text(self, kwargs):
+        p = self.get_plot()
+        p.annotate_text(1e-4, 1e-2, "Test text annotation", **kwargs)
+        p.render()
+        return p.plots["gas", "mass"].figure
+
+    @pytest.mark.mpl_image_compare
+    def test_phaseplot_set_title(self):
+        p = self.get_plot()
+        p.annotate_title("Test Title")
         p.render()
         return p.plots["gas", "mass"].figure
 

--- a/yt/visualization/tests/test_profile_plots.py
+++ b/yt/visualization/tests/test_profile_plots.py
@@ -67,61 +67,6 @@ class TestPhasePlotAPI:
         return p.plots["gas", "mass"].figure
 
 
-class TestPhasePlotParticleAPI:
-    @classmethod
-    def setup_class(cls):
-        bbox = np.array([[-1.0, 3.0], [1.0, 5.2], [-1.0, 3.0]])
-        cls.ds = fake_random_sph_ds(50, bbox)
-
-    def get_plot(self):
-        return PhasePlot(
-            self.ds, ("gas", "density"), ("gas", "density"), ("gas", "mass")
-        )
-
-    @pytest.mark.parametrize("kwargs", [{}, {"color": "b"}])
-    @pytest.mark.mpl_image_compare
-    def test_phaseplot_annotate_text(self, kwargs):
-        p = self.get_plot()
-        p.annotate_text(1e-4, 1e-2, "Test text annotation", **kwargs)
-        p.render()
-        return p.plots["gas", "mass"].figure
-
-    @pytest.mark.mpl_image_compare
-    def test_phaseplot_set_title(self):
-        p = self.get_plot()
-        p.annotate_title("Test Title")
-        p.render()
-        return p.plots["gas", "mass"].figure
-
-    @pytest.mark.mpl_image_compare
-    def test_phaseplot_set_log(self):
-        p = self.get_plot()
-        p.set_log(("gas", "mass"), False)
-        p.render()
-        return p.plots["gas", "mass"].figure
-
-    @pytest.mark.mpl_image_compare
-    def test_phaseplot_set_unit(self):
-        p = self.get_plot()
-        p.set_unit(("gas", "mass"), "Msun")
-        p.render()
-        return p.plots["gas", "mass"].figure
-
-    @pytest.mark.mpl_image_compare
-    def test_phaseplot_set_xlim(self):
-        p = self.get_plot()
-        p.set_xlim(1e-3, 1e0)
-        p.render()
-        return p.plots["gas", "mass"].figure
-
-    @pytest.mark.mpl_image_compare
-    def test_phaseplot_set_ylim(self):
-        p = self.get_plot()
-        p.set_ylim(1e-2, 1e0)
-        p.render()
-        return p.plots["gas", "mass"].figure
-
-
 def test_set_units():
     fields = ("density", "temperature")
     units = (


### PR DESCRIPTION
## PR Summary

Removing code that removes field type in set_title().  Not sure why this was ever here.  It is not present for any other plot annotations.

This resolves Issue #5087 .


