### PR TITLE
Fix gamer frontend: single-grid case by reshape instead of squeeze

### DIFF
--- a/yt/frontends/gamer/data_structures.py
+++ b/yt/frontends/gamer/data_structures.py
@@ -108,7 +108,7 @@ class GAMERHierarchy(GridIndex):
         #    (see _read_particle_coords and _read_particle_fields in io.py)
         self._particle_indices = np.zeros(self.num_grids + 1, dtype="int64")
         np.add.accumulate(
-            self.grid_particle_count.squeeze(), out=self._particle_indices[1:]
+            self.grid_particle_count.reshape(self.num_grids), out=self._particle_indices[1:]
         )
 
     def _populate_grid_objects(self):


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

This PR fixes an issue that occurs when running with a single grid on `gamer`. 
Previously, the code used `squeeze()` on `self.grid_particle_count`, which could reduce the array to a scalar and cause errors.

- Fix gamer-project/gamer#477

<details>
  <summary>Error message</summary>

```
TypeError: cannot accumulate on a scalar
```
</details>

This is replaced with `reshape(self.num_grids)`, which ensures the array always working regardless of the number of grids.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [x] Adds a test for bug fixed. 

### Test

1.  Follow [gamerQuick Start: 3D Blast Wave
](https://github.com/gamer-project/gamer/wiki/Quick-Start%3A-3D-Blast-Wave)
2. Before step 6, update `Input__Parameter` : set NX0_TOT_X, NX0_TOT_Y, and NX0_TOT_Z → 16.
3. Run the simulation.
4. Go into the plot_script directories. Use yt to plot with:
   ```
   python3 plot_slice_gas.py -s 0 -e 0
   ```

Without this fix, the single-grid case raises a `TypeError`. With this PR applied, the plot is generated successfully.
<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
