### PR TITLE
Reserve npt for numpy.typing

### DIFF
--- a/yt/visualization/tests/test_image_comp_2D_plots.py
+++ b/yt/visualization/tests/test_image_comp_2D_plots.py
@@ -3,7 +3,7 @@ from itertools import chain
 
 import matplotlib as mpl
 import numpy as np
-import numpy.testing as npt
+import numpy.testing as nptesting
 import pytest
 from matplotlib.colors import SymLogNorm
 
@@ -38,7 +38,7 @@ def test_sliceplot_set_unit_and_zlim_order():
     im0 = p0.plots[field].image._A
     im1 = p1.plots[field].image._A
 
-    npt.assert_allclose(im0, im1)
+    nptesting.assert_allclose(im0, im1)
 
 
 def test_annotation_parse_h():
@@ -69,7 +69,7 @@ def test_annotation_parse_h():
     img2 = p2.plots["gas", "density"].figure.canvas.renderer.buffer_rgba()
 
     # This should be the same image
-    npt.assert_allclose(img1, img2)
+    nptesting.assert_allclose(img1, img2)
 
 
 @pytest.mark.mpl_image_compare

--- a/yt/visualization/tests/test_set_zlim.py
+++ b/yt/visualization/tests/test_set_zlim.py
@@ -1,5 +1,5 @@
 import numpy as np
-import numpy.testing as npt
+import numpy.testing as nptesting
 import pytest
 
 from yt.testing import fake_amr_ds
@@ -24,7 +24,7 @@ def test_float_vmin_then_set_unit():
     p.render()
     cb = p.plots[field].image.colorbar
     new_lims = np.array((cb.vmin, cb.vmax))
-    npt.assert_almost_equal(new_lims, desired_lims)
+    nptesting.assert_almost_equal(new_lims, desired_lims)
 
     # 1 g/cm**3 == 1000 kg/m**3
     p.set_unit(field, "kg/m**3")
@@ -32,7 +32,7 @@ def test_float_vmin_then_set_unit():
 
     cb = p.plots[field].image.colorbar
     new_lims = np.array((cb.vmin, cb.vmax))
-    npt.assert_almost_equal(new_lims, 1000 * desired_lims)
+    nptesting.assert_almost_equal(new_lims, 1000 * desired_lims)
 
 
 def test_set_unit_then_float_vmin():
@@ -70,7 +70,7 @@ def test_reset_zlim():
 
     cb = p.plots[field].image.colorbar
     new_lims = np.array((cb.vmin, cb.vmax))
-    npt.assert_array_equal(new_lims, raw_lims)
+    nptesting.assert_array_equal(new_lims, raw_lims)
 
 
 def test_set_dynamic_range_with_vmin():
@@ -86,7 +86,7 @@ def test_set_dynamic_range_with_vmin():
     p.render()
     cb = p.plots[field].image.colorbar
     new_lims = np.array((cb.vmin, cb.vmax))
-    npt.assert_almost_equal(new_lims, (zmin, 2 * zmin))
+    nptesting.assert_almost_equal(new_lims, (zmin, 2 * zmin))
 
 
 def test_set_dynamic_range_with_vmax():
@@ -102,7 +102,7 @@ def test_set_dynamic_range_with_vmax():
     p.render()
     cb = p.plots[field].image.colorbar
     new_lims = np.array((cb.vmin, cb.vmax))
-    npt.assert_almost_equal(new_lims, (zmax / 2, zmax))
+    nptesting.assert_almost_equal(new_lims, (zmax / 2, zmax))
 
 
 def test_set_dynamic_range_with_min():
@@ -121,7 +121,7 @@ def test_set_dynamic_range_with_min():
     p.render()
     cb = p.plots[field].image.colorbar
     new_lims = np.array((cb.vmin, cb.vmax))
-    npt.assert_almost_equal(new_lims, (vmin, 2 * vmin))
+    nptesting.assert_almost_equal(new_lims, (vmin, 2 * vmin))
 
 
 def test_set_dynamic_range_with_None():
@@ -141,4 +141,4 @@ def test_set_dynamic_range_with_None():
     p.render()
     cb = p.plots[field].image.colorbar
     new_lims = np.array((cb.vmin, cb.vmax))
-    npt.assert_almost_equal(new_lims, (vmin, 2 * vmin))
+    nptesting.assert_almost_equal(new_lims, (vmin, 2 * vmin))


### PR DESCRIPTION
## PR Summary

We've got a couple spots where we `import numpy.testing as npt`, but it's become pretty ubiquitous to `import numpy.typing as npt`. with https://github.com/yt-project/yt/pull/5346, we'll have a bunch more uses of `numpy.typing as npt` across the codebase , so this PR cleans up just a few spots to avoid future alias collisions (5346 will change the one remaining stop in `yt/testing.py` not touched by this PR).

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
