### PR TITLE
[BUG] minor `typing.ClassVar` fix for class variables of `Index`

### DIFF
--- a/yt/geometry/geometry_handler.py
+++ b/yt/geometry/geometry_handler.py
@@ -23,7 +23,6 @@ class Index(ParallelAnalysisInterface, abc.ABC):
     """The base index class"""
 
     _unsupported_objects: ClassVar[tuple[str, ...]] = ()
-    _index_properties: ClassVar[tuple[str, ...]] = ()
 
     def __init__(self, ds, dataset_type):
         ParallelAnalysisInterface.__init__(self)

--- a/yt/geometry/grid_geometry_handler.py
+++ b/yt/geometry/grid_geometry_handler.py
@@ -21,13 +21,6 @@ class GridIndex(Index, abc.ABC):
 
     float_type = "float64"
     _preload_implemented = False
-    _index_properties = (
-        "grid_left_edge",
-        "grid_right_edge",
-        "grid_levels",
-        "grid_particle_count",
-        "grid_dimensions",
-    )
 
     def _setup_geometry(self):
         mylog.debug("Counting grids.")


### PR DESCRIPTION
## PR Summary

**Context:** To annotate the types of class variables, you need to wrap the type using the `typing.ClassVar` construct. If the class-variable has type `T`, the type should be annotated as `typing.ClassVar[T]`. [If you don't use this construct, python assumes that it is an instance variable.](https://docs.python.org/3/library/typing.html#typing.ClassVar).

**Overview:** This PR rectified started using the `typing.ClassVar` construct to wrap the type annotations for the `_unsupported_objects` and `_index_properties` class variables of `Index`.

## A quick aside

A quick grep showed that `GridGeometryHandler` is the only class to actually define `_index_properties`, and there isn't any code that examines this attribute. Can we delete it? If we want to keep it as an attribute of `GridGeometryHandler` for posterity, can we delete class attribute from `Index`. If there is interest in doing this, I will happily open another PR
