### PR TITLE
Represent comoving with a `c` prefix

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -1394,7 +1394,7 @@ class Dataset(abc.ABC):
                         new_unit,
                         my_u.base_value / (1 + self.current_redshift),
                         dimensions.length,
-                        f"\\rm{{{my_unit}}}/(1+z)",
+                        f"\\rm{{c{my_unit}}}",
                         prefixable=True,
                     )
                 self.unit_registry.modify("a", 1 / (1 + self.current_redshift))


### PR DESCRIPTION
## PR Summary

This changes the default latex representation of comoving axes from $\mathrm{Mpc}/(1+z)$ to being $\mathrm{cMpc}$, the latter being the convention, while the former - albeit correct - is quite confusing and cumbersome.

Happy to *not* merge this if this is deemed controversial.