### PR TITLE
[BUGFIX] RAMSES: Use one registry per dataset

### DIFF
--- a/yt/frontends/ramses/field_handlers.py
+++ b/yt/frontends/ramses/field_handlers.py
@@ -42,6 +42,7 @@ class HandlerMixin:
         self.ds = ds = domain.ds
         self.domain = domain
         self.domain_id = domain.domain_id
+
         basename = os.path.abspath(ds.root_folder)
         iout = int(os.path.basename(ds.parameter_filename).split(".")[0].split("_")[1])
 
@@ -166,6 +167,9 @@ class FieldFileHandler(abc.ABC, HandlerMixin):
             register_field_handler(cls)
 
         cls._unique_registry = {}
+        cls.parameters = {}
+        cls.rt_parameters = {}
+        cls._detected_field_list = {}
         return cls
 
     def __init__(self, domain):
@@ -231,6 +235,10 @@ class FieldFileHandler(abc.ABC, HandlerMixin):
 
         return self._level_count
 
+    @property
+    def field_list(self):
+        return self._detected_field_list[self.ds.unique_identifier]
+
     @cached_property
     def offset(self):
         """
@@ -242,7 +250,7 @@ class FieldFileHandler(abc.ABC, HandlerMixin):
         It should be generic enough for most of the cases, but if the
         *structure* of your fluid file is non-canonical, change this.
         """
-        nvars = len(self.field_list)
+        nvars = len(self._detected_field_list[self.ds.unique_identifier])
         with FortranFile(self.fname) as fd:
             # Skip headers
             nskip = len(self.attrs)
@@ -265,7 +273,7 @@ class FieldFileHandler(abc.ABC, HandlerMixin):
                 fd,
                 min_level,
                 self.domain.domain_id,
-                self.parameters["nvar"],
+                self.parameters[self.ds.unique_identifier]["nvar"],
                 self.domain.amr_header,
                 Nskip=nvars * 8,
             )
@@ -314,7 +322,7 @@ class HydroFieldFileHandler(FieldFileHandler):
         attrs = cls.attrs
         with FortranFile(fname) as fd:
             hvals = fd.read_attrs(attrs)
-        cls.parameters = hvals
+        cls.parameters[ds.unique_identifier] = hvals
 
         # Store some metadata
         ds.gamma = hvals["gamma"]
@@ -445,7 +453,9 @@ class HydroFieldFileHandler(FieldFileHandler):
             count_extra += 1
         if count_extra > 0:
             mylog.debug("Detected %s extra fluid fields.", count_extra)
-        cls.field_list = [(cls.ftype, e) for e in fields]
+        cls._detected_field_list[ds.unique_identifier] = [
+            (cls.ftype, e) for e in fields
+        ]
 
         cls.set_detected_fields(ds, fields)
 
@@ -476,9 +486,9 @@ class GravFieldFileHandler(FieldFileHandler):
         basedir = os.path.split(ds.parameter_filename)[0]
         fname = os.path.join(basedir, cls.fname.format(iout=iout, icpu=1))
         with FortranFile(fname) as fd:
-            cls.parameters = fd.read_attrs(cls.attrs)
+            cls.parameters[ds.unique_identifier] = fd.read_attrs(cls.attrs)
 
-        nvar = cls.parameters["nvar"]
+        nvar = cls.parameters[ds.unique_identifier]["nvar"]
         ndim = ds.dimensionality
 
         fields = cls.load_fields_from_yt_config()
@@ -497,7 +507,9 @@ class GravFieldFileHandler(FieldFileHandler):
                 for i in range(nvar - ndetected):
                     fields.append(f"var{i}")
 
-        cls.field_list = [(cls.ftype, e) for e in fields]
+        cls._detected_field_list[ds.unique_identifier] = [
+            (cls.ftype, e) for e in fields
+        ]
 
         cls.set_detected_fields(ds, fields)
 
@@ -572,7 +584,7 @@ class RTFieldFileHandler(FieldFileHandler):
             # Touchy part, we have to read the photon group properties
             mylog.debug("Not reading photon group properties")
 
-            cls.rt_parameters = rheader
+            cls.rt_parameters[ds.unique_identifier] = rheader
 
         ngroups = rheader["nGroups"]
 
@@ -581,7 +593,7 @@ class RTFieldFileHandler(FieldFileHandler):
         fname = os.path.join(basedir, cls.fname.format(iout=iout, icpu=1))
         fname_desc = os.path.join(basedir, cls.file_descriptor)
         with FortranFile(fname) as fd:
-            cls.parameters = fd.read_attrs(cls.attrs)
+            cls.parameters[ds.unique_identifier] = fd.read_attrs(cls.attrs)
 
         ok = False
 
@@ -615,16 +627,18 @@ class RTFieldFileHandler(FieldFileHandler):
             for ng in range(ngroups):
                 fields.extend([t % (ng + 1) for t in tmp])
 
