### PR TITLE
Convert YTRegion edges to code_length before selection

### DIFF
--- a/yt/data_objects/selection_objects/region.py
+++ b/yt/data_objects/selection_objects/region.py
@@ -56,13 +56,18 @@ class YTRegion(YTSelectionContainer3D):
         if not isinstance(left_edge, YTArray):
             self.left_edge = self.ds.arr(left_edge, "code_length", dtype="float64")
         else:
-            # need to assign this dataset's unit registry to the YTArray
-            self.left_edge = self.ds.arr(left_edge.copy(), dtype="float64")
+            # RegionSelector memory-views raw floats against domain edges
+            # in code_length. Attach this dataset's registry, then convert.
+            # See https://github.com/yt-project/yt/issues/5496
+            self.left_edge = self.ds.arr(left_edge.copy(), dtype="float64").in_units(
+                "code_length"
+            )
         if not isinstance(right_edge, YTArray):
             self.right_edge = self.ds.arr(right_edge, "code_length", dtype="float64")
         else:
-            # need to assign this dataset's unit registry to the YTArray
-            self.right_edge = self.ds.arr(right_edge.copy(), dtype="float64")
+            self.right_edge = self.ds.arr(right_edge.copy(), dtype="float64").in_units(
+                "code_length"
+            )
 
     def _get_bbox(self):
         """

--- a/yt/data_objects/tests/test_regions.py
+++ b/yt/data_objects/tests/test_regions.py
@@ -1,5 +1,7 @@
-from numpy.testing import assert_array_equal, assert_raises
+import numpy as np
+from numpy.testing import assert_array_equal, assert_equal, assert_raises
 
+import yt
 from yt.testing import fake_amr_ds, fake_random_ds
 from yt.units import cm
 
@@ -15,6 +17,41 @@ def test_box_creation():
     dens_no_units = reg["gas", "density"]
 
     assert_array_equal(dens_units, dens_no_units)
+
+
+def test_box_physical_unit_edges_match_code_length():
+    # https://github.com/yt-project/yt/issues/5496
+    # A subset box in physical units must select the same particles as the
+    # equivalent code_length box. The existing test_box_creation uses the
+    # full domain, which hides the mismatch.
+    positions = np.array([0.10, 0.45, 0.50, 0.55, 0.90])
+    data = {
+        "particle_position_x": positions,
+        "particle_position_y": positions,
+        "particle_position_z": positions,
+        "particle_mass": np.ones(positions.size),
+    }
+    ds = yt.load_particles(data, length_unit=(10.0, "Mpc"))
+    center_code = ds.arr([0.5, 0.5, 0.5], "code_length")
+    center_mpc = center_code.to("Mpc")
+    half_width_code = ds.quan(0.1, "code_length")
+    half_width_mpc = half_width_code.to("Mpc")
+
+    box_code = ds.box(center_code - half_width_code, center_code + half_width_code)
+    box_mpc = ds.box(center_mpc - half_width_mpc, center_mpc + half_width_mpc)
+    n_code = box_code["all", "particle_mass"].size
+    n_mpc = box_mpc["all", "particle_mass"].size
+    assert_equal(n_code, 3)
+    assert_equal(n_mpc, n_code)
+
+    reg_code = ds.region(center_code, center_code - half_width_code, center_code + half_width_code)
+    reg_mpc = ds.region(center_mpc, center_mpc - half_width_mpc, center_mpc + half_width_mpc)
+    assert_equal(reg_mpc["all", "particle_mass"].size, reg_code["all", "particle_mass"].size)
+
+    sph_code = ds.sphere(center_code, half_width_code)
+    sph_mpc = ds.sphere(center_mpc, half_width_mpc)
+    assert_equal(sph_code["all", "particle_mass"].size, 3)
+    assert_equal(sph_mpc["all", "particle_mass"].size, 3)
 
 
 def test_max_level_min_level_semantics():


### PR DESCRIPTION
## Summary

`ds.box` / `ds.region` with physical-unit edges selected a different particle set than the equivalent `code_length` box. `RegionSelector` memory-views the raw floats and compares them to domain boundaries in code units, so a periodic `[4, 6] Mpc` box against a `[0, 1]` domain wrapped and selected the whole stream.

`YTRegion` now converts YTArray edges to `code_length` after attaching the dataset registry, matching how `fix_length` already treats a sphere radius.

Closes #5496

## Test plan

- [x] Issue #5496 reproducer: `code_length` box 3 particles, Mpc box 3 particles (was 5 on yt 4.4.2)
- [x] `ds.region` with Mpc edges matches the `code_length` region
- [x] Sphere control still 3/3
- [x] Existing `test_box_creation` (full-domain cm vs unitless) still equal


Made with [Cursor](https://cursor.com)