### PR TITLE
Raise exception when index does not have print_stats method

### DIFF
--- a/yt/data_objects/static_output.py
+++ b/yt/data_objects/static_output.py
@@ -649,7 +649,10 @@ class Dataset(abc.ABC):
 
     @parallel_root_only
     def print_stats(self):
-        self.index.print_stats()
+        func = getattr(self.index, "print_stats", None)
+        if func is None:
+            raise NotImplementedError(f"{type(self.index)} has no print_stats method.")
+        func()
 
     @property
     def field_list(self):

--- a/yt/data_objects/tests/test_dataset_access.py
+++ b/yt/data_objects/tests/test_dataset_access.py
@@ -1,3 +1,5 @@
+from unittest import TestCase
+
 import numpy as np
 from nose.tools import assert_raises
 from numpy.testing import assert_almost_equal, assert_equal
@@ -182,6 +184,12 @@ def test_ortho_ray_from_r():
     ray7 = ds.r[0.25:0.75:100j, 0.3, 0.2]
     ray8 = LineBuffer(ds, [0.2525, 0.3, 0.2], [0.7475, 0.3, 0.2], 100)
     assert_equal(ray7["gas", "density"], ray8["gas", "density"])
+
+
+def test_no_print_stats():
+    ds = fake_particle_ds()
+    with TestCase.assertRaises(NotImplementedError):
+        ds.print_stats()
 
 
 def test_particle_counts():


### PR DESCRIPTION
Issue #5096 also noted that `ds.print_stats()` fails uninformatively for index types that don't implement it. This raises a NoteImplementedError that is hopefully a little more useful.