### PR TITLE
MNT: setup `.github/CODEOWNERS` and sign myself up

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,30 @@
+# Auto request reviews from specific users or teams matching patterns
+#
+# - the yt-project retains ownership of any code within this repo unless explicitly stated otherwise
+# - automated requests for reviews are informational and not binding: any party remains
+#   free to conduct reviews or not
+# - opting in is purely on a voluntary basis and cannot be done by a third party
+# - opting out does not require the person or team to open a PR themselves
+# but stakeholders should be contacted if done by a third party.
+#
+# Documentation at
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# general dependency and CI management
+pyproject.toml              @neutrinoceros
+uv.lock                     @neutrinoceros
+.pre-commit-config.yaml     @neutrinoceros
+.git(|hub)                  @neutrinoceros
+
+
+# build
+setup(|ext).py              @neutrinoceros
+MANIFEST.in                 @neutrinoceros
+
+
+# testing
+conftest.py                 @neutrinoceros
+
+
+# frontends
+yt/frontends/amrvac         @neutrinoceros


### PR DESCRIPTION
## PR Summary

This comes from a personal need to control the amount of notifications I get from GitHub as a whole; I cannot handle being notified about *all* activity on the repo, but I still would like to be systematically informed when certain files changes. `.github/CODEOWNERS` offers the mechanism to do just that, so I propose we addopt it.

> [!IMPORTANT]
> The filename is somewhat unfortunate as it doesn't actually have anything to do with ownership of the code, mind you.

I tried to lay out some basic rules to clarify how this file is meant to be used and updated in the future. In short:
- the bar for signing in is low, but requires explicit action from interested parties[^1]
- the bar for signing out is also low
- the terms are explicitly liberal and non binding: automated request should never constitute obligations for anyone.

Anyone is free to join me and sign up for notifications about certain updates, but no one *needs* to.

Thoughts ?

[^1]: I don't expect non-members to ever use it but it's an open possibility
