### PR TITLE
[BUGFIX] Fix missing paramter when expanding dimensions in particle deposition

### DIFF
--- a/yt/geometry/particle_deposit.pyx
+++ b/yt/geometry/particle_deposit.pyx
@@ -26,8 +26,7 @@ from yt.utilities.lib.misc_utilities import OnceIndirect
 cdef append_axes(np.ndarray arr, int naxes):
     if arr.ndim == naxes:
         return arr
-    for _ in range((naxes - arr.ndim)):
-        arr = np.expand_dims(arr)
+    arr = np.expand_dims(arr, axis=tuple(range(arr.ndim, naxes)))
     return arr
 
 cdef class ParticleDepositOperation:


### PR DESCRIPTION
## PR Summary

The `expand_dims` was missing its argument (that determines where to expand!).
This fixes a mistake introduced in https://github.com/yt-project/yt/pull/5365 (ce653efac57e1cac6fb89fd2e2c2965548feeca9)

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
