### PR TITLE
MPI-AMRVAC support for uniformly stretched grids

### DIFF
--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -220,6 +220,31 @@ overriding a maximum of three units. Allowed unit combinations at the moment are
 Appropriate errors are thrown for other combinations.
 
 
+.. rubric:: Stretched grids
+
+To inform yt that the data is represented on a stretched grid,
+define ``stretch_dim`` in a parfile in ``meshlist``
+
+.. code-block:: fortran
+   &meshlist
+      stretch_dim(1) = 'uni'
+   /
+
+and pass the parfile to yt when loading the data:
+
+.. code-block:: python
+
+  ds = yt.load("output0010.dat", parfiles="amrvac.par")
+
+Both indexed statements (``stretch_dim(1)='uni'``) and array definitions
+(``stretch_dim='uni','',''``) are accepted in the parfile.
+
+* Only uniform stretching is supported at the moment, to be defined
+  as ``'uni'`` or ``'uniform'``.
+* At present, stretched grids are only supported on a
+  single level of refinement.
+
+
 .. rubric:: Partially supported and unsupported features
 
 * a maximum of 100 dust species can be read by yt at the moment.

--- a/doc/source/examining/loading_data.rst
+++ b/doc/source/examining/loading_data.rst
@@ -253,11 +253,6 @@ Both indexed statements (``stretch_dim(1)='uni'``) and array definitions
 * particle data: currently not supported (but might come later)
 * staggered grids (AMRVAC 2.2 and later): yt logs a warning if you load
   staggered datasets, but the flag is currently ignored.
-* "stretched grids" are being implemented in yt, but are not yet
-  fully-supported.  (Previous versions of this file suggested they would
-  "never" be supported, which we hope to prove incorrect once we finish
-  implementing stretched grids in AMR.  At present, stretched grids are
-  only supported on a single level of refinement.)
 
 .. note::
 

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -198,6 +198,7 @@ class AMRVACHierarchy(GridIndex):
             qstretch = np.zeros((21, self.ds.dimensionality), dtype="float64")
             dxfirst = np.zeros((21, self.ds.dimensionality), dtype="float64")
             nstretchedblocks = np.zeros((20, self.ds.dimensionality), dtype="int32")
+            dxmid = np.zeros((21, self.ds.dimensionality), dtype="float64")
             if "qstretch_baselevel" not in meshlist:
                 # compute default values dynamically, just as done in AMRVAC
                 stretched_dims = [bool(k) for k in self.stretch_dim]
@@ -270,7 +271,7 @@ class AMRVACHierarchy(GridIndex):
                             )
                             dxmid[ilev, dim] = dxmid[ilev - 1, dim] / 2.0
             dxfirst_1mq = dxfirst / (1.0 - qstretch)
-        
+
         for igrid, (ytlevel, morton_index) in enumerate(
             zip(ytlevels, morton_indices, strict=True)
         ):

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -223,7 +223,8 @@ class AMRVACHierarchy(GridIndex):
                     dx = dx0 / self.dataset.refine_by**ytlevel
                     left_edge[dim] = xmin[dim] + (morton_index[dim] - 1) * block_nx[dim] * dx[dim]
                     right_edge[dim] = left_edge[dim] + block_nx[dim] * dx[dim]
-                    cell_widths[dim, :] = dx[dim]
+                    for i in range(block_nx[dim]):
+                        cell_widths[dim, ndim * i + dim] = dx[dim]
                 elif self.stretch_dim[dim] in ["uni", "uniform"]:
                     # left edge
                     center1 = (xmin[dim] + 0.5 * dxfirst[ytlevel+1, dim]) * qstretch[ytlevel+1, dim] ** ((morton_index[dim] - 1) * block_nx[dim])
@@ -240,9 +241,9 @@ class AMRVACHierarchy(GridIndex):
                         cell_widths[dim, ndim * i + dim] = dcenter
             
             # edges and dimensions are filled in a dimensionality-agnostic way
