### PR TITLE
BUG: Properly reference weight field in profile code for particle-based datasets

### DIFF
--- a/yt/data_objects/profiles.py
+++ b/yt/data_objects/profiles.py
@@ -1314,7 +1314,7 @@ def create_profile(
                 for f in bin_fields + fields
             ]
             if wf is not None:
-                is_local.append(wf.sampling_type == "local")
+                is_local.append(data_source.ds.field_info[wf].sampling_type == "local")
             is_local_or_pfield = [
                 pf or lf for (pf, lf) in zip(is_pfield, is_local, strict=True)
             ]

--- a/yt/data_objects/tests/test_profiles.py
+++ b/yt/data_objects/tests/test_profiles.py
@@ -534,6 +534,12 @@ def test_profile_sph_data():
         [("gas", "kinetic_energy_density")],
         weight_field=None,
     )
+    yt.create_profile(
+        ds.all_data(),
+        [("gas", "density"), ("gas", "temperature")],
+        [("gas", "kinetic_energy_density")],
+        weight_field=("gas", "density"),
+    )
 
 
 def test_profile_override_limits():


### PR DESCRIPTION
## PR Summary

This fixes Issue #5089 .  The weight field was not being properly referenced in the profiling code when a `weight_field` was specified for particle-based datasets.  This code also adds a test to the profiling code to ensure it doesn't break again.
