### PR TITLE
DEP: drop support for matplotlib 3.5.x (⏰ wait for #5081)

### DIFF
--- a/minimal_requirements.txt
+++ b/minimal_requirements.txt
@@ -4,6 +4,8 @@ cmyt==1.1.2
     # via yt (pyproject.toml)
 colorspacious==1.1.2
     # via cmyt
+contourpy==1.0.5
+    # via matplotlib
 cycler==0.12.1
     # via matplotlib
 ewah-bool-utils==1.2.0
@@ -12,7 +14,7 @@ fonttools==4.53.1
     # via matplotlib
 kiwisolver==1.4.7
     # via matplotlib
-matplotlib==3.5.0
+matplotlib==3.6.0
     # via
     #   yt (pyproject.toml)
     #   cmyt
@@ -27,6 +29,7 @@ numpy==1.21.3
     #   yt (pyproject.toml)
     #   cmyt
     #   colorspacious
+    #   contourpy
     #   ewah-bool-utils
     #   matplotlib
     #   unyt
@@ -34,7 +37,6 @@ packaging==20.9
     # via
     #   yt (pyproject.toml)
     #   matplotlib
-    #   setuptools-scm
 pillow==8.3.2
     # via
     #   yt (pyproject.toml)
@@ -44,10 +46,6 @@ pyparsing==3.1.4
     #   matplotlib
     #   packaging
 python-dateutil==2.9.0.post0
-    # via matplotlib
-setuptools==74.1.2
-    # via setuptools-scm
-setuptools-scm==8.1.0
     # via matplotlib
 six==1.16.0
     # via python-dateutil

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ requires-python = ">=3.10.3"
 dependencies = [
     "cmyt>=1.1.2",
     "ewah-bool-utils>=1.2.0",
-    "matplotlib>=3.5",
+    "matplotlib>=3.6.0",
     "more-itertools>=8.4",
     "numpy>=1.21.3, <3", # keep minimal requirement in sync with NPY_TARGET_VERSION
     # https://github.com/numpy/numpy/issues/27037


### PR DESCRIPTION
## PR Summary

Blocked by #5081

Quoting my rationale from https://github.com/yt-project/yt/pull/5081#issuecomment-2626689951
> `contourpy` became a dependency to `matplotlib` in [v3.6.0](https://matplotlib.org/stable/users/prev_whats_new/whats_new_3.6.0.html#improved-quad-contour-calculations-via-contourpy), and we currently support 3.5.0
>
>Now, if we were closely following [SPEC 0](https://scientific-python.org/specs/spec-0000/), we would be dropping support for 3.7.0 very soon, so I think we could just bump our minimal requirement to 3.6.0 and avoid additional complexity (soon to be obsolete) on your test.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