-            self.grid_left_edge[igrid, :dim] = left_edge
-            self.grid_right_edge[igrid, :dim] = right_edge
-            self.grid_dimensions[igrid, :dim] = block_nx
+            self.grid_left_edge[igrid, :ndim] = left_edge
+            self.grid_right_edge[igrid, :ndim] = right_edge
+            self.grid_dimensions[igrid, :ndim] = block_nx
             self.grids[igrid] = self.grid(
                 id=igrid,
                 index=self,

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -15,7 +15,6 @@ import numpy as np
 from more_itertools import always_iterable
 
 from yt.config import ytcfg
-from yt.data_objects.index_subobjects.grid_patch import AMRGridPatch
 from yt.data_objects.index_subobjects.stretched_grid import StretchedGrid
 from yt.data_objects.static_output import Dataset
 from yt.funcs import mylog, setdefaultattr
@@ -93,7 +92,7 @@ class AMRVACGrid(StretchedGrid):
 
 class AMRVACHierarchy(GridIndex):
     grid = AMRVACGrid
-    
+
     def __init__(self, ds, dataset_type="amrvac"):
         self.dataset_type = dataset_type
         self.dataset = weakref.proxy(ds)

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -97,21 +97,20 @@ class AMRVACHierarchy(GridIndex):
     def __init__(self, ds, dataset_type="amrvac"):
         self.dataset_type = dataset_type
         self.dataset = weakref.proxy(ds)
-        self._verify_uniformity()
         # the index file *is* the datfile
         self.index_filename = self.dataset.parameter_filename
         self.directory = os.path.dirname(self.index_filename)
         self.float_type = np.float64
 
-        super().__init__(ds, dataset_type)
+        self.stretch_dim = [self.dataset.dimensionality * "none"]
+        if self.dataset.namelist is not None:
+            meshlist = self.dataset.namelist["meshlist"]
+            if (stretch_dim := meshlist.get("stretch_dim")) is not None:
+                assert isinstance(stretch_dim, list)
+                assert len(stretch_dim) >= self.dataset.dimensionality
+                self.stretch_dim = stretch_dim
 
-    def _verify_uniformity(self):
-        """Check whether the dataset is nonuniform (i.e. has stretched grids)."""
-        meshlist = self.dataset.namelist["meshlist"]
-        if (stretch_dim := meshlist.get("stretch_dim")) is not None:
-            assert isinstance(stretch_dim, list)
-            assert len(stretch_dim) >= self.ds.dimensionality
-            self.stretch_dim = stretch_dim
+        super().__init__(ds, dataset_type)
 
     def _detect_output_fields(self):
         """Parse field names from the header, as stored in self.dataset.parameters"""
@@ -150,44 +149,44 @@ class AMRVACHierarchy(GridIndex):
         dx0 = (
             domain_width / self.dataset.parameters["domain_nx"]
         )  # dx at coarsest grid level (YT level 0)
-        dim = self.dataset.dimensionality
+        ndim = self.dataset.dimensionality
 
         self.grids = np.empty(self.num_grids, dtype="object")
-        meshlist = self.dataset.namelist["meshlist"]
-        stretch_baselevel = meshlist.get("qstretch_baselevel")
-        if "qstretch_baselevel" not in meshlist:
-            # compute default values dynamically, just as done in AMRVAC
-            stretched_dims = [bool(k) for k in self.stretch_dim]
-            assert sum(stretched_dims) == 1  # exactly one stretched direction
-            stretched_dim = stretched_dims.index(True)
-            _sbl = [
-                1.0,
-            ] * self.ds.dimensionality
-            _sbl[stretched_dim] = (
-                meshlist[f"xprobmax{stretched_dim + 1}"]
-                / meshlist[f"xprobmin{stretched_dim + 1}"]
-            ) ** (1.0 / meshlist[f"domain_nx{stretched_dim + 1}"])
-            stretch_baselevel = tuple(_sbl)
-        elif isinstance(stretch_baselevel := meshlist["qstretch_baselevel"], list):
-            assert len(stretch_baselevel) >= self.ds.dimensionality
-            stretch_baselevel = (
-                float(b) for b in stretch_baselevel[: self.ds.dimensionality]
-            )
-        else:
-            assert isinstance(stretch_baselevel, float | int)
-            stretched_dims = [bool(k) for k in self.stretch_dim]
-            assert sum(stretched_dims) == 1  # exactly one stretched direction
-            stretched_dim = stretched_dims.index(True)
-            _sbl = [
-                1.0,
-            ] * self.ds.dimensionality
-            _sbl[stretched_dim] = stretch_baselevel
-            stretch_baselevel = tuple(_sbl)
+        if np.any([x != "none" for x in self.stretch_dim]):
+            meshlist = self.dataset.namelist["meshlist"]
+            stretch_baselevel = meshlist.get("qstretch_baselevel")
+            if "qstretch_baselevel" not in meshlist:
+                # compute default values dynamically, just as done in AMRVAC
+                stretched_dims = [bool(k) for k in self.stretch_dim]
+                assert sum(stretched_dims) == 1  # exactly one stretched direction
+                stretched_dim = stretched_dims.index(True)
+                _sbl = [
+                    1.0,
+                ] * ndim
+                _sbl[stretched_dim] = (
+                    meshlist[f"xprobmax{stretched_dim + 1}"]
+                    / meshlist[f"xprobmin{stretched_dim + 1}"]
+                ) ** (1.0 / meshlist[f"domain_nx{stretched_dim + 1}"])
+                stretch_baselevel = tuple(_sbl)
+            elif isinstance(stretch_baselevel := meshlist["qstretch_baselevel"], list):
+                assert len(stretch_baselevel) >= ndim
+                stretch_baselevel = (
+                    float(b) for b in stretch_baselevel[: ndim]
+                )
+            else:
+                assert isinstance(stretch_baselevel, float | int)
+                stretched_dims = [bool(k) for k in self.stretch_dim]
+                assert sum(stretched_dims) == 1  # exactly one stretched direction
+                stretched_dim = stretched_dims.index(True)
+                _sbl = [
+                    1.0,
+                ] * ndim
+                _sbl[stretched_dim] = stretch_baselevel
+                stretch_baselevel = tuple(_sbl)
 
-        nlevelshi = self.meshlist["refine_max_level"]
-        qstretch = np.zeros((nlevelshi + 1, self.ds.dimensionality), dtype="float64")
-        dxfirst = np.zeros((nlevelshi + 1, self.ds.dimensionality), dtype="float64")
-        for dim in range(self.ds.dimensionality):
+        qstretch = np.zeros((self.max_level + 1, ndim), dtype="float64")
+        dxfirst = np.zeros((self.max_level + 1, ndim), dtype="float64")
+        for dim in range(ndim):
             if self.stretch_dim[dim] == "none":
                 continue
             elif self.stretch_dim[dim] in ["uni", "uniform"]:
@@ -216,11 +215,11 @@ class AMRVACHierarchy(GridIndex):
         for igrid, (ytlevel, morton_index) in enumerate(
             zip(ytlevels, morton_indices, strict=True)
         ):
-            left_edge = np.zeros(self.ds.dimensionality, dtype="float64")
-            right_edge = np.zeros(self.ds.dimensionality, dtype="float64")
-            cell_widths = np.zeros((self.ds.dimensionality, np.prod(block_nx)), dtype="float64")
+            left_edge = np.zeros(ndim, dtype="float64")
+            right_edge = np.zeros(ndim, dtype="float64")
+            cell_widths = np.zeros((ndim, np.prod(block_nx)), dtype="float64")
 
-            for dim in range(self.ds.dimensionality):
+            for dim in range(ndim):
                 if self.stretch_dim[dim] == "none":
                     dx = dx0 / self.dataset.refine_by**ytlevel
                     left_edge[dim] = xmin[dim] + (morton_index - 1) * block_nx[dim] * dx[dim]
@@ -239,7 +238,7 @@ class AMRVACHierarchy(GridIndex):
                     for i in range(block_nx[dim]):
                         center = (xmin[dim] + 0.5 * dxfirst[ytlevel+1, dim]) * qstretch[ytlevel+1, dim] ** ((morton_index - 1) * block_nx[dim] + i)
                         dcenter = 2.0 * center * (1.0 - qstretch[ytlevel+1, dim]) / (1.0 + qstretch[ytlevel+1, dim])
-                        cell_widths[dim, self.ds.dimensionality * i + dim] = dcenter
+                        cell_widths[dim, ndim * i + dim] = dcenter
             
             # edges and dimensions are filled in a dimensionality-agnostic way
             self.grid_left_edge[igrid, :dim] = left_edge

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -143,12 +143,10 @@ class AMRVACHierarchy(GridIndex):
 
     def _verify_uniformity(self):
         """Check whether the dataset is nonuniform (i.e. has stretched grids)."""
-        self._nonuniform = False
         meshlist = self.dataset.namelist["meshlist"]
         if (stretch_dim := meshlist.get("stretch_dim")) is not None:
             assert isinstance(stretch_dim, list)
             assert len(stretch_dim) >= self.ds.dimensionality
-            self._nonuniform = True
             self.stretch_dim = stretch_dim
 
     def _detect_output_fields(self):
@@ -191,131 +189,106 @@ class AMRVACHierarchy(GridIndex):
         dim = self.dataset.dimensionality
 
         self.grids = np.empty(self.num_grids, dtype="object")
-        if self._nonuniform:
-            meshlist = self.dataset.namelist["meshlist"]
-            stretch_baselevel = meshlist.get("qstretch_baselevel")
-            nlevelshi = 20 # hardcoded in AMRVAC
-            qstretch = np.zeros((nlevelshi + 1, self.ds.dimensionality), dtype="float64")
-            dxfirst = np.zeros((nlevelshi + 1, self.ds.dimensionality), dtype="float64")
-            nstretchedblocks = np.zeros((nlevelshi, self.ds.dimensionality), dtype="int32")
-            dxmid = np.zeros((nlevelshi + 1, self.ds.dimensionality), dtype="float64")
-            if "qstretch_baselevel" not in meshlist:
-                # compute default values dynamically, just as done in AMRVAC
-                stretched_dims = [bool(k) for k in self.stretch_dim]
-                assert sum(stretched_dims) == 1  # exactly one stretched direction
-                stretched_dim = stretched_dims.index(True)
-                _sbl = [
-                    1.0,
-                ] * self.ds.dimensionality
-                _sbl[stretched_dim] = (
-                    meshlist[f"xprobmax{stretched_dim + 1}"]
-                    / meshlist[f"xprobmin{stretched_dim + 1}"]
-                ) ** (1.0 / meshlist[f"domain_nx{stretched_dim + 1}"])
-                stretch_baselevel = tuple(_sbl)
-            elif isinstance(stretch_baselevel := meshlist["qstretch_baselevel"], list):
-                assert len(stretch_baselevel) >= self.ds.dimensionality
-                stretch_baselevel = (
-                    float(b) for b in stretch_baselevel[: self.ds.dimensionality]
+        meshlist = self.dataset.namelist["meshlist"]
+        stretch_baselevel = meshlist.get("qstretch_baselevel")
+        if "qstretch_baselevel" not in meshlist:
+            # compute default values dynamically, just as done in AMRVAC
+            stretched_dims = [bool(k) for k in self.stretch_dim]
+            assert sum(stretched_dims) == 1  # exactly one stretched direction
+            stretched_dim = stretched_dims.index(True)
+            _sbl = [
+                1.0,
+            ] * self.ds.dimensionality
+            _sbl[stretched_dim] = (
+                meshlist[f"xprobmax{stretched_dim + 1}"]
+                / meshlist[f"xprobmin{stretched_dim + 1}"]
+            ) ** (1.0 / meshlist[f"domain_nx{stretched_dim + 1}"])
+            stretch_baselevel = tuple(_sbl)
+        elif isinstance(stretch_baselevel := meshlist["qstretch_baselevel"], list):
+            assert len(stretch_baselevel) >= self.ds.dimensionality
+            stretch_baselevel = (
+                float(b) for b in stretch_baselevel[: self.ds.dimensionality]
+            )
+        else:
+            assert isinstance(stretch_baselevel, float | int)
+            stretched_dims = [bool(k) for k in self.stretch_dim]
+            assert sum(stretched_dims) == 1  # exactly one stretched direction
+            stretched_dim = stretched_dims.index(True)
+            _sbl = [
+                1.0,
+            ] * self.ds.dimensionality
+            _sbl[stretched_dim] = stretch_baselevel
+            stretch_baselevel = tuple(_sbl)
+
+        nlevelshi = self.meshlist["refine_max_level"]
+        qstretch = np.zeros((nlevelshi + 1, self.ds.dimensionality), dtype="float64")
+        dxfirst = np.zeros((nlevelshi + 1, self.ds.dimensionality), dtype="float64")
+        for dim in range(self.ds.dimensionality):
+            if self.stretch_dim[dim] == "none":
+                continue
+            elif self.stretch_dim[dim] in ["uni", "uniform"]:
+                qstretch[1, dim] = stretch_baselevel[dim]
+                dxfirst[1, dim] = (
+                    domain_width[dim] * (1.0 - qstretch[1, dim])
+                    / (1.0 - qstretch[1, dim] ** meshlist[f"domain_nx{dim + 1}"])
+                )
+                qstretch[0, dim] = qstretch[1, dim] ** 2
+                dxfirst[0, dim] = dxfirst[1, dim] * (1.0 + qstretch[1, dim])
+                if self.meshlist["refine_max_level"] > 1:
+                    for ilev in range(2, self.meshlist["refine_max_level"] + 1):
+                        qstretch[ilev, dim] = np.sqrt(qstretch[ilev - 1, dim])
+                        dxfirst[ilev, dim] = dxfirst[ilev - 1, dim] / (
+                            1.0 + np.sqrt(qstretch[ilev - 1, dim])
+                        )
+            elif self.stretch_dim[dim] in ["symm", "symmetric"]:
+                raise ValueError(
+                    f"Symmetric stretching is not currently supported for AMRVAC data."
                 )
             else:
-                assert isinstance(stretch_baselevel, float | int)
-                stretched_dims = [bool(k) for k in self.stretch_dim]
-                assert sum(stretched_dims) == 1  # exactly one stretched direction
-                stretched_dim = stretched_dims.index(True)
-                _sbl = [
-                    1.0,
-                ] * self.ds.dimensionality
-                _sbl[stretched_dim] = stretch_baselevel
-                stretch_baselevel = tuple(_sbl)
-
-            for dim in range(self.ds.dimensionality):
-                if self.stretch_dim[dim] in ["uni", "uniform"]:
-                    qstretch[1, dim] = stretch_baselevel[dim]
-                    dxfirst[1, dim] = (
-                        domain_width[dim] * (1.0 - qstretch[1, dim])
-                        / (1.0 - qstretch[1, dim] ** meshlist[f"domain_nx{dim + 1}"])
-                    )
-                    qstretch[0, dim] = qstretch[1, dim] ** 2
-                    dxfirst[0, dim] = dxfirst[1, dim] * (1.0 + qstretch[1, dim])
-                    if self.meshlist["refine_max_level"] > 1:
-                        for ilev in range(2, self.meshlist["refine_max_level"] + 1):
-                            qstretch[ilev, dim] = np.sqrt(qstretch[ilev - 1, dim])
-                            dxfirst[ilev, dim] = dxfirst[ilev - 1, dim] / (
-                                1.0 + np.sqrt(qstretch[ilev - 1, dim])
-                            )
-                elif self.stretch_dim[dim] in ["symm", "symmetric"]:
-                    warnings.warn(
-                        "symmetric stretching is not currently supported for AMRVAC data.",
-                        category=RuntimeWarning,
-                        stacklevel=2,
-                    )
-                    # ipower = (meshlist[f"nstretchedblocks_baselevel{dim + 1}"] / 2) * block_nx[dim]
-                    # if meshlist[f"nstretchedblocks_baselevel{dim + 1}"] == meshlist[f"domain_nx{dim + 1}"] / block_nx[dim]:
-                    #     xstretch = 0.5 * domain_width[dim]
-                    # else:
-                    #     xstretch = domain_width[dim] / (
-                    #         2.0
-                    #         + (meshlist[f"domain_nx{dim + 1}"] - meshlist[f"nstretchedblocks_baselevel{dim + 1}"] * block_nx[dim])
-                    #         * (1.0 - stretch_baselevel[dim])
-                    #         / (1.0 - stretch_baselevel[dim] ** ipower)
-                    #     )
-                    # dxfirst[1, dim] = (xstretch * (1.0 - stretch_baselevel[dim])
-                    #     / (1.0 - stretch_baselevel[dim] ** ipower))
-                    # nstretchedblocks[1, dim] = meshlist[f"nstretchedblocks_baselevel{dim + 1}"]
-                    # qstretch[1, dim] = stretch_baselevel[dim]
-                    # qstretch[0, dim] = qstretch[1, dim] ** 2
-                    # dxfirst[0, dim] = dxfirst[1, dim] * (1.0 + qstretch[1, dim])
-                    # dxmid[1, dim] = dxfirst[1, dim]
-                    # dxmid[0, dim] = dxfirst[1, dim] * 2
-                    # if meshlist["refine_max_level"] > 1:
-                    #     for ilev in range(2, meshlist["refine_max_level"] + 1):
-                    #         nstretchedblocks[ilev, dim] = 2 * nstretchedblocks[ilev - 1, dim]
-                    #         qstretch[ilev, dim] = np.sqrt(qstretch[ilev - 1, dim])
-                    #         dxfirst[ilev, dim] = dxfirst[ilev - 1, dim] / (
-                    #             1.0 + np.sqrt(qstretch[ilev - 1, dim])
-                    #         )
-                    #         dxmid[ilev, dim] = dxmid[ilev - 1, dim] / 2.0
-                elif self.stretch_dim[dim] == "none":
-                    continue
-                else:
-                    raise ValueError(
-                        f"Unknown stretch_dim '{self.stretch_dim[dim]}' for dimension {dim}."
-                    )
-            dxfirst_1mq = dxfirst / (1.0 - qstretch)
-
-            for igrid, (ytlevel, morton_index) in enumerate(
-                zip(ytlevels, morton_indices, strict=True)
-            ):
-                # dx = dx0 / self.dataset.refine_by**ytlevel
-                # left_edge = xmin + (morton_index - 1) * block_nx * dx
-                imin = (morton_index - 1) * block_nx
-                imax = morton_index * block_nx
-
-                # edges and dimensions are filled in a dimensionality-agnostic way
-                # self.grid_left_edge[igrid, :dim] = left_edge
-                # self.grid_right_edge[igrid, :dim] = left_edge + block_nx * dx
-                # self.grid_dimensions[igrid, :dim] = block_nx
-                self.grids[igrid] = self.grid(
-                    id=igrid,
-                    index=self,
-                    level=ytlevel,
-                    filename=self.index_filename,
-                    cell_widths=_cell_widths,
-                    dims=self.grid_dimensions[igrid],
+                raise ValueError(
+                    f"Unknown stretch_dim '{self.stretch_dim[dim]}' for dimension {dim}."
                 )
 
-        else:
-            for igrid, (ytlevel, morton_index) in enumerate(
-                zip(ytlevels, morton_indices, strict=True)
-            ):
-                dx = dx0 / self.dataset.refine_by**ytlevel
-                left_edge = xmin + (morton_index - 1) * block_nx * dx
+        for igrid, (ytlevel, morton_index) in enumerate(
+            zip(ytlevels, morton_indices, strict=True)
+        ):
+            left_edge = np.zeros(self.ds.dimensionality, dtype="float64")
+            right_edge = np.zeros(self.ds.dimensionality, dtype="float64")
+            cell_widths = np.zeros((self.ds.dimensionality, np.prod(block_nx)), dtype="float64")
 
-                # edges and dimensions are filled in a dimensionality-agnostic way
-                self.grid_left_edge[igrid, :dim] = left_edge
-                self.grid_right_edge[igrid, :dim] = left_edge + block_nx * dx
-                self.grid_dimensions[igrid, :dim] = block_nx
-                self.grids[igrid] = self.grid(igrid, self, ytlevel)
+            for dim in range(self.ds.dimensionality):
+                if self.stretch_dim[dim] == "none":
+                    dx = dx0 / self.dataset.refine_by**ytlevel
+                    left_edge[dim] = xmin[dim] + (morton_index - 1) * block_nx[dim] * dx[dim]
+                    right_edge[dim] = left_edge[dim] + block_nx[dim] * dx[dim]
+                    cell_widths[dim, :] = dx[dim]
+                elif self.stretch_dim[dim] in ["uni", "uniform"]:
+                    # left edge
+                    center1 = (xmin[dim] + 0.5 * dxfirst[ytlevel+1, dim]) * qstretch[ytlevel+1, dim] ** ((morton_index - 1) * block_nx[dim])
+                    dcenter1 = 2.0 * center1 * (1.0 - qstretch[ytlevel+1, dim]) / (1.0 + qstretch[ytlevel+1, dim])
+                    left_edge[dim] = center1 - 0.5 * dcenter1
+                    # right edge
+                    center2 = (xmin[dim] + 0.5 * dxfirst[ytlevel+1, dim]) * qstretch[ytlevel+1, dim] ** (morton_index * block_nx[dim] - 1)
+                    dcenter2 = 2.0 * center2 * (1.0 - qstretch[ytlevel+1, dim]) / (1.0 + qstretch[ytlevel+1, dim])
+                    right_edge[dim] = center2 + 0.5 * dcenter2
+                    # cell widths
+                    for i in range(block_nx[dim]):
+                        center = (xmin[dim] + 0.5 * dxfirst[ytlevel+1, dim]) * qstretch[ytlevel+1, dim] ** ((morton_index - 1) * block_nx[dim] + i)
+                        dcenter = 2.0 * center * (1.0 - qstretch[ytlevel+1, dim]) / (1.0 + qstretch[ytlevel+1, dim])
+                        cell_widths[dim, i] = dcenter
+            
+            # edges and dimensions are filled in a dimensionality-agnostic way
+            self.grid_left_edge[igrid, :dim] = left_edge
+            self.grid_right_edge[igrid, :dim] = right_edge
+            self.grid_dimensions[igrid, :dim] = block_nx
+            self.grids[igrid] = self.grid(
+                id=igrid,
+                index=self,
+                level=ytlevel,
+                filename=self.index_filename,
+                cell_widths=cell_widths,
+                dims=self.grid_dimensions[igrid],
+            )
 
     def _populate_grid_objects(self):
         # required method

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -53,44 +53,7 @@ def _parse_geometry(geometry_tag: str) -> Geometry:
     return Geometry(geometry_str.lower())
 
 
-class AMRVACGrid(AMRGridPatch):
-    """A class to populate AMRVACHierarchy.grids, setting parent/children relations."""
-
-    _id_offset = 0
-
-    def __init__(self, id, index, level):
-        # <level> should use yt's convention (start from 0)
-        super().__init__(id, filename=index.index_filename, index=index)
-        self.Parent = None
-        self.Children = []
-        self.Level = level
-
-    def get_global_startindex(self):
-        """Refresh and retrieve the starting index for each dimension at current level.
-
-        Returns
-        -------
-        self.start_index : int
-        """
-        start_index = (self.LeftEdge - self.ds.domain_left_edge) / self.dds
-        self.start_index = np.rint(start_index).astype("int64").ravel()
-        return self.start_index
-
-    def retrieve_ghost_zones(self, n_zones, fields, all_levels=False, smoothed=False):
-        if smoothed:
-            warnings.warn(
-                "ghost-zones interpolation/smoothing is not "
-                "currently supported for AMRVAC data.",
-                category=RuntimeWarning,
-                stacklevel=2,
-            )
-            smoothed = False
-        return super().retrieve_ghost_zones(
-            n_zones, fields, all_levels=all_levels, smoothed=smoothed
-        )
-
-
-class AMRVACStretchedGrid(StretchedGrid):
+class AMRVACGrid(StretchedGrid):
     """A class to populate AMRVACHierarchy.grids, setting parent/children relations."""
 
     _id_offset = 0
@@ -129,11 +92,12 @@ class AMRVACStretchedGrid(StretchedGrid):
 
 
 class AMRVACHierarchy(GridIndex):
+    grid = AMRVACGrid
+    
     def __init__(self, ds, dataset_type="amrvac"):
         self.dataset_type = dataset_type
         self.dataset = weakref.proxy(ds)
         self._verify_uniformity()
-        self.grid = AMRVACStretchedGrid if self._nonuniform else AMRVACGrid
         # the index file *is* the datfile
         self.index_filename = self.dataset.parameter_filename
         self.directory = os.path.dirname(self.index_filename)
@@ -275,7 +239,7 @@ class AMRVACHierarchy(GridIndex):
                     for i in range(block_nx[dim]):
                         center = (xmin[dim] + 0.5 * dxfirst[ytlevel+1, dim]) * qstretch[ytlevel+1, dim] ** ((morton_index - 1) * block_nx[dim] + i)
                         dcenter = 2.0 * center * (1.0 - qstretch[ytlevel+1, dim]) / (1.0 + qstretch[ytlevel+1, dim])
-                        cell_widths[dim, i] = dcenter
+                        cell_widths[dim, self.ds.dimensionality * i + dim] = dcenter
             
             # edges and dimensions are filled in a dimensionality-agnostic way
             self.grid_left_edge[igrid, :dim] = left_edge

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -222,21 +222,21 @@ class AMRVACHierarchy(GridIndex):
             for dim in range(ndim):
                 if self.stretch_dim[dim] == "none":
                     dx = dx0 / self.dataset.refine_by**ytlevel
-                    left_edge[dim] = xmin[dim] + (morton_index - 1) * block_nx[dim] * dx[dim]
+                    left_edge[dim] = xmin[dim] + (morton_index[dim] - 1) * block_nx[dim] * dx[dim]
                     right_edge[dim] = left_edge[dim] + block_nx[dim] * dx[dim]
                     cell_widths[dim, :] = dx[dim]
                 elif self.stretch_dim[dim] in ["uni", "uniform"]:
                     # left edge
-                    center1 = (xmin[dim] + 0.5 * dxfirst[ytlevel+1, dim]) * qstretch[ytlevel+1, dim] ** ((morton_index - 1) * block_nx[dim])
+                    center1 = (xmin[dim] + 0.5 * dxfirst[ytlevel+1, dim]) * qstretch[ytlevel+1, dim] ** ((morton_index[dim] - 1) * block_nx[dim])
                     dcenter1 = 2.0 * center1 * (1.0 - qstretch[ytlevel+1, dim]) / (1.0 + qstretch[ytlevel+1, dim])
                     left_edge[dim] = center1 - 0.5 * dcenter1
                     # right edge
-                    center2 = (xmin[dim] + 0.5 * dxfirst[ytlevel+1, dim]) * qstretch[ytlevel+1, dim] ** (morton_index * block_nx[dim] - 1)
+                    center2 = (xmin[dim] + 0.5 * dxfirst[ytlevel+1, dim]) * qstretch[ytlevel+1, dim] ** (morton_index[dim] * block_nx[dim] - 1)
                     dcenter2 = 2.0 * center2 * (1.0 - qstretch[ytlevel+1, dim]) / (1.0 + qstretch[ytlevel+1, dim])
                     right_edge[dim] = center2 + 0.5 * dcenter2
                     # cell widths
                     for i in range(block_nx[dim]):
-                        center = (xmin[dim] + 0.5 * dxfirst[ytlevel+1, dim]) * qstretch[ytlevel+1, dim] ** ((morton_index - 1) * block_nx[dim] + i)
+                        center = (xmin[dim] + 0.5 * dxfirst[ytlevel+1, dim]) * qstretch[ytlevel+1, dim] ** ((morton_index[dim] - 1) * block_nx[dim] + i)
                         dcenter = 2.0 * center * (1.0 - qstretch[ytlevel+1, dim]) / (1.0 + qstretch[ytlevel+1, dim])
                         cell_widths[dim, ndim * i + dim] = dcenter
             
@@ -247,7 +247,7 @@ class AMRVACHierarchy(GridIndex):
             self.grids[igrid] = self.grid(
                 id=igrid,
                 index=self,
-                level=ytlevel,
+                level=ytlevels[igrid],
                 filename=self.index_filename,
                 cell_widths=cell_widths,
                 dims=self.grid_dimensions[igrid],

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -12,6 +12,7 @@ import weakref
 from pathlib import Path
 
 import numpy as np
+from itertools import product
 from more_itertools import always_iterable
 
 from yt.config import ytcfg
@@ -217,14 +218,14 @@ class AMRVACHierarchy(GridIndex):
             left_edge = np.zeros(ndim, dtype="float64")
             right_edge = np.zeros(ndim, dtype="float64")
             cell_widths = np.zeros((ndim, np.prod(block_nx)), dtype="float64")
+            cw_aux = []
 
             for dim in range(ndim):
                 if self.stretch_dim[dim] == "none":
                     dx = dx0 / self.dataset.refine_by**ytlevel
                     left_edge[dim] = xmin[dim] + (morton_index[dim] - 1) * block_nx[dim] * dx[dim]
                     right_edge[dim] = left_edge[dim] + block_nx[dim] * dx[dim]
-                    for i in range(block_nx[dim]):
-                        cell_widths[dim, ndim * i + dim] = dx[dim]
+                    cw_aux.append([dx[dim]] * block_nx[dim])
                 elif self.stretch_dim[dim] in ["uni", "uniform"]:
                     # left edge
                     center1 = (xmin[dim] + 0.5 * dxfirst[ytlevel+1, dim]) * qstretch[ytlevel+1, dim] ** ((morton_index[dim] - 1) * block_nx[dim])
@@ -235,10 +236,14 @@ class AMRVACHierarchy(GridIndex):
                     dcenter2 = 2.0 * center2 * (1.0 - qstretch[ytlevel+1, dim]) / (1.0 + qstretch[ytlevel+1, dim])
                     right_edge[dim] = center2 + 0.5 * dcenter2
                     # cell widths
+                    aux2 = []
                     for i in range(block_nx[dim]):
                         center = (xmin[dim] + 0.5 * dxfirst[ytlevel+1, dim]) * qstretch[ytlevel+1, dim] ** ((morton_index[dim] - 1) * block_nx[dim] + i)
                         dcenter = 2.0 * center * (1.0 - qstretch[ytlevel+1, dim]) / (1.0 + qstretch[ytlevel+1, dim])
-                        cell_widths[dim, ndim * i + dim] = dcenter
+                        aux2.append(dcenter)
+                    cw_aux.append(aux2)
+            prod = np.array([x for x in product(*cw_aux[::-1])])
+            cell_widths = (prod.T)[::-1]
             
             # edges and dimensions are filled in a dimensionality-agnostic way
             self.grid_left_edge[igrid, :ndim] = left_edge

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -228,17 +228,17 @@ class AMRVACHierarchy(GridIndex):
                 elif self.stretch_dim[dim] in ["uni", "uniform"]:
                     # left edge
                     center1 = (xmin[dim] + 0.5 * dxfirst[ytlevel+1, dim]) * qstretch[ytlevel+1, dim] ** ((morton_index[dim] - 1) * block_nx[dim])
-                    dcenter1 = 2.0 * center1 * (1.0 - qstretch[ytlevel+1, dim]) / (1.0 + qstretch[ytlevel+1, dim])
+                    dcenter1 = 2.0 * center1 * (qstretch[ytlevel+1, dim] - 1.0) / (qstretch[ytlevel+1, dim] + 1.0)
                     left_edge[dim] = center1 - 0.5 * dcenter1
                     # right edge
                     center2 = (xmin[dim] + 0.5 * dxfirst[ytlevel+1, dim]) * qstretch[ytlevel+1, dim] ** (morton_index[dim] * block_nx[dim] - 1)
-                    dcenter2 = 2.0 * center2 * (1.0 - qstretch[ytlevel+1, dim]) / (1.0 + qstretch[ytlevel+1, dim])
+                    dcenter2 = 2.0 * center2 * (qstretch[ytlevel+1, dim] - 1.0) / (qstretch[ytlevel+1, dim] + 1.0)
                     right_edge[dim] = center2 + 0.5 * dcenter2
                     # cell widths
                     aux2 = []
                     for i in range(block_nx[dim]):
                         center = (xmin[dim] + 0.5 * dxfirst[ytlevel+1, dim]) * qstretch[ytlevel+1, dim] ** ((morton_index[dim] - 1) * block_nx[dim] + i)
-                        dcenter = 2.0 * center * (1.0 - qstretch[ytlevel+1, dim]) / (1.0 + qstretch[ytlevel+1, dim])
+                        dcenter = 2.0 * center * (qstretch[ytlevel+1, dim] - 1.0) / (qstretch[ytlevel+1, dim] + 1.0)
                         aux2.append(dcenter)
                     cw_aux.append(aux2)
             prod = np.array([x for x in product(*cw_aux[::-1])])

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -152,12 +152,12 @@ class AMRVACHierarchy(GridIndex):
         ndim = self.dataset.dimensionality
 
         self.grids = np.empty(self.num_grids, dtype="object")
-        if np.any([not (x == "none" or x == "") for x in self.stretch_dim]):
+        stretched_dims = [not (x == "none" or x == "") for x in self.stretch_dim]
+        if np.any(stretched_dims):
             meshlist = self.dataset.namelist["meshlist"]
             stretch_baselevel = meshlist.get("qstretch_baselevel")
             if "qstretch_baselevel" not in meshlist:
                 # compute default values dynamically, just as done in AMRVAC
-                stretched_dims = [bool(k) for k in self.stretch_dim]
                 assert sum(stretched_dims) == 1  # exactly one stretched direction
                 stretched_dim = stretched_dims.index(True)
                 _sbl = [
@@ -175,7 +175,6 @@ class AMRVACHierarchy(GridIndex):
                 )
             else:
                 assert isinstance(stretch_baselevel, float | int)
-                stretched_dims = [bool(k) for k in self.stretch_dim]
                 assert sum(stretched_dims) == 1  # exactly one stretched direction
                 stretched_dim = stretched_dims.index(True)
                 _sbl = [
@@ -183,6 +182,12 @@ class AMRVACHierarchy(GridIndex):
                 ] * ndim
                 _sbl[stretched_dim] = stretch_baselevel
                 stretch_baselevel = tuple(_sbl)
+            
+            warnings.warn(
+                str(stretch_baselevel),
+                category=RuntimeWarning,
+                stacklevel=2,
+            )
 
         qstretch = np.zeros((self.max_level + 2, ndim), dtype="float64")
         dxfirst = np.zeros((self.max_level + 2, ndim), dtype="float64")

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -152,7 +152,7 @@ class AMRVACHierarchy(GridIndex):
         ndim = self.dataset.dimensionality
 
         self.grids = np.empty(self.num_grids, dtype="object")
-        if np.any([x != "none" for x in self.stretch_dim]):
+        if np.any([not (x == "none" or x == "") for x in self.stretch_dim]):
             meshlist = self.dataset.namelist["meshlist"]
             stretch_baselevel = meshlist.get("qstretch_baselevel")
             if "qstretch_baselevel" not in meshlist:
@@ -187,9 +187,9 @@ class AMRVACHierarchy(GridIndex):
         qstretch = np.zeros((self.max_level + 2, ndim), dtype="float64")
         dxfirst = np.zeros((self.max_level + 2, ndim), dtype="float64")
         for dim in range(ndim):
-            if self.stretch_dim[dim] == "none":
+            if self.stretch_dim[dim] == "none" or self.stretch_dim[dim] == "":
                 continue
-            elif self.stretch_dim[dim] in ["uni", "uniform"] or self.stretch_dim[dim] == "":
+            elif self.stretch_dim[dim] in ["uni", "uniform"]:
                 qstretch[1, dim] = stretch_baselevel[dim]
                 dxfirst[1, dim] = (
                     domain_width[dim] * (1.0 - qstretch[1, dim])

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -244,45 +244,57 @@ class AMRVACHierarchy(GridIndex):
                                 1.0 + np.sqrt(qstretch[ilev - 1, dim])
                             )
                 elif self.stretch_dim[dim] in ["symm", "symmetric"]:
-                    ipower = (meshlist[f"nstretchedblocks_baselevel{dim + 1}"] / 2) * block_nx[dim]
-                    if meshlist[f"nstretchedblocks_baselevel{dim + 1}"] == meshlist[f"domain_nx{dim + 1}"] / block_nx[dim]:
-                        xstretch = 0.5 * domain_width[dim]
-                    else:
-                        xstretch = domain_width[dim] / (
-                            2.0
-                            + (meshlist[f"domain_nx{dim + 1}"] - meshlist[f"nstretchedblocks_baselevel{dim + 1}"] * block_nx[dim])
-                            * (1.0 - stretch_baselevel[dim])
-                            / (1.0 - stretch_baselevel[dim] ** ipower)
-                        )
-                    dxfirst[1, dim] = (xstretch * (1.0 - stretch_baselevel[dim])
-                        / (1.0 - stretch_baselevel[dim] ** ipower))
-                    nstretchedblocks[1, dim] = meshlist[f"nstretchedblocks_baselevel{dim + 1}"]
-                    qstretch[1, dim] = stretch_baselevel[dim]
-                    qstretch[0, dim] = qstretch[1, dim] ** 2
-                    dxfirst[0, dim] = dxfirst[1, dim] * (1.0 + qstretch[1, dim])
-                    dxmid[1, dim] = dxfirst[1, dim]
-                    dxmid[0, dim] = dxfirst[1, dim] * 2
-                    if meshlist["refine_max_level"] > 1:
-                        for ilev in range(2, meshlist["refine_max_level"] + 1):
-                            nstretchedblocks[ilev, dim] = 2 * nstretchedblocks[ilev - 1, dim]
-                            qstretch[ilev, dim] = np.sqrt(qstretch[ilev - 1, dim])
-                            dxfirst[ilev, dim] = dxfirst[ilev - 1, dim] / (
-                                1.0 + np.sqrt(qstretch[ilev - 1, dim])
-                            )
-                            dxmid[ilev, dim] = dxmid[ilev - 1, dim] / 2.0
+                    warnings.warn(
+                        "symmetric stretching is not currently supported for AMRVAC data.",
+                        category=RuntimeWarning,
+                        stacklevel=2,
+                    )
+                    # ipower = (meshlist[f"nstretchedblocks_baselevel{dim + 1}"] / 2) * block_nx[dim]
+                    # if meshlist[f"nstretchedblocks_baselevel{dim + 1}"] == meshlist[f"domain_nx{dim + 1}"] / block_nx[dim]:
+                    #     xstretch = 0.5 * domain_width[dim]
+                    # else:
+                    #     xstretch = domain_width[dim] / (
+                    #         2.0
+                    #         + (meshlist[f"domain_nx{dim + 1}"] - meshlist[f"nstretchedblocks_baselevel{dim + 1}"] * block_nx[dim])
+                    #         * (1.0 - stretch_baselevel[dim])
+                    #         / (1.0 - stretch_baselevel[dim] ** ipower)
+                    #     )
+                    # dxfirst[1, dim] = (xstretch * (1.0 - stretch_baselevel[dim])
+                    #     / (1.0 - stretch_baselevel[dim] ** ipower))
+                    # nstretchedblocks[1, dim] = meshlist[f"nstretchedblocks_baselevel{dim + 1}"]
+                    # qstretch[1, dim] = stretch_baselevel[dim]
+                    # qstretch[0, dim] = qstretch[1, dim] ** 2
+                    # dxfirst[0, dim] = dxfirst[1, dim] * (1.0 + qstretch[1, dim])
+                    # dxmid[1, dim] = dxfirst[1, dim]
+                    # dxmid[0, dim] = dxfirst[1, dim] * 2
+                    # if meshlist["refine_max_level"] > 1:
+                    #     for ilev in range(2, meshlist["refine_max_level"] + 1):
+                    #         nstretchedblocks[ilev, dim] = 2 * nstretchedblocks[ilev - 1, dim]
+                    #         qstretch[ilev, dim] = np.sqrt(qstretch[ilev - 1, dim])
+                    #         dxfirst[ilev, dim] = dxfirst[ilev - 1, dim] / (
+                    #             1.0 + np.sqrt(qstretch[ilev - 1, dim])
+                    #         )
+                    #         dxmid[ilev, dim] = dxmid[ilev - 1, dim] / 2.0
+                elif self.stretch_dim[dim] == "none":
+                    continue
+                else:
+                    raise ValueError(
+                        f"Unknown stretch_dim '{self.stretch_dim[dim]}' for dimension {dim}."
+                    )
             dxfirst_1mq = dxfirst / (1.0 - qstretch)
 
-        for igrid, (ytlevel, morton_index) in enumerate(
-            zip(ytlevels, morton_indices, strict=True)
-        ):
-            dx = dx0 / self.dataset.refine_by**ytlevel
-            left_edge = xmin + (morton_index - 1) * block_nx * dx
+            for igrid, (ytlevel, morton_index) in enumerate(
+                zip(ytlevels, morton_indices, strict=True)
+            ):
+                # dx = dx0 / self.dataset.refine_by**ytlevel
+                # left_edge = xmin + (morton_index - 1) * block_nx * dx
+                imin = (morton_index - 1) * block_nx
+                imax = morton_index * block_nx
 
-            # edges and dimensions are filled in a dimensionality-agnostic way
-            self.grid_left_edge[igrid, :dim] = left_edge
-            self.grid_right_edge[igrid, :dim] = left_edge + block_nx * dx
-            self.grid_dimensions[igrid, :dim] = block_nx
-            if self._nonuniform:
+                # edges and dimensions are filled in a dimensionality-agnostic way
+                # self.grid_left_edge[igrid, :dim] = left_edge
+                # self.grid_right_edge[igrid, :dim] = left_edge + block_nx * dx
+                # self.grid_dimensions[igrid, :dim] = block_nx
                 self.grids[igrid] = self.grid(
                     id=igrid,
                     index=self,
@@ -291,7 +303,18 @@ class AMRVACHierarchy(GridIndex):
                     cell_widths=_cell_widths,
                     dims=self.grid_dimensions[igrid],
                 )
-            else:
+
+        else:
+            for igrid, (ytlevel, morton_index) in enumerate(
+                zip(ytlevels, morton_indices, strict=True)
+            ):
+                dx = dx0 / self.dataset.refine_by**ytlevel
+                left_edge = xmin + (morton_index - 1) * block_nx * dx
+
+                # edges and dimensions are filled in a dimensionality-agnostic way
+                self.grid_left_edge[igrid, :dim] = left_edge
+                self.grid_right_edge[igrid, :dim] = left_edge + block_nx * dx
+                self.grid_dimensions[igrid, :dim] = block_nx
                 self.grids[igrid] = self.grid(igrid, self, ytlevel)
 
     def _populate_grid_objects(self):

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -16,6 +16,7 @@ from more_itertools import always_iterable
 
 from yt.config import ytcfg
 from yt.data_objects.index_subobjects.grid_patch import AMRGridPatch
+from yt.data_objects.index_subobjects.stretched_grid import StretchedGrid
 from yt.data_objects.static_output import Dataset
 from yt.funcs import mylog, setdefaultattr
 from yt.geometry.api import Geometry
@@ -89,18 +90,66 @@ class AMRVACGrid(AMRGridPatch):
         )
 
 
-class AMRVACHierarchy(GridIndex):
-    grid = AMRVACGrid
+class AMRVACStretchedGrid(StretchedGrid):
+    """A class to populate AMRVACHierarchy.grids, setting parent/children relations."""
 
+    _id_offset = 0
+
+    def __init__(self, id, cell_widths, filename, index, level, dims):
+        # <level> should use yt's convention (start from 0)
+        super().__init__(id=id, filename=filename, index=index, cell_widths=cell_widths)
+        self.Parent = None
+        self.Children = []
+        self.Level = level
+        self.ActiveDimensions = dims
+
+    def get_global_startindex(self):
+        """Refresh and retrieve the starting index for each dimension at current level.
+
+        Returns
+        -------
+        self.start_index : int
+        """
+        start_index = (self.LeftEdge - self.ds.domain_left_edge) / self.dds
+        self.start_index = np.rint(start_index).astype("int64").ravel()
+        return self.start_index
+
+    def retrieve_ghost_zones(self, n_zones, fields, all_levels=False, smoothed=False):
+        if smoothed:
+            warnings.warn(
+                "ghost-zones interpolation/smoothing is not "
+                "currently supported for AMRVAC data.",
+                category=RuntimeWarning,
+                stacklevel=2,
+            )
+            smoothed = False
+        return super().retrieve_ghost_zones(
+            n_zones, fields, all_levels=all_levels, smoothed=smoothed
+        )
+
+
+class AMRVACHierarchy(GridIndex):
     def __init__(self, ds, dataset_type="amrvac"):
         self.dataset_type = dataset_type
         self.dataset = weakref.proxy(ds)
+        self._verify_uniformity()
+        self.grid = AMRVACStretchedGrid if self._nonuniform else AMRVACGrid
         # the index file *is* the datfile
         self.index_filename = self.dataset.parameter_filename
         self.directory = os.path.dirname(self.index_filename)
         self.float_type = np.float64
 
         super().__init__(ds, dataset_type)
+
+    def _verify_uniformity(self):
+        """Check whether the dataset is nonuniform (i.e. has stretched grids)."""
+        self._nonuniform = False
+        meshlist = self.dataset.namelist["meshlist"]
+        if (stretch_dim := meshlist.get("stretch_dim")) is not None:
+            assert isinstance(stretch_dim, list)
+            assert len(stretch_dim) >= self.ds.dimensionality
+            self._nonuniform = True
+            self.stretch_dim = stretch_dim
 
     def _detect_output_fields(self):
         """Parse field names from the header, as stored in self.dataset.parameters"""
@@ -152,7 +201,17 @@ class AMRVACHierarchy(GridIndex):
             self.grid_left_edge[igrid, :dim] = left_edge
             self.grid_right_edge[igrid, :dim] = left_edge + block_nx * dx
             self.grid_dimensions[igrid, :dim] = block_nx
-            self.grids[igrid] = self.grid(igrid, self, ytlevels[igrid])
+            if self._nonuniform:
+                self.grids[igrid] = self.grid(
+                    id=igrid,
+                    index=self,
+                    level=ytlevel,
+                    filename=self.index_filename,
+                    cell_widths=_cell_widths,
+                    dims=self.grid_dimensions[igrid],
+                )
+            else:
+                self.grids[igrid] = self.grid(igrid, self, ytlevel)
 
     def _populate_grid_objects(self):
         # required method

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -220,7 +220,7 @@ class AMRVACHierarchy(GridIndex):
             cw_aux = []
 
             for dim in range(ndim):
-                if self.stretch_dim[dim] == "none":
+                if self.stretch_dim[dim] == "none" or self.stretch_dim[dim] == "":
                     dx = dx0 / self.dataset.refine_by**ytlevel
                     left_edge[dim] = xmin[dim] + (morton_index[dim] - 1) * block_nx[dim] * dx[dim]
                     right_edge[dim] = left_edge[dim] + block_nx[dim] * dx[dim]

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -191,6 +191,86 @@ class AMRVACHierarchy(GridIndex):
         dim = self.dataset.dimensionality
 
         self.grids = np.empty(self.num_grids, dtype="object")
+        if self._nonuniform:
+            meshlist = self.dataset.namelist["meshlist"]
+            stretch_baselevel = meshlist.get("qstretch_baselevel")
+            # nlevelshi = 20 hardcoded in AMRVAC
+            qstretch = np.zeros((21, self.ds.dimensionality), dtype="float64")
+            dxfirst = np.zeros((21, self.ds.dimensionality), dtype="float64")
+            nstretchedblocks = np.zeros((20, self.ds.dimensionality), dtype="int32")
+            if "qstretch_baselevel" not in meshlist:
+                # compute default values dynamically, just as done in AMRVAC
+                stretched_dims = [bool(k) for k in self.stretch_dim]
+                assert sum(stretched_dims) == 1  # exactly one stretched direction
+                stretched_dim = stretched_dims.index(True)
+                _sbl = [
+                    1.0,
+                ] * self.ds.dimensionality
+                _sbl[stretched_dim] = (
+                    meshlist[f"xprobmax{stretched_dim + 1}"]
+                    / meshlist[f"xprobmin{stretched_dim + 1}"]
+                ) ** (1.0 / meshlist[f"domain_nx{stretched_dim + 1}"])
+                stretch_baselevel = tuple(_sbl)
+            elif isinstance(stretch_baselevel := meshlist["qstretch_baselevel"], list):
+                assert len(stretch_baselevel) >= self.ds.dimensionality
+                stretch_baselevel = (
+                    float(b) for b in stretch_baselevel[: self.ds.dimensionality]
+                )
+            else:
+                assert isinstance(stretch_baselevel, float | int)
+                stretched_dims = [bool(k) for k in self.stretch_dim]
+                assert sum(stretched_dims) == 1  # exactly one stretched direction
+                stretched_dim = stretched_dims.index(True)
+                _sbl = [
+                    1.0,
+                ] * self.ds.dimensionality
+                _sbl[stretched_dim] = stretch_baselevel
+                stretch_baselevel = tuple(_sbl)
+
+            for dim in range(self.ds.dimensionality):
+                if self.stretch_dim[dim] in ["uni", "uniform"]:
+                    qstretch[1, dim] = stretch_baselevel[dim]
+                    dxfirst[1, dim] = (
+                        domain_width[dim] * (1.0 - qstretch[1, dim])
+                        / (1.0 - qstretch[1, dim] ** meshlist[f"domain_nx{dim + 1}"])
+                    )
+                    qstretch[0, dim] = qstretch[1, dim] ** 2
+                    dxfirst[0, dim] = dxfirst[1, dim] * (1.0 + qstretch[1, dim])
+                    if self.meshlist["refine_max_level"] > 1:
+                        for ilev in range(2, self.meshlist["refine_max_level"] + 1):
+                            qstretch[ilev, dim] = np.sqrt(qstretch[ilev - 1, dim])
+                            dxfirst[ilev, dim] = dxfirst[ilev - 1, dim] / (
+                                1.0 + np.sqrt(qstretch[ilev - 1, dim])
+                            )
+                elif self.stretch_dim[dim] in ["symm", "symmetric"]:
+                    ipower = (meshlist[f"nstretchedblocks_baselevel{dim + 1}"] / 2) * block_nx[dim]
+                    if meshlist[f"nstretchedblocks_baselevel{dim + 1}"] == meshlist[f"domain_nx{dim + 1}"] / block_nx[dim]:
+                        xstretch = 0.5 * domain_width[dim]
+                    else:
+                        xstretch = domain_width[dim] / (
+                            2.0
+                            + (meshlist[f"domain_nx{dim + 1}"] - meshlist[f"nstretchedblocks_baselevel{dim + 1}"] * block_nx[dim])
+                            * (1.0 - stretch_baselevel[dim])
+                            / (1.0 - stretch_baselevel[dim] ** ipower)
+                        )
+                    dxfirst[1, dim] = (xstretch * (1.0 - stretch_baselevel[dim])
+                        / (1.0 - stretch_baselevel[dim] ** ipower))
+                    nstretchedblocks[1, dim] = meshlist[f"nstretchedblocks_baselevel{dim + 1}"]
+                    qstretch[1, dim] = stretch_baselevel[dim]
+                    qstretch[0, dim] = qstretch[1, dim] ** 2
+                    dxfirst[0, dim] = dxfirst[1, dim] * (1.0 + qstretch[1, dim])
+                    dxmid[1, dim] = dxfirst[1, dim]
+                    dxmid[0, dim] = dxfirst[1, dim] * 2
+                    if meshlist["refine_max_level"] > 1:
+                        for ilev in range(2, meshlist["refine_max_level"] + 1):
+                            nstretchedblocks[ilev, dim] = 2 * nstretchedblocks[ilev - 1, dim]
+                            qstretch[ilev, dim] = np.sqrt(qstretch[ilev - 1, dim])
+                            dxfirst[ilev, dim] = dxfirst[ilev - 1, dim] / (
+                                1.0 + np.sqrt(qstretch[ilev - 1, dim])
+                            )
+                            dxmid[ilev, dim] = dxmid[ilev - 1, dim] / 2.0
+            dxfirst_1mq = dxfirst / (1.0 - qstretch)
+        
         for igrid, (ytlevel, morton_index) in enumerate(
             zip(ytlevels, morton_indices, strict=True)
         ):

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -184,12 +184,12 @@ class AMRVACHierarchy(GridIndex):
                 _sbl[stretched_dim] = stretch_baselevel
                 stretch_baselevel = tuple(_sbl)
 
-        qstretch = np.zeros((self.max_level + 1, ndim), dtype="float64")
-        dxfirst = np.zeros((self.max_level + 1, ndim), dtype="float64")
+        qstretch = np.zeros((self.max_level + 2, ndim), dtype="float64")
+        dxfirst = np.zeros((self.max_level + 2, ndim), dtype="float64")
         for dim in range(ndim):
             if self.stretch_dim[dim] == "none":
                 continue
-            elif self.stretch_dim[dim] in ["uni", "uniform"]:
+            elif self.stretch_dim[dim] in ["uni", "uniform"] or self.stretch_dim[dim] == "":
                 qstretch[1, dim] = stretch_baselevel[dim]
                 dxfirst[1, dim] = (
                     domain_width[dim] * (1.0 - qstretch[1, dim])
@@ -197,8 +197,8 @@ class AMRVACHierarchy(GridIndex):
                 )
                 qstretch[0, dim] = qstretch[1, dim] ** 2
                 dxfirst[0, dim] = dxfirst[1, dim] * (1.0 + qstretch[1, dim])
-                if self.meshlist["refine_max_level"] > 1:
-                    for ilev in range(2, self.meshlist["refine_max_level"] + 1):
+                if self.max_level > 0:
+                    for ilev in range(2, self.max_level + 2):
                         qstretch[ilev, dim] = np.sqrt(qstretch[ilev - 1, dim])
                         dxfirst[ilev, dim] = dxfirst[ilev - 1, dim] / (
                             1.0 + np.sqrt(qstretch[ilev - 1, dim])

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -182,12 +182,6 @@ class AMRVACHierarchy(GridIndex):
                 ] * ndim
                 _sbl[stretched_dim] = stretch_baselevel
                 stretch_baselevel = tuple(_sbl)
-            
-            warnings.warn(
-                str(stretch_baselevel),
-                category=RuntimeWarning,
-                stacklevel=2,
-            )
 
         qstretch = np.zeros((self.max_level + 2, ndim), dtype="float64")
         dxfirst = np.zeros((self.max_level + 2, ndim), dtype="float64")

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -102,7 +102,7 @@ class AMRVACHierarchy(GridIndex):
         self.directory = os.path.dirname(self.index_filename)
         self.float_type = np.float64
 
-        self.stretch_dim = [self.dataset.dimensionality * "none"]
+        self.stretch_dim = ["none"] * self.dataset.dimensionality
         if self.dataset.namelist is not None:
             meshlist = self.dataset.namelist["meshlist"]
             if (stretch_dim := meshlist.get("stretch_dim")) is not None:

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -194,11 +194,11 @@ class AMRVACHierarchy(GridIndex):
         if self._nonuniform:
             meshlist = self.dataset.namelist["meshlist"]
             stretch_baselevel = meshlist.get("qstretch_baselevel")
-            # nlevelshi = 20 hardcoded in AMRVAC
-            qstretch = np.zeros((21, self.ds.dimensionality), dtype="float64")
-            dxfirst = np.zeros((21, self.ds.dimensionality), dtype="float64")
-            nstretchedblocks = np.zeros((20, self.ds.dimensionality), dtype="int32")
-            dxmid = np.zeros((21, self.ds.dimensionality), dtype="float64")
+            nlevelshi = 20 # hardcoded in AMRVAC
+            qstretch = np.zeros((nlevelshi + 1, self.ds.dimensionality), dtype="float64")
+            dxfirst = np.zeros((nlevelshi + 1, self.ds.dimensionality), dtype="float64")
+            nstretchedblocks = np.zeros((nlevelshi, self.ds.dimensionality), dtype="int32")
+            dxmid = np.zeros((nlevelshi + 1, self.ds.dimensionality), dtype="float64")
             if "qstretch_baselevel" not in meshlist:
                 # compute default values dynamically, just as done in AMRVAC
                 stretched_dims = [bool(k) for k in self.stretch_dim]

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -219,7 +219,6 @@ class AMRVACHierarchy(GridIndex):
             right_edge = np.zeros(ndim, dtype="float64")
             cw_aux = []
 
-            dim_count = 0
             for dim in range(ndim):
                 match self.stretch_dim[dim]:
                     case "none" | "":
@@ -245,10 +244,7 @@ class AMRVACHierarchy(GridIndex):
                                 * 2.0 * (qstretch[amrvac_level, dim] - 1.0) / (qstretch[amrvac_level, dim] + 1.0)
                             ) for i in range(block_nx[dim])
                         ])
