### PR TITLE
[BUG] Make Gizmo's `creation_time` field robust against empty chunks

### DIFF
--- a/yt/frontends/gizmo/fields.py
+++ b/yt/frontends/gizmo/fields.py
@@ -147,13 +147,16 @@ class GizmoFieldInfo(GadgetFieldInfo):
             setup_magnetic_field_aliases(self, ptype, magnetic_field)
 
     def setup_star_particle_fields(self, ptype):
-        def _creation_time(data):
+        def _creation_time(field, data):
+            t_form = data[ptype, "StellarFormationTime"]
+
+            if t_form.size == 0:
+                return data.ds.arr([], data.ds.unit_system["time"])
+
             if data.ds.cosmological_simulation:
-                a_form = data[ptype, "StellarFormationTime"]
-                z_form = 1 / a_form - 1
+                z_form = 1 / t_form - 1
                 creation_time = data.ds.cosmology.t_from_z(z_form)
             else:
-                t_form = data[ptype, "StellarFormationTime"]
                 creation_time = data.ds.arr(t_form, "code_time")
             return creation_time
 

--- a/yt/frontends/gizmo/tests/test_outputs.py
+++ b/yt/frontends/gizmo/tests/test_outputs.py
@@ -132,6 +132,7 @@ def test_star_particle_fields():
     for field in derived_fields:
         assert (ptype, field) in ds.derived_field_list
 
+
 @requires_module("h5py")
 @requires_file("FIRE_M12i_ref11/snapshot_600.hdf5")
 def test_gizmo_creation_time_handles_empty_particle_chunks():

--- a/yt/frontends/gizmo/tests/test_outputs.py
+++ b/yt/frontends/gizmo/tests/test_outputs.py
@@ -131,3 +131,30 @@ def test_star_particle_fields():
     derived_fields = ["creation_time", "age"]
     for field in derived_fields:
         assert (ptype, field) in ds.derived_field_list
+
+@requires_module("h5py")
+@requires_file("FIRE_M12i_ref11/snapshot_600.hdf5")
+def test_gizmo_creation_time_handles_empty_particle_chunks():
+    ds = yt.load("FIRE_M12i_ref11/snapshot_600.hdf5")
+
+    def young_stars(pfilter, data):
+        age = data[pfilter.filtered_type, "age"]
+        return age.in_units("Myr") <= 10
+
+    yt.add_particle_filter(
+        "young_stars",
+        function=young_stars,
+        filtered_type="PartType4",
+        requires=["age"],
+    )
+
+    ds.add_particle_filter("young_stars")
+
+    ad = ds.all_data()
+    com = ad.quantities.center_of_mass(
+        use_gas=False,
+        use_particles=True,
+        particle_type="young_stars",
+    )
+
+    assert com.shape == (3,)


### PR DESCRIPTION
## PR Summary

The gizmo frontend's `creation_time` derived field assumes that each data chunk contains at least one star particle. When evaluating particle filters over chunked data, some chunks may contain zero particles of the filtered parent type. In this case, the `creation_time` field is evaluated on an empty array, which propagates into a call to:

`data.ds.cosmology.t_from_z(z_form)`

and ultimately raises the erorr:

`ValueError: zero-size array to reduction operation minimum which has no identity`

This issue arises in workflows that combine: particle filters, derived quantities, and chunked data access.

This PR modifies the GIZMO `creation_time` field to explicitly handle empty inputs:

If `StellarFormationTime` has zero size, return an empty yt array with appropriate time units.
Otherwise, proceed with the existing cosmological or non-cosmological calculation.

This ensures that downstream derived fields and particle filters behave correctly when applied to chunks with zero particles.

This PR resolves Issue #5439 .

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [X] New features are documented, with docstrings and narrative docs
- [X ] Adds a test for any bugs fixed. Adds tests for new features.