### PR TITLE
rm ruff ignore for deprecrated rule UP038

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -309,7 +309,6 @@ ignore = [
     "E501",  # line too long
     "E741",  # Do not use variables named 'I', 'O', or 'l'
     "B018",  # Found useless expression. # disabled because ds.index is idiomatic
-    "UP038", # non-pep604-isinstance
 ]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
Noticed a warning when running pre-commit locally

```
warning: The following rules have been removed and ignoring them has no effect:
    - UP038
```

https://docs.astral.sh/ruff/rules/non-pep604-isinstance/
