### PR TITLE
baroclinic vorticity typo fix in yt/fields/fluid_vector_fields.py

### DIFF
--- a/yt/fields/fluid_vector_fields.py
+++ b/yt/fields/fluid_vector_fields.py
@@ -39,7 +39,7 @@ def setup_fluid_vector_fields(
         rho2 = data[ftype, "density"].astype("float64", copy=False) ** 2
         return (
             data[ftype, "pressure_gradient_y"] * data[ftype, "density_gradient_z"]
-            - data[ftype, "pressure_gradient_z"] * data[ftype, "density_gradient_z"]
+            - data[ftype, "pressure_gradient_z"] * data[ftype, "density_gradient_y"]
         ) / rho2
 
     def _baroclinic_vorticity_y(field, data):


### PR DESCRIPTION
There was small typo in the code to calculate the x component on the baroclinic vorticity term, just a small switch of z and y component on the density gradient used in the calculation.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

There was small typo in the function to calculate the baroclinic_vorticity_x term. It used the z component of the density gradient rather than the y component of the density gradient. The change I made was simply deleting the z for a y.
Should be a 1 character change.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [N/A] New features are documented, with docstrings and narrative docs
- [] Adds a test for any bugs fixed. Adds tests for new features.

I did not do any testing, just a bug I noticed by eye.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
