### PR TITLE
BUG: fix hard-coded 2x2x2 zone-count assumptions in octree neighbour-finding (issue 5402)

### DIFF
--- a/yt/data_objects/tests/test_octree.py
+++ b/yt/data_objects/tests/test_octree.py
@@ -177,6 +177,8 @@ def test_octcellindex_neighbours_num_zones():
         num_octs = selector.count_octs(octree, -1)
         _, cell_inds = octree.fill_octcellindex_neighbours(selector)
 
+        # old code hard-coded 4**3=64 cells/oct; for nz=(2,3,4) it's really
+        # 4*5*6=120 - this assertion is what catches that
         assert_equal(cell_inds.size, num_octs * n_per_oct)
         assert cell_inds.min() >= 0
         assert cell_inds.max() <= nzones

--- a/yt/data_objects/tests/test_octree.py
+++ b/yt/data_objects/tests/test_octree.py
@@ -1,8 +1,11 @@
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal
 
-from yt.geometry.oct_container import OctreeContainer
+from yt.geometry.oct_container import _ORDER_MAX, OctreeContainer
+from yt.geometry.particle_oct_container import ParticleOctreeContainer
+from yt.geometry.selection_routines import AlwaysSelector
 from yt.testing import fake_sph_grid_ds
+from yt.utilities.lib.geometry_utils import get_morton_indices
 
 n_ref = 4
 
@@ -142,3 +145,38 @@ def test_num_zones_tuple():
     assert oct_scalar is not None
     assert oct_tuple is not None
     assert oct_nonuniform is not None
+
+
+def test_octcellindex_neighbours_num_zones():
+    """
+    Regression test for #5402: fill_octcellindex_neighbours hard-coded the
+    assumption that every oct holds 2x2x2 zones, so both the loop bounds and
+    the output buffer size were wrong whenever num_zones wasn't (2, 2, 2).
+    """
+    DLE = np.array([0.0, 0.0, 0.0])
+    DRE = np.array([8.0, 8.0, 8.0])
+    dx = (DRE - DLE) / (2**_ORDER_MAX)
+
+    # One particle per octant of the root oct: refines exactly one level deep.
+    centers = np.array(
+        [[x, y, z] for x in (2, 6) for y in (2, 6) for z in (2, 6)], dtype="float64"
+    )
+    morton = get_morton_indices(np.floor((centers - DLE) / dx).astype("uint64"))
+    morton.sort()
+
+    for nz in ((2, 2, 2), (2, 3, 4)):
+        octree = ParticleOctreeContainer((1, 1, 1), DLE, DRE, num_zones=nz)
+        octree.n_ref = 1
+        octree.add(morton)
+        octree.finalize()
+
+        nzones = nz[0] * nz[1] * nz[2]
+        n_per_oct = (nz[0] + 2) * (nz[1] + 2) * (nz[2] + 2)  # +1 ghost zone each side
+
+        selector = AlwaysSelector(None)
+        num_octs = selector.count_octs(octree, -1)
+        _, cell_inds = octree.fill_octcellindex_neighbours(selector)
+
+        assert_equal(cell_inds.size, num_octs * n_per_oct)
+        assert cell_inds.min() >= 0
+        assert cell_inds.max() <= nzones

--- a/yt/data_objects/tests/test_octree.py
+++ b/yt/data_objects/tests/test_octree.py
@@ -177,8 +177,8 @@ def test_octcellindex_neighbours_num_zones():
         num_octs = selector.count_octs(octree, -1)
         _, cell_inds = octree.fill_octcellindex_neighbours(selector)
 
-        # old code hard-coded 4**3=64 cells/oct; for nz=(2,3,4) it's really
-        # 4*5*6=120 - this assertion is what catches that
+        #old oct_visitors/containers hardcoded 4**3=64 cells/oct; for nz=(2,3,4) it's really
+        # 4*5*6=120. this assertion catches that
         assert_equal(cell_inds.size, num_octs * n_per_oct)
         assert cell_inds.min() >= 0
         assert cell_inds.max() <= nzones

--- a/yt/data_objects/tests/test_octree.py
+++ b/yt/data_objects/tests/test_octree.py
@@ -177,7 +177,7 @@ def test_octcellindex_neighbours_num_zones():
         num_octs = selector.count_octs(octree, -1)
         _, cell_inds = octree.fill_octcellindex_neighbours(selector)
 
-        #old oct_visitors/containers hardcoded 4**3=64 cells/oct; for nz=(2,3,4) it's really
+        # old oct_visitors/containers hardcoded 4**3=64 cells/oct; for nz=(2,3,4) it's really
         # 4*5*6=120. this assertion catches that
         assert_equal(cell_inds.size, num_octs * n_per_oct)
         assert cell_inds.min() >= 0

