### PR TITLE
[ENH] Preserve units with all_reduce MPI comms

### DIFF
--- a/yt/utilities/parallel_tools/parallel_analysis_interface.py
+++ b/yt/utilities/parallel_tools/parallel_analysis_interface.py
@@ -972,16 +972,27 @@ class Communicator:
                 )
                 for deeper_key in first_value.keys()
             }
+
+        # Get units (if any) from first value; we assume all values have the same
+        units = getattr(first_value, "units", None)
+        if self._distributed:
+            units = self.comm.bcast(units, root=0)
+
+        if units is not None:
+            inputs = (d.to(units).value for d in data.values())
         else:
-            # Otherwise, we assume our values can be concatenated
-            reduced_values = reduction_op([reduction_op(d) for d in data.values()])
+            inputs = data.values()
 
-            if self._distributed:
-                reduced_values = self.comm.allreduce(
-                    reduced_values, op=mpi_reduction_op
-                )
+        # Otherwise, we assume our values can be concatenated
+        reduced_values = reduction_op([reduction_op(d) for d in inputs])
 
-            return reduced_values
+        if units is not None:
+            reduced_values = reduced_values * units
+
+        if self._distributed:
+            reduced_values = self.comm.allreduce(reduced_values, op=mpi_reduction_op)
+
+        return reduced_values
 
     def all_concat(self, data: dict[Any, npt.NDArray | dict[str, npt.NDArray]]):
         """


### PR DESCRIPTION
Fixes #5428. When we apply np.sum([x, y, z]), with x, y and z unyt values/arrays, the argument gets coerced into a numpy array and hence strips the units. Here, I just add back the units (if any).

<!--Thank you so much for your PR! To help us review, fill out the form
to the best of your ability.  Please make use of the development guide at
http://yt-project.org/docs/dev/developing/index.html-->

<!--Provide a general summary of your changes in the title above, for
example "Raises ValueError on Non-Numeric Input to set_xlim".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

<!--If you are able to do so, please do not create the PR out of main, but out
of a separate branch. -->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
