### PR TITLE
DOC: cleanup now unneeded instructions to upgrade pip before installing yt

### DIFF
--- a/doc/source/installing.rst
+++ b/doc/source/installing.rst
@@ -76,7 +76,6 @@ The latest stable release can be obtained from PyPI with pip
 
 .. code-block:: bash
 
-  $ python -m pip install --upgrade pip
   $ python -m pip install --user yt
 
 
@@ -100,7 +99,6 @@ one can specify them as, for instance
 
 .. code-block:: bash
 
-  $ python -m pip install --upgrade pip
   $ python -m pip install --user "yt[ramses]"
 
 Extra requirements can be combined, separated by commas (say ``yt[ramses,enzo_e]``).
@@ -121,7 +119,6 @@ Then run
 
   $ git clone https://github.com/yt-project/yt
   $ cd yt
-  $ python -m pip install --upgrade pip
   $ python -m pip install --user -e .
 
 


### PR DESCRIPTION
## PR Summary

Follow up to #4270. Here's the relevant quote

> So in order to support this for any patch version of Python 3.8 and 3.9, we'd need to specifically instruct upgrading pip itself as part of the installation process, and this extra step can be dropped when we stop supporting versions older than 3.9.7 (so, basically, when we drop Python 3.9, most likely in 2024 at the current pace)

