### PR TITLE
ENH: ensure `yt.utils.funcs.ensure_numpy_array` consistently returns a copy

### DIFF
--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -86,15 +86,7 @@ def ensure_numpy_array(obj):
     This function ensures that *obj* is a numpy array. Typically used to
     convert scalar, list or tuple argument passed to functions using Cython.
     """
-    if isinstance(obj, np.ndarray):
-        if obj.shape == ():
-            return np.array([obj])
-        # We cast to ndarray to catch ndarray subclasses
-        return np.array(obj)
-    elif isinstance(obj, (list, tuple)):
-        return np.asarray(obj)
-    else:
-        return np.asarray([obj])
+    return np.atleast_1d(np.array(obj))
 
 
 def read_struct(f, fmt):


### PR DESCRIPTION
## PR Summary
I noticed this function could be heavily simplified, but also, and perhaps more importantly, that its return type would sometimes be a copy of the input data, but not always. This looks like a footgun so I'd rather make it always return a copy, so as to avoid subtle bugs.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
