### PR TITLE
TST: avoid mpl API pending-deprecation (`Colormap.set_bad`)

### DIFF
--- a/yt/visualization/tests/test_image_comp_2D_plots.py
+++ b/yt/visualization/tests/test_image_comp_2D_plots.py
@@ -437,8 +437,7 @@ class TestSetBackgroundColor:
         p.set_background_color(field, color="black")
 
         # copy the default colormap
-        cmap = mpl.colormaps["cmyt.arbre"]
-        cmap.set_bad("red")
+        cmap = mpl.colormaps["cmyt.arbre"].with_extremes(bad="red")
         p.set_cmap(field, cmap)
 
         p.render()


### PR DESCRIPTION
## PR Summary

[example logs](https://github.com/yt-project/yt/actions/runs/18231134374)
xref: https://github.com/matplotlib/matplotlib/pull/30531
The blessed replacement is available since matplotlib 3.4, and we already require >=3.6 so we can simply migrate.
backporting to improve testability on the backport branch
