### PR TITLE
WHL: cross compile macos x86_64 wheels

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -16,15 +16,32 @@ on:
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build ${{ matrix.archs }} wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
-      matrix:
-        os:
-          - ubuntu-22.04
-          - windows-2022
-          - macos-latest
       fail-fast: false
+      matrix:
+        include:
+        - os: ubuntu-latest
+          archs: x86_64
+          select: '*manylinux*'
+          id: manylinux_x86_64
+        - os: ubuntu-latest
+          archs: x86_64
+          select: '*musllinux*'
+          id: musllinux_x86_64
+        - os: macos-latest
+          archs: x86_64
+          select: '*'
+          id: macos_x86_64
+        - os: macos-latest
+          archs: arm64
+          select: '*'
+          id: macos_arm64
+        - os: windows-latest
+          archs: AMD64
+          select: '*'
+          id: windows_AMD64
 
     steps:
       - name: Checkout repo
@@ -34,10 +51,13 @@ jobs:
         uses: pypa/cibuildwheel@v3.0.0
         with:
           output-dir: dist
+        env:
+          CIBW_ARCHS: ${{ matrix.archs }}
+          CIBW_BUILD: ${{ matrix.select }}
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}
+          name: wheels-${{ matrix.os }}-${{ matrix.id }}
           path: ./dist/*.whl
 
   build_sdist:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -466,15 +466,3 @@ test-extras = "test"
 test-command = [
     "python -m pytest -c {project}/pyproject.toml --rootdir . --color=yes --pyargs yt -ra",
 ]
-
-[tool.cibuildwheel.linux]
-archs = "x86_64"
-
-[tool.cibuildwheel.macos]
-archs = [
-    "arm64",
-    "x86_64", # cross-compiled on arm64
-]
-
-[tool.cibuildwheel.windows]
-archs = "auto64"


### PR DESCRIPTION
## PR Summary

[GitHub is planning to retire the `macos-13` image](
https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/#macos-13-is-closing-down) in the coming months, so cross-compilation will become the only option to keep support for the `x86_64` (intel processors) arch on macos.


## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
