### PR TITLE
Removing YTSphereTooSmall

### DIFF
--- a/yt/data_objects/selection_objects/spheroids.py
+++ b/yt/data_objects/selection_objects/spheroids.py
@@ -14,7 +14,7 @@ from yt.funcs import (
     validate_sequence,
 )
 from yt.units import YTArray
-from yt.utilities.exceptions import YTEllipsoidOrdering, YTException, YTSphereTooSmall
+from yt.utilities.exceptions import YTEllipsoidOrdering, YTException
 from yt.utilities.logger import ytLogger as mylog
 from yt.utilities.math_utils import get_rotation_matrix
 from yt.utilities.on_demand_imports import _miniball
@@ -57,12 +57,6 @@ class YTSphere(YTSelectionContainer3D):
         super().__init__(center, ds, field_parameters, data_source)
         # Unpack the radius, if necessary
         radius = fix_length(radius, self.ds)
-        if radius < self.index.get_smallest_dx():
-            raise YTSphereTooSmall(
-                ds,
-                radius.in_units("code_length"),
-                self.index.get_smallest_dx().in_units("code_length"),
-            )
         self.set_field_parameter("radius", radius)
         self.set_field_parameter("center", self.center)
         self.radius = radius
@@ -187,8 +181,7 @@ class YTEllipsoid(YTSelectionContainer3D):
         self._A = self.ds.quan(A, "code_length")
         self._B = self.ds.quan(B, "code_length")
         self._C = self.ds.quan(C, "code_length")
-        if self._C < self.index.get_smallest_dx():
-            raise YTSphereTooSmall(self.ds, self._C, self.index.get_smallest_dx())
+
         self._e0 = e0 = e0 / (e0**2.0).sum() ** 0.5
         self._tilt = tilt
 

--- a/yt/utilities/exceptions.py
+++ b/yt/utilities/exceptions.py
@@ -62,16 +62,6 @@ class YTAmbiguousDataType(YTUnidentifiedDataType):
         return msg
 
 
-class YTSphereTooSmall(YTException):
-    def __init__(self, ds, radius, smallest_cell):
-        self.ds = ds
-        self.radius = radius
-        self.smallest_cell = smallest_cell
-
-    def __str__(self):
-        return f"{self.radius:0.5e} < {self.smallest_cell:0.5e}"
-
-
 class YTAxesNotOrthogonalError(YTException):
     def __init__(self, axes):
         self.axes = axes

--- a/yt/visualization/volume_rendering/tests/test_composite.py
+++ b/yt/visualization/volume_rendering/tests/test_composite.py
@@ -44,6 +44,9 @@ class CompositeVRTest(TestCase):
     def test_composite_vr(self):
         ds = fake_random_ds(64)
         dd = ds.sphere(ds.domain_center, 0.45 * ds.domain_width[0])
+
+        # Trigger creation of index
+        ds.index
         ds.field_info[ds.field_list[0]].take_log = False
 
         sc = Scene()

--- a/yt/visualization/volume_rendering/tests/test_points.py
+++ b/yt/visualization/volume_rendering/tests/test_points.py
@@ -42,6 +42,9 @@ class PointsVRTest(TestCase):
     def test_points_vr(self):
         ds = fake_random_ds(64)
         dd = ds.sphere(ds.domain_center, 0.45 * ds.domain_width[0])
+
+        # Trigger creation of index
+        ds.index
         ds.field_info[ds.field_list[0]].take_log = False
 
         sc = Scene()

--- a/yt/visualization/volume_rendering/tests/test_zbuff.py
+++ b/yt/visualization/volume_rendering/tests/test_zbuff.py
@@ -53,6 +53,8 @@ class ZBufferTest(TestCase):
     def test_composite_vr(self):
         ds = fake_random_ds(64)
         dd = ds.sphere(ds.domain_center, 0.45 * ds.domain_width[0])
+        # Trigger creation of index
+        ds.index
         ds.field_info[ds.field_list[0]].take_log = False
 
         sc = Scene()


### PR DESCRIPTION
## PR Summary

The check on grid size cause the building of the entirety of the index.
This causes a massive slowdown for e.g. RAMSES dataset where the smallest cell size requires reading the entirety of the AMR structure.

The fix? Remove this check and live on the edge.

Note: this makes https://github.com/yt-project/yt/pull/5060 more or less useless.