-                dim_count += 1
-            while dim_count < 3:
-                cw_aux.append([1.0])
-                dim_count += 1
+            cw_aux.extend([[1.0]] * (3 - ndim))
             prod = np.array(list(product(*cw_aux[::-1])))
             cell_widths = (prod.T)[::-1]
 

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -159,34 +159,30 @@ class AMRVACHierarchy(GridIndex):
             if "qstretch_baselevel" not in meshlist:
                 # compute default values dynamically, just as done in AMRVAC
                 assert sum(stretched_dims) == 1  # exactly one stretched direction
-                stretched_dim = stretched_dims.index(True)
-                _sbl = [
-                    1.0,
-                ] * ndim
-                _sbl[stretched_dim] = (
-                    meshlist[f"xprobmax{stretched_dim + 1}"]
-                    / meshlist[f"xprobmin{stretched_dim + 1}"]
-                ) ** (1.0 / meshlist[f"domain_nx{stretched_dim + 1}"])
+                stretched_dim = stretched_dims.index(True) + 1 # AMRVAC index (1 offset, Fortran convention)
+                _sbl = [1.0] * ndim
+                _sbl[stretched_dim-1] = (
+                    meshlist[f"xprobmax{stretched_dim}"]
+                    / meshlist[f"xprobmin{stretched_dim}"]
+                ) ** (1.0 / meshlist[f"domain_nx{stretched_dim}"])
                 stretch_baselevel = tuple(_sbl)
             elif isinstance(stretch_baselevel := meshlist["qstretch_baselevel"], list):
                 assert len(stretch_baselevel) >= ndim
                 stretch_baselevel = (
-                    float(b) for b in stretch_baselevel[: ndim]
+                    float(b) for b in stretch_baselevel[:ndim]
                 )
             else:
                 assert isinstance(stretch_baselevel, float | int)
                 assert sum(stretched_dims) == 1  # exactly one stretched direction
                 stretched_dim = stretched_dims.index(True)
