### PR TITLE
TST: fix image tests reporting-on-error and update failing tests

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -161,7 +161,7 @@ jobs:
     - name: Generate new image baseline
       if: failure()
       run: |
-        pytest --color=yes --mpl -m mpl_image_compare \
+        pytest yt --color=yes --mpl -m mpl_image_compare \
                --mpl-generate-path=pytest_mpl_new_baseline \
                --last-failed
 


### PR DESCRIPTION
## PR Summary
Looks like images tests are currently doubly broken: 2 of them fail, but the reporting step is itself broken on `pytest>=8.4`, so I'm starting with a fix for this last part, as a follow up to #5176. I'll see if I can fix the tests themselved then.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
