### PR TITLE
[BUG] minor Fix dataset hashing for non-ASCII paths by encoding `parameter_filename` as UTF-8

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -349,7 +349,7 @@ class Dataset(abc.ABC):
     @cached_property
     def unique_identifier(self) -> str:
         retv = int(os.stat(self.parameter_filename)[ST_CTIME])
-        name_as_bytes = bytearray(map(ord, self.parameter_filename))
+        name_as_bytes = bytearray(self.parameter_filename.encode("utf-8"))
         retv += fnv_hash(name_as_bytes)
         return str(retv)
 


### PR DESCRIPTION
## Problem

When loading a dataset whose path contains non-ASCII characters (e.g. emoji, Chinese, Greek letters), yt currently raises:
```bash
Traceback (most recent call last):
  File "/Users/jisuoqing/Downloads/🔥/slice.py", line 5, in <module>
    ds = yt.load(filename)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/yt/lib/python3.10/site-packages/yt/_maintenance/deprecation.py", line 68, in inner
    return func(*args, **kwargs)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/yt/lib/python3.10/site-packages/yt/loaders.py", line 141, in load
    return cls(fn, *args, **kwargs)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/yt/lib/python3.10/site-packages/yt/frontends/athena_pp/data_structures.py", line 164, in __init__
    Dataset.__init__(
  File "/opt/homebrew/Caskroom/miniforge/base/envs/yt/lib/python3.10/site-packages/yt/data_objects/static_output.py", line 308, in __init__
    _ds_store.check_ds(self)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/yt/lib/python3.10/site-packages/yt/utilities/parameter_file_storage.py", line 134, in check_ds
    hash = ds._hash()
  File "/opt/homebrew/Caskroom/miniforge/base/envs/yt/lib/python3.10/site-packages/yt/data_objects/static_output.py", line 434, in _hash
    s = f"{self.basename};{self.current_time};{self.unique_identifier}"
  File "/opt/homebrew/Caskroom/miniforge/base/envs/yt/lib/python3.10/functools.py", line 981, in __get__
    val = self.func(instance)
  File "/opt/homebrew/Caskroom/miniforge/base/envs/yt/lib/python3.10/site-packages/yt/data_objects/static_output.py", line 352, in unique_identifier
    name_as_bytes = bytearray(map(ord, self.parameter_filename))
ValueError: byte must be in range(0, 256)
```

Bug noticed by Hengzhi @12345a-a