### PR TITLE
BLD: avoid direct dependency on wheel library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ requires = [
   "Cython>=3.0.3",
   "numpy>=2.0.0",
   "ewah-bool-utils>=1.2.0",
-  "wheel>=0.38.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ from setupext import (
     check_for_pyembree,
     create_build_ext,
     get_python_include_dirs,
+    get_setup_options,
     install_ccompiler,
 )
 
@@ -83,7 +84,7 @@ cythonize_aliases.update(embree_aliases)
 lib_exts += embree_libs
 
 # This overrides using lib_exts, so it has to happen after lib_exts is fully defined
-build_ext, sdist, bdist_wheel = create_build_ext(lib_exts, cythonize_aliases)
+build_ext, sdist = create_build_ext(lib_exts, cythonize_aliases)
 
 
 # Force setuptools to consider that there are ext modules, even if empty.
@@ -122,8 +123,9 @@ if __name__ == "__main__":
     )
 
     setup(
-        cmdclass={"sdist": sdist, "build_ext": build_ext, "bdist_wheel": bdist_wheel},
+        cmdclass={"sdist": sdist, "build_ext": build_ext},
         distclass=BinaryDistribution,
         libraries=[fixed_interp_lib],
         ext_modules=[],  # !!! We override this inside build_ext above
+        options=get_setup_options(),
     )

--- a/setupext.py
+++ b/setupext.py
@@ -19,7 +19,6 @@ from setuptools.command.build_ext import build_ext as _build_ext
 from setuptools.command.sdist import sdist as _sdist
 from setuptools.errors import CompileError, LinkError
 import importlib.resources as importlib_resources
-from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 
 log = logging.getLogger("setupext")
 
@@ -491,13 +490,10 @@ def create_build_ext(lib_exts, cythonize_aliases):
             )
             _sdist.run(self)
 
-    class bdist_wheel(_bdist_wheel):
-        def get_tag(self):
-            python, abi, plat = super().get_tag()
+    return build_ext, sdist
 
-            if python.startswith("cp") and USE_PY_LIMITED_API:
-                return f"cp{ABI3_TARGET_VERSION}", "abi3", plat
-
-            return python, abi, plat
-
-    return build_ext, sdist, bdist_wheel
+def get_setup_options():
+    if USE_PY_LIMITED_API:
+        return {"bdist_wheel": {"py_limited_api": f"cp{ABI3_TARGET_VERSION}"}}
+    else:
+        return {}


### PR DESCRIPTION
## PR Summary

While setting up abi3 wheels for another package (h5py), I discovered this cleaner way to achieve the same result; instead of overriding the `get_tag` method, we just pass `py_limited_api` as an option.