### PR TITLE
[BUG] Filling cell indices with octree dataset and number of zones ≠ 2 causes a segfault

### DIFF
--- a/yt/data_objects/tests/test_octree.py
+++ b/yt/data_objects/tests/test_octree.py
@@ -2,6 +2,7 @@ import numpy as np
 from numpy.testing import assert_almost_equal, assert_equal
 
 from yt.geometry.oct_container import OctreeContainer
+from yt.geometry.selection_routines import AlwaysSelector
 from yt.testing import fake_sph_grid_ds
 
 n_ref = 4
@@ -142,3 +143,35 @@ def test_num_zones_tuple():
     assert oct_scalar is not None
     assert oct_tuple is not None
     assert oct_nonuniform is not None
+
+
+def test_fill_index_nonuniform_num_zones():
+    for shape in ((1, 1, 1), (3, 1, 2), (2, 3, 4), (2, 2, 2)):
+        octree = OctreeContainer(
+            [1, 1, 1],
+            np.array([0.0, 0.0, 0.0]),
+            np.array([1.0, 1.0, 1.0]),
+            num_zones=shape,
+        )
+        octree.allocate_domains([1])
+        octree.add(1, 0, np.array([[0.5, 0.5, 0.5]], dtype=np.float64))
+        octree.finalize()
+
+        result = octree.fill_index(AlwaysSelector(None))
+
+        assert result.shape == (octree.nocts, shape[2], shape[1], shape[0])
+
+        # yt visits octants first, then cells in each octant.
+        splits = tuple((0, size // 2, size) for size in shape)
+        expected_inds = np.empty(shape[::-1], dtype=np.int64)
+        ind = 0
+        for ii in range(2):
+            for jj in range(2):
+                for kk in range(2):
+                    for i in range(splits[0][ii], splits[0][ii + 1]):
+                        for j in range(splits[1][jj], splits[1][jj + 1]):
+                            for k in range(splits[2][kk], splits[2][kk + 1]):
+                                expected_inds[k, j, i] = ind
+                                ind += 1
+
+        assert_equal(result[0], expected_inds)

--- a/yt/geometry/oct_container.pyx
+++ b/yt/geometry/oct_container.pyx
@@ -781,7 +781,9 @@ cdef class OctreeContainer:
 
         cdef np.int64_t[:, :, :, :] cell_inds
 
-        cell_inds = np.full((self.nocts, 2, 2, 2), -1, dtype=np.int64)
+        cell_inds = np.full(
+            (self.nocts, self.nz[2], self.nz[1], self.nz[0]), -1, dtype=np.int64
+        )
 
         visitor = StoreIndex(self, -1)
         visitor.cell_inds = cell_inds


### PR DESCRIPTION
## PR Summary

Filling cell indices when we do not have 2×2×2 cells per leaf causes a segfault; see #5402. This was never triggered because we currently have no dataset actively using this layout.

This is easily fixed by expecting the number of 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->
- [x] New features are documented, with docstrings and narrative docs
- [x] Adds a test for any bugs fixed. Adds tests for new features.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or the
recommended next step seems overly demanding , or if you would like help in
addressing a reviewer's comments.  And please ping us if you've been waiting
too long to hear back on your PR.-->
