### PR TITLE
TST: reduce default verbosity in pytest test sessions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -300,8 +300,6 @@ known-first-party = ["yt"]
 # specified by the characters following the r. s: skipped, f: failed, E: error
 [tool.pytest.ini_options]
 addopts = '''
-    -s
-    -v
     -rsfE
     --ignore-glob='/*_nose.py'
     --ignore-glob='/*/yt/data_objects/level_sets/tests/test_clump_finding.py'


### PR DESCRIPTION
## PR Summary

CI logs are extremely verbose at the moment, where each and every test case prints a full line of log, amounting to ~10k lines in wheel testing jobs, which is very rarely (if ever) useful. Meanwhile, this logging strategy omits something actually useful: an overview of the current *progress* in a session. Reducing verbosity solves both issues.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