-        cls.field_list = [(cls.ftype, e) for e in fields]
+        cls._detected_field_list[ds.unique_identifier] = [
+            (cls.ftype, e) for e in fields
+        ]
 
         cls.set_detected_fields(ds, fields)
         return fields
 
     @classmethod
     def get_rt_parameters(cls, ds):
-        if cls.rt_parameters:
-            return cls.rt_parameters
+        if cls.rt_parameters[ds.unique_identifier]:
+            return cls.rt_parameters[ds.unique_identifier]
 
         # Call detect fields to get the rt_parameters
         cls.detect_fields(ds)
-        return cls.rt_parameters
+        return cls.rt_parameters[ds.unique_identifier]

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -794,3 +794,21 @@ def test_self_shielding_loading():
 
     # Also make sure the difference is large for some cells
     assert (np.abs(diff) > 0.1).any()
+
+
+@requires_file(output_00080)
+@requires_file(ramses_mhd_128)
+def test_order_does_not_matter():
+    for order in (1, 2):
+        ds0 = yt.load(output_00080)
+        ds1 = yt.load(ramses_mhd_128)
+
+        # This should not raise any exception
+        if order == 1:
+            _sp1 = ds1.all_data()
+            sp0 = ds0.all_data()
+        else:
+            sp0 = ds0.all_data()
+            _sp1 = ds1.all_data()
+
+        sp0["gas", "velocity_x"].max().to("km/s")

--- a/yt/frontends/ramses/tests/test_outputs.py
+++ b/yt/frontends/ramses/tests/test_outputs.py
@@ -390,8 +390,8 @@ def test_ramses_field_detection():
     fields_1 = set(DETECTED_FIELDS[ds1.unique_identifier]["ramses"])
 
     # Check the right number of variables has been loaded
-    assert P1["nvar"] == 10
-    assert len(fields_1) == P1["nvar"]
+    assert P1[ds1.unique_identifier]["nvar"] == 10
+    assert len(fields_1) == P1[ds1.unique_identifier]["nvar"]
 
     # Now load another dataset
     ds2 = yt.load(output_00080)
@@ -400,8 +400,8 @@ def test_ramses_field_detection():
     fields_2 = set(DETECTED_FIELDS[ds2.unique_identifier]["ramses"])
 
     # Check the right number of variables has been loaded
-    assert P2["nvar"] == 6
-    assert len(fields_2) == P2["nvar"]
+    assert P2[ds2.unique_identifier]["nvar"] == 6
+    assert len(fields_2) == P2[ds2.unique_identifier]["nvar"]
 
 
 @requires_file(ramses_new_format)


### PR DESCRIPTION
## PR Summary
This prevents issues when trying to load two snapshots/simulations with different variables. It makes all the detection specific to the one dataset at hand


## PR Checklist

- [x] ~New features are documented, with docstrings and narrative docs~
- [x] Adds a test for any bugs fixed. Adds tests for new features.


## Code to reproduce bug


```python
import yt

ds0 = yt.load_sample("output_00080")
ds1 = yt.load_sample("ramses_mhd_128")

# When loading sp0 then sp1, the code crashes
# When loading sp1 then sp0, it works :upside_down_face: 
#sp0 = ds0.sphere([0.5]*3, 0.01)
sp1 = ds1.sphere([0.5]*3, 0.01)
sp0 = ds0.sphere([0.5]*3, 0.01)

print(ds0.parameters)

sp0["gas", "velocity_x"].max().to("km/s")
```

Traceback:
```
ValueError
Cell In[28], line 12
      8 # sp0 = ds0.sphere([0.5]*3, 0.01)
     10 print(ds0.parameters)
---> 12 sp0["gas", "velocity_x"].max().to("km/s")  # this raises an OSError when reading the Fortran records.
[...]
File yt/frontends/ramses/field_handlers.py:264, in FieldFileHandler.offset(self)
    250     min_level = self.domain.ds.min_level
    252     # The file is as follows:
    253     # > headers
    254     # loop over levels
   (...)    262     # So there are 8 * nvars records each with length (nocts, )
    263     # at each (level, cpus)
--> 264     offset, level_count = read_offset(
    265         fd,
    266         min_level,
    267         self.domain.domain_id,
    268         self.parameters["nvar"],
    269         self.domain.amr_header,
    270         Nskip=nvars * 8,
    271     )
    273 self._level_count = level_count
    274 return offset

File yt/frontends/ramses/io_utils.pyx:119, in yt.frontends.ramses.io_utils.read_offset()

File yt/frontends/ramses/io_utils.pyx:147, in yt.frontends.ramses.io_utils.read_offset()

File yt/utilities/cython_fortran_utils.pyx:201, in yt.utilities.cython_fortran_utils.FortranFile.read_int()

ValueError: Size obtained (1068636786) does not match with the expected size (4) of record
```
