### PR TITLE
Fix incorrect particle coordinate scaling in fake_amr_ds (use *= inst…

### DIFF
--- a/yt/test_fake_amr_ds_particle_positions_within_domain.py
+++ b/yt/test_fake_amr_ds_particle_positions_within_domain.py
@@ -1,0 +1,11 @@
+from yt.testing import fake_amr_ds
+
+
+def test_fake_amr_ds_particles_within_grid_bounds():
+    ds = fake_amr_ds(particles=100)
+
+    for g in ds.index.grids:
+        px = g["io", "particle_position_x"]
+        le = g.LeftEdge[0].value
+        re = g.RightEdge[0].value
+        assert (px >= le).all() and (px < re).all()

--- a/yt/testing.py
+++ b/yt/testing.py
@@ -482,7 +482,7 @@ def fake_amr_ds(
         if particles:
             for i, f in enumerate(f"particle_position_{ax}" for ax in "xyz"):
                 pdata = prng.random_sample(particles)
-                pdata /= right_edge[i] - left_edge[i]
+                pdata *= right_edge[i] - left_edge[i]
                 pdata += left_edge[i]
                 gdata["io", f] = (pdata, "code_length")
             for f in (f"particle_velocity_{ax}" for ax in "xyz"):


### PR DESCRIPTION

## PR Summary

Fix incorrect particle coordinate scaling in fake_amr_ds.
Particle positions were mistakenly scaled using division instead of multiplication, which could place particles outside their grid bounds. This change restores correct linear mapping to [left_edge, right_edge) and adds a regression test.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ yes] Adds a test for any bugs fixed. Adds tests for new features.
