### PR TITLE
TST: adjust bleeding-edge CI to avoid uninstalling pre-releases of direct dependencies

### DIFF
--- a/.github/workflows/bleeding-edge.yaml
+++ b/.github/workflows/bleeding-edge.yaml
@@ -54,15 +54,15 @@ jobs:
 
     - name: Install dependencies
       run: |
-        uv pip install setuptools numpy matplotlib Cython ewah-bool-utils
         uv add --no-install-project git+https://github.com/yt-project/unyt.git
         uv add --no-install-project --optional test git+https://github.com/pytest-dev/pytest.git
+        uv pip install --upgrade setuptools numpy matplotlib Cython ewah-bool-utils
 
     - name: Build
       # --no-build-isolation is used to guarantee that build time dependencies
       # are not installed by uv sync as specified from pyproject.toml, hence we get
       # to use the dev version of numpy at build time.
-      run: uv sync --extra test --no-build-isolation
+      run: uv pip install --editable .[test] --no-build-isolation
 
     - run: yt config set --local yt log_level 50  # Disable excessive output
     - name: Run Tests


### PR DESCRIPTION
## PR Summary

I was wondering why bleeding-edge CI wasn't failing now that numpy dev *has* deprecated mutations to `ndarray.shape` attributes. Turns out `uv add` invokes also sync the env to the locked solution, which means we actually drop pre-releases we want to test against. Hopefully this fixes it.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
