### PR TITLE
Classes to support AMReX HDF5 Output

### DIFF
--- a/yt/frontends/chombo/api.py
+++ b/yt/frontends/chombo/api.py
@@ -9,6 +9,8 @@ from .data_structures import (
     Orion2Hierarchy,
     PlutoDataset,
     PlutoHierarchy,
+    AMReXHDF5Dataset,
+    AMReXHDF5Hierarchy
 )
 from .fields import (
     ChomboFieldInfo,

--- a/yt/frontends/chombo/data_structures.py
+++ b/yt/frontends/chombo/data_structures.py
@@ -916,14 +916,12 @@ class AMReXHDF5Dataset(ChomboDataset):
 
     def _calc_left_edge(self):
         fileh = self._handle
-        dx0 = fileh["/level_0"].attrs["dx"]
         D = self.dimensionality
         LE = (np.array(list(fileh["/level_0"].attrs["prob_lo"])))[0:D]
         return LE
 
     def _calc_right_edge(self):
         fileh = self._handle
-        dx0 = fileh["/level_0"].attrs["dx"]
         D = self.dimensionality
         RE = (np.array(list(fileh["/level_0"].attrs["prob_hi"])))[0:D]
         return RE

--- a/yt/frontends/chombo/io.py
+++ b/yt/frontends/chombo/io.py
@@ -194,6 +194,20 @@ class IOHandlerChomboHDF5(BaseIOHandler):
             data[field_index::items_per_particle], dtype=np.float64, order="F"
         )
 
+class IOHandlerAMReXHDF5(IOHandlerChomboHDF5):
+    _dataset_type = "amrex_hdf5"
+    _offset_string = "data:offsets=0"
+    _data_string = "data:datatype=0"
+    _offsets = None
+
+    def __init__(self, ds, *args, **kwargs):
+        IOHandlerChomboHDF5.__init__(self, ds, *args, **kwargs)
+        self.ds = ds
+        self._handle = ds._handle
+        self.dim = int(self._handle["Chombo_global/"].attrs["SpaceDim"])
+        self._read_ghost_info()
+        if self._offset_string not in self._handle["level_0"]:
+            self._calculate_offsets()
 
 def parse_orion_sinks(fn):
     r"""


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

Supersedes #5117 - creating PR from unique branch so that `pre-commit` stays happy. I have closed the previous PR.

The HDF5 plot file output produced by PeleC (and presumably all amrex-based codes) does not work directly with the existing `ChomboDataset` class. This is most easily observable through the dimensionality - the Chombo I/O handler works with `self.dim = self._handle["Chombo_global/"].attrs["SpaceDim"]`, however `self.dim` is not correctly read as an integer when reading the amrex-produced files, so I have fixed it by explicitly setting `self.dim = int(self._handle["Chombo_global/"].attrs["SpaceDim"])`. I've made this change in a few locations in this PR.

I also observed some errors in the spatial positioning when working with the PeleC HDF5 output files, which appeared to come from the `_calc_left_edge()` and `_calc_right_edge()` methods assuming that the domain starts at [0, 0, 0]. The PeleC HDF5 output files contain the edge information directly, so I have elected to read them directly from the file (since amrex includes that in the attributes anyway), which has fixed the spatial misalignment. 

I was torn between adding these classes to the `amrex` frontend or `chombo` frontend, but decided that the `chombo` frontend would be more appropriate since the two share the same underlying functionality. I believe that it would be fairly straightforward to integrate these changes into the `ChomboDataset` class directly, but I refrained since I was unsure if they would lead to issues in other types of chombo data.

**Update:** I did overwrite the `_is_valid()` method from the ChomboDataset by checking the datatype of the `dim` attribute as it is read from the HDF5 file. For regular chombo files, this should be correctly read as a integer, but it is read as a list from the AMReX HDF5 plot files. I also have it check for the bounding box in the `level_0` data (which should always exist), since that is used for determining the spatial information for the domain and grids.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
