### PR TITLE
TST: ignore shape-mutation deprecation warnings from numpy 2.5 on yt 4.4.x

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -160,6 +160,13 @@ def pytest_configure(config):
                 ":DeprecationWarning",
             )
 
+    if NUMPY_VERSION >= Version("2.5.0"):
+        config.addinivalue_line(
+            "filterwarnings",
+            r"ignore:Setting the shape on a NumPy array "
+            r"has been deprecated in NumPy 2\.5\.:DeprecationWarning",
+        )
+
     if PILLOW_VERSION >= Version("11.3.0") and MPL_VERSION <= Version("3.10.3"):
         # patched upstream: https://github.com/matplotlib/matplotlib/pull/30221
         config.addinivalue_line(


### PR DESCRIPTION
## PR Summary

For reference, these warnings are already correctly handled on the dev branch (#5309), but the patch isn't strictly backwards compatible so we chose not to backport it. As a result, ignoring the warning is necessary to fix CI on the backport branch.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [ ] New features are documented, with docstrings and narrative docs
- [ ] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