-                _sbl = [
-                    1.0,
-                ] * ndim
+                _sbl = [1.0] * ndim
                 _sbl[stretched_dim] = stretch_baselevel
                 stretch_baselevel = tuple(_sbl)
 
         qstretch = np.zeros((self.max_level + 2, ndim), dtype="float64")
         dxfirst = np.zeros((self.max_level + 2, ndim), dtype="float64")
         for dim in range(ndim):
-            if self.stretch_dim[dim] == "none" or self.stretch_dim[dim] == "":
+            if self.stretch_dim[dim] in ["none", ""]:
                 continue
             elif self.stretch_dim[dim] in ["uni", "uniform"]:
                 qstretch[1, dim] = stretch_baselevel[dim]
@@ -246,7 +242,7 @@ class AMRVACHierarchy(GridIndex):
             while dim_count < 3:
                 cw_aux.append([1.0])
                 dim_count += 1
-            prod = np.array([x for x in product(*cw_aux[::-1])])
+            prod = np.array(list(product(*cw_aux[::-1])))
             cell_widths = (prod.T)[::-1]
             
             # edges and dimensions are filled in a dimensionality-agnostic way

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -158,6 +158,15 @@ class AMRVACHierarchy(GridIndex):
             meshlist = self.dataset.namelist["meshlist"]
             stretch_baselevel = meshlist.get("qstretch_baselevel")
             match stretch_baselevel:
