### PR TITLE
Backport PR #5108 to yt-4.4.x (Bump pypa/gh-action-pypi-publish to 1.12.4)

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -124,7 +124,7 @@ jobs:
           merge-multiple: true
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.12.2
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           user: __token__
           password: ${{ secrets.pypi_token }}


### PR DESCRIPTION

## PR Summary

manual backport for #5108
(cherry picked from commit dc8b3144c9b349232521fd551fb6bb01cf4ba995)
