### PR TITLE
BUG: Better behavior when Cholla doesn't write "mu" attribute

### DIFF
--- a/yt/frontends/cholla/data_structures.py
+++ b/yt/frontends/cholla/data_structures.py
@@ -1,6 +1,5 @@
 import os
 import weakref
-from contextlib import suppress
 
 import numpy as np
 
@@ -112,7 +111,7 @@ class ChollaDataset(Dataset):
             self.current_time = attrs["t"][:]
             self._periodicity = tuple(attrs.get("periodicity", (False, False, False)))
             self.gamma = attrs.get("gamma", 5.0 / 3.0)
-            with suppress(KeyError):
+            if "mu" in attrs:
                 # other yt-machinery can't handle ds.mu == None, so we simply
                 # avoid defining the mu attribute if we don't know its value
                 self.mu = attrs["mu"]

--- a/yt/frontends/cholla/data_structures.py
+++ b/yt/frontends/cholla/data_structures.py
@@ -1,5 +1,6 @@
 import os
 import weakref
+from contextlib import suppress
 
 import numpy as np
 
@@ -111,7 +112,10 @@ class ChollaDataset(Dataset):
             self.current_time = attrs["t"][:]
             self._periodicity = tuple(attrs.get("periodicity", (False, False, False)))
             self.gamma = attrs.get("gamma", 5.0 / 3.0)
-            self.mu = attrs.get("mu", 1.0)
+            with suppress(KeyError):
+                # other yt-machinery can't handle ds.mu == None, so we simply
+                # avoid defining the mu attribute if we don't know its value
+                self.mu = attrs["mu"]
             self.refine_by = 1
 
             # If header specifies code units, default to those (in CGS)

--- a/yt/frontends/cholla/fields.py
+++ b/yt/frontends/cholla/fields.py
@@ -87,21 +87,23 @@ class ChollaFieldInfo(FieldInfoContainer):
         )
 
         # Add temperature field
-        def _temperature(field, data):
-            return (
-                data.ds.mu
-                * data["gas", "pressure"]
-                / data["gas", "density"]
-                * mh
-                / kboltz
-            )
+        if hasattr(self.ds, "mu"):
 
-        self.add_field(
-            ("gas", "temperature"),
-            sampling_type="cell",
-            function=_temperature,
-            units=unit_system["temperature"],
-        )
+            def _temperature(field, data):
+                return (
+                    data.ds.mu
+                    * data["gas", "pressure"]
+                    / data["gas", "density"]
+                    * mh
+                    / kboltz
+                )
+
+            self.add_field(
+                ("gas", "temperature"),
+                sampling_type="cell",
+                function=_temperature,
+                units=unit_system["temperature"],
+            )
 
         # Add color field if present (scalar0 / density)
         if ("cholla", "scalar0") in self.field_list:


### PR DESCRIPTION
## Basic Background

Currently, the Cholla frontend always tries to read the ``"mu"`` attribute from the hdf5 files. However, this is not a standard attribute written by Cholla. When this attribute is missing, the frontend falls back to a value of ``1.0``. This is almost always wrong (it is usually ``0.6``,  but in some cases it can be hardcoded to different values).

It's on my todo list to start having Cholla write out the ``"mu"`` attribute (when not using species fields).

## PR Summary

This patch tweaks the frontend to achieve better behavior for all existing Cholla datasets without the ``"mu"`` attribute. Namely, we don't set a default value. The patch also enures that we don't define a temperature field unless the ``"mu"`` attribute is explicitly defined (or the ``default_species_fields`` keyword argument is specified in ``yt.load``)