+                case ():
+                    assert len(stretch_baselevel) >= ndim
+                    base_stretch[:ndim] = (
+                        float(b) for b in stretch_baselevel[:ndim]
+                    )
+                case float() | int():
+                    assert sum(stretched_dims) == 1  # exactly one stretched direction
+                    stretched_dim = stretched_dims.index(True)
+                    base_stretch[stretched_dim] = float(stretch_baselevel)
                 case None:
                     # compute default values dynamically, just as done in AMRVAC
                     assert sum(stretched_dims) == 1  # exactly one stretched direction
@@ -166,15 +175,6 @@ class AMRVACHierarchy(GridIndex):
                         meshlist[f"xprobmax{stretched_dim}"]
                         / meshlist[f"xprobmin{stretched_dim}"]
                     ) ** (1.0 / meshlist[f"domain_nx{stretched_dim}"])
-                case list() | tuple():
-                    assert len(stretch_baselevel) >= ndim
-                    base_stretch[:ndim] = (
-                        float(b) for b in stretch_baselevel[:ndim]
-                    )
-                case float() | int():
-                    assert sum(stretched_dims) == 1  # exactly one stretched direction
-                    stretched_dim = stretched_dims.index(True)
-                    base_stretch[stretched_dim] = stretch_baselevel
                 case _:
                     raise ValueError(
                         f"Unknown type for qstretch_baselevel: {type(stretch_baselevel)}"
@@ -206,12 +206,13 @@ class AMRVACHierarchy(GridIndex):
                     )
                 case _:
                     raise ValueError(
-                        f"Unknown stretch_dim '{self.stretch_dim[dim]}' for dimension {dim}."
+                        f"Unknown stretch_dim {self.stretch_dim[dim]!r} for dimension {dim}."
                     )
 
         for igrid, (ytlevel, morton_index) in enumerate(
             zip(ytlevels, morton_indices, strict=True)
         ):