--- a/yt/geometry/oct_container.pyx
+++ b/yt/geometry/oct_container.pyx
@@ -823,7 +823,7 @@ cdef class OctreeContainer:
         cdef np.uint32_t[::1] cell_inds
         cdef np.int64_t[::1] oct_inds
 
-        # must match the per-oct cell count that NeighbourCellIndexVisitor.visit() writes
+        #match per-oct cell count in NeighbourCellIndexVisitor.visit()
         n_per_oct = ((self.nz[0] + 2*n_ghost_zones)
                      * (self.nz[1] + 2*n_ghost_zones)
                      * (self.nz[2] + 2*n_ghost_zones))
@@ -934,7 +934,7 @@ cdef class OctreeContainer:
         cdef int num_octs
         if num_cells < 0:
             num_octs = selector.count_octs(self, domain_id)
-            # must match the per-oct cell count that NeighbourCellVisitor.visit() writes
+            #match per-oct cell count in NeighbourCellVisitor.visit()
             num_cells = num_octs * ((self.nz[0] + 2*n_ghost_zones)
                                      * (self.nz[1] + 2*n_ghost_zones)
                                      * (self.nz[2] + 2*n_ghost_zones))

--- a/yt/geometry/oct_container.pyx
+++ b/yt/geometry/oct_container.pyx
@@ -823,10 +823,12 @@ cdef class OctreeContainer:
         cdef np.uint32_t[::1] cell_inds
         cdef np.int64_t[::1] oct_inds
 
-        #match per-oct cell count in NeighbourCellIndexVisitor.visit()
-        n_per_oct = ((self.nz[0] + 2*n_ghost_zones)
-                     * (self.nz[1] + 2*n_ghost_zones)
-                     * (self.nz[2] + 2*n_ghost_zones))
+        # Match per-oct cell count in NeighbourCellIndexVisitor.visit()
+        n_per_oct = (
+            (self.nz[0] + 2 * n_ghost_zones)
+            * (self.nz[1] + 2 * n_ghost_zones)
+            * (self.nz[2] + 2 * n_ghost_zones)
+        )
         cell_inds = np.full(num_octs*n_per_oct, self.nz[0] * self.nz[1] * self.nz[2], dtype=np.uint32)
         oct_inds = np.full(num_octs*n_per_oct, -1, dtype=np.int64)
 
@@ -934,10 +936,12 @@ cdef class OctreeContainer:
         cdef int num_octs
         if num_cells < 0:
             num_octs = selector.count_octs(self, domain_id)
-            #match per-oct cell count in NeighbourCellVisitor.visit()
-            num_cells = num_octs * ((self.nz[0] + 2*n_ghost_zones)
-                                     * (self.nz[1] + 2*n_ghost_zones)
-                                     * (self.nz[2] + 2*n_ghost_zones))
+            # Match per-oct cell count in NeighbourCellVisitor.visit()
+            num_cells = num_octs * (
+                (self.nz[0] + 2 * n_ghost_zones)
+                * (self.nz[1] + 2 * n_ghost_zones)
+                * (self.nz[2] + 2 * n_ghost_zones)
+            )
         cdef NeighbourCellVisitor visitor
 
         cdef np.ndarray[np.uint8_t, ndim=1] levels

--- a/yt/geometry/oct_container.pyx
+++ b/yt/geometry/oct_container.pyx
@@ -818,12 +818,17 @@ cdef class OctreeContainer:
             num_octs = selector.count_octs(self, domain_id)
 
         cdef NeighbourCellIndexVisitor visitor
+        cdef int n_per_oct
 
         cdef np.uint32_t[::1] cell_inds
         cdef np.int64_t[::1] oct_inds
 
-        cell_inds = np.full(num_octs*4**3, self.nz[0] * self.nz[1] * self.nz[2], dtype=np.uint32)
-        oct_inds = np.full(num_octs*4**3, -1, dtype=np.int64)
+        # must match the per-oct cell count that NeighbourCellIndexVisitor.visit() writes
+        n_per_oct = ((self.nz[0] + 2*n_ghost_zones)
+                     * (self.nz[1] + 2*n_ghost_zones)
+                     * (self.nz[2] + 2*n_ghost_zones))
+        cell_inds = np.full(num_octs*n_per_oct, self.nz[0] * self.nz[1] * self.nz[2], dtype=np.uint32)
+        oct_inds = np.full(num_octs*n_per_oct, -1, dtype=np.int64)
 
         visitor = NeighbourCellIndexVisitor(self, -1, n_ghost_zones)
         visitor.cell_inds = cell_inds
@@ -929,7 +934,10 @@ cdef class OctreeContainer:
         cdef int num_octs
         if num_cells < 0:
             num_octs = selector.count_octs(self, domain_id)
