### PR TITLE
BUG: fix NaNs in off-center FRB slices from ds.r

### DIFF
--- a/yt/data_objects/region_expression.py
+++ b/yt/data_objects/region_expression.py
@@ -138,7 +138,11 @@ class RegionExpression:
             height = source.right_edge[yax] - source.left_edge[yax]
             # Make a resolution tuple with
             resolution = (int(new_slice[xax].step.imag), int(new_slice[yax].step.imag))
-            sl = sl.to_frb(width=width, resolution=resolution, height=height)
+            # Use the center of the slice, not the entire domain
+            center = source.center
+            sl = sl.to_frb(
+                width=width, resolution=resolution, height=height, center=center
+            )
         return sl
 
     def _slice_to_edges(self, ax, val):

--- a/yt/data_objects/tests/test_dataset_access.py
+++ b/yt/data_objects/tests/test_dataset_access.py
@@ -112,6 +112,19 @@ def test_slice_from_r():
     frb4 = ds.r[0.5, 0.25:0.75:1024j, 0.25:0.75:512j]
     assert_equal(frb3["gas", "density"], frb4["gas", "density"])
 
+    # Test off-center slice
+    offset_box = ds.box([0.0, 0.0, 0.4], [1.0, 0.5, 0.9])
+
+    sl5 = ds.r[0.5, 0:0.5, 0.4:0.9]
+    sl6 = ds.slice("x", 0.5, data_source=offset_box)
+    assert_equal(sl5["gas", "density"], sl6["gas", "density"])
+
+    frb5 = sl5.to_frb(
+        width=0.5, height=0.5, resolution=(1024, 512), center=(0.5, 0.25, 0.65)
+    )
+    frb6 = ds.r[0.5, 0.0:0.5:1024j, 0.4:0.9:512j]
+    assert_equal(frb5["gas", "density"], frb6["gas", "density"])
+
 
 def test_point_from_r():
     ds = fake_amr_ds(fields=["density"], units=["g/cm**3"])


### PR DESCRIPTION
## PR Summary

FRBs of slices made with `ds.r` were selecting the wrong area when the center of the slice didn't match the center of the domain. The existing tests didn't catch this, as they only check regions that have the same center as the domain. I've added a test case that covers this.

Example code and resulting plots:
```python
import yt
import matplotlib.pyplot as plt

ds = yt.load_sample("IsolatedGalaxy")
region = ds.r[0:0.5:100j, 0.5:1.0:100j, 0.5]

# display NaNs as red
cmap = plt.colormaps["viridis"]
cmap.set_bad(color="red")

plt.imshow(region["index", "x"], origin="lower", vmin=0, vmax=1, cmap=cmap)
plt.colorbar()
```

![before](https://github.com/user-attachments/assets/bff67254-31d4-4daf-9492-6ecaf355363e)
![after](https://github.com/user-attachments/assets/08418afc-1d74-4414-a9f0-7189075dd12c)

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [x] Adds a test for any bugs fixed. Adds tests for new features.