+            amrvac_level = ytlevel + 1  # AMRVAC uses 1-based indexing for levels
             left_edge = np.zeros(ndim, dtype="float64")
             right_edge = np.zeros(ndim, dtype="float64")
             cw_aux = []
@@ -226,21 +227,20 @@ class AMRVACHierarchy(GridIndex):
                         cw_aux.append([dx[dim]] * block_nx[dim])
                     case "uni" | "uniform":
                         # left edge
-                        center1 = (xmin[dim] + 0.5 * dxfirst[ytlevel+1, dim]) * qstretch[ytlevel+1, dim] ** ((morton_index[dim] - 1) * block_nx[dim])
-                        dcenter1 = 2.0 * center1 * (qstretch[ytlevel+1, dim] - 1.0) / (qstretch[ytlevel+1, dim] + 1.0)
+                        center1 = (xmin[dim] + 0.5 * dxfirst[amrvac_level, dim]) * qstretch[amrvac_level, dim] ** ((morton_index[dim] - 1) * block_nx[dim])
+                        dcenter1 = 2.0 * center1 * (qstretch[amrvac_level, dim] - 1.0) / (qstretch[amrvac_level, dim] + 1.0)
                         left_edge[dim] = center1 - 0.5 * dcenter1
                         # right edge
-                        center2 = (xmin[dim] + 0.5 * dxfirst[ytlevel+1, dim]) * qstretch[ytlevel+1, dim] ** (morton_index[dim] * block_nx[dim] - 1)
-                        dcenter2 = 2.0 * center2 * (qstretch[ytlevel+1, dim] - 1.0) / (qstretch[ytlevel+1, dim] + 1.0)
+                        center2 = (xmin[dim] + 0.5 * dxfirst[amrvac_level, dim]) * qstretch[amrvac_level, dim] ** (morton_index[dim] * block_nx[dim] - 1)
+                        dcenter2 = 2.0 * center2 * (qstretch[amrvac_level, dim] - 1.0) / (qstretch[amrvac_level, dim] + 1.0)
                         right_edge[dim] = center2 + 0.5 * dcenter2
                         # cell widths
-                        dcenter = [
+                        cw_aux.append([
                             (
-                                (xmin[dim] + 0.5 * dxfirst[ytlevel+1, dim]) * qstretch[ytlevel+1, dim] ** ((morton_index[dim] - 1) * block_nx[dim] + i)
-                                * 2.0 * (qstretch[ytlevel+1, dim] - 1.0) / (qstretch[ytlevel+1, dim] + 1.0)
+                                (xmin[dim] + 0.5 * dxfirst[amrvac_level, dim]) * qstretch[amrvac_level, dim] ** ((morton_index[dim] - 1) * block_nx[dim] + i)
+                                * 2.0 * (qstretch[amrvac_level, dim] - 1.0) / (qstretch[amrvac_level, dim] + 1.0)
                             ) for i in range(block_nx[dim])
-                        ]
-                        cw_aux.append(dcenter)
+                        ])
                 dim_count += 1
             while dim_count < 3:
                 cw_aux.append([1.0])

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -107,9 +107,10 @@ class AMRVACHierarchy(GridIndex):
             meshlist = self.dataset.namelist["meshlist"]
             if (stretch_dim := meshlist.get("stretch_dim")) is not None:
                 assert isinstance(stretch_dim, list)
+                assert len(stretch_dim) <= self.dataset.dimensionality
+                stretch_dim = ['none' if v is None else v for v in stretch_dim]
                 assert all(isinstance(x, str) for x in stretch_dim)
-                assert len(stretch_dim) >= self.dataset.dimensionality
-                self.stretch_dim = stretch_dim
+                self.stretch_dim[:len(stretch_dim)] = stretch_dim
 
         super().__init__(ds, dataset_type)
 

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -9,7 +9,6 @@ import os
 import struct
 import warnings
 import weakref
-from itertools import product
 from pathlib import Path
 
 import numpy as np

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -228,9 +228,8 @@ class AMRVACHierarchy(GridIndex):
                     case "uni" | "uniform":
                         amrvac_level = ytlevel + 1  # AMRVAC uses 1-based indexing for levels
                         q = qstretch[amrvac_level, dim]
-                        dx = dxfirst[amrvac_level, dim]
 
-                        base = xmin[dim] + 0.5 * dx
+                        base = xmin[dim] + 0.5 * dxfirst[amrvac_level, dim]
                         correction = (q - 1.0) / (q + 1.0)
 
                         # left edge
@@ -251,7 +250,9 @@ class AMRVACHierarchy(GridIndex):
                             ) for i in range(block_nx[dim])
                         ])
             cell_widths.extend([[1.0]] * (3 - ndim))
