### PR TITLE
Add docs build CI workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,57 @@
+name: Build Documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "doc/**"
+      - "pyproject.toml"
+  pull_request:
+    paths:
+      - "doc/**"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  build-docs:
+    name: Build Sphinx docs
+    runs-on: ubuntu-latest
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    env:
+      READTHEDOCS: "True"
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
+      with:
+        version: ">=0.9.11,<0.10.0"
+        python-version: "3.12"
+        prune-cache: false
+
+    - name: Install pandoc
+      run: sudo apt-get update && sudo apt-get install -y pandoc
+
+    - name: Install dependencies
+      run: uv sync --group=docs
+
+    - name: Build HTML docs
+      run: |
+        cd doc
+        uv run make html
+
+    - name: Upload built docs
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: yt-docs-html
+        path: doc/build/html/

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -6,10 +6,12 @@ on:
       - main
     paths:
       - "doc/**"
+      - ".github/workflows/docs.yaml"
       - "pyproject.toml"
   pull_request:
     paths:
       - "doc/**"
+      - ".github/workflows/docs.yaml"
   workflow_dispatch:
 
 permissions: {}
@@ -35,9 +37,8 @@ jobs:
     - name: Set up uv
       uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6
       with:
-        version: ">=0.9.11,<0.10.0"
         python-version: "3.12"
-        prune-cache: false
+        enable-cache: false
 
     - name: Install pandoc
       run: sudo apt-get update && sudo apt-get install -y pandoc


### PR DESCRIPTION
Picks up the stalled work from #4391. The docs site has been down for about a year, and this adds a CI workflow to validate Sphinx builds on PRs and pushes to main.

## Changes
- New workflow: `.github/workflows/docs.yaml`
- Triggers on pushes to `main` and PRs that touch `doc/`
- Uses `uv sync --group=docs` (consistent with existing CI)
- Uploads built HTML as an artifact for review
- No linkcheck (per @zingale comment, too many false positives from site blocking)

## Fixes from the original PR
- Branch references: `main` only (no `development`)
- Dependencies: `uv sync --group=docs` instead of `pip install -r ./requirements.txt` (file does not exist)
- Directory: `doc/` not `docs/`
- Action versions: pinned SHAs matching the rest of the repo
- Skips cookbook script execution via `READTHEDOCS=True` to avoid data dependency issues

## What this does NOT do
- Does not deploy to GitHub Pages (separate discussion)
- Does not run linkcheck
- Does not change conf.py or any existing files

## Test plan
- [ ] Workflow YAML is valid
- [ ] Sphinx HTML build succeeds
- [ ] Built docs artifact is downloadable