### PR TITLE
BUG: fix swap_axes bug wih CellEdgesCallback

### DIFF
--- a/yt/visualization/plot_modifications.py
+++ b/yt/visualization/plot_modifications.py
@@ -3394,6 +3394,12 @@ class CellEdgesCallback(PlotCallback):
         extent = self._plot_bounds(plot)
         if plot._swap_axes:
             im_buffer = im_buffer.transpose((1, 0, 2))
+            # note: when using imshow, the extent keyword argument has to be the
+            # swapped extents, so the extent is swapped here (rather than
+            # calling self._set_plot_limits).
+            # https://github.com/yt-project/yt/issues/5094
+            extent = _swap_axes_extents(extent)
+
         plot._axes.imshow(
             im_buffer,
             origin="lower",
@@ -3401,4 +3407,3 @@ class CellEdgesCallback(PlotCallback):
             extent=extent,
             alpha=self.alpha,
         )
-        self._set_plot_limits(plot, extent)


### PR DESCRIPTION
Closes #5094 

Using the sample dataset in #5094, on this branch:

```python 
import yt
ds = yt.load("plt00450")
slice_plot = yt.SlicePlot(ds, "y", ("boxlib", "theta"))
slice_plot.set_width((6000, 10000)) # This sets the width in both directions
slice_plot.annotate_cell_edges(line_width=0.0001) # Add grid lines to the plot
slice_plot.swap_axes() # Swap the axes
slice_plot.show() # Display the plot
```
results in the correctly rotated cell edges
![image](https://github.com/user-attachments/assets/e6d9d5e8-97e3-4d9f-80c6-86928a6f9fbd)
