### PR TITLE
WHL: bump cibuildwheel to 3.1.1, start testing wheels on CPython 3.14

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -11,6 +11,7 @@ on:
     paths:
       - '.github/workflows/wheels.yaml'
       - MANIFEST.in
+      - pyproject.toml
   workflow_dispatch:
 
 
@@ -48,7 +49,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build wheels for CPython
-        uses: pypa/cibuildwheel@v3.0.0
+        uses: pypa/cibuildwheel@v3.1.1
         with:
           output-dir: dist
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Astronomy",
     "Topic :: Scientific/Engineering :: Physics",
     "Topic :: Scientific/Engineering :: Visualization",
@@ -459,8 +460,18 @@ exclude = "(test_*|lodgeit)"
 
 [tool.cibuildwheel]
 build-verbosity = 1
+skip = ["cp314t-*"]
 test-skip = "*-musllinux*"
 test-extras = "test"
 test-command = [
     "python -m pytest -c {project}/pyproject.toml --rootdir . --color=yes --pyargs yt -ra",
+]
+
+[[tool.cibuildwheel.overrides]]
+# Install nightly wheels for matplotlib, not yet available on PyPI.
+select = "cp314*"
+before-test = [
+    # numpy and contourpy, both dependencies to matplotlib, can safely be installed from PyPI
+    "python -m pip install numpy contourpy",
+    "python -m pip install --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple matplotlib --only-binary matplotlib",
 ]


### PR DESCRIPTION
## PR Summary

cibuildwheel 3.1.0 includes `cp314` and `cp314t` targets by default.
Testing on `cp314` requires a bit of fiddling since our dependencies are not there yet, but it's tractable.
I'm excluding `cp314t` since we've done exactly 0 effort towards supporting free threading so far.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