-            cell_widths = np.array(list(product(*cell_widths[::-1]))).T[::-1]
+            cell_widths = np.stack(
+                np.meshgrid(*cell_widths[::-1], indexing="ij")
+            )[::-1].reshape(3, -1)
 
             # edges and dimensions are filled in a dimensionality-agnostic way
             self.grid_left_edge[igrid, :ndim] = left_edge

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -153,31 +153,32 @@ class AMRVACHierarchy(GridIndex):
 
         self.grids = np.empty(self.num_grids, dtype="object")
         stretched_dims = [not (x == "none" or x == "") for x in self.stretch_dim]
+        base_stretch = np.ones(3, dtype="float64")
         if np.any(stretched_dims):
             meshlist = self.dataset.namelist["meshlist"]
             stretch_baselevel = meshlist.get("qstretch_baselevel")
-            if "qstretch_baselevel" not in meshlist:
-                # compute default values dynamically, just as done in AMRVAC
-                assert sum(stretched_dims) == 1  # exactly one stretched direction
-                stretched_dim = stretched_dims.index(True) + 1 # AMRVAC index (1 offset, Fortran convention)
-                _sbl = [1.0] * ndim
-                _sbl[stretched_dim-1] = (
-                    meshlist[f"xprobmax{stretched_dim}"]
-                    / meshlist[f"xprobmin{stretched_dim}"]
-                ) ** (1.0 / meshlist[f"domain_nx{stretched_dim}"])
-                stretch_baselevel = tuple(_sbl)
-            elif isinstance(stretch_baselevel := meshlist["qstretch_baselevel"], list):
-                assert len(stretch_baselevel) >= ndim
-                stretch_baselevel = (
-                    float(b) for b in stretch_baselevel[:ndim]
-                )
-            else:
-                assert isinstance(stretch_baselevel, float | int)
-                assert sum(stretched_dims) == 1  # exactly one stretched direction
-                stretched_dim = stretched_dims.index(True)
-                _sbl = [1.0] * ndim
-                _sbl[stretched_dim] = stretch_baselevel
-                stretch_baselevel = tuple(_sbl)
+            match stretch_baselevel:
+                case None:
+                    # compute default values dynamically, just as done in AMRVAC
+                    assert sum(stretched_dims) == 1  # exactly one stretched direction
+                    stretched_dim = stretched_dims.index(True) + 1 # AMRVAC index (1 offset, Fortran convention)
+                    base_stretch[stretched_dim-1] = (
+                        meshlist[f"xprobmax{stretched_dim}"]
+                        / meshlist[f"xprobmin{stretched_dim}"]
+                    ) ** (1.0 / meshlist[f"domain_nx{stretched_dim}"])
+                case list() | tuple():
+                    assert len(stretch_baselevel) >= ndim
+                    base_stretch[:ndim] = (
+                        float(b) for b in stretch_baselevel[:ndim]
+                    )
+                case float() | int():
+                    assert sum(stretched_dims) == 1  # exactly one stretched direction
+                    stretched_dim = stretched_dims.index(True)
+                    base_stretch[stretched_dim] = stretch_baselevel
+                case _:
+                    raise ValueError(
+                        f"Unknown type for qstretch_baselevel: {type(stretch_baselevel)}"
+                    )
 
         qstretch = np.zeros((self.max_level + 2, ndim), dtype="float64")
         dxfirst = np.zeros((self.max_level + 2, ndim), dtype="float64")
@@ -185,7 +186,7 @@ class AMRVACHierarchy(GridIndex):
             if self.stretch_dim[dim] in ["none", ""]:
                 continue
             elif self.stretch_dim[dim] in ["uni", "uniform"]:
