### PR TITLE
Allow non-cosmological halo catalogs

### DIFF
--- a/yt/frontends/halo_catalog/data_structures.py
+++ b/yt/frontends/halo_catalog/data_structures.py
@@ -353,7 +353,7 @@ class HaloDataset(ParticleDataset):
             "omega_matter",
             "unique_identifier",
         ]:
-            setattr(self, attr, getattr(self.real_ds, attr))
+            setattr(self, attr, getattr(self.real_ds, attr, None))
 
     def set_code_units(self):
         self._set_code_unit_attributes()


### PR DESCRIPTION
This resolves Issue #5096. We have been assuming that halo catalogs only come from cosmological datasets, but that doesn't have to be the case. This allows for that by providing a default of None to getattr when passing down dataset attributes. The original bug can be triggered by running a halo finder on, for example, IsolatedGalaxy, and then attempting to load the resulting output.