-            num_cells = num_octs * 4**3
+            # must match the per-oct cell count that NeighbourCellVisitor.visit() writes
+            num_cells = num_octs * ((self.nz[0] + 2*n_ghost_zones)
+                                     * (self.nz[1] + 2*n_ghost_zones)
+                                     * (self.nz[2] + 2*n_ghost_zones))
         cdef NeighbourCellVisitor visitor
 
         cdef np.ndarray[np.uint8_t, ndim=1] levels

--- a/yt/geometry/oct_visitors.pyx
+++ b/yt/geometry/oct_visitors.pyx
@@ -388,7 +388,7 @@ cdef class BaseNeighbourVisitor(OctVisitor):
                 fcoords[i] += 1
             elif fcoords[i] > 1:
                 fcoords[i] -= 1
-            local_oct &= (0 <= ishift[i] <= 1)
+            local_oct &= (0 <= ishift[i] < self.nz[i])
         other_oct = not local_oct
 
         # Use octree to find neighbour
@@ -412,7 +412,7 @@ cdef class BaseNeighbourVisitor(OctVisitor):
 
         # Index of neighbouring cell within its oct
         for i in range(3):
-            self.neigh_ind[i] = <np.uint32_t>(ishift[i]) % 2
+            self.neigh_ind[i] = <np.uint32_t>(ishift[i]) % self.nz[i]
 
         self.other_oct = other_oct
         if other_oct:
@@ -460,15 +460,14 @@ cdef class NeighbourCellIndexVisitor(BaseNeighbourVisitor):
 
         self.last = o.domain_ind
 
-        cdef int i0, i1
+        cdef int i0
         i0 = -self.n_ghost_zones
-        i1 = 2 + self.n_ghost_zones
         # Loop over cells in and directly around oct
-        for i in range(i0, i1):
+        for i in range(i0, self.nz[0] + self.n_ghost_zones):
             ishift[0] = i
-            for j in range(i0, i1):
+            for j in range(i0, self.nz[1] + self.n_ghost_zones):
                 ishift[1] = j
-                for k in range(i0, i1):
+                for k in range(i0, self.nz[2] + self.n_ghost_zones):
                     ishift[2] = k
                     self.set_neighbour_info(o, ishift)
 
@@ -480,7 +479,8 @@ cdef class NeighbourCellIndexVisitor(BaseNeighbourVisitor):
                         neigh_cell_ind   = self.neighbour_rind()
                     else:
                         neigh_domain_ind = -1
-                        neigh_cell_ind   = 8
+                        # sentinel: one past the last valid cell index, i.e. "no such cell"
+                        neigh_cell_ind   = self.nz[0] * self.nz[1] * self.nz[2]
 
                     self.cell_inds[self.index]   = neigh_cell_ind
                     self.domain_inds[self.index] = neigh_domain_ind
@@ -506,15 +506,14 @@ cdef class NeighbourCellVisitor(BaseNeighbourVisitor):
 
         self.last = o.domain_ind
 
-        cdef int i0, i1
+        cdef int i0
         i0 = -self.n_ghost_zones
-        i1 = 2 + self.n_ghost_zones
         # Loop over cells in and directly around oct
-        for i in range(i0, i1):
+        for i in range(i0, self.nz[0] + self.n_ghost_zones):
             ishift[0] = i
-            for j in range(i0, i1):
+            for j in range(i0, self.nz[1] + self.n_ghost_zones):
                 ishift[1] = j
-                for k in range(i0, i1):
+                for k in range(i0, self.nz[2] + self.n_ghost_zones):
                     ishift[2] = k
                     self.set_neighbour_info(o, ishift)
 
@@ -532,7 +531,8 @@ cdef class NeighbourCellVisitor(BaseNeighbourVisitor):
                         neigh_level    = 255
                         neigh_domain   = -1
                         neigh_file_ind = -1
-                        neigh_cell_ind = 8
+                        # sentinel: one past the last valid cell index, i.e. "no such cell"
+                        neigh_cell_ind = self.nz[0] * self.nz[1] * self.nz[2]
 
                     self.levels[self.index]    = neigh_level
                     self.file_inds[self.index] = neigh_file_ind

--- a/yt/geometry/oct_visitors.pyx
+++ b/yt/geometry/oct_visitors.pyx
@@ -461,6 +461,7 @@ cdef class NeighbourCellIndexVisitor(BaseNeighbourVisitor):
         self.last = o.domain_ind
 
         cdef int i0
+        cdef int out_of_bound_cell_ind = self.nz[0] * self.nz[1] * self.nz[2]
         i0 = -self.n_ghost_zones
         # Loop over cells in and directly around oct
         for i in range(i0, self.nz[0] + self.n_ghost_zones):
