### PR TITLE
Convert field_info into a property so it can be created on first access.

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -658,7 +658,7 @@ class Dataset(abc.ABC):
     @property
     def field_info(self):
         if self._field_info is None:
-            self.create_field_info()
+            self.index
         return self._field_info
 
     @field_info.setter
@@ -666,7 +666,13 @@ class Dataset(abc.ABC):
         self._field_info = value
 
     def create_field_info(self):
-        self.index
+        # create_field_info will be called at the end of instantiating
+        # the index object. This will trigger index creation, which will
+        # call this function again.
+        if self._instantiated_index is None:
+            self.index
+            return
+
         self.field_dependencies = {}
         self.derived_field_list = []
         self.filtered_particle_types = []


### PR DESCRIPTION
The field info container is notably brittle in that either a dataset's index or field_list must be accessed/created first before it can come into existence.  This PR makes `Dataset.field_info` into a property allowing it to be created on first access. Additionally, we now poke the index at the start of `create_field_info` to allow this to be run before the `field_list` is created. I argue this should have been considered a bug given the naming of the method without an underscore implying the user was free to call it.