### PR TITLE
[BUG] Allow data to have units when creating unstructured datasets

### DIFF
--- a/yt/frontends/stream/tests/test_stream_unstructured.py
+++ b/yt/frontends/stream/tests/test_stream_unstructured.py
@@ -72,3 +72,25 @@ def test_multi_field():
 
     sl = SlicePlot(ds, "z", ("connect1", "testAgain"))
     sl.annotate_mesh_lines()
+
+
+def test_units():
+    coords = np.array(
+        [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]], dtype=np.float64
+    )
+
+    connect = np.array([[0, 1, 3], [1, 2, 3]], dtype=np.int64)
+
+    data = {}
+    data["connect1", "density"] = (
+        np.array([[0.0, 1.0, 3.0], [1.0, 2.0, 3.0]], dtype=np.float64),
+        "mp/cm**3",
+    )
+    data["connect1", "testAgain"] = np.array(
+        [[0.0, 1.0, 3.0], [1.0, 2.0, 3.0]], dtype=np.float64
+    )
+
+    ds = load_unstructured_mesh(connect, coords, data)
+    ad = ds.all_data()
+    ad["connect1", "density"].to("kg/m**3")  # should work
+    ad["connect1", "testAgain"].to("1")  # should work

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -1417,7 +1417,7 @@ def load_unstructured_mesh(
         _f_unit, _data, _ = process_data(d)
         field_units.update(_f_unit)
         sfh[i] = _data
-        particle_types.update(set_particle_types(d))
+        particle_types.update(set_particle_types(_data))
 
     grid_left_edges = domain_left_edge
     grid_right_edges = domain_right_edge


### PR DESCRIPTION
## PR Summary

This fixes a bug preventing users to pass in data with units to the unstructured mesh loaders.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- ~[ ] New features are documented, with docstrings and narrative docs~
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
