### PR TITLE
add cosmology_time.cpp to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ yt/utilities/lib/points_in_volume.c
 yt/utilities/lib/quad_tree.c
 yt/utilities/lib/ragged_arrays.c
 yt/utilities/lib/cosmology_time.c
+yt/utilities/lib/cosmology_time.cpp
 yt/utilities/lib/grid_traversal.c
 yt/utilities/lib/marching_cubes.c
 yt/utilities/lib/png_writer.h


### PR DESCRIPTION
Stop @chrishavlin from accidentally committing `cosmology_time.cpp` again.