### PR TITLE
DOC: update item docstring in off_axis_projection

### DIFF
--- a/yt/visualization/volume_rendering/off_axis_projection.py
+++ b/yt/visualization/volume_rendering/off_axis_projection.py
@@ -59,8 +59,8 @@ def off_axis_projection(
         The number of pixels in each direction.
     item: tuple[str, str] or FieldKey
         The field to project through the volume, e.g. ("gas", "density").
-        This uses YT's (field_type, field_name) field pair. Common field types 
-        include "stream", "gas", "index"; common field names include "density", 
+        This uses YT's (field_type, field_name) field pair. Common field types
+        include "stream", "gas", "index"; common field names include "density",
         "number_density", "velocity_x", "velocity_y", and "velocity_z".
     weight : optional, default None
         If supplied, the field will be pre-multiplied by this, then divided by


### PR DESCRIPTION

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary
In `off_axis_projection`, the docstring specifies that the argument `item` has a type of `string` and provides little information on the current `item` input format. It seems like this part of the docstring was not updated in the upgrade to YT4.0.

This PR updates the ` off_axis_projection` `item` type hint to `tuple[str, str] or FieldKey`, and adds a short description of the (field_type, field_name) field pair.
<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [x] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
