### PR TITLE
Fix trailing whitespace in RAMSES sink particle field name

### DIFF
--- a/yt/frontends/ramses/io.py
+++ b/yt/frontends/ramses/io.py
@@ -159,6 +159,7 @@ def _ramses_particle_csv_file_handler(
     dat = pd.read_csv(
         fname,
         delimiter=r"\s*,\s*",
+        engine="python",
         usecols=[ind for _field, ind in list_field_ind],
         skiprows=2,
         header=None,
@@ -400,7 +401,7 @@ def _read_part_csv_file_descriptor(fname: Union[str, "os.PathLike[str]"]):
     }
 
     # read the all file to get the number of particle
-    dat = pd.read_csv(fname, delimiter=r"\s*,\s*")
+    dat = pd.read_csv(fname, delimiter=r"\s*,\s*", engine="python")
     fields = []
     local_particle_count = len(dat)
 


### PR DESCRIPTION
<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

This PR fixes a small bug where RAMSES sink particle fields contained unintentional trailing whitespace (e.g., `'particle_level '` instead of `'particle_level'`) when reading sink csv file. It fixes https://github.com/yt-project/yt/issues/5350.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
