### PR TITLE
Fix PhasePlot.save() overwriting output when several z fields are used

### DIFF
--- a/yt/visualization/profile_plotter.py
+++ b/yt/visualization/profile_plotter.py
@@ -1257,31 +1257,33 @@ class PhasePlot(ImagePlotContainer):
             xfn = xfn[1]
         if isinstance(yfn, tuple):
             yfn = yfn[1]
+
+        splitname = os.path.split(name)
+        if splitname[0] != "" and not os.path.isdir(splitname[0]):
+            os.makedirs(splitname[0])
+        if os.path.isdir(name) and name != str(self.profile.ds):
+            name = name + (os.sep if name[-1] != os.sep else "")
+            name += str(self.profile.ds)
+
+        new_name = validate_image_name(name, suffix)
+        if new_name == name:
+            for v in self.plots.values():
+                out_name = v.save(name, mpl_kwargs)
+                names.append(out_name)
+            return names
+
+        name = new_name
+        prefix, suffix = os.path.splitext(name)
+
         for f in self.profile.field_data:
             _f = f
             if isinstance(f, tuple):
                 _f = _f[1]
             middle = f"2d-Profile_{xfn}_{yfn}_{_f}"
-            splitname = os.path.split(name)
-            if splitname[0] != "" and not os.path.isdir(splitname[0]):
-                os.makedirs(splitname[0])
-            if os.path.isdir(name) and name != str(self.profile.ds):
-                name = name + (os.sep if name[-1] != os.sep else "")
-                name += str(self.profile.ds)
+            fname = f"{prefix}_{middle}{suffix}"
 
-            new_name = validate_image_name(name, suffix)
-            if new_name == name:
-                for v in self.plots.values():
-                    out_name = v.save(name, mpl_kwargs)
-                    names.append(out_name)
-                return names
-
-            name = new_name
-            prefix, suffix = os.path.splitext(name)
-            name = f"{prefix}_{middle}{suffix}"
-
-            names.append(name)
-            self.plots[f].save(name, mpl_kwargs)
+            names.append(fname)
+            self.plots[f].save(fname, mpl_kwargs)
         return names
 
     @invalidate_plot

--- a/yt/visualization/tests/test_profile_plots.py
+++ b/yt/visualization/tests/test_profile_plots.py
@@ -270,3 +270,52 @@ def test_phaseplot_showhide_colorbar_axes():
     plot.show_axes()
     with tempfile.NamedTemporaryFile(suffix="png") as f4:
         plot.save(f4.name)
+
+
+def test_phaseplot_save_multiple_z_fields(tmp_path):
+    # see issue https://github.com/yt-project/yt/issues/5152
+    # a PhasePlot with several z fields used to write every image to the
+    # same file (each one overwriting the last) and return that single
+    # name once per plot plus an extra time.
+    ds = fake_random_ds(
+        16,
+        fields=("density", "temperature", "velocity_x"),
+        units=("g/cm**3", "K", "cm/s"),
+    )
+    plot = yt.PhasePlot(
+        ds.all_data(),
+        ("gas", "density"),
+        ("gas", "temperature"),
+        [("gas", "mass"), ("gas", "velocity_x")],
+    )
+    names = plot.save(tmp_path / "test")
+
+    assert len(names) == 2
+    assert len(set(names)) == 2
+    assert [os.path.basename(name) for name in sorted(names)] == [
+        "test_2d-Profile_density_temperature_mass.png",
+        "test_2d-Profile_density_temperature_velocity_x.png",
+    ]
+    assert sorted(p.name for p in tmp_path.glob("*.png")) == [
+        "test_2d-Profile_density_temperature_mass.png",
+        "test_2d-Profile_density_temperature_velocity_x.png",
+    ]
+
+
+def test_phaseplot_save_multiple_z_fields_to_directory(tmp_path):
+    # same as above, but letting the dataset name provide the file prefix
+    ds = fake_random_ds(
+        16,
+        fields=("density", "temperature", "velocity_x"),
+        units=("g/cm**3", "K", "cm/s"),
+    )
+    plot = yt.PhasePlot(
+        ds.all_data(),
+        ("gas", "density"),
+        ("gas", "temperature"),
+        [("gas", "mass"), ("gas", "velocity_x")],
+    )
+    names = plot.save(str(tmp_path) + os.sep)
+
+    assert len(set(names)) == 2
+    assert len(list(tmp_path.glob("*.png"))) == 2


