### PR TITLE
Fix YTGridDataset domain_dimensions calculation

### DIFF
--- a/yt/frontends/ytdata/data_structures.py
+++ b/yt/frontends/ytdata/data_structures.py
@@ -528,7 +528,7 @@ class YTGridDataset(YTDataset):
                 self.domain_right_edge = (
                     self.domain_left_edge + self.parameters["ActiveDimensions"] * dx
                 )
-                self.domain_dimensions = (
+                self.domain_dimensions = np.rint(
                     (self.domain_right_edge - self.domain_left_edge) / dx
                 ).astype("int64")
             else:


### PR DESCRIPTION
Fix a bug which sometimes sets the inferred dimension incorrectly (by flooring the value instead of rounding) when loading a YTGridDataset, leading to errors when trying to read the data. For example, when loading a covering grid which had been saved as a .h5 file. 