### PR TITLE
Fix base64 deprecation

### DIFF
--- a/yt/funcs.py
+++ b/yt/funcs.py
@@ -436,9 +436,14 @@ _ss = "fURbBUUBE0cLXgETJnZgJRMXVhVGUQpQAUBuehQMUhJWRFFRAV1ERAtBXw1dAxMLXT4zXBFfA
 
 
 def _rdbeta(key):
-    enc_s = base64.decodestring(_ss)
-    dec_s = "".join(chr(ord(a) ^ ord(b)) for a, b in zip(enc_s, itertools.cycle(key)))
+    enc_s = base64.decodebytes(_ss.encode("ascii"))
+
+    key_b = key.encode("utf-8") if isinstance(key, str) else key
+
+    dec_b = bytes(a ^ b for a, b in zip(enc_s, itertools.cycle(key_b)))
+    dec_s = dec_b.decode("latin-1")
     print(dec_s)
+    return dec_s
 
 
 #

--- a/yt/tests/test_decodestring.py
+++ b/yt/tests/test_decodestring.py
@@ -1,0 +1,4 @@
+def test__rdbeta_py3_does_not_crash():
+    from yt.funcs import _rdbeta
+
+    _rdbeta("k")


### PR DESCRIPTION

## PR Summary

PR Summary

This PR updates the internal _rdbeta helper function to replace the deprecated base64.decodestring API with base64.decodebytes.

In addition, it fixes Python 3 byte handling in the XOR decoding logic. The previous implementation mixed str and bytes types and relied on ord() calls that raise TypeError under Python 3 (since iterating over bytes yields integers).

The updated implementation performs the XOR operation directly on byte values and decodes the result in a Python 3–compatible manner. This change preserves behavior while preventing runtime errors and future compatibility issues with newer Python versions.

## PR Checklist

Adds a test for any bugs fixed. Adds tests for new features.