-                qstretch[1, dim] = stretch_baselevel[dim]
+                qstretch[1, dim] = base_stretch[dim]
                 dxfirst[1, dim] = (
                     domain_width[dim] * (1.0 - qstretch[1, dim])
                     / (1.0 - qstretch[1, dim] ** meshlist[f"domain_nx{dim + 1}"])

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -107,6 +107,7 @@ class AMRVACHierarchy(GridIndex):
             meshlist = self.dataset.namelist["meshlist"]
             if (stretch_dim := meshlist.get("stretch_dim")) is not None:
                 assert isinstance(stretch_dim, list)
+                assert all(isinstance(x, str) for x in stretch_dim)
                 assert len(stretch_dim) >= self.dataset.dimensionality
                 self.stretch_dim = stretch_dim
 

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -227,13 +227,15 @@ class AMRVACHierarchy(GridIndex):
                         cw_aux.append([dx[dim]] * block_nx[dim])
                     case "uni" | "uniform":
                         # left edge
-                        center1 = (xmin[dim] + 0.5 * dxfirst[amrvac_level, dim]) * qstretch[amrvac_level, dim] ** ((morton_index[dim] - 1) * block_nx[dim])
-                        dcenter1 = 2.0 * center1 * (qstretch[amrvac_level, dim] - 1.0) / (qstretch[amrvac_level, dim] + 1.0)
-                        left_edge[dim] = center1 - 0.5 * dcenter1
+                        left_edge[dim] = (
+                            (xmin[dim] + 0.5 * dxfirst[amrvac_level, dim]) * qstretch[amrvac_level, dim] ** ((morton_index[dim] - 1) * block_nx[dim])
+                            * (1.0 - (qstretch[amrvac_level, dim] - 1.0) / (qstretch[amrvac_level, dim] + 1.0))
+                        )
                         # right edge
-                        center2 = (xmin[dim] + 0.5 * dxfirst[amrvac_level, dim]) * qstretch[amrvac_level, dim] ** (morton_index[dim] * block_nx[dim] - 1)
-                        dcenter2 = 2.0 * center2 * (qstretch[amrvac_level, dim] - 1.0) / (qstretch[amrvac_level, dim] + 1.0)
-                        right_edge[dim] = center2 + 0.5 * dcenter2
+                        right_edge[dim] = (
+                            (xmin[dim] + 0.5 * dxfirst[amrvac_level, dim]) * qstretch[amrvac_level, dim] ** (morton_index[dim] * block_nx[dim] - 1)
+                            * (1.0 + (qstretch[amrvac_level, dim] - 1.0) / (qstretch[amrvac_level, dim] + 1.0))
+                        )
                         # cell widths
                         cw_aux.append([
                             (

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -9,10 +9,10 @@ import os
 import struct
 import warnings
 import weakref
+from itertools import product
 from pathlib import Path
 
 import numpy as np
-from itertools import product
 from more_itertools import always_iterable
 
 from yt.config import ytcfg
@@ -204,7 +204,7 @@ class AMRVACHierarchy(GridIndex):
                             )
                 case "symm" | "symmetric":
                     raise ValueError(
-                        f"Symmetric stretching is not currently supported for AMRVAC data."
+                        "Symmetric stretching is not currently supported for AMRVAC data."
                     )
                 case _:
                     raise ValueError(
@@ -251,7 +251,7 @@ class AMRVACHierarchy(GridIndex):
                 dim_count += 1
             prod = np.array(list(product(*cw_aux[::-1])))
             cell_widths = (prod.T)[::-1]
-            
+
             # edges and dimensions are filled in a dimensionality-agnostic way
             self.grid_left_edge[igrid, :ndim] = left_edge
             self.grid_right_edge[igrid, :ndim] = right_edge

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -219,6 +219,7 @@ class AMRVACHierarchy(GridIndex):
             cell_widths = np.zeros((ndim, np.prod(block_nx)), dtype="float64")
             cw_aux = []
 
+            dim_count = 0
             for dim in range(ndim):
                 if self.stretch_dim[dim] == "none" or self.stretch_dim[dim] == "":
                     dx = dx0 / self.dataset.refine_by**ytlevel
@@ -241,6 +242,10 @@ class AMRVACHierarchy(GridIndex):
                         dcenter = 2.0 * center * (qstretch[ytlevel+1, dim] - 1.0) / (qstretch[ytlevel+1, dim] + 1.0)
                         aux2.append(dcenter)
                     cw_aux.append(aux2)
+                dim_count += 1
+            while dim_count < 3:
+                cw_aux.append([1.0])
+                dim_count += 1
             prod = np.array([x for x in product(*cw_aux[::-1])])
             cell_widths = (prod.T)[::-1]
             

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -227,21 +227,27 @@ class AMRVACHierarchy(GridIndex):
                         cell_widths.append([dx] * block_nx[dim])
                     case "uni" | "uniform":
                         amrvac_level = ytlevel + 1  # AMRVAC uses 1-based indexing for levels
+                        q = qstretch[amrvac_level, dim]
+                        dx = dxfirst[amrvac_level, dim]
+
+                        base = xmin[dim] + 0.5 * dx
+                        correction = (q - 1.0) / (q + 1.0)
+
                         # left edge
                         left_edge[dim] = (
-                            (xmin[dim] + 0.5 * dxfirst[amrvac_level, dim]) * qstretch[amrvac_level, dim] ** ((morton_index[dim] - 1) * block_nx[dim])
-                            * (1.0 - (qstretch[amrvac_level, dim] - 1.0) / (qstretch[amrvac_level, dim] + 1.0))
+                            base * q ** ((morton_index[dim] - 1) * block_nx[dim])
+                            * (1.0 - correction)
                         )
                         # right edge
                         right_edge[dim] = (
-                            (xmin[dim] + 0.5 * dxfirst[amrvac_level, dim]) * qstretch[amrvac_level, dim] ** (morton_index[dim] * block_nx[dim] - 1)
-                            * (1.0 + (qstretch[amrvac_level, dim] - 1.0) / (qstretch[amrvac_level, dim] + 1.0))
+                            base * q ** (morton_index[dim] * block_nx[dim] - 1)
+                            * (1.0 + correction)
                         )
                         # cell widths
                         cell_widths.append([
                             (
-                                (xmin[dim] + 0.5 * dxfirst[amrvac_level, dim]) * qstretch[amrvac_level, dim] ** ((morton_index[dim] - 1) * block_nx[dim] + i)
-                                * 2.0 * (qstretch[amrvac_level, dim] - 1.0) / (qstretch[amrvac_level, dim] + 1.0)
+                                base * q ** ((morton_index[dim] - 1) * block_nx[dim] + i)
+                                * 2.0 * correction
                             ) for i in range(block_nx[dim])
                         ])
             cell_widths.extend([[1.0]] * (3 - ndim))

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -183,30 +183,31 @@ class AMRVACHierarchy(GridIndex):
         qstretch = np.zeros((self.max_level + 2, ndim), dtype="float64")
         dxfirst = np.zeros((self.max_level + 2, ndim), dtype="float64")
         for dim in range(ndim):
-            if self.stretch_dim[dim] in ["none", ""]:
-                continue
-            elif self.stretch_dim[dim] in ["uni", "uniform"]:
-                qstretch[1, dim] = base_stretch[dim]
-                dxfirst[1, dim] = (
-                    domain_width[dim] * (1.0 - qstretch[1, dim])
-                    / (1.0 - qstretch[1, dim] ** meshlist[f"domain_nx{dim + 1}"])
-                )
-                qstretch[0, dim] = qstretch[1, dim] ** 2
-                dxfirst[0, dim] = dxfirst[1, dim] * (1.0 + qstretch[1, dim])
-                if self.max_level > 0:
-                    for ilev in range(2, self.max_level + 2):
-                        qstretch[ilev, dim] = np.sqrt(qstretch[ilev - 1, dim])
-                        dxfirst[ilev, dim] = dxfirst[ilev - 1, dim] / (
-                            1.0 + np.sqrt(qstretch[ilev - 1, dim])
-                        )
-            elif self.stretch_dim[dim] in ["symm", "symmetric"]:
-                raise ValueError(
-                    f"Symmetric stretching is not currently supported for AMRVAC data."
-                )
-            else:
-                raise ValueError(
-                    f"Unknown stretch_dim '{self.stretch_dim[dim]}' for dimension {dim}."
-                )
+            match self.stretch_dim[dim]:
+                case "none" | "":
+                    continue
+                case "uni" | "uniform":
+                    qstretch[1, dim] = base_stretch[dim]
+                    dxfirst[1, dim] = (
+                        domain_width[dim] * (1.0 - qstretch[1, dim])
+                        / (1.0 - qstretch[1, dim] ** meshlist[f"domain_nx{dim + 1}"])
+                    )
+                    qstretch[0, dim] = qstretch[1, dim] ** 2
+                    dxfirst[0, dim] = dxfirst[1, dim] * (1.0 + qstretch[1, dim])
+                    if self.max_level > 0:
+                        for ilev in range(2, self.max_level + 2):
+                            qstretch[ilev, dim] = np.sqrt(qstretch[ilev - 1, dim])
+                            dxfirst[ilev, dim] = dxfirst[ilev - 1, dim] / (
+                                1.0 + np.sqrt(qstretch[ilev - 1, dim])
+                            )
+                case "symm" | "symmetric":
+                    raise ValueError(
+                        f"Symmetric stretching is not currently supported for AMRVAC data."
+                    )
+                case _:
+                    raise ValueError(
+                        f"Unknown stretch_dim '{self.stretch_dim[dim]}' for dimension {dim}."
+                    )
 
         for igrid, (ytlevel, morton_index) in enumerate(
             zip(ytlevels, morton_indices, strict=True)
@@ -217,28 +218,29 @@ class AMRVACHierarchy(GridIndex):
 
             dim_count = 0
             for dim in range(ndim):
-                if self.stretch_dim[dim] == "none" or self.stretch_dim[dim] == "":
-                    dx = dx0 / self.dataset.refine_by**ytlevel
-                    left_edge[dim] = xmin[dim] + (morton_index[dim] - 1) * block_nx[dim] * dx[dim]
-                    right_edge[dim] = left_edge[dim] + block_nx[dim] * dx[dim]
-                    cw_aux.append([dx[dim]] * block_nx[dim])
-                elif self.stretch_dim[dim] in ["uni", "uniform"]:
-                    # left edge
-                    center1 = (xmin[dim] + 0.5 * dxfirst[ytlevel+1, dim]) * qstretch[ytlevel+1, dim] ** ((morton_index[dim] - 1) * block_nx[dim])
-                    dcenter1 = 2.0 * center1 * (qstretch[ytlevel+1, dim] - 1.0) / (qstretch[ytlevel+1, dim] + 1.0)
-                    left_edge[dim] = center1 - 0.5 * dcenter1
-                    # right edge
-                    center2 = (xmin[dim] + 0.5 * dxfirst[ytlevel+1, dim]) * qstretch[ytlevel+1, dim] ** (morton_index[dim] * block_nx[dim] - 1)
-                    dcenter2 = 2.0 * center2 * (qstretch[ytlevel+1, dim] - 1.0) / (qstretch[ytlevel+1, dim] + 1.0)
-                    right_edge[dim] = center2 + 0.5 * dcenter2
-                    # cell widths
-                    dcenter = [
-                        (
-                            (xmin[dim] + 0.5 * dxfirst[ytlevel+1, dim]) * qstretch[ytlevel+1, dim] ** ((morton_index[dim] - 1) * block_nx[dim] + i)
-                            * 2.0 * (qstretch[ytlevel+1, dim] - 1.0) / (qstretch[ytlevel+1, dim] + 1.0)
-                        ) for i in range(block_nx[dim])
-                    ]
-                    cw_aux.append(dcenter)
+                match self.stretch_dim[dim]:
+                    case "none" | "":
+                        dx = dx0 / self.dataset.refine_by**ytlevel
+                        left_edge[dim] = xmin[dim] + (morton_index[dim] - 1) * block_nx[dim] * dx[dim]
+                        right_edge[dim] = left_edge[dim] + block_nx[dim] * dx[dim]
+                        cw_aux.append([dx[dim]] * block_nx[dim])
+                    case "uni" | "uniform":
+                        # left edge
+                        center1 = (xmin[dim] + 0.5 * dxfirst[ytlevel+1, dim]) * qstretch[ytlevel+1, dim] ** ((morton_index[dim] - 1) * block_nx[dim])
+                        dcenter1 = 2.0 * center1 * (qstretch[ytlevel+1, dim] - 1.0) / (qstretch[ytlevel+1, dim] + 1.0)
+                        left_edge[dim] = center1 - 0.5 * dcenter1
+                        # right edge
+                        center2 = (xmin[dim] + 0.5 * dxfirst[ytlevel+1, dim]) * qstretch[ytlevel+1, dim] ** (morton_index[dim] * block_nx[dim] - 1)
+                        dcenter2 = 2.0 * center2 * (qstretch[ytlevel+1, dim] - 1.0) / (qstretch[ytlevel+1, dim] + 1.0)
+                        right_edge[dim] = center2 + 0.5 * dcenter2
+                        # cell widths
+                        dcenter = [
+                            (
+                                (xmin[dim] + 0.5 * dxfirst[ytlevel+1, dim]) * qstretch[ytlevel+1, dim] ** ((morton_index[dim] - 1) * block_nx[dim] + i)
+                                * 2.0 * (qstretch[ytlevel+1, dim] - 1.0) / (qstretch[ytlevel+1, dim] + 1.0)
+                            ) for i in range(block_nx[dim])
+                        ]
+                        cw_aux.append(dcenter)
                 dim_count += 1
             while dim_count < 3:
                 cw_aux.append([1.0])

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -214,19 +214,19 @@ class AMRVACHierarchy(GridIndex):
         for igrid, (ytlevel, morton_index) in enumerate(
             zip(ytlevels, morton_indices, strict=True)
         ):
-            amrvac_level = ytlevel + 1  # AMRVAC uses 1-based indexing for levels
             left_edge = np.zeros(ndim, dtype="float64")
             right_edge = np.zeros(ndim, dtype="float64")
-            cw_aux = []
+            cell_widths = []
 
             for dim in range(ndim):
                 match self.stretch_dim[dim]:
                     case "none" | "":
-                        dx = dx0 / self.dataset.refine_by**ytlevel
-                        left_edge[dim] = xmin[dim] + (morton_index[dim] - 1) * block_nx[dim] * dx[dim]
-                        right_edge[dim] = left_edge[dim] + block_nx[dim] * dx[dim]
-                        cw_aux.append([dx[dim]] * block_nx[dim])
+                        dx = dx0[dim] / self.dataset.refine_by**ytlevel
+                        left_edge[dim] = xmin[dim] + (morton_index[dim] - 1) * block_nx[dim] * dx
+                        right_edge[dim] = left_edge[dim] + block_nx[dim] * dx
+                        cell_widths.append([dx] * block_nx[dim])
                     case "uni" | "uniform":
+                        amrvac_level = ytlevel + 1  # AMRVAC uses 1-based indexing for levels
                         # left edge
                         left_edge[dim] = (
                             (xmin[dim] + 0.5 * dxfirst[amrvac_level, dim]) * qstretch[amrvac_level, dim] ** ((morton_index[dim] - 1) * block_nx[dim])
@@ -238,15 +238,14 @@ class AMRVACHierarchy(GridIndex):
                             * (1.0 + (qstretch[amrvac_level, dim] - 1.0) / (qstretch[amrvac_level, dim] + 1.0))
                         )
                         # cell widths
-                        cw_aux.append([
+                        cell_widths.append([
                             (
                                 (xmin[dim] + 0.5 * dxfirst[amrvac_level, dim]) * qstretch[amrvac_level, dim] ** ((morton_index[dim] - 1) * block_nx[dim] + i)
                                 * 2.0 * (qstretch[amrvac_level, dim] - 1.0) / (qstretch[amrvac_level, dim] + 1.0)
                             ) for i in range(block_nx[dim])
                         ])
-            cw_aux.extend([[1.0]] * (3 - ndim))
-            prod = np.array(list(product(*cw_aux[::-1])))
-            cell_widths = (prod.T)[::-1]
+            cell_widths.extend([[1.0]] * (3 - ndim))
+            cell_widths = np.array(list(product(*cell_widths[::-1]))).T[::-1]
 
             # edges and dimensions are filled in a dimensionality-agnostic way
             self.grid_left_edge[igrid, :ndim] = left_edge

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -232,12 +232,13 @@ class AMRVACHierarchy(GridIndex):
                     dcenter2 = 2.0 * center2 * (qstretch[ytlevel+1, dim] - 1.0) / (qstretch[ytlevel+1, dim] + 1.0)
                     right_edge[dim] = center2 + 0.5 * dcenter2
                     # cell widths
-                    aux2 = []
-                    for i in range(block_nx[dim]):
-                        center = (xmin[dim] + 0.5 * dxfirst[ytlevel+1, dim]) * qstretch[ytlevel+1, dim] ** ((morton_index[dim] - 1) * block_nx[dim] + i)
-                        dcenter = 2.0 * center * (qstretch[ytlevel+1, dim] - 1.0) / (qstretch[ytlevel+1, dim] + 1.0)
-                        aux2.append(dcenter)
-                    cw_aux.append(aux2)
+                    dcenter = [
+                        (
+                            (xmin[dim] + 0.5 * dxfirst[ytlevel+1, dim]) * qstretch[ytlevel+1, dim] ** ((morton_index[dim] - 1) * block_nx[dim] + i)
+                            * 2.0 * (qstretch[ytlevel+1, dim] - 1.0) / (qstretch[ytlevel+1, dim] + 1.0)
+                        ) for i in range(block_nx[dim])
+                    ]
+                    cw_aux.append(dcenter)
                 dim_count += 1
             while dim_count < 3:
                 cw_aux.append([1.0])

--- a/yt/frontends/amrvac/data_structures.py
+++ b/yt/frontends/amrvac/data_structures.py
@@ -213,7 +213,6 @@ class AMRVACHierarchy(GridIndex):
         ):
             left_edge = np.zeros(ndim, dtype="float64")
             right_edge = np.zeros(ndim, dtype="float64")
-            cell_widths = np.zeros((ndim, np.prod(block_nx)), dtype="float64")
             cw_aux = []
 
             dim_count = 0

--- a/yt/frontends/amrvac/io.py
+++ b/yt/frontends/amrvac/io.py
@@ -37,7 +37,10 @@ def read_amrvac_namelist(parfiles):
     parfiles = (os.path.expanduser(pf) for pf in always_iterable(parfiles))
 
     # first merge the namelists
-    namelists = [f90nml.read(parfile) for parfile in parfiles]
+    parser = f90nml.Parser()
+    parser.default_start_index = 1
+
+    namelists = [parser.read(parfile) for parfile in parfiles]
     unified_namelist = f90nml.Namelist()
     for nml in namelists:
         unified_namelist.patch(nml)

--- a/yt/frontends/amrvac/io.py
+++ b/yt/frontends/amrvac/io.py
@@ -38,7 +38,7 @@ def read_amrvac_namelist(parfiles):
 
     # first merge the namelists
     parser = f90nml.Parser()
-    parser.default_start_index = 1
+    parser.global_start_index = 1
 
     namelists = [parser.read(parfile) for parfile in parfiles]
     unified_namelist = f90nml.Namelist()

--- a/yt/utilities/on_demand_imports.py
+++ b/yt/utilities/on_demand_imports.py
@@ -438,7 +438,7 @@ class f90nml_imports(OnDemand):
         from f90nml import Namelist
 
         return Namelist
-    
+
     @safe_import
     def Parser(self):
         from f90nml import Parser

--- a/yt/utilities/on_demand_imports.py
+++ b/yt/utilities/on_demand_imports.py
@@ -438,6 +438,12 @@ class f90nml_imports(OnDemand):
         from f90nml import Namelist
 
         return Namelist
+    
+    @safe_import
+    def Parser(self):
+        from f90nml import Parser
+
+        return Parser
 
 
 _f90nml = f90nml_imports()


### PR DESCRIPTION
## PR Summary

Redefines the AMRVACGrid as a subclass of StretchedGrid and calculates the cell widths' deviation from uniform.

## PR Checklist

- [x] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
