### PR TITLE
[BUG/ENH] RAMSES: Support non-Hilbert decomposition

### DIFF
--- a/yt/frontends/ramses/data_structures.py
+++ b/yt/frontends/ramses/data_structures.py
@@ -261,8 +261,15 @@ class RAMSESDomainFile:
             else:
                 self._ngridbound = np.zeros(hvals["nlevelmax"], dtype="int64")
             _free_mem = f.read_attrs((("free_mem", 5, "i"),))
-            _ordering = f.read_vector("c")
-            f.skip(4)
+            ordering = f.read_vector("c")
+            ordering = "".join(_.decode() for _ in ordering).strip()
+            if ordering == "hilbert":
+                Nskip = 1  # bound_key
+            elif ordering == "bisection":
+                Nskip = 5  #  bisec_wall, bisec_next, bisec_indx, bisec_cpubox_min, bisec_cpubox_max
+            else:
+                raise RuntimeError(f"Unknown ordering {ordering!r} in AMR file")
+            f.skip(Nskip + 3)  # skip son, flag1, cpu_map
             # Now we're at the tree itself
             # Now we iterate over each level and each CPU.
             position = f.tell()


### PR DESCRIPTION
See https://github.com/ramses-organisation/ramses/issues/72.

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

RAMSES has a well-hidden option to use a domain-decomposition strategy that isn't based on a Hilbert curve decomposition. This PR adds support for this case. Unfortunately, due to the rarity of this option, I don't have any dataset at hand to test it, but my colleagues (@matthiasglz) confirmed this fixed the issue.