### PR TITLE
WHL: test macos-x86_64 wheels on native runners

### DIFF
--- a/.github/workflows/wheels.yaml
+++ b/.github/workflows/wheels.yaml
@@ -33,7 +33,7 @@ jobs:
           archs: x86_64
           select: '*musllinux*'
           id: musllinux_x86_64
-        - os: macos-latest
+        - os: macos-15-intel
           archs: x86_64
           select: '*'
           id: macos_x86_64


### PR DESCRIPTION
## PR Summary
Native runners for this target are available for free again. Native compilation is actually *slower* than cross-compilation from macos-arm64 runners, but the bottleneck is running tests 5 times, not compiling twice, so I expect this should overall yield shorter build times.