### PR TITLE
WHL: test musllinux wheels

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build_wheels:
-    name: Build ${{ matrix.archs }} wheels on ${{ matrix.os }}
+    name: Build ${{ matrix.select }}-${{ matrix.archs }} wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build wheels for CPython
-        uses: pypa/cibuildwheel@v3.1.2
+        uses: pypa/cibuildwheel@v3.1.4
         with:
           output-dir: dist
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -469,9 +469,9 @@ exclude = "(test_*|lodgeit)"
 [tool.cibuildwheel]
 build-verbosity = 1
 skip = ["cp314t-*"]
-test-skip = "*-musllinux*"
 test-extras = "test"
 test-command = [
+    'python -c "import yt"',
     "python -m pytest -c {project}/pyproject.toml --rootdir . --color=yes --pyargs yt -ra",
 ]
 environment = {"YT_LIMITED_API" = "1"}


### PR DESCRIPTION
## PR Summary
If I recall correctly the rationale for not testing these wheels was that NumPy didn't support the platform at the time, but they do now, so let's give it a try.