### PR TITLE
Remove unnecessary instances of ds.index

### DIFF
--- a/doc/helper_scripts/show_fields.py
+++ b/doc/helper_scripts/show_fields.py
@@ -183,7 +183,6 @@ def print_all_fields(fl):
             print()
 
 
-ds.index
 print_all_fields(ds.field_info)
 
 

--- a/doc/source/analyzing/fields.rst
+++ b/doc/source/analyzing/fields.rst
@@ -118,7 +118,6 @@ field, like its default units or the source code for it.
 .. code-block:: python
 
    ds = yt.load("my_data")
-   ds.index
    print(ds.field_info["gas", "pressure"].get_units())
    print(ds.field_info["gas", "pressure"].get_source())
 

--- a/doc/source/cookbook/yt_gadget_analysis.ipynb
+++ b/doc/source/cookbook/yt_gadget_analysis.ipynb
@@ -64,7 +64,6 @@
     "bbox = [[-bbox_lim, bbox_lim], [-bbox_lim, bbox_lim], [-bbox_lim, bbox_lim]]\n",
     "\n",
     "ds = yt.load(fname, unit_base=unit_base, bounding_box=bbox)\n",
-    "ds.index\n",
     "ad = ds.all_data()"
    ]
   },

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -763,7 +763,6 @@ to the z direction.
 
 .. code-block:: python
 
-    ds.index
     ad = ds.all_data()
     print(ds.field_info["raw", "Ex"].nodal_flag)
     print(ad["raw", "Ex"].shape)
@@ -880,7 +879,6 @@ direction.
 
 .. code-block:: python
 
-    ds.index
     ad = ds.all_data()
     print(ds.field_info["enzo", "Ex"].nodal_flag)
     print(ad["enzo", "Ex"].shape)
@@ -928,7 +926,6 @@ types will be known as soon as the dataset index is created.
 .. code-block:: python
 
    ds = yt.load("ENZOP_DD0140/ENZOP_DD0140.block_list")
-   ds.index
    print(ds.particle_types)
    print(ds.particle_type_counts)
    print(ds.r["dark", "particle_position"])

--- a/doc/source/faq/index.rst
+++ b/doc/source/faq/index.rst
@@ -251,12 +251,10 @@ logged, you could type:
 .. code-block:: python
 
     ds = load("my_data")
-    ds.index
     ds.field_info["gas", "density"].take_log = False
 
 From that point forward, data products such as slices, projections, etc., would
-be presented in linear space. Note that you have to instantiate ds.index before
-you can access ds.field info.  For more information see the documentation on
+be presented in linear space. For more information see the documentation on
 :ref:`fields` and :ref:`creating-derived-fields`.
 
 .. _faq-new-field:

--- a/yt/visualization/volume_rendering/tests/test_composite.py
+++ b/yt/visualization/volume_rendering/tests/test_composite.py
@@ -46,7 +46,6 @@ class CompositeVRTest(TestCase):
         dd = ds.sphere(ds.domain_center, 0.45 * ds.domain_width[0])
 
         # Trigger creation of index
-        ds.index
         ds.field_info[ds.field_list[0]].take_log = False
 
         sc = Scene()

--- a/yt/visualization/volume_rendering/tests/test_points.py
+++ b/yt/visualization/volume_rendering/tests/test_points.py
@@ -44,7 +44,6 @@ class PointsVRTest(TestCase):
         dd = ds.sphere(ds.domain_center, 0.45 * ds.domain_width[0])
 
         # Trigger creation of index
-        ds.index
         ds.field_info[ds.field_list[0]].take_log = False
 
         sc = Scene()

--- a/yt/visualization/volume_rendering/tests/test_zbuff.py
+++ b/yt/visualization/volume_rendering/tests/test_zbuff.py
@@ -54,7 +54,6 @@ class ZBufferTest(TestCase):
         ds = fake_random_ds(64)
         dd = ds.sphere(ds.domain_center, 0.45 * ds.domain_width[0])
         # Trigger creation of index
-        ds.index
         ds.field_info[ds.field_list[0]].take_log = False
 
         sc = Scene()


### PR DESCRIPTION
This addresses Issue #5275. After PR #5250, we no longer need to access `ds.index` to create `ds.field_info`. This removes some calls added in PR #5211 as well as a few other places that were very obviously the same. I stayed away from modifying any source code, other than one helper function. I was also able to eliminate a place in the docs that mentions having to do `ds.index` before accessing `ds.field_info`.