### PR TITLE
Use matplotlib backend registry when possible

### DIFF
--- a/nose_ignores.txt
+++ b/nose_ignores.txt
@@ -1,5 +1,6 @@
 --ignore-file=test_add_field\.py
 --ignore-file=test_ambiguous_fields\.py
+--ignore-file=test_base_plot_types\.py
 --ignore-file=test_callable_grids\.py
 --ignore-file=test_callbacks_geographic\.py
 --ignore-file=test_commons\.py

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -183,6 +183,7 @@ other_tests:
      - "--ignore=test_outputs_pytest"
      - "--ignore-file=test_add_field\\.py"
      - "--ignore-file=test_ambiguous_fields\\.py"
+     - "--ignore-file=test_base_plot_types\\.py"
      - "--ignore-file=test_callable_grids\\.py"
      - "--ignore-file=test_callbacks_geographic\\.py"
      - "--ignore-file=test_commons\\.py"

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -45,9 +45,6 @@ if TYPE_CHECKING:
 
 
 BACKEND_SPECS = {
-    "gtk": ["backend_gtk", "FigureCanvasGTK", "FigureManagerGTK"],
-    "gtkagg": ["backend_gtkagg", "FigureCanvasGTKAgg", None],
-    "gtkcairo": ["backend_gtkcairo", "FigureCanvasGTKCairo", None],
     "macosx": ["backend_macosx", "FigureCanvasMac", "FigureManagerMac"],
     "qt5agg": ["backend_qt5agg", "FigureCanvasQTAgg", None],
     "qtagg": ["backend_qtagg", "FigureCanvasQTAgg", None],

--- a/yt/visualization/base_plot_types.py
+++ b/yt/visualization/base_plot_types.py
@@ -138,6 +138,8 @@ class PlotMPL:
         figure_canvas, figure_manager = self._get_canvas_classes()
         self.canvas = figure_canvas(self.figure)
         if figure_manager is not None:
+            # with matplotlib >= 3.9, figure_manager should always be not None
+            # see _get_canvas_classes for details.
             self.manager = figure_manager(self.canvas, 1)
 
         self.axes.tick_params(
@@ -151,11 +153,20 @@ class PlotMPL:
 
     def _get_canvas_classes(self):
         if self.interactivity:
-            key = str(matplotlib.get_backend()).lower()
+            key = str(matplotlib.get_backend())
         else:
             key = "agg"
 
-        module, fig_canvas, fig_manager = BACKEND_SPECS[key]
+        if matplotlib.__version_info__ >= (3, 9):
+            # once yt has a minimum matplotlib version of 3.9, this branch
+            # can replace the rest of this function and BACKEND_SPECS can
+            # be removed. See https://github.com/yt-project/yt/issues/5138
+            from matplotlib.backends import backend_registry
+
+            mod = backend_registry.load_backend_module(key)
+            return mod.FigureCanvas, mod.FigureManager
+
+        module, fig_canvas, fig_manager = BACKEND_SPECS[key.lower()]
 
         mod = __import__(
             "matplotlib.backends",

--- a/yt/visualization/tests/test_base_plot_types.py
+++ b/yt/visualization/tests/test_base_plot_types.py
@@ -1,0 +1,19 @@
+import matplotlib
+import pytest
+
+from yt.visualization.base_plot_types import BACKEND_SPECS
+
+
+@pytest.mark.skipif(
+    matplotlib.__version_info__ < (3, 9),
+    reason="This test requires matplotlib 3.9 or higher.",
+)
+@pytest.mark.parametrize("backend_key", BACKEND_SPECS.keys())
+def test_backend_specs(backend_key):
+    # note: while this test itself requires matplotlib 3.9, it is
+    # testing functionality in yt that can be removed once yt has
+    # a minimal matplotlib version of 3.9,
+    # see https://github.com/yt-project/yt/issues/5138
+    from matplotlib.backends import backend_registry
+
+    assert backend_registry.is_valid_backend(backend_key)


### PR DESCRIPTION
Closes #5138 

I also added a test for the existing `BACKEND_SPECS`, just checking that the backend keys are valid, which resulted in me realizing that gtk, gtkagg and gtkcairo have all been deprecated for a while (https://github.com/ipython/ipython/issues/14368 , https://github.com/matplotlib/matplotlib/pull/10426) in favor of versioned keys (e.g., GTK3Agg). I removed the deprecated keys. 

Also worth noting that with this change, for folks using matplotlib>=3.9, yt plotting should now work with all the interactive backends listed at https://matplotlib.org/stable/users/explain/figure/backends.html#interactive-backends , which includes some that were missing from `BACKEND_SPECS`, e.g.: `GTK4Agg` and `GTK4Cairo`. 