### PR TITLE
[RAMSES] Optimisation: fast bbox rejection when finding intersecting domains

### DIFF
--- a/yt/frontends/ramses/hilbert.py
+++ b/yt/frontends/ramses/hilbert.py
@@ -75,7 +75,7 @@ def get_intersecting_cpus(
     dx_cond: float | None = None,
     factor: float = 4.0,
     bound_keys: Optional["np.ndarray[Any, np.dtype[np.float64]]"] = None,
-    bbox: Optional[Any] = None,
+    bbox: Any | None = None,
 ) -> set[int]:
     """
     Find the subset of CPUs that intersect the bbox in a recursive fashion.


### PR DESCRIPTION
## PR Summary

When deciding which files to load from a RAMSES dataset to get data for a YTRegion, we do a recursive check on the overlap between the YTRegion's bbox and the space covered by a cpu. The current implementation takes a very long time (~hours) to find the intersecting cpus for a thin disk (whose height can be only a few cells) inside of a large simulation volume, as it gets stuck in extremely deep/expensive recursion. I add here an initial check that the cube is within the bbox, reducing the number of subcubes visited for small/thin disks. This brings down the intersection computation time for thin disks to a few seconds, while leaving the behavior for spheres and bulkier regions seemingly unchanged (although this could be checked more extensively.)
