### PR TITLE
fix/update tfh tutorial

### DIFF
--- a/doc/source/visualizing/TransferFunctionHelper_Tutorial.ipynb
+++ b/doc/source/visualizing/TransferFunctionHelper_Tutorial.ipynb
@@ -23,7 +23,8 @@
     "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -33,16 +34,7 @@
     "import yt\n",
     "from yt.visualization.volume_rendering.transfer_function_helper import (\n",
     "    TransferFunctionHelper,\n",
-    ")\n",
-    "\n",
-    "\n",
-    "def showme(im):\n",
-    "    # screen out NaNs\n",
-    "    im[im != im] = 0.0\n",
-    "\n",
-    "    # Create an RGBA bitmap to display\n",
-    "    imb = yt.write_bitmap(im, None)\n",
-    "    return Image(imb)"
+    ")"
    ]
   },
   {
@@ -59,7 +51,8 @@
     "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -80,7 +73,8 @@
     "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -101,7 +95,8 @@
     "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -129,7 +124,8 @@
     "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -150,7 +146,8 @@
     "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -159,15 +156,6 @@
     "tfh.set_bounds()\n",
     "tfh.set_log(True)\n",
     "tfh.build_transfer_function()\n",
-    "tfh.tf.add_layers(\n",
-    "    8,\n",
-    "    w=0.01,\n",
-    "    mi=4.0,\n",
-    "    ma=8.0,\n",
-    "    col_bounds=[4.0, 8.0],\n",
-    "    alpha=np.logspace(-1, 2, 7),\n",
-    "    colormap=\"RdBu_r\",\n",
-    ")\n",
     "tfh.tf.map_to_colormap(6.0, 8.0, colormap=\"Reds\")\n",
     "tfh.tf.map_to_colormap(-1.0, 6.0, colormap=\"Blues_r\")\n",
     "\n",
@@ -196,10 +184,16 @@
     "\n",
     "source = sc.get_source()\n",
     "source.set_transfer_function(tfh.tf)\n",
-    "im2 = sc.render()\n",
-    "\n",
-    "showme(im2[:, :, :3])"
+    "sc.render()\n",
+    "sc.show()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -215,7 +209,8 @@
     "collapsed": false,
     "jupyter": {
      "outputs_hidden": false
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -224,15 +219,6 @@
     "tfh2.set_bounds()\n",
     "tfh2.set_log(True)\n",
     "tfh2.build_transfer_function()\n",
-    "tfh2.tf.add_layers(\n",
-    "    8,\n",
-    "    w=0.01,\n",
-    "    mi=4.0,\n",
-    "    ma=8.0,\n",
-    "    col_bounds=[4.0, 8.0],\n",
-    "    alpha=np.logspace(-1, 2, 7),\n",
-    "    colormap=\"RdBu_r\",\n",
-    ")\n",
     "tfh2.tf.map_to_colormap(6.0, 8.0, colormap=\"Reds\", scale=5.0)\n",
     "tfh2.tf.map_to_colormap(-1.0, 6.0, colormap=\"Blues_r\", scale=1.0)\n",
     "\n",
@@ -258,9 +244,8 @@
    "outputs": [],
    "source": [
     "source.set_transfer_function(tfh2.tf)\n",
-    "im3 = sc.render()\n",
-    "\n",
-    "showme(im3[:, :, :3])"
+    "sc.render()\n",
+    "sc.show()"
    ]
   },
   {
@@ -287,7 +272,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
https://yt-project.org/doc/visualizing/TransferFunctionHelper_Tutorial.html shows a couple cells with the following error:

```python-traceback
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[6], line 6
      4 tfh.set_log(True)
      5 tfh.build_transfer_function()
----> 6 tfh.tf.add_layers(
      7     8,
      8     w=0.01,
      9     mi=4.0,
     10     ma=8.0,
     11     col_bounds=[4.0, 8.0],
     12     alpha=np.logspace(-1, 2, 7),
     13     colormap="RdBu_r",
     14 )
     15 tfh.tf.map_to_colormap(6.0, 8.0, colormap="Reds")
     16 tfh.tf.map_to_colormap(-1.0, 6.0, colormap="Blues_r")

File /tmp/yt/yt/visualization/volume_rendering/transfer_functions.py:893, in ColorTransferFunction.add_layers(self, N, w, mi, ma, alpha, colormap, col_bounds)
    891 elif alpha is None and not self.grey_opacity:
    892     alpha = np.logspace(-3, 0, N)
--> 893 for v, a in zip(np.mgrid[mi : ma : N * 1j], alpha, strict=True):
    894     self.sample_colormap(v, w, a, colormap=colormap, col_bounds=col_bounds)

ValueError: zip() argument 2 is shorter than argument 1
```

This arises because the `alpha` array length does not match `N`: `N=8`, `alpha=np.logspace(-1, 2, 7),`, and with the strict zipping it now fails. Could fix that, but the subsequent `map_to_colormap` calls overwrite the gaussians anyway, so we can just remove them. 

Also, I don't see a need for the `showme` function defined in the first cell anymore, so I removed it. 

I separately pushed up a rendered version of the notebook, you can check it out [here](https://github.com/chrishavlin/yt/blob/tfh_example_rendered/doc/source/visualizing/TransferFunctionHelper_Tutorial.ipynb).
