### PR TITLE
WHL: upgrade cibuildwheel to 3.0.0

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build wheels for CPython
-        uses: pypa/cibuildwheel@v2.23.3
+        uses: pypa/cibuildwheel@v3.0.0
         with:
           output-dir: dist
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -461,12 +461,11 @@ show_error_context = true
 exclude = "(test_*|lodgeit)"
 
 [tool.cibuildwheel]
-build = "cp310-* cp311-* cp312-* cp313-*"
 build-verbosity = 1
 test-skip = "*-musllinux*"
 test-extras = "test"
 test-command = [
-    "pytest -c {project}/pyproject.toml --rootdir . --color=yes --pyargs yt -ra",
+    "python -m pytest -c {project}/pyproject.toml --rootdir . --color=yes --pyargs yt -ra",
 ]
 
 [tool.cibuildwheel.linux]


### PR DESCRIPTION
## PR Summary
This upgrade is necessary to enable building and testing against CPython 3.14 later this year.
