### PR TITLE
[ENH] Allow generic octree datasets to load fields from a function

### DIFF
--- a/yt/frontends/stream/io.py
+++ b/yt/frontends/stream/io.py
@@ -258,6 +258,9 @@ class IOHandlerStreamOctree(BaseIOHandler):
                     field_vals[field] = self.fields[
                         subset.domain_id - subset._domain_offset
                     ][field]
+
+                    if callable(field_vals[field]):
+                        field_vals[field] = field_vals[field]()
                 subset.fill(field_vals, rv, selector, ind)
         return rv
 

--- a/yt/loaders.py
+++ b/yt/loaders.py
@@ -1124,6 +1124,8 @@ def load_octree(
     >>> octree_mask = np.array(oct_mask, dtype=np.uint8)
     >>> quantities = {}
     >>> quantities["gas", "density"] = np.random.random((29, 1)) # num of false's
+    >>> # Quantities can also contain parameter-less callbacks
+    >>> quantities["gas", "temperature"] = lambda: np.random.random((29, 1)) * 1e4
     >>> bbox = np.array([[-10.0, 10.0], [-10.0, 10.0], [-10.0, 10.0]])
 
     >>> ds = load_octree(

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -1080,10 +1080,11 @@ def fake_octree_ds(
 
     if quantities is None:
         quantities = {}
+        # Try both callable and arrays
         quantities["gas", "density"] = prng.random_sample((particles, 1))
         quantities["gas", "velocity_x"] = prng.random_sample((particles, 1))
         quantities["gas", "velocity_y"] = prng.random_sample((particles, 1))
-        quantities["gas", "velocity_z"] = prng.random_sample((particles, 1))
+        quantities["gas", "velocity_z"] = lambda: prng.random_sample((particles, 1))
 
     ds = load_octree(
         octree_mask=octree_mask,


### PR DESCRIPTION
## PR Summary

Fixes #5337. It allows passing a callable in the data dictionary which will only be read when required for lazy-loading.

## PR Checklist

- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.