### PR DESCRIPTION
`PhasePlot.save()` writes every image to the same file when the plot has more than one z field, so all but the last are silently lost. The returned list is wrong too — it contains the same name repeated, once per plot plus an extra.

Reproducing on current `main` with two z fields:

```python
ds = fake_random_ds(16, fields=("density", "temperature", "velocity_x"),
                    units=("g/cm**3", "K", "cm/s"))
plot = yt.PhasePlot(ds.all_data(), ("gas", "density"), ("gas", "temperature"),
                    [("gas", "mass"), ("gas", "velocity_x")])
print(plot.save("test"))
```

```
returned: ['test_2d-Profile_density_temperature_mass.png',
           'test_2d-Profile_density_temperature_mass.png',
           'test_2d-Profile_density_temperature_mass.png']
on disk : ['test_2d-Profile_density_temperature_mass.png']
```

Two plots were requested, three names came back, and one file exists — holding the *second* field's image under the *first* field's name.

## What was going wrong

`PhasePlot.save()` did all of its filename construction *inside* the loop over `self.profile.field_data`, and it assigned the result back to `name` — the same variable the next iteration reads. On the first pass `name` is something like `test`, `validate_image_name` turns it into `test.png`, and the loop rewrites it to `test_2d-Profile_density_temperature_mass.png`.

On the second pass that value already ends in `.png`, so `validate_image_name` hands it straight back, `new_name == name` is true, and the early-return branch fires — the branch meant for "the user gave me a complete filename, just write to it". That branch loops over `self.plots.values()` writing all of them to that one path and returns immediately. Hence the single file, the overwritten image, and the third entry in the list.

`ProfilePlot.save()` right above it doesn't have this problem: it normalises the name once, splits `prefix`/`suffix` once, and then builds each per-field name into a *separate* variable inside the loop.

## The fix

Same shape as `ProfilePlot.save()`. The directory handling, the `validate_image_name` call and the `os.path.splitext` all move above the loop, and the per-field name is built into a new local `fname` rather than clobbering `name`. Nothing else changes — the early-return branch still exists and still does what it did, it just can no longer be triggered by the method's own output.

After the change:

```
returned: ['test_2d-Profile_density_temperature_mass.png',
           'test_2d-Profile_density_temperature_velocity_x.png']
on disk : ['test_2d-Profile_density_temperature_mass.png',
           'test_2d-Profile_density_temperature_velocity_x.png']
```

## Testing

Two regression tests in `yt/visualization/tests/test_profile_plots.py`, one saving to a file prefix and one saving into a directory (that path goes through the `os.path.isdir` branch, which was also inside the loop). Both fail on `main` and pass with the fix:

```
# fix reverted, tests present
FAILED test_phaseplot_save_multiple_z_fields    - assert 1 == 2
FAILED test_phaseplot_save_multiple_z_fields_to_directory - assert 1 == 2
2 failed, 21 deselected

# with the fix
2 passed, 21 deselected
```

I also checked the single-z-field case, `name=None`, saving into a directory, and an explicit `suffix=".pdf"` by hand — all behave the same as before the change.

Wider suite:

```
pytest yt/visualization/tests/  (excluding the two image-comparison modules)
1 failed, 162 passed, 9 skipped
```

The one failure is `test_offaxisprojection.py::test_field_cut_off_axis_octree`, which fails identically on a pristine checkout of `main` with the change stashed — it's unrelated to this. Skips are missing optional deps (cartopy, scipy, astropy, tex).

`ruff check` and `ruff format --check` (v0.16.1, the version pinned in `.pre-commit-config.yaml`) are clean on both files.

Fixes #5152