@@ -479,8 +480,7 @@ cdef class NeighbourCellIndexVisitor(BaseNeighbourVisitor):
                         neigh_cell_ind   = self.neighbour_rind()
                     else:
                         neigh_domain_ind = -1
-                        #one past the last valid cell index, i.e. "no such cell"
-                        neigh_cell_ind   = self.nz[0] * self.nz[1] * self.nz[2]
+                        neigh_cell_ind   = out_of_bound_cell_ind
 
                     self.cell_inds[self.index]   = neigh_cell_ind
                     self.domain_inds[self.index] = neigh_domain_ind
@@ -507,6 +507,7 @@ cdef class NeighbourCellVisitor(BaseNeighbourVisitor):
         self.last = o.domain_ind
 
         cdef int i0
+        cdef int out_of_bound_cell_ind = self.nz[0] * self.nz[1] * self.nz[2]
         i0 = -self.n_ghost_zones
         # Loop over cells in and directly around oct
         for i in range(i0, self.nz[0] + self.n_ghost_zones):
@@ -531,8 +532,7 @@ cdef class NeighbourCellVisitor(BaseNeighbourVisitor):
                         neigh_level    = 255
                         neigh_domain   = -1
                         neigh_file_ind = -1
-                        #one past the last valid cell index, i.e. "no such cell"
-                        neigh_cell_ind = self.nz[0] * self.nz[1] * self.nz[2]
+                        neigh_cell_ind = out_of_bound_cell_ind
 
                     self.levels[self.index]    = neigh_level
                     self.file_inds[self.index] = neigh_file_ind

--- a/yt/geometry/oct_visitors.pyx
+++ b/yt/geometry/oct_visitors.pyx
@@ -479,7 +479,7 @@ cdef class NeighbourCellIndexVisitor(BaseNeighbourVisitor):
                         neigh_cell_ind   = self.neighbour_rind()
                     else:
                         neigh_domain_ind = -1
-                        # sentinel: one past the last valid cell index, i.e. "no such cell"
+                        #one past the last valid cell index, i.e. "no such cell"
                         neigh_cell_ind   = self.nz[0] * self.nz[1] * self.nz[2]
 
                     self.cell_inds[self.index]   = neigh_cell_ind
@@ -531,7 +531,7 @@ cdef class NeighbourCellVisitor(BaseNeighbourVisitor):
                         neigh_level    = 255
                         neigh_domain   = -1
                         neigh_file_ind = -1
-                        # sentinel: one past the last valid cell index, i.e. "no such cell"
+                        #one past the last valid cell index, i.e. "no such cell"
                         neigh_cell_ind = self.nz[0] * self.nz[1] * self.nz[2]
 
                     self.levels[self.index]    = neigh_level


### PR DESCRIPTION
Addresses issue #5402.
## PR Summary
Neighbour finding in `oct_container.pyx/oct_visitors.pyx `(used for ghost zone construction) assumed every oct is 2x2x2 cells, failing when non cubic zones encountered. The fix is changing how the index of neighbour cells are calculated in several places (issue list was not exhaustive)

Changes:
`BaseNeighbourVisitor.set_neighbour_info`: checking "am I still in this oct" and neighbour cell index used `%2 and <=1`, now uses `self.nz[I]` for the actual width.

`NeighbourCellIndexVisitor.visit/NeighbourCellVisitor.visit`: Used a shared bound `2 + n_ghost_zones` to check each axis, and hardcoded `8` as the no cell condition. now  uses `self.nz[axis]` and `self.nz[0,1,2]**3`(not real python, but you get the idea)

`oct_container.pyx`: the output for `fill_octcellindex_neighbours/file_index_octs_with_ghost_zones` were sized as `4**3` regardless of actual cell count.

Two of the cases above were not present in the original ticket `set_neighbour_info`.

Testing:

Added `test_octcellindex_neighbours_num_zones:yt/data_objects/tests/test_octree.py` which builds the error case with `num_zones=(2,2,2) and (2,3,4)` and asserts the expected cell count. Old code fails this, where this change fixes situations like these. All previous tests pass unchanged.

While tracing function calls, I noticed in a higher level function that `yt/frontends/ramses/data_structures.py:fcoords`
calls 
`oct_container.pyx:fill_octcellindex_neighbours`
like `oh.fill_octcellindex_neighbours(self.selector, self._num_ghost_zones)`
which is actually `num_octs` in
`def fill_octcellindex_neighbours(self, selector, num_octs=-1, domain_id=-1)`
passing ghost_zones incorrectly. This could cause overflow of a single oct and give incorrect results. Maybe a Issue should be opened up for this?
## PR Checklist

- [X] New features are documented, with docstrings and narrative docs
- [X] Adds a test for any bugs fixed. Adds tests for new features.

