### PR TITLE
STY: enforce `RUF031` in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,15 @@ repos:
       --fix,
       --show-fixes,
     ]
+  - id: ruff-check
+    name: ruff-check (preview)
+    args: [
+      --preview,
+      --fix,
+      --show-fixes,
+      --select,
+      RUF031, # incorrectly-parenthesized-tuple-in-subscript
+    ]
 
 -   repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.10.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -303,7 +303,6 @@ select = [
     "UP",   # pyupgrade
     "I",    # isort
     "NPY",  # numpy specific rules
-    "RUF031"# incorrectly-parenthesized-tuple-in-subscript
 ]
 ignore = [
     "E501",  # line too long

--- a/yt/visualization/tests/test_offaxisprojection_pytestonly.py
+++ b/yt/visualization/tests/test_offaxisprojection_pytestonly.py
@@ -236,5 +236,5 @@ def test_offaxisprojection_sph_defaultdepth(normal_vec, n_particles):
     p.render()
 
     # get the number of circles in the plot
-    cg = contour_generator(z=p.frb[("gas", "mass")].d)
+    cg = contour_generator(z=p.frb["gas", "mass"].d)
     assert n_particles == len(cg.lines(1.0))


### PR DESCRIPTION
A bit of background: this linting rule was implemented in `ruff` specifically because we requested it for usage in `yt`. I originally selected the rule at the global level, knowning it was still in "preview" (i.e. unstable) mode, which had no effect beyond triggering a warning, because I was expecting it would be stabilized soon after. This hasn't happened (yet), presumably for a lack of feedback.
Because the rule was *tailored* for an idiom very commonly seen in `yt`, I figure it would make sense that *we* beta-test the unstable (but so far, absolutely correct) implementation so we can later confidently ask it be marked stable without change.



refs:
- https://github.com/yt-project/yt/pull/4844
- https://github.com/astral-sh/ruff/issues/11990
- https://github.com/astral-sh/ruff/pull/12480