### PR TITLE
BUG: Save ProfilePlot output inside directory paths

### DIFF
--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -303,11 +303,17 @@ class ProfilePlot(BaseLinePlot):
         else:
             iters = self.plots.items()
 
+        if len(self.profiles) == 1:  # type: ignore
+            default_name = str(self.profiles[0].ds)  # type: ignore
+        else:
+            default_name = "Multi-data"
+
         if name is None:
-            if len(self.profiles) == 1:  # type: ignore
-                name = str(self.profiles[0].ds)  # type: ignore
-            else:
-                name = "Multi-data"
+            name = default_name
+
+        name = os.path.expanduser(name)
+        if os.path.isdir(name) and name != default_name:
+            name = os.path.join(name, default_name)
 
         name = validate_image_name(name, suffix)
         prefix, suffix = os.path.splitext(name)

--- a/yt/visualization/tests/test_profile_plots.py
+++ b/yt/visualization/tests/test_profile_plots.py
@@ -125,6 +125,17 @@ def test_set_units():
     p2.set_unit(("gas", "temperature"), "R")
 
 
+def test_profileplot_save_to_directory(tmp_path):
+    ds = fake_random_ds(16)
+    plot = yt.ProfilePlot(
+        ds.all_data(), ("index", "radius"), ("gas", "density"), weight_field=None
+    )
+
+    expected = tmp_path / f"{ds}_1d-Profile_radius_density.png"
+    assert plot.save(f"{tmp_path}{os.sep}") == [str(expected)]
+    assert expected.is_file()
+
+
 def test_set_labels():
     ds = fake_random_ds(16)
     ad = ds.all_data()


### PR DESCRIPTION
## PR Summary

`ProfilePlot.save()` currently validates a directory path as an image name before adding the dataset basename, producing paths such as `folder/.png_1d-Profile_radius_density`. This change recognizes existing output directories first, appends the same dataset-based default name used by `save()`, and only then validates the image suffix.

A regression test saves a real profile plot into a temporary directory and verifies both the returned filename and the created file.

Fixes #5192.

## PR Checklist

- [ ] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

## Verification

- `.venv/bin/python -m pytest yt/visualization/tests/test_profile_plots.py yt/visualization/tests/test_base_plot_types.py yt/visualization/tests/test_commons.py -q` (50 passed)
- `.venv/bin/mypy yt/visualization/profile_plotter.py`
- `uvx ruff check yt/visualization/profile_plotter.py yt/visualization/tests/test_profile_plots.py`
- `uvx ruff format --check yt/visualization/profile_plotter.py yt/visualization/tests/test_profile_plots.py`