### PR TITLE
Manual Backport PR #5161: Bump typing-extensions from to 4.13.2 in /requirements in the actions group

### DIFF
--- a/requirements/typecheck.txt
+++ b/requirements/typecheck.txt
@@ -1,5 +1,5 @@
 mypy==1.13.0
 types-PyYAML==6.0.12.20240917
 types-chardet==5.0.4.6
-types-requests==2.32.0.20241016
-typing-extensions==4.6.0; python_version < '3.12'
+types-requests==2.32.0.20250328
+typing-extensions==4.13.2; python_version < '3.12'


### PR DESCRIPTION
So I went and added #5161 to 4.4.1 since it seemed like most of the dependabot requirement updates have gotten backported in the past. But when fixing this conflict, I realized the 4.4.x branch typing-extensions was still at 4.6.0... so maybe backporting this wasn't needed. But I don't see a reason it'd hurt? If there's a reason to not backport this, we can just close it :) 