### PR TITLE
Refactor: Move `derived_field_list` to `field_info`

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -169,7 +169,6 @@ class Dataset(abc.ABC):
     known_filters: dict[ParticleType, ParticleFilter] | None = None
     _index_class: type[Index]
     field_units: dict[AnyFieldKey, Unit] | None = None
-    derived_field_list = requires_index("derived_field_list")
     fields = requires_index("fields")
     conversion_factors: dict[str, float] | None = None
     # _instantiated represents an instantiation time (since Epoch)
@@ -654,9 +653,12 @@ class Dataset(abc.ABC):
     def field_list(self):
         return self.index.field_list
 
+    @property
+    def derived_field_list(self):
+        return self.field_info.derived_field_list
+
     def create_field_info(self):
         self.field_dependencies = {}
-        self.derived_field_list = []
         self.filtered_particle_types = []
         self.field_info = self._field_info_class(self, self.field_list)
         self.coordinates.setup_fields(self.field_info)
@@ -915,7 +917,7 @@ class Dataset(abc.ABC):
             if fn[0] == filter.filtered_type:
                 # Now we can add this
                 available = True
-                self.derived_field_list.append((filter.name, fn[1]))
+                self.field_info.derived_field_list.append((filter.name, fn[1]))
                 fi[filter.name, fn[1]] = filter.wrap_func(fn, fi[fn])
                 # Now we append the dependencies
                 fd[filter.name, fn[1]] = fd[fn]

--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -655,6 +655,7 @@ class Dataset(abc.ABC):
 
     @property
     def derived_field_list(self):
+        self.index
         return self.field_info.derived_field_list
 
     def create_field_info(self):

--- a/yt/frontends/fits/data_structures.py
+++ b/yt/frontends/fits/data_structures.py
@@ -228,7 +228,7 @@ class FITSHierarchy(GridIndex):
         [self.dataset.conversion_factors[field] for field in self.field_list]
         for field in self.field_list:
             if field not in self.derived_field_list:
-                self.derived_field_list.append(field)
+                self.dataset.field_info.derived_field_list.append(field)
 
         for field in self.derived_field_list:
             f = self.dataset.field_info[field]

--- a/yt/frontends/ytdata/data_structures.py
+++ b/yt/frontends/ytdata/data_structures.py
@@ -197,7 +197,6 @@ class YTDataset(SavedDataset):
 
     def create_field_info(self):
         self.field_dependencies = {}
-        self.derived_field_list = []
         self.filtered_particle_types = []
         self.field_info = self._field_info_class(self, self.field_list)
         self.coordinates.setup_fields(self.field_info)


### PR DESCRIPTION
## PR Summary

Aimed to be a no-op refactor: this PR moves the `derived_field_list` to an attribute within the dataset's `field_info` container to help with https://github.com/yt-project/yt/issues/5214 . I have a follow up with the same change for the `field_list`, but that's much more invasive, so wanted to check how this smaller changeset does in the test suite (but the change here can be merged on its own).